### PR TITLE
[tantivy] Fix unnecessary .store file generation in full-text index

### DIFF
--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -153,26 +153,17 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         searcher = self._searcher
         query = self._index.parse_query(query_text, ["text"])
 
-        scored_results = searcher.search(query, limit)
-        if not scored_results.hits:
+        results = searcher.search(query, limit)
+        if not results.hits:
             return DictBasedScoredIndexResult({})
 
-        addr_to_score: Dict[tuple, float] = {
-            (addr.segment_ord, addr.doc): score
-            for score, addr in scored_results.hits
-        }
+        doc_addresses = [addr for score, addr in results.hits]
+        scores = [score for score, addr in results.hits]
+        row_ids = searcher.fast_field_values("row_id", doc_addresses)
 
-        # This can be replaced by https://github.com/quickwit-oss/tantivy-py/pull/641 when it's released
-        all_by_rowid = searcher.search(query, searcher.num_docs, order_by_field='row_id')
         id_to_scores: Dict[int, float] = {}
-        remaining = len(addr_to_score)
-        for row_id, addr in all_by_rowid.hits:
-            score = addr_to_score.get((addr.segment_ord, addr.doc))
-            if score is not None:
-                id_to_scores[row_id] = score
-                remaining -= 1
-                if remaining == 0:
-                    break
+        for row_id, score in zip(row_ids, scores):
+            id_to_scores[row_id] = score
 
         return DictBasedScoredIndexResult(id_to_scores)
 

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -152,13 +152,27 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
         searcher = self._searcher
         query = self._index.parse_query(query_text, ["text"])
-        results = searcher.search(query, limit)
 
+        scored_results = searcher.search(query, limit)
+        if not scored_results.hits:
+            return DictBasedScoredIndexResult({})
+
+        addr_to_score: Dict[tuple, float] = {
+            (addr.segment_ord, addr.doc): score
+            for score, addr in scored_results.hits
+        }
+
+        # This can be replaced by https://github.com/quickwit-oss/tantivy-py/pull/641 when it's released
+        all_by_rowid = searcher.search(query, searcher.num_docs, order_by_field='row_id')
         id_to_scores: Dict[int, float] = {}
-        for score, doc_address in results.hits:
-            doc = searcher.doc(doc_address)
-            row_id = doc["row_id"][0]
-            id_to_scores[row_id] = score
+        remaining = len(addr_to_score)
+        for row_id, addr in all_by_rowid.hits:
+            score = addr_to_score.get((addr.segment_ord, addr.doc))
+            if score is not None:
+                id_to_scores[row_id] = score
+                remaining -= 1
+                if remaining == 0:
+                    break
 
         return DictBasedScoredIndexResult(id_to_scores)
 
@@ -178,7 +192,7 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
             # Open tantivy index from stream-backed directory
             schema_builder = tantivy.SchemaBuilder()
-            schema_builder.add_unsigned_field("row_id", stored=True, indexed=True, fast=True)
+            schema_builder.add_unsigned_field("row_id", stored=False, indexed=True, fast=True)
             schema_builder.add_text_field("text", stored=False)
             schema = schema_builder.build()
 

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -152,13 +152,27 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
         searcher = self._searcher
         query = self._index.parse_query(query_text, ["text"])
-        results = searcher.search(query, limit)
 
+        scored_results = searcher.search(query, limit)
+        if not scored_results.hits:
+            return DictBasedScoredIndexResult({})
+
+        addr_to_score: Dict[tuple, float] = {
+            (addr.segment_ord, addr.doc): score
+            for score, addr in scored_results.hits
+        }
+
+        # This can be replaced by https://github.com/quickwit-oss/tantivy-py/pull/641 when it's released
+        all_by_rowid = searcher.search(query, searcher.num_docs, order_by_field='row_id')
         id_to_scores: Dict[int, float] = {}
-        for score, doc_address in results.hits:
-            doc = searcher.doc(doc_address)
-            row_id = doc["row_id"][0]
-            id_to_scores[row_id] = score
+        remaining = len(addr_to_score)
+        for row_id, addr in all_by_rowid.hits:
+            score = addr_to_score.get((addr.segment_ord, addr.doc))
+            if score is not None:
+                id_to_scores[row_id] = score
+                remaining -= 1
+                if remaining == 0:
+                    break
 
         return DictBasedScoredIndexResult(id_to_scores)
 
@@ -180,7 +194,7 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
             # Open tantivy index from stream-backed directory
             schema_builder = tantivy.SchemaBuilder()
-            schema_builder.add_unsigned_field("row_id", stored=True, indexed=True, fast=True)
+            schema_builder.add_unsigned_field("row_id", stored=False, indexed=True, fast=True)
             schema_builder.add_text_field("text", stored=False)
             schema = schema_builder.build()
 

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
@@ -134,7 +134,7 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
             // Filter to regular files only before writing count
             List<File> indexFiles = new ArrayList<>();
             for (File file : allFiles) {
-                if (file.isFile() && !file.getName().endsWith(".store")) {
+                if (file.isFile()) {
                     indexFiles.add(file);
                 }
             }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
@@ -134,7 +134,7 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
             // Filter to regular files only before writing count
             List<File> indexFiles = new ArrayList<>();
             for (File file : allFiles) {
-                if (file.isFile()) {
+                if (file.isFile() && !file.getName().endsWith(".store")) {
                     indexFiles.add(file);
                 }
             }

--- a/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
@@ -23,7 +23,7 @@ use jni::JNIEnv;
 use std::ptr;
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
-use tantivy::schema::{Field, NumericOptions, Schema, TEXT};
+use tantivy::schema::{Field, IndexRecordOption, NumericOptions, Schema, TextFieldIndexing, TextOptions};
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy};
 
 use crate::jni_directory::JniDirectory;
@@ -58,7 +58,12 @@ fn build_schema() -> (Schema, Field, Field) {
         "row_id",
         NumericOptions::default().set_indexed().set_fast(),
     );
-    let text_field = builder.add_text_field("text", TEXT);
+    let text_options = TextOptions::default().set_indexing_options(
+        TextFieldIndexing::default()
+            .set_tokenizer("default")
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+    );
+    let text_field = builder.add_text_field("text", text_options);
     (builder.build(), row_id_field, text_field)
 }
 

--- a/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
@@ -56,10 +56,7 @@ fn build_schema() -> (Schema, Field, Field) {
     let mut builder = Schema::builder();
     let row_id_field = builder.add_u64_field(
         "row_id",
-        NumericOptions::default()
-            .set_stored()
-            .set_indexed()
-            .set_fast(),
+        NumericOptions::default().set_indexed().set_fast(),
     );
     let text_field = builder.add_text_field("text", TEXT);
     (builder.build(), row_id_field, text_field)


### PR DESCRIPTION
### Purpose
Tantivy is used purely as an inverted index in Paimon, so `.store` files (raw field values) are never needed or read. The original implementation mistakenly set `row_id` as `stored=True`, wasting 30% or even more of archive size per index file.

This PR removes `.set_stored()` from the schema and filters `.store` files when packing the archive, and updates the Python reader accordingly.

### Tests
Re-using `JavaPyTantivyE2ETest#testTantivyFullTextIndexWrite` +`test_read_tantivy_full_text_inde`