### PR TITLE
[flink] StoreMultiCommitter support dynamic options per table

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcMultiTableSink.java
@@ -170,6 +170,7 @@ public class FlinkCdcMultiTableSink implements Serializable {
                         context,
                         false,
                         Collections.emptyMap(),
+                        null,
                         eagerInit,
                         tableFilter);
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreMultiCommitter.java
@@ -28,6 +28,8 @@ import org.apache.paimon.table.sink.CommitMessage;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +58,7 @@ public class StoreMultiCommitter
     // Currently, only compact_database job needs to ignore empty commit and set dynamic options
     private final boolean ignoreEmptyCommit;
     private final Map<String, String> dynamicOptions;
+    @Nullable private final Map<Identifier, Map<String, String>> dynamicOptionsPerTable;
 
     private final TableFilter tableFilter;
 
@@ -68,7 +71,7 @@ public class StoreMultiCommitter
             Context context,
             boolean ignoreEmptyCommit,
             Map<String, String> dynamicOptions) {
-        this(catalogLoader, context, ignoreEmptyCommit, dynamicOptions, false, null);
+        this(catalogLoader, context, ignoreEmptyCommit, dynamicOptions, null, false, null);
     }
 
     public StoreMultiCommitter(
@@ -76,12 +79,14 @@ public class StoreMultiCommitter
             Context context,
             boolean ignoreEmptyCommit,
             Map<String, String> dynamicOptions,
+            @Nullable Map<Identifier, Map<String, String>> dynamicOptionsPerTable,
             boolean eagerInit,
             TableFilter tableFilter) {
         this.catalog = catalogLoader.load();
         this.context = context;
         this.ignoreEmptyCommit = ignoreEmptyCommit;
         this.dynamicOptions = dynamicOptions;
+        this.dynamicOptionsPerTable = dynamicOptionsPerTable;
         this.tableCommitters = new HashMap<>();
 
         this.tableFilter = tableFilter;
@@ -213,7 +218,7 @@ public class StoreMultiCommitter
         if (committer == null) {
             FileStoreTable table;
             try {
-                table = (FileStoreTable) catalog.getTable(tableId).copy(dynamicOptions);
+                table = (FileStoreTable) catalog.getTable(tableId).copy(getDynamicOptions(tableId));
             } catch (Catalog.TableNotExistException e) {
                 throw new RuntimeException(
                         String.format(
@@ -230,6 +235,16 @@ public class StoreMultiCommitter
         }
 
         return committer;
+    }
+
+    private Map<String, String> getDynamicOptions(Identifier identifier) {
+        if (dynamicOptionsPerTable != null) {
+            Map<String, String> dynamicOptions = dynamicOptionsPerTable.get(identifier);
+            if (dynamicOptions != null) {
+                return dynamicOptions;
+            }
+        }
+        return this.dynamicOptions;
     }
 
     @Override


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

For example, if option `commit.strict-mode.last-safe-snapshot` is needed, we can set it by different tables.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
