### PR TITLE
[core] Add table properties sync to JDBC catalog

### DIFF
--- a/docs/layouts/shortcodes/generated/catalog_configuration.html
+++ b/docs/layouts/shortcodes/generated/catalog_configuration.html
@@ -144,7 +144,7 @@ under the License.
             <td><h5>sync-all-properties</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Sync all table properties to hive metastore</td>
+            <td>Sync all table properties to the catalog metastore (e.g. Hive metastore, JDBC catalog store)</td>
         </tr>
         <tr>
             <td><h5>table.type</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -153,10 +153,11 @@ public class CatalogOptions {
     public static final ConfigOption<Boolean> SYNC_ALL_PROPERTIES =
             ConfigOptions.key("sync-all-properties")
                     .booleanType()
-                    // We should set default value to true in case of hive metastore losing table
+                    // We should set default value to true in case of metastore losing table
                     // properties.
                     .defaultValue(true)
-                    .withDescription("Sync all table properties to hive metastore");
+                    .withDescription(
+                            "Sync all table properties to the catalog metastore (e.g. Hive metastore, JDBC catalog store)");
 
     public static final ConfigOption<Boolean> FORMAT_TABLE_ENABLED =
             ConfigOptions.key("format-table.enabled")

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.jdbc;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.AbstractCatalog;
 import org.apache.paimon.catalog.CatalogContext;
@@ -150,6 +151,19 @@ public class JdbcCatalog extends AbstractCatalog {
                             .execute();
                 });
 
+        // Check and create table properties table.
+        connections.run(
+                conn -> {
+                    DatabaseMetaData dbMeta = conn.getMetaData();
+                    ResultSet tableExists =
+                            dbMeta.getTables(
+                                    null, null, JdbcUtils.TABLE_PROPERTIES_TABLE_NAME, null);
+                    if (tableExists.next()) {
+                        return true;
+                    }
+                    return conn.prepareStatement(JdbcUtils.CREATE_TABLE_PROPERTIES_TABLE).execute();
+                });
+
         // if lock enabled, Check and create distributed lock table.
         if (lockEnabled()) {
             JdbcUtils.createDistributedLockTable(connections, options);
@@ -218,6 +232,14 @@ public class JdbcCatalog extends AbstractCatalog {
         execute(connections, JdbcUtils.DELETE_TABLES_SQL, catalogKey, name);
         // Delete properties from paimon_database_properties
         execute(connections, JdbcUtils.DELETE_ALL_DATABASE_PROPERTIES_SQL, catalogKey, name);
+        // Delete table properties from paimon_table_properties
+        if (syncTableProperties()) {
+            execute(
+                    connections,
+                    JdbcUtils.DELETE_ALL_TABLE_PROPERTIES_FOR_DB_SQL,
+                    catalogKey,
+                    name);
+        }
     }
 
     @Override
@@ -283,6 +305,14 @@ public class JdbcCatalog extends AbstractCatalog {
                 LOG.info("Skipping drop, table does not exist: {}", identifier);
                 return;
             }
+            if (syncTableProperties()) {
+                execute(
+                        connections,
+                        JdbcUtils.DELETE_ALL_TABLE_PROPERTIES_SQL,
+                        catalogKey,
+                        identifier.getDatabaseName(),
+                        identifier.getTableName());
+            }
             Path path = getTableLocation(identifier);
             try {
                 if (fileIO.exists(path)) {
@@ -306,7 +336,8 @@ public class JdbcCatalog extends AbstractCatalog {
         try {
             // create table file
             SchemaManager schemaManager = getSchemaManager(identifier);
-            runWithLock(identifier, () -> schemaManager.createTable(schema));
+            TableSchema tableSchema =
+                    runWithLock(identifier, () -> schemaManager.createTable(schema));
             // Update schema metadata
             Path path = getTableLocation(identifier);
             if (JdbcUtils.insertTable(
@@ -326,6 +357,14 @@ public class JdbcCatalog extends AbstractCatalog {
                                 "Failed to create table %s in catalog %s",
                                 identifier.getFullName(), catalogKey));
             }
+            if (syncTableProperties()) {
+                JdbcUtils.insertTableProperties(
+                        connections,
+                        catalogKey,
+                        identifier.getDatabaseName(),
+                        identifier.getTableName(),
+                        collectTableProperties(tableSchema));
+            }
         } catch (Exception e) {
             throw new RuntimeException("Failed to create table " + identifier.getFullName(), e);
         }
@@ -336,6 +375,16 @@ public class JdbcCatalog extends AbstractCatalog {
         try {
             // update table metadata info
             updateTable(connections, catalogKey, fromTable, toTable);
+            if (syncTableProperties()) {
+                execute(
+                        connections,
+                        JdbcUtils.RENAME_TABLE_PROPERTIES_SQL,
+                        toTable.getDatabaseName(),
+                        toTable.getObjectName(),
+                        catalogKey,
+                        fromTable.getDatabaseName(),
+                        fromTable.getObjectName());
+            }
 
             Path fromPath = getTableLocation(fromTable);
             if (!new SchemaManager(fileIO, fromPath).listAllIds().isEmpty()) {
@@ -364,6 +413,21 @@ public class JdbcCatalog extends AbstractCatalog {
         SchemaManager schemaManager = getSchemaManager(identifier);
         try {
             runWithLock(identifier, () -> schemaManager.commitChanges(changes));
+            if (syncTableProperties()) {
+                TableSchema updatedSchema = schemaManager.latest().get();
+                execute(
+                        connections,
+                        JdbcUtils.DELETE_ALL_TABLE_PROPERTIES_SQL,
+                        catalogKey,
+                        identifier.getDatabaseName(),
+                        identifier.getTableName());
+                JdbcUtils.insertTableProperties(
+                        connections,
+                        catalogKey,
+                        identifier.getDatabaseName(),
+                        identifier.getTableName(),
+                        collectTableProperties(updatedSchema));
+            }
         } catch (TableNotExistException
                 | ColumnAlreadyExistException
                 | ColumnNotExistException
@@ -486,12 +550,53 @@ public class JdbcCatalog extends AbstractCatalog {
                 LOG.error("Failed to repair table: {}", identifier);
             }
         }
-        // If table exists in both file system and JDBC catalog, nothing to repair
+        if (syncTableProperties()) {
+            // Delete existing properties and reinsert from filesystem schema
+            execute(
+                    connections,
+                    JdbcUtils.DELETE_ALL_TABLE_PROPERTIES_SQL,
+                    catalogKey,
+                    identifier.getDatabaseName(),
+                    identifier.getTableName());
+            JdbcUtils.insertTableProperties(
+                    connections,
+                    catalogKey,
+                    identifier.getDatabaseName(),
+                    identifier.getTableName(),
+                    collectTableProperties(tableSchema));
+        }
     }
 
     @Override
     public void close() throws Exception {
         connections.close();
+    }
+
+    private boolean syncTableProperties() {
+        return options.get(CatalogOptions.SYNC_ALL_PROPERTIES);
+    }
+
+    private Map<String, String> convertToPropertiesTableKey(TableSchema tableSchema) {
+        Map<String, String> properties = new HashMap<>();
+        if (!tableSchema.primaryKeys().isEmpty()) {
+            properties.put(
+                    CoreOptions.PRIMARY_KEY.key(), String.join(",", tableSchema.primaryKeys()));
+        }
+        if (!tableSchema.partitionKeys().isEmpty()) {
+            properties.put(
+                    CoreOptions.PARTITION.key(), String.join(",", tableSchema.partitionKeys()));
+        }
+        if (!tableSchema.bucketKeys().isEmpty()) {
+            properties.put(
+                    CoreOptions.BUCKET_KEY.key(), String.join(",", tableSchema.bucketKeys()));
+        }
+        return properties;
+    }
+
+    private Map<String, String> collectTableProperties(TableSchema tableSchema) {
+        Map<String, String> properties = new HashMap<>(tableSchema.options());
+        properties.putAll(convertToPropertiesTableKey(tableSchema));
+        return properties;
     }
 
     private SchemaManager getSchemaManager(Identifier identifier) {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcUtils.java
@@ -231,6 +231,100 @@ public class JdbcUtils {
                     + CATALOG_KEY
                     + " = ?";
 
+    // Table Properties
+    static final String TABLE_PROPERTIES_TABLE_NAME = "paimon_table_properties";
+    static final String TABLE_PROPERTY_KEY = "property_key";
+    static final String TABLE_PROPERTY_VALUE = "property_value";
+
+    static final String CREATE_TABLE_PROPERTIES_TABLE =
+            "CREATE TABLE "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + "("
+                    + CATALOG_KEY
+                    + " VARCHAR(255) NOT NULL,"
+                    + TABLE_DATABASE
+                    + " VARCHAR(255) NOT NULL,"
+                    + TABLE_NAME
+                    + " VARCHAR(255) NOT NULL,"
+                    + TABLE_PROPERTY_KEY
+                    + " VARCHAR(255) NOT NULL,"
+                    + TABLE_PROPERTY_VALUE
+                    + " VARCHAR(1000),"
+                    + "PRIMARY KEY ("
+                    + CATALOG_KEY
+                    + ", "
+                    + TABLE_DATABASE
+                    + ", "
+                    + TABLE_NAME
+                    + ", "
+                    + TABLE_PROPERTY_KEY
+                    + ")"
+                    + ")";
+
+    static final String INSERT_TABLE_PROPERTIES_SQL =
+            "INSERT INTO "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + " ("
+                    + CATALOG_KEY
+                    + ", "
+                    + TABLE_DATABASE
+                    + ", "
+                    + TABLE_NAME
+                    + ", "
+                    + TABLE_PROPERTY_KEY
+                    + ", "
+                    + TABLE_PROPERTY_VALUE
+                    + ") VALUES ";
+    static final String INSERT_TABLE_PROPERTIES_VALUES_BASE = "(?,?,?,?,?)";
+
+    static final String DELETE_ALL_TABLE_PROPERTIES_SQL =
+            "DELETE FROM "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + " WHERE "
+                    + CATALOG_KEY
+                    + " = ? AND "
+                    + TABLE_DATABASE
+                    + " = ? AND "
+                    + TABLE_NAME
+                    + " = ?";
+
+    static final String DELETE_ALL_TABLE_PROPERTIES_FOR_DB_SQL =
+            "DELETE FROM "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + " WHERE "
+                    + CATALOG_KEY
+                    + " = ? AND "
+                    + TABLE_DATABASE
+                    + " = ?";
+
+    static final String RENAME_TABLE_PROPERTIES_SQL =
+            "UPDATE "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + " SET "
+                    + TABLE_DATABASE
+                    + " = ? , "
+                    + TABLE_NAME
+                    + " = ? "
+                    + " WHERE "
+                    + CATALOG_KEY
+                    + " = ? AND "
+                    + TABLE_DATABASE
+                    + " = ? AND "
+                    + TABLE_NAME
+                    + " = ? ";
+
+    static final String GET_ALL_TABLE_PROPERTIES_SQL =
+            "SELECT * "
+                    + " FROM "
+                    + TABLE_PROPERTIES_TABLE_NAME
+                    + " WHERE "
+                    + CATALOG_KEY
+                    + " = ? AND "
+                    + TABLE_DATABASE
+                    + " = ? AND "
+                    + TABLE_NAME
+                    + " = ? ";
+
     // Distributed locks table
     static final String DISTRIBUTED_LOCKS_TABLE_NAME = "paimon_distributed_locks";
     static final String LOCK_ID = "lock_id";
@@ -423,6 +517,52 @@ public class JdbcUtils {
                 String.format(
                         "Failed to insert: %d of %d succeeded",
                         insertedRecords, properties.size()));
+    }
+
+    public static boolean insertTableProperties(
+            JdbcClientPool connections,
+            String storeKey,
+            String databaseName,
+            String tableName,
+            Map<String, String> properties) {
+        if (properties.isEmpty()) {
+            return true;
+        }
+        String[] args =
+                properties.entrySet().stream()
+                        .flatMap(
+                                entry ->
+                                        Stream.of(
+                                                storeKey,
+                                                databaseName,
+                                                tableName,
+                                                entry.getKey(),
+                                                entry.getValue()))
+                        .toArray(String[]::new);
+
+        int insertedRecords =
+                execute(
+                        connections,
+                        JdbcUtils.insertTablePropertiesStatement(properties.size()),
+                        args);
+        if (insertedRecords == properties.size()) {
+            return true;
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "Failed to insert: %d of %d succeeded",
+                        insertedRecords, properties.size()));
+    }
+
+    private static String insertTablePropertiesStatement(int size) {
+        StringBuilder sqlStatement = new StringBuilder(JdbcUtils.INSERT_TABLE_PROPERTIES_SQL);
+        for (int i = 0; i < size; i++) {
+            if (i != 0) {
+                sqlStatement.append(", ");
+            }
+            sqlStatement.append(JdbcUtils.INSERT_TABLE_PROPERTIES_VALUES_BASE);
+        }
+        return sqlStatement.toString();
     }
 
     private static String insertPropertiesStatement(int size) {

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -37,8 +38,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -298,6 +302,291 @@ public class JdbcCatalogTest extends CatalogTestBase {
             assertThat(catalogDatabases).contains(dbName);
             assertThat(catalog.listTables(dbName)).contains("test_table");
         }
+    }
+
+    private JdbcCatalog initCatalogWithSync(boolean syncAllProperties) {
+        Map<String, String> props = Maps.newHashMap();
+        props.put(CatalogOptions.SYNC_ALL_PROPERTIES.key(), String.valueOf(syncAllProperties));
+        return initCatalog(props);
+    }
+
+    private Map<String, String> fetchTableProperties(
+            JdbcCatalog jdbcCatalog, String databaseName, String tableName) {
+        try {
+            return jdbcCatalog
+                    .getConnections()
+                    .run(
+                            conn -> {
+                                Map<String, String> result = new HashMap<>();
+                                try (PreparedStatement ps =
+                                        conn.prepareStatement(
+                                                JdbcUtils.GET_ALL_TABLE_PROPERTIES_SQL)) {
+                                    ps.setString(1, jdbcCatalog.getCatalogKey());
+                                    ps.setString(2, databaseName);
+                                    ps.setString(3, tableName);
+                                    try (ResultSet rs = ps.executeQuery()) {
+                                        while (rs.next()) {
+                                            result.put(
+                                                    rs.getString(JdbcUtils.TABLE_PROPERTY_KEY),
+                                                    rs.getString(JdbcUtils.TABLE_PROPERTY_VALUE));
+                                        }
+                                    }
+                                }
+                                return result;
+                            });
+        } catch (SQLException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnCreate() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        options.put("file.format", "parquet");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        syncCatalog.createTable(identifier, schema, false);
+
+        Map<String, String> storedProps =
+                fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).containsEntry("bucket", "4");
+        assertThat(storedProps).containsEntry("file.format", "parquet");
+        assertThat(storedProps).containsEntry("primary-key", "pk,pt");
+        assertThat(storedProps).containsEntry("partition", "pt");
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnAlter() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        syncCatalog.createTable(identifier, schema, false);
+
+        // Alter table: set a new option
+        syncCatalog.alterTable(
+                identifier,
+                Lists.newArrayList(SchemaChange.setOption("file.format", "orc")),
+                false);
+
+        Map<String, String> storedProps =
+                fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).containsEntry("file.format", "orc");
+        assertThat(storedProps).containsEntry("bucket", "4");
+
+        // Alter table: remove an option
+        syncCatalog.alterTable(
+                identifier, Lists.newArrayList(SchemaChange.removeOption("file.format")), false);
+
+        storedProps = fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).doesNotContainKey("file.format");
+        assertThat(storedProps).containsEntry("bucket", "4");
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnDrop() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        syncCatalog.createTable(identifier, schema, false);
+
+        // Verify properties exist
+        Map<String, String> storedProps =
+                fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).isNotEmpty();
+
+        // Drop the table
+        syncCatalog.dropTable(identifier, false);
+
+        // Verify properties are cleaned up
+        storedProps = fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).isEmpty();
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnRename() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier fromTable = Identifier.create("test_db", "old_table");
+        syncCatalog.createTable(fromTable, schema, false);
+
+        // Verify properties exist under old name
+        Map<String, String> storedProps = fetchTableProperties(syncCatalog, "test_db", "old_table");
+        assertThat(storedProps).containsEntry("bucket", "4");
+
+        // Rename the table
+        Identifier toTable = Identifier.create("test_db", "new_table");
+        syncCatalog.renameTable(fromTable, toTable, false);
+
+        // Verify properties moved to new name
+        storedProps = fetchTableProperties(syncCatalog, "test_db", "new_table");
+        assertThat(storedProps).containsEntry("bucket", "4");
+
+        // Verify old name has no properties
+        storedProps = fetchTableProperties(syncCatalog, "test_db", "old_table");
+        assertThat(storedProps).isEmpty();
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnDropDatabase() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        syncCatalog.createTable(Identifier.create("test_db", "table1"), schema, false);
+        syncCatalog.createTable(Identifier.create("test_db", "table2"), schema, false);
+
+        // Verify properties exist
+        assertThat(fetchTableProperties(syncCatalog, "test_db", "table1")).isNotEmpty();
+        assertThat(fetchTableProperties(syncCatalog, "test_db", "table2")).isNotEmpty();
+
+        // Drop the database cascade
+        syncCatalog.dropDatabase("test_db", false, true);
+
+        // Verify all table properties are cleaned up
+        assertThat(fetchTableProperties(syncCatalog, "test_db", "table1")).isEmpty();
+        assertThat(fetchTableProperties(syncCatalog, "test_db", "table2")).isEmpty();
+    }
+
+    @Test
+    public void testTablePropertiesSyncDisabled() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(false);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        syncCatalog.createTable(identifier, schema, false);
+
+        // Verify no properties are stored when sync is disabled
+        Map<String, String> storedProps =
+                fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).isEmpty();
+    }
+
+    @Test
+    public void testTablePropertiesSyncOnRepair() throws Exception {
+        JdbcCatalog syncCatalog = initCatalogWithSync(true);
+        syncCatalog.createDatabase("test_db", false);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("bucket", "4");
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "pt", DataTypes.STRING()),
+                                new DataField(2, "col1", DataTypes.STRING())),
+                        Lists.newArrayList("pt"),
+                        Lists.newArrayList("pk", "pt"),
+                        options,
+                        "");
+
+        Identifier identifier = Identifier.create("test_db", "test_table");
+        syncCatalog.createTable(identifier, schema, false);
+
+        // Delete the JDBC table row and properties (simulating corruption)
+        JdbcUtils.execute(
+                syncCatalog.getConnections(),
+                JdbcUtils.DROP_TABLE_SQL,
+                syncCatalog.getCatalogKey(),
+                "test_db",
+                "test_table");
+        JdbcUtils.execute(
+                syncCatalog.getConnections(),
+                JdbcUtils.DELETE_ALL_TABLE_PROPERTIES_SQL,
+                syncCatalog.getCatalogKey(),
+                "test_db",
+                "test_table");
+
+        // Verify properties are gone
+        assertThat(fetchTableProperties(syncCatalog, "test_db", "test_table")).isEmpty();
+
+        // Repair the table
+        syncCatalog.repairTable(identifier);
+
+        // Verify properties are restored
+        Map<String, String> storedProps =
+                fetchTableProperties(syncCatalog, "test_db", "test_table");
+        assertThat(storedProps).containsEntry("bucket", "4");
     }
 
     @Test


### PR DESCRIPTION
### Purpose
Linked issue:  https://github.com/apache/paimon/issues/7421

Supporting table properties in JdbcCatalog similar to HiveCatalog support. Some implementation details are different due to differences in Hive vs Jdbc.

Table properties are stored in SQL table `paimon_table_properties` controlled by the existing `sync-all-properties` option.

### Tests

Unit tests in JdbcCatalogTest. These use in memory sqlite database so they function like integration tests.

### API and Format

N/A

### Documentation

Updated docs

### Generative AI tooling
Generated-by: claude code

I have reviewed the code.