### PR TITLE
[deploy] Fix JDK 17 deploy script to use renamed Spark4 module artifactIds

### DIFF
--- a/tools/releasing/deploy_staging_jars_for_jdk17.sh
+++ b/tools/releasing/deploy_staging_jars_for_jdk17.sh
@@ -47,6 +47,6 @@ ${MVN} clean install -ntp -Pdocs-and-source,spark4 -DskipTests -pl paimon-spark/
 
 echo "Deploying spark4 module to repository.apache.org"
 ${MVN} deploy -ntp -Papache-release,docs-and-source,spark4 -DskipTests -DretryFailedDeploymentCount=10 \
- -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common,org.apache.paimon:paimon-spark-4.0 $CUSTOM_OPTIONS
+ -pl org.apache.paimon:paimon-spark-common_2.13,org.apache.paimon:paimon-spark4-common_2.13,org.apache.paimon:paimon-spark-4.0_2.13 $CUSTOM_OPTIONS
 
 cd ${CURR_DIR}


### PR DESCRIPTION

### Purpose
paimon-spark4-common and paimon-spark-4.0 were renamed with _2.13 suffix in #6128, but the deploy script
   was not updated accordingly, causing JDK 17 deploy to fail with "Could not find the selected project in
   the reactor".
### Tests
