### PR TITLE
[arrow] Normalize timezone strings for arrow-rust compatibility

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/ArrowFieldTypeConversion.java
@@ -149,7 +149,8 @@ public class ArrowFieldTypeConversion {
             int precision = localZonedTimestampType.getPrecision();
             TimeUnit timeUnit = getTimeUnit(precision);
             ArrowType arrowType =
-                    new ArrowType.Timestamp(timeUnit, ZoneId.systemDefault().toString());
+                    new ArrowType.Timestamp(
+                            timeUnit, ZoneId.systemDefault().normalized().toString());
             return new FieldType(localZonedTimestampType.isNullable(), arrowType, null);
         }
 


### PR DESCRIPTION
## Summary

Fixes #7704.

`ZoneId.systemDefault().toString()` can produce GMT-prefix timezone strings like `GMT-10:00` when the JVM timezone is set to a GMT-prefix offset. Arrow-rust doesn't recognize the `GMT` prefix and rejects these strings.

`normalized()` converts them to formats arrow-rust accepts:
- `GMT-10:00` becomes `-10:00`
- `GMT+05:30` becomes `+05:30`
- `UTC` / `GMT` becomes `Z`
- IANA names like `America/New_York` pass through unchanged

This was discovered while investigating #6648. The CI randomizes `-Duser.timezone` and hit `GMT+5:00`, which triggered a crash in the Lance native writer.