### PR TITLE
[iceberg] Fix compaction commits emitting 'overwrite' instead of 'replace' in Iceberg snapshot operation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -548,7 +548,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                             addedFiles,
                             modifiedPartitions,
                             baseDataManifestFileMetas,
-                            snapshotId);
+                            snapshotId,
+                            snapshot.commitKind());
             newDataManifestFileMetas = result.getLeft();
             snapshotSummary = result.getRight();
         }
@@ -778,7 +779,8 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     Map<String, Pair<BinaryRow, DataFileMeta>> addedFiles,
                     List<BinaryRow> modifiedPartitions,
                     List<IcebergManifestFileMeta> baseManifestFileMetas,
-                    long currentSnapshotId)
+                    long currentSnapshotId,
+                    Snapshot.CommitKind commitKind)
                     throws IOException {
         IcebergSnapshotSummary snapshotSummary = IcebergSnapshotSummary.APPEND;
         List<IcebergManifestFileMeta> newManifestFileMetas = new ArrayList<>();
@@ -833,7 +835,10 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     newManifestFileMetas.add(fileMeta);
                 } else {
                     // some file is removed, rewrite this file meta
-                    snapshotSummary = IcebergSnapshotSummary.OVERWRITE;
+                    snapshotSummary =
+                            commitKind == Snapshot.CommitKind.COMPACT
+                                    ? IcebergSnapshotSummary.REPLACE
+                                    : IcebergSnapshotSummary.OVERWRITE;
                     List<IcebergManifestEntry> newEntries = new ArrayList<>();
                     for (IcebergManifestEntry entry : entries) {
                         if (entry.isLive()) {

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSnapshotSummary.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergSnapshotSummary.java
@@ -38,6 +38,7 @@ public class IcebergSnapshotSummary {
 
     public static final IcebergSnapshotSummary APPEND = new IcebergSnapshotSummary("append");
     public static final IcebergSnapshotSummary OVERWRITE = new IcebergSnapshotSummary("overwrite");
+    public static final IcebergSnapshotSummary REPLACE = new IcebergSnapshotSummary("replace");
 
     private final Map<String, String> summary;
 

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -185,6 +185,16 @@ public class IcebergCompatibilityTest {
         // In dv mode, full compaction will remove all dv index and rewrite data files
         assertThat(getIcebergResult()).containsExactlyInAnyOrder("Record(2, 21)");
 
+        FileIO fileIO = table.fileIO();
+        long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        fileIO,
+                        new Path(
+                                table.location(),
+                                "metadata/v" + latestSnapshotId + ".metadata.json"));
+        assertThat(metadata.currentSnapshot().summary().operation()).isEqualTo("replace");
+
         write.close();
         commit.close();
     }


### PR DESCRIPTION
## Summary

Fixes #7683.

When Paimon compacts an LSM table with the Iceberg metadata committer enabled, the resulting Iceberg snapshot has its `operation` field set to `"overwrite"`. According to the [Iceberg spec](https://iceberg.apache.org/spec/#snapshots), compaction and file rewrite operations should use `"replace"` instead. Using `"overwrite"` makes downstream consumers like Polaris REST catalogs and query engines think the compaction was a data mutation, which is incorrect.

The problem was in `IcebergCommitCallback.createWithDeleteManifestFileMetas()`, which hardcoded `IcebergSnapshotSummary.OVERWRITE` whenever files were removed, without checking whether the commit was actually a compaction.

The fix:
- Add an `IcebergSnapshotSummary.REPLACE` constant for the `"replace"` operation
- Pass `Snapshot.CommitKind` into `createWithDeleteManifestFileMetas()` and use `REPLACE` when `commitKind == COMPACT`, `OVERWRITE` otherwise
- Add an assertion in `IcebergCompatibilityTest.testDeleteImpl()` to verify that compaction commits produce `operation: "replace"` in the Iceberg snapshot metadata