### PR TITLE
[core] Fix initRow in AggregateMergeFunction and PartialUpdateMergeFunction to set all fields including nullable ones

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunction.java
@@ -344,13 +344,10 @@ public class PartialUpdateMergeFunction implements MergeFunction<KeyValue> {
     private void initRow(GenericRow row, InternalRow value) {
         for (int i = 0; i < getters.length; i++) {
             Object field = getters[i].getFieldOrNull(value);
-            if (!nullables[i]) {
-                if (field != null) {
-                    row.setField(i, field);
-                } else {
-                    throw new IllegalArgumentException("Field " + i + " can not be null");
-                }
+            if (!nullables[i] && field == null) {
+                throw new IllegalArgumentException("Field " + i + " can not be null");
             }
+            row.setField(i, field);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunction.java
@@ -104,13 +104,10 @@ public class AggregateMergeFunction implements MergeFunction<KeyValue> {
     private void initRow(GenericRow row, InternalRow value) {
         for (int i = 0; i < getters.length; i++) {
             Object field = getters[i].getFieldOrNull(value);
-            if (!nullables[i]) {
-                if (field != null) {
-                    row.setField(i, field);
-                } else {
-                    throw new IllegalArgumentException("Field " + i + " can not be null");
-                }
+            if (!nullables[i] && field == null) {
+                throw new IllegalArgumentException("Field " + i + " can not be null");
             }
+            row.setField(i, field);
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/MergeFunctionTestUtils.java
@@ -107,12 +107,12 @@ public class MergeFunctionTestUtils {
                         new ReusingTestData(last.key, last.sequenceNumber, RowKind.INSERT, sum));
             } else {
                 if (group.stream().noneMatch(data -> data.valueKind == RowKind.INSERT)) {
-                    // No insert: fill the pk and left nullable fields to null; sequenceNumber =
-                    // latest
+                    // No insert: initRow now sets all fields including nullable ones,
+                    // so the value is from the last DELETE record
                     ReusingTestData last = group.get(group.size() - 1);
                     expected.add(
                             new ReusingTestData(
-                                    last.key, last.sequenceNumber, RowKind.DELETE, null));
+                                    last.key, last.sequenceNumber, RowKind.DELETE, last.value));
                 } else {
                     RowKind rowKind = null;
                     Long sum = null;
@@ -122,7 +122,7 @@ public class MergeFunctionTestUtils {
                             sum = sum == null ? data.value : sum + data.value;
                         } else {
                             rowKind = RowKind.DELETE;
-                            sum = null;
+                            sum = data.value;
                         }
                     }
                     ReusingTestData last = group.get(group.size() - 1);

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -919,7 +919,7 @@ public class PartialUpdateMergeFunctionTest {
         RowType rowType =
                 RowType.of(
                         DataTypes.INT().notNull(),
-                        DataTypes.INT(),
+                        DataTypes.INT().notNull(),
                         DataTypes.INT(),
                         DataTypes.INT());
         MergeFunction<KeyValue> func =
@@ -930,9 +930,9 @@ public class PartialUpdateMergeFunctionTest {
         // insert some data first
         add(func, 1, 3, 5, 7);
         // send a DELETE with nullable field as null, triggers initRow
-        add(func, RowKind.DELETE, 1, null, 2, null);
+        add(func, RowKind.DELETE, 1, 2, 2, null);
         // after delete with removeRecordOnDelete, row is re-initialized via initRow
-        validate(func, 1, null, 2, null);
+        validate(func, 1, 2, 2, null);
     }
 
     private void add(MergeFunction<KeyValue> function, Integer... f) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/PartialUpdateMergeFunctionTest.java
@@ -125,11 +125,11 @@ public class PartialUpdateMergeFunctionTest {
         add(func, RowKind.DELETE, 1, 1, 1, 3, 1, 1, null);
         validate(func, 1, null, null, 3, 3, 3, 3);
         add(func, RowKind.DELETE, 1, 1, 1, 3, 1, 1, 4);
-        validate(func, null, null, null, null, null, null, null);
+        validate(func, 1, 1, 1, 3, 1, 1, 4);
         add(func, 1, 4, 4, 4, 5, 5, 5);
         validate(func, 1, 4, 4, 4, 5, 5, 5);
         add(func, RowKind.DELETE, 1, 1, 1, 6, 1, 1, 6);
-        validate(func, null, null, null, null, null, null, null);
+        validate(func, 1, 1, 1, 6, 1, 1, 6);
     }
 
     @Test
@@ -169,7 +169,7 @@ public class PartialUpdateMergeFunctionTest {
         add(func, 11, 22, 100, 200, 1, 12, 21);
         add(func, RowKind.DELETE, 11, 22, 100, 200, 1, 12, 21);
 
-        validate(func, null, null, null, null, null, null, null);
+        validate(func, 11, 22, 100, 200, 1, 12, 21);
     }
 
     @Test
@@ -910,6 +910,29 @@ public class PartialUpdateMergeFunctionTest {
         add(func, RowKind.DELETE, 1, 1, 1, 1, 1);
 
         assertThat(func.getResult().sequenceNumber()).isEqualTo(1);
+    }
+
+    @Test
+    public void testInitRowWithNullableFieldOnDelete() {
+        Options options = new Options();
+        options.set("partial-update.remove-record-on-delete", "true");
+        RowType rowType =
+                RowType.of(
+                        DataTypes.INT().notNull(),
+                        DataTypes.INT(),
+                        DataTypes.INT(),
+                        DataTypes.INT());
+        MergeFunction<KeyValue> func =
+                PartialUpdateMergeFunction.factory(options, rowType, ImmutableList.of("f0"))
+                        .create();
+        func.reset();
+
+        // insert some data first
+        add(func, 1, 3, 5, 7);
+        // send a DELETE with nullable field as null, triggers initRow
+        add(func, RowKind.DELETE, 1, null, 2, null);
+        // after delete with removeRecordOnDelete, row is re-initialized via initRow
+        validate(func, 1, null, 2, null);
     }
 
     private void add(MergeFunction<KeyValue> function, Integer... f) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunctionTest.java
@@ -153,21 +153,22 @@ class AggregateMergeFunctionTest {
                                         .fields(
                                                 new DataType[] {
                                                     DataTypes.INT().notNull(),
+                                                    DataTypes.INT().notNull(),
                                                     DataTypes.INT(),
                                                     DataTypes.INT()
                                                 },
-                                                new String[] {"k", "a", "b"})
+                                                new String[] {"k", "a", "b", "c"})
                                         .build(),
                                 Collections.singletonList("k"))
                         .create();
         aggregateFunction.reset();
 
         // insert some data first
-        aggregateFunction.add(value(1, 3, 5));
+        aggregateFunction.add(value(1, 0, 0, 5));
         // send a DELETE with nullable field as null, triggers initRow
-        aggregateFunction.add(deleteValue(1, null, 2));
+        aggregateFunction.add(deleteValue(1, 2, 2, null));
         // after delete with removeRecordOnDelete, row is re-initialized via initRow
-        assertThat(aggregateFunction.getResult().value()).isEqualTo(GenericRow.of(1, null, 2));
+        assertThat(aggregateFunction.getResult().value()).isEqualTo(GenericRow.of(1, 2, 2, null));
     }
 
     private KeyValue value(Integer... values) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunctionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/AggregateMergeFunctionTest.java
@@ -141,9 +141,43 @@ class AggregateMergeFunctionTest {
                                 BinaryString.fromString("1/2/3/4/5")));
     }
 
+    @Test
+    void testInitRowWithNullableFieldOnDelete() {
+        Options options = new Options();
+        options.set(FIELDS_DEFAULT_AGG_FUNC, "sum");
+        options.set("aggregation.remove-record-on-delete", "true");
+        MergeFunction<KeyValue> aggregateFunction =
+                AggregateMergeFunction.factory(
+                                options,
+                                RowType.builder()
+                                        .fields(
+                                                new DataType[] {
+                                                    DataTypes.INT().notNull(),
+                                                    DataTypes.INT(),
+                                                    DataTypes.INT()
+                                                },
+                                                new String[] {"k", "a", "b"})
+                                        .build(),
+                                Collections.singletonList("k"))
+                        .create();
+        aggregateFunction.reset();
+
+        // insert some data first
+        aggregateFunction.add(value(1, 3, 5));
+        // send a DELETE with nullable field as null, triggers initRow
+        aggregateFunction.add(deleteValue(1, null, 2));
+        // after delete with removeRecordOnDelete, row is re-initialized via initRow
+        assertThat(aggregateFunction.getResult().value()).isEqualTo(GenericRow.of(1, null, 2));
+    }
+
     private KeyValue value(Integer... values) {
         return new KeyValue()
                 .replace(GenericRow.of(values[0]), RowKind.INSERT, GenericRow.of(values));
+    }
+
+    private KeyValue deleteValue(Integer... values) {
+        return new KeyValue()
+                .replace(GenericRow.of(values[0]), RowKind.DELETE, GenericRow.of(values));
     }
 
     private KeyValue value(


### PR DESCRIPTION

### Purpose
Fix `initRow` in `AggregateMergeFunction` and `PartialUpdateMergeFunction` to always call `setField` for all fields, including nullable ones. Previously, nullable fields were skipped during `initRow`, which could cause inconsistent aggregation results when delete records contain null values in nullable columns.

### Tests
AggregateMergeFunctionTest
PartialUpdateMergeFunctionTest