### PR TITLE
[core] Improve error message for fallback branch schema mismatch

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -215,10 +215,14 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         RowType otherRowType = other.schema().logicalRowType();
         Preconditions.checkArgument(
                 sameRowTypeIgnoreNullable(mainRowType, otherRowType),
-                "Branch %s and %s does not have the same row type.\n"
+                "Branch %s and %s does not have the same row type. "
+                        + "This validation is triggered because '%s' is configured to '%s'. "
+                        + "The fallback branch must have the same schema as the main branch.\n"
                         + "Row type of branch %s is %s.\n"
                         + "Row type of branch %s is %s.",
                 mainBranch,
+                otherBranch,
+                CoreOptions.SCAN_FALLBACK_BRANCH.key(),
                 otherBranch,
                 mainBranch,
                 mainRowType,


### PR DESCRIPTION
## Summary
- Improve the error message in `FallbackReadFileStoreTable.validateSchema()` to explicitly mention that the validation is triggered by the `scan.fallback-branch` option, helping users quickly identify the root cause of the schema mismatch.

## Test plan
- [x] Compile verified

🤖 Generated with [Qoder][https://qoder.com]