### PR TITLE
[core] Add VARCHAR check for FieldListaggAgg

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -50,7 +50,6 @@ public class FieldListaggAgg extends FieldAggregator {
         }
         // ordered by type root definition
 
-        // TODO: ensure not VARCHAR(n)
         BinaryString mergeFieldSD = (BinaryString) accumulator;
         BinaryString inFieldSD = (BinaryString) inputField;
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldListaggAggFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldListaggAggFactory.java
@@ -36,7 +36,12 @@ public class FieldListaggAggFactory implements FieldAggregatorFactory {
                 fieldType instanceof VarCharType,
                 "Data type for list agg column must be 'VarCharType' but was '%s'.",
                 fieldType);
-        return new FieldListaggAgg(identifier(), (VarCharType) fieldType, options, field);
+        VarCharType varCharType = (VarCharType) fieldType;
+        checkArgument(
+                varCharType.getLength() == VarCharType.MAX_LENGTH,
+                "Data type for list agg column must be STRING (unbounded VARCHAR), but was VARCHAR(%s).",
+                varCharType.getLength());
+        return new FieldListaggAgg(identifier(), varCharType, options, field);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -83,6 +83,7 @@ import java.util.stream.Stream;
 
 import static org.apache.paimon.utils.ThetaSketch.sketchOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -158,7 +159,10 @@ public class FieldAggregatorTest {
     public void testFieldListAggWithDefaultDelimiter() {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
-                        .create(new VarCharType(), new CoreOptions(new HashMap<>()), "fieldName");
+                        .create(
+                                new VarCharType(VarCharType.MAX_LENGTH),
+                                new CoreOptions(new HashMap<>()),
+                                "fieldName");
         BinaryString accumulator = BinaryString.fromString("user1");
         BinaryString inputField = BinaryString.fromString("user2");
         assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
@@ -170,7 +174,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of("fields.fieldName.distinct", "true")),
                                 "fieldName");
@@ -194,7 +198,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
                                                 "fields.fieldName.distinct",
@@ -218,7 +222,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of("fields.fieldName.distinct", "true")),
                                 "fieldName");
@@ -241,7 +245,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of("fields.fieldName.distinct", "true")),
                                 "fieldName");
@@ -264,7 +268,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
                                                 "fields.fieldName.distinct",
@@ -291,7 +295,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
                                                 "fields.fieldName.distinct",
@@ -318,7 +322,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of("fields.fieldName.distinct", "true")),
                                 "fieldName");
@@ -341,7 +345,7 @@ public class FieldAggregatorTest {
         FieldListaggAgg fieldListaggAgg =
                 new FieldListaggAggFactory()
                         .create(
-                                new VarCharType(),
+                                new VarCharType(VarCharType.MAX_LENGTH),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
                                                 "fields.fieldName.list-agg-delimiter", "-")),
@@ -350,6 +354,21 @@ public class FieldAggregatorTest {
         BinaryString inputField = BinaryString.fromString("user2");
         assertThat(fieldListaggAgg.agg(accumulator, inputField).toString())
                 .isEqualTo("user1-user2");
+    }
+
+    @Test
+    public void testFieldListAggWithBoundedVarcharShouldFail() {
+        FieldListaggAggFactory factory = new FieldListaggAggFactory();
+        // Should throw IllegalArgumentException when using VARCHAR(n) with length limit
+        assertThatThrownBy(
+                        () ->
+                                factory.create(
+                                        new VarCharType(100),
+                                        CoreOptions.fromMap(new HashMap<>()),
+                                        "fieldName"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Data type for list agg column must be STRING (unbounded VARCHAR), but was VARCHAR(100)");
     }
 
     @Test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
The fields in the current FieldListaggAgg should not be of fixed length; a check for the field type has been added.
（In actual testing, most version Flink or Spark layer will convert varchar(n) to String, so only the test was added on the Paimon side.）

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
