### PR TITLE
[spark] Fix table name conflict in concurrent MergeInto tests

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/MergeIntoTableTestBase.scala
@@ -790,31 +790,34 @@ trait MergeIntoAppendTableTest extends PaimonSparkTestBase with PaimonAppendTabl
 
   test("Paimon MergeInto: concurrent merge and compact") {
     for (dvEnabled <- Seq("true", "false")) {
-      withTable("s", "t") {
-        sql("CREATE TABLE s (id INT, b INT, c INT)")
-        sql("INSERT INTO s VALUES (1, 1, 1)")
+      val source = s"mc_s_$dvEnabled"
+      val target = s"mc_t_$dvEnabled"
+      withTable(source, target) {
+        sql(s"CREATE TABLE $source (id INT, b INT, c INT)")
+        sql(s"INSERT INTO $source VALUES (1, 1, 1)")
 
         sql(
-          s"CREATE TABLE t_$dvEnabled (id INT, b INT, c INT) TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')")
-        sql(s"INSERT INTO t_$dvEnabled VALUES (1, 1, 1)")
+          s"CREATE TABLE $target (id INT, b INT, c INT) TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')")
+        sql(s"INSERT INTO $target VALUES (1, 1, 1)")
 
         val mergeInto = Future {
           for (_ <- 1 to 10) {
             try {
-              sql(s"""
-                     |MERGE INTO t_$dvEnabled t
-                     |USING s
-                     |ON t.id = s.id
-                     |WHEN MATCHED THEN
-                     |UPDATE SET t.id = s.id, t.b = s.b + t.b, t.c = s.c + t.c
-                     |""".stripMargin)
+              sql(
+                s"""
+                   |MERGE INTO $target
+                   |USING $source
+                   |ON $target.id = $source.id
+                   |WHEN MATCHED THEN
+                   |UPDATE SET $target.id = $source.id, $target.b = $source.b + $target.b, $target.c = $source.c + $target.c
+                   |""".stripMargin)
             } catch {
               case a: Throwable =>
                 assert(
                   a.getMessage.contains("Conflicts during commits") || a.getMessage.contains(
                     "Missing file"))
             }
-            checkAnswer(sql(s"SELECT count(*) FROM t_$dvEnabled"), Seq(Row(1)))
+            checkAnswer(sql(s"SELECT count(*) FROM $target"), Seq(Row(1)))
           }
         }
 
@@ -822,11 +825,11 @@ trait MergeIntoAppendTableTest extends PaimonSparkTestBase with PaimonAppendTabl
           for (_ <- 1 to 10) {
             try {
               sql(
-                s"CALL sys.compact(table => 't_$dvEnabled', order_strategy => 'order', order_by => 'id')")
+                s"CALL sys.compact(table => '$target', order_strategy => 'order', order_by => 'id')")
             } catch {
               case a: Throwable => assert(a.getMessage.contains("Conflicts during commits"))
             }
-            checkAnswer(sql(s"SELECT count(*) FROM t_$dvEnabled"), Seq(Row(1)))
+            checkAnswer(sql(s"SELECT count(*) FROM $target"), Seq(Row(1)))
           }
         }
 
@@ -838,33 +841,36 @@ trait MergeIntoAppendTableTest extends PaimonSparkTestBase with PaimonAppendTabl
 
   test("Paimon MergeInto: concurrent two merge") {
     for (dvEnabled <- Seq("true", "false")) {
-      withTable("s", "t") {
-        sql("CREATE TABLE s (id INT, b INT, c INT)")
+      val source = s"tm_s_$dvEnabled"
+      val target = s"tm_t_$dvEnabled"
+      withTable(source, target) {
+        sql(s"CREATE TABLE $source (id INT, b INT, c INT)")
         sql(
-          "INSERT INTO s VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")
+          s"INSERT INTO $source VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")
 
         sql(
-          s"CREATE TABLE t_$dvEnabled (id INT, b INT, c INT) TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')")
+          s"CREATE TABLE $target (id INT, b INT, c INT) TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')")
         sql(
-          s"INSERT INTO t_$dvEnabled VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")
+          s"INSERT INTO $target VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")
 
         def doMergeInto(): Unit = {
           for (i <- 1 to 9) {
             try {
-              sql(s"""
-                     |MERGE INTO t_$dvEnabled t
-                     |USING (SELECT * FROM s WHERE id = $i)
-                     |ON t.id = s.id
-                     |WHEN MATCHED THEN
-                     |UPDATE SET t.id = s.id, t.b = s.b + t.b, t.c = s.c + t.c
-                     |""".stripMargin)
+              sql(
+                s"""
+                   |MERGE INTO $target
+                   |USING (SELECT * FROM $source WHERE id = $i)
+                   |ON $target.id = $source.id
+                   |WHEN MATCHED THEN
+                   |UPDATE SET $target.id = $source.id, $target.b = $source.b + $target.b, $target.c = $source.c + $target.c
+                   |""".stripMargin)
             } catch {
               case a: Throwable =>
                 assert(
                   a.getMessage.contains("Conflicts during commits") || a.getMessage.contains(
                     "Missing file"))
             }
-            checkAnswer(sql(s"SELECT count(*) FROM t_$dvEnabled"), Seq(Row(9)))
+            checkAnswer(sql(s"SELECT count(*) FROM $target"), Seq(Row(9)))
           }
         }
 


### PR DESCRIPTION
### Purpose

- Paimon MergeInto: concurrent two merge *** FAILED ***
  org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException: Table test.t_true already exists
  at org.apache.spark.sql.errors.QueryCompilationErrors$.tableAlreadyExistsError(QueryCompilationErrors.scala:875)
  at org.apache.spark.sql.execution.datasources.v2.CreateTableExec.run(CreateTableExec.scala:51)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49)
  at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:98)
  at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:109)
  at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:169)
  at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:95)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779)
  ...

### Tests

CI