### PR TITLE
[iceberg] Fix NPE in IcebergRestMetadataCommitter when table has no snapshots

### DIFF
--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -162,8 +162,12 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                 } else {
                     LOG.info(
                             "create updates without base metadata. currentSnapshotId for base metadata: {}, for new metadata:{}",
-                            metadata.currentSnapshot().snapshotId(),
-                            newMetadata.currentSnapshot().snapshotId());
+                            metadata.currentSnapshot() != null
+                                    ? metadata.currentSnapshot().snapshotId()
+                                    : "No snapshot",
+                            newMetadata.currentSnapshot() != null
+                                    ? newMetadata.currentSnapshot().snapshotId()
+                                    : "No snapshot");
                     updatdeBuilder = updatesForIncorrectBase(newMetadata);
                 }
             }


### PR DESCRIPTION
## Motivation

When committing Iceberg metadata via the REST catalog, `commitMetadataImpl` takes the `!withBase` code path if the base metadata check fails. 
In this path, a log statement calls `currentSnapshot().snapshotId()` on both the existing and new table metadata. However, `currentSnapshot()` returns null when a table exists but has no snapshots (e.g., a freshly created or empty table), causing a `NullPointerException` that fails the entire commit. Since it happens only for an empty iceberg table, we can manually delete the table and be unblocked. 

Meanwhile we should not have NPE in the log method.

```
Caused by: java.lang.NullPointerException
    at org.apache.paimon.iceberg.IcebergRestMetadataCommitter.commitMetadataImpl(IcebergRestMetadataCommitter.java:161)
```

## Implementation

Added null guards for `metadata.currentSnapshot()` and `newMetadata.currentSnapshot()` in the log statement, logging `"No snapshot"` when the snapshot is absent.