### PR TITLE
[spark] Fix nested struct field mapping for V2 write merge schema

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRowWrapper.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRowWrapper.java
@@ -292,11 +292,9 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
         }
         StructType nestedTableSchema = (StructType) tableSchema.fields()[pos].dataType();
         if (dataSchema != null) {
-            StructType nestedDataSchema =
-                    (StructType) dataSchema.fields()[actualPos].dataType();
+            StructType nestedDataSchema = (StructType) dataSchema.fields()[actualPos].dataType();
             int dataNumFields = nestedDataSchema.size();
-            return new SparkInternalRowWrapper(
-                            nestedTableSchema, numFields, nestedDataSchema, null)
+            return new SparkInternalRowWrapper(nestedTableSchema, numFields, nestedDataSchema, null)
                     .replace(internalRow.getStruct(actualPos, dataNumFields));
         }
         return new SparkInternalRowWrapper(nestedTableSchema, numFields)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/V2WriteMergeSchemaTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/V2WriteMergeSchemaTest.scala
@@ -326,9 +326,10 @@ class V2WriteMergeSchemaTest extends PaimonSparkTestBase {
         Seq(Row(1, Row(Row("v2a", "v3a"))), Row(2, Row(Row("v2b", "v3b"))))
       )
 
-      sql("INSERT INTO t BY NAME " +
-        "SELECT 3 AS id, " +
-        "named_struct('key1', named_struct('key2', 'v2c', 'key4', 'v4c', 'key3', 'v3c')) AS info")
+      sql(
+        "INSERT INTO t BY NAME " +
+          "SELECT 3 AS id, " +
+          "named_struct('key1', named_struct('key2', 'v2c', 'key4', 'v4c', 'key3', 'v3c')) AS info")
       checkAnswer(
         sql("SELECT * FROM t ORDER BY id"),
         Seq(


### PR DESCRIPTION
### Purpose

Fix nested struct field mapping in SparkInternalRowWrapper for V2 write merge schema.

### Tests

Added test cases for nested struct field evolution.