### PR TITLE
[python] Add comment method for file_store_table

### DIFF
--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -86,6 +86,10 @@ class FileStoreTable(Table):
         """Get the current branch name from options."""
         return self.options.branch()
 
+    def comment(self) -> Optional[str]:
+        """Get the table comment."""
+        return self.table_schema.comment
+
     def consumer_manager(self):
         """Get the consumer manager for this table."""
         from pypaimon.consumer.consumer_manager import ConsumerManager

--- a/paimon-python/pypaimon/tests/table/file_store_table_test.py
+++ b/paimon-python/pypaimon/tests/table/file_store_table_test.py
@@ -338,3 +338,46 @@ class FileStoreTableTest(unittest.TestCase):
         # Verify other properties are preserved
         self.assertEqual(copied_table.identifier, self.table.identifier)
         self.assertEqual(copied_table.table_path, self.table.table_path)
+
+    def test_comment_none(self):
+        """Test that comment() returns None when table has no comment."""
+        # Default table created without comment should return None
+        self.assertIsNone(self.table.comment())
+
+    def test_comment_with_value(self):
+        """Test that comment() returns the correct comment when table has one."""
+        # Create a table with a comment
+        comment_text = "This is a test table comment"
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=['dt'],
+            options={CoreOptions.BUCKET.key(): "2"},
+            comment=comment_text
+        )
+        self.catalog.create_table('default.test_comment_table', schema, False)
+        comment_table = self.catalog.get_table('default.test_comment_table')
+
+        # Verify comment is returned correctly
+        self.assertEqual(comment_table.comment(), comment_text)
+
+    def test_comment_preserved_after_copy(self):
+        """Test that comment is preserved after copying the table."""
+        # Create a table with a comment
+        comment_text = "Test comment for copy"
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=['dt'],
+            options={CoreOptions.BUCKET.key(): "2"},
+            comment=comment_text
+        )
+        self.catalog.create_table('default.test_comment_copy_table', schema, False)
+        original_table = self.catalog.get_table('default.test_comment_copy_table')
+
+        # Verify original table has comment
+        self.assertEqual(original_table.comment(), comment_text)
+
+        # Copy the table
+        copied_table = original_table.copy({})
+
+        # Verify comment is preserved in copied table
+        self.assertEqual(copied_table.comment(), comment_text)


### PR DESCRIPTION
### Purpose
Currently Python API can not directly retrieve the `comment` from table; a `comment` method provided to make it easier for users to get comment of table.

### Tests
