### PR TITLE
[test] Add missing LeafFunction coverage in PredicateJsonSerdeTest

### DIFF
--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateJsonSerdeTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateJsonSerdeTest.java
@@ -156,6 +156,31 @@ class PredicateJsonSerdeTest {
                         .expectJson(
                                 "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":2,\"name\":\"f2\",\"type\":\"STRING\"}},\"function\":\"LIKE\",\"literals\":[\"%a%b%\"]}"),
 
+                // LeafPredicate - StartsWith (field index)
+                TestSpec.forPredicate(builder.startsWith(2, BinaryString.fromString("hello")))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":2,\"name\":\"f2\",\"type\":\"STRING\"}},\"function\":\"STARTS_WITH\",\"literals\":[\"hello\"]}"),
+
+                // LeafPredicate - EndsWith (field index)
+                TestSpec.forPredicate(builder.endsWith(2, BinaryString.fromString("world")))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":2,\"name\":\"f2\",\"type\":\"STRING\"}},\"function\":\"ENDS_WITH\",\"literals\":[\"world\"]}"),
+
+                // LeafPredicate - Contains (field index)
+                TestSpec.forPredicate(builder.contains(2, BinaryString.fromString("foo")))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":2,\"name\":\"f2\",\"type\":\"STRING\"}},\"function\":\"CONTAINS\",\"literals\":[\"foo\"]}"),
+
+                // LeafPredicate - Between
+                TestSpec.forPredicate(builder.between(0, 3, 7))
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":0,\"name\":\"f0\",\"type\":\"INT\"}},\"function\":\"BETWEEN\",\"literals\":[3,7]}"),
+
+                // LeafPredicate - NotBetween (negate of Between)
+                TestSpec.forPredicate(builder.between(0, 3, 7).negate().get())
+                        .expectJson(
+                                "{\"kind\":\"LEAF\",\"transform\":{\"name\":\"FIELD_REF\",\"fieldRef\":{\"index\":0,\"name\":\"f0\",\"type\":\"INT\"}},\"function\":\"NOT_BETWEEN\",\"literals\":[3,7]}"),
+
                 // LeafPredicate - AlwaysTrue
                 TestSpec.forPredicate(builder.alwaysTrue())
                         .expectJson(


### PR DESCRIPTION
### Purpose
Add test cases for BETWEEN, NOT_BETWEEN, STARTS_WITH, ENDS_WITH and CONTAINS functions that were registered in LeafFunction but not covered by PredicateJsonSerdeTest.