### PR TITLE
[core] Fix sort by sequence.field.sort-order when writing pk table.

### DIFF
--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -53,6 +53,15 @@ public class CodeGeneratorImpl implements CodeGenerator {
     }
 
     @Override
+    public GeneratedClass<RecordComparator> generateRecordComparator(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders) {
+        return ComparatorCodeGenerator.gen(
+                "RecordComparator",
+                RowType.builder().fields(inputTypes).build(),
+                getSortSpec(sortFields, ascendingOrders));
+    }
+
+    @Override
     public GeneratedClass<RecordEqualiser> generateRecordEqualiser(
             List<DataType> fieldTypes, int[] fields) {
         return new EqualiserCodeGenerator(fieldTypes.toArray(new DataType[0]), fields)
@@ -63,6 +72,14 @@ public class CodeGeneratorImpl implements CodeGenerator {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
         for (int sortField : sortFields) {
             builder.addField(sortField, isAscendingOrder, false);
+        }
+        return builder.build();
+    }
+
+    private SortSpec getSortSpec(int[] sortFields, boolean[] ascendingOrders) {
+        SortSpec.SortSpecBuilder builder = SortSpec.builder();
+        for (int i = 0; i < sortFields.length; i++) {
+            builder.addField(sortFields[i], ascendingOrders[i], false);
         }
         return builder.build();
     }

--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -44,6 +44,15 @@ public class CodeGeneratorImpl implements CodeGenerator {
     }
 
     @Override
+    public GeneratedClass<NormalizedKeyComputer> generateNormalizedKeyComputer(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders) {
+        return new SortCodeGenerator(
+                        RowType.builder().fields(inputTypes).build(),
+                        getAscendingSortSpec(sortFields, ascendingOrders))
+                .generateNormalizedKeyComputer("NormalizedKeyComputer");
+    }
+
+    @Override
     public GeneratedClass<RecordComparator> generateRecordComparator(
             List<DataType> inputTypes, int[] sortFields, boolean isAscendingOrder) {
         return ComparatorCodeGenerator.gen(

--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -38,8 +38,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
     public GeneratedClass<NormalizedKeyComputer> generateNormalizedKeyComputer(
             List<DataType> inputTypes, int[] sortFields) {
         return new SortCodeGenerator(
-                        RowType.builder().fields(inputTypes).build(),
-                        getSortSpec(sortFields, true))
+                        RowType.builder().fields(inputTypes).build(), getSortSpec(sortFields, true))
                 .generateNormalizedKeyComputer("NormalizedKeyComputer");
     }
 

--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -39,7 +39,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
             List<DataType> inputTypes, int[] sortFields) {
         return new SortCodeGenerator(
                         RowType.builder().fields(inputTypes).build(),
-                        getAscendingSortSpec(sortFields, true))
+                        getSortSpec(sortFields, true))
                 .generateNormalizedKeyComputer("NormalizedKeyComputer");
     }
 
@@ -48,7 +48,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
             List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders) {
         return new SortCodeGenerator(
                         RowType.builder().fields(inputTypes).build(),
-                        getAscendingSortSpec(sortFields, ascendingOrders))
+                        getSortSpec(sortFields, ascendingOrders))
                 .generateNormalizedKeyComputer("NormalizedKeyComputer");
     }
 
@@ -58,7 +58,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
         return ComparatorCodeGenerator.gen(
                 "RecordComparator",
                 RowType.builder().fields(inputTypes).build(),
-                getAscendingSortSpec(sortFields, isAscendingOrder));
+                getSortSpec(sortFields, isAscendingOrder));
     }
 
     @Override
@@ -67,7 +67,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
         return ComparatorCodeGenerator.gen(
                 "RecordComparator",
                 RowType.builder().fields(inputTypes).build(),
-                getAscendingSortSpec(sortFields, ascendingOrders));
+                getSortSpec(sortFields, ascendingOrders));
     }
 
     @Override
@@ -77,7 +77,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
                 .generateRecordEqualiser("RecordEqualiser");
     }
 
-    private SortSpec getAscendingSortSpec(int[] sortFields, boolean isAscendingOrder) {
+    private SortSpec getSortSpec(int[] sortFields, boolean isAscendingOrder) {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
         for (int sortField : sortFields) {
             builder.addField(sortField, isAscendingOrder, false);
@@ -85,7 +85,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
         return builder.build();
     }
 
-    private SortSpec getAscendingSortSpec(int[] sortFields, boolean[] ascendingOrders) {
+    private SortSpec getSortSpec(int[] sortFields, boolean[] ascendingOrders) {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
         for (int i = 0; i < sortFields.length; i++) {
             builder.addField(sortFields[i], ascendingOrders[i], false);

--- a/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
+++ b/paimon-codegen/src/main/java/org/apache/paimon/codegen/CodeGeneratorImpl.java
@@ -58,7 +58,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
         return ComparatorCodeGenerator.gen(
                 "RecordComparator",
                 RowType.builder().fields(inputTypes).build(),
-                getSortSpec(sortFields, ascendingOrders));
+                getAscendingSortSpec(sortFields, ascendingOrders));
     }
 
     @Override
@@ -76,7 +76,7 @@ public class CodeGeneratorImpl implements CodeGenerator {
         return builder.build();
     }
 
-    private SortSpec getSortSpec(int[] sortFields, boolean[] ascendingOrders) {
+    private SortSpec getAscendingSortSpec(int[] sortFields, boolean[] ascendingOrders) {
         SortSpec.SortSpecBuilder builder = SortSpec.builder();
         for (int i = 0; i < sortFields.length; i++) {
             builder.addField(sortFields[i], ascendingOrders[i], false);

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
@@ -49,6 +49,16 @@ public interface CodeGenerator {
     GeneratedClass<RecordComparator> generateRecordComparator(
             List<DataType> inputTypes, int[] sortFields, boolean isAscendingOrder);
 
+    /**
+     * Generate a {@link RecordComparator} with per-field ascending order control.
+     *
+     * @param inputTypes input types.
+     * @param sortFields the sort key fields.
+     * @param ascendingOrders per-field ascending order, must have the same length as sortFields.
+     */
+    GeneratedClass<RecordComparator> generateRecordComparator(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders);
+
     /** Generate a {@link RecordEqualiser} with fields. */
     GeneratedClass<RecordEqualiser> generateRecordEqualiser(
             List<DataType> fieldTypes, int[] fields);

--- a/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/codegen/CodeGenerator.java
@@ -39,6 +39,16 @@ public interface CodeGenerator {
             List<DataType> inputTypes, int[] sortFields);
 
     /**
+     * Generate a {@link NormalizedKeyComputer} with per-field ascending order control.
+     *
+     * @param inputTypes input types.
+     * @param sortFields the sort key fields.
+     * @param ascendingOrders per-field ascending order, must have the same length as sortFields.
+     */
+    GeneratedClass<NormalizedKeyComputer> generateNormalizedKeyComputer(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders);
+
+    /**
      * Generate a {@link RecordComparator}.
      *
      * @param inputTypes input types.

--- a/paimon-common/src/main/java/org/apache/paimon/utils/FieldsComparator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/FieldsComparator.java
@@ -26,4 +26,9 @@ import java.util.Comparator;
 public interface FieldsComparator extends Comparator<InternalRow> {
 
     int[] compareFields();
+
+    /** Whether the comparison order is ascending. Default is true. */
+    default boolean isAscendingOrder() {
+        return true;
+    }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -87,6 +87,18 @@ public class CodeGenUtils {
                                         inputTypes, sortFields, isAscendingOrder));
     }
 
+    public static RecordComparator newRecordComparator(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders) {
+        return generate(
+                RecordComparator.class,
+                inputTypes,
+                sortFields,
+                Arrays.hashCode(ascendingOrders),
+                () ->
+                        getCodeGenerator()
+                                .generateRecordComparator(inputTypes, sortFields, ascendingOrders));
+    }
+
     public static RecordEqualiser newRecordEqualiser(List<DataType> fieldTypes) {
         return newRecordEqualiser(fieldTypes, IntStream.range(0, fieldTypes.size()).toArray());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/codegen/CodeGenUtils.java
@@ -69,6 +69,19 @@ public class CodeGenUtils {
                 () -> getCodeGenerator().generateNormalizedKeyComputer(inputTypes, sortFields));
     }
 
+    public static NormalizedKeyComputer newNormalizedKeyComputer(
+            List<DataType> inputTypes, int[] sortFields, boolean[] ascendingOrders) {
+        return generate(
+                NormalizedKeyComputer.class,
+                inputTypes,
+                sortFields,
+                Arrays.hashCode(ascendingOrders),
+                () ->
+                        getCodeGenerator()
+                                .generateNormalizedKeyComputer(
+                                        inputTypes, sortFields, ascendingOrders));
+    }
+
     public static RecordComparator newRecordComparator(List<DataType> inputTypes) {
         return newRecordComparator(
                 inputTypes, IntStream.range(0, inputTypes.size()).toArray(), true);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -92,6 +92,26 @@ public class SortBufferWriteBuffer implements WriteBuffer {
 
         int[] sortFieldArray = sortFields.toArray();
 
+        // build per-field ascending orders:
+        // key fields -> ascending, uds fields -> based on config, sequence number -> ascending
+        boolean[] ascendingOrders = new boolean[sortFieldArray.length];
+        int keyFieldCount = keyType.getFieldCount();
+        int udsFieldCount =
+                userDefinedSeqComparator != null
+                        ? userDefinedSeqComparator.compareFields().length
+                        : 0;
+        boolean udsAscending =
+                userDefinedSeqComparator == null || userDefinedSeqComparator.isAscendingOrder();
+        for (int i = 0; i < sortFieldArray.length; i++) {
+            if (i < keyFieldCount) {
+                ascendingOrders[i] = true;
+            } else if (i < keyFieldCount + udsFieldCount) {
+                ascendingOrders[i] = udsAscending;
+            } else {
+                ascendingOrders[i] = true;
+            }
+        }
+
         // row type
         List<DataType> fieldTypes = new ArrayList<>(keyType.getFieldTypes());
         fieldTypes.add(new BigIntType(false));
@@ -101,7 +121,7 @@ public class SortBufferWriteBuffer implements WriteBuffer {
         NormalizedKeyComputer normalizedKeyComputer =
                 CodeGenUtils.newNormalizedKeyComputer(fieldTypes, sortFieldArray);
         RecordComparator keyComparator =
-                CodeGenUtils.newRecordComparator(fieldTypes, sortFieldArray, true);
+                CodeGenUtils.newRecordComparator(fieldTypes, sortFieldArray, ascendingOrders);
 
         if (memoryPool.freePages() < 3) {
             throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -111,12 +111,8 @@ public class SortBufferWriteBuffer implements WriteBuffer {
         fieldTypes.add(new TinyIntType(false));
         fieldTypes.addAll(valueType.getFieldTypes());
 
-        // When UDS is descending, NormalizedKey only covers key fields to ensure
-        // keyFullyDetermines=false, so RecordComparator handles UDS ordering correctly.
-        int[] normalizedKeyFields =
-                udsAscending ? sortFieldArray : IntStream.range(0, keyFieldCount).toArray();
         NormalizedKeyComputer normalizedKeyComputer =
-                CodeGenUtils.newNormalizedKeyComputer(fieldTypes, normalizedKeyFields);
+                CodeGenUtils.newNormalizedKeyComputer(fieldTypes, sortFieldArray, ascendingOrders);
         RecordComparator keyComparator =
                 CodeGenUtils.newRecordComparator(fieldTypes, sortFieldArray, ascendingOrders);
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -94,22 +95,14 @@ public class SortBufferWriteBuffer implements WriteBuffer {
 
         // build per-field ascending orders:
         // key fields -> ascending, uds fields -> based on config, sequence number -> ascending
-        boolean[] ascendingOrders = new boolean[sortFieldArray.length];
         int keyFieldCount = keyType.getFieldCount();
-        int udsFieldCount =
-                userDefinedSeqComparator != null
-                        ? userDefinedSeqComparator.compareFields().length
-                        : 0;
         boolean udsAscending =
                 userDefinedSeqComparator == null || userDefinedSeqComparator.isAscendingOrder();
-        for (int i = 0; i < sortFieldArray.length; i++) {
-            if (i < keyFieldCount) {
-                ascendingOrders[i] = true;
-            } else if (i < keyFieldCount + udsFieldCount) {
-                ascendingOrders[i] = udsAscending;
-            } else {
-                ascendingOrders[i] = true;
-            }
+        boolean[] ascendingOrders = new boolean[sortFieldArray.length];
+        Arrays.fill(ascendingOrders, true);
+        if (!udsAscending) {
+            int udsFieldCount = userDefinedSeqComparator.compareFields().length;
+            Arrays.fill(ascendingOrders, keyFieldCount, keyFieldCount + udsFieldCount, false);
         }
 
         // row type
@@ -118,8 +111,12 @@ public class SortBufferWriteBuffer implements WriteBuffer {
         fieldTypes.add(new TinyIntType(false));
         fieldTypes.addAll(valueType.getFieldTypes());
 
+        // When UDS is descending, NormalizedKey only covers key fields to ensure
+        // keyFullyDetermines=false, so RecordComparator handles UDS ordering correctly.
+        int[] normalizedKeyFields =
+                udsAscending ? sortFieldArray : IntStream.range(0, keyFieldCount).toArray();
         NormalizedKeyComputer normalizedKeyComputer =
-                CodeGenUtils.newNormalizedKeyComputer(fieldTypes, sortFieldArray);
+                CodeGenUtils.newNormalizedKeyComputer(fieldTypes, normalizedKeyFields);
         RecordComparator keyComparator =
                 CodeGenUtils.newRecordComparator(fieldTypes, sortFieldArray, ascendingOrders);
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/UserDefinedSeqComparator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/UserDefinedSeqComparator.java
@@ -33,15 +33,23 @@ public class UserDefinedSeqComparator implements FieldsComparator {
 
     private final int[] fields;
     private final RecordComparator comparator;
+    private final boolean ascendingOrder;
 
-    public UserDefinedSeqComparator(int[] fields, RecordComparator comparator) {
+    public UserDefinedSeqComparator(
+            int[] fields, RecordComparator comparator, boolean ascendingOrder) {
         this.fields = fields;
         this.comparator = comparator;
+        this.ascendingOrder = ascendingOrder;
     }
 
     @Override
     public int[] compareFields() {
         return fields;
+    }
+
+    @Override
+    public boolean isAscendingOrder() {
+        return ascendingOrder;
     }
 
     @Override
@@ -78,6 +86,6 @@ public class UserDefinedSeqComparator implements FieldsComparator {
         RecordComparator comparator =
                 CodeGenUtils.newRecordComparator(
                         rowType.getFieldTypes(), sequenceFields, isAscendingOrder);
-        return new UserDefinedSeqComparator(sequenceFields, comparator);
+        return new UserDefinedSeqComparator(sequenceFields, comparator, isAscendingOrder);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1054,7 +1054,7 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
     public void testSequenceFieldSortOrderWithIntKeys() {
         // When both primary key and sequence field are INT types, their NormalizedKey
         // would fit within 18 bytes (5+5=10). This test verifies that UDS descending
-        // still works correctly because NormalizedKey only covers key fields in that case.
+        // still works correctly because NormalizedKey only covers key fields in this case.
         sql(
                 "CREATE TABLE T_INT_MERGE (a INT PRIMARY KEY NOT ENFORCED, b INT)"
                         + " WITH ("

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1051,6 +1051,25 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testSequenceFieldSortOrderWithIntKeys() {
+        // When both primary key and sequence field are INT types, their NormalizedKey
+        // would fit within 18 bytes (5+5=10). This test verifies that UDS descending
+        // still works correctly because NormalizedKey only covers key fields in that case.
+        sql(
+                "CREATE TABLE T_INT_MERGE (a INT PRIMARY KEY NOT ENFORCED, b INT)"
+                        + " WITH ("
+                        + "'sequence.field'='b', "
+                        + "'sequence.field.sort-order'='descending', "
+                        + "'bucket'='1')");
+
+        // Insert multiple rows with the same key to trigger write-side merge
+        sql("INSERT INTO T_INT_MERGE VALUES (1, 10), (1, 30), (1, 20)");
+
+        // With descending sort order, the smallest sequence value (b=10) should win
+        assertThat(sql("select * from T_INT_MERGE").toString()).isEqualTo("[+I[1, 10]]");
+    }
+
+    @Test
     public void testAlterTableMetadataComment() {
         sql("CREATE TABLE T (a INT, name VARCHAR METADATA COMMENT 'header1', b INT)");
         List<Row> result = sql("SHOW CREATE TABLE T");

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -1031,6 +1031,26 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testSequenceFieldSortOrderWithWriteSideMerge() {
+        // When multiple rows with the same primary key are written in a single INSERT,
+        // they are merged on the write side by SortBufferWriteBuffer.
+        // This test verifies that sequence.field.sort-order=descending is correctly
+        // applied during write-side merge (not just merge-on-read).
+        sql(
+                "CREATE TABLE T_WRITE_MERGE (a STRING PRIMARY KEY NOT ENFORCED, b STRING, c BIGINT)"
+                        + " WITH ("
+                        + "'sequence.field'='c', "
+                        + "'sequence.field.sort-order'='descending', "
+                        + "'bucket'='1')");
+
+        // Insert multiple rows with the same key in a single statement to trigger write-side merge
+        sql("INSERT INTO T_WRITE_MERGE VALUES ('a', 'b', 1), ('a', 'd', 3), ('a', 'e', 2)");
+
+        // With descending sort order, the smallest sequence value (c=1) should win
+        assertThat(sql("select * from T_WRITE_MERGE").toString()).isEqualTo("[+I[a, b, 1]]");
+    }
+
+    @Test
     public void testAlterTableMetadataComment() {
         sql("CREATE TABLE T (a INT, name VARCHAR METADATA COMMENT 'header1', b INT)");
         List<Row> result = sql("SHOW CREATE TABLE T");


### PR DESCRIPTION
### Purpose
When the user configured sequence.field.sort-order, this configuration did not take effect when writing to merge. This pr supports this configuration.
### Tests
`SchemaChangeITCase.testSequenceFieldSortOrderWithWriteSideMerge()`