### PR TITLE
[doc] Update document version to 1.3.2

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,7 +34,7 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "1.3.1"
+  Version = "1.3.2"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version


### PR DESCRIPTION
### Purpose

This PR updates the version number in document configuration to 1.3.2, in reference to https://github.com/apache/paimon/commit/002ab28eced8af09aabe8b447267f7a60fa2551d.

### Tests
