### PR TITLE
[lance] Support timestamp_ltz by normalizing timezone strings for Arrow-Rust compatibility

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
@@ -149,7 +149,8 @@ public class ArrowFieldTypeConversion {
             int precision = localZonedTimestampType.getPrecision();
             TimeUnit timeUnit = getTimeUnit(precision);
             ArrowType arrowType =
-                    new ArrowType.Timestamp(timeUnit, ZoneId.systemDefault().toString());
+                    new ArrowType.Timestamp(
+                            timeUnit, ZoneId.systemDefault().normalized().toString());
             return new FieldType(localZonedTimestampType.isNullable(), arrowType, null);
         }
 

--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
@@ -169,13 +169,7 @@ public class LanceFileFormat extends FileFormat {
 
         @Override
         public Void visit(LocalZonedTimestampType localZonedTimestampType) {
-            // lance has a bug here, if the local in GMT-10:00, it failed by reson: called
-            // `Result::unwrap()` on an `Err` value: Schema { message: "Unsupported timestamp type:
-            // timestamp:us:GMT-10:00", location: Location { file:
-            // "rust/lance-core/src/datatypes.rs", line: 326, column: 39 } }
-            // Disable it for now.
-            throw new UnsupportedOperationException(
-                    "Lance file format does not support type LOCAL_ZONED_TIMESTAMP");
+            return null;
         }
 
         @Override

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatReadWriteTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatReadWriteTest.java
@@ -64,6 +64,7 @@ public class LanceFileFormatReadWriteTest extends FormatReadWriteTest {
                         .field("bytes", DataTypes.BYTES())
                         .field("timestamp", DataTypes.TIMESTAMP())
                         .field("timestamp_3", DataTypes.TIMESTAMP(3))
+                        .field("timestamp_ltz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                         .field("date", DataTypes.DATE())
                         .field("decimal", DataTypes.DECIMAL(2, 2))
                         .field("decimal2", DataTypes.DECIMAL(38, 2))
@@ -106,6 +107,7 @@ public class LanceFileFormatReadWriteTest extends FormatReadWriteTest {
                         new byte[] {1, 5, 2},
                         Timestamp.fromMicros(123123123),
                         Timestamp.fromEpochMillis(123123123),
+                        Timestamp.fromMicros(456456456),
                         2456,
                         Decimal.fromBigDecimal(new BigDecimal("0.22"), 2, 2),
                         Decimal.fromBigDecimal(new BigDecimal("12312455.22"), 38, 2),

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
@@ -69,6 +69,7 @@ public class LanceFileFormatTest {
                         .field("isActive", DataTypes.BOOLEAN())
                         .field("bytes", DataTypes.BYTES())
                         .field("timestamp", DataTypes.TIMESTAMP())
+                        .field("timestamp_ltz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
                         .field("date", DataTypes.DATE())
                         .field("decimal", DataTypes.DECIMAL(10, 2))
                         .field("array", DataTypes.ARRAY(DataTypes.INT()))


### PR DESCRIPTION
## Summary

Fixes #6648.

When using Lance format with `TIMESTAMP WITH LOCAL TIME ZONE`, Lance's Rust-side schema parser fails on timezone strings like `GMT-10:00` with `Unsupported timestamp type: timestamp:us:GMT-10:00`. This happens because Arrow-Rust only accepts IANA timezone names (e.g. `America/New_York`) or standard UTC offset format (e.g. `+05:30`, `-10:00`, `Z`), but Java's `ZoneId.systemDefault().toString()` produces the `GMT-10:00` prefix form.

The fix uses `ZoneId.normalized()` before converting to string. This converts `GMT-10:00` to `-10:00`, `GMT+05:30` to `+05:30`, `UTC` to `Z`, and leaves IANA names like `America/New_York` unchanged. All of these are formats that Arrow-Rust accepts.

Changes:
- In `ArrowFieldTypeConversion`, call `.normalized()` on the ZoneId before `.toString()` when creating Arrow Timestamp types
- In `LanceFileFormat`, remove the `UnsupportedOperationException` that blocked `LOCAL_ZONED_TIMESTAMP` entirely
- Add `timestamp_ltz` coverage to `LanceFileFormatTest` (validation) and `LanceFileFormatReadWriteTest` (round-trip read/write)