### PR TITLE
[python] Fix update_by_row_id conflict when file rolling splits

### DIFF
--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1109,18 +1109,11 @@ class TableUpdateTest(unittest.TestCase):
         for msg in msgs:
             all_files.extend(msg.new_files)
 
-        self.assertGreater(len(all_files), 1,
-                           "Update should produce multiple files")
-
-        first_ids = [f.first_row_id for f in all_files]
-        self.assertEqual(len(first_ids), len(set(first_ids)),
-                         "All files must have unique first_row_id")
-
-        expected_id = 0
-        for f in sorted(all_files, key=lambda x: x.first_row_id):
-            self.assertEqual(f.first_row_id, expected_id)
-            expected_id += f.row_count
-        self.assertEqual(expected_id, N)
+        self.assertEqual(
+            len(all_files), 1,
+            "Update should produce exactly one file per group")
+        self.assertEqual(all_files[0].first_row_id, 0)
+        self.assertEqual(all_files[0].row_count, N)
 
         tc = wb.new_commit()
         tc.commit(msgs)

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -85,10 +85,7 @@ class ConflictDetection:
             return RuntimeError(
                 "File deletion conflicts detected! Give up committing. " + str(e))
 
-        if commit_kind == "COMPACT":
-            conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
-        else:
-            conflict = self.check_row_id_range_conflicts(commit_kind, delta_entries)
+        conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
         if conflict is not None:
             return conflict
 

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -46,6 +46,11 @@ class FileStoreWrite:
                              (f"{self.options.data_file_prefix()}-u-{commit_user}"
                               f"-s-{random.randint(0, 2 ** 31 - 2)}-w-"))
 
+    def disable_rolling(self):
+        """Disable file rolling by setting target_file_size to max."""
+        self.options.set(
+            CoreOptions.TARGET_FILE_SIZE, str(2 ** 63 - 1))
+
     def write(self, partition: Tuple, bucket: int, data: pa.RecordBatch):
         key = (partition, bucket)
         if key not in self.data_writers:

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -292,24 +292,31 @@ class TableUpdateByRowId:
         # Merge update data with original data
         merged_data = self._merge_update_with_original(original_data, data, column_names, first_row_id)
 
+        # Create a file store write for this partition
+        # Disable rolling to ensure one output file per first_row_id group,
         file_store_write = FileStoreWrite(self.table, self.commit_user)
+        file_store_write.disable_rolling()
+
+        # Set write columns to only update specific columns
         write_cols = column_names
         file_store_write.write_cols = write_cols
 
+        # Convert partition to tuple for hashing
         partition_tuple = tuple(partition.values)
 
+        # Write merged data - convert Table to RecordBatch
         for batch in merged_data.to_batches():
             file_store_write.write(partition_tuple, 0, batch)
 
+        # Prepare commit and assign first_row_id
         commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
 
-        current_row_id = first_row_id
+        # Assign first_row_id to the new files
         for msg in commit_messages:
             msg.check_from_snapshot = self.snapshot_id
             for file in msg.new_files:
-                file.first_row_id = current_row_id
+                file.first_row_id = first_row_id
                 file.write_cols = write_cols
-                current_row_id += file.row_count
 
         self.commit_messages.extend(commit_messages)
 


### PR DESCRIPTION
### Purpose
When calling `update_by_arrow_with_row_id` or `upsert_by_arrow_with_key` on large files, there is `RuntimeError: For Data Evolution table, multiple 'MERGE INTO' and 'COMPACT' operations have encountered conflicts`. This PR fixes the above issue by disabling rolling for one file when `update_by_arrow_with_row_id`.

### Tests
