### PR TITLE
[python] Add json format for CLI table read and list-partitions

### DIFF
--- a/docs/content/pypaimon/cli.md
+++ b/docs/content/pypaimon/cli.md
@@ -85,6 +85,7 @@ paimon table read mydb.users
 - `--select, -s`: Select specific columns to read (comma-separated)
 - `--where, -w`: Filter condition in SQL-like syntax
 - `--limit, -l`: Maximum number of results to display (default: 100)
+- `--format, -f`: Output format: `table` (default) or `json`
 
 **Examples:**
 
@@ -100,6 +101,9 @@ paimon table read mydb.users --where "age > 18"
 
 # Combine select, where, and limit
 paimon table read mydb.users -s id,name -w "age >= 20 AND city = 'Beijing'" -l 50
+
+# Output as JSON (for programmatic use)
+paimon table read mydb.users --format json
 ```
 
 **WHERE Operators**
@@ -320,6 +324,7 @@ paimon table list-partitions mydb.orders
 **Options:**
 
 - `--pattern, -p`: Partition name pattern to filter partitions
+- `--format, -f`: Output format: `table` (default) or `json`
 
 **Examples:**
 
@@ -329,6 +334,9 @@ paimon table list-partitions mydb.orders
 
 # List partitions matching a pattern
 paimon table list-partitions mydb.orders --pattern "dt=2024*"
+
+# Output as JSON (for programmatic use)
+paimon table list-partitions mydb.orders --format json
 ```
 
 Output:

--- a/paimon-python/pypaimon/cli/cli_table.py
+++ b/paimon-python/pypaimon/cli/cli_table.py
@@ -139,7 +139,12 @@ def cmd_table_read(args):
     if extra_where_columns:
         df = df.drop(columns=extra_where_columns, errors='ignore')
 
-    print(df.to_string(index=False))
+    output_format = getattr(args, 'format', 'table')
+    if output_format == 'json':
+        import json
+        print(json.dumps(df.to_dict(orient='records'), ensure_ascii=False))
+    else:
+        print(df.to_string(index=False))
 
 
 def cmd_table_get(args):
@@ -626,8 +631,13 @@ def cmd_table_list_partitions(args):
                 'UpdatedBy': p.updated_by or '',
             })
 
-        df = pd.DataFrame(data)
-        print(df.to_string(index=False))
+        output_format = getattr(args, 'format', 'table')
+        if output_format == 'json':
+            import json
+            print(json.dumps(data, ensure_ascii=False))
+        else:
+            df = pd.DataFrame(data)
+            print(df.to_string(index=False))
 
     except NotImplementedError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -670,6 +680,13 @@ def add_table_subcommands(table_parser):
         type=int,
         default=100,
         help='Maximum number of results to display (default: 100)'
+    )
+    read_parser.add_argument(
+        '--format', '-f',
+        type=str,
+        choices=['table', 'json'],
+        default='table',
+        help='Output format: table (default) or json'
     )
     read_parser.set_defaults(func=cmd_table_read)
     
@@ -744,6 +761,13 @@ def add_table_subcommands(table_parser):
         type=str,
         default=None,
         help='Partition name pattern to filter partitions (e.g., "dt=2024*")'
+    )
+    list_partitions_parser.add_argument(
+        '--format', '-f',
+        type=str,
+        choices=['table', 'json'],
+        default='table',
+        help='Output format: table (default) or json'
     )
     list_partitions_parser.set_defaults(func=cmd_table_list_partitions)
 

--- a/paimon-python/pypaimon/tests/cli_table_test.py
+++ b/paimon-python/pypaimon/tests/cli_table_test.py
@@ -1254,6 +1254,81 @@ class CliTableTest(unittest.TestCase):
                 self.assertIn('dt=2024-01-01,region=us', output)
                 self.assertNotIn('dt=2024-01-02', output)
 
+    def test_cli_table_read_format_json(self):
+        """Test table read with --format json output."""
+        import json
+        with patch('sys.argv',
+                   ['paimon', '-c', self.config_file,
+                    'table', 'read', 'test_db.users', '--format', 'json']):
+            with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+                output = mock_stdout.getvalue()
+                rows = json.loads(output)
+                self.assertIsInstance(rows, list)
+                self.assertGreaterEqual(len(rows), 5)
+                names = {r['name'] for r in rows}
+                self.assertIn('Alice', names)
+                self.assertIn('Bob', names)
+                for r in rows:
+                    self.assertIn('id', r)
+                    self.assertIn('name', r)
+                    self.assertIn('age', r)
+                    self.assertIn('city', r)
+
+    def test_cli_table_read_format_json_with_select(self):
+        """Test table read with --format json and --select."""
+        import json
+        with patch('sys.argv',
+                   ['paimon', '-c', self.config_file,
+                    'table', 'read', 'test_db.users',
+                    '--select', 'name,age', '--format', 'json']):
+            with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+                output = mock_stdout.getvalue()
+                rows = json.loads(output)
+                self.assertIsInstance(rows, list)
+                for r in rows:
+                    self.assertIn('name', r)
+                    self.assertIn('age', r)
+                    self.assertNotIn('id', r)
+                    self.assertNotIn('city', r)
+
+    def test_cli_table_list_partitions_format_json(self):
+        """Test list-partitions with --format json output."""
+        import json
+        self._create_partitioned_table()
+
+        with patch('sys.argv',
+                   ['paimon', '-c', self.config_file,
+                    'table', 'list-partitions', 'test_db.partitioned',
+                    '--format', 'json']):
+            with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+                try:
+                    main()
+                except SystemExit:
+                    pass
+
+                output = mock_stdout.getvalue()
+                rows = json.loads(output)
+                self.assertIsInstance(rows, list)
+                self.assertEqual(len(rows), 2)
+                for r in rows:
+                    self.assertIn('Partition', r)
+                    self.assertIn('RecordCount', r)
+                    self.assertIn('FileSizeInBytes', r)
+                    self.assertIn('FileCount', r)
+                partitions = {r['Partition'] for r in rows}
+                self.assertIn('dt=2024-01-01,region=us', partitions)
+                self.assertIn('dt=2024-01-02,region=eu', partitions)
+
     def test_cli_table_list_partitions_empty(self):
         """Test list-partitions on non-partitioned table (no snapshot = empty)."""
         # Create a table with no data


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->

Json is AI friendly.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
