### PR TITLE
[core] upgrade snappy-java to 1.1.10.8 due to CVE

### DIFF
--- a/paimon-filesystems/paimon-azure-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-azure-impl/src/main/resources/META-INF/NOTICE
@@ -46,7 +46,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-api:2.17.1
 - org.apache.logging.log4j:log4j-core:2.17.1
 - org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
-- org.xerial.snappy:snappy-java:1.1.8.2
+- org.xerial.snappy:snappy-java:1.1.10.8
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause):
 - com.github.luben:zstd-jni:1.5.5-11

--- a/paimon-filesystems/paimon-cosn-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-cosn-impl/src/main/resources/META-INF/NOTICE
@@ -34,7 +34,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
 - com.fasterxml.woodstox:woodstox-core:5.3.0
-- org.xerial.snappy:snappy-java:1.1.8.2
+- org.xerial.snappy:snappy-java:1.1.10.8
 - org.apache.hadoop:hadoop-cos:3.3.5
 - com.qcloud:cos_api-bundle:5.6.69
 - com.qcloud:cos_api:5.6.139

--- a/paimon-filesystems/paimon-gs-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-gs-impl/src/main/resources/META-INF/NOTICE
@@ -54,7 +54,7 @@ This project bundles the following dependencies under the Apache Software Licens
 -org.apache.kerby:kerby-asn1:1.0.1
 -org.apache.kerby:kerby-pkix:1.0.1
 -org.apache.kerby:kerby-util:1.0.1
--org.xerial.snappy:snappy-java:1.1.8.2
+-org.xerial.snappy:snappy-java:1.1.10.8
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 You find it under licenses/LICENSE.dnsjava.

--- a/paimon-filesystems/paimon-hadoop-shaded-3.4/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-shaded-3.4/src/main/resources/META-INF/NOTICE
@@ -31,7 +31,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.2
+- org.xerial.snappy:snappy-java:1.1.10.8
 - com.google.code.findbugs:jsr305:1.3.9
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT).

--- a/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -31,7 +31,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.2
+- org.xerial.snappy:snappy-java:1.1.10.8
 - com.google.code.findbugs:jsr305:1.3.9
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT).

--- a/paimon-filesystems/paimon-hadoop-uber/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-hadoop-uber/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.zookeeper:zookeeper:3.4.10
 - org.codehaus.jackson:jackson-core-asl:1.9.13
 - org.codehaus.jackson:jackson-mapper-asl:1.9.13
-- org.xerial.snappy:snappy-java:1.1.4
+- org.xerial.snappy:snappy-java:1.1.10.8
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.

--- a/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
+++ b/paimon-filesystems/paimon-oss-impl/src/main/resources/META-INF/NOTICE
@@ -44,7 +44,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-util:1.0.1
 - com.fasterxml.jackson.core:jackson-databind:2.12.7
 - com.fasterxml.woodstox:woodstox-core:5.3.0
-- org.xerial.snappy:snappy-java:1.1.8.2
+- org.xerial.snappy:snappy-java:1.1.10.8
 - com.fasterxml.jackson.core:jackson-core:2.14.2
 - com.fasterxml.jackson.core:jackson-annotations:2.14.2
 - com.google.code.findbugs:jsr305:1.3.9

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ under the License.
         <scala213.version>2.13.16</scala213.version>
         <scala.version>${scala212.version}</scala.version>
         <codegen.scala.version>${scala212.version}</codegen.scala.version>
-        <snappy.version>1.1.8.4</snappy.version>
+        <snappy.version>1.1.10.8</snappy.version>
         <airlift.version>2.0.3</airlift.version>
         <lz4.version>1.8.1</lz4.version>
         <slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION

### Purpose

Linked issue: close https://github.com/apache/paimon/issues/7368

### Tests

### API and Format

### Documentation

### Generative AI tooling
