### PR TITLE
[docs] Add Spark SQL example for fast_forward in manage-branches

### DIFF
--- a/docs/content/maintenance/manage-branches.md
+++ b/docs/content/maintenance/manage-branches.md
@@ -202,6 +202,17 @@ Run the following command:
     --branch_name <branch-name> \
     [--catalog_conf <paimon-catalog-conf> [--catalog_conf <paimon-catalog-conf> ...]]
 ```
+
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+
+Run the following sql:
+
+```sql
+CALL sys.fast_forward('default.T', 'branch1');
+```
+
 {{< /tab >}}
 
 {{< /tabs >}}


### PR DESCRIPTION
### Purpose
 Add Spark SQL example for fast_forward in manage-branches and avoid misleading users into thinking that spark does not support fast_forward.

### Tests
