### PR TITLE
[Spark] Support Comet native vectorization for Append-Only tables

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -263,6 +263,13 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Specify the message format of data files, currently orc, parquet and avro are supported.");
 
+    public static final ConfigOption<Boolean> COMET_ENABLED =
+            key("comet.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable Comet native vectorized reading for Paimon tables (currently only supports Append-Only tables).");
+
     public static final ConfigOption<Map<String, String>> FILE_COMPRESSION_PER_LEVEL =
             key("file.compression.per.level")
                     .mapType()

--- a/paimon-spark/paimon-spark-common/pom.xml
+++ b/paimon-spark/paimon-spark-common/pom.xml
@@ -67,6 +67,27 @@ under the License.
             <artifactId>antlr4-runtime</artifactId>
             <version>${antlr4.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.datafusion</groupId>
+            <artifactId>comet-spark-spark3.5_2.12</artifactId>
+            <version>0.11.0</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-sql_2.12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-core_2.12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-catalyst_2.12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/CometColumnReader.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/CometColumnReader.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet;
+
+import org.apache.comet.CometSchemaImporter;
+import org.apache.comet.parquet.AbstractColumnReader;
+import org.apache.comet.parquet.ColumnReader;
+import org.apache.comet.parquet.Utils;
+import org.apache.comet.shaded.arrow.memory.RootAllocator;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+
+import java.io.IOException;
+
+/**
+ * A Paimon adaptation of Iceberg's CometColumnReader. Reads a single column using Comet's native
+ * reader.
+ */
+public class CometColumnReader implements AutoCloseable {
+    // use the Comet default batch size
+    public static final int DEFAULT_BATCH_SIZE = 8192;
+
+    private final ColumnDescriptor descriptor;
+    private final DataType sparkType;
+
+    // The delegated ColumnReader from Comet side
+    private AbstractColumnReader delegate;
+    private boolean initialized = false;
+    private int batchSize = DEFAULT_BATCH_SIZE;
+    private CometSchemaImporter importer;
+
+    public CometColumnReader(DataType sparkType, ColumnDescriptor descriptor) {
+        this.sparkType = sparkType;
+        this.descriptor = descriptor;
+    }
+
+    public AbstractColumnReader delegate() {
+        return delegate;
+    }
+
+    void setDelegate(AbstractColumnReader delegate) {
+        this.delegate = delegate;
+    }
+
+    void setInitialized(boolean initialized) {
+        this.initialized = initialized;
+    }
+
+    public int batchSize() {
+        return batchSize;
+    }
+
+    /**
+     * This method is to initialized/reset the CometColumnReader. This needs to be called for each
+     * row group after readNextRowGroup, so a new dictionary encoding can be set for each of the new
+     * row groups.
+     */
+    public void reset() {
+        if (importer != null) {
+            importer.close();
+        }
+
+        if (delegate != null) {
+            delegate.close();
+        }
+
+        this.importer = new CometSchemaImporter(new RootAllocator());
+        this.delegate =
+                Utils.getColumnReader(sparkType, descriptor, importer, batchSize, false, false);
+        this.initialized = true;
+    }
+
+    public ColumnDescriptor descriptor() {
+        return descriptor;
+    }
+
+    /** Returns the Spark data type for this column. */
+    public DataType sparkType() {
+        return sparkType;
+    }
+
+    /**
+     * Set the page reader to be 'pageReader'.
+     *
+     * <p>NOTE: this should be called before reading a new Parquet column chunk, and after {@link
+     * CometColumnReader#reset} is called.
+     */
+    public void setPageReader(PageReader pageReader) throws IOException {
+        if (!initialized) {
+            throw new IllegalStateException("Invalid state: 'reset' should be called first");
+        }
+        ((ColumnReader) delegate).setPageReader(pageReader);
+    }
+
+    @Override
+    public void close() {
+        // close resources on native side
+        if (importer != null) {
+            importer.close();
+        }
+
+        if (delegate != null) {
+            delegate.close();
+        }
+    }
+
+    public void setBatchSize(int size) {
+        this.batchSize = size;
+    }
+
+    public ColumnVector read(ColumnVector reuse, int numRowsToRead) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/CometColumnarBatchReader.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/CometColumnarBatchReader.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet;
+
+import org.apache.comet.parquet.AbstractColumnReader;
+import org.apache.comet.parquet.BatchReader;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * A Paimon adaptation of Iceberg's CometColumnarBatchReader. Reads a batch of rows using Comet's
+ * native reader and returns a Spark ColumnarBatch.
+ */
+public class CometColumnarBatchReader implements AutoCloseable {
+
+    private final CometColumnReader[] readers;
+    private final BatchReader delegate;
+    private final int capacity;
+    private ColumnarBatch currentBatch;
+
+    public CometColumnarBatchReader(CometColumnReader[] readers, StructType schema, int capacity) {
+        this.readers = readers;
+        this.capacity = capacity;
+
+        AbstractColumnReader[] abstractColumnReaders = new AbstractColumnReader[readers.length];
+        for (int i = 0; i < readers.length; i++) {
+            abstractColumnReaders[i] = readers[i].delegate();
+        }
+
+        this.delegate = new BatchReader(abstractColumnReaders);
+        this.delegate.setSparkSchema(schema);
+    }
+
+    public void setRowGroupInfo(PageReadStore pageStore) {
+        for (int i = 0; i < readers.length; i++) {
+            try {
+                readers[i].reset();
+                readers[i].setPageReader(pageStore.getPageReader(readers[i].descriptor()));
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to setRowGroupInfo for Comet vectorization", e);
+            }
+        }
+
+        // Update delegate's column readers after reset
+        for (int i = 0; i < readers.length; i++) {
+            delegate.getColumnReaders()[i] = this.readers[i].delegate();
+        }
+    }
+
+    public ColumnarBatch read(int numRowsToRead) {
+        if (numRowsToRead <= 0) {
+            throw new IllegalArgumentException("Invalid number of rows to read: " + numRowsToRead);
+        }
+
+        // Fetch rows for all readers in the delegate
+        // Delegate.nextBatch returns the number of rows read, but we expect it to match request or
+        // be handled.
+        // Actually Comet's BatchReader.nextBatch takes the count.
+        delegate.nextBatch(numRowsToRead);
+
+        if (currentBatch == null) {
+            ColumnVector[] columnVectors = new ColumnVector[readers.length];
+            for (int i = 0; i < readers.length; i++) {
+                columnVectors[i] = readers[i].delegate().currentBatch();
+            }
+            currentBatch = new ColumnarBatch(columnVectors);
+        }
+
+        currentBatch.setNumRows(numRowsToRead);
+        return currentBatch;
+    }
+
+    public void setBatchSize(int batchSize) {
+        for (CometColumnReader reader : readers) {
+            if (reader != null) {
+                reader.setBatchSize(batchSize);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        for (CometColumnReader reader : readers) {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/PaimonCometReaderBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/PaimonCometReaderBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Builder for {@link CometColumnarBatchReader}. */
+public class PaimonCometReaderBuilder {
+
+    public static CometColumnarBatchReader build(
+            StructType sparkSchema, MessageType parquetSchema) {
+        List<CometColumnReader> readers = new ArrayList<>();
+
+        for (StructField field : sparkSchema.fields()) {
+            String fieldName = field.name();
+            // Paimon is case-sensitive, so we strictly match the field name.
+            if (parquetSchema.containsField(fieldName)) {
+                Type parquetType = parquetSchema.getType(fieldName);
+                if (parquetType.isPrimitive()) {
+                    // Find the column descriptor
+                    // TODO: Support nested types.
+                    // Currently, we only support flat schemas (primitive types) to simplify the
+                    // implementation.
+                    // Comet supports nested types, but it requires recursive reader construction
+                    // which is not yet implemented here.
+                    String[] path = {fieldName};
+                    ColumnDescriptor descriptor = parquetSchema.getColumnDescription(path);
+                    readers.add(new CometColumnReader(field.dataType(), descriptor));
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Nested types are not supported in Paimon Comet integration yet: "
+                                    + fieldName);
+                }
+            } else {
+                // TODO: Support missing fields (ConstantColumnReader)
+                throw new UnsupportedOperationException(
+                        "Field missing in Parquet file: " + fieldName);
+            }
+        }
+
+        return new CometColumnarBatchReader(
+                readers.toArray(new CometColumnReader[0]), sparkSchema, 8192); // Default batch size
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/SparkParquetInputFile.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/SparkParquetInputFile.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+
+import java.io.IOException;
+
+/**
+ * A {@link InputFile} adapter for Paimon. This is used to bridge Paimon's file system with Spark's
+ * Parquet reader (which uses unshaded Parquet).
+ */
+public class SparkParquetInputFile implements InputFile {
+    private final FileIO fileIO;
+    private final Path path;
+    private final long length;
+
+    public SparkParquetInputFile(FileIO fileIO, Path path, long length) {
+        this.fileIO = fileIO;
+        this.path = path;
+        this.length = length;
+    }
+
+    @Override
+    public long getLength() throws IOException {
+        return length;
+    }
+
+    @Override
+    public SeekableInputStream newStream() throws IOException {
+        return new SparkParquetInputStream(fileIO.newInputStream(path));
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/SparkParquetInputStream.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/comet/SparkParquetInputStream.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet;
+
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A {@link org.apache.parquet.io.SeekableInputStream} adapter for Paimon's {@link
+ * SeekableInputStream}. This is used to bridge Paimon's file system with Spark's Parquet reader
+ * (which uses unshaded Parquet).
+ */
+public class SparkParquetInputStream extends org.apache.parquet.io.SeekableInputStream {
+    private final SeekableInputStream stream;
+
+    public SparkParquetInputStream(SeekableInputStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return stream.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+        stream.seek(newPos);
+    }
+
+    @Override
+    public void readFully(byte[] bytes) throws IOException {
+        readFully(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void readFully(byte[] bytes, int start, int len) throws IOException {
+        int read = 0;
+        while (read < len) {
+            int n = stream.read(bytes, start + read, len - read);
+            if (n < 0) {
+                throw new IOException("Unexpected end of stream");
+            }
+            read += n;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        return stream.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return stream.read(b, off, len);
+    }
+
+    @Override
+    public void readFully(ByteBuffer buf) throws IOException {
+        if (buf.hasArray()) {
+            readFully(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+            buf.position(buf.limit());
+        } else {
+            byte[] bytes = new byte[buf.remaining()];
+            readFully(bytes);
+            buf.put(bytes);
+        }
+    }
+
+    @Override
+    public int read(ByteBuffer buf) throws IOException {
+        if (buf.hasArray()) {
+            int read =
+                    stream.read(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+            if (read > 0) {
+                buf.position(buf.position() + read);
+            }
+            return read;
+        } else {
+            byte[] bytes = new byte[buf.remaining()];
+            int read = stream.read(bytes);
+            if (read > 0) {
+                buf.put(bytes, 0, read);
+            }
+            return read;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        stream.close();
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBatch.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBatch.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
+import org.apache.paimon.table.Table
 import org.apache.paimon.table.source.ReadBuilder
 
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory}
@@ -27,6 +28,7 @@ import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionRead
 case class PaimonBatch(
     inputPartitions: Seq[PaimonInputPartition],
     readBuilder: ReadBuilder,
+    table: Table,
     blobAsDescriptor: Boolean,
     metadataColumns: Seq[PaimonMetadataColumn] = Seq.empty)
   extends Batch {
@@ -35,5 +37,5 @@ case class PaimonBatch(
     inputPartitions.map(_.asInstanceOf[InputPartition]).toArray
 
   override def createReaderFactory(): PartitionReaderFactory =
-    PaimonPartitionReaderFactory(readBuilder, metadataColumns, blobAsDescriptor)
+    PaimonPartitionReaderFactory(readBuilder, table, metadataColumns, blobAsDescriptor)
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionReaderFactory.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonPartitionReaderFactory.scala
@@ -19,15 +19,20 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.source.ReadBuilder
+import org.apache.paimon.table.Table
+import org.apache.paimon.table.source.{DataSplit, ReadBuilder}
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
+import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import java.util.Objects
 
+import scala.collection.JavaConverters._
+
 case class PaimonPartitionReaderFactory(
     readBuilder: ReadBuilder,
+    table: Table,
     metadataColumns: Seq[PaimonMetadataColumn] = Seq.empty,
     blobAsDescriptor: Boolean)
   extends PartitionReaderFactory {
@@ -39,6 +44,36 @@ case class PaimonPartitionReaderFactory(
       case _ =>
         throw new RuntimeException(s"It's not a Paimon input partition, $partition")
     }
+  }
+
+  override def supportColumnarReads(partition: InputPartition): Boolean = {
+    val options = table.options()
+    if (
+      options.containsKey("comet.enabled") && java.lang.Boolean.parseBoolean(
+        options.get("comet.enabled"))
+    ) {
+      partition match {
+        case p: PaimonInputPartition =>
+          // Ensure all splits are DataSplit (no system splits)
+          p.splits.forall(_.isInstanceOf[DataSplit])
+        case _ => false
+      }
+    } else {
+      false
+    }
+  }
+
+  override def createColumnarReader(partition: InputPartition): PartitionReader[ColumnarBatch] = {
+    val dataFields = new java.util.ArrayList(readBuilder.readType().getFields)
+    dataFields.addAll(metadataColumns.map(_.toPaimonDataField).asJava)
+    val rowType = new org.apache.paimon.types.RowType(dataFields)
+    val schema = org.apache.paimon.spark.SparkTypeUtils.fromPaimonRowType(rowType)
+
+    new org.apache.paimon.spark.comet.PaimonCometPartitionReader(
+      table.fileIO(),
+      partition.asInstanceOf[PaimonInputPartition],
+      schema,
+      table)
   }
 
   override def equals(obj: Any): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/comet/PaimonCometPartitionReader.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/comet/PaimonCometPartitionReader.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet
+
+import org.apache.paimon.fs.FileIO
+import org.apache.paimon.fs.Path
+import org.apache.paimon.spark.PaimonInputPartition
+import org.apache.paimon.table.FileStoreTable
+import org.apache.paimon.table.Table
+import org.apache.paimon.table.source.DataSplit
+
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.spark.sql.connector.read.PartitionReader
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import java.io.IOException
+
+import scala.collection.JavaConverters._
+
+class PaimonCometPartitionReader(
+    fileIO: FileIO,
+    partition: PaimonInputPartition,
+    schema: StructType,
+    table: Table)
+  extends PartitionReader[ColumnarBatch] {
+
+  private val files: Iterator[(String, Long)] = partition.splits.iterator.flatMap {
+    case dataSplit: DataSplit =>
+      dataSplit.dataFiles().asScala.iterator.map {
+        f =>
+          if (table.isInstanceOf[FileStoreTable]) {
+            val fst = table.asInstanceOf[FileStoreTable]
+            val pathFactory = fst.store().pathFactory()
+            val bucketPath = pathFactory.bucketPath(dataSplit.partition(), dataSplit.bucket())
+            val fullPath = new Path(bucketPath, f.fileName()).toString
+            (fullPath, f.fileSize())
+          } else {
+            throw new UnsupportedOperationException("Only FileStoreTable supports Comet reader")
+          }
+      }
+    case _ => Iterator.empty
+  }
+
+  private var currentParquetReader: ParquetFileReader = _
+  private var currentCometReader: CometColumnarBatchReader = _
+  private var currentBatch: ColumnarBatch = _
+  private var rowsInCurrentGroup: Long = 0
+  private var rowsReadInCurrentGroup: Long = 0
+
+  override def next(): Boolean = {
+    // The currentBatch is reused by CometColumnarBatchReader, so we don't need to close it here.
+    // Spark expects the batch returned by get() to be valid until next() is called.
+    // We update the batch content in advance() call.
+
+    try {
+      advance()
+    } catch {
+      case e: IOException => throw new RuntimeException(e)
+    }
+  }
+
+  private def advance(): Boolean = {
+    // 1. Try to read from current row group
+    if (currentCometReader != null && rowsReadInCurrentGroup < rowsInCurrentGroup) {
+      val needed = Math.min(4096, rowsInCurrentGroup - rowsReadInCurrentGroup).toInt
+      currentBatch = currentCometReader.read(needed)
+      rowsReadInCurrentGroup += currentBatch.numRows()
+      return true
+    }
+
+    // 2. Current row group finished, try next row group
+    if (currentParquetReader != null) {
+      val pages = currentParquetReader.readNextRowGroup()
+      if (pages != null) {
+        rowsInCurrentGroup = pages.getRowCount
+        rowsReadInCurrentGroup = 0
+        currentCometReader.setRowGroupInfo(pages)
+        return advance() // Recurse to read batch
+      } else {
+        // File finished
+        currentParquetReader.close()
+        currentParquetReader = null
+        if (currentCometReader != null) {
+          currentCometReader.close()
+          currentCometReader = null
+        }
+      }
+    }
+
+    // 3. Next file
+    if (files.hasNext) {
+      val (file, length) = files.next()
+      val inputFile = new SparkParquetInputFile(fileIO, new Path(file), length)
+      currentParquetReader = ParquetFileReader.open(inputFile)
+      val footer = currentParquetReader.getFooter
+      val messageType = footer.getFileMetaData.getSchema
+
+      currentCometReader = PaimonCometReaderBuilder.build(schema, messageType)
+      // Recurse to read first row group
+      return advance()
+    }
+
+    false
+  }
+
+  override def get(): ColumnarBatch = currentBatch
+
+  override def close(): Unit = {
+    if (currentBatch != null) {
+      currentBatch.close()
+    }
+    if (currentCometReader != null) {
+      currentCometReader.close()
+    }
+    if (currentParquetReader != null) {
+      currentParquetReader.close()
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -128,7 +128,12 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   override def toBatch: Batch = {
     val metadataColumns = metadataFields.map(
       field => PaimonMetadataColumn.get(field.name, SparkTypeUtils.toSparkPartitionType(table)))
-    PaimonBatch(inputPartitions, readBuilder, coreOptions.blobAsDescriptor(), metadataColumns)
+    PaimonBatch(
+      inputPartitions,
+      readBuilder,
+      table,
+      coreOptions.blobAsDescriptor(),
+      metadataColumns)
   }
 
   def estimateStatistics: Statistics = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonMicroBatchStream.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonMicroBatchStream.scala
@@ -130,7 +130,7 @@ class PaimonMicroBatchStream(
   }
 
   override def createReaderFactory(): PartitionReaderFactory = {
-    PaimonPartitionReaderFactory(readBuilder, blobAsDescriptor = blobAsDescriptor)
+    PaimonPartitionReaderFactory(readBuilder, table, blobAsDescriptor = blobAsDescriptor)
   }
 
   override def initialOffset(): Offset = {

--- a/paimon-spark/paimon-spark-ut/pom.xml
+++ b/paimon-spark/paimon-spark-ut/pom.xml
@@ -88,6 +88,27 @@ under the License.
             <version>${spark.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.datafusion</groupId>
+            <artifactId>comet-spark-spark3.5_2.12</artifactId>
+            <version>0.11.0</version>
+            <scope>test</scope>
+             <exclusions>
+                 <exclusion>
+                     <groupId>org.apache.spark</groupId>
+                     <artifactId>spark-sql_2.12</artifactId>
+                 </exclusion>
+                 <exclusion>
+                     <groupId>org.apache.spark</groupId>
+                     <artifactId>spark-core_2.12</artifactId>
+                 </exclusion>
+                 <exclusion>
+                     <groupId>org.apache.spark</groupId>
+                     <artifactId>spark-catalyst_2.12</artifactId>
+                 </exclusion>
+             </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/comet/CometPaimonReadTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/comet/CometPaimonReadTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.comet
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+
+import org.apache.spark.sql.Row
+
+class CometPaimonReadTest extends PaimonSparkTestBase {
+
+  test("Paimon Comet Integration: Read simple table") {
+    spark.sql(
+      s"CREATE TABLE T (id INT, data STRING) USING paimon TBLPROPERTIES ('file.format'='parquet', 'bucket'='-1')")
+    spark.sql("INSERT INTO T VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+    // Enable Comet
+    spark.sql("ALTER TABLE T SET TBLPROPERTIES ('comet.enabled'='true')")
+
+    val df = spark.sql("SELECT * FROM T ORDER BY id")
+    checkAnswer(df, Row(1, "a") :: Row(2, "b") :: Row(3, "c") :: Nil)
+  }
+}


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Purpose This PR introduces integration with Apache DataFusion Comet to enable native vectorized reading for Paimon tables in Spark. This significantly improves query performance for Append-Only tables by leveraging Comet's native Parquet reader.


### Tests
Added CometPaimonReadTest to verify the integration.
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
