### PR TITLE
[spark] Support AlwaysTrue and AlwaysFalse predicates in SparkFilterConverter

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkFilterConverter.java
@@ -23,6 +23,8 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
+import org.apache.spark.sql.sources.AlwaysFalse;
+import org.apache.spark.sql.sources.AlwaysTrue;
 import org.apache.spark.sql.sources.And;
 import org.apache.spark.sql.sources.EqualNullSafe;
 import org.apache.spark.sql.sources.EqualTo;
@@ -68,7 +70,9 @@ public class SparkFilterConverter {
                     "Not",
                     "StringStartsWith",
                     "StringEndsWith",
-                    "StringContains");
+                    "StringContains",
+                    "AlwaysTrue",
+                    "AlwaysFalse");
 
     private final RowType rowType;
     private final PredicateBuilder builder;
@@ -171,9 +175,12 @@ public class SparkFilterConverter {
             int index = fieldIndex(contains.attribute());
             Object literal = convertLiteral(index, contains.value());
             return builder.contains(index, literal);
+        } else if (filter instanceof AlwaysTrue) {
+            return builder.alwaysTrue();
+        } else if (filter instanceof AlwaysFalse) {
+            return builder.alwaysFalse();
         }
 
-        // TODO: AlwaysTrue, AlwaysFalse
         throw new UnsupportedOperationException(
                 filter + " is unsupported. Support Filters: " + SUPPORT_FILTERS);
     }

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkFilterConverterTest.java
@@ -31,6 +31,8 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
+import org.apache.spark.sql.sources.AlwaysFalse;
+import org.apache.spark.sql.sources.AlwaysTrue;
 import org.apache.spark.sql.sources.EqualNullSafe;
 import org.apache.spark.sql.sources.EqualTo;
 import org.apache.spark.sql.sources.GreaterThan;
@@ -227,6 +229,36 @@ public class SparkFilterConverterTest {
 
         assertThat(dateExpression).isEqualTo(rawExpression);
         assertThat(localDateExpression).isEqualTo(rawExpression);
+    }
+
+    @Test
+    public void testAlwaysTrue() {
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "id", new IntType())));
+        SparkFilterConverter converter = new SparkFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        AlwaysTrue alwaysTrue = AlwaysTrue.apply();
+        Predicate expectedAlwaysTrue = builder.alwaysTrue();
+        Predicate actualAlwaysTrue = converter.convert(alwaysTrue);
+        assertThat(actualAlwaysTrue).isEqualTo(expectedAlwaysTrue);
+        assertThat(actualAlwaysTrue.test(GenericRow.of(1))).isTrue();
+        assertThat(actualAlwaysTrue.test(GenericRow.of((Object) null))).isTrue();
+    }
+
+    @Test
+    public void testAlwaysFalse() {
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "id", new IntType())));
+        SparkFilterConverter converter = new SparkFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        AlwaysFalse alwaysFalse = AlwaysFalse.apply();
+        Predicate expectedAlwaysFalse = builder.alwaysFalse();
+        Predicate actualAlwaysFalse = converter.convert(alwaysFalse);
+        assertThat(actualAlwaysFalse).isEqualTo(expectedAlwaysFalse);
+        assertThat(actualAlwaysFalse.test(GenericRow.of(1))).isFalse();
+        assertThat(actualAlwaysFalse.test(GenericRow.of((Object) null))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Support AlwaysTrue and AlwaysFalse predicates in SparkFilterConverter

### Tests

CI
