### PR TITLE
[spark] Fix V1 DELETE statement incorrectly removing rows with NULL values

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DeleteFromPaimonTableCommand.scala
@@ -27,7 +27,7 @@ import org.apache.paimon.types.RowKind
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils.createDataset
-import org.apache.spark.sql.catalyst.expressions.{Expression, Not}
+import org.apache.spark.sql.catalyst.expressions.{EqualNullSafe, Expression, Literal, Not}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, SupportsSubquery}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.functions.lit
@@ -92,7 +92,11 @@ case class DeleteFromPaimonTableCommand(
         extractFilesAndCreateNewScan(touchedFilePaths, dataFilePathToMeta, relation)
 
       // Step4: build a dataframe that contains the unchanged data, and write out them.
-      val toRewriteScanRelation = Filter(Not(condition), newRelation)
+      // Use Not(EqualNullSafe(condition, true)) instead of Not(condition) to correctly
+      // handle NULL values. Not(NULL) evaluates to NULL (filtered out), which would
+      // incorrectly delete rows where the condition column is NULL.
+      val toRewriteScanRelation =
+        Filter(Not(EqualNullSafe(condition, Literal.TrueLiteral)), newRelation)
       var data = createDataset(sparkSession, toRewriteScanRelation)
       if (coreOptions.rowTrackingEnabled()) {
         data = selectWithRowTracking(data)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DeleteFromTableTestBase.scala
@@ -531,4 +531,44 @@ abstract class DeleteFromTableTestBase extends PaimonSparkTestBase {
       )
     }
   }
+
+  test("Paimon Delete: delete should not remove rows with NULL in condition column") {
+    // Verifies that DELETE WHERE col = value does not incorrectly remove rows
+    // where col IS NULL. This tests the fix for the NULL handling bug where
+    // Not(condition) was used instead of Not(EqualNullSafe(condition, true)).
+    for (dvEnabled <- Seq(true, false)) {
+      withTable("t") {
+        sql(
+          s"CREATE TABLE t (id INT, name STRING) TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')")
+        sql("INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, NULL), (4, 'a'), (5, NULL), (6, 'c')")
+
+        sql("DELETE FROM t WHERE name = 'a'")
+
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(2, "b"), Row(3, null), Row(5, null), Row(6, "c"))
+        )
+      }
+    }
+  }
+
+  test("Paimon Delete: delete with NULL in condition column for partitioned table") {
+    for (dvEnabled <- Seq(true, false)) {
+      withTable("t") {
+        sql(s"""CREATE TABLE t (id INT, name STRING, pt STRING)
+               |PARTITIONED BY (pt)
+               |TBLPROPERTIES ('deletion-vectors.enabled' = '$dvEnabled')
+               |""".stripMargin)
+        sql(
+          "INSERT INTO t VALUES (1, 'a', 'p1'), (2, NULL, 'p1'), (3, 'b', 'p1'), (4, NULL, 'p2'), (5, 'a', 'p2')")
+
+        sql("DELETE FROM t WHERE name = 'a'")
+
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(2, null, "p1"), Row(3, "b", "p1"), Row(4, null, "p2"))
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Purpose

Fix V1 DELETE statement incorrectly removing rows with NULL values

### Tests

CI