### PR TITLE
[python] Fix null partition value causing TypeError in manifest stats calculation

### DIFF
--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -404,6 +404,53 @@ class TestFileStoreCommit(unittest.TestCase):
         # Verify results
         self.assertEqual(len(statistics), 0)
 
+    def test_null_partition_value(
+            self, mock_manifest_list_manager, mock_manifest_file_manager, mock_snapshot_manager):
+        from pypaimon.data.timestamp import Timestamp
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        from pypaimon.schema.data_types import DataField, AtomicType
+
+        file_store_commit = self._create_file_store_commit()
+        self.mock_table.partition_keys = ['dt']
+        self.mock_table.partition_keys_fields = [
+            DataField(0, 'dt', AtomicType('STRING'))
+        ]
+        self.mock_table.table_schema = Mock()
+        self.mock_table.table_schema.id = 0
+
+        file_store_commit.manifest_file_manager = Mock()
+        file_store_commit.manifest_file_manager.manifest_path = '/test/manifest'
+        self.mock_table.file_io.get_file_size.return_value = 1024
+
+        creation_time = Timestamp.from_local_date_time(datetime(2024, 1, 15, 10, 30, 0))
+
+        def make_file(name):
+            return DataFileMeta.create(
+                file_name=name,
+                file_size=1024,
+                row_count=100,
+                min_key=GenericRow([], []),
+                max_key=GenericRow([], []),
+                key_stats=SimpleStats.empty_stats(),
+                value_stats=SimpleStats.empty_stats(),
+                min_sequence_number=1,
+                max_sequence_number=10,
+                schema_id=0,
+                level=0,
+                extra_files=[],
+                creation_time=creation_time,
+            )
+
+        entries = [
+            ManifestEntry(kind=0, partition=GenericRow([None], None), bucket=0, total_buckets=None,
+                          file=make_file("f1.parquet")),
+            ManifestEntry(kind=0, partition=GenericRow(['2024-01-15'], None), bucket=0, total_buckets=None,
+                          file=make_file("f2.parquet")),
+        ]
+
+        result = file_store_commit._write_manifest_file(entries, "manifest-test")
+        self.assertIsNotNone(result)
+
     @staticmethod
     def _to_entries(commit_messages):
         commit_entries = []

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -437,11 +437,13 @@ class FileStoreCommit:
 
         # Calculate partition statistics
         partition_columns = list(zip(*(entry.partition.values for entry in commit_entries)))
-        partition_min_stats = [min(col) for col in partition_columns]
-        partition_max_stats = [max(col) for col in partition_columns]
-        partition_null_counts = [sum(value == 0 for value in col) for col in partition_columns]
-        if not all(count == 0 for count in partition_null_counts):
-            raise RuntimeError("Partition value should not be null")
+        partition_null_counts = [sum(1 for value in col if value is None) for col in partition_columns]
+        partition_min_stats = [
+            min((v for v in col if v is not None), default=None) for col in partition_columns
+        ]
+        partition_max_stats = [
+            max((v for v in col if v is not None), default=None) for col in partition_columns
+        ]
 
         # Calculate min_row_id and max_row_id from commit_entries
         min_row_id = None


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Follow-up to #7472 which fixed reading null/empty partition values. While investigating, we found that writing null partition values also fails in pypaimon. `_write_manifest_file raises TypeError: '<' not supported between instances of 'str' and 'NoneType'` This PR will fixed by processing null value when stats calculation

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
