### PR TITLE
[core] Support partition predicate pushdown for PartitionsTable

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BucketsTable.java
@@ -234,7 +234,8 @@ public class BucketsTable implements ReadonlyTable {
                             snapshotReader,
                             bucketsSplit.partitionPredicate,
                             partitionKeys,
-                            partitionType);
+                            partitionType,
+                            fileStoreTable.coreOptions().partitionDefaultName());
             if (!hasResults) {
                 return new IteratorRecordReader<>(Collections.emptyIterator());
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileKeyRangesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileKeyRangesTable.java
@@ -170,7 +170,11 @@ public class FileKeyRangesTable implements ReadonlyTable {
             RowType partitionType = fileStoreTable.schema().logicalPartitionType();
             boolean hasResults =
                     PartitionPredicateHelper.applyPartitionFilter(
-                            snapshotReader, partitionPredicate, partitionKeys, partitionType);
+                            snapshotReader,
+                            partitionPredicate,
+                            partitionKeys,
+                            partitionType,
+                            fileStoreTable.coreOptions().partitionDefaultName());
             if (!hasResults) {
                 return Collections::emptyList;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -196,7 +196,11 @@ public class FilesTable implements ReadonlyTable {
             RowType partitionType = fileStoreTable.schema().logicalPartitionType();
             boolean hasResults =
                     PartitionPredicateHelper.applyPartitionFilter(
-                            snapshotReader, partitionPredicate, partitionKeys, partitionType);
+                            snapshotReader,
+                            partitionPredicate,
+                            partitionKeys,
+                            partitionType,
+                            fileStoreTable.coreOptions().partitionDefaultName());
             if (!hasResults) {
                 return Collections::emptyList;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -429,6 +429,7 @@ public class PartitionsTable implements ReadonlyTable {
                 return partitions;
             }
             List<String> partitionKeys = fileStoreTable.partitionKeys();
+            String defaultPartitionName = fileStoreTable.coreOptions().partitionDefaultName();
             return partitions.stream()
                     .filter(
                             p -> {
@@ -437,9 +438,10 @@ public class PartitionsTable implements ReadonlyTable {
                                     if (i > 0) {
                                         sb.append("/");
                                     }
+                                    String value = p.spec().get(partitionKeys.get(i));
                                     sb.append(partitionKeys.get(i))
                                             .append("=")
-                                            .append(p.spec().get(partitionKeys.get(i)));
+                                            .append(value == null ? defaultPartitionName : value);
                                 }
                                 return partitionPredicate.test(
                                         GenericRow.of(BinaryString.fromString(sb.toString())));

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -35,7 +35,12 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.In;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.LeafPredicateExtractor;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.ReadonlyTable;
@@ -56,15 +61,19 @@ import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.IteratorRecordReader;
 import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.PartitionPredicateHelper;
 import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.SerializationUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.Iterators;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -140,14 +149,67 @@ public class PartitionsTable implements ReadonlyTable {
 
     private static class PartitionsScan extends ReadOnceTableScan {
 
+        @Nullable private LeafPredicate partitionPredicate;
+
         @Override
         public InnerTableScan withFilter(Predicate predicate) {
+            if (predicate == null) {
+                return this;
+            }
+
+            Map<String, LeafPredicate> leafPredicates =
+                    predicate.visit(LeafPredicateExtractor.INSTANCE);
+            this.partitionPredicate = leafPredicates.get("partition");
+
+            // Handle Or(Equal, Equal...) pattern from PredicateBuilder.in() with <=20 literals
+            if (this.partitionPredicate == null) {
+                for (Predicate andChild : PredicateBuilder.splitAnd(predicate)) {
+                    LeafPredicate inPred = convertOrEqualsToIn(andChild, "partition");
+                    if (inPred != null) {
+                        this.partitionPredicate = inPred;
+                        break;
+                    }
+                }
+            }
             return this;
+        }
+
+        @Nullable
+        private static LeafPredicate convertOrEqualsToIn(Predicate predicate, String targetField) {
+            List<Predicate> orChildren = PredicateBuilder.splitOr(predicate);
+            if (orChildren.size() <= 1) {
+                return null;
+            }
+            List<Object> literals = new ArrayList<>();
+            String fieldName = null;
+            int fieldIndex = -1;
+            DataType fieldType = null;
+            for (Predicate child : orChildren) {
+                if (!(child instanceof LeafPredicate)) {
+                    return null;
+                }
+                LeafPredicate leaf = (LeafPredicate) child;
+                if (!(leaf.function() instanceof Equal)) {
+                    return null;
+                }
+                if (fieldName == null) {
+                    fieldName = leaf.fieldName();
+                    fieldIndex = leaf.index();
+                    fieldType = leaf.type();
+                } else if (!fieldName.equals(leaf.fieldName())) {
+                    return null;
+                }
+                literals.addAll(leaf.literals());
+            }
+            if (!targetField.equals(fieldName)) {
+                return null;
+            }
+            return new LeafPredicate(In.INSTANCE, fieldType, fieldIndex, fieldName, literals);
         }
 
         @Override
         public Plan innerPlan() {
-            return () -> Collections.singletonList(new PartitionsSplit());
+            return () -> Collections.singletonList(new PartitionsSplit(partitionPredicate));
         }
     }
 
@@ -155,17 +217,27 @@ public class PartitionsTable implements ReadonlyTable {
 
         private static final long serialVersionUID = 1L;
 
+        @Nullable private final LeafPredicate partitionPredicate;
+
+        private PartitionsSplit(@Nullable LeafPredicate partitionPredicate) {
+            this.partitionPredicate = partitionPredicate;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
             }
-            return o != null && getClass() == o.getClass();
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PartitionsSplit that = (PartitionsSplit) o;
+            return Objects.equals(partitionPredicate, that.partitionPredicate);
         }
 
         @Override
         public int hashCode() {
-            return 1;
+            return Objects.hash(partitionPredicate);
         }
 
         @Override
@@ -186,7 +258,7 @@ public class PartitionsTable implements ReadonlyTable {
 
         @Override
         public InnerTableRead withFilter(Predicate predicate) {
-            // TODO
+            // filter pushdown is handled at the Scan layer through PartitionsSplit
             return this;
         }
 
@@ -207,7 +279,8 @@ public class PartitionsTable implements ReadonlyTable {
                 throw new IllegalArgumentException("Unsupported split: " + split.getClass());
             }
 
-            List<Partition> partitions = listPartitions();
+            PartitionsSplit partitionsSplit = (PartitionsSplit) split;
+            List<Partition> partitions = listPartitions(partitionsSplit.partitionPredicate);
 
             List<DataType> fieldTypes =
                     fileStoreTable.schema().logicalPartitionType().getFieldTypes();
@@ -320,17 +393,17 @@ public class PartitionsTable implements ReadonlyTable {
                             Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()));
         }
 
-        private List<Partition> listPartitions() {
+        private List<Partition> listPartitions(@Nullable LeafPredicate partitionPredicate) {
             CatalogLoader catalogLoader = fileStoreTable.catalogEnvironment().catalogLoader();
             if (TimeTravelUtil.hasTimeTravelOptions(new Options(fileStoreTable.options()))
                     || catalogLoader == null) {
-                return listPartitionEntries();
+                return listPartitionEntries(partitionPredicate);
             }
 
             try (Catalog catalog = catalogLoader.load()) {
                 Identifier baseIdentifier = fileStoreTable.catalogEnvironment().identifier();
                 if (baseIdentifier == null) {
-                    return listPartitionEntries();
+                    return listPartitionEntries(partitionPredicate);
                 }
                 String branch = fileStoreTable.coreOptions().branch();
                 Identifier identifier;
@@ -343,15 +416,53 @@ public class PartitionsTable implements ReadonlyTable {
                 } else {
                     identifier = baseIdentifier;
                 }
-                return catalog.listPartitions(identifier);
+                List<Partition> partitions = catalog.listPartitions(identifier);
+                return filterByPredicate(partitions, partitionPredicate);
             } catch (Exception e) {
-                return listPartitionEntries();
+                return listPartitionEntries(partitionPredicate);
             }
         }
 
-        private List<Partition> listPartitionEntries() {
-            List<PartitionEntry> partitionEntries =
-                    fileStoreTable.newScan().withLevelFilter(level -> true).listPartitionEntries();
+        private List<Partition> filterByPredicate(
+                List<Partition> partitions, @Nullable LeafPredicate partitionPredicate) {
+            if (partitionPredicate == null) {
+                return partitions;
+            }
+            List<String> partitionKeys = fileStoreTable.partitionKeys();
+            return partitions.stream()
+                    .filter(
+                            p -> {
+                                StringBuilder sb = new StringBuilder();
+                                for (int i = 0; i < partitionKeys.size(); i++) {
+                                    if (i > 0) {
+                                        sb.append("/");
+                                    }
+                                    sb.append(partitionKeys.get(i))
+                                            .append("=")
+                                            .append(p.spec().get(partitionKeys.get(i)));
+                                }
+                                return partitionPredicate.test(
+                                        GenericRow.of(BinaryString.fromString(sb.toString())));
+                            })
+                    .collect(Collectors.toList());
+        }
+
+        private List<Partition> listPartitionEntries(@Nullable LeafPredicate partitionPredicate) {
+            InnerTableScan scan = fileStoreTable.newScan().withLevelFilter(level -> true);
+
+            if (partitionPredicate != null) {
+                List<String> partitionKeys = fileStoreTable.partitionKeys();
+                RowType partitionType = fileStoreTable.schema().logicalPartitionType();
+                Predicate partPred =
+                        PartitionPredicateHelper.buildPartitionPredicate(
+                                partitionPredicate, partitionKeys, partitionType);
+                if (partPred == null) {
+                    return Collections.emptyList();
+                }
+                scan.withPartitionFilter(partPred);
+            }
+
+            List<PartitionEntry> partitionEntries = scan.listPartitionEntries();
             RowType partitionType = fileStoreTable.schema().logicalPartitionType();
             String defaultPartitionName = fileStoreTable.coreOptions().partitionDefaultName();
             String[] partitionColumns = fileStoreTable.partitionKeys().toArray(new String[0]);

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -455,13 +455,19 @@ public class PartitionsTable implements ReadonlyTable {
             if (partitionPredicate != null) {
                 List<String> partitionKeys = fileStoreTable.partitionKeys();
                 RowType partitionType = fileStoreTable.schema().logicalPartitionType();
-                Predicate partPred =
+                String defaultPartitionName = fileStoreTable.coreOptions().partitionDefaultName();
+                Predicate partitionFilter =
                         PartitionPredicateHelper.buildPartitionPredicate(
-                                partitionPredicate, partitionKeys, partitionType);
-                if (partPred == null) {
-                    return Collections.emptyList();
+                                partitionPredicate,
+                                partitionKeys,
+                                partitionType,
+                                defaultPartitionName);
+                if (partitionFilter != null) {
+                    if (PartitionPredicateHelper.isAlwaysFalse(partitionFilter)) {
+                        return Collections.emptyList();
+                    }
+                    scan.withPartitionFilter(partitionFilter);
                 }
-                scan.withPartitionFilter(partPred);
             }
 
             List<PartitionEntry> partitionEntries = scan.listPartitionEntries();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPredicateHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPredicateHelper.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.predicate.AlwaysFalse;
 import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.In;
 import org.apache.paimon.predicate.LeafBinaryFunction;
@@ -44,26 +45,33 @@ public class PartitionPredicateHelper {
      * Build a partition-typed predicate from a string-based leaf predicate on the "partition"
      * column.
      *
-     * @return the predicate on partition fields, or {@code null} if the partition spec is invalid
-     *     (indicating no results should be returned)
+     * @return {@code null} if the predicate type is unsupported for pushdown (caller should skip
+     *     pushdown), {@link PredicateBuilder#alwaysFalse()} if no partition can match (caller
+     *     should return empty), or a normal predicate to push down.
      */
     @Nullable
     public static Predicate buildPartitionPredicate(
-            LeafPredicate partitionPredicate, List<String> partitionKeys, RowType partitionType) {
+            LeafPredicate partitionPredicate,
+            List<String> partitionKeys,
+            RowType partitionType,
+            String defaultPartitionName) {
         if (partitionPredicate.function() instanceof Equal) {
             LinkedHashMap<String, String> partSpec =
                     parsePartitionSpec(
                             partitionPredicate.literals().get(0).toString(), partitionKeys);
             if (partSpec == null) {
-                return null;
+                return PredicateBuilder.alwaysFalse();
             }
             PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
             List<Predicate> predicates = new ArrayList<>();
             for (int i = 0; i < partitionKeys.size(); i++) {
-                Object value =
-                        TypeUtils.castFromString(
-                                partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
-                predicates.add(partBuilder.equal(i, value));
+                String strValue = partSpec.get(partitionKeys.get(i));
+                if (defaultPartitionName.equals(strValue)) {
+                    predicates.add(partBuilder.isNull(i));
+                } else {
+                    Object value = TypeUtils.castFromString(strValue, partitionType.getTypeAt(i));
+                    predicates.add(partBuilder.equal(i, value));
+                }
             }
             return PredicateBuilder.and(predicates);
         } else if (partitionPredicate.function() instanceof In) {
@@ -77,34 +85,44 @@ public class PartitionPredicateHelper {
                 }
                 List<Predicate> andPredicates = new ArrayList<>();
                 for (int i = 0; i < partitionKeys.size(); i++) {
-                    Object value =
-                            TypeUtils.castFromString(
-                                    partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
-                    andPredicates.add(partBuilder.equal(i, value));
+                    String strValue = partSpec.get(partitionKeys.get(i));
+                    if (defaultPartitionName.equals(strValue)) {
+                        andPredicates.add(partBuilder.isNull(i));
+                    } else {
+                        Object value =
+                                TypeUtils.castFromString(strValue, partitionType.getTypeAt(i));
+                        andPredicates.add(partBuilder.equal(i, value));
+                    }
                 }
                 orPredicates.add(PredicateBuilder.and(andPredicates));
             }
-            return orPredicates.isEmpty() ? null : PredicateBuilder.or(orPredicates);
-        } else if (partitionPredicate.function() instanceof LeafBinaryFunction) {
+            return orPredicates.isEmpty()
+                    ? PredicateBuilder.alwaysFalse()
+                    : PredicateBuilder.or(orPredicates);
+        }
+        if (partitionPredicate.function() instanceof LeafBinaryFunction) {
             LinkedHashMap<String, String> partSpec =
                     parsePartitionSpec(
                             partitionPredicate.literals().get(0).toString(), partitionKeys);
             if (partSpec == null) {
-                return null;
+                return PredicateBuilder.alwaysFalse();
             }
             PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
             List<Predicate> predicates = new ArrayList<>();
             for (int i = 0; i < partitionKeys.size(); i++) {
-                Object value =
-                        TypeUtils.castFromString(
-                                partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
-                predicates.add(
-                        new LeafPredicate(
-                                partitionPredicate.function(),
-                                partitionType.getTypeAt(i),
-                                i,
-                                partitionKeys.get(i),
-                                Collections.singletonList(value)));
+                String strValue = partSpec.get(partitionKeys.get(i));
+                if (defaultPartitionName.equals(strValue)) {
+                    predicates.add(partBuilder.isNull(i));
+                } else {
+                    Object value = TypeUtils.castFromString(strValue, partitionType.getTypeAt(i));
+                    predicates.add(
+                            new LeafPredicate(
+                                    partitionPredicate.function(),
+                                    partitionType.getTypeAt(i),
+                                    i,
+                                    partitionKeys.get(i),
+                                    Collections.singletonList(value)));
+                }
             }
             return PredicateBuilder.and(predicates);
         }
@@ -115,18 +133,28 @@ public class PartitionPredicateHelper {
             SnapshotReader snapshotReader,
             @Nullable LeafPredicate partitionPredicate,
             List<String> partitionKeys,
-            RowType partitionType) {
+            RowType partitionType,
+            String defaultPartitionName) {
         if (partitionPredicate == null) {
             return true;
         }
 
-        Predicate predicate =
-                buildPartitionPredicate(partitionPredicate, partitionKeys, partitionType);
-        if (predicate == null) {
+        Predicate result =
+                buildPartitionPredicate(
+                        partitionPredicate, partitionKeys, partitionType, defaultPartitionName);
+        if (result == null) {
+            return true;
+        }
+        if (isAlwaysFalse(result)) {
             return false;
         }
-        snapshotReader.withPartitionFilter(predicate);
+        snapshotReader.withPartitionFilter(result);
         return true;
+    }
+
+    public static boolean isAlwaysFalse(Predicate predicate) {
+        return predicate instanceof LeafPredicate
+                && ((LeafPredicate) predicate).function().equals(AlwaysFalse.INSTANCE);
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPredicateHelper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/PartitionPredicateHelper.java
@@ -36,27 +36,36 @@ import java.util.List;
 
 /**
  * Helper for applying partition predicate pushdown in system tables (BucketsTable, FilesTable,
- * FileKeyRangesTable).
+ * FileKeyRangesTable, PartitionsTable).
  */
 public class PartitionPredicateHelper {
 
-    public static boolean applyPartitionFilter(
-            SnapshotReader snapshotReader,
-            @Nullable LeafPredicate partitionPredicate,
-            List<String> partitionKeys,
-            RowType partitionType) {
-        if (partitionPredicate == null) {
-            return true;
-        }
-
+    /**
+     * Build a partition-typed predicate from a string-based leaf predicate on the "partition"
+     * column.
+     *
+     * @return the predicate on partition fields, or {@code null} if the partition spec is invalid
+     *     (indicating no results should be returned)
+     */
+    @Nullable
+    public static Predicate buildPartitionPredicate(
+            LeafPredicate partitionPredicate, List<String> partitionKeys, RowType partitionType) {
         if (partitionPredicate.function() instanceof Equal) {
             LinkedHashMap<String, String> partSpec =
                     parsePartitionSpec(
                             partitionPredicate.literals().get(0).toString(), partitionKeys);
             if (partSpec == null) {
-                return false;
+                return null;
             }
-            snapshotReader.withPartitionFilter(partSpec);
+            PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
+            List<Predicate> predicates = new ArrayList<>();
+            for (int i = 0; i < partitionKeys.size(); i++) {
+                Object value =
+                        TypeUtils.castFromString(
+                                partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
+                predicates.add(partBuilder.equal(i, value));
+            }
+            return PredicateBuilder.and(predicates);
         } else if (partitionPredicate.function() instanceof In) {
             List<Predicate> orPredicates = new ArrayList<>();
             PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
@@ -75,51 +84,88 @@ public class PartitionPredicateHelper {
                 }
                 orPredicates.add(PredicateBuilder.and(andPredicates));
             }
-            if (!orPredicates.isEmpty()) {
-                snapshotReader.withPartitionFilter(PredicateBuilder.or(orPredicates));
-            }
+            return orPredicates.isEmpty() ? null : PredicateBuilder.or(orPredicates);
         } else if (partitionPredicate.function() instanceof LeafBinaryFunction) {
             LinkedHashMap<String, String> partSpec =
                     parsePartitionSpec(
                             partitionPredicate.literals().get(0).toString(), partitionKeys);
-            if (partSpec != null) {
-                PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
-                List<Predicate> predicates = new ArrayList<>();
-                for (int i = 0; i < partitionKeys.size(); i++) {
-                    Object value =
-                            TypeUtils.castFromString(
-                                    partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
-                    predicates.add(
-                            new LeafPredicate(
-                                    partitionPredicate.function(),
-                                    partitionType.getTypeAt(i),
-                                    i,
-                                    partitionKeys.get(i),
-                                    Collections.singletonList(value)));
-                }
-                snapshotReader.withPartitionFilter(PredicateBuilder.and(predicates));
+            if (partSpec == null) {
+                return null;
             }
+            PredicateBuilder partBuilder = new PredicateBuilder(partitionType);
+            List<Predicate> predicates = new ArrayList<>();
+            for (int i = 0; i < partitionKeys.size(); i++) {
+                Object value =
+                        TypeUtils.castFromString(
+                                partSpec.get(partitionKeys.get(i)), partitionType.getTypeAt(i));
+                predicates.add(
+                        new LeafPredicate(
+                                partitionPredicate.function(),
+                                partitionType.getTypeAt(i),
+                                i,
+                                partitionKeys.get(i),
+                                Collections.singletonList(value)));
+            }
+            return PredicateBuilder.and(predicates);
+        }
+        return null;
+    }
+
+    public static boolean applyPartitionFilter(
+            SnapshotReader snapshotReader,
+            @Nullable LeafPredicate partitionPredicate,
+            List<String> partitionKeys,
+            RowType partitionType) {
+        if (partitionPredicate == null) {
+            return true;
         }
 
+        Predicate predicate =
+                buildPartitionPredicate(partitionPredicate, partitionKeys, partitionType);
+        if (predicate == null) {
+            return false;
+        }
+        snapshotReader.withPartitionFilter(predicate);
         return true;
     }
 
     @Nullable
     public static LinkedHashMap<String, String> parsePartitionSpec(
             String partitionStr, List<String> partitionKeys) {
+        // Handle {value1, value2} format (BucketsTable, FilesTable, FileKeyRangesTable)
         if (partitionStr.startsWith("{")) {
             partitionStr = partitionStr.substring(1);
+            if (partitionStr.endsWith("}")) {
+                partitionStr = partitionStr.substring(0, partitionStr.length() - 1);
+            }
+            String[] partFields = partitionStr.split(", ");
+            if (partitionKeys.size() != partFields.length) {
+                return null;
+            }
+            LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
+            for (int i = 0; i < partitionKeys.size(); i++) {
+                partSpec.put(partitionKeys.get(i), partFields[i]);
+            }
+            return partSpec;
         }
-        if (partitionStr.endsWith("}")) {
-            partitionStr = partitionStr.substring(0, partitionStr.length() - 1);
-        }
-        String[] partFields = partitionStr.split(", ");
+
+        // Handle key=value/key=value format (PartitionsTable)
+        String[] partFields = partitionStr.split("/");
         if (partitionKeys.size() != partFields.length) {
             return null;
         }
         LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
-        for (int i = 0; i < partitionKeys.size(); i++) {
-            partSpec.put(partitionKeys.get(i), partFields[i]);
+        for (String field : partFields) {
+            int eqIndex = field.indexOf('=');
+            if (eqIndex < 0) {
+                return null;
+            }
+            partSpec.put(field.substring(0, eqIndex), field.substring(eqIndex + 1));
+        }
+        for (String key : partitionKeys) {
+            if (!partSpec.containsKey(key)) {
+                return null;
+            }
         }
         return partSpec;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/BucketsTableTest.java
@@ -148,6 +148,15 @@ public class BucketsTableTest extends TableTestBase {
         assertThat(readWithFilter(bucketsTable, filter, new int[] {0, 1, 2, 4})).isEmpty();
     }
 
+    @Test
+    public void testBucketsTableUnsupportedPredicateFallsBackToFullScan() throws Exception {
+        PredicateBuilder builder = new PredicateBuilder(BucketsTable.TABLE_TYPE);
+
+        // isNotNull cannot be pushed down as partition filter — must fall back to full scan
+        Predicate filter = builder.isNotNull(0);
+        assertThat(readWithFilter(bucketsTable, filter, new int[] {0, 1, 2, 4})).hasSize(2);
+    }
+
     private List<InternalRow> readWithFilter(Table table, Predicate filter, int[] projection)
             throws Exception {
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(filter);

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/PartitionsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/PartitionsTableTest.java
@@ -23,22 +23,30 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.SchemaUtils;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.Projection;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -166,5 +174,121 @@ public class PartitionsTableTest extends TableTestBase {
 
         List<InternalRow> result = read(testPartitionsTable, new int[] {0, 1});
         assertThat(result).containsExactlyInAnyOrderElementsOf(expectedRow);
+    }
+
+    @Test
+    public void testPartitionPredicateFilterEqual() throws Exception {
+        PredicateBuilder builder = new PredicateBuilder(PartitionsTable.TABLE_TYPE);
+
+        // Equal filter: partition = 'pt=1'
+        Predicate filter = builder.equal(0, BinaryString.fromString("pt=1"));
+        assertThat(readWithFilter(partitionsTable, filter, new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(BinaryString.fromString("pt=1"), 2L));
+
+        // Equal filter: partition = 'pt=2'
+        filter = builder.equal(0, BinaryString.fromString("pt=2"));
+        assertThat(readWithFilter(partitionsTable, filter, new int[] {0, 1}))
+                .containsExactlyInAnyOrder(GenericRow.of(BinaryString.fromString("pt=2"), 1L));
+    }
+
+    @Test
+    public void testPartitionPredicateFilterIn() throws Exception {
+        PredicateBuilder builder = new PredicateBuilder(PartitionsTable.TABLE_TYPE);
+
+        Predicate filter =
+                builder.in(
+                        0,
+                        Arrays.asList(
+                                BinaryString.fromString("pt=1"), BinaryString.fromString("pt=3")));
+        assertThat(readWithFilter(partitionsTable, filter, new int[] {0, 1}))
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(BinaryString.fromString("pt=1"), 2L),
+                        GenericRow.of(BinaryString.fromString("pt=3"), 1L));
+    }
+
+    @Test
+    public void testPartitionPredicateFilterNoMatch() throws Exception {
+        PredicateBuilder builder = new PredicateBuilder(PartitionsTable.TABLE_TYPE);
+
+        Predicate filter = builder.equal(0, BinaryString.fromString("pt=999"));
+        assertThat(readWithFilter(partitionsTable, filter, new int[] {0, 1})).isEmpty();
+    }
+
+    @Test
+    public void testPartitionPredicateFilterNonPartitionColumn() throws Exception {
+        PredicateBuilder builder = new PredicateBuilder(PartitionsTable.TABLE_TYPE);
+
+        // Filter on record_count column — should be safely ignored, return all partitions
+        Predicate filter = builder.greaterThan(1, 0L);
+        assertThat(readWithFilter(partitionsTable, filter, new int[] {0, 1})).hasSize(3);
+    }
+
+    @Test
+    public void testPartitionPredicateFilterMultiColumnKeys() throws Exception {
+        String testTableName = "MultiPartTable";
+        FileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, testTableName));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("pk", DataTypes.INT())
+                        .column("dt", DataTypes.INT())
+                        .column("region", DataTypes.INT())
+                        .column("col1", DataTypes.INT())
+                        .partitionKeys("dt", "region")
+                        .primaryKey("pk", "dt", "region")
+                        .option(CoreOptions.CHANGELOG_PRODUCER.key(), "input")
+                        .option("bucket", "1")
+                        .build();
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(new SchemaManager(fileIO, tablePath), schema);
+        FileStoreTable multiTable =
+                FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+
+        Identifier multiPartitionsTableId =
+                identifier(testTableName + SYSTEM_TABLE_SPLITTER + PartitionsTable.PARTITIONS);
+        PartitionsTable multiPartitionsTable =
+                (PartitionsTable) catalog.getTable(multiPartitionsTableId);
+
+        write(multiTable, GenericRow.of(1, 20260410, 1, 100));
+        write(multiTable, GenericRow.of(2, 20260410, 2, 200));
+        write(multiTable, GenericRow.of(3, 20260411, 1, 300));
+
+        PredicateBuilder builder = new PredicateBuilder(PartitionsTable.TABLE_TYPE);
+
+        // Equal filter on multi-column partition
+        Predicate filter = builder.equal(0, BinaryString.fromString("dt=20260410/region=1"));
+        assertThat(readWithFilter(multiPartitionsTable, filter, new int[] {0, 1}))
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(BinaryString.fromString("dt=20260410/region=1"), 1L));
+
+        // IN filter on multi-column partition
+        filter =
+                builder.in(
+                        0,
+                        Arrays.asList(
+                                BinaryString.fromString("dt=20260410/region=1"),
+                                BinaryString.fromString("dt=20260411/region=1")));
+        assertThat(readWithFilter(multiPartitionsTable, filter, new int[] {0, 1}))
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(BinaryString.fromString("dt=20260410/region=1"), 1L),
+                        GenericRow.of(BinaryString.fromString("dt=20260411/region=1"), 1L));
+    }
+
+    private List<InternalRow> readWithFilter(Table table, Predicate filter, int[] projection)
+            throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(filter);
+        if (projection != null) {
+            readBuilder.withProjection(projection);
+        }
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        InternalRowSerializer serializer =
+                new InternalRowSerializer(
+                        projection == null
+                                ? table.rowType()
+                                : Projection.of(projection).project(table.rowType()));
+        List<InternalRow> rows = new ArrayList<>();
+        reader.forEachRemaining(row -> rows.add(serializer.copy(row)));
+        return rows;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/PartitionsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/PartitionsTableTest.java
@@ -226,8 +226,6 @@ public class PartitionsTableTest extends TableTestBase {
     @Test
     public void testPartitionPredicateFilterMultiColumnKeys() throws Exception {
         String testTableName = "MultiPartTable";
-        FileIO fileIO = LocalFileIO.create();
-        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, testTableName));
         Schema schema =
                 Schema.newBuilder()
                         .column("pk", DataTypes.INT())
@@ -239,10 +237,9 @@ public class PartitionsTableTest extends TableTestBase {
                         .option(CoreOptions.CHANGELOG_PRODUCER.key(), "input")
                         .option("bucket", "1")
                         .build();
-        TableSchema tableSchema =
-                SchemaUtils.forceCommit(new SchemaManager(fileIO, tablePath), schema);
-        FileStoreTable multiTable =
-                FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+        Identifier multiTableId = identifier(testTableName);
+        catalog.createTable(multiTableId, schema, true);
+        FileStoreTable multiTable = (FileStoreTable) catalog.getTable(multiTableId);
 
         Identifier multiPartitionsTableId =
                 identifier(testTableName + SYSTEM_TABLE_SPLITTER + PartitionsTable.PARTITIONS);


### PR DESCRIPTION
### Purpose

`PartitionsTable.withFilter()` was a no-op (`// TODO` at line 189), causing full manifest scans when querying with partition filters like `SELECT * FROM t$partitions WHERE partition = 'dt=20260410'`. This adds partition predicate pushdown following the same pattern established by BucketsTable (#7592), FilesTable (#7376), ManifestsTable (#7310), and ConsumersTable (#7329).

The implementation uses a dual-path filtering strategy:
- **Catalog path**: preserves `catalog.listPartitions()` call and filters results in memory, keeping metadata columns (`created_at`, `created_by`, `updated_by`, `options`) intact
- **TableScan fallback path**: pushes predicate down to `InnerTableScan.withPartitionFilter()` for manifest-level pruning

Also refactors `PartitionPredicateHelper.applyPartitionFilter()` into a two-step build+apply pattern (`buildPartitionPredicate()` + apply), and extends `parsePartitionSpec()` to support PartitionsTable's `key=value/key=value` format in addition to the existing `{value1, value2}` format.

### Tests

- Equal filter on single partition key
- IN filter on multiple partition values
- No-match filter returns empty result
- Non-partition column filter safely ignored
- Multi-column partition keys with Equal and IN filters
- Existing `BucketsTableTest` passes (verifies refactored helper is backward-compatible)

### API and Format

No API or storage format changes.

### Documentation

No documentation changes needed.