### PR TITLE
[core] Add IF NOT EXISTS support for create_branch operation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -788,6 +788,28 @@ public interface Catalog extends AutoCloseable {
             throws TableNotExistException, BranchAlreadyExistException, TagNotExistException;
 
     /**
+     * Create a branch for this table with option to ignore if the branch already exists.
+     *
+     * @param identifier path of the table, cannot be system or branch name.
+     * @param branch the branch name
+     * @param fromTag from the tag
+     * @param ignoreIfExists if true, do nothing when branch already exists
+     * @throws TableNotExistException if the table in identifier doesn't exist
+     * @throws BranchAlreadyExistException if the branch already exists and ignoreIfExists is false
+     * @throws TagNotExistException if the tag doesn't exist
+     * @throws UnsupportedOperationException if the catalog does not {@link
+     *     #supportsVersionManagement()}
+     */
+    default void createBranch(
+            Identifier identifier, String branch, @Nullable String fromTag, boolean ignoreIfExists)
+            throws TableNotExistException, BranchAlreadyExistException, TagNotExistException {
+        if (ignoreIfExists && listBranches(identifier).contains(branch)) {
+            return;
+        }
+        createBranch(identifier, branch, fromTag);
+    }
+
+    /**
      * Drop the branch for this table.
      *
      * @param identifier path of the table, cannot be system or branch name.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -229,6 +229,13 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public void createBranch(
+            Identifier identifier, String branch, @Nullable String fromTag, boolean ignoreIfExists)
+            throws TableNotExistException, BranchAlreadyExistException, TagNotExistException {
+        wrapped.createBranch(identifier, branch, fromTag, ignoreIfExists);
+    }
+
+    @Override
     public void dropBranch(Identifier identifier, String branch) throws BranchNotExistException {
         wrapped.dropBranch(identifier, branch);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedFileStoreTable.java
@@ -181,6 +181,18 @@ public class PrivilegedFileStoreTable extends DelegatedFileStoreTable {
     }
 
     @Override
+    public void createBranch(String branchName, boolean ignoreIfExists) {
+        privilegeChecker.assertCanInsert(identifier);
+        wrapped.createBranch(branchName, ignoreIfExists);
+    }
+
+    @Override
+    public void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        privilegeChecker.assertCanInsert(identifier);
+        wrapped.createBranch(branchName, tagName, ignoreIfExists);
+    }
+
+    @Override
     public void deleteBranch(String branchName) {
         privilegeChecker.assertCanInsert(identifier);
         wrapped.deleteBranch(branchName);

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -674,6 +674,16 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public void createBranch(String branchName, boolean ignoreIfExists) {
+        branchManager().createBranch(branchName, ignoreIfExists);
+    }
+
+    @Override
+    public void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        branchManager().createBranch(branchName, tagName, ignoreIfExists);
+    }
+
+    @Override
     public void deleteBranch(String branchName) {
         String fallbackBranch =
                 coreOptions().toConfiguration().get(CoreOptions.SCAN_FALLBACK_BRANCH);

--- a/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/DelegatedFileStoreTable.java
@@ -266,6 +266,16 @@ public abstract class DelegatedFileStoreTable implements FileStoreTable {
     }
 
     @Override
+    public void createBranch(String branchName, boolean ignoreIfExists) {
+        wrapped.createBranch(branchName, ignoreIfExists);
+    }
+
+    @Override
+    public void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        wrapped.createBranch(branchName, tagName, ignoreIfExists);
+    }
+
+    @Override
     public void deleteBranch(String branchName) {
         wrapped.deleteBranch(branchName);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
@@ -385,6 +385,16 @@ public interface FormatTable extends Table {
     }
 
     @Override
+    default void createBranch(String branchName, boolean ignoreIfExists) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    default void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     default void deleteBranch(String branchName) {
         throw new UnsupportedOperationException();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ReadonlyTable.java
@@ -234,6 +234,22 @@ public interface ReadonlyTable extends InnerTable {
     }
 
     @Override
+    default void createBranch(String branchName, boolean ignoreIfExists) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support create branch.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
+    default void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Readonly Table %s does not support create branch.",
+                        this.getClass().getSimpleName()));
+    }
+
+    @Override
     default void deleteBranch(String branchName) {
         throw new UnsupportedOperationException(
                 String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/table/Table.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/Table.java
@@ -165,6 +165,25 @@ public interface Table extends Serializable {
     @Experimental
     void createBranch(String branchName, String tagName);
 
+    /**
+     * Create an empty branch with option to ignore if the branch already exists.
+     *
+     * @param branchName the branch name
+     * @param ignoreIfExists if true, do nothing when branch already exists
+     */
+    @Experimental
+    void createBranch(String branchName, boolean ignoreIfExists);
+
+    /**
+     * Create a branch from given tag with option to ignore if the branch already exists.
+     *
+     * @param branchName the branch name
+     * @param tagName the tag name to create branch from
+     * @param ignoreIfExists if true, do nothing when branch already exists
+     */
+    @Experimental
+    void createBranch(String branchName, String tagName, boolean ignoreIfExists);
+
     /** Delete a branch by branchName. */
     @Experimental
     void deleteBranch(String branchName);

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BranchManager.java
@@ -36,6 +36,25 @@ public interface BranchManager {
 
     void createBranch(String branchName, @Nullable String tagName);
 
+    /**
+     * Create a branch with option to ignore if the branch already exists.
+     *
+     * @param branchName the branch name
+     * @param ignoreIfExists if true, do nothing when branch already exists; if false, throw
+     *     exception
+     */
+    void createBranch(String branchName, boolean ignoreIfExists);
+
+    /**
+     * Create a branch from tag with option to ignore if the branch already exists.
+     *
+     * @param branchName the branch name
+     * @param tagName the tag name to create branch from
+     * @param ignoreIfExists if true, do nothing when branch already exists; if false, throw
+     *     exception
+     */
+    void createBranch(String branchName, @Nullable String tagName, boolean ignoreIfExists);
+
     void dropBranch(String branchName);
 
     void fastForward(String branchName);

--- a/paimon-core/src/main/java/org/apache/paimon/utils/CatalogBranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/CatalogBranchManager.java
@@ -68,14 +68,27 @@ public class CatalogBranchManager implements BranchManager {
 
     @Override
     public void createBranch(String branchName) {
-        executePost(catalog -> catalog.createBranch(identifier, branchName, null));
+        createBranch(branchName, false);
     }
 
     @Override
     public void createBranch(String branchName, @Nullable String tagName) {
+        createBranch(branchName, tagName, false);
+    }
+
+    @Override
+    public void createBranch(String branchName, boolean ignoreIfExists) {
+        createBranch(branchName, null, ignoreIfExists);
+    }
+
+    @Override
+    public void createBranch(String branchName, @Nullable String tagName, boolean ignoreIfExists) {
         executePost(
                 catalog -> {
                     BranchManager.validateBranch(branchName);
+                    if (ignoreIfExists && catalog.listBranches(identifier).contains(branchName)) {
+                        return;
+                    }
                     catalog.createBranch(identifier, branchName, tagName);
                 });
     }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
@@ -73,6 +73,14 @@ public class FileSystemBranchManager implements BranchManager {
 
     @Override
     public void createBranch(String branchName) {
+        createBranch(branchName, false);
+    }
+
+    @Override
+    public void createBranch(String branchName, boolean ignoreIfExists) {
+        if (ignoreIfExists && branchExists(branchName)) {
+            return;
+        }
         validateBranch(branchName);
         try {
             TableSchema latestSchema = schemaManager.latest().get();
@@ -88,6 +96,14 @@ public class FileSystemBranchManager implements BranchManager {
 
     @Override
     public void createBranch(String branchName, String tagName) {
+        createBranch(branchName, tagName, false);
+    }
+
+    @Override
+    public void createBranch(String branchName, String tagName, boolean ignoreIfExists) {
+        if (ignoreIfExists && branchExists(branchName)) {
+            return;
+        }
         validateBranch(branchName);
         Snapshot snapshot = tagManager.getOrThrow(tagName).trimToSnapshot();
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -1135,6 +1135,56 @@ public abstract class SimpleTableTestBase {
     }
 
     @Test
+    public void testCreateBranchWithIgnoreIfExists() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        try (StreamTableWrite write = table.newWrite(commitUser);
+                StreamTableCommit commit = table.newCommit(commitUser)) {
+            write.write(rowData(1, 10, 100L));
+            commit.commit(0, write.prepareCommit(false, 1));
+            write.write(rowData(2, 20, 200L));
+            commit.commit(1, write.prepareCommit(false, 2));
+        }
+
+        table.createTag("test-tag", 2);
+        BranchManager branchManager = table.branchManager();
+
+        // Test create branch with ignoreIfExists=true (branch doesn't exist)
+        table.createBranch("new-branch", "test-tag", true);
+        assertThat(branchManager.branchExists("new-branch")).isTrue();
+
+        // Test create branch with ignoreIfExists=false (branch doesn't exist)
+        table.createBranch("another-branch", "test-tag", false);
+        assertThat(branchManager.branchExists("another-branch")).isTrue();
+
+        // Test create existing branch with ignoreIfExists=true (should succeed silently)
+        table.createBranch("new-branch", "test-tag", true);
+        assertThat(branchManager.branchExists("new-branch")).isTrue();
+
+        // Test create existing branch with ignoreIfExists=false (should throw exception)
+        assertThatThrownBy(() -> table.createBranch("new-branch", "test-tag", false))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Branch name 'new-branch' already exists."));
+
+        // Test create empty branch with ignoreIfExists
+        table.createBranch("empty-branch", true);
+        assertThat(branchManager.branchExists("empty-branch")).isTrue();
+
+        // Test create existing empty branch with ignoreIfExists=true
+        table.createBranch("empty-branch", true);
+        assertThat(branchManager.branchExists("empty-branch")).isTrue();
+
+        // Test create existing empty branch with ignoreIfExists=false
+        assertThatThrownBy(() -> table.createBranch("empty-branch", false))
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "Branch name 'empty-branch' already exists."));
+    }
+
+    @Test
     public void testDeleteBranch() throws Exception {
         FileStoreTable table = createFileStoreTable();
 

--- a/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateBranchProcedure.java
+++ b/paimon-flink/paimon-flink-1.18/src/main/java/org/apache/paimon/flink/procedure/CreateBranchProcedure.java
@@ -45,21 +45,32 @@ public class CreateBranchProcedure extends ProcedureBase {
     public String[] call(
             ProcedureContext procedureContext, String tableId, String branchName, String tagName)
             throws Catalog.TableNotExistException {
-        return innerCall(tableId, branchName, tagName);
+        return innerCall(tableId, branchName, tagName, false);
     }
 
     public String[] call(ProcedureContext procedureContext, String tableId, String branchName)
             throws Catalog.TableNotExistException {
-        return innerCall(tableId, branchName, null);
+        return innerCall(tableId, branchName, null, false);
     }
 
-    private String[] innerCall(String tableId, String branchName, String tagName)
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String branchName,
+            String tagName,
+            Boolean ignoreIfExists)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, branchName, tagName, ignoreIfExists != null && ignoreIfExists);
+    }
+
+    private String[] innerCall(
+            String tableId, String branchName, String tagName, boolean ignoreIfExists)
             throws Catalog.TableNotExistException {
         Table table = catalog.getTable(Identifier.fromString(tableId));
         if (!StringUtils.isBlank(tagName)) {
-            table.createBranch(branchName, tagName);
+            table.createBranch(branchName, tagName, ignoreIfExists);
         } else {
-            table.createBranch(branchName);
+            table.createBranch(branchName, ignoreIfExists);
         }
         return new String[] {"Success"};
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchAction.java
@@ -26,24 +26,27 @@ import java.util.Map;
 public class CreateBranchAction extends TableActionBase implements LocalAction {
     private final String branchName;
     private final String tagName;
+    private final boolean ignoreIfExists;
 
     public CreateBranchAction(
             String databaseName,
             String tableName,
             Map<String, String> catalogConfig,
             String branchName,
-            String tagName) {
+            String tagName,
+            boolean ignoreIfExists) {
         super(databaseName, tableName, catalogConfig);
         this.branchName = branchName;
         this.tagName = tagName;
+        this.ignoreIfExists = ignoreIfExists;
     }
 
     @Override
     public void executeLocally() {
         if (!StringUtils.isBlank(tagName)) {
-            table.createBranch(branchName, tagName);
+            table.createBranch(branchName, tagName, ignoreIfExists);
         } else {
-            table.createBranch(branchName);
+            table.createBranch(branchName, ignoreIfExists);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateBranchActionFactory.java
@@ -27,6 +27,7 @@ public class CreateBranchActionFactory implements ActionFactory {
 
     private static final String TAG_NAME = "tag_name";
     private static final String BRANCH_NAME = "branch_name";
+    private static final String IGNORE_IF_EXISTS = "ignore_if_exists";
 
     @Override
     public String identifier() {
@@ -41,7 +42,8 @@ public class CreateBranchActionFactory implements ActionFactory {
                         params.getRequired(TABLE),
                         catalogConfigMap(params),
                         params.getRequired(BRANCH_NAME),
-                        params.get(TAG_NAME));
+                        params.get(TAG_NAME),
+                        params.getBoolean(IGNORE_IF_EXISTS, false));
         return Optional.of(action);
     }
 
@@ -57,7 +59,8 @@ public class CreateBranchActionFactory implements ActionFactory {
                         + "--database <database_name> \\\n"
                         + "--table <table_name> \\\n"
                         + "--branch_name <branch_name> \\\n"
-                        + "[--tag_name <tag_name>]");
+                        + "[--tag_name <tag_name>] \\\n"
+                        + "[--ignore_if_exists <true/false>]");
         System.out.println();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateBranchProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateBranchProcedure.java
@@ -33,7 +33,10 @@ import org.apache.flink.table.procedure.ProcedureContext;
  * Create branch procedure for given tag. Usage:
  *
  * <pre><code>
+ *  CALL sys.create_branch('tableId', 'branchName')
  *  CALL sys.create_branch('tableId', 'branchName', 'tagName')
+ *  CALL sys.create_branch('tableId', 'branchName', true)
+ *  CALL sys.create_branch('tableId', 'branchName', 'tagName', true)
  * </code></pre>
  */
 public class CreateBranchProcedure extends ProcedureBase {
@@ -49,16 +52,71 @@ public class CreateBranchProcedure extends ProcedureBase {
             argument = {
                 @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
                 @ArgumentHint(name = "branch", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "tag", type = @DataTypeHint("STRING"), isOptional = true),
+                @ArgumentHint(
+                        name = "ignoreIfExists",
+                        type = @DataTypeHint("BOOLEAN"),
+                        isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String branchName,
+            String tagName,
+            Boolean ignoreIfExists)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, branchName, tagName, ignoreIfExists);
+    }
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "branch", type = @DataTypeHint("STRING")),
+                @ArgumentHint(
+                        name = "ignoreIfExists",
+                        type = @DataTypeHint("BOOLEAN"),
+                        isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String branchName,
+            Boolean ignoreIfExists)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, branchName, null, ignoreIfExists);
+    }
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "branch", type = @DataTypeHint("STRING")),
                 @ArgumentHint(name = "tag", type = @DataTypeHint("STRING"), isOptional = true)
             })
     public String[] call(
             ProcedureContext procedureContext, String tableId, String branchName, String tagName)
             throws Catalog.TableNotExistException {
+        return innerCall(tableId, branchName, tagName, false);
+    }
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "branch", type = @DataTypeHint("STRING"))
+            })
+    public String[] call(ProcedureContext procedureContext, String tableId, String branchName)
+            throws Catalog.TableNotExistException {
+        return innerCall(tableId, branchName, null, false);
+    }
+
+    private String[] innerCall(
+            String tableId, String branchName, String tagName, Boolean ignoreIfExists)
+            throws Catalog.TableNotExistException {
         Table table = catalog.getTable(Identifier.fromString(tableId));
+        boolean ignore = ignoreIfExists != null && ignoreIfExists;
         if (!StringUtils.isBlank(tagName)) {
-            table.createBranch(branchName, tagName);
+            table.createBranch(branchName, tagName, ignore);
         } else {
-            table.createBranch(branchName);
+            table.createBranch(branchName, ignore);
         }
         return new String[] {"Success"};
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/BranchActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/BranchActionITCase.java
@@ -30,6 +30,7 @@ import org.apache.paimon.utils.BranchManager;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -87,7 +88,7 @@ public class BranchActionITCase extends ActionITCaseBase {
 
         executeSQL(
                 String.format(
-                        "CALL sys.create_branch(`table` => '%s.%s', branch => 'branch_name_named_argument', tag => 'tag2')",
+                        "CALL sys.create_branch('%s.%s', 'branch_name_named_argument', 'tag2')",
                         database, tableName));
         assertThat(branchManager.branchExists("branch_name_named_argument")).isTrue();
 
@@ -168,7 +169,7 @@ public class BranchActionITCase extends ActionITCaseBase {
 
         executeSQL(
                 String.format(
-                        "CALL sys.create_branch(`table` => '%s.%s', branch => 'empty_branch_named_argument')",
+                        "CALL sys.create_branch('%s.%s', 'empty_branch_named_argument')",
                         database, tableName));
         assertThat(branchManager.branchExists("empty_branch_named_argument")).isTrue();
 
@@ -211,6 +212,170 @@ public class BranchActionITCase extends ActionITCaseBase {
                         "empty_branch_name")
                 .run();
         assertThat(branchManager.branchExists("empty_branch_name")).isFalse();
+    }
+
+    @Test
+    void testCreateBranchWithIgnoreIfExists() throws Exception {
+        init(warehouse);
+
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.BIGINT(), DataTypes.STRING()},
+                        new String[] {"k", "v"});
+        FileStoreTable table =
+                createFileStoreTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+
+        StreamWriteBuilder writeBuilder = table.newStreamWriteBuilder().withCommitUser(commitUser);
+        write = writeBuilder.newWrite();
+        commit = writeBuilder.newCommit();
+
+        // 3 snapshots
+        writeData(rowData(1L, BinaryString.fromString("Hi")));
+        writeData(rowData(2L, BinaryString.fromString("Hello")));
+        writeData(rowData(3L, BinaryString.fromString("Paimon")));
+
+        TagManager tagManager = new TagManager(table.fileIO(), table.location());
+        executeSQL(String.format("CALL sys.create_tag('%s.%s', 'tag1', 1)", database, tableName));
+        assertThat(tagManager.tagExists("tag1")).isTrue();
+
+        BranchManager branchManager = table.branchManager();
+
+        // Create branch without ignoreIfExists
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'branch_if_exists', 'tag1')",
+                        database, tableName));
+        assertThat(branchManager.branchExists("branch_if_exists")).isTrue();
+
+        // Try to create the same branch again without ignoreIfExists - should throw exception
+        try {
+            executeSQL(
+                    String.format(
+                            "CALL sys.create_branch('%s.%s', 'branch_if_exists', 'tag1')",
+                            database, tableName));
+            Assertions.fail("Expected exception not thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("already exists");
+        }
+
+        // Create branch with ignoreIfExists=true - should succeed silently
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'branch_if_exists', 'tag1', true)",
+                        database, tableName));
+        assertThat(branchManager.branchExists("branch_if_exists")).isTrue();
+
+        // Create branch with ignoreIfExists=false - should throw exception
+        try {
+            executeSQL(
+                    String.format(
+                            "CALL sys.create_branch('%s.%s', 'branch_if_exists', 'tag1', false)",
+                            database, tableName));
+            Assertions.fail("Expected exception not thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("already exists");
+        }
+
+        // Test with action API
+        createAction(
+                        CreateBranchAction.class,
+                        "create_branch",
+                        "--warehouse",
+                        warehouse,
+                        "--database",
+                        database,
+                        "--table",
+                        tableName,
+                        "--branch_name",
+                        "branch_if_exists",
+                        "--tag_name",
+                        "tag1",
+                        "--ignore_if_exists",
+                        "true")
+                .run();
+        assertThat(branchManager.branchExists("branch_if_exists")).isTrue();
+
+        // Test creating new branch with ignoreIfExists=true (branch doesn't exist yet)
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'new_branch', 'tag1', true)",
+                        database, tableName));
+        assertThat(branchManager.branchExists("new_branch")).isTrue();
+
+        // Test creating new branch with ignoreIfExists=false (branch doesn't exist yet)
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'another_branch', 'tag1', false)",
+                        database, tableName));
+        assertThat(branchManager.branchExists("another_branch")).isTrue();
+    }
+
+    @Test
+    void testCreateEmptyBranchWithIgnoreIfExists() throws Exception {
+        init(warehouse);
+
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.BIGINT(), DataTypes.STRING()},
+                        new String[] {"k", "v"});
+        FileStoreTable table =
+                createFileStoreTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+
+        StreamWriteBuilder writeBuilder = table.newStreamWriteBuilder().withCommitUser(commitUser);
+        write = writeBuilder.newWrite();
+        commit = writeBuilder.newCommit();
+
+        // 3 snapshots
+        writeData(rowData(1L, BinaryString.fromString("Hi")));
+        writeData(rowData(2L, BinaryString.fromString("Hello")));
+        writeData(rowData(3L, BinaryString.fromString("Paimon")));
+
+        BranchManager branchManager = table.branchManager();
+
+        // Create empty branch
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'empty_branch')", database, tableName));
+        assertThat(branchManager.branchExists("empty_branch")).isTrue();
+
+        // Try to create the same empty branch again without ignoreIfExists - should throw exception
+        try {
+            executeSQL(
+                    String.format(
+                            "CALL sys.create_branch('%s.%s', 'empty_branch')",
+                            database, tableName));
+            Assertions.fail("Expected exception not thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("already exists");
+        }
+
+        // Create empty branch with ignoreIfExists=true - should succeed silently
+        executeSQL(
+                String.format(
+                        "CALL sys.create_branch('%s.%s', 'empty_branch', true)",
+                        database, tableName));
+        assertThat(branchManager.branchExists("empty_branch")).isTrue();
+
+        // Create empty branch with ignoreIfExists=false - should throw exception
+        try {
+            executeSQL(
+                    String.format(
+                            "CALL sys.create_branch('%s.%s', 'empty_branch', false)",
+                            database, tableName));
+            Assertions.fail("Expected exception not thrown");
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("already exists");
+        }
     }
 
     @ParameterizedTest

--- a/paimon-flink/paimon-flink1-common/src/main/java/org/apache/paimon/flink/action/MultipleParameterToolAdapter.java
+++ b/paimon-flink/paimon-flink1-common/src/main/java/org/apache/paimon/flink/action/MultipleParameterToolAdapter.java
@@ -64,6 +64,14 @@ public class MultipleParameterToolAdapter {
         return value;
     }
 
+    public Boolean getBoolean(String key, Boolean defaultValue) {
+        String value = get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
     public MultipleParameterToolAdapter mergeWith(MultipleParameterToolAdapter other) {
         return new MultipleParameterToolAdapter(this.params.mergeWith(other.params));
     }

--- a/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/action/MultipleParameterToolAdapter.java
+++ b/paimon-flink/paimon-flink2-common/src/main/java/org/apache/paimon/flink/action/MultipleParameterToolAdapter.java
@@ -64,6 +64,14 @@ public class MultipleParameterToolAdapter {
         return value;
     }
 
+    public Boolean getBoolean(String key, Boolean defaultValue) {
+        String value = get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
     public MultipleParameterToolAdapter mergeWith(MultipleParameterToolAdapter other) {
         return new MultipleParameterToolAdapter(this.params.mergeWith(other.params));
     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateBranchProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateBranchProcedure.java
@@ -35,7 +35,8 @@ public class CreateBranchProcedure extends BaseProcedure {
             new ProcedureParameter[] {
                 ProcedureParameter.required("table", StringType),
                 ProcedureParameter.required("branch", StringType),
-                ProcedureParameter.optional("tag", StringType)
+                ProcedureParameter.optional("tag", StringType),
+                ProcedureParameter.optional("ignoreIfExists", StringType)
             };
 
     private static final StructType OUTPUT_TYPE =
@@ -63,14 +64,15 @@ public class CreateBranchProcedure extends BaseProcedure {
         Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
         String branch = args.getString(1);
         String tag = args.isNullAt(2) ? null : args.getString(2);
+        boolean ignoreIfExists = !args.isNullAt(3) && Boolean.parseBoolean(args.getString(3));
 
         return modifyPaimonTable(
                 tableIdent,
                 table -> {
                     if (tag != null) {
-                        table.createBranch(branch, tag);
+                        table.createBranch(branch, tag, ignoreIfExists);
                     } else {
-                        table.createBranch(branch);
+                        table.createBranch(branch, ignoreIfExists);
                     }
 
                     InternalRow outputRow = newInternalRow(true);


### PR DESCRIPTION
This commit adds the `ignoreIfExists` parameter to the create_branch operation across all layers:

Core Layer:
- Add `createBranch(String branchName, boolean ignoreIfExists)` method to Table interface
- Add `createBranch(String branchName, String tagName, boolean ignoreIfExists)` method to Table interface
- Add corresponding methods to BranchManager interface
- Update AbstractFileStoreTable, FormatTable, DelegatedFileStoreTable, ReadonlyTable, PrivilegedFileStoreTable implementations
- Update Catalog interface with default method for ignoreIfExists support
- Update CatalogBranchManager and FileSystemBranchManager implementations

Flink Layer:
- Update CreateBranchProcedure with optional ignoreIfExists parameter
- Update CreateBranchAction and CreateBranchActionFactory
- Update MultipleParameterToolAdapter for parsing ignoreIfExists option

Spark Layer:
- Update CreateBranchProcedure with optional ignoreIfExists parameter

Testing:
- Add test cases for createBranch with ignoreIfExists in SimpleTableTestBase
- Add test cases for createBranch with ignoreIfExists in BranchActionITCase

All existing tests continue to pass, ensuring backward compatibility.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #7277 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
