### PR TITLE
[python] Introduce Python CLI table snapshot

### DIFF
--- a/docs/content/pypaimon/cli.md
+++ b/docs/content/pypaimon/cli.md
@@ -136,6 +136,36 @@ Output:
 
 **Note:** The output JSON can be saved to a file and used directly with the `table create` command to recreate the table structure.
 
+### Table Snapshot
+
+Get and display the latest snapshot information of a Paimon table in JSON format. The snapshot contains metadata about the current state of the table.
+
+```shell
+paimon table snapshot mydb.users
+```
+
+Output:
+```json
+{
+  "version": 3,
+  "id": 5,
+  "schemaId": 1,
+  "baseManifestList": "manifest-list-5-base-...",
+  "deltaManifestList": "manifest-list-5-delta-...",
+  "changelogManifestList": null,
+  "totalRecordCount": 1000,
+  "deltaRecordCount": 100,
+  "changelogRecordCount": null,
+  "commitUser": "user-123",
+  "commitIdentifier": 1709123456789,
+  "commitKind": "APPEND",
+  "timeMillis": 1709123456789,
+  "watermark": null,
+  "statistics": null,
+  "nextRowId": null
+}
+```
+
 ### Table Create
 
 Create a new Paimon table with a schema defined in a JSON file. The schema JSON format is the same as the output from

--- a/paimon-python/pypaimon/cli/cli_table.py
+++ b/paimon-python/pypaimon/cli/cli_table.py
@@ -122,6 +122,65 @@ def cmd_table_get(args):
     print(JSON.to_json(schema, indent=2))
 
 
+def cmd_table_snapshot(args):
+    """
+    Execute the 'table snapshot' command.
+    
+    Gets and displays the latest snapshot of a Paimon table in JSON format.
+    
+    Args:
+        args: Parsed command line arguments.
+    """
+    from pypaimon.cli.cli import load_catalog_config, create_catalog
+    from pypaimon.table.file_store_table import FileStoreTable
+    
+    # Load catalog configuration
+    config_path = args.config
+    config = load_catalog_config(config_path)
+    
+    # Create catalog
+    catalog = create_catalog(config)
+    
+    # Parse table identifier
+    table_identifier = args.table
+    parts = table_identifier.split('.')
+    if len(parts) != 2:
+        print(f"Error: Invalid table identifier '{table_identifier}'. "
+              f"Expected format: 'database.table'", file=sys.stderr)
+        sys.exit(1)
+    
+    database_name, table_name = parts
+    
+    # Get table
+    try:
+        table = catalog.get_table(f"{database_name}.{table_name}")
+    except Exception as e:
+        print(f"Error: Failed to get table '{table_identifier}': {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    # Check if table is FileStoreTable
+    if not isinstance(table, FileStoreTable):
+        print(f"Error: Table '{table_identifier}' is not a FileStoreTable. "
+              f"Snapshot operation is not supported for this table type.", file=sys.stderr)
+        sys.exit(1)
+    
+    # Get latest snapshot
+    try:
+        snapshot_manager = table.snapshot_manager()
+        snapshot = snapshot_manager.get_latest_snapshot()
+        
+        if snapshot is None:
+            print(f"Error: No snapshot found for table '{table_identifier}'.", file=sys.stderr)
+            sys.exit(1)
+        
+        # Output snapshot as JSON
+        print(JSON.to_json(snapshot, indent=2))
+        
+    except Exception as e:
+        print(f"Error: Failed to get snapshot: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_table_create(args):
     """
     Execute the 'table create' command.
@@ -484,6 +543,14 @@ def add_table_subcommands(table_parser):
         help='Table identifier in format: database.table'
     )
     get_parser.set_defaults(func=cmd_table_get)
+    
+    # table snapshot command
+    snapshot_parser = table_subparsers.add_parser('snapshot', help='Get the latest snapshot of a table')
+    snapshot_parser.add_argument(
+        'table',
+        help='Table identifier in format: database.table'
+    )
+    snapshot_parser.set_defaults(func=cmd_table_snapshot)
     
     # table create command
     create_parser = table_subparsers.add_parser('create', help='Create a new table')

--- a/paimon-python/pypaimon/tests/cli_table_test.py
+++ b/paimon-python/pypaimon/tests/cli_table_test.py
@@ -172,6 +172,34 @@ class CliTableTest(unittest.TestCase):
                 self.assertIn('age', field_names)
                 self.assertIn('city', field_names)
 
+    def test_cli_table_snapshot_basic(self):
+        """Test basic table snapshot via CLI."""
+        # Simulate CLI command: paimon -c <config> table snapshot test_db.users
+        with patch('sys.argv', ['paimon', '-c', self.config_file, 'table', 'snapshot', 'test_db.users']):
+            with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                try:
+                    main()
+                except SystemExit:
+                    pass
+                
+                output = mock_stdout.getvalue()
+                
+                # Verify output is valid JSON
+                import json
+                snapshot_json = json.loads(output)
+                
+                # Verify snapshot structure
+                self.assertIn('id', snapshot_json)
+                self.assertIn('schemaId', snapshot_json)
+                self.assertIn('commitKind', snapshot_json)
+                self.assertIn('timeMillis', snapshot_json)
+                self.assertIn('totalRecordCount', snapshot_json)
+                self.assertIn('deltaRecordCount', snapshot_json)
+                
+                # Verify snapshot has valid data
+                self.assertGreater(snapshot_json['id'], 0)
+                self.assertGreater(snapshot_json['totalRecordCount'], 0)
+
     def test_cli_table_create_with_json_schema(self):
         """Test table create with JSON schema file."""
         import json


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Get and display the latest snapshot information of a Paimon table in JSON format. The snapshot contains metadata about the current state of the table.

```shell
paimon table snapshot mydb.users
```

Output:
```json
{
  "version": 3,
  "id": 5,
  "schemaId": 1,
  "baseManifestList": "manifest-list-5-base-...",
  "deltaManifestList": "manifest-list-5-delta-...",
  "changelogManifestList": null,
  "totalRecordCount": 1000,
  "deltaRecordCount": 100,
  "changelogRecordCount": null,
  "commitUser": "user-123",
  "commitIdentifier": 1709123456789,
  "commitKind": "APPEND",
  "timeMillis": 1709123456789,
  "watermark": null,
  "statistics": null,
  "nextRowId": null
}
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

GLM 5
