### PR TITLE
[core][flink] supports count star pushdown for all-global-indexed filters.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
@@ -71,6 +71,10 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
 
         FileStoreTable storeTable = (FileStoreTable) table;
 
+        if (!storeTable.coreOptions().dataEvolutionEnabled()) {
+            return false;
+        }
+
         if (predicate == null || !storeTable.coreOptions().globalIndexEnabled()) {
             return false;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.predicate.And;
+import org.apache.paimon.predicate.Between;
+import org.apache.paimon.predicate.CompoundFunction;
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.In;
+import org.apache.paimon.predicate.IsNull;
+import org.apache.paimon.predicate.LeafFunction;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Or;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
+
+/**
+ * A visitor to test whether a predicate is fully covered by scalar index.
+ */
+public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
+
+    private static final String BTREE_INDEX_TYPE = "btree";
+
+    private final Set<String> scalarIndexedFields;
+
+    public ScalarIndexedFieldsVisitor(Set<String> scalarIndexedFields) {
+        this.scalarIndexedFields = scalarIndexedFields;
+    }
+
+    public static boolean allFieldsIndexed(
+            Table table, @Nullable Predicate predicate) {
+        if (!(table instanceof FileStoreTable)) {
+            return false;
+        }
+
+        FileStoreTable storeTable = (FileStoreTable) table;
+
+        if (predicate == null || !storeTable.coreOptions().globalIndexEnabled()) {
+            return false;
+        }
+
+        Set<String> indexedFields =
+                storeTable.store().newIndexFileHandler().scan(tryTravelOrLatest(storeTable), entryFilter())
+                        .stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .map(indexFile -> indexFile.globalIndexMeta())
+                        .filter(Objects::nonNull)
+                        .map(GlobalIndexMeta::indexFieldId)
+                        .filter(storeTable.rowType()::containsField)
+                        .map(fieldId -> storeTable.rowType().getField(fieldId).name())
+                        .collect(Collectors.toSet());
+
+        if (indexedFields.isEmpty()) {
+            return false;
+        }
+
+        return predicate.visit(new ScalarIndexedFieldsVisitor(indexedFields));
+    }
+
+    private static org.apache.paimon.utils.Filter<IndexManifestEntry> entryFilter() {
+        return entry -> {
+            GlobalIndexMeta globalIndexMeta = entry.indexFile().globalIndexMeta();
+            return globalIndexMeta != null
+                    && BTREE_INDEX_TYPE.equals(entry.indexFile().indexType());
+        };
+    }
+
+    @Override
+    public Boolean visit(LeafPredicate predicate) {
+        Optional<FieldRef> fieldRefOptional = predicate.fieldRefOptional();
+        if (!fieldRefOptional.isPresent()) {
+            return false;
+        }
+
+        FieldRef fieldRef = fieldRefOptional.get();
+        if (!isScalarIndexed(fieldRef)) {
+            return false;
+        }
+
+        LeafFunction function = predicate.function();
+        return function instanceof Equal
+                || function instanceof In
+                || function instanceof Between
+                || function instanceof IsNull;
+    }
+
+    @Override
+    public Boolean visit(CompoundPredicate predicate) {
+        CompoundFunction function = predicate.function();
+        if (!(function instanceof And) && !(function instanceof Or)) {
+            return false;
+        }
+
+        for (Predicate child : predicate.children()) {
+            if (!child.visit(this)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isScalarIndexed(FieldRef fieldRef) {
+        return scalarIndexedFields.contains(fieldRef.name());
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
@@ -45,9 +45,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
 
-/**
- * A visitor to test whether a predicate is fully covered by scalar index.
- */
+/** A visitor to test whether a predicate is fully covered by scalar index. */
 public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
 
     private static final String BTREE_INDEX_TYPE = "btree";
@@ -58,8 +56,7 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
         this.scalarIndexedFields = scalarIndexedFields;
     }
 
-    public static boolean allFieldsIndexed(
-            Table table, @Nullable Predicate predicate) {
+    public static boolean allFieldsIndexed(Table table, @Nullable Predicate predicate) {
         if (!(table instanceof FileStoreTable)) {
             return false;
         }
@@ -71,8 +68,8 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
         }
 
         Set<String> indexedFields =
-                storeTable.store().newIndexFileHandler().scan(tryTravelOrLatest(storeTable), entryFilter())
-                        .stream()
+                storeTable.store().newIndexFileHandler()
+                        .scan(tryTravelOrLatest(storeTable), entryFilter()).stream()
                         .map(IndexManifestEntry::indexFile)
                         .map(indexFile -> indexFile.globalIndexMeta())
                         .filter(Objects::nonNull)

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitor.java
@@ -20,6 +20,7 @@ package org.apache.paimon.globalindex;
 
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.Between;
 import org.apache.paimon.predicate.CompoundFunction;
@@ -32,17 +33,21 @@ import org.apache.paimon.predicate.LeafFunction;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.Pair;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
 
 /** A visitor to test whether a predicate is fully covered by scalar index. */
@@ -56,7 +61,10 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
         this.scalarIndexedFields = scalarIndexedFields;
     }
 
-    public static boolean allFieldsIndexed(Table table, @Nullable Predicate predicate) {
+    public static boolean allFieldsIndexed(
+            Table table,
+            @Nullable Predicate predicate,
+            @Nullable PartitionPredicate partitionPredicate) {
         if (!(table instanceof FileStoreTable)) {
             return false;
         }
@@ -67,9 +75,22 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
             return false;
         }
 
+        // We should split the PartitionPredicate to filter index entries, or the result may be
+        // wrong. For example, if we have two partitions `dt=1`(indexed) and `dt=2`(unindexed),
+        // the where condition `id=10 AND dt=2` should not be consumed. Because the index evaluation
+        // during the plan phase will decide not to use the index.
+        Pair<Optional<PartitionPredicate>, List<Predicate>> splitPredicates =
+                splitPartitionPredicatesAndDataPredicates(
+                        predicate, table.rowType(), table.partitionKeys());
+        PartitionPredicate effectivePartPredicate =
+                partitionPredicate != null
+                        ? partitionPredicate
+                        : splitPredicates.getLeft().orElse(null);
+
         Set<String> indexedFields =
                 storeTable.store().newIndexFileHandler()
-                        .scan(tryTravelOrLatest(storeTable), entryFilter()).stream()
+                        .scan(tryTravelOrLatest(storeTable), entryFilter(effectivePartPredicate))
+                        .stream()
                         .map(IndexManifestEntry::indexFile)
                         .map(indexFile -> indexFile.globalIndexMeta())
                         .filter(Objects::nonNull)
@@ -82,11 +103,16 @@ public class ScalarIndexedFieldsVisitor implements PredicateVisitor<Boolean> {
             return false;
         }
 
-        return predicate.visit(new ScalarIndexedFieldsVisitor(indexedFields));
+        return PredicateBuilder.and(splitPredicates.getRight())
+                .visit(new ScalarIndexedFieldsVisitor(indexedFields));
     }
 
-    private static org.apache.paimon.utils.Filter<IndexManifestEntry> entryFilter() {
+    private static org.apache.paimon.utils.Filter<IndexManifestEntry> entryFilter(
+            PartitionPredicate partitionPredicate) {
         return entry -> {
+            if (partitionPredicate != null && !partitionPredicate.test(entry.partition())) {
+                return false;
+            }
             GlobalIndexMeta globalIndexMeta = entry.indexFile().globalIndexMeta();
             return globalIndexMeta != null
                     && BTREE_INDEX_TYPE.equals(entry.indexFile().indexType());

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitorTest.java
@@ -65,9 +65,7 @@ public class ScalarIndexedFieldsVisitorTest {
         Predicate andPredicate =
                 PredicateBuilder.and(BUILDER.equal(0, 10), BUILDER.between(2, 90, 100));
         Predicate orPredicate =
-                PredicateBuilder.or(
-                        BUILDER.in(0, Arrays.asList(1, 2, 3)),
-                        BUILDER.isNull(2));
+                PredicateBuilder.or(BUILDER.in(0, Arrays.asList(1, 2, 3)), BUILDER.isNull(2));
 
         assertThat(andPredicate.visit(VISITOR)).isTrue();
         assertThat(orPredicate.visit(VISITOR)).isTrue();

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/ScalarIndexedFieldsVisitorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.UpperTransform;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ScalarIndexedFieldsVisitor}. */
+public class ScalarIndexedFieldsVisitorTest {
+
+    private static final RowType ROW_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new DataField(0, "id", DataTypes.INT()),
+                            new DataField(1, "name", DataTypes.STRING()),
+                            new DataField(2, "score", DataTypes.INT())));
+
+    private static final PredicateBuilder BUILDER = new PredicateBuilder(ROW_TYPE);
+
+    private static final ScalarIndexedFieldsVisitor VISITOR =
+            new ScalarIndexedFieldsVisitor(new HashSet<>(Arrays.asList("id", "score")));
+
+    @Test
+    public void testSupportedPredicates() {
+        assertThat(BUILDER.equal(0, 10).visit(VISITOR)).isTrue();
+        assertThat(BUILDER.in(0, Arrays.asList(1, 2, 3)).visit(VISITOR)).isTrue();
+        assertThat(BUILDER.between(2, 90, 100).visit(VISITOR)).isTrue();
+        assertThat(BUILDER.isNull(0).visit(VISITOR)).isTrue();
+    }
+
+    @Test
+    public void testCompoundPredicates() {
+        Predicate andPredicate =
+                PredicateBuilder.and(BUILDER.equal(0, 10), BUILDER.between(2, 90, 100));
+        Predicate orPredicate =
+                PredicateBuilder.or(
+                        BUILDER.in(0, Arrays.asList(1, 2, 3)),
+                        BUILDER.isNull(2));
+
+        assertThat(andPredicate.visit(VISITOR)).isTrue();
+        assertThat(orPredicate.visit(VISITOR)).isTrue();
+    }
+
+    @Test
+    public void testUnsupportedPredicates() {
+        assertThat(BUILDER.greaterThan(0, 10).visit(VISITOR)).isFalse();
+        assertThat(BUILDER.equal(1, BinaryString.fromString("name_10")).visit(VISITOR)).isFalse();
+    }
+
+    @Test
+    public void testNonFieldPredicate() {
+        LeafPredicate upperNameEquals =
+                LeafPredicate.of(
+                        new UpperTransform(
+                                Collections.singletonList(
+                                        new FieldRef(1, "name", DataTypes.STRING()))),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("NAME_10")));
+
+        assertThat(upperNameEquals.visit(VISITOR)).isFalse();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -26,6 +26,7 @@ import org.apache.paimon.flink.PredicateConverter;
 import org.apache.paimon.flink.lookup.DynamicPartitionLoader;
 import org.apache.paimon.flink.lookup.PartitionLoader;
 import org.apache.paimon.flink.lookup.StaticPartitionLoader;
+import org.apache.paimon.globalindex.ScalarIndexedFieldsVisitor;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -115,6 +116,9 @@ public abstract class FlinkTableSource
         List<ResolvedExpression> unConsumedFilters = new ArrayList<>();
         List<ResolvedExpression> consumedFilters = new ArrayList<>();
         List<Predicate> converted = new ArrayList<>();
+        // Check non-only-partition filters for indexed count star pushdown
+        List<Predicate> nonPartitionFilters = new ArrayList<>();
+        boolean hasUnconvertedFilter = false;
         PredicateVisitor<Boolean> onlyPartFieldsVisitor =
                 new PartitionPredicateVisitor(partitionKeys);
 
@@ -123,10 +127,14 @@ public abstract class FlinkTableSource
 
             if (!predicateOptional.isPresent()) {
                 unConsumedFilters.add(filter);
+                hasUnconvertedFilter = true;
             } else {
                 Predicate p = predicateOptional.get();
                 if (isUnbounded() || !p.visit(onlyPartFieldsVisitor)) {
                     unConsumedFilters.add(filter);
+                    if (!isUnbounded()) {
+                        nonPartitionFilters.add(p);
+                    }
                 } else {
                     consumedFilters.add(filter);
                 }
@@ -134,6 +142,16 @@ public abstract class FlinkTableSource
             }
         }
         predicate = converted.isEmpty() ? null : PredicateBuilder.and(converted);
+
+        if (!isUnbounded()
+                && !hasUnconvertedFilter
+                && !nonPartitionFilters.isEmpty()
+                && ScalarIndexedFieldsVisitor.allFieldsIndexed(
+                        table, PredicateBuilder.and(nonPartitionFilters))) {
+            unConsumedFilters.clear();
+            consumedFilters = new ArrayList<>(filters);
+        }
+
         LOG.info("Consumed filters: {} of {}", consumedFilters, filters);
 
         return Result.of(filters, unConsumedFilters);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FlinkTableSource.java
@@ -116,8 +116,6 @@ public abstract class FlinkTableSource
         List<ResolvedExpression> unConsumedFilters = new ArrayList<>();
         List<ResolvedExpression> consumedFilters = new ArrayList<>();
         List<Predicate> converted = new ArrayList<>();
-        // Check non-only-partition filters for indexed count star pushdown
-        List<Predicate> nonPartitionFilters = new ArrayList<>();
         boolean hasUnconvertedFilter = false;
         PredicateVisitor<Boolean> onlyPartFieldsVisitor =
                 new PartitionPredicateVisitor(partitionKeys);
@@ -132,9 +130,6 @@ public abstract class FlinkTableSource
                 Predicate p = predicateOptional.get();
                 if (isUnbounded() || !p.visit(onlyPartFieldsVisitor)) {
                     unConsumedFilters.add(filter);
-                    if (!isUnbounded()) {
-                        nonPartitionFilters.add(p);
-                    }
                 } else {
                     consumedFilters.add(filter);
                 }
@@ -143,11 +138,11 @@ public abstract class FlinkTableSource
         }
         predicate = converted.isEmpty() ? null : PredicateBuilder.and(converted);
 
+        // If all predicates are covered by global index, they can be consumed.
         if (!isUnbounded()
                 && !hasUnconvertedFilter
-                && !nonPartitionFilters.isEmpty()
                 && ScalarIndexedFieldsVisitor.allFieldsIndexed(
-                        table, PredicateBuilder.and(nonPartitionFilters))) {
+                        table, predicate, partitionPredicate)) {
             unConsumedFilters.clear();
             consumedFilters = new ArrayList<>(filters);
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -847,50 +847,60 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     @Test
     public void testCountStarBTreeIndexPartitionedTable() {
         sql(
-                "CREATE TABLE count_btree_index_partitioned (id INT, name STRING, category INT, pt STRING) "
-                        + "PARTITIONED BY (pt) WITH ("
+                "CREATE TABLE count_btree_index_partitioned (id INT, name STRING, category INT, dt STRING) "
+                        + "PARTITIONED BY (dt) WITH ("
                         + "'global-index.enabled' = 'true', "
                         + "'row-tracking.enabled' = 'true', "
                         + "'data-evolution.enabled' = 'true'"
                         + ")");
 
         String values =
-                IntStream.range(0, 20)
+                IntStream.range(0, 10)
                         .mapToObj(
                                 i ->
                                         String.format(
-                                                "(%s, '%s', %s, '%s')",
-                                                i, "name_" + i, i % 3, i < 10 ? "p1" : "p2"))
+                                                "(%s, '%s', %s, 'dt1'), (%s, '%s', %s, 'dt2')",
+                                                i, "name_" + i, i % 2, i, "name_" + i, (i + 1) % 2))
                         .collect(Collectors.joining(","));
         sql("INSERT INTO count_btree_index_partitioned VALUES " + values);
         sql(
-                "CALL sys.create_global_index(`table` => 'default.count_btree_index_partitioned', index_column => 'id', index_type => 'btree')");
+                "CALL sys.create_global_index("
+                        + "`table` => 'default.count_btree_index_partitioned', "
+                        + "index_column => 'id', "
+                        + "index_type => 'btree', "
+                        + "partitions => 'dt=dt1')");
 
         assertCountStarQuery(
-                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p1' AND id BETWEEN 3 AND 7",
-                5L,
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE dt = 'dt1' AND id = 1",
+                1L,
                 true);
         assertCountStarQuery(
-                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p2' AND id IN (10, 12, 14)",
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE dt = 'dt1' AND id IN (1, 2, 3)",
                 3L,
                 true);
         assertCountStarQuery(
-                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p1' AND id = 4 AND category = 1",
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE dt = 'dt2' AND id = 1",
                 1L,
                 false);
         assertCountStarQuery(
-                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p2' AND id > 15",
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE id = 1", 1L, true);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE dt = 'dt1' AND id = 1 AND category = 1",
+                1L,
+                false);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE dt = 'dt1' AND id > 5",
                 4L,
                 false);
     }
 
     private void assertCountStarQuery(String sql, long expectedCount, boolean pushDown) {
-        assertThat(sql(sql)).containsOnly(Row.of(expectedCount));
         if (pushDown) {
             validateCount1PushDown(sql);
         } else {
             validateCount1NotPushDown(sql);
         }
+        assertThat(sql(sql)).containsOnly(Row.of(expectedCount));
     }
 
     private void validateCount1PushDown(String sql) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
@@ -808,6 +809,88 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
         String sql = "SELECT COUNT(*) FROM count_pk_dv";
         assertThat(sql(sql)).containsOnly(Row.of(4L));
         validateCount1PushDown(sql);
+    }
+
+    @Test
+    public void testCountStarBTreeIndexNonPartitionedTable() {
+        sql(
+                "CREATE TABLE count_btree_index_non_partitioned (id INT, name STRING, category INT) WITH ("
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+
+        String values =
+                IntStream.range(0, 20)
+                        .mapToObj(i -> String.format("(%s, '%s', %s)", i, "name_" + i, i % 2))
+                        .collect(Collectors.joining(","));
+        sql("INSERT INTO count_btree_index_non_partitioned VALUES " + values);
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.count_btree_index_non_partitioned', index_column => 'id', index_type => 'btree')");
+
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_non_partitioned WHERE id IN (1, 2, 3)",
+                3L,
+                true);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_non_partitioned WHERE id BETWEEN 10 AND 14",
+                5L,
+                true);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_non_partitioned WHERE id = 6 AND category = 0",
+                1L,
+                false);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_non_partitioned WHERE id > 15", 4L, false);
+    }
+
+    @Test
+    public void testCountStarBTreeIndexPartitionedTable() {
+        sql(
+                "CREATE TABLE count_btree_index_partitioned (id INT, name STRING, category INT, pt STRING) "
+                        + "PARTITIONED BY (pt) WITH ("
+                        + "'global-index.enabled' = 'true', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true'"
+                        + ")");
+
+        String values =
+                IntStream.range(0, 20)
+                        .mapToObj(
+                                i ->
+                                        String.format(
+                                                "(%s, '%s', %s, '%s')",
+                                                i, "name_" + i, i % 3, i < 10 ? "p1" : "p2"))
+                        .collect(Collectors.joining(","));
+        sql("INSERT INTO count_btree_index_partitioned VALUES " + values);
+        sql(
+                "CALL sys.create_global_index(`table` => 'default.count_btree_index_partitioned', index_column => 'id', index_type => 'btree')");
+
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p1' AND id BETWEEN 3 AND 7",
+                5L,
+                true);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p2' AND id IN (10, 12, 14)",
+                3L,
+                true);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p1' AND id = 4 AND category = 1",
+                1L,
+                false);
+        assertCountStarQuery(
+                "SELECT COUNT(*) FROM count_btree_index_partitioned WHERE pt = 'p2' AND id > 15",
+                4L,
+                false);
+    }
+
+    private void assertCountStarQuery(String sql, long expectedCount, boolean pushDown) {
+        assertThat(sql(sql)).containsOnly(Row.of(expectedCount));
+        if (pushDown) {
+            validateCount1PushDown(sql);
+        } else {
+            validateCount1NotPushDown(sql);
+        }
     }
 
     private void validateCount1PushDown(String sql) {


### PR DESCRIPTION
### Purpose
This introduce a PredicateVisitor to decide whether a Predicate is all covered by scalar index (e.g. btree now).
Then we can accelerate `count(*)` queries on indexed columns without touching data files. This is useful in some AI situations. For example, before filtering high quality data, we might want to check the portion to decide the threshold.


### Tests
`org.apache.paimon.globalindex.ScalarIndexedFieldsVisitorTest` for UnitTest
`org.apache.paimon.flink.BatchFileStoreITCase` for ITCase