### PR TITLE
[core] Support options in ObjectTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -439,6 +439,7 @@ public class CatalogUtils {
                 .fileIO(fileIO.apply(new Path(location)))
                 .identifier(identifier)
                 .location(location)
+                .options(options)
                 .comment(schema.comment())
                 .build();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTable.java
@@ -24,6 +24,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -61,6 +62,7 @@ public interface ObjectTable extends Table {
         private Identifier identifier;
         private FileIO fileIO;
         private String location;
+        private Map<String, String> options = Collections.emptyMap();
         private String comment;
 
         public ObjectTable.Builder identifier(Identifier identifier) {
@@ -78,13 +80,18 @@ public interface ObjectTable extends Table {
             return this;
         }
 
+        public ObjectTable.Builder options(Map<String, String> options) {
+            this.options = options;
+            return this;
+        }
+
         public ObjectTable.Builder comment(String comment) {
             this.comment = comment;
             return this;
         }
 
         public ObjectTable build() {
-            return new ObjectTableImpl(identifier, fileIO, location, comment);
+            return new ObjectTableImpl(identifier, fileIO, location, options, comment);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTableImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/object/ObjectTableImpl.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -61,13 +62,19 @@ public class ObjectTableImpl implements ReadonlyTable, ObjectTable {
     private final Identifier identifier;
     private final FileIO fileIO;
     private final String location;
+    private final Map<String, String> options;
     @Nullable private final String comment;
 
     public ObjectTableImpl(
-            Identifier identifier, FileIO fileIO, String location, @Nullable String comment) {
+            Identifier identifier,
+            FileIO fileIO,
+            String location,
+            Map<String, String> options,
+            @Nullable String comment) {
         this.identifier = identifier;
         this.fileIO = fileIO;
         this.location = location;
+        this.options = options;
         this.comment = comment;
     }
 
@@ -98,7 +105,7 @@ public class ObjectTableImpl implements ReadonlyTable, ObjectTable {
 
     @Override
     public Map<String, String> options() {
-        return Collections.emptyMap();
+        return options;
     }
 
     @Override
@@ -123,7 +130,9 @@ public class ObjectTableImpl implements ReadonlyTable, ObjectTable {
 
     @Override
     public ObjectTable copy(Map<String, String> dynamicOptions) {
-        return new ObjectTableImpl(identifier, fileIO, location, comment);
+        Map<String, String> newOptions = new HashMap<>(options);
+        newOptions.putAll(dynamicOptions);
+        return new ObjectTableImpl(identifier, fileIO, location, newOptions, comment);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -2697,14 +2697,37 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     @Test
     public void testObjectTable() throws Exception {
-        // create object table
+        // create object table with custom options
         catalog.createDatabase("test_db", false);
         Identifier identifier = Identifier.create("test_db", "object_table");
-        Schema schema = Schema.newBuilder().option(TYPE.key(), OBJECT_TABLE.toString()).build();
+        Schema schema =
+                Schema.newBuilder()
+                        .option(TYPE.key(), OBJECT_TABLE.toString())
+                        .option("custom-key", "custom-value")
+                        .build();
         catalog.createTable(identifier, schema, false);
         Table table = catalog.getTable(identifier);
         assertThat(table).isInstanceOf(ObjectTable.class);
         ObjectTable objectTable = (ObjectTable) table;
+
+        // verify options are preserved
+        assertThat(objectTable.options()).containsEntry("custom-key", "custom-value");
+        assertThat(objectTable.options().containsKey("path")).isTrue();
+
+        // verify copy merges dynamic options
+        ObjectTable copiedTable =
+                objectTable.copy(Collections.singletonMap("dynamic-key", "dynamic-value"));
+        assertThat(copiedTable.options()).containsEntry("custom-key", "custom-value");
+        assertThat(copiedTable.options()).containsEntry("dynamic-key", "dynamic-value");
+
+        // verify copy can override existing options
+        ObjectTable overriddenTable =
+                objectTable.copy(Collections.singletonMap("custom-key", "overridden"));
+        assertThat(overriddenTable.options()).containsEntry("custom-key", "overridden");
+
+        // verify original table is not modified after copy
+        assertThat(objectTable.options()).containsEntry("custom-key", "custom-value");
+        assertThat(objectTable.options()).doesNotContainKey("dynamic-key");
 
         // write file to object path
         FileIO fileIO = objectTable.fileIO();


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Previously, ObjectTable did not support storing and passing options — its options() method always returned an empty map, and copy() ignored dynamic options entirely. This was inconsistent with other table types like FormatTable, LanceTable, and IcebergTable, which all properly support options.

This PR adds options support to ObjectTable, aligning it with other table type implementations.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Modified RESTCatalogTest#testObjectTable to verify:
- Custom options set during table creation are preserved and accessible via options()
- copy() correctly merges dynamic options with existing options
- copy() can override existing option values
- copy() does not modify the original table's options

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Aone Copilot
