### PR TITLE
[core] Make BTreeGlobalIndexBuilder members protected to be convenient to extend

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
@@ -79,18 +79,18 @@ public class BTreeGlobalIndexBuilder implements Serializable {
 
     private static final double FLOATING = 1.2;
 
-    private final FileStoreTable table;
-    private final RowType rowType;
-    private final Options options;
-    private final long recordsPerRange;
+    protected final FileStoreTable table;
+    protected final RowType rowType;
+    protected final Options options;
+    protected final long recordsPerRange;
 
-    private String indexType;
-    private DataField indexField;
+    protected String indexType;
+    protected DataField indexField;
 
     // readRowType is composed by partition fields, indexed field and _ROW_ID field
-    private RowType readRowType;
+    protected RowType readRowType;
 
-    @Nullable private PartitionPredicate partitionPredicate;
+    @Nullable protected PartitionPredicate partitionPredicate;
 
     public BTreeGlobalIndexBuilder(Table table) {
         this.table = (FileStoreTable) table;


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

Make BTreeGlobalIndexBuilder members protected not private

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
