### PR TITLE
[WIP][python] Add user identity-based token cache for RESTTokenFileIO

### DIFF
--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -78,6 +78,10 @@ class RESTCatalog(Catalog):
         This is used as part of the token cache key to ensure proper isolation
         between different users accessing the same table location.
 
+        Note: For DLF auth types, this calls get_token() which may trigger
+        a token load (e.g., HTTP request to ECS metadata service). This is
+        intentional — we need the actual access_key_id for cache isolation.
+
         Returns:
             User identity string:
             - For Bear Token: "bear:{token}"
@@ -88,25 +92,17 @@ class RESTCatalog(Catalog):
         # Bear Token authentication
         from pypaimon.api.auth import BearTokenAuthProvider
         if isinstance(auth_provider, BearTokenAuthProvider):
-            return f"bear:{auth_provider.token}"
+            import hashlib
+            token_hash = hashlib.sha256(auth_provider.token.encode()).hexdigest()[:16]
+            return f"bear:{token_hash}"
 
         # DLF authentication (includes AccessKey, ECS Role, STS File)
         from pypaimon.api.auth import DLFAuthProvider
         if isinstance(auth_provider, DLFAuthProvider):
-            # Get actual token to extract access_key_id
-            try:
-                token = auth_provider.get_token()
-                if token and token.access_key_id:
-                    # Use actual access_key_id for all DLF auth types
-                    # ECS Role returns STS.xxx, STS File also returns STS.xxx
-                    return f"dlf:{token.access_key_id}"
-            except Exception:
-                # If getting token fails, use a fallback identifier
-                pass
-
-            # Fallback: use loader type as identifier (should rarely happen)
-            if auth_provider.token_loader:
-                return f"loader:{type(auth_provider.token_loader).__name__}"
+            token = auth_provider.get_token()
+            if token and token.access_key_id:
+                return f"dlf:{token.access_key_id}"
+            raise ValueError("Failed to extract user identity: DLF token or access_key_id is None")
 
         # Default/fallback
         return "anonymous"

--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -45,8 +45,21 @@ class RESTTokenFileIO(FileIO):
     _FILE_IO_CACHE_LOCK = threading.Lock()
 
     # Token cache: (path, user_identity) -> RESTToken
-    _TOKEN_CACHE: dict = {}
+    # Intentionally shared across all instances for cross-instance token reuse.
+    _TOKEN_CACHE_MAXSIZE = 1000
+    _TOKEN_CACHE: TTLCache = None
     _TOKEN_CACHE_LOCK = threading.Lock()
+
+    @classmethod
+    def _get_token_cache(cls) -> TTLCache:
+        if cls._TOKEN_CACHE is None:
+            with cls._TOKEN_CACHE_LOCK:
+                if cls._TOKEN_CACHE is None:
+                    cls._TOKEN_CACHE = TTLCache(
+                        maxsize=cls._TOKEN_CACHE_MAXSIZE,
+                        ttl=cls._FILE_IO_CACHE_TTL
+                    )
+        return cls._TOKEN_CACHE
 
     @classmethod
     def _get_file_io_cache(cls) -> TTLCache:
@@ -214,50 +227,31 @@ class RESTTokenFileIO(FileIO):
         Uses (path, user_identity) as cache key to ensure proper isolation
         between different users accessing the same table location.
         """
-        # Build cache key from path and user identity
         cache_key = (self.path, self.user_identity)
 
-        # Fast path: check if we have a valid token without locking
+        # Fast path: no locking needed
         if self.token is not None and not self._should_refresh():
             return
 
-        cached_token = self._get_cached_token(cache_key)
-        if cached_token and not self._should_refresh_token(cached_token):
-            self.token = cached_token
-            return
-
-        # Slow path: acquire lock and refresh
+        # Slow path: acquire lock, then do all cache operations directly
         with self._TOKEN_CACHE_LOCK:
-            # Double-check after acquiring lock
-            cached_token = self._get_cached_token(cache_key)
-            if cached_token and not self._should_refresh_token(cached_token):
+            # Double-check: another thread may have refreshed while we waited
+            cache = self._get_token_cache()
+            cached_token = cache.get(cache_key)
+            if cached_token and not self._should_refresh(cached_token):
                 self.token = cached_token
                 return
 
-            # Actually refresh the token
             self.refresh_token()
-            self._set_cached_token(cache_key, self.token)
+            cache[cache_key] = self.token
 
-    def _should_refresh_token(self, token: RESTToken) -> bool:
-        """Check if a specific token should be refreshed."""
-        current_time = int(time.time() * 1000)
-        return (token.expire_at_millis - current_time) < RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS
-
-    def _get_cached_token(self, cache_key: tuple) -> Optional[RESTToken]:
-        """Get cached token by (path, user_identity) key."""
-        with self._TOKEN_CACHE_LOCK:
-            return self._TOKEN_CACHE.get(cache_key)
-
-    def _set_cached_token(self, cache_key: tuple, token: RESTToken) -> None:
-        """Set cached token by (path, user_identity) key."""
-        with self._TOKEN_CACHE_LOCK:
-            self._TOKEN_CACHE[cache_key] = token
-
-    def _should_refresh(self):
-        if self.token is None:
+    def _should_refresh(self, token: Optional[RESTToken] = None) -> bool:
+        """Check if a token should be refreshed. Uses self.token if no token is provided."""
+        target = token if token is not None else self.token
+        if target is None:
             return True
         current_time = int(time.time() * 1000)
-        return (self.token.expire_at_millis - current_time) < RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS
+        return (target.expire_at_millis - current_time) < RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS
 
     def refresh_token(self):
         self.log.info(f"begin refresh data token for identifier [{self.identifier}]")

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -397,14 +397,16 @@ class RESTTokenFileIOTest(unittest.TestCase):
         called_identifier = mock_api.load_table_token.call_args[0][0]
         self.assertEqual(called_identifier.get_object_name(), "my_table")
 
-    def test_different_instances_do_not_share_token(self):
-        """Two instances with same identifier get independent tokens (no class-level cache)."""
+    def test_different_user_identities_do_not_share_token(self):
+        """Two instances with different user_identity get independent tokens."""
         same_identifier = Identifier.from_string("db.shared_table")
 
         file_io_a = RESTTokenFileIO(
-            same_identifier, self.warehouse_path, self.catalog_options)
+            same_identifier, self.warehouse_path, self.catalog_options,
+            user_identity="user_a")
         file_io_b = RESTTokenFileIO(
-            same_identifier, self.warehouse_path, self.catalog_options)
+            same_identifier, self.warehouse_path, self.catalog_options,
+            user_identity="user_b")
 
         token_a = RESTToken({'ak': 'ak-A'}, int(time.time() * 1000) + 7200_000)
         token_b = RESTToken({'ak': 'ak-B'}, int(time.time() * 1000) + 7200_000)
@@ -425,11 +427,14 @@ class RESTTokenFileIOTest(unittest.TestCase):
         mock_api_b.load_table_token.return_value = mock_response_b
         file_io_b.api_instance = mock_api_b
 
+        # Clear cache to ensure clean state
+        RESTTokenFileIO._get_token_cache().clear()
+
         # Refresh both
         file_io_a.try_to_refresh_token()
         file_io_b.try_to_refresh_token()
 
-        # Each instance should hold its own token
+        # Each instance should hold its own token (different user_identity = different cache key)
         self.assertEqual(file_io_a.token.token['ak'], 'ak-A')
         self.assertEqual(file_io_b.token.token['ak'], 'ak-B')
         self.assertIsNot(file_io_a.token, file_io_b.token)

--- a/paimon-python/pypaimon/tests/rest/test_token_cache_isolation.py
+++ b/paimon-python/pypaimon/tests/rest/test_token_cache_isolation.py
@@ -33,16 +33,16 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         self.catalog_options = Options({})
         
         # Clear token cache before each test
-        RESTTokenFileIO._TOKEN_CACHE.clear()
+        RESTTokenFileIO._get_token_cache().clear()
     
     def tearDown(self):
         # Clean up token cache after tests
-        RESTTokenFileIO._TOKEN_CACHE.clear()
+        RESTTokenFileIO._get_token_cache().clear()
     
     def test_different_users_have_separate_token_cache(self):
         """Test that different users accessing same path have separate tokens."""
         # Clear cache first
-        RESTTokenFileIO._TOKEN_CACHE.clear()
+        RESTTokenFileIO._get_token_cache().clear()
         
         # User A creates FileIO
         file_io_a = RESTTokenFileIO(
@@ -68,15 +68,16 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         cache_key_a = (self.path, "user_a")
         cache_key_b = (self.path, "user_b")
         
-        file_io_a._set_cached_token(cache_key_a, token_a)
-        file_io_b._set_cached_token(cache_key_b, token_b)
+        cache = RESTTokenFileIO._get_token_cache()
+        cache[cache_key_a] = token_a
+        cache[cache_key_b] = token_b
         
         # Verify the global cache has 2 entries
-        self.assertEqual(len(RESTTokenFileIO._TOKEN_CACHE), 2)
+        self.assertEqual(len(cache), 2)
         
         # Verify both tokens are cached with correct keys
-        cached_token_a = RESTTokenFileIO._TOKEN_CACHE.get(cache_key_a)
-        cached_token_b = RESTTokenFileIO._TOKEN_CACHE.get(cache_key_b)
+        cached_token_a = cache.get(cache_key_a)
+        cached_token_b = cache.get(cache_key_b)
         
         self.assertIsNotNone(cached_token_a)
         self.assertIsNotNone(cached_token_b)
@@ -88,8 +89,8 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         
         # Each FileIO instance can access both tokens via direct cache access
         # But they use DIFFERENT keys, so isolation is maintained
-        wrong_token_for_a = RESTTokenFileIO._TOKEN_CACHE.get(cache_key_b)
-        wrong_token_for_b = RESTTokenFileIO._TOKEN_CACHE.get(cache_key_a)
+        wrong_token_for_a = cache.get(cache_key_b)
+        wrong_token_for_b = cache.get(cache_key_a)
         
         # Both exist in cache but with different keys
         self.assertIsNotNone(wrong_token_for_a)
@@ -113,14 +114,15 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
             user_identity="same_user"
         )
         
-        # Set token for first FileIO
+        # Set token in cache
         token = RESTToken({"fs.oss.accessKeyId": "ak_shared"}, 9999999999999)
         file_io_1.token = token
-        file_io_1._set_cached_token((self.path, "same_user"), token)
+        cache = RESTTokenFileIO._get_token_cache()
+        cache[(self.path, "same_user")] = token
         
         # Second FileIO should get cached token
         cache_key = (self.path, "same_user")
-        cached_token = file_io_2._get_cached_token(cache_key)
+        cached_token = cache.get(cache_key)
         
         self.assertIsNotNone(cached_token)
         self.assertEqual(cached_token.token["fs.oss.accessKeyId"], "ak_shared")
@@ -136,10 +138,10 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
             user_identity="user_1"
         )
         
-        # Set token for old table
+        # Set token in cache for old table
         token = RESTToken({"fs.oss.accessKeyId": "ak_1"}, 9999999999999)
         file_io_old.token = token
-        file_io_old._set_cached_token((self.path, "user_1"), token)
+        RESTTokenFileIO._get_token_cache()[(self.path, "user_1")] = token
         
         # Renamed table (same path, different identifier)
         identifier_new = Identifier.create("db", "new_table")
@@ -152,7 +154,7 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         
         # Should reuse cached token because path + user_identity is the same
         cache_key = (self.path, "user_1")
-        cached_token = file_io_new._get_cached_token(cache_key)
+        cached_token = RESTTokenFileIO._get_token_cache().get(cache_key)
         
         self.assertIsNotNone(cached_token)
         self.assertEqual(cached_token.token["fs.oss.accessKeyId"], "ak_1")
@@ -176,10 +178,11 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         # Both should use the same cache key (path, "")
         token = RESTToken({"fs.oss.accessKeyId": "ak_empty"}, 9999999999999)
         file_io_empty.token = token
-        file_io_empty._set_cached_token((self.path, ""), token)
+        cache = RESTTokenFileIO._get_token_cache()
+        cache[(self.path, "")] = token
         
         cache_key = (self.path, "")
-        cached_token = file_io_none._get_cached_token(cache_key)
+        cached_token = cache.get(cache_key)
         
         self.assertIsNotNone(cached_token)
         self.assertEqual(cached_token.token["fs.oss.accessKeyId"], "ak_empty")
@@ -200,18 +203,16 @@ class TestRESTTokenFileIOWithUserIdentity(unittest.TestCase):
         expired_token = RESTToken({"fs.oss.accessKeyId": "ak_expired"}, expired_time)
         
         cache_key = (self.path, "user_test")
-        file_io._set_cached_token(cache_key, expired_token)
+        RESTTokenFileIO._get_token_cache()[cache_key] = expired_token
         
         # Expired token should not be considered valid
-        should_refresh = file_io._should_refresh_token(expired_token)
-        self.assertTrue(should_refresh)
+        self.assertTrue(file_io._should_refresh(expired_token))
         
         # Valid token (far future expiry)
         valid_time = int(time.time() * 1000) + 7200000  # 2 hours in future
         valid_token = RESTToken({"fs.oss.accessKeyId": "ak_valid"}, valid_time)
         
-        should_refresh_valid = file_io._should_refresh_token(valid_token)
-        self.assertFalse(should_refresh_valid)
+        self.assertFalse(file_io._should_refresh(valid_token))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Purpose

This PR implements user identity-based token cache isolation in `RESTTokenFileIO` to prevent multiple users from sharing the same data token when accessing the same table location.

**Problem**: The previous implementation used only table identifier as the token cache key, causing token cache pollution when multiple users accessed the same table within a single process. All users would share the same data token regardless of their actual authentication credentials.

**Solution**: 
- Use `(path, user_identity)` as the token cache key to ensure proper isolation between different users
- Extract user identity from authentication provider (Bear Token, DLF AccessKey, ECS Role, STS File, etc.) - all use actual access_key_id
- Implement double-check locking pattern for thread-safe token caching
- Path-based caching avoids issues with table renames (physical location remains constant)

**Key Changes**:
1. Add `user_identity` parameter to `RESTTokenFileIO.__init__()` - stores user identity for cache key construction
2. Add `_extract_user_identity()` method in `RESTCatalog` to extract user identity from auth provider:
   - Bear Token → `"bear:{token}"`
   - DLF AccessKey/ECS Role/STS File → `"dlf:{access_key_id}"` (actual AK from token, e.g., STS.xxx)
3. Modify `try_to_refresh_token()` to use `(path, user_identity)` tuple as cache key
4. Implement thread-safe token cache with double-check locking (instance lock + global cache lock)
5. Pass `user_identity` when creating `RESTTokenFileIO` instances in `file_io_for_data()`

### Tests

**New Unit Tests** (`test_token_cache_isolation.py`):
- `test_different_users_have_separate_token_cache` - Verifies different users get separate tokens for same path
- `test_same_user_reuses_token_cache` - Verifies same user reuses cached token
- `test_table_rename_preserves_token_cache` - Verifies table rename doesn't break token cache (path-based)
- `test_empty_user_identity_isolation` - Verifies empty user identity handling
- `test_token_cache_with_expiry_check` - Verifies token expiration checking logic
