### PR TITLE
[spark] Fix NPE in SparkHilbertUDF and SparkZOrderUDF for null values

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkHilbertUDF.java
@@ -42,7 +42,6 @@ import org.apache.spark.sql.types.TimestampType;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.math.BigDecimal;
 
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
@@ -171,7 +170,12 @@ public class SparkHilbertUDF implements Serializable {
         UserDefinedFunction udf =
                 functions
                         .udf(
-                                (String value) -> ConvertBinaryUtil.convertStringToLong(value),
+                                (String value) -> {
+                                    if (value == null) {
+                                        return PRIMITIVE_EMPTY;
+                                    }
+                                    return ConvertBinaryUtil.convertStringToLong(value);
+                                },
                                 DataTypes.LongType)
                         .withName("STRING-LEXICAL-BYTES");
 
@@ -182,17 +186,13 @@ public class SparkHilbertUDF implements Serializable {
         UserDefinedFunction udf =
                 functions
                         .udf(
-                                (byte[] value) -> ConvertBinaryUtil.convertBytesToLong(value),
+                                (byte[] value) -> {
+                                    if (value == null) {
+                                        return PRIMITIVE_EMPTY;
+                                    }
+                                    return ConvertBinaryUtil.convertBytesToLong(value);
+                                },
                                 DataTypes.LongType)
-                        .withName("BYTE-TRUNCATE");
-
-        return udf;
-    }
-
-    private UserDefinedFunction decimalTypeToOrderedLongUDF() {
-        UserDefinedFunction udf =
-                functions
-                        .udf((BigDecimal value) -> value.longValue(), DataTypes.LongType)
                         .withName("BYTE-TRUNCATE");
 
         return udf;
@@ -221,7 +221,7 @@ public class SparkHilbertUDF implements Serializable {
         } else if (type instanceof TimestampType) {
             return longToOrderedLongUDF().apply(column.cast(DataTypes.LongType));
         } else if (type instanceof DecimalType) {
-            return decimalTypeToOrderedLongUDF().apply(column.cast(DataTypes.LongType));
+            return longToOrderedLongUDF().apply(column.cast(DataTypes.LongType));
         } else if (type instanceof DateType) {
             return longToOrderedLongUDF().apply(column.cast(DataTypes.LongType));
         } else {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkZOrderUDF.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/sort/SparkZOrderUDF.java
@@ -247,6 +247,9 @@ public class SparkZOrderUDF implements Serializable {
                 functions
                         .udf(
                                 (Boolean value) -> {
+                                    if (value == null) {
+                                        return PRIMITIVE_EMPTY;
+                                    }
                                     ByteBuffer buffer =
                                             inputBuffer(
                                                     position,
@@ -267,12 +270,16 @@ public class SparkZOrderUDF implements Serializable {
         UserDefinedFunction udf =
                 functions
                         .udf(
-                                (String value) ->
-                                        ZOrderByteUtils.stringToOrderedBytes(
-                                                        value,
-                                                        varTypeSize,
-                                                        inputBuffer(position, varTypeSize))
-                                                .array(),
+                                (String value) -> {
+                                    if (value == null) {
+                                        return new byte[varTypeSize];
+                                    }
+                                    return ZOrderByteUtils.stringToOrderedBytes(
+                                                    value,
+                                                    varTypeSize,
+                                                    inputBuffer(position, varTypeSize))
+                                            .array();
+                                },
                                 DataTypes.BinaryType)
                         .withName("STRING-LEXICAL-BYTES");
 
@@ -287,12 +294,16 @@ public class SparkZOrderUDF implements Serializable {
         UserDefinedFunction udf =
                 functions
                         .udf(
-                                (byte[] value) ->
-                                        ZOrderByteUtils.byteTruncateOrFill(
-                                                        value,
-                                                        varTypeSize,
-                                                        inputBuffer(position, varTypeSize))
-                                                .array(),
+                                (byte[] value) -> {
+                                    if (value == null) {
+                                        return new byte[varTypeSize];
+                                    }
+                                    return ZOrderByteUtils.byteTruncateOrFill(
+                                                    value,
+                                                    varTypeSize,
+                                                    inputBuffer(position, varTypeSize))
+                                            .array();
+                                },
                                 DataTypes.BinaryType)
                         .withName("BYTE-TRUNCATE");
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -1308,6 +1308,37 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     }
   }
 
+  test("Paimon Procedure: sort compact with null values in string clustering column") {
+    withTable("T") {
+      spark.sql(s"""
+                   |CREATE TABLE T (a STRING, b INT)
+                   |TBLPROPERTIES ('bucket'='-1')
+                   |""".stripMargin)
+
+      spark.sql("INSERT INTO T VALUES (null, 1), ('abc', 2), (null, 3), ('def', 4)")
+      spark.sql("INSERT INTO T VALUES ('ghi', 5), (null, 6)")
+
+      // zorder compact with null string clustering column should not NPE
+      checkAnswer(
+        spark.sql(
+          "CALL paimon.sys.compact(table => 'T', order_strategy => 'zorder', order_by => 'a,b')"),
+        Row(true) :: Nil)
+
+      val zorderResult = spark.sql("SELECT * FROM T").collect()
+      Assertions.assertThat(zorderResult.length).isEqualTo(6)
+
+      // hilbert compact with null string clustering column should not NPE
+      spark.sql("INSERT INTO T VALUES (null, 7), ('jkl', 8)")
+      checkAnswer(
+        spark.sql(
+          "CALL paimon.sys.compact(table => 'T', order_strategy => 'hilbert', order_by => 'a,b')"),
+        Row(true) :: Nil)
+
+      val hilbertResult = spark.sql("SELECT * FROM T").collect()
+      Assertions.assertThat(hilbertResult.length).isEqualTo(8)
+    }
+  }
+
   def checkSnapshot(table: FileStoreTable): Unit = {
     Assertions
       .assertThat(table.latestSnapshot().get().commitKind().toString)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

```text
Job aborted due to stage failure: Task 1 in stage 9.0 failed 1 times, most recent failure: Lost task 1.0 in stage 9.0 (TID 16) (x executor driver): org.apache.spark.SparkException: [FAILED_EXECUTE_UDF] Failed to execute user defined function (`STRING-LEXICAL-BYTES (functions$$$Lambda$3612/3737976)`: (string) => bigint).
	at org.apache.spark.sql.errors.QueryExecutionErrors$.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala:198)
	at org.apache.spark.sql.errors.QueryExecutionErrors.failedExecuteUserDefinedFunctionError(QueryExecutionErrors.scala)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.project_doConsume_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
```

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

Claude 4.6

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.


-->
