### PR TITLE
[test] Fix FormatTable directory creation in RESTFileSystemCatalog

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -1473,9 +1473,7 @@ public class RESTCatalogServer {
                     Identifier identifier = requestBody.getIdentifier();
                     Schema schema = requestBody.getSchema();
                     TableMetadata tableMetadata;
-                    if (isFormatTable(schema)) {
-                        tableMetadata = createFormatTable(identifier, schema);
-                    } else if (isObjectTable(schema)) {
+                    if (isObjectTable(schema)) {
                         tableMetadata = createObjectTable(identifier, schema);
                     } else {
                         catalog.createTable(identifier, schema, false);
@@ -2720,10 +2718,6 @@ public class RESTCatalogServer {
                         options,
                         schema.comment());
         return new TableMetadata(tableSchema, isExternal, uuid);
-    }
-
-    private TableMetadata createFormatTable(Identifier identifier, Schema schema) {
-        return createTableMetadata(identifier, 1L, schema, UUID.randomUUID().toString(), true);
     }
 
     private TableMetadata createObjectTable(Identifier identifier, Schema schema) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTFileSystemCatalog.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTFileSystemCatalog.java
@@ -50,4 +50,16 @@ public class RESTFileSystemCatalog extends FileSystemCatalog {
             super.createTable(identifier, schema, ignoreIfExists);
         }
     }
+
+    @Override
+    public void createFormatTable(Identifier identifier, Schema schema) {
+        try {
+            runWithLock(
+                    identifier, () -> uncheck(() -> fileIO.mkdirs(getTableLocation(identifier))));
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonFormatTableTest.scala
@@ -50,13 +50,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
           "'format-table.implementation'='paimon') PARTITIONED BY (`ds` bigint)")
       val table =
         paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      val readTable =
-        paimonCatalog
-          .getTable(Identifier.create("test_db", s"$readTableName"))
-          .asInstanceOf[FormatTable]
-
-      table.fileIO().mkdirs(new Path(table.location()))
-      readTable.fileIO().mkdirs(new Path(readTable.location()))
 
       val partition = 20250920
       val partitionPath = new Path(table.location(), s"ds=$partition")
@@ -109,9 +102,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
            |CREATE TABLE $tableName (age INT, name STRING)
            |USING CSV TBLPROPERTIES ('format-table.implementation'='paimon', 'file.compression'='gzip', 'lineSep'='abc')
            |""".stripMargin)
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       spark.sql(s"INSERT INTO $tableName  VALUES (5, 'ab'), (7, 'Larry')")
       checkAnswer(
         spark.sql(s"SELECT age, name FROM $tableName ORDER BY age"),
@@ -126,9 +116,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
       sql(
         s"CREATE TABLE $tableName (`ds` bigint, age INT, `ds1` bigint, name STRING, `ds2` bigint) USING ORC TBLPROPERTIES (" +
           s"'format-table.implementation'='paimon') PARTITIONED BY (`ds`, `ds1`, `ds2`)")
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       spark.sql(s"INSERT INTO $tableName  VALUES (5, 11, 12, 'ab', 13), (7, 11, 12, 'Larry', 13)")
       checkAnswer(
         spark.sql(s"SELECT ds, age, ds1, name, ds2 FROM $tableName ORDER BY ds"),
@@ -187,9 +174,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
                    |CREATE TABLE $tableName (age INT, name STRING)
                    |USING CSV TBLPROPERTIES ('format-table.implementation'='paimon')
                    |""".stripMargin)
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       spark.sql(s"INSERT INTO $tableName  VALUES (5, 'Ben'), (7, 'Larry')")
       checkAnswer(
         spark.sql(s"SELECT age, name FROM $tableName ORDER BY age"),
@@ -211,9 +195,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
                    |USING CSV TBLPROPERTIES ('format-table.implementation'='paimon')
                    |PARTITIONED BY (id INT)
                    |""".stripMargin)
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       spark.sql(s"INSERT INTO $tableName PARTITION (id = 1) VALUES (5, 'Ben'), (7, 'Larry')")
       spark.sql(s"INSERT OVERWRITE $tableName PARTITION (id = 1) VALUES (5, 'Jerry'), (7, 'Tom')")
       checkAnswer(
@@ -234,9 +215,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName (f0 INT, f1 string) USING CSV TBLPROPERTIES (" +
         s"'seq'='|', 'lineSep'='\n', 'format-table.implementation'='paimon') PARTITIONED BY (`ds` bigint)")
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       val partition = 20250920
       sql(
         s"INSERT INTO $tableName VALUES (1, 'asfasdfsdf', $partition), (2, 'asfasdfsdf', $partition)")
@@ -252,9 +230,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName (f0 INT, f1 string) USING CSV TBLPROPERTIES (" +
         s"'format-table.implementation'='paimon','format-table.partition-path-only-value'='true') PARTITIONED BY (`ds` bigint)")
-      val table =
-        paimonCatalog.getTable(Identifier.create("test_db", tableName)).asInstanceOf[FormatTable]
-      table.fileIO().mkdirs(new Path(table.location()))
       val partition = 20250920
       sql(
         s"INSERT INTO $tableName VALUES (1, 'asfasdfsdf', $partition), (2, 'asfasdfsdf', $partition)")
@@ -284,9 +259,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
           s"CREATE TABLE $tableName (id INT, name STRING, value DOUBLE) USING $format " +
             s"TBLPROPERTIES ('file.compression'='$compression', 'seq'=',', 'lineSep'='\n'," +
             " 'format-table.implementation'='paimon')")
-        val path =
-          paimonCatalog.getTable(Identifier.create("test_db", tableName)).options().get("path")
-        fileIO.mkdirs(new Path(path))
         // Insert data using our new write implementation
         sql(s"INSERT INTO $tableName VALUES (1, 'Alice', 10.5)")
         sql(s"INSERT INTO $tableName VALUES (2, 'Bob', 20.7)")
@@ -339,10 +311,6 @@ class PaimonFormatTableTest extends PaimonSparkTestWithRestCatalogBase {
           s"CREATE TABLE $tableName (id INT, name STRING, value DOUBLE) USING $format " +
             s"PARTITIONED BY (dept STRING) TBLPROPERTIES ('file.compression'='$compression'," +
             " 'format-table.implementation'='paimon')")
-        val paimonTable = paimonCatalog.getTable(Identifier.create("test_db", tableName))
-        val path =
-          paimonCatalog.getTable(Identifier.create("test_db", tableName)).options().get("path")
-        fileIO.mkdirs(new Path(path))
         // Insert data into different partitions
         sql(
           s"INSERT INTO $tableName VALUES (1, 'Alice', 10.5, 'Engineering')," +


### PR DESCRIPTION
### Purpose

Fix format table tests when using REST catalog. Add `createFormatTable` override in `RESTFileSystemCatalog` to automatically create the table directory, and remove redundant manual `mkdirs` calls from `PaimonFormatTableTest`.

### Tests

Existing `PaimonFormatTableTest`.