### PR TITLE
[core] Add Compaction Sort Buffer metrics

### DIFF
--- a/docs/content/maintenance/metrics.md
+++ b/docs/content/maintenance/metrics.md
@@ -294,6 +294,26 @@ Below is lists of Paimon built-in metrics. They are summarized into types of sca
             <td>Gauge</td>
             <td>The average total file size of all active (currently being written) buckets.</td>
         </tr>
+        <tr>
+            <td>maxSortBufferUsedBytes</td>
+            <td>Gauge</td>
+            <td>The maximum sort buffer memory currently used across all active compaction buckets, in bytes. High values relative to <code>maxSortBufferTotalBytes</code> indicate memory pressure during compaction; consider lowering <code>sort-spill-threshold</code> or reducing <code>sort-spill-buffer-size</code>.</td>
+        </tr>
+        <tr>
+            <td>avgSortBufferUsedBytes</td>
+            <td>Gauge</td>
+            <td>The average sort buffer memory used across all active compaction buckets, in bytes.</td>
+        </tr>
+        <tr>
+            <td>maxSortBufferUtilisationPercent</td>
+            <td>Gauge</td>
+            <td>The maximum sort buffer utilisation percentage (0–100) across all active compaction buckets. A value consistently near 100 indicates the sort buffer pool is exhausted and spilling to disk is occurring or imminent.</td>
+        </tr>
+        <tr>
+            <td>avgSortBufferUtilisationPercent</td>
+            <td>Gauge</td>
+            <td>The average sort buffer utilisation percentage across all active compaction buckets.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/paimon-common/src/main/java/org/apache/paimon/memory/CachelessSegmentPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/memory/CachelessSegmentPool.java
@@ -58,4 +58,8 @@ public class CachelessSegmentPool implements MemorySegmentPool {
     public int freePages() {
         return maxPages - numPage;
     }
+
+    public int maxPages() {
+        return maxPages;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeSorter.java
@@ -66,7 +66,7 @@ public class MergeSorter {
     private final int spillThreshold;
     private final CompressOptions compression;
 
-    private final MemorySegmentPool memoryPool;
+    private final CachelessSegmentPool memoryPool;
 
     @Nullable private IOManager ioManager;
 
@@ -83,6 +83,14 @@ public class MergeSorter {
         this.memoryPool =
                 new CachelessSegmentPool(options.sortSpillBufferSize(), options.pageSize());
         this.ioManager = ioManager;
+    }
+
+    public long sortBufferTotalBytes() {
+        return (long) memoryPool.maxPages() * memoryPool.pageSize();
+    }
+
+    public long sortBufferUsedBytes() {
+        return (long) (memoryPool.maxPages() - memoryPool.freePages()) * memoryPool.pageSize();
     }
 
     public MemorySegmentPool memoryPool() {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactRewriter.java
@@ -30,6 +30,7 @@ import org.apache.paimon.mergetree.DropDeleteReader;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.MergeTreeReaders;
 import org.apache.paimon.mergetree.SortedRun;
+import org.apache.paimon.operation.metrics.CompactionMetrics;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.utils.ExceptionUtils;
@@ -51,6 +52,7 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
     @Nullable protected final FieldsComparator userDefinedSeqComparator;
     protected final MergeFunctionFactory<KeyValue> mfFactory;
     protected final MergeSorter mergeSorter;
+    @Nullable private CompactionMetrics.Reporter metricsReporter;
 
     public MergeTreeCompactRewriter(
             FileReaderFactory<KeyValue> readerFactory,
@@ -106,6 +108,10 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
         notifyRewriteCompactBefore(before);
         List<DataFileMeta> after = writer.result();
         after = notifyRewriteCompactAfter(after);
+        if (metricsReporter != null) {
+            metricsReporter.reportSortBufferMetrics(
+                    mergeSorter.sortBufferUsedBytes(), mergeSorter.sortBufferTotalBytes());
+        }
         return new CompactResult(before, after);
     }
 
@@ -125,5 +131,9 @@ public class MergeTreeCompactRewriter extends AbstractCompactRewriter {
 
     protected List<DataFileMeta> notifyRewriteCompactAfter(List<DataFileMeta> files) {
         return files;
+    }
+
+    public void setMetricsReporter(@Nullable CompactionMetrics.Reporter reporter) {
+        this.metricsReporter = reporter;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/KeyValueFileStoreWrite.java
@@ -47,7 +47,6 @@ import org.apache.paimon.mergetree.LookupFile;
 import org.apache.paimon.mergetree.LookupLevels;
 import org.apache.paimon.mergetree.MergeSorter;
 import org.apache.paimon.mergetree.MergeTreeWriter;
-import org.apache.paimon.mergetree.compact.CompactRewriter;
 import org.apache.paimon.mergetree.compact.CompactStrategy;
 import org.apache.paimon.mergetree.compact.EarlyFullCompaction;
 import org.apache.paimon.mergetree.compact.ForceUpLevel0Compaction;
@@ -68,6 +67,7 @@ import org.apache.paimon.mergetree.lookup.PersistProcessor;
 import org.apache.paimon.mergetree.lookup.PersistValueAndPosProcessor;
 import org.apache.paimon.mergetree.lookup.PersistValueProcessor;
 import org.apache.paimon.mergetree.lookup.RemoteLookupFileManager;
+import org.apache.paimon.operation.metrics.CompactionMetrics;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.KeyValueFieldsExtractor;
 import org.apache.paimon.schema.SchemaManager;
@@ -285,7 +285,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
         } else {
             Comparator<InternalRow> keyComparator = keyComparatorSupplier.get();
             @Nullable FieldsComparator userDefinedSeqComparator = udsComparatorSupplier.get();
-            CompactRewriter rewriter =
+            MergeTreeCompactRewriter rewriter =
                     createRewriter(
                             partition,
                             bucket,
@@ -293,6 +293,13 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                             userDefinedSeqComparator,
                             levels,
                             dvMaintainer);
+            CompactionMetrics.Reporter metricsReporter =
+                    compactionMetrics == null
+                            ? null
+                            : compactionMetrics.createReporter(partition, bucket);
+            if (metricsReporter != null) {
+                rewriter.setMetricsReporter(metricsReporter);
+            }
             return new MergeTreeCompactManager(
                     compactExecutor,
                     levels,
@@ -301,9 +308,7 @@ public class KeyValueFileStoreWrite extends MemoryFileStoreWrite<KeyValue> {
                     options.compactionFileSize(true),
                     options.numSortedRunStopTrigger(),
                     rewriter,
-                    compactionMetrics == null
-                            ? null
-                            : compactionMetrics.createReporter(partition, bucket),
+                    metricsReporter,
                     dvMaintainer,
                     options.prepareCommitWaitCompaction(),
                     options.needLookup(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/metrics/CompactionMetrics.java
@@ -52,6 +52,11 @@ public class CompactionMetrics {
     public static final String MAX_TOTAL_FILE_SIZE = "maxTotalFileSize";
     public static final String AVG_TOTAL_FILE_SIZE = "avgTotalFileSize";
 
+    public static final String MAX_SORT_BUFFER_USED_BYTES = "maxSortBufferUsedBytes";
+    public static final String AVG_SORT_BUFFER_USED_BYTES = "avgSortBufferUsedBytes";
+    public static final String MAX_SORT_BUFFER_UTILISATION = "maxSortBufferUtilisationPercent";
+    public static final String AVG_SORT_BUFFER_UTILISATION = "avgSortBufferUtilisationPercent";
+
     private static final long BUSY_MEASURE_MILLIS = 60_000;
     private static final int COMPACTION_TIME_WINDOW = 100;
 
@@ -102,6 +107,18 @@ public class CompactionMetrics {
 
         metricGroup.gauge(MAX_TOTAL_FILE_SIZE, () -> getTotalFileSizeStream().max().orElse(-1));
         metricGroup.gauge(AVG_TOTAL_FILE_SIZE, () -> getTotalFileSizeStream().average().orElse(-1));
+
+        metricGroup.gauge(
+                MAX_SORT_BUFFER_USED_BYTES, () -> getSortBufferUsedBytesStream().max().orElse(-1));
+        metricGroup.gauge(
+                AVG_SORT_BUFFER_USED_BYTES,
+                () -> getSortBufferUsedBytesStream().average().orElse(-1));
+        metricGroup.gauge(
+                MAX_SORT_BUFFER_UTILISATION,
+                () -> getSortBufferUtilisationStream().max().orElse(-1));
+        metricGroup.gauge(
+                AVG_SORT_BUFFER_UTILISATION,
+                () -> getSortBufferUtilisationStream().average().orElse(-1));
     }
 
     private LongStream getLevel0FileCountStream() {
@@ -128,6 +145,14 @@ public class CompactionMetrics {
     @VisibleForTesting
     public LongStream getTotalFileSizeStream() {
         return reporters.values().stream().mapToLong(r -> r.totalFileSize);
+    }
+
+    private LongStream getSortBufferUsedBytesStream() {
+        return reporters.values().stream().mapToLong(r -> r.sortBufferUsedBytes);
+    }
+
+    private DoubleStream getSortBufferUtilisationStream() {
+        return reporters.values().stream().mapToDouble(r -> r.sortBufferUtilisationPercent);
     }
 
     public void close() {
@@ -157,6 +182,8 @@ public class CompactionMetrics {
 
         void reportTotalFileSize(long bytes);
 
+        void reportSortBufferMetrics(long usedBytes, long totalBytes);
+
         void unregister();
     }
 
@@ -167,6 +194,8 @@ public class CompactionMetrics {
         private long compactionInputSize = 0;
         private long compactionOutputSize = 0;
         private long totalFileSize = 0;
+        private long sortBufferUsedBytes = 0;
+        private double sortBufferUtilisationPercent = 0.0;
 
         private ReporterImpl(PartitionAndBucket key) {
             this.key = key;
@@ -208,6 +237,13 @@ public class CompactionMetrics {
         @Override
         public void reportLevel0FileCount(long count) {
             this.level0FileCount = count;
+        }
+
+        @Override
+        public void reportSortBufferMetrics(long usedBytes, long totalBytes) {
+            this.sortBufferUsedBytes = usedBytes;
+            this.sortBufferUtilisationPercent =
+                    totalBytes > 0 ? 100.0 * usedBytes / totalBytes : 0.0;
         }
 
         @Override

--- a/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/metrics/CompactionMetricsTest.java
@@ -58,6 +58,49 @@ public class CompactionMetricsTest {
     @TempDir java.nio.file.Path tempDir;
 
     @Test
+    public void testSortBufferMetrics() {
+        CompactionMetrics metrics = new CompactionMetrics(new TestMetricRegistry(), "myTable");
+
+        // no reporters yet: gauges return -1 (no data)
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_USED_BYTES)).isEqualTo(-1L);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_SORT_BUFFER_USED_BYTES))
+                .isEqualTo(-1.0);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_UTILISATION))
+                .isEqualTo(-1.0);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_SORT_BUFFER_UTILISATION))
+                .isEqualTo(-1.0);
+
+        CompactionMetrics.Reporter r0 = metrics.createReporter(BinaryRow.EMPTY_ROW, 0);
+        CompactionMetrics.Reporter r1 = metrics.createReporter(BinaryRow.EMPTY_ROW, 1);
+
+        // bucket 0: 32 MB used of 64 MB total = 50% utilisation
+        r0.reportSortBufferMetrics(32L * 1024 * 1024, 64L * 1024 * 1024);
+        // bucket 1: 48 MB used of 64 MB total = 75% utilisation
+        r1.reportSortBufferMetrics(48L * 1024 * 1024, 64L * 1024 * 1024);
+
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_USED_BYTES))
+                .isEqualTo(48L * 1024 * 1024);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_SORT_BUFFER_USED_BYTES))
+                .isEqualTo(40.0 * 1024 * 1024);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_UTILISATION))
+                .isEqualTo(75.0);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_SORT_BUFFER_UTILISATION))
+                .isEqualTo(62.5);
+
+        // update bucket 0 to full utilisation
+        r0.reportSortBufferMetrics(64L * 1024 * 1024, 64L * 1024 * 1024);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_UTILISATION))
+                .isEqualTo(100.0);
+        assertThat(getMetric(metrics, CompactionMetrics.AVG_SORT_BUFFER_UTILISATION))
+                .isEqualTo(87.5);
+
+        // zero-total pool reports 0% utilisation (no division by zero)
+        r0.reportSortBufferMetrics(0L, 0L);
+        assertThat(getMetric(metrics, CompactionMetrics.MAX_SORT_BUFFER_UTILISATION))
+                .isEqualTo(75.0);
+    }
+
+    @Test
     public void testReportMetrics() {
         CompactionMetrics metrics = new CompactionMetrics(new TestMetricRegistry(), "myTable");
         assertThat(getMetric(metrics, CompactionMetrics.MAX_LEVEL0_FILE_COUNT)).isEqualTo(-1L);


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Adding Compaction Sort Buffer metrics to gain visibility in the current sort buffer usage to assist with tuning the `[sort-spill-threshold](https://paimon.apache.org/docs/1.3/primary-key-table/compaction/#compaction-options) option.

### Tests

Added unit tests 

### API and Format

No changes in the API or Format

### Documentation

Updated [metrics.md](docs/content/maintenance/metrics.md) with the new metrics

### Generative AI tooling

Assisted by Rovodev and Claude Sonnet 4.6