### PR TITLE
[python] Support FileScanner partition_predicate to fix FileStoreCommit overwrite for sanity check

### DIFF
--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -168,7 +168,8 @@ class FileScanner:
         table,
         manifest_scanner: Callable[[], Tuple[List[ManifestFileMeta], Optional[Snapshot]]],
         predicate: Optional[Predicate] = None,
-        limit: Optional[int] = None
+        limit: Optional[int] = None,
+        partition_predicate: Optional[Predicate] = None
     ):
         from pypaimon.table.file_store_table import FileStoreTable
 
@@ -185,8 +186,11 @@ class FileScanner:
         self.primary_key_predicate = trim_and_transform_predicate(
             self.predicate, self.table.field_names, self.table.trimmed_primary_keys)
 
-        self.partition_key_predicate = trim_and_transform_predicate(
-            self.predicate, self.table.field_names, self.table.partition_keys)
+        if partition_predicate is None:
+            self.partition_key_predicate = trim_and_transform_predicate(
+                self.predicate, self.table.field_names, self.table.partition_keys)
+        else:
+            self.partition_key_predicate = partition_predicate
         options = self.table.options
         # Get split target size and open file cost from table options
         self.target_split_size = options.source_split_target_size()

--- a/paimon-python/pypaimon/tests/partition_predicate_test.py
+++ b/paimon-python/pypaimon/tests/partition_predicate_test.py
@@ -1,0 +1,254 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import unittest
+from unittest.mock import Mock, patch
+
+from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
+from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.read.scanner.file_scanner import FileScanner
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.row.offset_row import OffsetRow
+from pypaimon.write.commit.commit_scanner import CommitScanner
+from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.file_store_commit import FileStoreCommit
+
+PARTITION_FIELDS = [
+    DataField(0, 'dt', AtomicType('STRING')),
+    DataField(1, 'region', AtomicType('STRING')),
+]
+
+TABLE_FIELDS = [
+    DataField(0, 'dt', AtomicType('STRING')),
+    DataField(1, 'id', AtomicType('INT')),
+    DataField(2, 'name', AtomicType('STRING')),
+    DataField(3, 'region', AtomicType('STRING')),
+]
+
+_partition_builder = PredicateBuilder(PARTITION_FIELDS)
+
+
+def _mock_table():
+    table = Mock()
+    table.field_names = ['dt', 'id', 'name', 'region']
+    table.fields = TABLE_FIELDS
+    table.partition_keys = ['dt', 'region']
+    table.partition_keys_fields = PARTITION_FIELDS
+    return table
+
+
+def _mock_scanner_table():
+    table = _mock_table()
+    table.trimmed_primary_keys = []
+    table.is_primary_key_table = False
+    table.options.source_split_target_size.return_value = 128 * 1024 * 1024
+    table.options.source_split_open_file_cost.return_value = 4 * 1024 * 1024
+    table.options.bucket.return_value = -1
+    table.options.data_evolution_enabled.return_value = False
+    table.options.deletion_vectors_enabled.return_value = False
+    table.options.scan_manifest_parallelism.return_value = 1
+    table.table_schema = Mock(id=0)
+    table.schema_manager = Mock()
+    table.schema_manager.get_schema.return_value = Mock(fields=TABLE_FIELDS)
+    return table
+
+
+def _manifest_file_meta(partition_min, partition_max):
+    return ManifestFileMeta(
+        file_name='manifest-test',
+        file_size=1024,
+        num_added_files=1,
+        num_deleted_files=0,
+        partition_stats=SimpleStats(
+            min_values=GenericRow(partition_min, PARTITION_FIELDS),
+            max_values=GenericRow(partition_max, PARTITION_FIELDS),
+            null_counts=[0, 0],
+        ),
+        schema_id=0,
+    )
+
+
+def _manifest_entry(partition_values):
+    return ManifestEntry(
+        kind=0,
+        partition=GenericRow(partition_values, PARTITION_FIELDS),
+        bucket=0,
+        total_buckets=1,
+        file=Mock(),
+    )
+
+
+@patch('pypaimon.read.scanner.file_scanner.SnapshotManager')
+@patch('pypaimon.read.scanner.file_scanner.ManifestFileManager')
+@patch('pypaimon.read.scanner.file_scanner.ManifestListManager')
+class TestFileScannerPartitionPredicate(unittest.TestCase):
+
+    def _scanner(self, predicate=None, partition_predicate=None):
+        return FileScanner(
+            _mock_scanner_table(), lambda: ([], None),
+            predicate=predicate, partition_predicate=partition_predicate,
+        )
+
+    def test_partition_predicate_used_directly(self, *_):
+        pred = _partition_builder.equal('dt', '2024-01-15')
+        scanner = self._scanner(partition_predicate=pred)
+
+        self.assertIs(scanner.partition_key_predicate, pred)
+        self.assertIsNone(scanner.predicate)
+        self.assertIsNone(scanner.predicate_for_stats)
+        self.assertIsNone(scanner.primary_key_predicate)
+
+    def test_no_partition_predicate_derives_from_predicate(self, *_):
+        full_pred = PredicateBuilder(TABLE_FIELDS).equal('dt', '2024-01-15')
+        scanner = self._scanner(predicate=full_pred)
+
+        self.assertIsNotNone(scanner.partition_key_predicate)
+        self.assertEqual(scanner.partition_key_predicate.field, 'dt')
+
+    def test_neither_predicate_means_no_filtering(self, *_):
+        scanner = self._scanner()
+
+        self.assertIsNone(scanner.partition_key_predicate)
+        self.assertTrue(scanner._filter_manifest_entry(
+            _manifest_entry(['2024-01-15', 'us-east-1'])))
+
+    def test_filters_manifest_file_by_stats(self, *_):
+        scanner = self._scanner(
+            partition_predicate=_partition_builder.equal('dt', '2024-01-15'))
+
+        self.assertTrue(scanner._filter_manifest_file(
+            _manifest_file_meta(['2024-01-15', 'us-east-1'], ['2024-01-15', 'us-west-2'])))
+        self.assertFalse(scanner._filter_manifest_file(
+            _manifest_file_meta(['2024-01-16', 'us-east-1'], ['2024-01-16', 'us-west-2'])))
+
+    def test_filters_manifest_entry_by_partition(self, *_):
+        scanner = self._scanner(
+            partition_predicate=_partition_builder.and_predicates([
+                _partition_builder.equal('dt', '2024-01-15'),
+                _partition_builder.equal('region', 'us-east-1'),
+            ]))
+
+        self.assertTrue(scanner._filter_manifest_entry(
+            _manifest_entry(['2024-01-15', 'us-east-1'])))
+        self.assertFalse(scanner._filter_manifest_entry(
+            _manifest_entry(['2024-01-16', 'us-east-1'])))
+        self.assertFalse(scanner._filter_manifest_entry(
+            _manifest_entry(['2024-01-15', 'us-west-2'])))
+
+
+@patch('pypaimon.write.file_store_commit.SnapshotManager')
+@patch('pypaimon.write.file_store_commit.ManifestFileManager')
+@patch('pypaimon.write.file_store_commit.ManifestListManager')
+class TestOverwritePartitionPredicate(unittest.TestCase):
+
+    _TARGET = {'dt': '2024-01-15', 'region': 'us-east-1'}
+
+    def setUp(self):
+        self.table = _mock_table()
+
+    def _create_commit(self, stub_commit=True):
+        commit = FileStoreCommit(Mock(), self.table, 'test_user')
+        if stub_commit:
+            commit._try_commit = Mock()
+        return commit
+
+    @staticmethod
+    def _msg(partition):
+        return CommitMessage(partition=partition, bucket=0, new_files=[Mock(row_count=10)])
+
+    def _extract_partition_predicate(self, commit):
+        entries_plan = commit._try_commit.call_args[1]['commit_entries_plan']
+        with patch('pypaimon.write.file_store_commit.FileScanner') as mock_cls:
+            mock_cls.return_value.read_manifest_entries.return_value = []
+            commit.manifest_list_manager.read_all.return_value = []
+            entries_plan(Mock(id=1))
+            return mock_cls.call_args[1]['partition_predicate']
+
+    def test_overwrite_rejects_mismatched_partition(self, *_):
+        commit = self._create_commit(stub_commit=False)
+        with self.assertRaises(RuntimeError) as ctx:
+            commit.overwrite(self._TARGET, [self._msg(('2024-01-15', 'us-west-2'))], 1)
+        self.assertIn('does not belong to this partition', str(ctx.exception))
+
+    def test_overwrite_passes_partition_scoped_predicate(self, *_):
+        commit = self._create_commit()
+        commit.overwrite(self._TARGET, [self._msg(('2024-01-15', 'us-east-1'))], 1)
+
+        pred = self._extract_partition_predicate(commit)
+        self.assertTrue(pred.test(OffsetRow(('2024-01-15', 'us-east-1'), 0, 2)))
+        self.assertFalse(pred.test(OffsetRow(('2024-01-15', 'us-west-2'), 0, 2)))
+
+    def test_drop_partitions_passes_or_predicate(self, *_):
+        commit = self._create_commit()
+        commit.drop_partitions([
+            {'dt': '2024-01-15', 'region': 'us-east-1'},
+            {'dt': '2024-01-16', 'region': 'us-west-2'},
+        ], 1)
+
+        pred = self._extract_partition_predicate(commit)
+        self.assertTrue(pred.test(OffsetRow(('2024-01-15', 'us-east-1'), 0, 2)))
+        self.assertTrue(pred.test(OffsetRow(('2024-01-16', 'us-west-2'), 0, 2)))
+        self.assertFalse(pred.test(OffsetRow(('2024-01-17', 'eu-west-1'), 0, 2)))
+
+
+class TestCommitScannerPartitionPredicate(unittest.TestCase):
+
+    def _scanner(self):
+        return CommitScanner(_mock_table(), Mock())
+
+    def test_filter_uses_partition_key_index(self):
+        scanner = self._scanner()
+        pred = scanner._build_partition_filter_from_entries([
+            _manifest_entry(['2024-01-15', 'us-east-1']),
+            _manifest_entry(['2024-01-16', 'us-west-2']),
+        ])
+
+        self.assertTrue(pred.test(GenericRow(['2024-01-15', 'us-east-1'], PARTITION_FIELDS)))
+        self.assertTrue(pred.test(GenericRow(['2024-01-16', 'us-west-2'], PARTITION_FIELDS)))
+        self.assertFalse(pred.test(GenericRow(['2024-01-17', 'eu-west-1'], PARTITION_FIELDS)))
+
+    def test_filter_none_without_partition_keys(self):
+        scanner = CommitScanner(Mock(partition_keys=[]), Mock())
+
+        pred = scanner._build_partition_filter_from_entries(
+            [_manifest_entry(['2024-01-15', 'us-east-1'])])
+        self.assertIsNone(pred)
+
+    @patch('pypaimon.write.commit.commit_scanner.FileScanner')
+    def test_passes_partition_predicate_to_file_scanner(self, mock_scanner_cls):
+        mock_scanner_cls.return_value.read_manifest_entries.return_value = []
+        entries = [_manifest_entry(['2024-01-15', 'us-east-1'])]
+
+        cases = [
+            ('read_all_entries_from_changed_partitions', 'read_all', []),
+            ('read_incremental_entries_from_changed_partitions', 'read_delta', [Mock()]),
+        ]
+        for method, setup_attr, setup_return in cases:
+            with self.subTest(method=method):
+                mock_scanner_cls.reset_mock()
+                scanner = self._scanner()
+                getattr(scanner.manifest_list_manager, setup_attr).return_value = setup_return
+                getattr(scanner, method)(Mock(), entries)
+
+                kwargs = mock_scanner_cls.call_args[1]
+                self.assertIn('partition_predicate', kwargs)
+                self.assertIsNotNone(kwargs['partition_predicate'])
+                self.assertNotIn('predicate', kwargs)

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -66,7 +66,7 @@ class CommitScanner:
 
         all_manifests = self.manifest_list_manager.read_all(latest_snapshot)
         return FileScanner(
-            self.table, lambda: ([], None), partition_filter
+            self.table, lambda: ([], None), partition_predicate=partition_filter
         ).read_manifest_entries(all_manifests)
 
     def read_incremental_entries_from_changed_partitions(self, snapshot: Snapshot,
@@ -92,7 +92,7 @@ class CommitScanner:
         partition_filter = self._build_partition_filter_from_entries(commit_entries)
 
         return FileScanner(
-            self.table, lambda: ([], None), partition_filter
+            self.table, lambda: ([], None), partition_predicate=partition_filter
         ).read_manifest_entries(delta_manifests)
 
     def _build_partition_filter_from_entries(self, entries: List[ManifestEntry]):
@@ -116,7 +116,7 @@ class CommitScanner:
         if not changed_partitions:
             return None
 
-        predicate_builder = PredicateBuilder(self.table.fields)
+        predicate_builder = PredicateBuilder(self.table.partition_keys_fields)
         partition_predicates = []
         for partition_values in changed_partitions:
             sub_predicates = []

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -204,9 +204,7 @@ class FileStoreCommit:
                         f"Partition keys are: {list(self.table.partition_keys)}."
                     )
 
-        # Use full table fields so FullStartingScanner's trim_and_transform_predicate
-        # maps indices correctly (full schema index -> partition index).
-        predicate_builder = PredicateBuilder(self.table.fields)
+        predicate_builder = PredicateBuilder(self.table.partition_keys_fields)
         partition_predicates = []
         for part in partitions:
             sub_predicates = [
@@ -524,7 +522,7 @@ class FileStoreCommit:
         """Generate commit entries for OVERWRITE mode based on latest snapshot."""
         entries = []
         current_entries = [] if latest_snapshot is None \
-            else (FileScanner(self.table, lambda: ([], None), partition_filter).
+            else (FileScanner(self.table, lambda: ([], None), partition_predicate=partition_filter).
                   read_manifest_entries(self.manifest_list_manager.read_all(latest_snapshot)))
         for entry in current_entries:
             entry.kind = 1  # DELETE


### PR DESCRIPTION
### Purpose

Add `partition_predicate` support to `FileScanner`, matching the Java and Rust implementations:

- Previously, callers like `FileStoreCommit.overwrite()`, `drop_partitions()`, and `CommitScanner` had to build full-schema-indexed predicates (`PredicateBuilder(table.fields)`) that `FileScanner` would internally re-trim to partition keys via `trim_and_transform_predicate`.
- Now `FileScanner` accepts an optional `partition_predicate` parameter indexed directly by partition keys. When provided, it is used as `partition_key_predicate` without any index translation. The existing predicate parameter is preserved for the read path. All write-path callers are simplified to use `PredicateBuilder(partition_keys_fields)` and pass the result as `partition_predicate`.

Close #7708.
                                             
### Tests

- `TestFileScannerPartitionPredicate`: direct use, fallback derivation, no-filter pass-through, manifest file/entry filtering.
- `TestOverwritePartitionPredicate`: partition mismatch rejection, partition-scoped predicate passing, `drop_partitions` OR-predicate.
- `TestCommitScannerPartitionPredicate`: partition-key-indexed predicate construction, unpartitioned table returns None, keyword argument forwarding to FileScanner.