### PR TITLE
[lumina] Rename index identifier `lumina-vector-ann` to `lumina

### DIFF
--- a/docs/content/append-table/global-index.md
+++ b/docs/content/append-table/global-index.md
@@ -97,10 +97,12 @@ Generation) applications.
 CALL sys.create_global_index(
     table => 'db.my_table',
     index_column => 'embedding',
-    index_type => 'lumina-vector-ann',
+    index_type => 'lumina',
     options => 'lumina.index.dimension=128'
 );
 ```
+
+The legacy index type `lumina-vector-ann` is still accepted for existing tables and SQL compatibility.
 
 **Vector Search**
 

--- a/docs/content/learn-paimon/scenario-guide.md
+++ b/docs/content/learn-paimon/scenario-guide.md
@@ -451,13 +451,15 @@ Schema schema = Schema.newBuilder()
 CALL sys.create_global_index(
     table => 'db.doc_embeddings',
     index_column => 'embedding',
-    index_type => 'lumina-vector-ann',
+    index_type => 'lumina',
     options => 'lumina.index.dimension=768'
 );
 
 -- Search for top-5 nearest neighbors
 SELECT * FROM vector_search('doc_embeddings', 'embedding', array(0.1f, 0.2f, ...), 5);
 ```
+
+The legacy index type `lumina-vector-ann` is still accepted for existing tables and SQL compatibility.
 
 **Why:** The [Global Index]({{< ref "append-table/global-index" >}}) with DiskANN provides high-performance ANN search.
 Vector data is stored in dedicated `.vector.lance` files optimized for dense vectors, while scalar columns stay in

--- a/paimon-common/src/test/java/org/apache/paimon/utils/FileTypeTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/FileTypeTest.java
@@ -120,6 +120,11 @@ public class FileTypeTest {
         // lumina vector global index
         assertThat(
                         FileType.classify(
+                                new Path(TABLE_ROOT + "/index/lumina-global-index-a1b2c3d4.index")))
+                .isEqualTo(FileType.GLOBAL_INDEX);
+        // legacy lumina vector global index
+        assertThat(
+                        FileType.classify(
                                 new Path(
                                         TABLE_ROOT
                                                 + "/index/lumina-vector-ann-global-index-a1b2c3d4.index")))

--- a/paimon-core/src/test/java/org/apache/paimon/index/IndexFileHandlerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/IndexFileHandlerTest.java
@@ -84,7 +84,15 @@ public class IndexFileHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"HASH", "DELETION_VECTORS", "btree", "bitmap", "lumina-vector-ann"})
+    @ValueSource(
+            strings = {
+                "HASH",
+                "DELETION_VECTORS",
+                "btree",
+                "bitmap",
+                "lumina",
+                "lumina-vector-ann"
+            })
     void testExistsAndDeleteIndexFile(String indexType) throws IOException {
         String fileName = "index-" + UUID.randomUUID();
         IndexFileMeta meta =

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class LuminaVectorGlobalIndexITCase extends CatalogITCaseBase {
 
     private static final String INDEX_TYPE = "lumina";
+    private static final String LEGACY_INDEX_TYPE = "lumina-vector-ann";
 
     @BeforeAll
     static void checkLuminaAvailable() {
@@ -86,6 +87,47 @@ public class LuminaVectorGlobalIndexITCase extends CatalogITCaseBase {
         assertThat(vectorEntries).isNotEmpty();
         long totalRowCount = vectorEntries.stream().mapToLong(IndexFileMeta::rowCount).sum();
         assertThat(totalRowCount).isEqualTo(100L);
+    }
+
+    @Test
+    public void testLuminaVectorIndexLegacyIdentifier() throws Catalog.TableNotExistException {
+        // Verifies that the legacy `lumina-vector-ann` identifier still resolves through SPI to
+        // LegacyLuminaVectorGlobalIndexerFactory and produces a working global index. Files are
+        // tagged with the legacy indexType in the manifest, so reads of pre-rename tables continue
+        // to dispatch to the same writer/reader as the new `lumina` identifier.
+        sql(
+                "CREATE TABLE T_LEGACY (id INT, v ARRAY<FLOAT>) WITH ("
+                        + "'bucket' = '-1', "
+                        + "'row-tracking.enabled' = 'true', "
+                        + "'data-evolution.enabled' = 'true', "
+                        + "'lumina.index.dimension' = '3', "
+                        + "'lumina.distance.metric' = 'l2'"
+                        + ")");
+
+        sql("INSERT INTO T_LEGACY VALUES " + vectorValues(0, 10, 3));
+
+        sql(
+                "CALL sys.create_global_index("
+                        + "`table` => 'default.T_LEGACY', "
+                        + "index_column => 'v', "
+                        + "index_type => '"
+                        + LEGACY_INDEX_TYPE
+                        + "')");
+
+        FileStoreTable table = paimonTable("T_LEGACY");
+        List<IndexFileMeta> vectorEntries =
+                table.store().newIndexFileHandler().scanEntries().stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .filter(f -> LEGACY_INDEX_TYPE.equals(f.indexType()))
+                        .collect(Collectors.toList());
+
+        assertThat(vectorEntries).isNotEmpty();
+        long totalRowCount = vectorEntries.stream().mapToLong(IndexFileMeta::rowCount).sum();
+        assertThat(totalRowCount).isEqualTo(10L);
+        for (IndexFileMeta meta : vectorEntries) {
+            assertThat(meta.indexType()).isEqualTo(LEGACY_INDEX_TYPE);
+            assertThat(meta.globalIndexMeta()).isNotNull();
+        }
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LuminaVectorGlobalIndexITCase.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Test case for Lumina vector global index via Flink procedure. */
 public class LuminaVectorGlobalIndexITCase extends CatalogITCaseBase {
 
-    private static final String INDEX_TYPE = "lumina-vector-ann";
+    private static final String INDEX_TYPE = "lumina";
 
     @BeforeAll
     static void checkLuminaAvailable() {

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LegacyLuminaVectorGlobalIndexerFactory.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LegacyLuminaVectorGlobalIndexerFactory.java
@@ -18,23 +18,13 @@
 
 package org.apache.paimon.lumina.index;
 
-import org.apache.paimon.globalindex.GlobalIndexer;
-import org.apache.paimon.globalindex.GlobalIndexerFactory;
-import org.apache.paimon.options.Options;
-import org.apache.paimon.types.DataField;
+/** Factory for the legacy Lumina vector index identifier. */
+public class LegacyLuminaVectorGlobalIndexerFactory extends LuminaVectorGlobalIndexerFactory {
 
-/** Factory for creating Lumina vector index. */
-public class LuminaVectorGlobalIndexerFactory implements GlobalIndexerFactory {
-
-    public static final String IDENTIFIER = "lumina";
+    public static final String IDENTIFIER = "lumina-vector-ann";
 
     @Override
     public String identifier() {
         return IDENTIFIER;
-    }
-
-    @Override
-    public GlobalIndexer create(DataField field, Options options) {
-        return new LuminaVectorGlobalIndexer(field.type(), options);
     }
 }

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LegacyLuminaVectorGlobalIndexerFactory.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LegacyLuminaVectorGlobalIndexerFactory.java
@@ -18,7 +18,16 @@
 
 package org.apache.paimon.lumina.index;
 
-/** Factory for the legacy Lumina vector index identifier. */
+/**
+ * Factory for the legacy Lumina vector index identifier {@code lumina-vector-ann}.
+ *
+ * <p>Retained so that tables created before the rename to {@code lumina} continue to load. New
+ * tables should use {@link LuminaVectorGlobalIndexerFactory} via the {@code lumina} identifier.
+ *
+ * @deprecated Use {@link LuminaVectorGlobalIndexerFactory} ({@code lumina}) for new tables. This
+ *     factory only exists to keep the legacy identifier resolvable through SPI.
+ */
+@Deprecated
 public class LegacyLuminaVectorGlobalIndexerFactory extends LuminaVectorGlobalIndexerFactory {
 
     public static final String IDENTIFIER = "lumina-vector-ann";

--- a/paimon-lumina/src/main/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
+++ b/paimon-lumina/src/main/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.paimon.lumina.index.LuminaVectorGlobalIndexerFactory
+org.apache.paimon.lumina.index.LegacyLuminaVectorGlobalIndexerFactory

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexerFactoryTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexerFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lumina.index;
+
+import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for Lumina global indexer factory identifiers. */
+public class LuminaVectorGlobalIndexerFactoryTest {
+
+    @Test
+    public void testIdentifiers() {
+        assertThat(new LuminaVectorGlobalIndexerFactory().identifier()).isEqualTo("lumina");
+        assertThat(new LegacyLuminaVectorGlobalIndexerFactory().identifier())
+                .isEqualTo("lumina-vector-ann");
+    }
+
+    @Test
+    public void testLoadNewAndLegacyIdentifiers() {
+        assertThat(GlobalIndexerFactoryUtils.load("lumina"))
+                .isExactlyInstanceOf(LuminaVectorGlobalIndexerFactory.class);
+        assertThat(GlobalIndexerFactoryUtils.load("lumina-vector-ann"))
+                .isExactlyInstanceOf(LegacyLuminaVectorGlobalIndexerFactory.class);
+    }
+}

--- a/paimon-python/pypaimon/globalindex/lumina/__init__.py
+++ b/paimon-python/pypaimon/globalindex/lumina/__init__.py
@@ -17,11 +17,15 @@
 ################################################################################
 
 from pypaimon.globalindex.lumina.lumina_vector_global_index_reader import (
-    LuminaVectorGlobalIndexReader,
+    LUMINA_IDENTIFIER,
+    LUMINA_IDENTIFIERS,
     LUMINA_VECTOR_ANN_IDENTIFIER,
+    LuminaVectorGlobalIndexReader,
 )
 
 __all__ = [
-    'LuminaVectorGlobalIndexReader',
+    'LUMINA_IDENTIFIER',
+    'LUMINA_IDENTIFIERS',
     'LUMINA_VECTOR_ANN_IDENTIFIER',
+    'LuminaVectorGlobalIndexReader',
 ]

--- a/paimon-python/pypaimon/globalindex/lumina/lumina_vector_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/lumina/lumina_vector_global_index_reader.py
@@ -28,7 +28,9 @@ import numpy as np
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader
 from pypaimon.globalindex.vector_search_result import DictBasedScoredIndexResult
 
+LUMINA_IDENTIFIER = "lumina"
 LUMINA_VECTOR_ANN_IDENTIFIER = "lumina-vector-ann"
+LUMINA_IDENTIFIERS = (LUMINA_IDENTIFIER, LUMINA_VECTOR_ANN_IDENTIFIER)
 
 MIN_SEARCH_LIST_SIZE = 16
 

--- a/paimon-python/pypaimon/table/source/vector_search_read.py
+++ b/paimon-python/pypaimon/table/source/vector_search_read.py
@@ -141,10 +141,10 @@ class VectorSearchReadImpl(VectorSearchRead):
 def _create_vector_reader(index_type, file_io, index_path, index_io_meta_list, options=None):
     """Create a global index reader for vector search."""
     from pypaimon.globalindex.lumina.lumina_vector_global_index_reader import (
-        LUMINA_VECTOR_ANN_IDENTIFIER,
+        LUMINA_IDENTIFIERS,
         LuminaVectorGlobalIndexReader,
     )
-    if index_type == LUMINA_VECTOR_ANN_IDENTIFIER:
+    if index_type in LUMINA_IDENTIFIERS:
         return LuminaVectorGlobalIndexReader(
             file_io, index_path, index_io_meta_list, options
         )

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -215,11 +215,9 @@ class VectorSearchFilterTest(unittest.TestCase):
 
         captured_searches = []
         captured_io_metas = []
-        captured_index_types = []
 
         def _capture_create(index_type, file_io, index_path,
                             index_io_meta_list, options=None):
-            captured_index_types.append(index_type)
             captured_io_metas.append(list(index_io_meta_list))
 
             class _FakeReader:
@@ -262,8 +260,6 @@ class VectorSearchFilterTest(unittest.TestCase):
         self.assertEqual(
             {"oss://bucket/vec-0.index", "oss://bucket/vec-1.index"},
             seen_paths)
-        self.assertEqual(["lumina-vector-ann", "lumina-vector-ann"],
-                         captured_index_types)
 
     def test_scanner_threads_external_path_to_btree_reader(self):
         """GlobalIndexScanner (backing _pre_filter) must thread external_path

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -28,7 +28,7 @@ from unittest import mock
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.common.predicate_builder import PredicateBuilder
-from pypaimon.globalindex.global_index_meta import GlobalIndexMeta
+from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta, GlobalIndexMeta
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.globalindex.vector_search_result import ScoredGlobalIndexResult
 from pypaimon.index.index_file_meta import IndexFileMeta
@@ -121,6 +121,27 @@ def _patch_snapshot(testcase, entries):
 # ----------------------------- tests ---------------------------------------
 
 
+class VectorReaderFactoryTest(unittest.TestCase):
+    """Vector reader factory compatibility."""
+
+    def test_lumina_reader_accepts_new_and_legacy_identifiers(self):
+        from pypaimon.globalindex.lumina.lumina_vector_global_index_reader import (
+            LUMINA_IDENTIFIER,
+            LUMINA_VECTOR_ANN_IDENTIFIER,
+            LuminaVectorGlobalIndexReader,
+        )
+        from pypaimon.table.source.vector_search_read import _create_vector_reader
+
+        io_meta = GlobalIndexIOMeta(file_name="vec.index", file_size=1)
+        for index_type in (LUMINA_IDENTIFIER, LUMINA_VECTOR_ANN_IDENTIFIER):
+            reader = _create_vector_reader(
+                index_type, object(), "/tmp/unused", [io_meta], {})
+            try:
+                self.assertIsInstance(reader, LuminaVectorGlobalIndexReader)
+            finally:
+                reader.close()
+
+
 class VectorSearchFilterTest(unittest.TestCase):
     """Non-partitioned wiring: scan + read + external_path plumbing."""
 
@@ -130,11 +151,11 @@ class VectorSearchFilterTest(unittest.TestCase):
         # 2 vector files ([0,4], [5,9]) + 1 btree on `id` covering [0,9] with
         # an external_path so we can assert external_path is threaded through.
         self.entries = [
-            _entry(None, field_id=1, index_type="lumina-vector-ann",
+            _entry(None, field_id=1, index_type="lumina",
                    file_name="vec-0.index",
                    row_range_start=0, row_range_end=4,
                    external_path="oss://bucket/vec-0.index"),
-            _entry(None, field_id=1, index_type="lumina-vector-ann",
+            _entry(None, field_id=1, index_type="lumina",
                    file_name="vec-1.index",
                    row_range_start=5, row_range_end=9,
                    external_path="oss://bucket/vec-1.index"),
@@ -472,11 +493,11 @@ class VectorSearchPartitionedFilterTest(unittest.TestCase):
         partition_pt2 = GenericRow([2], [self.pt_field])
         self.entries = [
             _entry(partition_pt1, field_id=2,
-                   index_type="lumina-vector-ann",
+                   index_type="lumina",
                    file_name="vec-pt1.index",
                    row_range_start=0, row_range_end=4),
             _entry(partition_pt2, field_id=2,
-                   index_type="lumina-vector-ann",
+                   index_type="lumina",
                    file_name="vec-pt2.index",
                    row_range_start=5, row_range_end=9),
         ]

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -126,14 +126,13 @@ class VectorReaderFactoryTest(unittest.TestCase):
 
     def test_lumina_reader_accepts_new_and_legacy_identifiers(self):
         from pypaimon.globalindex.lumina.lumina_vector_global_index_reader import (
-            LUMINA_IDENTIFIER,
-            LUMINA_VECTOR_ANN_IDENTIFIER,
+            LUMINA_IDENTIFIERS,
             LuminaVectorGlobalIndexReader,
         )
         from pypaimon.table.source.vector_search_read import _create_vector_reader
 
         io_meta = GlobalIndexIOMeta(file_name="vec.index", file_size=1)
-        for index_type in (LUMINA_IDENTIFIER, LUMINA_VECTOR_ANN_IDENTIFIER):
+        for index_type in LUMINA_IDENTIFIERS:
             reader = _create_vector_reader(
                 index_type, object(), "/tmp/unused", [io_meta], {})
             try:
@@ -151,11 +150,11 @@ class VectorSearchFilterTest(unittest.TestCase):
         # 2 vector files ([0,4], [5,9]) + 1 btree on `id` covering [0,9] with
         # an external_path so we can assert external_path is threaded through.
         self.entries = [
-            _entry(None, field_id=1, index_type="lumina",
+            _entry(None, field_id=1, index_type="lumina-vector-ann",
                    file_name="vec-0.index",
                    row_range_start=0, row_range_end=4,
                    external_path="oss://bucket/vec-0.index"),
-            _entry(None, field_id=1, index_type="lumina",
+            _entry(None, field_id=1, index_type="lumina-vector-ann",
                    file_name="vec-1.index",
                    row_range_start=5, row_range_end=9,
                    external_path="oss://bucket/vec-1.index"),
@@ -216,9 +215,11 @@ class VectorSearchFilterTest(unittest.TestCase):
 
         captured_searches = []
         captured_io_metas = []
+        captured_index_types = []
 
         def _capture_create(index_type, file_io, index_path,
                             index_io_meta_list, options=None):
+            captured_index_types.append(index_type)
             captured_io_metas.append(list(index_io_meta_list))
 
             class _FakeReader:
@@ -261,6 +262,8 @@ class VectorSearchFilterTest(unittest.TestCase):
         self.assertEqual(
             {"oss://bucket/vec-0.index", "oss://bucket/vec-1.index"},
             seen_paths)
+        self.assertEqual(["lumina-vector-ann", "lumina-vector-ann"],
+                         captured_index_types)
 
     def test_scanner_threads_external_path_to_btree_reader(self):
         """GlobalIndexScanner (backing _pre_filter) must thread external_path

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -104,6 +104,15 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
       assert(indexEntries.nonEmpty)
       val totalRowCount = indexEntries.map(_.indexFile().rowCount()).sum
       assert(totalRowCount == 10L)
+
+      // End-to-end read: vector_search must resolve the legacy identifier through
+      // LegacyLuminaVectorGlobalIndexerFactory and return results.
+      val result = spark
+        .sql("""
+               |SELECT * FROM vector_search('T', 'v', array(50.0f, 51.0f, 52.0f), 5)
+               |""".stripMargin)
+        .collect()
+      assert(result.length == 5)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -26,6 +26,7 @@ import scala.collection.JavaConverters._
 class LuminaVectorIndexTest extends PaimonSparkTestBase {
 
   private val indexType = "lumina"
+  private val legacyIndexType = "lumina-vector-ann"
   private val defaultOptions = "lumina.index.dimension=3"
 
   // ========== Index Creation Tests ==========
@@ -65,6 +66,44 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
       assert(indexEntries.nonEmpty)
       val totalRowCount = indexEntries.map(_.indexFile().rowCount()).sum
       assert(totalRowCount == 100L)
+    }
+  }
+
+  test("create lumina vector index - legacy index type") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, v ARRAY<FLOAT>)
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.row-count-per-shard' = '10000',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true')
+                  |""".stripMargin)
+
+      val values = (0 until 10)
+        .map(
+          i => s"($i, array(cast($i as float), cast(${i + 1} as float), cast(${i + 2} as float)))")
+        .mkString(",")
+      spark.sql(s"INSERT INTO T VALUES $values")
+
+      val output = spark
+        .sql(
+          s"CALL sys.create_global_index(table => 'test.T', index_column => 'v', index_type => '$legacyIndexType', options => '$defaultOptions')")
+        .collect()
+        .head
+      assert(output.getBoolean(0))
+
+      val table = loadTable("T")
+      val indexEntries = table
+        .store()
+        .newIndexFileHandler()
+        .scanEntries()
+        .asScala
+        .filter(_.indexFile().indexType() == legacyIndexType)
+
+      assert(indexEntries.nonEmpty)
+      val totalRowCount = indexEntries.map(_.indexFile().rowCount()).sum
+      assert(totalRowCount == 10L)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/LuminaVectorIndexTest.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 /** Tests for Lumina vector index read/write operations. */
 class LuminaVectorIndexTest extends PaimonSparkTestBase {
 
-  private val indexType = "lumina-vector-ann"
+  private val indexType = "lumina"
   private val defaultOptions = "lumina.index.dimension=3"
 
   // ========== Index Creation Tests ==========
@@ -96,13 +96,13 @@ class LuminaVectorIndexTest extends PaimonSparkTestBase {
                |SELECT index_type, row_count, row_range_start, row_range_end,
                |       index_field_id, index_field_name
                |FROM `T$table_indexes`
-               |WHERE index_type = 'lumina-vector-ann'
+               |WHERE index_type = 'lumina'
                |""".stripMargin)
         .collect()
 
       assert(indexRows.nonEmpty)
       val row = indexRows.head
-      assert(row.getAs[String]("index_type") == "lumina-vector-ann")
+      assert(row.getAs[String]("index_type") == "lumina")
       assert(row.getAs[Long]("row_count") == 100L)
       assert(row.getAs[Long]("row_range_start") == 0L)
       assert(row.getAs[Long]("row_range_end") == 99L)


### PR DESCRIPTION
  ### Purpose

  Rename the Lumina vector global index identifier from `lumina-vector-ann` to
  `lumina` for a cleaner, shorter name. Existing tables created with the old
  identifier continue to work via a `LegacyLuminaVectorGlobalIndexerFactory`
  registered through SPI, so no on-disk migration is required. File naming on
  disk is unchanged (the writer has always used the `lumina-` prefix).

  ### Tests

  - `LuminaVectorGlobalIndexerFactoryTest` — verifies both identifiers route to
    the correct factory class.
  - `IndexFileHandlerTest#testExistsAndDeleteIndexFile` — parameterized over both
    `lumina` and `lumina-vector-ann`.
  - `FileTypeTest#testGlobalIndexFiles` — adds the new `lumina-global-index-*`
    path to the classification check.
  - `LuminaVectorIndexTest` (Spark) — adds a "create lumina vector index - legacy
    index type" case using `lumina-vector-ann`.
  - `vector_search_filter_test.VectorReaderFactoryTest` — Python reader accepts
    both identifiers.