### PR TITLE
[core] Enable incrementalScan for BTreeGlobalIndexBuilder

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.globalindex.btree;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
@@ -31,6 +32,7 @@ import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.reader.RecordReader;
@@ -48,6 +50,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.MutableObjectIteratorAdapter;
 import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
 
@@ -119,13 +122,56 @@ public class BTreeGlobalIndexBuilder implements Serializable {
     }
 
     public List<DataSplit> scan() {
-        // 1. read the whole dataset of target partitions
         SnapshotReader snapshotReader = table.newSnapshotReader();
         if (partitionPredicate != null) {
             snapshotReader = snapshotReader.withPartitionFilter(partitionPredicate);
         }
 
         return snapshotReader.read().dataSplits();
+    }
+
+    public List<DataSplit> incrementalScan() {
+        SnapshotReader snapshotReader = table.newSnapshotReader();
+        if (partitionPredicate != null) {
+            snapshotReader = snapshotReader.withPartitionFilter(partitionPredicate);
+        }
+        Snapshot latestSnapshot = snapshotReader.snapshotManager().latestSnapshot();
+        if (latestSnapshot == null) {
+            return Collections.emptyList();
+        }
+        snapshotReader = snapshotReader.withSnapshot(latestSnapshot);
+
+        Preconditions.checkArgument(indexField != null, "indexField must be set before scan.");
+
+        Range dataRange = new Range(0, latestSnapshot.nextRowId() - 1);
+        List<Range> indexedRanges = indexedRowRanges(latestSnapshot);
+        List<Range> nonIndexedRanges = dataRange.exclude(indexedRanges);
+        if (nonIndexedRanges.isEmpty()) {
+            return Collections.emptyList();
+        }
+        snapshotReader = snapshotReader.withRowRanges(nonIndexedRanges);
+        return snapshotReader.read().dataSplits();
+    }
+
+    private List<Range> indexedRowRanges(Snapshot snapshot) {
+        List<Range> ranges = new ArrayList<>();
+        for (IndexManifestEntry entry :
+                table.store().newIndexFileHandler().scan(snapshot, "btree")) {
+            if (partitionPredicate != null && !partitionPredicate.test(entry.partition())) {
+                continue;
+            }
+            if (entry.indexFile().globalIndexMeta() == null) {
+                continue;
+            }
+            if (entry.indexFile().globalIndexMeta().indexFieldId() != indexField.id()) {
+                continue;
+            }
+            ranges.add(
+                    new Range(
+                            entry.indexFile().globalIndexMeta().rowRangeStart(),
+                            entry.indexFile().globalIndexMeta().rowRangeEnd()));
+        }
+        return Range.sortAndMergeOverlap(ranges, true);
     }
 
     @VisibleForTesting

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilderTest.java
@@ -152,6 +152,133 @@ public class BTreeGlobalIndexBuilderTest extends TableTestBase {
         metasByParts.forEach(this::assertFilesNonOverlapping);
     }
 
+    @Test
+    public void testIncrementalScanNoData() throws Exception {
+        createTableDefault();
+
+        FileStoreTable table = getTableDefault();
+        BTreeGlobalIndexBuilder builder = new BTreeGlobalIndexBuilder(table);
+        builder.withIndexField("f0");
+
+        List<DataSplit> splits = builder.incrementalScan();
+        Assertions.assertTrue(
+                splits.isEmpty(), "incrementalScan on empty table should return empty");
+    }
+
+    @Test
+    public void testIncrementalScanAllIndexed() throws Exception {
+        write();
+        createIndex(null);
+
+        FileStoreTable table = getTableDefault();
+        BTreeGlobalIndexBuilder builder = new BTreeGlobalIndexBuilder(table);
+        builder.withIndexField("f0");
+
+        List<DataSplit> splits = builder.incrementalScan();
+        Assertions.assertTrue(
+                splits.isEmpty(),
+                "incrementalScan should return empty when all data is already indexed");
+    }
+
+    @Test
+    public void testIncrementalScanWithNewData() throws Exception {
+        write();
+        createIndex(null);
+
+        // Write additional data to partition p0
+        FileStoreTable table = getTableDefault();
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite batchWrite = writeBuilder.newWrite()) {
+            for (int i = (int) PART_ROW_NUM; i < PART_ROW_NUM + 500; i++) {
+                batchWrite.write(
+                        GenericRow.of(
+                                BinaryString.fromString("p0"),
+                                i,
+                                BinaryString.fromString("f1_" + i)));
+            }
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(batchWrite.prepareCommit());
+            }
+        }
+
+        table = getTableDefault();
+        BTreeGlobalIndexBuilder builder = new BTreeGlobalIndexBuilder(table);
+        builder.withIndexField("f0");
+
+        List<DataSplit> splits = builder.incrementalScan();
+        Assertions.assertFalse(
+                splits.isEmpty(),
+                "incrementalScan should return non-empty splits for newly written data");
+
+        long totalRowCount = 0;
+        for (DataSplit split : splits) {
+            totalRowCount += split.rowCount();
+        }
+        Assertions.assertEquals(
+                500, totalRowCount, "incrementalScan should only return the newly written rows");
+    }
+
+    @Test
+    public void testIncrementalScanWithPartitionPredicate() throws Exception {
+        write();
+
+        // Only index partition p0
+        FileStoreTable table = getTableDefault();
+        RowType partType = table.rowType().project("dt");
+        Predicate predicate =
+                PartitionPredicate.createPartitionPredicate(
+                        partType, Collections.singletonMap("dt", BinaryString.fromString("p0")));
+        createIndex(PartitionPredicate.fromPredicate(partType, predicate));
+
+        // Write new data to both partitions
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite batchWrite = writeBuilder.newWrite()) {
+            for (int i = (int) PART_ROW_NUM; i < PART_ROW_NUM + 200; i++) {
+                batchWrite.write(
+                        GenericRow.of(
+                                BinaryString.fromString("p0"),
+                                i,
+                                BinaryString.fromString("f1_" + i)));
+                batchWrite.write(
+                        GenericRow.of(
+                                BinaryString.fromString("p1"),
+                                i,
+                                BinaryString.fromString("f1_" + i)));
+            }
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(batchWrite.prepareCommit());
+            }
+        }
+
+        // incrementalScan with p0 filter: should return only the new p0 data
+        table = getTableDefault();
+        predicate =
+                PartitionPredicate.createPartitionPredicate(
+                        partType, Collections.singletonMap("dt", BinaryString.fromString("p0")));
+        BTreeGlobalIndexBuilder builder = new BTreeGlobalIndexBuilder(table);
+        builder.withIndexField("f0");
+        builder.withPartitionPredicate(PartitionPredicate.fromPredicate(partType, predicate));
+
+        List<DataSplit> splits = builder.incrementalScan();
+        Assertions.assertFalse(splits.isEmpty());
+
+        for (DataSplit split : splits) {
+            Assertions.assertEquals(
+                    BinaryString.fromString("p0"),
+                    split.partition().getString(0),
+                    "incrementalScan with partition predicate should only return matching partition");
+        }
+
+        long totalRowCount = 0;
+        for (DataSplit split : splits) {
+            totalRowCount += split.rowCount();
+        }
+        Assertions.assertEquals(
+                200,
+                totalRowCount,
+                "incrementalScan should only return the new rows in partition p0");
+    }
+
     private Map<BinaryRow, List<Pair<String, FileStats>>> gatherIndexMetas(FileStoreTable table) {
         IndexFileHandler handler = table.store().newIndexFileHandler();
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Enable incremental scan for btree index builder

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
