### PR TITLE
[spark] Fix SparkGenericCatalog not recognizing Paimon system database sys

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkGenericCatalog.java
@@ -116,13 +116,23 @@ public class SparkGenericCatalog extends SparkBaseCatalog implements CatalogExte
 
     @Override
     public boolean namespaceExists(String[] namespace) {
+        if (isPaimonSystemNamespace(namespace)) {
+            return true;
+        }
         return asNamespaceCatalog().namespaceExists(namespace);
     }
 
     @Override
     public Map<String, String> loadNamespaceMetadata(String[] namespace)
             throws NoSuchNamespaceException {
+        if (isPaimonSystemNamespace(namespace)) {
+            return sparkCatalog.loadNamespaceMetadata(namespace);
+        }
         return asNamespaceCatalog().loadNamespaceMetadata(namespace);
+    }
+
+    private boolean isPaimonSystemNamespace(String[] namespace) {
+        return namespace.length == 1 && Catalog.SYSTEM_DATABASE_NAME.equals(namespace[0]);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkGenericCatalogTest.java
@@ -108,6 +108,12 @@ public class SparkGenericCatalogTest {
     }
 
     @Test
+    public void testSystemDatabaseExists() {
+        // Paimon's system database 'sys' should be visible via SparkGenericCatalog
+        assertThatCode(() -> spark.sql("USE sys")).doesNotThrowAnyException();
+    }
+
+    @Test
     public void testCsvTable() {
         spark.sql("CREATE TABLE CT (a INT, b INT, c STRING) USING csv");
         testReadWrite("CT");


### PR DESCRIPTION
### Purpose
When using SparkGenericCatalog as the session catalog, `USE sys` fails with SCHEMA_NOT_FOUND because namespace operations (namespaceExists, loadNamespaceMetadata) delegate only to the session catalog (Hive
Metastore), not to the Paimon catalog. However, Paimon's system database 'sys' is a virtual database handled by AbstractCatalog. getDatabase() via isSystemDatabase() check, which never reaches the
Hive Metastore.

This fix adds a targeted check for the Paimon system namespace in namespaceExists and loadNamespaceMetadata, without affecting regular database operations that should continue to delegate to the session catalog only.

### Tests
CI