### PR TITLE
[spark] Support by-name resolution for nested struct fields during schema merge

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -223,6 +223,15 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
       parent: NamedExpression,
       source: StructType,
       target: StructType): NamedExpression = {
+    // If source struct has fields not in target, reject so that merge-schema
+    // can handle the evolution instead of silently dropping the extra fields.
+    val targetFieldNames = target.fieldNames.toSet
+    val extraFields = source.fieldNames.filterNot(targetFieldNames.contains)
+    if (extraFields.nonEmpty) {
+      throw new RuntimeException(
+        s"Cannot write incompatible data: nested struct has extra fields: ${extraFields.mkString(", ")}.")
+    }
+
     val fields = target.map {
       case targetField @ StructField(name, nested: StructType, _, _) =>
         val sourceIndex = source.fieldIndex(name)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SchemaHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/SchemaHelper.scala
@@ -25,9 +25,9 @@ import org.apache.paimon.spark.util.OptionUtils
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.types.RowType
 
-import org.apache.spark.sql.{DataFrame, PaimonUtils, SparkSession}
-import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, DataFrame, PaimonUtils, SparkSession}
+import org.apache.spark.sql.functions.{col, lit, struct}
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
 import scala.collection.JavaConverters._
 
@@ -44,16 +44,55 @@ private[spark] trait SchemaHelper extends WithFileStoreTable {
     val newTableSchema = mergeSchema(input.schema, options)
     if (!PaimonUtils.sameType(newTableSchema, dataSchema)) {
       val resolve = sparkSession.sessionState.conf.resolver
-      val cols = newTableSchema.map {
-        field =>
-          dataSchema.find(f => resolve(f.name, field.name)) match {
-            case Some(f) => col(f.name)
-            case _ => lit(null).as(field.name)
-          }
-      }
+      val cols = alignColumns(newTableSchema, dataSchema, resolve)
       input.select(cols: _*)
     } else {
       input
+    }
+  }
+
+  /**
+   * Recursively align columns from dataSchema to targetSchema by name. For nested struct fields,
+   * reorder and fill nulls for missing sub-fields.
+   */
+  private def alignColumns(
+      targetSchema: StructType,
+      dataSchema: StructType,
+      resolve: (String, String) => Boolean): Seq[Column] = {
+    targetSchema.map {
+      targetField =>
+        dataSchema.find(f => resolve(f.name, targetField.name)) match {
+          case Some(dataField) =>
+            alignColumn(col(dataField.name), dataField.dataType, targetField, resolve)
+          case _ =>
+            lit(null).cast(targetField.dataType).as(targetField.name)
+        }
+    }
+  }
+
+  private def alignColumn(
+      sourceCol: Column,
+      sourceType: DataType,
+      targetField: StructField,
+      resolve: (String, String) => Boolean): Column = {
+    (sourceType, targetField.dataType) match {
+      case (s: StructType, t: StructType) if !PaimonUtils.sameType(s, t) =>
+        val subCols = t.map {
+          subTargetField =>
+            s.find(f => resolve(f.name, subTargetField.name)) match {
+              case Some(subDataField) =>
+                alignColumn(
+                  sourceCol.getField(subDataField.name),
+                  subDataField.dataType,
+                  subTargetField,
+                  resolve)
+              case _ =>
+                lit(null).cast(subTargetField.dataType).as(subTargetField.name)
+            }
+        }
+        struct(subCols: _*).as(targetField.name)
+      case _ =>
+        sourceCol.as(targetField.name)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteMergeSchemaTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteMergeSchemaTest.scala
@@ -290,6 +290,33 @@ class WriteMergeSchemaTest extends PaimonSparkTestBase {
     }
   }
 
+  test("Write merge schema: nested struct with new fields by sql") {
+    withTable("t") {
+      withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+        sql("CREATE TABLE t (id INT, info STRUCT<key1 STRUCT<key2 STRING, key3 STRING>>)")
+        sql("INSERT INTO t VALUES (1, struct(struct('v2a', 'v3a')))")
+        sql("INSERT INTO t VALUES (2, struct(struct('v2b', 'v3b')))")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(1, Row(Row("v2a", "v3a"))), Row(2, Row(Row("v2b", "v3b"))))
+        )
+
+        // insert data with new nested field key4 added BEFORE key3 to verify byName semantics
+        // inside struct (not positional). The named_struct ensures field names are explicit.
+        sql("INSERT INTO t BY NAME " +
+          "SELECT 3 AS id, " +
+          "named_struct('key1', named_struct('key2', 'v2c', 'key4', 'v4c', 'key3', 'v3c')) AS info")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(
+            Row(1, Row(Row("v2a", "v3a", null))),
+            Row(2, Row(Row("v2b", "v3b", null))),
+            Row(3, Row(Row("v2c", "v3c", "v4c"))))
+        )
+      }
+    }
+  }
+
   test("Write merge schema: binary and boolean types") {
     withTable("t") {
       withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
@@ -328,4 +355,147 @@ class WriteMergeSchemaTest extends PaimonSparkTestBase {
     }
   }
 
+  test("Write merge schema: nested struct with new fields by dataframe") {
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, info STRUCT<key1 STRUCT<key2 STRING, key3 STRING>>)")
+      sql("INSERT INTO t VALUES (1, struct(struct('v2a', 'v3a')))")
+
+      // Construct a DataFrame with new nested field key4 in different order using explicit schema
+      import org.apache.spark.sql.types._
+      val dataSchema = StructType(
+        Seq(
+          StructField("id", IntegerType),
+          StructField(
+            "info",
+            StructType(
+              Seq(
+                StructField(
+                  "key1",
+                  StructType(
+                    Seq(
+                      StructField("key2", StringType),
+                      StructField("key4", StringType),
+                      StructField("key3", StringType)
+                    )))
+              ))
+          )
+        ))
+      val data = java.util.Arrays.asList(
+        Row(2, Row(Row("v2b", "v4b", "v3b")))
+      )
+      spark
+        .createDataFrame(data, dataSchema)
+        .write
+        .format("paimon")
+        .mode("append")
+        .option("write.merge-schema", "true")
+        .saveAsTable("t")
+
+      checkAnswer(
+        sql("SELECT * FROM t ORDER BY id"),
+        Seq(Row(1, Row(Row("v2a", "v3a", null))), Row(2, Row(Row("v2b", "v3b", "v4b"))))
+      )
+    }
+  }
+
+  test("Write merge schema: deeply nested struct with new fields") {
+    withTable("t") {
+      withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+        sql("CREATE TABLE t (id INT, data STRUCT<a STRUCT<b STRUCT<c1 STRING, c2 STRING>>>)")
+        sql("INSERT INTO t VALUES (1, struct(struct(struct('c1v', 'c2v'))))")
+
+        // Add new field c3 at the deepest level
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 2 AS id, " +
+            "named_struct('a', named_struct('b', named_struct('c1', 'c1v2', 'c3', 'c3v2', 'c2', 'c2v2'))) AS data")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(
+            Row(1, Row(Row(Row("c1v", "c2v", null)))),
+            Row(2, Row(Row(Row("c1v2", "c2v2", "c3v2")))))
+        )
+      }
+    }
+  }
+
+  test("Write merge schema: nested struct new fields and top-level new column together") {
+    withTable("t") {
+      withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+        sql("CREATE TABLE t (id INT, info STRUCT<f1 STRING, f2 STRING>)")
+        sql("INSERT INTO t VALUES (1, struct('a', 'b'))")
+
+        // Add both a new nested field f3 and a new top-level column extra
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 2 AS id, " +
+            "named_struct('f1', 'c', 'f3', 'd', 'f2', 'e') AS info, " +
+            "'top' AS extra")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(1, Row("a", "b", null), null), Row(2, Row("c", "e", "d"), "top"))
+        )
+      }
+    }
+  }
+
+  test("Write merge schema: nested struct with missing fields") {
+    withTable("t") {
+      withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+        sql("CREATE TABLE t (id INT, info STRUCT<f1 STRING, f2 STRING, f3 STRING>)")
+        sql("INSERT INTO t VALUES (1, struct('a', 'b', 'c'))")
+
+        // Data missing f1, no new fields — pure nested field missing
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 2 AS id, " +
+            "named_struct('f2', 'y', 'f3', 'z') AS info")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(1, Row("a", "b", "c")), Row(2, Row(null, "y", "z")))
+        )
+
+        // Data missing f2, and adding new field f4 in the middle
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 3 AS id, " +
+            "named_struct('f1', 'x', 'f4', 'w', 'f3', 'z') AS info")
+
+        // Data missing f1, f4 at the end (no new fields, just missing + reorder)
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 4 AS id, " +
+            "named_struct('f2', 'p', 'f3', 'q', 'f4', 'r') AS info")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(
+            Row(1, Row("a", "b", "c", null)),
+            Row(2, Row(null, "y", "z", null)),
+            Row(3, Row("x", null, "z", "w")),
+            Row(4, Row(null, "p", "q", "r")))
+        )
+      }
+    }
+  }
+
+  test("Write merge schema: nested struct with type evolution") {
+    withTable("t") {
+      withSparkSQLConf(
+        "spark.paimon.write.merge-schema" -> "true",
+        "spark.paimon.write.merge-schema.explicit-cast" -> "true") {
+        sql("CREATE TABLE t (id INT, info STRUCT<f1 INT, f2 STRING>)")
+        sql("INSERT INTO t VALUES (1, struct(10, 'a'))")
+
+        // f1 evolves from INT to BIGINT, and add new field f3
+        sql(
+          "INSERT INTO t BY NAME " +
+            "SELECT 2 AS id, " +
+            "named_struct('f1', cast(20 as bigint), 'f3', 'new', 'f2', 'b') AS info")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY id"),
+          Seq(Row(1, Row(10L, "a", null)), Row(2, Row(20L, "b", "new")))
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Purpose

When using `write.merge-schema=true`, nested struct fields were matched by position instead of by name, causing data to be written to wrong fields.

Fix: 
1. `PaimonAnalysis.addCastToStructByName`: Reject when source struct has extra fields, so merge-schema path handles it instead of silently dropping data.
2. `SchemaHelper`: Recursive by-name column alignment for nested structs after schema merge.

### Tests

- SQL/DataFrame: nested struct new fields in different order (verify by-name)
- Three-level deep nested struct
- Nested new fields + top-level new column together
- Nested struct with missing fields, missing + new fields, multiple sequential merges

### API and Format

No.

### Documentation

No.

### Generative AI tooling

Generated-by: Kiro (Claude Opus 4.6)
