### PR TITLE
[spark] Support merge schema through catalog for REST catalog

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -269,7 +269,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
 
     @Override
     public boolean mergeSchema(RowType rowType, boolean allowExplicitCast) {
-        return schemaManager.mergeSchema(rowType, allowExplicitCast);
+        return schemaManager.mergeSchema(
+                rowType, allowExplicitCast, catalogEnvironment.schemaModification());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -37,6 +37,7 @@ import org.apache.paimon.schema.SchemaChange.UpdateColumnPosition;
 import org.apache.paimon.schema.SchemaChange.UpdateColumnType;
 import org.apache.paimon.schema.SchemaChange.UpdateComment;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.SchemaModification;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -706,7 +707,10 @@ public class SchemaManager implements Serializable {
         }
     }
 
-    public boolean mergeSchema(RowType rowType, boolean allowExplicitCast) {
+    public boolean mergeSchema(
+            RowType rowType,
+            boolean allowExplicitCast,
+            @Nullable SchemaModification schemaModification) {
         TableSchema current =
                 latest().orElseThrow(
                                 () ->
@@ -715,12 +719,17 @@ public class SchemaManager implements Serializable {
         TableSchema update = SchemaMergingUtils.mergeSchemas(current, rowType, allowExplicitCast);
         if (current.equals(update)) {
             return false;
-        } else {
-            try {
+        }
+        try {
+            if (schemaModification != null) {
+                List<SchemaChange> changes = SchemaMergingUtils.diffSchemaChanges(current, update);
+                schemaModification.alterSchema(changes);
+                return true;
+            } else {
                 return commit(update);
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to commit the schema.", e);
             }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to commit the schema.", e);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaMergingUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaMergingUtils.java
@@ -29,6 +29,7 @@ import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.ReassignFieldId;
 import org.apache.paimon.types.RowType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -232,5 +233,58 @@ public class SchemaMergingUtils {
                 dataType,
                 field.description(),
                 field.defaultValue());
+    }
+
+    /**
+     * Generate a list of {@link SchemaChange} by comparing the old and new {@link TableSchema}.
+     * This supports detecting added columns and type changes (including nested structs).
+     */
+    public static List<SchemaChange> diffSchemaChanges(
+            TableSchema oldSchema, TableSchema newSchema) {
+        List<SchemaChange> changes = new ArrayList<>();
+        diffFields(
+                oldSchema.logicalRowType().getFields(),
+                newSchema.logicalRowType().getFields(),
+                new String[0],
+                changes);
+        return changes;
+    }
+
+    private static void diffFields(
+            List<DataField> oldFields,
+            List<DataField> newFields,
+            String[] parentNames,
+            List<SchemaChange> changes) {
+        Map<String, DataField> oldFieldMap =
+                oldFields.stream().collect(Collectors.toMap(DataField::name, Function.identity()));
+
+        for (DataField newField : newFields) {
+            String[] fieldNames = appendFieldName(parentNames, newField.name());
+            DataField oldField = oldFieldMap.get(newField.name());
+            if (oldField == null) {
+                // new column added
+                changes.add(
+                        SchemaChange.addColumn(
+                                fieldNames, newField.type(), newField.description(), null));
+            } else if (!oldField.type().equals(newField.type())) {
+                // type changed — check if it's a nested struct change
+                if (oldField.type() instanceof RowType && newField.type() instanceof RowType) {
+                    diffFields(
+                            ((RowType) oldField.type()).getFields(),
+                            ((RowType) newField.type()).getFields(),
+                            fieldNames,
+                            changes);
+                } else {
+                    changes.add(SchemaChange.updateColumnType(fieldNames, newField.type(), true));
+                }
+            }
+        }
+    }
+
+    private static String[] appendFieldName(String[] parentNames, String fieldName) {
+        String[] result = new String[parentNames.length + 1];
+        System.arraycopy(parentNames, 0, result, 0, parentNames.length);
+        result[parentNames.length] = fieldName;
+        return result;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -114,6 +114,15 @@ public class CatalogEnvironment implements Serializable {
     }
 
     @Nullable
+    public SchemaModification schemaModification() {
+        if (catalogLoader == null) {
+            return null;
+        }
+        Catalog catalog = catalogLoader.load();
+        return SchemaModification.create(catalog, identifier);
+    }
+
+    @Nullable
     public SnapshotCommit snapshotCommit(SnapshotManager snapshotManager) {
         SnapshotCommit snapshotCommit;
         if (catalogLoader != null && supportsVersionManagement) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/SchemaModification.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/SchemaModification.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.schema.SchemaChange;
+
+import java.util.List;
+
+/** Handler to alter table schema via catalog. */
+public interface SchemaModification extends AutoCloseable {
+
+    void alterSchema(List<SchemaChange> changes) throws Exception;
+
+    static SchemaModification create(Catalog catalog, Identifier identifier) {
+        return new SchemaModification() {
+
+            @Override
+            public void alterSchema(List<SchemaChange> changes) throws Exception {
+                catalog.alterTable(identifier, changes, false);
+            }
+
+            @Override
+            public void close() throws Exception {
+                catalog.close();
+            }
+        };
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteMergeSchemaWithRestCatalogTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/WriteMergeSchemaWithRestCatalogTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestWithRestCatalogBase
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+
+class WriteMergeSchemaWithRestCatalogTest extends PaimonSparkTestWithRestCatalogBase {
+
+  import testImplicits._
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.sql.catalog.paimon.cache-enabled", "false")
+  }
+
+  test("Write merge schema with REST catalog: dataframe write") {
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b STRING)")
+      Seq((1, "1"), (2, "2"))
+        .toDF("a", "b")
+        .write
+        .format("paimon")
+        .mode("append")
+        .saveAsTable("t")
+
+      // new columns
+      Seq((3, "3", 3))
+        .toDF("a", "b", "c")
+        .write
+        .format("paimon")
+        .mode("append")
+        .option("write.merge-schema", "true")
+        .saveAsTable("t")
+      checkAnswer(
+        sql("SELECT * FROM t ORDER BY a"),
+        Seq(Row(1, "1", null), Row(2, "2", null), Row(3, "3", 3))
+      )
+    }
+  }
+
+  test("Write merge schema with REST catalog: sql write") {
+    withTable("t") {
+      withSparkSQLConf("spark.paimon.write.merge-schema" -> "true") {
+        sql("CREATE TABLE t (a INT, b STRING)")
+        sql("INSERT INTO t VALUES (1, '1'), (2, '2')")
+
+        // new columns
+        sql("INSERT INTO t BY NAME SELECT 3 AS a, '3' AS b, 3 AS c")
+        checkAnswer(
+          sql("SELECT * FROM t ORDER BY a"),
+          Seq(Row(1, "1", null), Row(2, "2", null), Row(3, "3", 3))
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Purpose
When using REST catalog, schema merge during write bypasses the catalog and directly commits to SchemaManager, which doesn't work for REST catalog. This PR introduces SchemaModification to route schema changes through Catalog.alterTable(), and adds diffSchemaChanges() to convert merged schemas into SchemaChange lists.

### Tests
Added WriteMergeSchemaWithRestCatalogTest.