### PR TITLE
[doc] Fix master docs version to 1.5-SNAPSHOT

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,11 +34,11 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "1.4-SNAPSHOT"
+  Version = "1.5-SNAPSHOT"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "1.4-SNAPSHOT"
+  VersionTitle = "1.5-SNAPSHOT"
 
   # The branch for this version of Apache Paimon
   Branch = "master"


### PR DESCRIPTION
## Why
The master branch has already moved to 1.5-SNAPSHOT in pom.xml, but docs/config.toml still uses 1.4-SNAPSHOT for `Version` and `VersionTitle`. This makes the master docs site render outdated artifact and version references.

## What is changed
- Update `docs/config.toml` `Version` to `1.5-SNAPSHOT`
- Update `docs/config.toml` `VersionTitle` to `1.5-SNAPSHOT`

`StableDocs` remains unchanged because this PR only fixes the master docs snapshot version.