### PR TITLE
[deploy] Fix empty javadoc jar when building with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,6 +515,31 @@ under the License.
         </profile>
 
         <profile>
+            <!-- JDK 9+ supports the ignore-source-errors flag for javadoc -->
+            <id>javadoc-jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <release>8</release>
+                                <additionalJOptions combine.children="append">
+                                    <!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
+                                    <additionalJOption>--ignore-source-errors</additionalJOption>
+                                </additionalJOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
             <id>fast-build</id>
             <properties>
                 <checkstyle.skip>true</checkstyle.skip>
@@ -1046,12 +1071,10 @@ under the License.
                     <configuration>
                         <quiet>true</quiet>
                         <detectOfflineLinks>false</detectOfflineLinks>
-                        <release>8</release>
+                        <source>8</source>
                         <failOnError>false</failOnError>
                         <additionalJOptions>
                             <additionalJOption>-Xdoclint:none</additionalJOption>
-                            <!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
-                            <additionalJOption>--ignore-source-errors</additionalJOption>
                         </additionalJOptions>
                     </configuration>
                 </plugin>


### PR DESCRIPTION

### Purpose
The --ignore-source-errors flag is only supported by JDK 9+. Move it to a JDK 9+ activated profile so that JDK 8 builds can generate javadoc correctly. 

### Before：
Only META-INF files are generated in doc jar with JDK8
Doc jar looks good in JDK11 and JDK17.

### After:
Doc jar looks good in JDK8, JDK11 and JDK17.


### Tests
