### PR TITLE
[core] make dynamic-bucket.initial-buckets immutable

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1391,6 +1391,7 @@ public class CoreOptions implements Serializable {
                             "If the bucket is -1, for primary key table, is dynamic bucket mode, "
                                     + "this option controls the target row number for one bucket.");
 
+    @Immutable
     public static final ConfigOption<Integer> DYNAMIC_BUCKET_INITIAL_BUCKETS =
             key("dynamic-bucket.initial-buckets")
                     .intType()


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

[ISSUE](https://github.com/apache/paimon/issues/7490)

<!-- What is the purpose of the change -->
`dynamic-bucket.initial-buckets` affects assigner/bootstrap semantics for dynamic bucket tables.
For existing tables, changing this option may break Flink recovery/checkpoint for cross-partition upsert jobs, and may finally fail during bootstrap with duplicate-key related exceptions.
This PR marks `dynamic-bucket.initial-buckets` as immutable so that users get a clear validation error earlier instead of hitting runtime failures later.

## Changes
- add `@Immutable` to `CoreOptions.DYNAMIC_BUCKET_INITIAL_BUCKETS`
- add tests to reject altering this option on existing tables

### Tests

- manual test

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
