### PR TITLE
[docs][flink] Add guide for self-merge use case and minor fix.

### DIFF
--- a/docs/content/append-table/data-evolution.md
+++ b/docs/content/append-table/data-evolution.md
@@ -114,6 +114,43 @@ SELECT * FROM source_table
 Note that:
 * Compared to Spark implementation, Flink data_evolution_merge_into procedure only supports updating/inserting new columns now. Inserting new rows is not supported yet.
 
+#### Self Merge
+
+Self-merge refers to the case where the source and target of the merge operation are the **same table**. This is useful
+when you want to transform existing column values in place — for example, applying a UDF to rewrite a column.
+
+Since the source table cannot be the same as the target table directly, you need to create a **temporary view** based on
+the system table `T$row_tracking` (which exposes the hidden `_ROW_ID` column) and use `_ROW_ID` as the merge condition.
+
+```sql
+-- 1. Register a UDF
+CREATE TEMPORARY FUNCTION concat_string AS 'com.example.StringConcatUdf';
+
+-- 2. Create a view from the row-tracking system table
+CREATE TEMPORARY VIEW source_view AS
+SELECT _ROW_ID, concat_string(name) AS name
+FROM my_db.target_table$row_tracking;
+
+-- 3. Self-merge: update the name column using the UDF result
+CALL sys.data_evolution_merge_into(
+    'my_db.target_table',
+    'TempT',
+    -- alternatively, you could also pass the create sqls in procedure directly
+    -- like: 'CREATE TEMPORARY FUNCTION concat_string AS ''com.example.StringConcatUdf''; CREATE TEMPORARY VIEW XXX'
+    '',
+    'source_view',
+    'TempT._ROW_ID=source_view._ROW_ID',
+    'name=source_view.name',
+    2
+);
+```
+
+Note that:
+* The source and target table name cannot be the same. You must create a temporary view as the source.
+* use `view._ROW_ID` = `source._ROW_ID` to identify the self-merge pattern.
+* `_ROW_ID` is only available via the `$row_tracking` system table.
+* Self-merge only supports `WHEN MATCHED THEN UPDATE` semantics.
+
 ## File Group Spec
 
 Through the RowId metadata, files are organized into a file group.

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -234,6 +234,14 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
     }
 
     public Tuple2<DataStream<RowData>, RowType> buildSource() {
+        if (targetTableName().equals(sourceTableName())) {
+            throw new RuntimeException(
+                    String.format(
+                            "Source table '%s' and target table '%s' are the same, not permitted now."
+                                    + "Please lookup docs for how to merge on self.",
+                            sourceTableName(), targetTableName()));
+        }
+
         // handle sqls
         handleSqls();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionPartialWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionPartialWriteOperator.java
@@ -76,9 +76,9 @@ public class DataEvolutionPartialWriteOperator
     // data type excludes of _ROW_ID field.
     private final RowType writeType;
 
-    private List<Committable> committables = new ArrayList<>();
-
     // --------------------- transient fields ---------------------------
+
+    private transient List<Committable> committables;
 
     // first-row-id related fields
     private transient FirstRowIdLookup firstRowIdLookup;
@@ -137,6 +137,8 @@ public class DataEvolutionPartialWriteOperator
                 (TableWriteImpl<InternalRow>)
                         table.newBatchWriteBuilder().newWrite().withWriteType(writeType);
         tableWrite = (AbstractFileStoreWrite<InternalRow>) (writeImpl.getWrite());
+
+        committables = new ArrayList<>();
     }
 
     @Override
@@ -298,24 +300,28 @@ public class DataEvolutionPartialWriteOperator
                             writtenNum, rowCount));
 
             // 2. finish writer
-            CommitIncrement written = writer.prepareCommit(false);
-            List<DataFileMeta> fileMetas = written.newFilesIncrement().newFiles();
-            Preconditions.checkState(
-                    fileMetas.size() == 1, "This is a bug, Writer could only produce one file");
-            DataFileMeta fileMeta = fileMetas.get(0).assignFirstRowId(firstRowId);
+            try {
+                CommitIncrement written = writer.prepareCommit(false);
+                List<DataFileMeta> fileMetas = written.newFilesIncrement().newFiles();
+                Preconditions.checkState(
+                        fileMetas.size() == 1, "This is a bug, Writer could only produce one file");
+                DataFileMeta fileMeta = fileMetas.get(0).assignFirstRowId(firstRowId);
 
-            CommitMessage commitMessage =
-                    new CommitMessageImpl(
-                            partition,
-                            0,
-                            null,
-                            new DataIncrement(
-                                    Collections.singletonList(fileMeta),
-                                    Collections.emptyList(),
-                                    Collections.emptyList()),
-                            CompactIncrement.emptyIncrement());
+                CommitMessage commitMessage =
+                        new CommitMessageImpl(
+                                partition,
+                                0,
+                                null,
+                                new DataIncrement(
+                                        Collections.singletonList(fileMeta),
+                                        Collections.emptyList(),
+                                        Collections.emptyList()),
+                                CompactIncrement.emptyIncrement());
 
-            return new Committable(Long.MAX_VALUE, commitMessage);
+                return new Committable(Long.MAX_VALUE, commitMessage);
+            } finally {
+                writer.close();
+            }
         }
 
         private boolean contains(long rowId) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/FirstRowIdAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/FirstRowIdAssigner.java
@@ -29,6 +29,8 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -37,6 +39,8 @@ import java.util.List;
  * out.
  */
 public class FirstRowIdAssigner extends RichFlatMapFunction<RowData, Tuple2<Long, RowData>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FirstRowIdAssigner.class);
 
     private final FirstRowIdLookup firstRowIdLookup;
     private final long maxRowId;
@@ -55,6 +59,8 @@ public class FirstRowIdAssigner extends RichFlatMapFunction<RowData, Tuple2<Long
         long rowId = value.getLong(rowIdFieldIndex);
         if (rowId >= 0 && rowId <= maxRowId) {
             out.collect(new Tuple2<>(firstRowIdLookup.lookup(rowId), value));
+        } else {
+            LOG.warn("Invalid Row id {} is out of range [0, {}].", rowId, maxRowId);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.table.FileStoreTable;
 
+import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -469,6 +470,67 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
 
         testBatchRead(
                 "SELECT id, name, `value` FROM T$row_tracking where _ROW_ID in (1, 2, 3, 7, 8, 11, 15, 18)",
+                expected);
+    }
+
+    @ParameterizedTest(name = "use default db = {0}, invoker - {1}")
+    @MethodSource("testArguments")
+    public void testSelfMerge(boolean inDefault, String invoker) throws Exception {
+        String targetDb = inDefault ? database : "test_db";
+        if (!inDefault) {
+            // create target table in a new database
+            sEnv.executeSql("DROP TABLE T");
+            sEnv.executeSql("CREATE DATABASE test_db");
+            sEnv.executeSql("USE test_db");
+            bEnv.executeSql("USE test_db");
+            prepareTargetTable();
+        }
+
+        List<Row> expected =
+                Arrays.asList(
+                        changelogRow("+I", 2, "name2_test_udf"),
+                        changelogRow("+I", 3, "name3_test_udf"),
+                        changelogRow("+I", 4, "name4_test_udf"),
+                        changelogRow("+I", 8, "name8_test_udf"),
+                        changelogRow("+I", 9, "name9_test_udf"),
+                        changelogRow("+I", 12, "name12_test_udf"),
+                        changelogRow("+I", 16, "name16_test_udf"),
+                        changelogRow("+I", 19, "name19_test_udf"));
+
+        String udfName =
+                "org.apache.paimon.flink.action.DataEvolutionMergeIntoActionITCase$StringConcatUdf";
+        String createFuncSql = "CREATE TEMPORARY FUNCTION concat_string AS";
+        String createViewSql =
+                String.format(
+                        "CREATE TEMPORARY VIEW SS AS SELECT _ROW_ID, concat_string(name) AS name FROM `%s`.`T$row_tracking`",
+                        targetDb);
+        if (invoker.equals("action")) {
+            DataEvolutionMergeIntoActionBuilder builder =
+                    builder(warehouse, targetDb, "T")
+                            .withMergeCondition("TempT._ROW_ID=SS._ROW_ID")
+                            .withMatchedUpdateSet("TempT.name=SS.name")
+                            .withSourceTable("SS")
+                            .withTargetAlias("TempT")
+                            .withSourceSqls(
+                                    String.format("%s '%s'", createFuncSql, udfName), createViewSql)
+                            .withSinkParallelism(2);
+
+            builder.build().run();
+        } else {
+            String procedureStatement =
+                    String.format(
+                            "CALL sys.data_evolution_merge_into('%s.T', 'TempT', '%s',"
+                                    + " 'SS', 'TempT._ROW_ID=SS._ROW_ID', 'name=SS.name', 2)",
+                            targetDb,
+                            String.format("%s ''%s''", createFuncSql, udfName)
+                                    + ";"
+                                    + createViewSql);
+
+            executeSQL(procedureStatement, false, true);
+        }
+
+        testBatchRead(
+                "SELECT id, name FROM T$row_tracking where _ROW_ID in (1, 2, 3, 7, 8, 11, 15, 18)",
                 expected);
     }
 
@@ -919,5 +981,13 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
             hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
         }
         return new String(hexChars);
+    }
+
+    /** The test udf to test udf in merge into situation. */
+    public static class StringConcatUdf extends ScalarFunction {
+
+        public String eval(String input) {
+            return input + "_test_udf";
+        }
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
This PR add the docs about how to use flink merge into procedure on data evolution tables with self-merge pattern.
The motivation is like `Update T.img = clean_udf(T.img)` with paimon's data-evolution feature.
<!-- Linking this pull request to the issue -->


<!-- What is the purpose of the change -->

### Tests
Add a test: `org.apache.paimon.flink.action.DataEvolutionMergeIntoActionITCase#testSelfMerge`
<!-- List UT and IT cases to verify this change -->

### API and Format
None
<!-- Does this change affect API or storage format -->

### Documentation
update the data-evolution page
<!-- Does this change introduce a new feature -->

### Generative AI tooling
None
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
