### PR TITLE
[core] Support BlobRef in internal blob serializer

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/AbstractBinaryWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.serializer.InternalArraySerializer;
 import org.apache.paimon.data.serializer.InternalMapSerializer;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
@@ -203,7 +204,7 @@ abstract class AbstractBinaryWriter implements BinaryWriter {
 
     @Override
     public void writeBlob(int pos, Blob blob) {
-        byte[] bytes = blob.toData();
+        byte[] bytes = BlobSerializer.INSTANCE.serializeInternalBytes(blob);
         writeBinary(pos, bytes, 0, bytes.length);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryArray.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
@@ -247,7 +248,7 @@ public final class BinaryArray extends BinarySection implements InternalArray, D
 
     @Override
     public Blob getBlob(int pos) {
-        return new BlobData(getBinary(pos));
+        return BlobSerializer.INSTANCE.deserializeInternalBytes(getBinary(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BinaryRow.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
@@ -346,7 +347,7 @@ public final class BinaryRow extends BinarySection implements InternalRow, DataS
 
     @Override
     public Blob getBlob(int pos) {
-        return new BlobData(getBinary(pos));
+        return BlobSerializer.INSTANCE.deserializeInternalBytes(getBinary(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/NestedRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/NestedRow.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
@@ -291,7 +292,7 @@ public final class NestedRow extends BinarySection implements InternalRow, DataS
 
     @Override
     public Blob getBlob(int pos) {
-        return new BlobData(getBinary(pos));
+        return BlobSerializer.INSTANCE.deserializeInternalBytes(getBinary(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryArray.java
@@ -21,13 +21,13 @@ package org.apache.paimon.data.safe;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.BytesUtils;
 
@@ -157,7 +157,7 @@ public final class SafeBinaryArray implements InternalArray {
 
     @Override
     public Blob getBlob(int pos) {
-        return new BlobData(getBinary(pos));
+        return BlobSerializer.INSTANCE.deserializeInternalBytes(getBinary(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/safe/SafeBinaryRow.java
@@ -21,13 +21,13 @@ package org.apache.paimon.data.safe;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.serializer.BlobSerializer;
 import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.memory.BytesUtils;
 import org.apache.paimon.types.RowKind;
@@ -163,7 +163,7 @@ public final class SafeBinaryRow implements InternalRow {
 
     @Override
     public Blob getBlob(int pos) {
-        return new BlobData(getBinary(pos));
+        return BlobSerializer.INSTANCE.deserializeInternalBytes(getBinary(pos));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
@@ -20,15 +20,24 @@ package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.BlobStream;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataOutputView;
+import org.apache.paimon.utils.UriReader;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /** Type serializer for {@code Blob}. */
 public class BlobSerializer extends SerializerSingleton<Blob> {
 
     private static final long serialVersionUID = 1L;
+    private static final byte[] MAGIC = new byte[] {'B', 'L', 'O', 'B', 'S', 'E', 'R', '1'};
+    private static final byte KIND_DATA = 0;
+    private static final byte KIND_REF = 1;
+    private static final UriReader THROWING_URI_READER = new ThrowingUriReader();
 
     public static final BlobSerializer INSTANCE = new BlobSerializer();
 
@@ -39,12 +48,98 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
 
     @Override
     public void serialize(Blob blob, DataOutputView target) throws IOException {
-        BinarySerializer.INSTANCE.serialize(blob.toData(), target);
+        BinarySerializer.INSTANCE.serialize(serializeBody(blob), target);
     }
 
     @Override
     public Blob deserialize(DataInputView source) throws IOException {
         byte[] bytes = BinarySerializer.INSTANCE.deserialize(source);
-        return new BlobData(bytes);
+        return deserializeBody(bytes);
+    }
+
+    public byte[] serializeInternalBytes(Blob blob) {
+        try {
+            return serializeToBytes(blob);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to serialize blob.", e);
+        }
+    }
+
+    public Blob deserializeInternalBytes(byte[] bytes) {
+        try {
+            return deserializeFromBytes(bytes);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize blob.", e);
+        }
+    }
+
+    private byte[] serializeBody(Blob blob) throws IOException {
+        byte[] payload;
+        byte kind;
+
+        if (blob instanceof BlobData) {
+            payload = ((BlobData) blob).toData();
+            kind = KIND_DATA;
+        } else if (blob instanceof BlobRef) {
+            payload = blob.toDescriptor().serialize();
+            kind = KIND_REF;
+        } else if (blob instanceof BlobStream) {
+            throw new UnsupportedOperationException("BlobSerializer does not support BlobStream.");
+        } else {
+            throw new UnsupportedOperationException(
+                    "BlobSerializer only supports BlobData and BlobRef, but found "
+                            + blob.getClass().getSimpleName()
+                            + ".");
+        }
+
+        byte[] result = new byte[MAGIC.length + 1 + payload.length];
+        System.arraycopy(MAGIC, 0, result, 0, MAGIC.length);
+        result[MAGIC.length] = kind;
+        System.arraycopy(payload, 0, result, MAGIC.length + 1, payload.length);
+        return result;
+    }
+
+    private Blob deserializeBody(byte[] bytes) throws IOException {
+        if (!hasMagic(bytes)) {
+            // Backward compatibility for blobs serialized before BlobSerializer became
+            // descriptor-aware.
+            return new BlobData(bytes);
+        }
+
+        byte kind = bytes[MAGIC.length];
+        byte[] payload = Arrays.copyOfRange(bytes, MAGIC.length + 1, bytes.length);
+        switch (kind) {
+            case KIND_DATA:
+                return new BlobData(payload);
+            case KIND_REF:
+                return Blob.fromDescriptor(
+                        THROWING_URI_READER, BlobDescriptor.deserialize(payload));
+            default:
+                throw new IOException("Unknown blob serializer kind: " + kind);
+        }
+    }
+
+    private boolean hasMagic(byte[] bytes) {
+        if (bytes.length < MAGIC.length + 1) {
+            return false;
+        }
+
+        for (int i = 0; i < MAGIC.length; i++) {
+            if (bytes[i] != MAGIC[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static class ThrowingUriReader implements UriReader {
+
+        @Override
+        public org.apache.paimon.fs.SeekableInputStream newInputStream(String uri) throws IOException {
+            throw new IOException(
+                    "BlobRef deserialized by BlobSerializer does not carry a UriReader. "
+                            + "Use toDescriptor() instead. Descriptor URI: "
+                            + uri);
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
@@ -135,7 +135,8 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
     private static class ThrowingUriReader implements UriReader {
 
         @Override
-        public org.apache.paimon.fs.SeekableInputStream newInputStream(String uri) throws IOException {
+        public org.apache.paimon.fs.SeekableInputStream newInputStream(String uri)
+                throws IOException {
             throw new IOException(
                     "BlobRef deserialized by BlobSerializer does not carry a UriReader. "
                             + "Use toDescriptor() instead. Descriptor URI: "

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
@@ -28,14 +28,11 @@ import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.utils.UriReader;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 /** Type serializer for {@code Blob}. */
 public class BlobSerializer extends SerializerSingleton<Blob> {
 
     private static final long serialVersionUID = 1L;
-    private static final byte KIND_DATA = 0;
-    private static final byte KIND_REF = 1;
     private static final UriReader THROWING_URI_READER = new ThrowingUriReader();
 
     public static final BlobSerializer INSTANCE = new BlobSerializer();
@@ -73,15 +70,10 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
     }
 
     private byte[] serializeBody(Blob blob) throws IOException {
-        byte[] payload;
-        byte kind;
-
         if (blob instanceof BlobData) {
-            payload = ((BlobData) blob).toData();
-            kind = KIND_DATA;
+            return ((BlobData) blob).toData();
         } else if (blob instanceof BlobRef) {
-            payload = blob.toDescriptor().serialize();
-            kind = KIND_REF;
+            return blob.toDescriptor().serialize();
         } else if (blob instanceof BlobStream) {
             throw new UnsupportedOperationException("BlobSerializer does not support BlobStream.");
         } else {
@@ -90,29 +82,13 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
                             + blob.getClass().getSimpleName()
                             + ".");
         }
-
-        byte[] result = new byte[1 + payload.length];
-        result[0] = kind;
-        System.arraycopy(payload, 0, result, 1, payload.length);
-        return result;
     }
 
     private Blob deserializeBody(byte[] bytes) throws IOException {
-        if (bytes.length == 0) {
-            throw new IOException("Blob serializer payload is empty.");
+        if (BlobDescriptor.isBlobDescriptor(bytes)) {
+            return Blob.fromDescriptor(THROWING_URI_READER, BlobDescriptor.deserialize(bytes));
         }
-
-        byte kind = bytes[0];
-        byte[] payload = Arrays.copyOfRange(bytes, 1, bytes.length);
-        switch (kind) {
-            case KIND_DATA:
-                return new BlobData(payload);
-            case KIND_REF:
-                return Blob.fromDescriptor(
-                        THROWING_URI_READER, BlobDescriptor.deserialize(payload));
-            default:
-                throw new IOException("Unknown blob serializer kind: " + kind);
-        }
+        return new BlobData(bytes);
     }
 
     private static class ThrowingUriReader implements UriReader {

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BlobSerializer.java
@@ -34,7 +34,6 @@ import java.util.Arrays;
 public class BlobSerializer extends SerializerSingleton<Blob> {
 
     private static final long serialVersionUID = 1L;
-    private static final byte[] MAGIC = new byte[] {'B', 'L', 'O', 'B', 'S', 'E', 'R', '1'};
     private static final byte KIND_DATA = 0;
     private static final byte KIND_REF = 1;
     private static final UriReader THROWING_URI_READER = new ThrowingUriReader();
@@ -92,22 +91,19 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
                             + ".");
         }
 
-        byte[] result = new byte[MAGIC.length + 1 + payload.length];
-        System.arraycopy(MAGIC, 0, result, 0, MAGIC.length);
-        result[MAGIC.length] = kind;
-        System.arraycopy(payload, 0, result, MAGIC.length + 1, payload.length);
+        byte[] result = new byte[1 + payload.length];
+        result[0] = kind;
+        System.arraycopy(payload, 0, result, 1, payload.length);
         return result;
     }
 
     private Blob deserializeBody(byte[] bytes) throws IOException {
-        if (!hasMagic(bytes)) {
-            // Backward compatibility for blobs serialized before BlobSerializer became
-            // descriptor-aware.
-            return new BlobData(bytes);
+        if (bytes.length == 0) {
+            throw new IOException("Blob serializer payload is empty.");
         }
 
-        byte kind = bytes[MAGIC.length];
-        byte[] payload = Arrays.copyOfRange(bytes, MAGIC.length + 1, bytes.length);
+        byte kind = bytes[0];
+        byte[] payload = Arrays.copyOfRange(bytes, 1, bytes.length);
         switch (kind) {
             case KIND_DATA:
                 return new BlobData(payload);
@@ -117,19 +113,6 @@ public class BlobSerializer extends SerializerSingleton<Blob> {
             default:
                 throw new IOException("Unknown blob serializer kind: " + kind);
         }
-    }
-
-    private boolean hasMagic(byte[] bytes) {
-        if (bytes.length < MAGIC.length + 1) {
-            return false;
-        }
-
-        for (int i = 0; i < MAGIC.length; i++) {
-            if (bytes[i] != MAGIC[i]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private static class ThrowingUriReader implements UriReader {

--- a/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BinaryRowTest.java
@@ -56,6 +56,7 @@ import static org.apache.paimon.data.BinaryString.fromBytes;
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.data.MapDataUtil.convertToJavaMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test of {@link BinaryRow} and {@link BinaryRowWriter}. */
 public class BinaryRowTest {
@@ -1010,5 +1011,28 @@ public class BinaryRowTest {
         assertThat(blob0).isInstanceOf(BlobData.class);
         assertThat(blob0.toData()).isEqualTo(new byte[] {1, 3, 1});
         assertThat(row.isNullAt(1)).isTrue();
+    }
+
+    @Test
+    public void testBlobRefDoesNotMaterializeOnBinaryWrite() {
+        BinaryRow row = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        BlobDescriptor descriptor = new BlobDescriptor("file:/tmp/blob.bin", 5L, 11L);
+        Blob blob =
+                Blob.fromDescriptor(
+                        uri -> {
+                            throw new AssertionError("Binary writer should not read blob bytes.");
+                        },
+                        descriptor);
+
+        writer.writeBlob(0, blob);
+        writer.complete();
+
+        Blob deserialized = row.getBlob(0);
+        assertThat(deserialized).isInstanceOf(BlobRef.class);
+        assertThat(deserialized.toDescriptor()).isEqualTo(descriptor);
+        assertThatThrownBy(deserialized::toData)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasMessageContaining("does not carry a UriReader");
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BlobSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BlobSerializerTest.java
@@ -20,6 +20,16 @@ package org.apache.paimon.data.serializer;
 
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.BlobStream;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link BlobSerializer}. */
 public class BlobSerializerTest extends SerializerTestBase<Blob> {
@@ -36,6 +46,46 @@ public class BlobSerializerTest extends SerializerTestBase<Blob> {
 
     @Override
     protected Blob[] getTestData() {
+        return new Blob[] {
+            new BlobData(new byte[] {1, 3, 1}),
+            Blob.fromDescriptor(
+                    uri -> {
+                        throw new AssertionError("BlobRef serialization should not read data.");
+                    },
+                    new BlobDescriptor("file:/tmp/blob.bin", 12L, 34L))
+        };
+    }
+
+    @Override
+    protected Blob[] getSerializableTestData() {
         return new Blob[] {new BlobData(new byte[] {1, 3, 1})};
+    }
+
+    @Test
+    public void testDeserializeBlobRefUsesThrowingUriReader() throws IOException {
+        BlobDescriptor descriptor = new BlobDescriptor("file:/tmp/blob.bin", 3L, 7L);
+        Blob deserialized =
+                BlobSerializer.INSTANCE.deserializeFromBytes(
+                        BlobSerializer.INSTANCE.serializeToBytes(
+                                Blob.fromDescriptor(
+                                        uri -> {
+                                            throw new AssertionError(
+                                                    "BlobRef serialization should not read data.");
+                                        },
+                                        descriptor)));
+
+        assertThat(deserialized).isInstanceOf(BlobRef.class);
+        assertThat(deserialized.toDescriptor()).isEqualTo(descriptor);
+        assertThatThrownBy(deserialized::toData)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasMessageContaining("does not carry a UriReader");
+    }
+
+    @Test
+    public void testBlobStreamIsUnsupported() {
+        Blob blob = new BlobStream(() -> null);
+        assertThatThrownBy(() -> BlobSerializer.INSTANCE.serializeToBytes(blob))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("BlobStream");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.flink;
 
-import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobData;
@@ -53,9 +52,10 @@ public class FlinkRowWrapper implements InternalRow {
         this(row, null);
     }
 
-    public FlinkRowWrapper(org.apache.flink.table.data.RowData row, CatalogContext catalogContext) {
+    public FlinkRowWrapper(
+            org.apache.flink.table.data.RowData row, UriReaderFactory uriReaderFactory) {
         this.row = row;
-        this.uriReaderFactory = new UriReaderFactory(catalogContext);
+        this.uriReaderFactory = uriReaderFactory;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/FlinkSinkBuilder.java
@@ -35,6 +35,7 @@ import org.apache.paimon.table.PostponeUtils;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.ChannelComputer;
 import org.apache.paimon.utils.BlobDescriptorUtils;
+import org.apache.paimon.utils.UriReaderFactory;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -246,10 +247,11 @@ public class FlinkSinkBuilder {
             DataStream<RowData> input,
             org.apache.paimon.types.RowType rowType,
             CatalogContext catalogContext) {
+        final UriReaderFactory uriReaderFactory = new UriReaderFactory(catalogContext);
         SingleOutputStreamOperator<InternalRow> result =
                 input.map(
                                 (MapFunction<RowData, InternalRow>)
-                                        r -> new FlinkRowWrapper(r, catalogContext))
+                                        r -> new FlinkRowWrapper(r, uriReaderFactory))
                         .returns(
                                 org.apache.paimon.flink.utils.InternalTypeInfo.fromRowType(
                                         rowType));


### PR DESCRIPTION
## What
- support serializing both BlobData and BlobRef in BlobSerializer
- serialize BlobRef as descriptor bytes without materializing blob payload
- make internal binary blob write/read paths consistently use BlobSerializer
- reject BlobStream in BlobSerializer because it cannot be safely materialized here

## Why
BlobSerializer and internal binary writers previously called `blob.toData()` unconditionally. For BlobRef this forces loading the full blob payload, which defeats the lazy reference semantics and can be prohibitively expensive.

## Tests
- mvn -pl paimon-common -Pfast-build -Dtest=BlobSerializerTest,BinaryRowTest test