### PR TITLE
[Flink] Fix SystemTableSource unordered flag for bucket-unaware system talbes

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
@@ -101,11 +101,7 @@ public class SystemTableSource extends FlinkTableSource {
         if (unbounded && table instanceof DataTable) {
             source =
                     new ContinuousFileStoreSource(
-                            readBuilder,
-                            table.options(),
-                            limit,
-                            isUnordered(table),
-                            rowData);
+                            readBuilder, table.options(), limit, isUnordered(table), rowData);
         } else {
             source =
                     new StaticFileStoreSource(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/DataTableSourceTest.java
@@ -153,7 +153,8 @@ class DataTableSourceTest {
         // Retrieve the source from the transformation and verify unordered = true
         ContinuousFileStoreSource source =
                 (ContinuousFileStoreSource)
-                        ((org.apache.flink.streaming.api.transformations.SourceTransformation<?, ?, ?>)
+                        ((org.apache.flink.streaming.api.transformations.SourceTransformation<
+                                                ?, ?, ?>)
                                         sourceStream.getTransformation())
                                 .getSource();
         java.lang.reflect.Field unorderedField =
@@ -164,14 +165,14 @@ class DataTableSourceTest {
 
     @Test
     public void testSystemTableSourceOrderedForHashFixedTable() throws Exception {
-        // bucket > 0 (HASH_FIXED) with bucket-append-ordered = true should produce unordered = false
+        // bucket > 0 (HASH_FIXED) with bucket-append-ordered = true should produce unordered =
+        // false
         FileStoreTable hashFixedTable =
                 createTable(ImmutableMap.of("bucket", "4", "bucket-key", "a"));
         ReadOptimizedTable roTable = new ReadOptimizedTable(hashFixedTable);
 
         SystemTableSource tableSource =
-                new SystemTableSource(
-                        roTable, true, ObjectIdentifier.of("cat", "db", "table$ro"));
+                new SystemTableSource(roTable, true, ObjectIdentifier.of("cat", "db", "table$ro"));
         PaimonDataStreamScanProvider runtimeProvider = runtimeProvider(tableSource);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
@@ -180,7 +181,8 @@ class DataTableSourceTest {
 
         ContinuousFileStoreSource source =
                 (ContinuousFileStoreSource)
-                        ((org.apache.flink.streaming.api.transformations.SourceTransformation<?, ?, ?>)
+                        ((org.apache.flink.streaming.api.transformations.SourceTransformation<
+                                                ?, ?, ?>)
                                         sourceStream.getTransformation())
                                 .getSource();
         java.lang.reflect.Field unorderedField =


### PR DESCRIPTION
### Purpose
  Linked issue: close #7326 
  Previously, SystemTableSource always passed unordered=false when creating
  ContinuousFileStoreSource, causing PreAssignSplitAssigner to assign all
  splits to a single subtask for bucket=-1 (BUCKET_UNAWARE) tables. This
  resulted in severe data skew where only one subtask received all records.

  Fix this by introducing isUnordered() to derive the correct value from
  the underlying table's bucket configuration, consistent with the logic
  in FlinkSourceBuilder. For BUCKET_UNAWARE tables (bucket=-1), unordered
  is set to true so FIFOSplitAssigner distributes splits across all tasks.

### Tests
Ci

