### PR TITLE
[core] Optimize error message when creating PK table with row-tracking enabled 

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -648,13 +648,13 @@ public class SchemaValidation {
         boolean rowTrackingEnabled = options.rowTrackingEnabled();
         if (rowTrackingEnabled) {
             checkArgument(
-                    options.bucket() == -1,
-                    "Cannot define %s for row tracking table, it only support bucket = -1",
-                    CoreOptions.BUCKET.key());
-            checkArgument(
                     schema.primaryKeys().isEmpty(),
                     "Cannot define %s for row tracking table.",
                     PRIMARY_KEY.key());
+            checkArgument(
+                    options.bucket() == -1,
+                    "Cannot define %s for row tracking table, it only support bucket = -1",
+                    CoreOptions.BUCKET.key());
         }
 
         if (options.dataEvolutionEnabled()) {

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -314,4 +314,31 @@ class SchemaValidationTest {
                 .hasMessage(
                         "Data evolution config must enabled for table with vector-store file format.");
     }
+
+    @Test
+    void testRowTrackingWithPkTable() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(BUCKET.key(), String.valueOf(-2));
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.INT()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "f2", DataTypes.STRING()));
+        List<String> primaryKeys = singletonList("f1");
+
+        assertThatThrownBy(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                primaryKeys,
+                                                options,
+                                                "")))
+                .hasMessageContaining("primary-key");
+    }
 }


### PR DESCRIPTION
### Purpose
When creating a PK table with `row-tracking.enabled=true` with setting bucket = -2,
  the error reports "Cannot define bucket for row tracking table, it only support
  bucket = -1" instead of "Cannot define primary-key for row tracking table". Which will make user confused. This PR optimize the error message. 
### Tests
