### PR TITLE
[core] Fix integer overflow in FieldSumAgg causing silent data corruption

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
@@ -55,16 +55,16 @@ public class FieldSumAgg extends FieldAggregator {
                                 mergeFieldDD.scale());
                 break;
             case TINYINT:
-                sum = (byte) ((byte) accumulator + (byte) inputField);
+                sum = addExactByte((byte) accumulator, (byte) inputField);
                 break;
             case SMALLINT:
-                sum = (short) ((short) accumulator + (short) inputField);
+                sum = addExactShort((short) accumulator, (short) inputField);
                 break;
             case INTEGER:
-                sum = (int) accumulator + (int) inputField;
+                sum = Math.addExact((int) accumulator, (int) inputField);
                 break;
             case BIGINT:
-                sum = (long) accumulator + (long) inputField;
+                sum = Math.addExact((long) accumulator, (long) inputField);
                 break;
             case FLOAT:
                 sum = (float) accumulator + (float) inputField;
@@ -105,16 +105,16 @@ public class FieldSumAgg extends FieldAggregator {
                                 mergeFieldDD.scale());
                 break;
             case TINYINT:
-                sum = (byte) ((byte) accumulator - (byte) inputField);
+                sum = subtractExactByte((byte) accumulator, (byte) inputField);
                 break;
             case SMALLINT:
-                sum = (short) ((short) accumulator - (short) inputField);
+                sum = subtractExactShort((short) accumulator, (short) inputField);
                 break;
             case INTEGER:
-                sum = (int) accumulator - (int) inputField;
+                sum = Math.subtractExact((int) accumulator, (int) inputField);
                 break;
             case BIGINT:
-                sum = (long) accumulator - (long) inputField;
+                sum = Math.subtractExact((long) accumulator, (long) inputField);
                 break;
             case FLOAT:
                 sum = (float) accumulator - (float) inputField;
@@ -142,13 +142,13 @@ public class FieldSumAgg extends FieldAggregator {
                 return Decimal.fromBigDecimal(
                         decimal.toBigDecimal().negate(), decimal.precision(), decimal.scale());
             case TINYINT:
-                return (byte) -((byte) value);
+                return subtractExactByte((byte) 0, (byte) value);
             case SMALLINT:
-                return (short) -((short) value);
+                return subtractExactShort((short) 0, (short) value);
             case INTEGER:
-                return -((int) value);
+                return Math.negateExact((int) value);
             case BIGINT:
-                return -((long) value);
+                return Math.negateExact((long) value);
             case FLOAT:
                 return -((float) value);
             case DOUBLE:
@@ -160,5 +160,37 @@ public class FieldSumAgg extends FieldAggregator {
                                 fieldType.getTypeRoot().toString(), this.getClass().getName());
                 throw new IllegalArgumentException(msg);
         }
+    }
+
+    private static byte addExactByte(byte a, byte b) {
+        int result = a + b;
+        if (result > Byte.MAX_VALUE || result < Byte.MIN_VALUE) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return (byte) result;
+    }
+
+    private static short addExactShort(short a, short b) {
+        int result = a + b;
+        if (result > Short.MAX_VALUE || result < Short.MIN_VALUE) {
+            throw new ArithmeticException("short overflow");
+        }
+        return (short) result;
+    }
+
+    private static byte subtractExactByte(byte a, byte b) {
+        int result = a - b;
+        if (result > Byte.MAX_VALUE || result < Byte.MIN_VALUE) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return (byte) result;
+    }
+
+    private static short subtractExactShort(short a, short b) {
+        int result = a - b;
+        if (result > Short.MAX_VALUE || result < Short.MIN_VALUE) {
+            throw new ArithmeticException("short overflow");
+        }
+        return (short) result;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldSumAgg.java
@@ -55,10 +55,10 @@ public class FieldSumAgg extends FieldAggregator {
                                 mergeFieldDD.scale());
                 break;
             case TINYINT:
-                sum = addExactByte((byte) accumulator, (byte) inputField);
+                sum = toExactByte((byte) accumulator + (byte) inputField);
                 break;
             case SMALLINT:
-                sum = addExactShort((short) accumulator, (short) inputField);
+                sum = toExactShort((short) accumulator + (short) inputField);
                 break;
             case INTEGER:
                 sum = Math.addExact((int) accumulator, (int) inputField);
@@ -105,10 +105,10 @@ public class FieldSumAgg extends FieldAggregator {
                                 mergeFieldDD.scale());
                 break;
             case TINYINT:
-                sum = subtractExactByte((byte) accumulator, (byte) inputField);
+                sum = toExactByte((byte) accumulator - (byte) inputField);
                 break;
             case SMALLINT:
-                sum = subtractExactShort((short) accumulator, (short) inputField);
+                sum = toExactShort((short) accumulator - (short) inputField);
                 break;
             case INTEGER:
                 sum = Math.subtractExact((int) accumulator, (int) inputField);
@@ -142,9 +142,9 @@ public class FieldSumAgg extends FieldAggregator {
                 return Decimal.fromBigDecimal(
                         decimal.toBigDecimal().negate(), decimal.precision(), decimal.scale());
             case TINYINT:
-                return subtractExactByte((byte) 0, (byte) value);
+                return toExactByte(-(byte) value);
             case SMALLINT:
-                return subtractExactShort((short) 0, (short) value);
+                return toExactShort(-(short) value);
             case INTEGER:
                 return Math.negateExact((int) value);
             case BIGINT:
@@ -162,32 +162,14 @@ public class FieldSumAgg extends FieldAggregator {
         }
     }
 
-    private static byte addExactByte(byte a, byte b) {
-        int result = a + b;
+    private static byte toExactByte(int result) {
         if (result > Byte.MAX_VALUE || result < Byte.MIN_VALUE) {
             throw new ArithmeticException("byte overflow");
         }
         return (byte) result;
     }
 
-    private static short addExactShort(short a, short b) {
-        int result = a + b;
-        if (result > Short.MAX_VALUE || result < Short.MIN_VALUE) {
-            throw new ArithmeticException("short overflow");
-        }
-        return (short) result;
-    }
-
-    private static byte subtractExactByte(byte a, byte b) {
-        int result = a - b;
-        if (result > Byte.MAX_VALUE || result < Byte.MIN_VALUE) {
-            throw new ArithmeticException("byte overflow");
-        }
-        return (byte) result;
-    }
-
-    private static short subtractExactShort(short a, short b) {
-        int result = a - b;
+    private static short toExactShort(int result) {
         if (result > Short.MAX_VALUE || result < Short.MIN_VALUE) {
             throw new ArithmeticException("short overflow");
         }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -82,6 +82,7 @@ import java.util.stream.Stream;
 
 import static org.apache.paimon.utils.ThetaSketch.sketchOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -479,6 +480,57 @@ public class FieldAggregatorTest {
         assertThat(fieldSumAgg.agg((double) 1, (double) 10)).isEqualTo((double) 11);
         assertThat(fieldSumAgg.retract((double) 10, (double) 5)).isEqualTo((double) 5);
         assertThat(fieldSumAgg.retract(null, (double) 5)).isEqualTo((double) -5);
+    }
+
+    @Test
+    public void testFieldSumByteOverflow() {
+        FieldSumAgg fieldSumAgg = new FieldSumAggFactory().create(new TinyIntType(), null, null);
+        // Normal case still works
+        assertThat(fieldSumAgg.agg((byte) 1, (byte) 2)).isEqualTo((byte) 3);
+        // Overflow should throw ArithmeticException instead of silently wrapping
+        assertThatThrownBy(() -> fieldSumAgg.agg(Byte.MAX_VALUE, (byte) 1))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Byte.MIN_VALUE, (byte) -1))
+                .isInstanceOf(ArithmeticException.class);
+        // Retract overflow
+        assertThatThrownBy(() -> fieldSumAgg.retract(Byte.MIN_VALUE, (byte) 1))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    public void testFieldSumShortOverflow() {
+        FieldSumAgg fieldSumAgg = new FieldSumAggFactory().create(new SmallIntType(), null, null);
+        assertThat(fieldSumAgg.agg((short) 1, (short) 2)).isEqualTo((short) 3);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Short.MAX_VALUE, (short) 1))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Short.MIN_VALUE, (short) -1))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.retract(Short.MIN_VALUE, (short) 1))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    public void testFieldSumIntOverflow() {
+        FieldSumAgg fieldSumAgg = new FieldSumAggFactory().create(new IntType(), null, null);
+        assertThat(fieldSumAgg.agg(1, 2)).isEqualTo(3);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Integer.MAX_VALUE, 1))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Integer.MIN_VALUE, -1))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.retract(Integer.MIN_VALUE, 1))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    @Test
+    public void testFieldSumLongOverflow() {
+        FieldSumAgg fieldSumAgg = new FieldSumAggFactory().create(new BigIntType(), null, null);
+        assertThat(fieldSumAgg.agg(1L, 2L)).isEqualTo(3L);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Long.MAX_VALUE, 1L))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.agg(Long.MIN_VALUE, -1L))
+                .isInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> fieldSumAgg.retract(Long.MIN_VALUE, 1L))
+                .isInstanceOf(ArithmeticException.class);
     }
 
     @Test


### PR DESCRIPTION


### Purpose

`FieldSumAgg` performs unchecked arithmetic for TINYINT, SMALLINT, INTEGER, and BIGINT types. When the accumulator overflows, the result silently wraps around (e.g., `Byte.MAX_VALUE + 1` becomes `-128`), producing incorrect aggregation results without any error or warning. This is silent data corruption in the merge-tree SUM aggregation path.

The root cause differs by type:
- **TINYINT/SMALLINT:** Java promotes operands to `int` for arithmetic, then the `(byte)` or `(short)` cast silently truncates the overflow bits.
- **INTEGER/BIGINT:** Standard `+` and `-` wrap around at `MAX_VALUE` / `MIN_VALUE` per Java spec.

This fix adds overflow detection to all three affected methods (`agg`, `retract`, `negative`):
- For INTEGER and BIGINT: uses `Math.addExact` / `Math.subtractExact` / `Math.negateExact`, which throw `ArithmeticException` on overflow.
- For TINYINT and SMALLINT: uses range-checked helper methods that perform arithmetic in `int` width and verify the result fits in `byte` / `short` range before casting.

This is consistent with the overflow-protection pattern already used in `DecimalUtils.add()` and `DecimalUtils.subtract()` in the same codebase.

### Tests

- `testFieldSumByteOverflow` — TINYINT: verifies normal addition works, positive overflow throws `ArithmeticException`, negative overflow throws, and retract overflow throws.
- `testFieldSumShortOverflow` — SMALLINT: same coverage.
- `testFieldSumIntOverflow` — INTEGER: same coverage.
- `testFieldSumLongOverflow` — BIGINT: same coverage.

### API and Format

No API or storage format changes.

### Documentation

No new feature introduced.

### Generative AI tooling

Generated-by: Claude Code 1.0.0