### PR TITLE
[parquet]: Cache requestedSchema and fields in ParquetReaderFactory to avoid redundant computation

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -57,7 +57,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.paimon.data.variant.VariantMetadataUtils.path;
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.PAIMON_SCHEMA;
@@ -80,17 +82,17 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     @Nullable private final FilterCompat.Filter filter;
 
     /**
-     * Cached requestedSchema derived from the read type. Since this factory instance is bound to a
-     * fixed read type (set at construction time) and the underlying file schema for a given schema
-     * version is immutable, the clipped schema only needs to be computed once per instance.
+     * Cache: fileSchema -> (requestedSchema, parquetFields).
+     *
+     * <p>Within one factory instance the readType is fixed, so the result of {@code
+     * clipParquetSchema(fileSchema)} is deterministic for a given {@code fileSchema}. Most
+     * Paimon-written files sharing the same schema version will have identical file schemas, so the
+     * cache will almost always have at most one entry. Keying by the actual {@code fileSchema}
+     * (rather than assuming all files have the same schema) keeps correctness for edge cases such
+     * as externally-migrated Parquet files whose on-disk schema may vary.
      */
-    @Nullable private volatile MessageType cachedRequestedSchema;
-
-    /**
-     * Cached ParquetField list corresponding to {@link #cachedRequestedSchema}. Computed together
-     * with the schema on first read and reused for all subsequent files.
-     */
-    @Nullable private volatile List<ParquetField> cachedFields;
+    private final Map<MessageType, Pair<MessageType, List<ParquetField>>> schemaCache =
+            new ConcurrentHashMap<>();
 
     public ParquetReaderFactory(
             Options conf, RowType readType, int batchSize, @Nullable FilterCompat.Filter filter) {
@@ -116,19 +118,23 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                         context.selection());
         MessageType fileSchema = reader.getFileMetaData().getSchema();
 
-        // Compute requestedSchema and fields once per factory instance and cache them.
-        // This factory is bound to a fixed readType and is reused across multiple files that share
-        // the same schema version (via KeyValueFileReaderFactory.formatReaderMappings), so the
-        // clipped schema and field list only need to be computed on the first file read.
-        MessageType requestedSchema = cachedRequestedSchema;
-        List<ParquetField> fields = cachedFields;
-        if (requestedSchema == null) {
-            requestedSchema = clipParquetSchema(fileSchema);
-            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(requestedSchema);
-            fields = buildFieldsList(readFields, columnIO, requestedSchema);
-            cachedRequestedSchema = requestedSchema;
-            cachedFields = fields;
-        }
+        // clipParquetSchema and buildFieldsList are pure functions of (readFields, fileSchema).
+        // Cache the result keyed by fileSchema so that files sharing the same on-disk schema
+        // within this factory instance avoid redundant computation. Keying by fileSchema (rather
+        // than a simple "compute once" flag) correctly handles edge cases where different files
+        // read by the same factory instance may have different on-disk schemas, e.g. externally
+        // migrated Parquet files.
+        Pair<MessageType, List<ParquetField>> cached =
+                schemaCache.computeIfAbsent(
+                        fileSchema,
+                        fs -> {
+                            MessageType rs = clipParquetSchema(fs);
+                            MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(rs);
+                            List<ParquetField> f = buildFieldsList(readFields, columnIO, rs);
+                            return Pair.of(rs, f);
+                        });
+        MessageType requestedSchema = cached.getLeft();
+        List<ParquetField> fields = cached.getRight();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSchemaCacheTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSchemaCacheTest.java
@@ -31,24 +31,24 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.apache.parquet.filter2.compat.FilterCompat;
-import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.lang.reflect.Field;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for the instance-level schema cache in {@link ParquetReaderFactory}.
+ * Tests for the schema cache in {@link ParquetReaderFactory}.
  *
- * <p>The cache stores the computed {@code requestedSchema} and {@code fields} list on the first
- * file read and reuses them for all subsequent reads on the same factory instance. This avoids
- * re-running {@code clipParquetSchema} and {@code buildFieldsList} for every file.
+ * <p>The cache stores the computed {@code requestedSchema} and {@code fields} list keyed by the
+ * actual {@code fileSchema} read from the Parquet footer. This avoids re-running {@code
+ * clipParquetSchema} and {@code buildFieldsList} for every file that shares the same on-disk schema
+ * within one factory instance.
  */
 public class ParquetSchemaCacheTest {
 
@@ -58,16 +58,15 @@ public class ParquetSchemaCacheTest {
     @TempDir public File folder;
 
     // -------------------------------------------------------------------------
-    // Cache population: verify fields are null before first read, non-null after
+    // Cache population: empty before first read, one entry after
     // -------------------------------------------------------------------------
 
     @Test
-    void testCacheIsNullBeforeFirstRead() throws Exception {
+    void testCacheIsEmptyBeforeFirstRead() throws Exception {
         ParquetReaderFactory factory =
                 new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
 
-        assertThat(getCachedRequestedSchema(factory)).isNull();
-        assertThat(getCachedFields(factory)).isNull();
+        assertThat(getSchemaCacheSize(factory)).isEqualTo(0);
     }
 
     @Test
@@ -79,16 +78,15 @@ public class ParquetSchemaCacheTest {
 
         readAll(factory, path);
 
-        assertThat(getCachedRequestedSchema(factory)).isNotNull();
-        assertThat(getCachedFields(factory)).isNotNull();
+        assertThat(getSchemaCacheSize(factory)).isEqualTo(1);
     }
 
     // -------------------------------------------------------------------------
-    // Cache reuse: same instance object is returned on subsequent reads
+    // Cache reuse: same fileSchema produces only one cache entry
     // -------------------------------------------------------------------------
 
     @Test
-    void testCachedSchemaIsReusedAcrossMultipleFiles() throws Exception {
+    void testSameFileSchemaCausesOnlyOneCacheEntry() throws Exception {
         Path path1 = writeSingleFile();
         Path path2 = writeSingleFile();
         Path path3 = writeSingleFile();
@@ -97,19 +95,15 @@ public class ParquetSchemaCacheTest {
                 new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
 
         readAll(factory, path1);
-        MessageType schemaAfterFirst = getCachedRequestedSchema(factory);
-        List<?> fieldsAfterFirst = getCachedFields(factory);
-
         readAll(factory, path2);
         readAll(factory, path3);
 
-        // The exact same object instances must be reused (reference equality)
-        assertThat(getCachedRequestedSchema(factory)).isSameAs(schemaAfterFirst);
-        assertThat(getCachedFields(factory)).isSameAs(fieldsAfterFirst);
+        // All files have the same on-disk schema → only one cache entry
+        assertThat(getSchemaCacheSize(factory)).isEqualTo(1);
     }
 
     // -------------------------------------------------------------------------
-    // Correctness: data is read correctly both with and without cache
+    // Correctness: data is read correctly both on cold and warm cache
     // -------------------------------------------------------------------------
 
     @Test
@@ -119,7 +113,6 @@ public class ParquetSchemaCacheTest {
         ParquetReaderFactory factory =
                 new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
 
-        // First read - cache is cold
         assertThat(countRows(factory, path)).isEqualTo(3);
     }
 
@@ -130,9 +123,7 @@ public class ParquetSchemaCacheTest {
         ParquetReaderFactory factory =
                 new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
 
-        // First read populates cache
         assertThat(countRows(factory, path)).isEqualTo(3);
-        // Second and third reads use cache
         assertThat(countRows(factory, path)).isEqualTo(3);
         assertThat(countRows(factory, path)).isEqualTo(3);
     }
@@ -162,12 +153,10 @@ public class ParquetSchemaCacheTest {
         ParquetReaderFactory factory2 =
                 new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
 
-        // Read only via factory1
         readAll(factory1, path);
 
-        assertThat(getCachedRequestedSchema(factory1)).isNotNull();
-        // factory2 cache must remain untouched
-        assertThat(getCachedRequestedSchema(factory2)).isNull();
+        assertThat(getSchemaCacheSize(factory1)).isEqualTo(1);
+        assertThat(getSchemaCacheSize(factory2)).isEqualTo(0);
     }
 
     // -------------------------------------------------------------------------
@@ -209,16 +198,10 @@ public class ParquetSchemaCacheTest {
         return cnt.get();
     }
 
-    private MessageType getCachedRequestedSchema(ParquetReaderFactory factory) throws Exception {
-        Field field = ParquetReaderFactory.class.getDeclaredField("cachedRequestedSchema");
+    private int getSchemaCacheSize(ParquetReaderFactory factory) throws Exception {
+        Field field = ParquetReaderFactory.class.getDeclaredField("schemaCache");
         field.setAccessible(true);
-        return (MessageType) field.get(factory);
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<?> getCachedFields(ParquetReaderFactory factory) throws Exception {
-        Field field = ParquetReaderFactory.class.getDeclaredField("cachedFields");
-        field.setAccessible(true);
-        return (List<?>) field.get(factory);
+        Map<?, ?> cache = (Map<?, ?>) field.get(factory);
+        return cache.size();
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
  The clipped Parquet schema (requestedSchema) and its corresponding
  ParquetField list are recomputed on every file read via clipParquetSchema()
  and buildFieldsList(), even though the result is identical for all files
  sharing the same schema version.

  Since ParquetReaderFactory is bound to a fixed readType at construction
  time and is reused across multiple files with the same schema version
  (via KeyValueFileReaderFactory.formatReaderMappings), the result only
  needs to be computed once. Add two volatile instance fields to cache the
  result on the first read and reuse them for all subsequent reads.

<!-- Linking this pull request to the issue -->
Linked issue: close #7281 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
CI
