### PR TITLE
[core] Use snapshots in ExpireSnapshotsImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -174,7 +174,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         }
 
         // collect all snapshots
-        List<Snapshot> snapshotsIncludingEnd = collectSortedSnapshots(earliestId, endExclusiveId);
+        List<Snapshot> snapshotsIncludingEnd = collectSnapshots(earliestId, endExclusiveId);
         if (snapshotsIncludingEnd.isEmpty()) {
             return 0;
         }
@@ -274,7 +274,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return snapshotsExcludingEnd.size();
     }
 
-    private List<Snapshot> collectSortedSnapshots(long earliestId, long endExclusiveId)
+    private List<Snapshot> collectSnapshots(long earliestId, long endExclusiveId)
             throws InterruptedException, ExecutionException {
         List<CompletableFuture<Optional<Snapshot>>> futures = new ArrayList<>();
         for (long id = earliestId; id <= endExclusiveId; id++) {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
This PR refactors the pattern of iterating by ID range + Map lookup in ExpireSnapshotsImpl to a direct iteration over the Snapshot list.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
