### PR TITLE
[core] Fix an occasional bug in the use of DedicatedFormatRollingFileWriter

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/AppendOnlyWriter.java
@@ -310,8 +310,16 @@ public class AppendOnlyWriter implements BatchRecordWriter, MemoryOwner {
     }
 
     private RollingFileWriter<InternalRow, DataFileMeta> createRollingRowWriter() {
-        if (blobContext != null
-                || !fieldsInVectorFile(writeSchema, vectorFileFormat != null).isEmpty()) {
+        boolean hasVectorFields =
+                !fieldsInVectorFile(writeSchema, vectorFileFormat != null).isEmpty();
+        boolean useDedicatedWriter =
+                blobContext != null
+                        || (hasVectorFields
+                                && vectorFileFormat != null
+                                && !fileFormat
+                                        .getFormatIdentifier()
+                                        .equals(vectorFileFormat.getFormatIdentifier()));
+        if (useDedicatedWriter) {
             return new DedicatedFormatRollingFileWriter(
                     fileIO,
                     schemaId,


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Occasional test errors in **AppendOnlyWriterTest.testVectorStoreSameFormatUsesRowDataWriter**：

Error:  Failures: 
Error:    AppendOnlyWriterTest.testVectorStoreSameFormatUsesRowDataWriter:600 

Expected size: 1 but was: 2 in:
[{fileName: data-ff992cd8-d03b-4b40-b7ec-53e6839e7b1d-0.avro, fileSize: 299, rowCount: 1, embeddedIndex: null, minKey: org.apache.paimon.data.BinaryRow@9c67b85d, maxKey: org.apache.paimon.data.BinaryRow@9c67b85d, keyStats: org.apache.paimon.stats.SimpleStats@ae52951c, valueStats: org.apache.paimon.stats.SimpleStats@97a4a93b, minSequenceNumber: 0, maxSequenceNumber: 0, schemaId: 0, level: 0, extraFiles: [], creationTime: 2026-03-18T17:38:20.841, deleteRowCount: 0, fileSource: APPEND, valueStatsCols: null, externalPath: null, firstRowId: null, writeCols: [id, name]},
    {fileName: data-ff992cd8-d03b-4b40-b7ec-53e6839e7b1d-1.vector.avro, fileSize: 293, rowCount: 1, embeddedIndex: null, minKey: org.apache.paimon.data.BinaryRow@9c67b85d, maxKey: org.apache.paimon.data.BinaryRow@9c67b85d, keyStats: org.apache.paimon.stats.SimpleStats@ae52951c, valueStats: org.apache.paimon.stats.SimpleStats@8d0f5c3, minSequenceNumber: 0, maxSequenceNumber: 0, schemaId: 0, level: 0, extraFiles: [], creationTime: 2026-03-18T17:38:20.844, deleteRowCount: 0, fileSource: APPEND, valueStatsCols: null, externalPath: null, firstRowId: null, writeCols: [embed]}]


Cause analysis：

When vectorFileFormat and fileFormat are the same (both AVRO), the system should use a regular RowDataRollingFileWriter to write data, producing only one file. However, the original code did not check whether the two formats were the same; it used DedicatedFormatRollingFileWriter whenever there was a vector field, resulting in two files (one regular file and one file with the .vector extension).

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
AppendOnlyWriterTest.testVectorStoreSameFormatUsesRowDataWriter

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
