### PR TITLE
[python] Fix token cache isolation by adding user identity to cache key

### DIFF
--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -29,7 +29,7 @@ from pypaimon.common.file_io import FileIO
 from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
 from pypaimon.api.auth.bearer import BearTokenAuthProvider
 from pypaimon.api.auth.dlf_provider import DLFAuthProvider
-from pypaimon.common.identifier import Identifier
+from pypaimon.common.identifier import Identifier, SYSTEM_TABLE_SPLITTER
 from pypaimon.common.options import Options
 from pypaimon.common.options.config import CatalogOptions, OssOptions
 from pypaimon.common.uri_reader import UriReaderFactory
@@ -39,17 +39,17 @@ class RESTTokenFileIO(FileIO):
     """
     A FileIO to support getting token from REST Server.
     """
-    
+
     _FILE_IO_CACHE_MAXSIZE = 1000
     _FILE_IO_CACHE_TTL = 36000  # 10 hours in seconds
-    
+
     _FILE_IO_CACHE: TTLCache = None
     _FILE_IO_CACHE_LOCK = threading.Lock()
-    
+
     _TOKEN_CACHE: dict = {}
     _TOKEN_LOCKS: dict = {}
     _TOKEN_LOCKS_LOCK = threading.Lock()
-    
+
     @classmethod
     def _get_file_io_cache(cls) -> TTLCache:
         if cls._FILE_IO_CACHE is None:
@@ -60,7 +60,7 @@ class RESTTokenFileIO(FileIO):
                         ttl=cls._FILE_IO_CACHE_TTL
                     )
         return cls._FILE_IO_CACHE
-    
+
     def __init__(self, identifier: Identifier, path: str,
                  catalog_options: Optional[Union[dict, Options]] = None):
         self.identifier = identifier
@@ -75,14 +75,12 @@ class RESTTokenFileIO(FileIO):
         self.properties = self.catalog_options or Options({})  # For compatibility with refresh_token()
         self.token: Optional[RESTToken] = None
         self.api_instance: Optional[RESTApi] = None
-        self.lock = threading.Lock()
         self.log = logging.getLogger(__name__)
         self._uri_reader_factory_cache: Optional[UriReaderFactory] = None
 
     def __getstate__(self):
         state = self.__dict__.copy()
         # Remove non-serializable objects
-        state.pop('lock', None)
         state.pop('api_instance', None)
         state.pop('_uri_reader_factory_cache', None)
         # token can be serialized, but we'll refresh it on deserialization
@@ -90,8 +88,6 @@ class RESTTokenFileIO(FileIO):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        # Recreate lock after deserialization
-        self.lock = threading.Lock()
         self._uri_reader_factory_cache = None
         # api_instance will be recreated when needed
         self.api_instance = None
@@ -101,26 +97,26 @@ class RESTTokenFileIO(FileIO):
 
         if self.token is None:
             return FileIO.get(self.path, self.catalog_options or Options({}))
-        
+
         cache_key = self.token
         cache = self._get_file_io_cache()
-        
+
         file_io = cache.get(cache_key)
         if file_io is not None:
             return file_io
-        
+
         with self._FILE_IO_CACHE_LOCK:
             self.try_to_refresh_token()
-            
+
             if self.token is None:
                 return FileIO.get(self.path, self.catalog_options or Options({}))
-            
+
             cache_key = self.token
             cache = self._get_file_io_cache()
             file_io = cache.get(cache_key)
             if file_io is not None:
                 return file_io
-            
+
             merged_properties = RESTUtil.merge(
                 self.catalog_options.to_map() if self.catalog_options else {},
                 self.token.token
@@ -130,7 +126,7 @@ class RESTTokenFileIO(FileIO):
                 if dlf_oss_endpoint and dlf_oss_endpoint.strip():
                     merged_properties[OssOptions.OSS_ENDPOINT.key()] = dlf_oss_endpoint
             merged_options = Options(merged_properties)
-            
+
             file_io = PyArrowFileIO(self.path, merged_options)
             cache[cache_key] = file_io
             return file_io
@@ -200,7 +196,7 @@ class RESTTokenFileIO(FileIO):
         if self._uri_reader_factory_cache is None:
             catalog_options = self.catalog_options or Options({})
             self._uri_reader_factory_cache = UriReaderFactory(catalog_options)
-        
+
         return self._uri_reader_factory_cache
 
     @property
@@ -229,23 +225,23 @@ class RESTTokenFileIO(FileIO):
 
     def try_to_refresh_token(self):
         identifier_str = self._build_cache_key()
-        
+
         if self.token is not None and not self._is_token_expired(self.token):
             return
-        
+
         cached_token = self._get_cached_token(identifier_str)
         if cached_token and not self._is_token_expired(cached_token):
             self.token = cached_token
             return
-        
+
         global_lock = self._get_global_token_lock(identifier_str)
-        
+
         with global_lock:
             cached_token = self._get_cached_token(identifier_str)
             if cached_token and not self._is_token_expired(cached_token):
                 self.token = cached_token
                 return
-            
+
             token_to_check = cached_token if cached_token else self.token
             if token_to_check is None or self._is_token_expired(token_to_check):
                 self.refresh_token()
@@ -254,40 +250,41 @@ class RESTTokenFileIO(FileIO):
     def _get_cached_token(self, identifier_str: str) -> Optional[RESTToken]:
         with self._TOKEN_LOCKS_LOCK:
             return self._TOKEN_CACHE.get(identifier_str)
-    
+
     def _set_cached_token(self, identifier_str: str, token: RESTToken):
         with self._TOKEN_LOCKS_LOCK:
             self._TOKEN_CACHE[identifier_str] = token
-    
+
     def _is_token_expired(self, token: Optional[RESTToken]) -> bool:
         if token is None:
             return True
         current_time = int(time.time() * 1000)
         return (token.expire_at_millis - current_time) < RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS
-    
+
     def _get_global_token_lock(self, identifier_str: str) -> threading.Lock:
         with self._TOKEN_LOCKS_LOCK:
             if identifier_str not in self._TOKEN_LOCKS:
                 self._TOKEN_LOCKS[identifier_str] = threading.Lock()
             return self._TOKEN_LOCKS[identifier_str]
 
-    def should_refresh(self):
-        if self.token is None:
-            return True
-        current_time = int(time.time() * 1000)
-        time_until_expiry = self.token.expire_at_millis - current_time
-        return time_until_expiry < RESTApi.TOKEN_EXPIRATION_SAFE_TIME_MILLIS
-
     def refresh_token(self):
         self.log.info(f"begin refresh data token for identifier [{self.identifier}]")
         if self.api_instance is None:
             self.api_instance = RESTApi(self.properties, False)
 
-        response = self.api_instance.load_table_token(self.identifier)
+        table_identifier = self.identifier
+        if SYSTEM_TABLE_SPLITTER in self.identifier.get_object_name():
+            base_table = self.identifier.get_object_name().split(SYSTEM_TABLE_SPLITTER)[0]
+            table_identifier = Identifier(
+                database=self.identifier.get_database_name(),
+                object=base_table,
+                branch=self.identifier.get_branch_name())
+
+        response = self.api_instance.load_table_token(table_identifier)
         self.log.info(
             f"end refresh data token for identifier [{self.identifier}] expiresAtMillis [{response.expires_at_millis}]"
         )
-        
+
         merged_token_dict = self._merge_token_with_catalog_options(response.token)
         new_token = RESTToken(merged_token_dict, response.expires_at_millis)
         self.token = new_token

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -103,13 +103,13 @@ class RESTTokenFileIOTest(unittest.TestCase):
 
             target_dir = os.path.join(self.temp_dir, "target_dir")
             os.makedirs(target_dir)
-            
+
             result = file_io.try_to_write_atomic(f"file://{target_dir}", "test content")
             self.assertFalse(result, "try_to_write_atomic should return False when target is a directory")
-            
+
             self.assertTrue(os.path.isdir(target_dir))
             self.assertEqual(len(os.listdir(target_dir)), 0, "No file should be created inside the directory")
-            
+
             normal_file = os.path.join(self.temp_dir, "normal_file.txt")
             result = file_io.try_to_write_atomic(f"file://{normal_file}", "test content")
             self.assertTrue(result, "try_to_write_atomic should succeed for a normal file path")
@@ -148,9 +148,6 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.catalog_options
             )
 
-            self.assertTrue(hasattr(original_file_io, 'lock'))
-            self.assertIsNotNone(original_file_io.lock)
-
             pickled = pickle.dumps(original_file_io)
 
             deserialized_file_io = pickle.loads(pickled)
@@ -158,10 +155,6 @@ class RESTTokenFileIOTest(unittest.TestCase):
             self.assertEqual(deserialized_file_io.identifier, original_file_io.identifier)
             self.assertEqual(deserialized_file_io.path, original_file_io.path)
             self.assertEqual(deserialized_file_io.properties.data, original_file_io.properties.data)
-
-            self.assertTrue(hasattr(deserialized_file_io, 'lock'))
-            self.assertIsNotNone(deserialized_file_io.lock)
-            self.assertIsNot(deserialized_file_io.lock, original_file_io.lock)
 
             self.assertIsNone(deserialized_file_io.api_instance)
 
@@ -225,35 +218,35 @@ class RESTTokenFileIOTest(unittest.TestCase):
             CatalogOptions.URI.key(): "http://test-uri",
             "custom.key": "custom.value"
         })
-        
+
         catalog_options_copy = Options(original_catalog_options.to_map())
-        
+
         with patch.object(RESTTokenFileIO, 'try_to_refresh_token'):
             file_io = RESTTokenFileIO(
                 self.identifier,
                 self.warehouse_path,
                 original_catalog_options
             )
-            
+
             token_dict = {
                 OssOptions.OSS_ACCESS_KEY_ID.key(): "token-access-key",
                 OssOptions.OSS_ACCESS_KEY_SECRET.key(): "token-secret-key",
                 OssOptions.OSS_ENDPOINT.key(): "token-endpoint"
             }
-            
+
             merged_token = file_io._merge_token_with_catalog_options(token_dict)
-            
+
             self.assertEqual(
                 original_catalog_options.to_map(),
                 catalog_options_copy.to_map(),
                 "Original catalog_options should not be modified"
             )
-            
+
             merged_properties = RESTUtil.merge(
                 original_catalog_options.to_map(),
                 merged_token
             )
-            
+
             self.assertIn("custom.key", merged_properties)
             self.assertEqual(merged_properties["custom.key"], "custom.value")
             self.assertIn(OssOptions.OSS_ACCESS_KEY_ID.key(), merged_properties)
@@ -266,11 +259,11 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.warehouse_path,
                 self.catalog_options
             )
-            
+
             self.assertTrue(hasattr(file_io, 'filesystem'), "RESTTokenFileIO should have filesystem property")
             filesystem = file_io.filesystem
             self.assertIsNotNone(filesystem, "filesystem should not be None")
-            
+
             self.assertTrue(hasattr(filesystem, 'open_input_file'),
                             "filesystem should support open_input_file method")
 
@@ -281,12 +274,12 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.warehouse_path,
                 self.catalog_options
             )
-            
+
             self.assertTrue(hasattr(file_io, 'uri_reader_factory'),
                             "RESTTokenFileIO should have uri_reader_factory property")
             uri_reader_factory = file_io.uri_reader_factory
             self.assertIsNotNone(uri_reader_factory, "uri_reader_factory should not be None")
-            
+
             self.assertTrue(hasattr(uri_reader_factory, 'create'),
                             "uri_reader_factory should support create method")
 
@@ -297,10 +290,10 @@ class RESTTokenFileIOTest(unittest.TestCase):
                 self.warehouse_path,
                 self.catalog_options
             )
-            
+
             pickled = pickle.dumps(original_file_io)
             restored_file_io = pickle.loads(pickled)
-            
+
             self.assertIsNotNone(restored_file_io.filesystem,
                                  "filesystem should work after deserialization")
             self.assertIsNotNone(restored_file_io.uri_reader_factory,
@@ -483,6 +476,45 @@ class RESTTokenFileIOTest(unittest.TestCase):
         cached = file_io_2._get_cached_token(file_io_2._build_cache_key())
         self.assertIsNotNone(cached, "file_io_2 should see file_io_1's cached token")
         self.assertEqual(cached.token.get("fs.oss.accessKeyId"), "shared-data-ak")
+
+    def test_refresh_token_strips_system_table_suffix(self):
+        """refresh_token() strips $snapshots suffix before requesting token."""
+        system_identifier = Identifier.create("db", "my_table$snapshots")
+        file_io = RESTTokenFileIO(
+            system_identifier, self.warehouse_path, self.catalog_options)
+
+        mock_response = MagicMock()
+        mock_response.token = {'ak': 'test-ak'}
+        mock_response.expires_at_millis = int(time.time() * 1000) + 7_200_000
+
+        mock_api = MagicMock()
+        mock_api.load_table_token.return_value = mock_response
+        file_io.api_instance = mock_api
+
+        file_io.refresh_token()
+
+        called_identifier = mock_api.load_table_token.call_args[0][0]
+        self.assertEqual(called_identifier.get_database_name(), "db")
+        self.assertEqual(called_identifier.get_object_name(), "my_table")
+
+    def test_refresh_token_keeps_normal_identifier(self):
+        """refresh_token() does not modify normal (non-system) identifiers."""
+        normal_identifier = Identifier.create("db", "my_table")
+        file_io = RESTTokenFileIO(
+            normal_identifier, self.warehouse_path, self.catalog_options)
+
+        mock_response = MagicMock()
+        mock_response.token = {'ak': 'test-ak'}
+        mock_response.expires_at_millis = int(time.time() * 1000) + 7_200_000
+
+        mock_api = MagicMock()
+        mock_api.load_table_token.return_value = mock_response
+        file_io.api_instance = mock_api
+
+        file_io.refresh_token()
+
+        called_identifier = mock_api.load_table_token.call_args[0][0]
+        self.assertEqual(called_identifier.get_object_name(), "my_table")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Purpose

Revert #7562 and fix token cache pollution with a minimal approach.

**Problem:**
In #7562, the class-level `_TOKEN_CACHE` was completely removed to fix token pollution across different catalog instances. However, this also removed the ability to reuse tokens for the same user on the same table, causing unnecessary token refresh requests.

The root cause of the original pollution was that `_TOKEN_CACHE` was keyed only by table identifier (`str(self.identifier)`), so different users (different AK/SK credentials) operating on the same table within one process would share the same cached data token.

**Fix:**
Instead of removing the cache entirely, this PR adds **user identity** to the cache key to isolate tokens across different credentials while preserving token reuse for the same user.

- Revert commit `8a310149` to restore the class-level `_TOKEN_CACHE` mechanism
- Add `_build_cache_key()` and `_get_user_identity()` methods
- Cache key format changes from `"{identifier}"` to `"{user_identity}:{identifier}"`
- User identity is obtained from the existing `api_instance`'s auth provider:
  - **DLF auth** (AK/SK, STS, ECS Role): `auth_provider.get_token().access_key_id`
  - **Bear Token auth**: `auth_provider.token`
  - **Unknown auth**: `'anonymous'`

No new instance fields are added, so `__getstate__`/`__setstate__` serialization remains unchanged.

### Tests

Added 4 new test cases in `rest_token_file_io_test.py`:
- `test_build_cache_key_with_dlf_auth`: verifies DLF cache key includes `access_key_id`
- `test_build_cache_key_with_bear_auth`: verifies Bear cache key includes bearer token
- `test_different_ak_same_table_token_isolation`: verifies different AKs on the same table produce isolated cache entries
- `test_same_ak_same_table_token_reuse`: verifies same AK on the same table can reuse cached tokens

All 13 tests pass.

