### PR TITLE
[core] fix BlobDescriptor toString format

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
@@ -99,7 +99,6 @@ public class BlobDescriptor implements Serializable {
         return "BlobDescriptor{"
                 + "version="
                 + version
-                + '\''
                 + ", uri='"
                 + uri
                 + '\''


### PR DESCRIPTION
### Purpose
The toString method of BlobDescriptor has a isolated `'`. It makes parsing the string hard.
<img width="662" height="112" alt="image" src="https://github.com/user-attachments/assets/ea489dae-8fac-4d86-a7a7-73daa6db07ed" />



### Tests
None