### PR TITLE
[core] Optimize the printing of error logs for snapshot expiration

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/NextSnapshotFetcher.java
@@ -87,12 +87,50 @@ public class NextSnapshotFetcher {
                     nextSnapshotId);
         } else {
             if (!changelogDecoupled) {
+                long earliestTime = -1;
+                long latestTime = -1;
+
+                if (earliestSnapshotId != null) {
+                    try {
+                        if (snapshotManager.snapshotExists(earliestSnapshotId)) {
+                            earliestTime =
+                                    snapshotManager.snapshot(earliestSnapshotId).timeMillis();
+                        }
+                    } catch (Exception e) {
+                        LOG.warn(
+                                "Failed to get snapshot time for ID earliest: {}",
+                                earliestSnapshotId,
+                                e);
+                    }
+                }
+
+                if (latestSnapshotId != null) {
+                    try {
+                        if (snapshotManager.snapshotExists(latestSnapshotId)) {
+                            latestTime = snapshotManager.snapshot(latestSnapshotId).timeMillis();
+                        }
+                    } catch (Exception e) {
+                        LOG.warn(
+                                "Failed to get snapshot time for ID latest: {}",
+                                latestSnapshotId,
+                                e);
+                    }
+                }
+
                 throw new OutOfRangeException(
                         String.format(
-                                "The snapshot with id %d has expired. You can: "
-                                        + "1. increase the snapshot or changelog expiration time. "
+                                "The wanted read snapshot with id %d has expired.\n"
+                                        + "Current status:\n"
+                                        + "  Earliest Snapshot ID: %s, Time: %d\n"
+                                        + "  Latest Snapshot ID: %s, Time: %d\n"
+                                        + "You can: \n"
+                                        + "1. increase the snapshot or changelog expiration time. \n"
                                         + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.",
-                                nextSnapshotId));
+                                nextSnapshotId,
+                                earliestSnapshotId,
+                                earliestTime,
+                                latestSnapshotId == null ? "N/A" : latestSnapshotId,
+                                latestTime));
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -736,7 +736,10 @@ public abstract class SimpleTableTestBase {
                         })
                 .satisfies(
                         anyCauseMatches(
-                                OutOfRangeException.class, "The snapshot with id 5 has expired."));
+                                OutOfRangeException.class,
+                                "The wanted read snapshot with id 5 has expired."))
+                .hasMessageContaining("Earliest Snapshot ID:")
+                .hasMessageContaining("Latest Snapshot ID:");
 
         write.close();
         commit.close();

--- a/paimon-core/src/test/java/org/apache/paimon/utils/NextSnapshotFetcherTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/NextSnapshotFetcherTest.java
@@ -127,7 +127,8 @@ public class NextSnapshotFetcherTest {
         assertThatThrownBy(() -> fetcher.getNextSnapshot(nextSnapshotId))
                 .isInstanceOf(OutOfRangeException.class)
                 .hasMessageContaining(
-                        "The snapshot with id 2 has expired. You can: 1. increase the snapshot or changelog expiration time. "
+                        "You can: \n"
+                                + "1. increase the snapshot or changelog expiration time. \n"
                                 + "2. use consumer-id to ensure that unconsumed snapshots will not be expired.");
     }
 


### PR DESCRIPTION
### Purpose
When throwing a snapshot expiration exception, log the earliest and latest snapshot information