### PR TITLE
[core] validate retained global index row ranges

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
@@ -20,8 +20,10 @@ package org.apache.paimon.manifest;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.DeletionVectorMeta;
+import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.table.BucketMode;
+import org.apache.paimon.utils.Range;
 
 import javax.annotation.Nullable;
 
@@ -93,7 +95,7 @@ public class IndexManifestFileHandler {
 
     private IndexManifestFileCombiner getIndexManifestFileCombine(String indexType) {
         if (!DELETION_VECTORS_INDEX.equals(indexType) && !HASH_INDEX.equals(indexType)) {
-            return new GlobalFileNameCombiner();
+            return new GlobalIndexCombiner();
         }
 
         if (DELETION_VECTORS_INDEX.equals(indexType) && BucketMode.BUCKET_UNAWARE == bucketMode) {
@@ -197,7 +199,7 @@ public class IndexManifestFileHandler {
     }
 
     /** We combine the previous and new index files by file name. */
-    static class GlobalFileNameCombiner implements IndexManifestFileCombiner {
+    static class GlobalIndexCombiner implements IndexManifestFileCombiner {
 
         @Override
         public List<IndexManifestEntry> combine(
@@ -219,10 +221,49 @@ public class IndexManifestFileHandler {
             for (IndexManifestEntry entry : removed) {
                 indexEntries.remove(entry.indexFile().fileName());
             }
+            validateRetainedIndexFiles(indexEntries.values(), added);
             for (IndexManifestEntry entry : added) {
                 indexEntries.put(entry.indexFile().fileName(), entry);
             }
             return new ArrayList<>(indexEntries.values());
+        }
+
+        private void validateRetainedIndexFiles(
+                Iterable<IndexManifestEntry> retainedIndexFiles,
+                List<IndexManifestEntry> addedIndexFiles) {
+            for (IndexManifestEntry retained : retainedIndexFiles) {
+                GlobalIndexMeta retainedMeta = retained.indexFile().globalIndexMeta();
+                if (retainedMeta == null) {
+                    continue;
+                }
+
+                for (IndexManifestEntry added : addedIndexFiles) {
+                    GlobalIndexMeta addedMeta = added.indexFile().globalIndexMeta();
+                    if (addedMeta == null
+                            || retainedMeta.indexFieldId() != addedMeta.indexFieldId()
+                            || !Range.intersect(
+                                    retainedMeta.rowRangeStart(),
+                                    retainedMeta.rowRangeEnd(),
+                                    addedMeta.rowRangeStart(),
+                                    addedMeta.rowRangeEnd())) {
+                        continue;
+                    }
+
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Trying to add global index file %s of type %s for index field %s"
+                                            + " with row range [%s, %s], but previous file %s still exists"
+                                            + " with overlapping row range [%s, %s]. Remove the previous file first.",
+                                    added.indexFile().fileName(),
+                                    added.indexFile().indexType(),
+                                    addedMeta.indexFieldId(),
+                                    addedMeta.rowRangeStart(),
+                                    addedMeta.rowRangeEnd(),
+                                    retained.indexFile().fileName(),
+                                    retainedMeta.rowRangeStart(),
+                                    retainedMeta.rowRangeEnd()));
+                }
+            }
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestFileHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/IndexManifestFileHandlerTest.java
@@ -21,6 +21,8 @@ package org.apache.paimon.manifest;
 import org.apache.paimon.TestAppendFileStore;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.table.BucketMode;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +34,7 @@ import java.util.List;
 
 import static org.apache.paimon.index.IndexFileMetaSerializerTest.randomDeletionVectorIndexFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for IndexManifestFileHandler. */
 public class IndexManifestFileHandlerTest {
@@ -113,5 +116,114 @@ public class IndexManifestFileHandlerTest {
         assertThat(entries.contains(entry2)).isFalse();
         assertThat(entries.contains(entry3)).isTrue();
         assertThat(entries.contains(entry4)).isTrue();
+    }
+
+    @Test
+    public void testGlobalIndexOverlappingRangeRejectedWhenPreviousFileKept() throws Exception {
+        TestAppendFileStore fileStore =
+                TestAppendFileStore.createAppendStore(tempDir, new HashMap<>());
+
+        IndexManifestFile indexManifestFile = createIndexManifestFile(fileStore);
+        IndexManifestFileHandler indexManifestFileHandler =
+                new IndexManifestFileHandler(indexManifestFile, BucketMode.BUCKET_UNAWARE);
+
+        IndexManifestEntry previous = globalIndexEntry("prev-index", 0, 99, 1);
+        String manifestFileName = indexManifestFileHandler.write(null, Arrays.asList(previous));
+
+        IndexManifestEntry added = globalIndexEntry("new-index", 50, 149, 1);
+        assertThatThrownBy(
+                        () ->
+                                indexManifestFileHandler.write(
+                                        manifestFileName, Arrays.asList(added)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("prev-index")
+                .hasMessageContaining("new-index")
+                .hasMessageContaining("overlapping row range");
+    }
+
+    @Test
+    public void testGlobalIndexOverlappingRangeAllowedAfterDelete() throws Exception {
+        TestAppendFileStore fileStore =
+                TestAppendFileStore.createAppendStore(tempDir, new HashMap<>());
+
+        IndexManifestFile indexManifestFile = createIndexManifestFile(fileStore);
+        IndexManifestFileHandler indexManifestFileHandler =
+                new IndexManifestFileHandler(indexManifestFile, BucketMode.BUCKET_UNAWARE);
+
+        IndexManifestEntry previous = globalIndexEntry("prev-index", 0, 99, 1);
+        String manifestFileName = indexManifestFileHandler.write(null, Arrays.asList(previous));
+
+        IndexManifestEntry added = globalIndexEntry("new-index", 50, 149, 1);
+        String newManifestFileName =
+                indexManifestFileHandler.write(
+                        manifestFileName, Arrays.asList(previous.toDeleteEntry(), added));
+
+        List<IndexManifestEntry> entries = indexManifestFile.read(newManifestFileName);
+        assertThat(entries).containsExactly(added);
+    }
+
+    @Test
+    public void testGlobalIndexOverlappingRangeAllowedForDifferentFieldId() throws Exception {
+        TestAppendFileStore fileStore =
+                TestAppendFileStore.createAppendStore(tempDir, new HashMap<>());
+
+        IndexManifestFile indexManifestFile = createIndexManifestFile(fileStore);
+        IndexManifestFileHandler indexManifestFileHandler =
+                new IndexManifestFileHandler(indexManifestFile, BucketMode.BUCKET_UNAWARE);
+
+        IndexManifestEntry previous = globalIndexEntry("prev-index", 0, 99, 1);
+        String manifestFileName = indexManifestFileHandler.write(null, Arrays.asList(previous));
+
+        IndexManifestEntry added = globalIndexEntry("new-index", 50, 149, 2);
+        String newManifestFileName =
+                indexManifestFileHandler.write(manifestFileName, Arrays.asList(added));
+
+        List<IndexManifestEntry> entries = indexManifestFile.read(newManifestFileName);
+        assertThat(entries).containsExactlyInAnyOrder(previous, added);
+    }
+
+    @Test
+    public void testGlobalIndexNonOverlappingRangeAllowedForSameFieldId() throws Exception {
+        TestAppendFileStore fileStore =
+                TestAppendFileStore.createAppendStore(tempDir, new HashMap<>());
+
+        IndexManifestFile indexManifestFile = createIndexManifestFile(fileStore);
+        IndexManifestFileHandler indexManifestFileHandler =
+                new IndexManifestFileHandler(indexManifestFile, BucketMode.BUCKET_UNAWARE);
+
+        IndexManifestEntry previous = globalIndexEntry("prev-index", 0, 99, 1);
+        String manifestFileName = indexManifestFileHandler.write(null, Arrays.asList(previous));
+
+        IndexManifestEntry added = globalIndexEntry("new-index", 100, 199, 1);
+        String newManifestFileName =
+                indexManifestFileHandler.write(manifestFileName, Arrays.asList(added));
+
+        List<IndexManifestEntry> entries = indexManifestFile.read(newManifestFileName);
+        assertThat(entries).containsExactlyInAnyOrder(previous, added);
+    }
+
+    private IndexManifestFile createIndexManifestFile(TestAppendFileStore fileStore) {
+        return new IndexManifestFile.Factory(
+                        fileStore.fileIO(),
+                        FileFormat.manifestFormat(fileStore.options()),
+                        "zstd",
+                        fileStore.pathFactory(),
+                        null)
+                .create();
+    }
+
+    private IndexManifestEntry globalIndexEntry(
+            String fileName, long rowRangeStart, long rowRangeEnd, int indexFieldId) {
+        return new IndexManifestEntry(
+                FileKind.ADD,
+                BinaryRow.EMPTY_ROW,
+                0,
+                new IndexFileMeta(
+                        "btree",
+                        fileName,
+                        1L,
+                        rowRangeEnd - rowRangeStart + 1,
+                        new GlobalIndexMeta(rowRangeStart, rowRangeEnd, indexFieldId, null, null),
+                        null));
     }
 }


### PR DESCRIPTION
## Summary
- validate retained global index files against overlapping row ranges before merging new index manifest entries
- allow replacing an overlapping global index range when the previous file is deleted in the same commit
- add coverage for overlapping, non-overlapping, and different-field-id cases in `IndexManifestFileHandlerTest`

## Testing
- `mvn -pl paimon-core -am -DfailIfNoTests=false -Dcheckstyle.skip -Dspotless.check.skip -Denforcer.skip -Dtest=IndexManifestFileHandlerTest test`

## AI Disclosure
This PR was mainly written by Codex/GPT-5.4.
