### PR TITLE
[common] Fix OOM when writing/compacting table with large records

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -36,6 +36,14 @@ public class RowHelper implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Threshold in bytes for releasing the internal reuse buffer. When big records are written, the
+     * BinaryRowWriter's internal segment can grow very large via grow(). The {@link
+     * #resetIfTooLarge()} method checks this threshold and releases the bloated
+     * reuseRow/reuseWriter to avoid holding onto oversized buffers indefinitely.
+     */
+    private static final int REUSE_RELEASE_THRESHOLD = 4 * 1024 * 1024; // 4MB
+
     private final FieldGetter[] fieldGetters;
     private final ValueSetter[] valueSetters;
     private final boolean[] writeNulls;
@@ -79,6 +87,20 @@ public class RowHelper implements Serializable {
             }
         }
         reuseWriter.complete();
+    }
+
+    /**
+     * Release the internal reuse buffer if the segment exceeds the threshold. This should be called
+     * after the caller has finished using the reuseRow (e.g. after serialization), so that large
+     * records don't linger in memory.
+     */
+    public void resetIfTooLarge() {
+        if (reuseWriter != null
+                && reuseWriter.getSegments() != null
+                && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD) {
+            reuseRow = null;
+            reuseWriter = null;
+        }
     }
 
     public BinaryRow reuseRow() {

--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -90,14 +90,15 @@ public class RowHelper implements Serializable {
     }
 
     /**
-     * Release the internal reuse buffer if the segment exceeds the threshold. This should be called
-     * after the caller has finished using the reuseRow (e.g. after serialization), so that large
-     * records don't linger in memory.
+     * Release the internal reuse buffer if the segment exceeds the threshold AND the last written
+     * record is small. This hysteresis avoids thrashing when records are consistently large, while
+     * still reclaiming memory when the workload transitions back to small records.
      */
     public void resetIfTooLarge() {
         if (reuseWriter != null
                 && reuseWriter.getSegments() != null
-                && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD) {
+                && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD
+                && reuseRow.getSizeInBytes() < REUSE_RELEASE_THRESHOLD) {
             reuseRow = null;
             reuseWriter = null;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
@@ -106,19 +106,27 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
         Arrays.fill(this.length, value.length);
     }
 
+    /** The maximum size of array to allocate. Some VMs reserve header words in an array. */
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
     private void reserveBytes(int newCapacity) {
         if (newCapacity > buffer.length) {
-            int newBytesCapacity = newCapacity * 2;
-            try {
-                buffer = Arrays.copyOf(buffer, newBytesCapacity);
-            } catch (NegativeArraySizeException e) {
+            if (newCapacity > MAX_ARRAY_SIZE) {
                 throw new RuntimeException(
                         String.format(
-                                "The new claimed capacity %s is too large, will overflow the INTEGER.MAX after multiply by 2. "
-                                        + "Try reduce `read.batch-size` to avoid this exception.",
-                                newCapacity),
-                        e);
+                                "The required byte buffer capacity %s exceeds the maximum array size. "
+                                        + "Try reducing `read.batch-size` to avoid this exception.",
+                                newCapacity));
             }
+            // Try to double the capacity for amortized growth. If doubling would overflow,
+            // fall back to the exact required capacity (capped at MAX_ARRAY_SIZE).
+            int newBytesCapacity;
+            if (newCapacity <= (MAX_ARRAY_SIZE >> 1)) {
+                newBytesCapacity = newCapacity << 1;
+            } else {
+                newBytesCapacity = MAX_ARRAY_SIZE;
+            }
+            buffer = Arrays.copyOf(buffer, newBytesCapacity);
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/heap/HeapBytesVector.java
@@ -80,7 +80,8 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
 
     @Override
     public void putByteArray(int elementNum, byte[] sourceBuf, int start, int length) {
-        reserveBytes(bytesAppended + length);
+        long requiredCapacity = (long) bytesAppended + length;
+        reserveBytes(requiredCapacity);
         System.arraycopy(sourceBuf, start, buffer, bytesAppended, length);
         this.start[elementNum] = bytesAppended;
         this.length[elementNum] = length;
@@ -96,7 +97,8 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
 
     @Override
     public void fill(byte[] value) {
-        reserveBytes(start.length * value.length);
+        long requiredCapacity = (long) start.length * value.length;
+        reserveBytes(requiredCapacity);
         for (int i = 0; i < start.length; i++) {
             System.arraycopy(value, 0, buffer, i * value.length, value.length);
         }
@@ -107,26 +109,34 @@ public class HeapBytesVector extends AbstractHeapVector implements WritableBytes
     }
 
     /** The maximum size of array to allocate. Some VMs reserve header words in an array. */
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
-    private void reserveBytes(int newCapacity) {
-        if (newCapacity > buffer.length) {
-            if (newCapacity > MAX_ARRAY_SIZE) {
-                throw new RuntimeException(
-                        String.format(
-                                "The required byte buffer capacity %s exceeds the maximum array size. "
-                                        + "Try reducing `read.batch-size` to avoid this exception.",
-                                newCapacity));
-            }
-            // Try to double the capacity for amortized growth. If doubling would overflow,
-            // fall back to the exact required capacity (capped at MAX_ARRAY_SIZE).
-            int newBytesCapacity;
-            if (newCapacity <= (MAX_ARRAY_SIZE >> 1)) {
-                newBytesCapacity = newCapacity << 1;
-            } else {
-                newBytesCapacity = MAX_ARRAY_SIZE;
-            }
-            buffer = Arrays.copyOf(buffer, newBytesCapacity);
+    private void reserveBytes(long requiredCapacity) {
+        if (requiredCapacity > buffer.length) {
+            buffer = Arrays.copyOf(buffer, calculateNewBytesCapacity(requiredCapacity));
+        }
+    }
+
+    /**
+     * Calculate the new buffer capacity for the given required capacity. Visible for testing.
+     *
+     * <p>The strategy is: double the required capacity for amortized growth when safe. If doubling
+     * would exceed {@link #MAX_ARRAY_SIZE}, fall back to the exact required capacity. Throws if the
+     * required capacity itself exceeds {@link #MAX_ARRAY_SIZE}.
+     */
+    static int calculateNewBytesCapacity(long requiredCapacity) {
+        if (requiredCapacity > MAX_ARRAY_SIZE) {
+            throw new RuntimeException(
+                    String.format(
+                            "The required byte buffer capacity %d exceeds the maximum array size %d. "
+                                    + "Try reducing `read.batch-size` to avoid this exception.",
+                            requiredCapacity, MAX_ARRAY_SIZE));
+        }
+        int intCapacity = (int) requiredCapacity;
+        if (intCapacity <= (MAX_ARRAY_SIZE >> 1)) {
+            return intCapacity << 1;
+        } else {
+            return intCapacity;
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
@@ -80,6 +80,13 @@ public class BinaryRowSerializer extends AbstractRowDataSerializer<BinaryRow> {
         return row;
     }
 
+    /**
+     * Threshold above which we consider a reuse buffer "oversized" and eligible for shrinking. This
+     * prevents accumulation of large byte arrays when a few large records inflate the reuse buffer
+     * and subsequent small records never trigger reallocation.
+     */
+    private static final int REUSE_SHRINK_THRESHOLD = 4 * 1024 * 1024; // 4MB
+
     public BinaryRow deserialize(BinaryRow reuse, DataInputView source) throws IOException {
         MemorySegment[] segments = reuse.getSegments();
         checkArgument(
@@ -88,6 +95,12 @@ public class BinaryRowSerializer extends AbstractRowDataSerializer<BinaryRow> {
 
         int length = source.readInt();
         if (segments == null || segments[0].size() < length) {
+            // Need a larger buffer
+            segments = new MemorySegment[] {MemorySegment.wrap(new byte[length])};
+        } else if (segments[0].size() > REUSE_SHRINK_THRESHOLD) {
+            // The existing buffer is oversized (> 4MB). Shrink it to avoid holding onto large
+            // byte arrays indefinitely, which can cause OOM when many merge channels each
+            // retain a bloated reuse buffer.
             segments = new MemorySegment[] {MemorySegment.wrap(new byte[length])};
         }
         source.readFully(segments[0].getArray(), 0, length);

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
@@ -97,10 +97,11 @@ public class BinaryRowSerializer extends AbstractRowDataSerializer<BinaryRow> {
         if (segments == null || segments[0].size() < length) {
             // Need a larger buffer
             segments = new MemorySegment[] {MemorySegment.wrap(new byte[length])};
-        } else if (segments[0].size() > REUSE_SHRINK_THRESHOLD) {
-            // The existing buffer is oversized (> 4MB). Shrink it to avoid holding onto large
-            // byte arrays indefinitely, which can cause OOM when many merge channels each
-            // retain a bloated reuse buffer.
+        } else if (segments[0].size() > REUSE_SHRINK_THRESHOLD && length < REUSE_SHRINK_THRESHOLD) {
+            // Hysteresis: only shrink when the buffer is oversized AND the current record is
+            // small. This avoids thrashing (release-and-rebuild on every record) when records
+            // are consistently large (e.g. 5-10MB), while still reclaiming memory when the
+            // workload transitions back to small records.
             segments = new MemorySegment[] {MemorySegment.wrap(new byte[length])};
         }
         source.readFully(segments[0].getArray(), 0, length);

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
@@ -59,7 +59,16 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
 
     @Override
     public void serialize(InternalRow row, DataOutputView target) throws IOException {
-        binarySerializer.serialize(toBinaryRow(row), target);
+        try {
+            binarySerializer.serialize(toBinaryRow(row), target);
+        } finally {
+            // Must use finally here: toBinaryRow() may inflate RowHelper's internal buffer
+            // for large records (e.g. 100MB+). The serialization can exit via EOFException
+            // thrown by SimpleCollectingOutputView.nextSegment() when the sort buffer is
+            // full, which is caught by BinaryInMemorySortBuffer.write() as a normal signal.
+            // Without finally, the bloated buffer would never be released on that path.
+            rowHelper.resetIfTooLarge();
+        }
     }
 
     @Override
@@ -132,7 +141,13 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
     @Override
     public int serializeToPages(InternalRow row, AbstractPagedOutputView target)
             throws IOException {
-        return binarySerializer.serializeToPages(toBinaryRow(row), target);
+        try {
+            return binarySerializer.serializeToPages(toBinaryRow(row), target);
+        } finally {
+            // Same as serialize(): must use finally because EOFException may bypass normal
+            // return when the sort buffer is full.
+            rowHelper.resetIfTooLarge();
+        }
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RowHelper}, focusing on the resetIfTooLarge() behavior. */
+class RowHelperTest {
+
+    @Test
+    void testResetIfTooLargeReleasesOversizedBuffer() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a large record (> 4MB) to inflate the internal buffer
+        byte[] largePayload = new byte[5 * 1024 * 1024]; // 5MB
+        Arrays.fill(largePayload, (byte) 'x');
+        GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
+        largeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(largeRow);
+
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // resetIfTooLarge() should release the bloated buffer
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testResetIfTooLargeKeepsSmallBuffer() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.INT()));
+
+        // Write a small record (< 4MB)
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("hello"), 42);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // resetIfTooLarge() should NOT release the small buffer
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+    }
+
+    @Test
+    void testResetIfTooLargeBeforeCopyInto() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING()));
+
+        // reuseRow is null before any copyInto
+        assertThat(helper.reuseRow()).isNull();
+
+        // resetIfTooLarge() should be safe to call when reuseRow is null
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testReuseIsRecreatedAfterRelease() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a large record to inflate the buffer
+        byte[] largePayload = new byte[5 * 1024 * 1024];
+        GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
+        largeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(largeRow);
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+
+        // Write a small record — reuseRow should be recreated
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("small"), new byte[10]);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Small buffer should survive resetIfTooLarge()
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RowHelperTest {
 
     @Test
-    void testResetIfTooLargeReleasesOversizedBuffer() {
+    void testResetIfTooLargeReleasesAfterTransitionToSmallRecord() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
 
         // Write a large record (> 4MB) to inflate the internal buffer
@@ -43,7 +43,16 @@ class RowHelperTest {
 
         assertThat(helper.reuseRow()).isNotNull();
 
-        // resetIfTooLarge() should release the bloated buffer
+        // Hysteresis: resetIfTooLarge() should NOT release when last record is large
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Now write a small record — buffer is still oversized from the large record
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("s"), new byte[10]);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        // resetIfTooLarge() should release now: buffer > 4MB but last record < 4MB
         helper.resetIfTooLarge();
         assertThat(helper.reuseRow()).isNull();
     }
@@ -80,17 +89,21 @@ class RowHelperTest {
     void testReuseIsRecreatedAfterRelease() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
 
-        // Write a large record to inflate the buffer
+        // Write a large record to inflate the buffer, then a small record to trigger release
         byte[] largePayload = new byte[5 * 1024 * 1024];
         GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
         largeRow.setRowKind(RowKind.INSERT);
         helper.copyInto(largeRow);
+
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("small"), new byte[10]);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        // Buffer is oversized + last record is small → release
         helper.resetIfTooLarge();
         assertThat(helper.reuseRow()).isNull();
 
-        // Write a small record — reuseRow should be recreated
-        GenericRow smallRow = GenericRow.of(BinaryString.fromString("small"), new byte[10]);
-        smallRow.setRowKind(RowKind.INSERT);
+        // Write another small record — reuseRow should be recreated
         helper.copyInto(smallRow);
         assertThat(helper.reuseRow()).isNotNull();
 

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.columnar.heap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HeapBytesVector#putByteArray}, focusing on reserveBytes() overflow safety. */
+class HeapBytesVectorReserveBytesTest {
+
+    @Test
+    void testNormalGrowthDoublesCapacity() {
+        HeapBytesVector vector = new HeapBytesVector(4);
+        int initialBufferSize = vector.buffer.length;
+
+        // Write enough data to trigger growth
+        byte[] data = new byte[initialBufferSize + 1];
+        vector.putByteArray(0, data, 0, data.length);
+
+        // Buffer should have doubled
+        assertThat(vector.buffer.length).isEqualTo((initialBufferSize + 1) * 2);
+    }
+
+    @Test
+    void testPutByteArrayStoresDataCorrectly() {
+        HeapBytesVector vector = new HeapBytesVector(4);
+
+        byte[] data1 = new byte[] {1, 2, 3};
+        byte[] data2 = new byte[] {4, 5, 6, 7};
+        vector.putByteArray(0, data1, 0, data1.length);
+        vector.putByteArray(1, data2, 0, data2.length);
+
+        HeapBytesVector.Bytes bytes0 = vector.getBytes(0);
+        assertThat(bytes0.len).isEqualTo(3);
+        assertThat(vector.buffer[bytes0.offset]).isEqualTo((byte) 1);
+        assertThat(vector.buffer[bytes0.offset + 2]).isEqualTo((byte) 3);
+
+        HeapBytesVector.Bytes bytes1 = vector.getBytes(1);
+        assertThat(bytes1.len).isEqualTo(4);
+        assertThat(vector.buffer[bytes1.offset]).isEqualTo((byte) 4);
+    }
+
+    @Test
+    void testLargeCapacityDoesNotOverflow() {
+        HeapBytesVector vector = new HeapBytesVector(2);
+
+        // Simulate a scenario where the required capacity is large but still within
+        // MAX_ARRAY_SIZE. We can't actually allocate Integer.MAX_VALUE bytes in a test,
+        // but we can verify the logic by checking that a moderately large allocation works.
+        int largeSize = 64 * 1024 * 1024; // 64MB
+        byte[] largeData = new byte[largeSize];
+        vector.putByteArray(0, largeData, 0, largeData.length);
+
+        assertThat(vector.buffer.length).isGreaterThanOrEqualTo(largeSize);
+        assertThat(vector.getBytes(0).len).isEqualTo(largeSize);
+    }
+
+    @Test
+    void testResetClearsBytesAppended() {
+        HeapBytesVector vector = new HeapBytesVector(4);
+
+        byte[] data = new byte[] {1, 2, 3};
+        vector.putByteArray(0, data, 0, data.length);
+
+        vector.reset();
+
+        // After reset, we should be able to write again from the beginning
+        byte[] data2 = new byte[] {10, 20};
+        vector.putByteArray(0, data2, 0, data2.length);
+
+        HeapBytesVector.Bytes bytes = vector.getBytes(0);
+        assertThat(bytes.offset).isEqualTo(0);
+        assertThat(bytes.len).isEqualTo(2);
+        assertThat(vector.buffer[0]).isEqualTo((byte) 10);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/heap/HeapBytesVectorReserveBytesTest.java
@@ -21,8 +21,12 @@ package org.apache.paimon.data.columnar.heap;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for {@link HeapBytesVector#putByteArray}, focusing on reserveBytes() overflow safety. */
+/**
+ * Tests for {@link HeapBytesVector#putByteArray}, focusing on reserveBytes() overflow safety and
+ * the capacity-growth calculation in {@link HeapBytesVector#calculateNewBytesCapacity}.
+ */
 class HeapBytesVectorReserveBytesTest {
 
     @Test
@@ -70,6 +74,66 @@ class HeapBytesVectorReserveBytesTest {
 
         assertThat(vector.buffer.length).isGreaterThanOrEqualTo(largeSize);
         assertThat(vector.getBytes(0).len).isEqualTo(largeSize);
+    }
+
+    // ---- Tests for calculateNewBytesCapacity (no large allocation needed) ----
+
+    @Test
+    void testCalculateNewBytesCapacityDoublesSmallValues() {
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(100)).isEqualTo(200);
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(1)).isEqualTo(2);
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(1024 * 1024))
+                .isEqualTo(2 * 1024 * 1024);
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityAtHalfMaxReturnsDoubled() {
+        int halfMax = HeapBytesVector.MAX_ARRAY_SIZE >> 1;
+        // Exactly at the boundary: should still double
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(halfMax)).isEqualTo(halfMax << 1);
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityAboveHalfMaxReturnsExact() {
+        int halfMax = HeapBytesVector.MAX_ARRAY_SIZE >> 1;
+        int justAboveHalf = halfMax + 1;
+        // Above the doubling threshold: should return exact required capacity, not MAX_ARRAY_SIZE
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(justAboveHalf))
+                .isEqualTo(justAboveHalf);
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityAtMaxArraySizeReturnsExact() {
+        // Exactly at MAX_ARRAY_SIZE: should return exact value
+        assertThat(HeapBytesVector.calculateNewBytesCapacity(HeapBytesVector.MAX_ARRAY_SIZE))
+                .isEqualTo(HeapBytesVector.MAX_ARRAY_SIZE);
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityAboveMaxArraySizeThrows() {
+        long aboveMax = (long) HeapBytesVector.MAX_ARRAY_SIZE + 1;
+        assertThatThrownBy(() -> HeapBytesVector.calculateNewBytesCapacity(aboveMax))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("exceeds the maximum array size");
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityLongOverflowThrows() {
+        // Simulate what would happen if int arithmetic overflowed:
+        // e.g. bytesAppended=Integer.MAX_VALUE, length=1 => long sum > MAX_ARRAY_SIZE
+        long overflowedCapacity = (long) Integer.MAX_VALUE + 1;
+        assertThatThrownBy(() -> HeapBytesVector.calculateNewBytesCapacity(overflowedCapacity))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("exceeds the maximum array size");
+    }
+
+    @Test
+    void testCalculateNewBytesCapacityNegativeLongThrows() {
+        // A very large long value that would represent an int overflow scenario
+        long hugeCapacity = 3_000_000_000L;
+        assertThatThrownBy(() -> HeapBytesVector.calculateNewBytesCapacity(hugeCapacity))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("exceeds the maximum array size");
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerShrinkTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerShrinkTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.serializer;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.io.DataInputDeserializer;
+import org.apache.paimon.io.DataOutputSerializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link BinaryRowSerializer#deserialize(BinaryRow, org.apache.paimon.io.DataInputView)},
+ * focusing on the REUSE_SHRINK_THRESHOLD behavior.
+ */
+class BinaryRowSerializerShrinkTest {
+
+    private static final int SHRINK_THRESHOLD = 4 * 1024 * 1024; // 4MB
+
+    @Test
+    void testDeserializeShrinksOversizedReuseBuffer() throws Exception {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+
+        // Serialize a large record (> 4MB)
+        BinaryRow largeRow = createRowWithPayload(5 * 1024 * 1024);
+        byte[] largeBytes = serializeRow(serializer, largeRow);
+
+        // Deserialize into a fresh reuse row — buffer grows to hold the large record
+        BinaryRow reuse = serializer.createInstance();
+        DataInputDeserializer largeInput = new DataInputDeserializer(largeBytes);
+        reuse = serializer.deserialize(reuse, largeInput);
+        int largeBufferSize = reuse.getSegments()[0].size();
+        assertThat(largeBufferSize).isGreaterThanOrEqualTo(5 * 1024 * 1024);
+
+        // Serialize a small record
+        BinaryRow smallRow = createRowWithPayload(100);
+        byte[] smallBytes = serializeRow(serializer, smallRow);
+
+        // Deserialize the small record into the same reuse row
+        // The oversized buffer (> 4MB) should be shrunk to the exact size needed
+        DataInputDeserializer smallInput = new DataInputDeserializer(smallBytes);
+        reuse = serializer.deserialize(reuse, smallInput);
+        int shrunkBufferSize = reuse.getSegments()[0].size();
+        assertThat(shrunkBufferSize).isLessThan(SHRINK_THRESHOLD);
+    }
+
+    @Test
+    void testDeserializeKeepsSmallReuseBuffer() throws Exception {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+
+        // Serialize a small record (< 4MB)
+        BinaryRow row1 = createRowWithPayload(1024);
+        byte[] bytes1 = serializeRow(serializer, row1);
+
+        BinaryRow reuse = serializer.createInstance();
+        DataInputDeserializer input1 = new DataInputDeserializer(bytes1);
+        reuse = serializer.deserialize(reuse, input1);
+        int bufferSize1 = reuse.getSegments()[0].size();
+
+        // Serialize an even smaller record
+        BinaryRow row2 = createRowWithPayload(100);
+        byte[] bytes2 = serializeRow(serializer, row2);
+
+        // Deserialize — buffer should be reused (not shrunk), since it's < 4MB
+        DataInputDeserializer input2 = new DataInputDeserializer(bytes2);
+        reuse = serializer.deserialize(reuse, input2);
+        int bufferSize2 = reuse.getSegments()[0].size();
+        assertThat(bufferSize2).isEqualTo(bufferSize1);
+    }
+
+    @Test
+    void testDeserializeGrowsBufferWhenNeeded() throws Exception {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+
+        // Start with a small record
+        BinaryRow smallRow = createRowWithPayload(100);
+        byte[] smallBytes = serializeRow(serializer, smallRow);
+
+        BinaryRow reuse = serializer.createInstance();
+        DataInputDeserializer smallInput = new DataInputDeserializer(smallBytes);
+        reuse = serializer.deserialize(reuse, smallInput);
+
+        // Deserialize a larger record — buffer should grow
+        BinaryRow largerRow = createRowWithPayload(2048);
+        byte[] largerBytes = serializeRow(serializer, largerRow);
+
+        DataInputDeserializer largerInput = new DataInputDeserializer(largerBytes);
+        reuse = serializer.deserialize(reuse, largerInput);
+        assertThat(reuse.getSegments()[0].size()).isGreaterThanOrEqualTo(2048);
+    }
+
+    private static BinaryRow createRowWithPayload(int payloadSize) {
+        BinaryRow row = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(row, payloadSize + 32);
+        byte[] payload = new byte[payloadSize];
+        writer.writeString(0, BinaryString.fromBytes(payload));
+        writer.complete();
+        return row;
+    }
+
+    private static byte[] serializeRow(BinaryRowSerializer serializer, BinaryRow row)
+            throws Exception {
+        DataOutputSerializer output = new DataOutputSerializer(row.getSizeInBytes() + 4);
+        serializer.serialize(row, output);
+        return output.getCopyOfBuffer();
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerShrinkTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerShrinkTest.java
@@ -88,6 +88,31 @@ class BinaryRowSerializerShrinkTest {
     }
 
     @Test
+    void testDeserializeRetainsBufferForConsecutiveLargeRecords() throws Exception {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+
+        // Serialize a large record (> 4MB) to inflate the buffer
+        BinaryRow largeRow1 = createRowWithPayload(5 * 1024 * 1024);
+        byte[] largeBytes1 = serializeRow(serializer, largeRow1);
+
+        BinaryRow reuse = serializer.createInstance();
+        DataInputDeserializer input1 = new DataInputDeserializer(largeBytes1);
+        reuse = serializer.deserialize(reuse, input1);
+        int bufferAfterFirst = reuse.getSegments()[0].size();
+        assertThat(bufferAfterFirst).isGreaterThanOrEqualTo(5 * 1024 * 1024);
+
+        // Deserialize another large record (also > 4MB)
+        // Hysteresis: buffer should NOT be shrunk because the incoming record is also large
+        BinaryRow largeRow2 = createRowWithPayload(SHRINK_THRESHOLD + 100);
+        byte[] largeBytes2 = serializeRow(serializer, largeRow2);
+
+        DataInputDeserializer input2 = new DataInputDeserializer(largeBytes2);
+        reuse = serializer.deserialize(reuse, input2);
+        int bufferAfterSecond = reuse.getSegments()[0].size();
+        assertThat(bufferAfterSecond).isEqualTo(bufferAfterFirst);
+    }
+
+    @Test
     void testDeserializeGrowsBufferWhenNeeded() throws Exception {
         BinaryRowSerializer serializer = new BinaryRowSerializer(1);
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -96,7 +96,23 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
                         .withBloomFilterEnabled(
                                 conf.getBoolean(
                                         ParquetOutputFormat.BLOOM_FILTER_ENABLED,
-                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED));
+                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED))
+                        .withMinRowCountForPageSizeCheck(
+                                conf.getInt(
+                                        ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
+                                        ParquetProperties.DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK))
+                        .withMaxRowCountForPageSizeCheck(
+                                conf.getInt(
+                                        ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
+                                        ParquetProperties.DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK))
+                        .withStatisticsTruncateLength(
+                                conf.getInt(
+                                        ParquetOutputFormat.STATISTICS_TRUNCATE_LENGTH,
+                                        ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH))
+                        .withColumnIndexTruncateLength(
+                                conf.getInt(
+                                        ParquetOutputFormat.COLUMN_INDEX_TRUNCATE_LENGTH,
+                                        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH));
         new ColumnConfigParser()
                 .withColumnConfig(
                         ParquetOutputFormat.ENABLE_DICTIONARY,

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -96,23 +96,7 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
                         .withBloomFilterEnabled(
                                 conf.getBoolean(
                                         ParquetOutputFormat.BLOOM_FILTER_ENABLED,
-                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED))
-                        .withMinRowCountForPageSizeCheck(
-                                conf.getInt(
-                                        ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
-                                        ParquetProperties.DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK))
-                        .withMaxRowCountForPageSizeCheck(
-                                conf.getInt(
-                                        ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
-                                        ParquetProperties.DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK))
-                        .withStatisticsTruncateLength(
-                                conf.getInt(
-                                        ParquetOutputFormat.STATISTICS_TRUNCATE_LENGTH,
-                                        ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH))
-                        .withColumnIndexTruncateLength(
-                                conf.getInt(
-                                        ParquetOutputFormat.COLUMN_INDEX_TRUNCATE_LENGTH,
-                                        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH));
+                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED));
         new ColumnConfigParser()
                 .withColumnConfig(
                         ParquetOutputFormat.ENABLE_DICTIONARY,


### PR DESCRIPTION
  ### Purpose
  Linked issue: close #7620
  Fix OOM when writing table with large records (100MB+) and many buckets (e.g. 256) due to unbounded buffer growth in sort, merge and compaction paths. Each bucket's writer independently holds its own sort buffer, merge channels, and compaction readers. When a large record inflates an internal reuse buffer, that bloated buffer is retained per-bucket, causing memory usage to quickly exceed available heap.

  Heap dump analysis identified three independent root causes:

  **1. Sort path — `RowHelper` internal buffer never shrinks**

  `RowHelper.reuseWriter` grows its internal `MemorySegment` for large records, but `BinaryRowWriter.reset()` only resets the cursor without releasing the oversized segment. Additionally, `InternalRowSerializer.serialize()` can exit via `EOFException` (a normal signal when the sort buffer is full), skipping any cleanup of the bloated buffer.

  **2. Merge path — `BinaryRowSerializer.deserialize(reuse)` only grows, never shrinks**

  Each merge channel holds a `BinaryRow` reuse instance. When a large record is deserialized, the backing `MemorySegment` grows to fit it but is never shrunk for subsequent small records. With `max-num-file-handles` (default 128) channels each retaining a 100MB+ buffer, memory usage explodes.

  **3. Compaction read path — `HeapBytesVector.reserveBytes()` integer overflow**

  `reserveBytes()` computes `newCapacity * 2` using plain multiplication. When `newCapacity` exceeds ~1.07 billion bytes, this overflows `Integer.MAX_VALUE`, causing `NegativeArraySizeException` or silent data corruption.

  #### Changes

  1. **`RowHelper`**: add `resetIfTooLarge()` with hysteresis — release internal buffer only when the segment exceeds 4MB **and** the last written record is smaller than 4MB. This avoids thrashing for sustained large-record workloads while reclaiming memory when the workload transitions back to small records.
  2. **`InternalRowSerializer`**: call `resetIfTooLarge()` in `finally` block of `serialize()` and `serializeToPages()` to handle `EOFException` exit path.
  3. **`BinaryRowSerializer`**: add shrink logic with hysteresis in `deserialize(reuse)` — reallocate only when existing buffer > 4MB **and** current record < 4MB.
  4. **`HeapBytesVector`**: promote to `long` before capacity arithmetic, extract `calculateNewBytesCapacity(long)` helper, cap at `MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8`, return exact required capacity when doubling would exceed max, throw clear error on overflow.

  > **Note:** The Parquet config pass-through (`RowDataParquetBuilder`) has been moved to #7956 as it is an independent enhancement.

  ### Tests
  - `RowHelperTest` — validates hysteresis: buffer retained for large records, released only on transition to small records
  - `BinaryRowSerializerShrinkTest` — validates hysteresis: buffer retained for consecutive large records, shrunk on transition to small records
  - `HeapBytesVectorReserveBytesTest` — validates overflow-safe `reserveBytes()` growth, `calculateNewBytesCapacity` edge cases (doubling, exact capacity, overflow), and data correctness

  ### API and Format

  N/A — no public API or format changes.

  ### Documentation

  N/A