### PR TITLE
[core] Add partition format check if partition expire time is set

### DIFF
--- a/docs/layouts/shortcodes/generated/core_configuration.html
+++ b/docs/layouts/shortcodes/generated/core_configuration.html
@@ -27,16 +27,16 @@ under the License.
     </thead>
     <tbody>
         <tr>
-            <td><h5>aggregation.remove-record-on-delete</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to remove the whole row in aggregation engine when -D records are received.</td>
-        </tr>
-        <tr>
             <td><h5>add-column-before-partition</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If true, when adding a new column without specifying a position, the column will be placed before the first partition column instead of at the end of the schema. This only takes effect for partitioned tables.</td>
+        </tr>
+        <tr>
+            <td><h5>aggregation.remove-record-on-delete</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to remove the whole row in aggregation engine when -D records are received.</td>
         </tr>
         <tr>
             <td><h5>alter-column-null-to-not-null.disabled</h5></td>
@@ -1042,6 +1042,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">NONE</td>
             <td><p>Enum</p></td>
             <td>This is only for partitioned append table or postpone pk table, and the purpose is to reduce small files and improve write performance. Through this repartitioning strategy to reduce the number of partitions written by each task to as few as possible.<ul><li>none: Rebalanced or Forward partitioning, this is the default behavior, this strategy is suitable for the number of partitions you write in a batch is much smaller than write parallelism.</li><li>hash: Hash the partitions value, this strategy is suitable for the number of partitions you write in a batch is greater equals than write parallelism.</li></ul><br /><br />Possible values:<ul><li>"NONE"</li><li>"HASH"</li></ul></td>
+        </tr>
+        <tr>
+            <td><h5>partition.timestamp-format.strict</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>When enabled, if a partition value does not match the 'partition.timestamp-formatter' or 'partition.timestamp-pattern' configuration, an error will be thrown during writing. This helps prevent dirty partition directories caused by incorrectly specified partition fields.</td>
         </tr>
         <tr>
             <td><h5>partition.timestamp-formatter</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1189,6 +1189,16 @@ public class CoreOptions implements Serializable {
                                                             + "$hour:00:00'."))
                                     .build());
 
+    public static final ConfigOption<Boolean> PARTITION_TIMESTAMP_FORMAT_STRICT =
+            key("partition.timestamp-format.strict")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "When enabled, if a partition value does not match the "
+                                    + "'partition.timestamp-formatter' or 'partition.timestamp-pattern' configuration, "
+                                    + "an error will be thrown during writing. "
+                                    + "This helps prevent dirty partition directories caused by incorrectly specified partition fields.");
+
     public static final ConfigOption<Boolean> PARTITION_MARK_DONE_WHEN_END_INPUT =
             ConfigOptions.key("partition.end-input-to-done")
                     .booleanType()
@@ -3239,6 +3249,10 @@ public class CoreOptions implements Serializable {
 
     public String partitionTimestampPattern() {
         return options.get(PARTITION_TIMESTAMP_PATTERN);
+    }
+
+    public boolean partitionTimestampFormatStrict() {
+        return options.get(PARTITION_TIMESTAMP_FORMAT_STRICT);
     }
 
     public String httpReportMarkDoneActionUrl() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -612,6 +612,9 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
         @Nullable
         private static PartitionTimestampValidator create(
                 CoreOptions options, RowType partitionType) {
+            if (!options.partitionTimestampFormatStrict()) {
+                return null;
+            }
             String timeFormatter = options.partitionTimestampFormatter();
             String timePattern = options.partitionTimestampPattern();
             if ((timeFormatter != null || timePattern != null)

--- a/paimon-core/src/test/java/org/apache/paimon/table/sink/TableWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/sink/TableWriteTest.java
@@ -303,6 +303,7 @@ public class TableWriteTest {
         Options conf = new Options();
         conf.set(CoreOptions.BUCKET, 1);
         conf.set(CoreOptions.PARTITION_TIMESTAMP_FORMATTER, "yyyyMMdd");
+        conf.set(CoreOptions.PARTITION_TIMESTAMP_FORMAT_STRICT, true);
         FileStoreTable table = createFileStoreTable(conf);
 
         TableWriteImpl<?> write = table.newWrite(commitUser);


### PR DESCRIPTION
### Purpose

Users may set an incorrect partition key, or an incorrect time format for partition expire. Under such case, partitions won't expire and will increase the storage size infinitely. To avoid this problem, this PR adds a check for partition format if partition expire time is set

### Tests

* `TableWriteTest#testPartitionTimestampValidation`.

### API and Format

No format changes.

### Documentation

Config option is added to enable this feature.

### Generative AI tooling

Generated-by: qodercli 0.1.31