### PR TITLE
[python] Fix Identifier.is_system_table()

### DIFF
--- a/paimon-python/pypaimon/common/identifier.py
+++ b/paimon-python/pypaimon/common/identifier.py
@@ -107,4 +107,9 @@ class Identifier:
         return hash((self.database, self.object, self.branch))
 
     def is_system_table(self) -> bool:
-        return self.object.startswith('$')
+        if SYSTEM_TABLE_SPLITTER not in self.object:
+            return False
+        parts = self.object.split(SYSTEM_TABLE_SPLITTER)
+        if len(parts) == 2:
+            return not parts[1].startswith(SYSTEM_BRANCH_PREFIX)
+        return len(parts) == 3

--- a/paimon-python/pypaimon/tests/identifier_test.py
+++ b/paimon-python/pypaimon/tests/identifier_test.py
@@ -92,6 +92,22 @@ class IdentifierTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             Identifier.from_string("`a`.`b`.`c`")
 
+    def test_is_system_table_regular_table(self):
+        """A plain table object is not a system table."""
+        self.assertFalse(Identifier.create("mydb", "mytable").is_system_table())
+
+    def test_is_system_table_snapshots_suffix(self):
+        """object name '<base>$snapshots' is a system table."""
+        self.assertTrue(Identifier.create("mydb", "orders$snapshots").is_system_table())
+
+    def test_is_system_table_schemas_suffix(self):
+        """object name '<base>$schemas' is a system table."""
+        self.assertTrue(Identifier.create("mydb", "orders$schemas").is_system_table())
+
+    def test_is_system_table_files_suffix(self):
+        """object name '<base>$files' is a system table."""
+        self.assertTrue(Identifier.create("mydb", "orders$files").is_system_table())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Purpose
 The previous implementation checked `self.object.startswith('$')`, but Paimon system-table object names are `<base>$<system_table>` (e.g.`orders$snapshots`), not `$<system_table>`.