### PR TITLE
[hive] Add hive.skip-update-stats config option to control DO_NOT_UPDATE_STATS in HiveCatalog alter table

### DIFF
--- a/docs/generated/hive_catalog_configuration.html
+++ b/docs/generated/hive_catalog_configuration.html
@@ -39,6 +39,12 @@ If not configured, try to load from 'HIVE_CONF_DIR' env.
 </td>
         </tr>
         <tr>
+            <td><h5>hive.skip-update-stats</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, sets DO_NOT_UPDATE_STATS in the Hive EnvironmentContext when altering tables, preventing Hive from updating table statistics.</td>
+        </tr>
+        <tr>
             <td><h5>location-in-properties</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveAlterTableUtils.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveAlterTableUtils.java
@@ -29,20 +29,22 @@ import org.apache.thrift.TException;
 /** Utils for hive alter table. */
 public class HiveAlterTableUtils {
 
-    public static void alterTable(IMetaStoreClient client, Identifier identifier, Table table)
+    public static void alterTable(
+            IMetaStoreClient client, Identifier identifier, Table table, boolean skipUpdateStats)
             throws TException {
         try {
-            alterTableWithEnv(client, identifier, table);
+            alterTableWithEnv(client, identifier, table, skipUpdateStats);
         } catch (NoClassDefFoundError | NoSuchMethodError e) {
             alterTableWithoutEnv(client, identifier, table);
         }
     }
 
     private static void alterTableWithEnv(
-            IMetaStoreClient client, Identifier identifier, Table table) throws TException {
+            IMetaStoreClient client, Identifier identifier, Table table, boolean skipUpdateStats)
+            throws TException {
         boolean skipHiveUpdateStats =
-                Boolean.parseBoolean(
-                        table.getParameters().get(StatsSetupConst.DO_NOT_UPDATE_STATS));
+                Boolean.parseBoolean(table.getParameters().get(StatsSetupConst.DO_NOT_UPDATE_STATS))
+                        || skipUpdateStats;
         EnvironmentContext environmentContext = new EnvironmentContext();
         environmentContext.putToProperties(StatsSetupConst.CASCADE, "true");
         environmentContext.putToProperties(

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -116,6 +116,7 @@ import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.format.csv.CsvOptions.FIELD_DELIMITER;
 import static org.apache.paimon.hive.HiveCatalogOptions.HADOOP_CONF_DIR;
 import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_CONF_DIR;
+import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_SKIP_UPDATE_STATS;
 import static org.apache.paimon.hive.HiveCatalogOptions.IDENTIFIER;
 import static org.apache.paimon.hive.HiveCatalogOptions.LOCATION_IN_PROPERTIES;
 import static org.apache.paimon.hive.HiveTableUtils.tryToFormatSchema;
@@ -1292,7 +1293,12 @@ public class HiveCatalog extends AbstractCatalog {
         Path location = getTableLocation(identifier, table);
         // file format is null, because only data table support alter table.
         updateHmsTable(table, identifier, newSchema, null, location);
-        clients().execute(client -> HiveAlterTableUtils.alterTable(client, identifier, table));
+        boolean skipUpdateStats = options.get(HIVE_SKIP_UPDATE_STATS);
+        clients()
+                .execute(
+                        client ->
+                                HiveAlterTableUtils.alterTable(
+                                        client, identifier, table, skipUpdateStats));
     }
 
     @Override

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalogOptions.java
@@ -72,6 +72,14 @@ public final class HiveCatalogOptions {
                     .defaultValue(TimeUnit.MINUTES.toMillis(5))
                     .withDescription("Setting the client's pool cache eviction interval(ms).\n");
 
+    public static final ConfigOption<Boolean> HIVE_SKIP_UPDATE_STATS =
+            ConfigOptions.key("hive.skip-update-stats")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, sets DO_NOT_UPDATE_STATS in the Hive EnvironmentContext "
+                                    + "when altering tables, preventing Hive from updating table statistics.");
+
     public static final ConfigOption<String> CLIENT_POOL_CACHE_KEYS =
             ConfigOptions.key("client-pool-cache.keys")
                     .stringType()

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveTableStatsTest.java
@@ -33,7 +33,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 import org.apache.paimon.shade.guava30.com.google.common.collect.Maps;
 
-import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +43,7 @@ import java.util.Collections;
 import java.util.UUID;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY;
+import static org.apache.paimon.hive.HiveCatalogOptions.HIVE_SKIP_UPDATE_STATS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Verify that table stats has been updated. */
@@ -59,7 +59,7 @@ public class HiveTableStatsTest {
         hiveConf.setVar(METASTORECONNECTURLKEY, jdoConnectionURL + ";create=true");
         String metastoreClientClass = "org.apache.hadoop.hive.metastore.HiveMetaStoreClient";
         Options catalogOptions = new Options();
-        catalogOptions.set(StatsSetupConst.DO_NOT_UPDATE_STATS, "true");
+        catalogOptions.set(HIVE_SKIP_UPDATE_STATS, true);
         catalogOptions.set(CatalogOptions.WAREHOUSE, warehouse);
         CatalogContext catalogContext = CatalogContext.create(catalogOptions);
         FileIO fileIO = FileIO.get(new Path(warehouse), catalogContext);
@@ -81,14 +81,15 @@ public class HiveTableStatsTest {
                         Maps.newHashMap(),
                         ""),
                 false);
+        HiveCatalog hiveCatalog = (HiveCatalog) catalog;
+        Table table1 = hiveCatalog.getHmsTable(identifier);
         catalog.alterTable(
                 identifier,
                 Lists.newArrayList(
                         SchemaChange.addColumn("col2", DataTypes.DATE()),
                         SchemaChange.addColumn("col3", DataTypes.STRING(), "col3 field")),
                 false);
-        HiveCatalog hiveCatalog = (HiveCatalog) catalog;
-        Table table = hiveCatalog.getHmsTable(identifier);
-        assertThat(table.getParameters().get("COLUMN_STATS_ACCURATE")).isEqualTo(null);
+        Table table2 = hiveCatalog.getHmsTable(identifier);
+        assertThat(table1.getParameters()).isEqualTo(table2.getParameters());
     }
 }


### PR DESCRIPTION
### Purpose

Commit 989a433 introduced a fix to avoid excessive HMS memory usage during alter table by setting DO_NOT_UPDATE_STATS in the EnvironmentContext. However, commit 8688206 later rewrote HiveAlterTableUtils for Hive 1.x compatibility and hardcoded DO_NOT_UPDATE_STATS to "false", breaking the previous fix.

https://github.com/apache/paimon/pull/4549

### Tests
Fix HiveTableStatsTest, the originally implemented Test does not take effect.
