### PR TITLE
[common] Fix possible deadlock in ParallelExecution

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ParallelExecution.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ParallelExecution.java
@@ -111,6 +111,16 @@ public class ParallelExecution<T, E> implements Closeable {
 
     private void asyncRead(
             Supplier<Pair<RecordReader<T>, E>> readerSupplier, Serializer<T> serializer) {
+        try {
+            asyncReadImpl(readerSupplier, serializer);
+        } catch (Throwable e) {
+            this.exception.set(e);
+        }
+    }
+
+    private void asyncReadImpl(
+            Supplier<Pair<RecordReader<T>, E>> readerSupplier, Serializer<T> serializer)
+            throws Exception {
         Pair<RecordReader<T>, E> pair = readerSupplier.get();
         try (CloseableIterator<T> iterator = pair.getLeft().toCloseableIterator()) {
             int count = 0;
@@ -148,8 +158,6 @@ public class ParallelExecution<T, E> implements Closeable {
             }
 
             latch.countDown();
-        } catch (Throwable e) {
-            this.exception.set(e);
         }
     }
 


### PR DESCRIPTION
### Purpose

Currently, if `readerSupplier.get()` in `ParallelExecution#asyncRead` throws an exception, it is not catched, causing deadlock. This PR fixes the possible deadlock.
