### PR TITLE
[flink] supports dynamic options for system table

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/AbstractFlinkTableFactory.java
@@ -43,6 +43,7 @@ import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableFactory;
@@ -83,10 +84,7 @@ public abstract class AbstractFlinkTableFactory
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
         CatalogTable origin = context.getCatalogTable().getOrigin();
-        Table table =
-                origin instanceof SystemCatalogTable
-                        ? ((SystemCatalogTable) origin).table()
-                        : buildPaimonTable(context);
+        Table table = getPaimonTable(origin, context);
         boolean unbounded =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
                         == RuntimeExecutionMode.STREAMING;
@@ -128,6 +126,15 @@ public abstract class AbstractFlinkTableFactory
     static CatalogContext createCatalogContext(DynamicTableFactory.Context context) {
         return CatalogContext.create(
                 Options.fromMap(context.getCatalogTable().getOptions()), new FlinkFileIOLoader());
+    }
+
+    Table getPaimonTable(CatalogTable origin, DynamicTableFactory.Context context) {
+        if (origin instanceof SystemCatalogTable) {
+            Map<String, String> dynamicOptions = getDynamicConfigOptions(context);
+            return ((SystemCatalogTable) origin).table().copy(dynamicOptions);
+        } else {
+            return buildPaimonTable(context);
+        }
     }
 
     Table buildPaimonTable(DynamicTableFactory.Context context) {
@@ -242,14 +249,18 @@ public abstract class AbstractFlinkTableFactory
      */
     static Map<String, String> getDynamicConfigOptions(DynamicTableFactory.Context context) {
         Map<String, String> conf = getAllOptions(context);
+        ObjectIdentifier identifier = context.getObjectIdentifier();
+        String tableName =
+                new Identifier(identifier.getDatabaseName(), identifier.getObjectName())
+                        .getTableName();
 
         String template =
                 String.format(
                         "(%s)(%s|\\*)\\.(%s|\\*)\\.(%s|\\*)\\.(.+)",
                         FlinkConnectorOptions.TABLE_DYNAMIC_OPTION_PREFIX,
-                        context.getObjectIdentifier().getCatalogName(),
-                        context.getObjectIdentifier().getDatabaseName(),
-                        context.getObjectIdentifier().getObjectName());
+                        identifier.getCatalogName(),
+                        identifier.getDatabaseName(),
+                        tableName);
         Pattern pattern = Pattern.compile(template);
         Map<String, String> optionsFromTableConfig =
                 OptionsUtils.convertToDynamicTableProperties(conf, "", pattern, 5);
@@ -257,7 +268,7 @@ public abstract class AbstractFlinkTableFactory
         if (!optionsFromTableConfig.isEmpty()) {
             LOG.info(
                     "Loading dynamic table options for {} in table config: {}",
-                    context.getObjectIdentifier().getObjectName(),
+                    tableName,
                     optionsFromTableConfig);
         }
         return optionsFromTableConfig;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -21,11 +21,13 @@ package org.apache.paimon.flink;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.UriReader;
 import org.apache.paimon.utils.UriReaderFactory;
 
 import org.apache.flink.types.Row;
@@ -252,6 +254,26 @@ public class BlobTableITCase extends CatalogITCaseBase {
                     stream.filter(p -> p.getFileName().toString().endsWith(".blob")).count();
             assertThat(externalStorageFiles).isGreaterThanOrEqualTo(2);
         }
+    }
+
+    @Test
+    public void testDynamicOptions() throws Exception {
+        batchSql("INSERT INTO blob_table VALUES (1, 'paimon', X'48656C6C6F')");
+        assertThat(batchSql("SELECT * FROM blob_table"))
+                .containsExactlyInAnyOrder(
+                        Row.of(1, "paimon", new byte[] {72, 101, 108, 108, 111}));
+
+        // set blob-as-descriptor to true
+        tEnv.getConfig().set("paimon.*.*.blob_table.blob-as-descriptor", "true");
+        List<Row> result = batchSql("SELECT * FROM blob_table$row_tracking");
+        assertThat(result).size().isEqualTo(1);
+
+        byte[] descriptorBytes = result.get(0).getFieldAs(2);
+        BlobDescriptor descriptor = BlobDescriptor.deserialize(descriptorBytes);
+
+        UriReader reader = UriReader.fromFile(LocalFileIO.INSTANCE);
+        Blob blob = new BlobRef(reader, descriptor);
+        assertThat(blob.toData()).isEqualTo(new byte[] {72, 101, 108, 108, 111});
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
This PR is about to enable dynamic options for system table in flink.
For example:
```
    SET 'paimon.*.*.blob_table.blob-as-descriptor' = 'true';
    SELECT * FROM blob_table$row_tracking WHERE _ROW_ID = 1;
```

<!-- Linking this pull request to the issue -->
Linked issue: none #xxx

<!-- What is the purpose of the change -->

### Tests
See BlobTableITCase
<!-- List UT and IT cases to verify this change -->

### API and Format
None
<!-- Does this change affect API or storage format -->

### Documentation
None
<!-- Does this change introduce a new feature -->

### Generative AI tooling
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
