### PR TITLE
[core] Do not create GlobalIndexScanner when no index files

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -267,8 +267,13 @@ public class DataEvolutionBatchScan implements DataTableScan {
         }
         PartitionPredicate partitionFilter =
                 batchScan.snapshotReader().manifestsReader().partitionFilter();
-        try (GlobalIndexScanner scanner =
-                GlobalIndexScanner.create(table, partitionFilter, filter)) {
+        Optional<GlobalIndexScanner> optionalScanner =
+                GlobalIndexScanner.create(table, partitionFilter, filter);
+        if (!optionalScanner.isPresent()) {
+            return Optional.empty();
+        }
+
+        try (GlobalIndexScanner scanner = optionalScanner.get()) {
             return scanner.scan(filter);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -97,17 +97,21 @@ public class GlobalIndexScanner implements Closeable {
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }
 
-    public static GlobalIndexScanner create(
+    public static Optional<GlobalIndexScanner> create(
             FileStoreTable table, Collection<IndexFileMeta> indexFiles) {
-        return new GlobalIndexScanner(
-                table.coreOptions().toConfiguration(),
-                table.rowType(),
-                table.fileIO(),
-                table.store().pathFactory().globalIndexFileFactory(),
-                indexFiles);
+        if (indexFiles.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                new GlobalIndexScanner(
+                        table.coreOptions().toConfiguration(),
+                        table.rowType(),
+                        table.fileIO(),
+                        table.store().pathFactory().globalIndexFileFactory(),
+                        indexFiles));
     }
 
-    public static GlobalIndexScanner create(
+    public static Optional<GlobalIndexScanner> create(
             FileStoreTable table, PartitionPredicate partitionFilter, Predicate filter) {
         Set<Integer> filterFieldIds =
                 collectFieldNames(filter).stream()
@@ -131,7 +135,6 @@ public class GlobalIndexScanner implements Closeable {
                         .stream()
                         .map(IndexManifestEntry::indexFile)
                         .collect(Collectors.toList());
-
         return create(table, indexFiles);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -119,11 +119,13 @@ public class VectorReadImpl implements VectorRead {
         for (VectorSearchSplit split : splits) {
             scalarIndexFiles.addAll(split.scalarIndexFiles());
         }
-        if (scalarIndexFiles.isEmpty()) {
+
+        Optional<GlobalIndexScanner> optionalScanner =
+                GlobalIndexScanner.create(table, scalarIndexFiles);
+        if (!optionalScanner.isPresent()) {
             return Optional.empty();
         }
-
-        try (GlobalIndexScanner scanner = GlobalIndexScanner.create(table, scalarIndexFiles)) {
+        try (GlobalIndexScanner scanner = optionalScanner.get()) {
             return scanner.scan(filter).map(GlobalIndexResult::results);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/paimon-core/src/test/java/org/apache/paimon/table/BitmapGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BitmapGlobalIndexTableTest.java
@@ -248,7 +248,7 @@ public class BitmapGlobalIndexTableTest extends DataEvolutionTestBase {
     private RoaringNavigableMap64 globalIndexScan(FileStoreTable table, Predicate predicate)
             throws Exception {
         try (GlobalIndexScanner scanner =
-                GlobalIndexScanner.create(table, PartitionPredicate.ALWAYS_TRUE, predicate)) {
+                GlobalIndexScanner.create(table, PartitionPredicate.ALWAYS_TRUE, predicate).get()) {
             return scanner.scan(predicate).get().results();
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.data.BinaryString;
-import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.globalindex.DataEvolutionBatchScan;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.GlobalIndexScanner;
@@ -29,13 +28,10 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.sink.BatchTableCommit;
-import org.apache.paimon.table.sink.BatchTableWrite;
-import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -206,27 +202,10 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
                 .collect(Collectors.toList());
     }
 
-    private void append(int startInclusive, int endExclusive) throws Exception {
-        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
-        RowType writeType = schemaDefault().rowType();
-        try (BatchTableWrite write0 = builder.newWrite().withWriteType(writeType)) {
-            for (int i = startInclusive; i < endExclusive; i++) {
-                write0.write(
-                        GenericRow.of(
-                                i,
-                                BinaryString.fromString("a" + i),
-                                BinaryString.fromString("b" + i)));
-            }
-            try (BatchTableCommit commit = builder.newCommit()) {
-                commit.commit(write0.prepareCommit());
-            }
-        }
-    }
-
     private RoaringNavigableMap64 globalIndexScan(FileStoreTable table, Predicate predicate)
             throws Exception {
         try (GlobalIndexScanner scanner =
-                GlobalIndexScanner.create(table, PartitionPredicate.ALWAYS_TRUE, predicate)) {
+                GlobalIndexScanner.create(table, PartitionPredicate.ALWAYS_TRUE, predicate).get()) {
             return scanner.scan(predicate).get().results();
         }
     }

--- a/paimon-python/pypaimon/globalindex/global_index_scanner.py
+++ b/paimon-python/pypaimon/globalindex/global_index_scanner.py
@@ -76,7 +76,7 @@ class GlobalIndexScanner:
         return GlobalIndexEvaluator(fields, readers_function)
 
     @staticmethod
-    def create(table, index_files=None, partition_filter=None, predicate=None):
+    def create(table, index_files=None, partition_filter=None, predicate=None) -> Optional['GlobalIndexScanner']:
         """Create a GlobalIndexScanner.
 
         Can be called in two ways:
@@ -86,6 +86,8 @@ class GlobalIndexScanner:
         from pypaimon.index.index_file_handler import IndexFileHandler
 
         if index_files is not None:
+            if len(index_files) == 0:
+                return None
             return GlobalIndexScanner(
                 options=table.table_schema.options,
                 fields=table.fields,
@@ -117,6 +119,8 @@ class GlobalIndexScanner:
         entries = index_file_handler.scan(snapshot, index_file_filter)
         scanned_index_files = [entry.index_file for entry in entries]
 
+        if len(scanned_index_files) == 0:
+            return None
         return GlobalIndexScanner(
             options=table.table_schema.options,
             fields=table.fields,

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -313,6 +313,8 @@ class FileScanner:
                 partition_filter=self.partition_key_predicate,
                 predicate=self.predicate
             )
+            if scanner is None:
+                return None
             with scanner:
                 return scanner.scan(self.predicate)
         except Exception:


### PR DESCRIPTION
### Purpose

Bypass `GlobalIndexScanner` for better performance.

### Tests
