### PR TITLE
[hotfix][docs] replace the documentation URL for data-types blob

### DIFF
--- a/docs/content/concepts/data-types.md
+++ b/docs/content/concepts/data-types.md
@@ -186,7 +186,7 @@ All data types supported by Paimon are as follows:
       <td><code>BLOB</code></td>
       <td><code>Data type of a binary large object.</code><br><br>
           <code>Designed for storing large binary data such as images, videos, audio files, and other multimodal data. Unlike BYTES type which stores data inline, BLOB stores large binary data in separate files and maintains references to them, providing better performance for large objects.</code><br><br>
-          <code>Note: Requires 'row-tracking.enabled' and 'data-evolution.enabled' to be set to true. See <a href="{{< ref "append-table/data-evolution#blob-type" >}}">Blob Type</a> for details.</code>
+          <code>Note: Requires 'row-tracking.enabled' and 'data-evolution.enabled' to be set to true. See <a href="{{< ref "append-table/blob/#overview" >}}">Blob Type</a> for details.</code>
       </td>
     </tr>
     </tbody>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Replace the documentation URL for data-types blob.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
