### PR TITLE
[spark] Support CREATE TABLE LIKE

### DIFF
--- a/docs/content/spark/sql-ddl.md
+++ b/docs/content/spark/sql-ddl.md
@@ -285,6 +285,39 @@ CREATE TABLE my_table_all (
 CREATE TABLE my_table_all_as PARTITIONED BY (dt) TBLPROPERTIES ('primary-key' = 'dt,hh') AS SELECT * FROM my_table_all;
 ```
 
+### Create Table Like
+
+A new table can be created from an existing source table. Available from **Spark 3.4**.
+
+```sql
+CREATE TABLE target_table LIKE source_table;
+```
+
+`CREATE TABLE LIKE` copies the source schema and partitioning.
+
+In `SparkCatalog`, if `USING xxx` is not specified, the target inherits the source provider.
+
+In `SparkGenericCatalog`, use `USING paimon` to enable Paimon `CREATE TABLE LIKE` semantics.
+
+When Paimon handles the command, comments and table properties are copied only when the source and target providers are the same. If the providers are different, only the comment is copied.
+
+`path`, `provider`, `location`, `owner`, `external` and `is-managed-location` are never copied. Users can still override the target table with `TBLPROPERTIES`.
+
+`STORED AS` is not supported in `SparkCatalog`. In `SparkGenericCatalog`, commands without `USING paimon` use Spark native behavior.
+
+```sql
+CREATE TABLE source_tbl (
+    id INT,
+    name STRING,
+    pt STRING
+) COMMENT 'source comment'
+PARTITIONED BY (pt)
+TBLPROPERTIES ('primary-key' = 'id,pt', 'bucket' = '5');
+
+-- target inherits the source provider
+CREATE TABLE target_tbl LIKE source_tbl;
+```
+
 ## View
 
 Views are based on the result-set of an SQL query, when using `org.apache.paimon.spark.SparkCatalog`, views are managed by paimon itself. 
@@ -366,4 +399,3 @@ List all tags of a table.
 ```sql
 SHOW TAGS T;
 ```
-

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCreateTableLikeCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonCreateTableLikeCommand.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.commands
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.spark.SparkSource
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.util.CharVarcharUtils
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+
+case class PaimonCreateTableLikeCommand(
+    targetCatalog: TableCatalog,
+    targetIdent: Identifier,
+    sourceCatalog: TableCatalog,
+    sourceIdent: Identifier,
+    provider: Option[String],
+    location: Option[String],
+    properties: Map[String, String] = Map.empty,
+    ifNotExists: Boolean)
+  extends LeafRunnableCommand
+  with Logging {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val sourceTable = sourceCatalog.loadTable(sourceIdent)
+    val sourceProperties = sourceTable.properties().asScala.toMap
+    val sourceProvider =
+      normalizedProvider(sourceProperties.get(TableCatalog.PROP_PROVIDER), unknownProvider)
+    val targetProvider = normalizedProvider(
+      provider.orElse(sourceProperties.get(TableCatalog.PROP_PROVIDER)),
+      defaultTargetProvider)
+    val sourceSchema =
+      CharVarcharUtils.getRawSchema(sourceTable.schema(), sparkSession.sessionState.conf)
+    try {
+      targetCatalog.createTable(
+        targetIdent,
+        sourceSchema,
+        sourceTable.partitioning(),
+        buildCreateProperties(sourceProperties, sourceProvider, targetProvider).asJava)
+    } catch {
+      case _: TableAlreadyExistsException if ifNotExists =>
+    }
+
+    Seq.empty
+  }
+
+  private def buildCreateProperties(
+      sourceProperties: Map[String, String],
+      sourceProvider: String,
+      targetProvider: String): Map[String, String] = {
+    copySourceProperties(sourceProperties, sourceProvider, targetProvider) ++
+      Map(TableCatalog.PROP_PROVIDER -> targetProvider) ++
+      location.map(TableCatalog.PROP_LOCATION -> _).toMap ++
+      properties
+  }
+
+  private def copySourceProperties(
+      sourceProperties: Map[String, String],
+      sourceProvider: String,
+      targetProvider: String): Map[String, String] = {
+    val copiedComment = sourceProperties
+      .get(TableCatalog.PROP_COMMENT)
+      .map(TableCatalog.PROP_COMMENT -> _)
+      .toMap
+    val copiedProperties = filterCopiedProperties(sourceProperties)
+
+    if (sourceProvider == targetProvider) {
+      copiedProperties ++ copiedComment
+    } else {
+      warnSkippedProperties(sourceProvider, targetProvider, copiedProperties.keySet)
+      copiedComment
+    }
+  }
+
+  private def warnSkippedProperties(
+      sourceProvider: String,
+      targetProvider: String,
+      skippedKeys: Set[String]): Unit = {
+    if (skippedKeys.nonEmpty) {
+      logWarning(
+        s"Skip copying source table properties in CREATE TABLE LIKE because source provider " +
+          s"'$sourceProvider' differs from target provider " +
+          s"'$targetProvider': " +
+          skippedKeys.toSeq.sorted.mkString(","))
+    }
+  }
+
+  private def normalizedProvider(provider: Option[String], defaultProvider: String): String = {
+    provider.map(normalizeProvider).getOrElse(defaultProvider)
+  }
+
+  private def normalizeProvider(provider: String): String = {
+    provider.toLowerCase(Locale.ROOT)
+  }
+
+  private val unknownProvider = "unknown"
+
+  private val defaultTargetProvider = normalizeProvider(SparkSource.NAME)
+
+  private def filterCopiedProperties(sourceProperties: Map[String, String]): Map[String, String] = {
+    sourceProperties.filterNot {
+      case (key, _) if key == CoreOptions.PATH.key() => true
+      case (TableCatalog.PROP_PROVIDER, _) => true
+      case (TableCatalog.PROP_COMMENT, _) => true
+      case (TableCatalog.PROP_LOCATION, _) => true
+      case (TableCatalog.PROP_OWNER, _) => true
+      case (TableCatalog.PROP_EXTERNAL, _) => true
+      case (TableCatalog.PROP_IS_MANAGED_LOCATION, _) => true
+      case _ => false
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/format/PaimonFormatTable.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
+import java.util.Locale
 
 import scala.collection.JavaConverters._
 
@@ -50,6 +51,7 @@ case class PaimonFormatTable(table: FormatTable)
 
   override def properties: util.Map[String, String] = {
     val properties = new util.HashMap[String, String](table.options())
+    properties.put(TableCatalog.PROP_PROVIDER, table.format.name().toLowerCase(Locale.ROOT))
     if (table.comment.isPresent) {
       properties.put(TableCatalog.PROP_COMMENT, table.comment.get)
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/AbstractPaimonSparkSqlExtensionsParser.scala
@@ -80,6 +80,7 @@ abstract class AbstractPaimonSparkSqlExtensionsParser(val delegate: ParserInterf
     Seq(
       RewritePaimonViewCommands(sparkSession),
       RewritePaimonFunctionCommands(sparkSession),
+      RewriteCreateTableLikeCommand(sparkSession),
       RewriteSparkDDLCommands(sparkSession)
     )
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/RewriteCreateTableLikeCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/RewriteCreateTableLikeCommand.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.parser.extensions
+
+import org.apache.paimon.spark.{SparkCatalog, SparkGenericCatalog}
+import org.apache.paimon.spark.catalog.SparkBaseCatalog
+import org.apache.paimon.spark.commands.PaimonCreateTableLikeCommand
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogStorageFormat
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier, LookupCatalog, TableCatalog}
+import org.apache.spark.sql.execution.command.{CreateTableLikeCommand => SparkCreateTableLikeCommand}
+
+case class RewriteCreateTableLikeCommand(spark: SparkSession)
+  extends Rule[LogicalPlan]
+  with LookupCatalog {
+
+  protected lazy val catalogManager: CatalogManager = spark.sessionState.catalogManager
+  private lazy val gteqSpark3_4: Boolean = org.apache.spark.SPARK_VERSION >= "3.4"
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!gteqSpark3_4) {
+      return plan
+    }
+
+    plan.resolveOperatorsUp {
+      case c: SparkCreateTableLikeCommand =>
+        val targetParts = toMultipartIdentifier(c.targetTable)
+
+        targetParts match {
+          case CatalogAndIdentifier(targetCatalog: SparkCatalog, targetIdent) =>
+            if (usesHiveStorageSyntax(c.fileFormat)) {
+              throw new UnsupportedOperationException(
+                "CREATE TABLE LIKE ... STORED AS is not supported for SparkCatalog.")
+            }
+            createTableLikeCommand(c, targetCatalog, targetIdent)
+          case CatalogAndIdentifier(targetCatalog: SparkGenericCatalog, targetIdent)
+              if !usesHiveStorageSyntax(c.fileFormat) &&
+                c.provider.exists(SparkBaseCatalog.usePaimon) =>
+            createTableLikeCommand(c, targetCatalog, targetIdent)
+          case _ => c
+        }
+    }
+  }
+
+  private def createTableLikeCommand(
+      command: SparkCreateTableLikeCommand,
+      targetCatalog: SparkBaseCatalog,
+      targetIdent: Identifier): LogicalPlan = {
+    toMultipartIdentifier(command.sourceTable) match {
+      case CatalogAndIdentifier(sourceCatalog: TableCatalog, sourceIdent) =>
+        PaimonCreateTableLikeCommand(
+          targetCatalog,
+          targetIdent,
+          sourceCatalog,
+          sourceIdent,
+          command.provider,
+          command.fileFormat.locationUri.map(_.toString),
+          command.properties,
+          command.ifNotExists
+        )
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"CREATE TABLE LIKE source table must be resolved from TableCatalog: ${command.sourceTable}.")
+    }
+  }
+
+  private def usesHiveStorageSyntax(fileFormat: CatalogStorageFormat): Boolean = {
+    fileFormat.inputFormat.isDefined
+  }
+
+  private def toMultipartIdentifier(
+      targetTable: org.apache.spark.sql.catalyst.TableIdentifier): Seq[String] = {
+    (targetTable.catalog.toSeq ++ targetTable.database.toSeq :+ targetTable.table).toList
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Assertions
 import java.sql.{Date, Timestamp}
 import java.time.LocalDateTime
 
+import scala.collection.JavaConverters._
+
 abstract class DDLTestBase extends PaimonSparkTestBase {
 
   import testImplicits._
@@ -130,6 +132,147 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
     withTable("paimon_tbl") {
       sql("CREATE TABLE paimon_tbl (id int)")
       assert(!loadTable("paimon_tbl").options().containsKey("provider"))
+    }
+  }
+
+  test("Paimon DDL: create table like with paimon SparkCatalog") {
+    assume(gteqSpark3_4)
+    withTable("source_tbl", "target_tbl") {
+      sql("""
+            |CREATE TABLE source_tbl (
+            |  id INT,
+            |  name STRING COMMENT 'name column',
+            |  pt STRING
+            |) COMMENT 'source comment'
+            |PARTITIONED BY (pt)
+            |TBLPROPERTIES (
+            |  'primary-key' = 'id,pt',
+            |  'bucket' = '5',
+            |  'target-file-size' = '128MB'
+            |)
+            |""".stripMargin)
+
+      sql("""
+            |CREATE TABLE target_tbl
+            |LIKE source_tbl
+            |TBLPROPERTIES ('bucket' = '8')
+            |""".stripMargin)
+
+      val source = loadTable("source_tbl")
+      val target = loadTable("target_tbl")
+
+      Assertions.assertEquals(spark.table("source_tbl").schema, spark.table("target_tbl").schema)
+      Assertions.assertEquals("source comment", target.comment().get())
+      Assertions.assertEquals(List("pt"), target.partitionKeys().asScala.toList)
+      Assertions.assertEquals(List("id", "pt"), target.primaryKeys().asScala.toList)
+      Assertions.assertEquals("8", target.options().get("bucket"))
+      Assertions.assertEquals("128MB", target.options().get("target-file-size"))
+      Assertions.assertNotEquals(source.location().toString, target.location().toString)
+    }
+  }
+
+  test("Paimon DDL: create table like from branch with paimon SparkCatalog") {
+    assume(gteqSpark3_4)
+    withTable("source_tbl", "target_tbl") {
+      sql("""
+            |CREATE TABLE source_tbl (
+            |  id INT,
+            |  name STRING COMMENT 'name column',
+            |  pt STRING
+            |) COMMENT 'source comment'
+            |PARTITIONED BY (pt)
+            |TBLPROPERTIES (
+            |  'primary-key' = 'id,pt',
+            |  'bucket' = '5'
+            |)
+            |""".stripMargin)
+      sql("INSERT INTO source_tbl VALUES (1, 'a', 'p1')")
+
+      checkAnswer(
+        sql("CALL paimon.sys.create_branch(table => 'test.source_tbl', branch => 'test_branch')"),
+        Row(true) :: Nil)
+      sql("ALTER TABLE `source_tbl$branch_test_branch` ADD COLUMNS(extra STRING)")
+
+      sql("""
+            |CREATE TABLE target_tbl
+            |LIKE `source_tbl$branch_test_branch`
+            |""".stripMargin)
+
+      val target = loadTable("target_tbl")
+
+      Assertions.assertFalse(spark.table("source_tbl").schema.fieldNames.contains("extra"))
+      Assertions.assertTrue(spark.table("target_tbl").schema.fieldNames.contains("extra"))
+      Assertions.assertEquals(
+        sql("SELECT * FROM `source_tbl$branch_test_branch`").schema,
+        spark.table("target_tbl").schema)
+      Assertions.assertEquals("source comment", target.comment().get())
+      Assertions.assertEquals(List("pt"), target.partitionKeys().asScala.toList)
+      Assertions.assertEquals(List("id", "pt"), target.primaryKeys().asScala.toList)
+      Assertions.assertEquals("5", target.options().get("bucket"))
+    }
+  }
+
+  test("Paimon DDL: create table like if not exists with paimon SparkCatalog") {
+    assume(gteqSpark3_4)
+    withTable("source_tbl", "target_tbl") {
+      sql("""
+            |CREATE TABLE source_tbl (
+            |  id INT,
+            |  name STRING,
+            |  pt STRING
+            |)
+            |PARTITIONED BY (pt)
+            |TBLPROPERTIES (
+            |  'primary-key' = 'id,pt',
+            |  'bucket' = '5'
+            |)
+            |""".stripMargin)
+
+      sql("""
+            |CREATE TABLE target_tbl (
+            |  id BIGINT,
+            |  pt STRING
+            |) COMMENT 'target comment'
+            |PARTITIONED BY (pt)
+            |TBLPROPERTIES (
+            |  'primary-key' = 'id,pt',
+            |  'bucket' = '3'
+            |)
+            |""".stripMargin)
+
+      val targetSchema = spark.table("target_tbl").schema
+      val targetLocation = loadTable("target_tbl").location().toString
+
+      sql("""
+            |CREATE TABLE IF NOT EXISTS target_tbl
+            |LIKE source_tbl
+            |""".stripMargin)
+
+      val target = loadTable("target_tbl")
+
+      Assertions.assertEquals(targetSchema, spark.table("target_tbl").schema)
+      Assertions.assertFalse(spark.table("target_tbl").schema.fieldNames.contains("name"))
+      Assertions.assertEquals("target comment", target.comment().get())
+      Assertions.assertEquals("3", target.options().get("bucket"))
+      Assertions.assertEquals(targetLocation, target.location().toString)
+    }
+  }
+
+  test("Paimon DDL: create table like stored as is unsupported with paimon SparkCatalog") {
+    assume(gteqSpark3_4)
+    withTable("source_tbl", "target_tbl") {
+      sql("CREATE TABLE source_tbl (id INT)")
+
+      val error = intercept[Exception] {
+        sql("""
+              |CREATE TABLE target_tbl
+              |LIKE source_tbl
+              |STORED AS PARQUET
+              |""".stripMargin)
+      }.getMessage
+
+      Assertions.assertTrue(
+        error.contains("CREATE TABLE LIKE ... STORED AS is not supported for SparkCatalog."))
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLWithHiveCatalogTestBase.scala
@@ -24,7 +24,10 @@ import org.apache.paimon.table.FileStoreTable
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.junit.jupiter.api.Assertions
+
+import scala.collection.JavaConverters._
 
 abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
 
@@ -643,6 +646,82 @@ abstract class DDLWithHiveCatalogTestBase extends PaimonHiveTestBase {
         spark.sql("ALTER TABLE t UNSET TBLPROPERTIES ('write-buffer-spillable')")
         assert(
           !hmsClient.getTable("paimon_db", "t").getParameters.containsKey("write-buffer-spillable"))
+      }
+    }
+  }
+
+  test("Paimon DDL with hive catalog: create table like with SparkGenericCatalog") {
+    assume(gteqSpark3_4)
+    spark.sql(s"USE $sparkCatalogName")
+    withDatabase("paimon_db") {
+      spark.sql("CREATE DATABASE paimon_db")
+      spark.sql("USE paimon_db")
+
+      withTable("paimon_source", "paimon_like", "csv_source", "csv_like", "csv_like_paimon") {
+        spark.sql("""
+                    |CREATE TABLE paimon_source (
+                    |  id INT,
+                    |  name STRING,
+                    |  pt STRING
+                    |) USING paimon
+                    |PARTITIONED BY (pt)
+                    |COMMENT 'paimon source comment'
+                    |TBLPROPERTIES (
+                    |  'primary-key' = 'id,pt',
+                    |  'bucket' = '4',
+                    |  'target-file-size' = '128MB'
+                    |)
+                    |""".stripMargin)
+        spark.sql("CREATE TABLE paimon_like LIKE paimon_source USING paimon")
+
+        val paimonLike = loadTable("paimon_db", "paimon_like")
+        Assertions.assertEquals(
+          spark.table("paimon_source").schema,
+          spark.table("paimon_like").schema)
+        Assertions.assertEquals("paimon source comment", paimonLike.comment().get())
+        Assertions.assertEquals(List("pt"), paimonLike.partitionKeys().asScala.toList)
+        Assertions.assertEquals(List("id", "pt"), paimonLike.primaryKeys().asScala.toList)
+        Assertions.assertEquals("4", paimonLike.options().get("bucket"))
+        Assertions.assertEquals("128MB", paimonLike.options().get("target-file-size"))
+
+        spark.sql("""
+                    |CREATE TABLE csv_source (
+                    |  id INT,
+                    |  c_char CHAR(9),
+                    |  c_varchar VARCHAR(10),
+                    |  pt STRING
+                    |) USING csv
+                    |PARTITIONED BY (pt)
+                    |COMMENT 'csv source comment'
+                    |TBLPROPERTIES ('target-file-size' = '256MB')
+                    |""".stripMargin)
+        spark.sql("CREATE TABLE csv_like LIKE csv_source")
+
+        val csvLike = spark.sessionState.catalog.getTableMetadata(
+          TableIdentifier("csv_like", Some("paimon_db")))
+        Assertions.assertEquals(Seq("pt"), csvLike.partitionColumnNames)
+        Assertions.assertTrue(csvLike.provider.contains("csv"))
+        Assertions.assertTrue(csvLike.comment.isEmpty)
+        Assertions.assertFalse(csvLike.properties.contains("target-file-size"))
+
+        spark.sql("CREATE TABLE csv_like_paimon LIKE csv_source USING paimon")
+
+        val csvLikePaimon = loadTable("paimon_db", "csv_like_paimon")
+        Assertions.assertEquals(
+          spark.table("csv_source").schema,
+          spark.table("csv_like_paimon").schema)
+        checkAnswer(
+          spark
+            .sql("DESC csv_like_paimon")
+            .select("col_name", "data_type")
+            .where("col_name IN ('c_char', 'c_varchar')")
+            .orderBy("col_name"),
+          Row("c_char", "char(9)") :: Row("c_varchar", "varchar(10)") :: Nil
+        )
+        Assertions.assertEquals("csv source comment", csvLikePaimon.comment().get())
+        Assertions.assertEquals(List("pt"), csvLikePaimon.partitionKeys().asScala.toList)
+        Assertions.assertTrue(csvLikePaimon.primaryKeys().isEmpty)
+        Assertions.assertFalse(csvLikePaimon.options().containsKey("target-file-size"))
       }
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
@@ -148,6 +148,38 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
     }
   }
 
+  test("PaimonFormatTable: create table like copies properties for same provider") {
+    assume(gteqSpark3_4)
+    withTable("source_tbl", "target_tbl") {
+      sql("""
+            |CREATE TABLE source_tbl (
+            |  id INT,
+            |  pt STRING
+            |) USING CSV
+            |PARTITIONED BY (pt)
+            |COMMENT 'source comment'
+            |TBLPROPERTIES (
+            |  'k' = 'v',
+            |  'csv.field-delimiter' = ';'
+            |)
+            |""".stripMargin)
+
+      sql("""
+            |CREATE TABLE target_tbl
+            |LIKE source_tbl
+            |""".stripMargin)
+
+      val target =
+        paimonCatalog.getTable(Identifier.create("test_db", "target_tbl")).asInstanceOf[FormatTable]
+      assert(target.partitionKeys().size() == 1)
+      assert(target.partitionKeys().get(0) == "pt")
+      assert(target.comment.isPresent)
+      assert(target.comment.get == "source comment")
+      assert(target.options().get("k") == "v")
+      assert(target.options().get("csv.field-delimiter") == ";")
+    }
+  }
+
   test("PaimonFormatTable non partition table overwrite: csv") {
     val tableName = "paimon_non_partiiton_overwrite_test"
     withTable(tableName) {


### PR DESCRIPTION
### Purpose

Support `CREATE TABLE LIKE` in Paimon Spark integration on Spark 3.4+.

Behavior:
- `SparkCatalog`: rewrite `CREATE TABLE LIKE` to the Paimon command, except `STORED AS`, which remains unsupported.
- If `USING` is omitted in `SparkCatalog`, inherit the source table provider.
- `SparkGenericCatalog`: rewrite only when `USING paimon` is specified; otherwise keep Spark native behavior.
- Copy source table comment and properties only when source and target providers match. If providers differ, keep only the comment and log a warning.

### Tests

Updated/covered by:
- `DDLTest`
- `DDLWithHiveCatalogTest`
- `PaimonFormatTableTest`
