### PR TITLE
[core] Fix orphan files clean deleting data files during concurrent snapshot expiration

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -108,11 +109,42 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         }
         candidateDeletes = new HashSet<>(candidates.keySet());
 
+        AtomicLong missingManifestListCount = new AtomicLong(0);
+        AtomicLong missingManifestCount = new AtomicLong(0);
+
         // find used files
         Set<String> usedFiles =
                 branches.stream()
-                        .flatMap(branch -> getUsedFiles(branch).stream())
+                        .flatMap(
+                                branch ->
+                                        getUsedFiles(
+                                                        branch,
+                                                        missingManifestListCount,
+                                                        missingManifestCount)
+                                                .stream())
                         .collect(Collectors.toSet());
+
+        if (usedFiles.isEmpty()) {
+            LOG.warn(
+                    "Collected used files is empty while {} candidates are present, "
+                            + "aborting orphan files clean to prevent data loss.",
+                    candidateDeletes.size());
+            return new CleanOrphanFilesResult(
+                    deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
+        }
+
+        if (missingManifestListCount.get() > 0 || missingManifestCount.get() > 0) {
+            LOG.warn(
+                    "Detected {} missing manifest-list/index-manifest and {} missing manifest "
+                            + "file(s) during used-files collection while {} candidates are "
+                            + "present; this indicates a concurrent snapshot expiration. "
+                            + "Aborting orphan files clean to prevent data loss.",
+                    missingManifestListCount.get(),
+                    missingManifestCount.get(),
+                    candidateDeletes.size());
+            return new CleanOrphanFilesResult(
+                    deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
+        }
 
         // delete unused files
         candidateDeletes.removeAll(usedFiles);
@@ -157,14 +189,21 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
     }
 
     private void collectWithoutDataFile(
-            String branch, Consumer<String> usedFileConsumer, Consumer<String> manifestConsumer)
+            String branch,
+            Consumer<String> usedFileConsumer,
+            Consumer<String> manifestConsumer,
+            Consumer<String> missingManifestListConsumer)
             throws IOException {
         randomlyOnlyExecute(
                 executor,
                 snapshot -> {
                     try {
                         collectWithoutDataFile(
-                                branch, snapshot, usedFileConsumer, manifestConsumer);
+                                branch,
+                                snapshot,
+                                usedFileConsumer,
+                                manifestConsumer,
+                                missingManifestListConsumer);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -172,20 +211,29 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                 safelyGetAllSnapshots(branch));
     }
 
-    private Set<String> getUsedFiles(String branch) {
+    private Set<String> getUsedFiles(
+            String branch,
+            AtomicLong missingManifestListCount,
+            AtomicLong missingManifestCount) {
         Set<String> usedFiles = ConcurrentHashMap.newKeySet();
         ManifestFile manifestFile =
                 table.switchToBranch(branch).store().manifestFileFactory().create();
         try {
             Set<String> manifests = ConcurrentHashMap.newKeySet();
-            collectWithoutDataFile(branch, usedFiles::add, manifests::add);
+            collectWithoutDataFile(
+                    branch,
+                    usedFiles::add,
+                    manifests::add,
+                    name -> missingManifestListCount.incrementAndGet());
             randomlyOnlyExecute(
                     executor,
                     manifestName -> {
                         try {
+                            AtomicBoolean manifestMissing = new AtomicBoolean(false);
                             retryReadingFiles(
                                             () -> manifestFile.readWithIOException(manifestName),
-                                            Collections.<ManifestEntry>emptyList())
+                                            Collections.<ManifestEntry>emptyList(),
+                                            manifestMissing)
                                     .stream()
                                     .map(ManifestEntry::file)
                                     .forEach(
@@ -197,6 +245,9 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                                                         .filter(candidateDeletes::contains)
                                                         .forEach(usedFiles::add);
                                             });
+                            if (manifestMissing.get()) {
+                                missingManifestCount.incrementAndGet();
+                            }
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -109,39 +109,22 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
         }
         candidateDeletes = new HashSet<>(candidates.keySet());
 
-        AtomicLong missingManifestListCount = new AtomicLong(0);
-        AtomicLong missingManifestCount = new AtomicLong(0);
+        AtomicBoolean missingManifest = new AtomicBoolean(false);
 
         // find used files
         Set<String> usedFiles =
                 branches.stream()
-                        .flatMap(
-                                branch ->
-                                        getUsedFiles(
-                                                        branch,
-                                                        missingManifestListCount,
-                                                        missingManifestCount)
-                                                .stream())
+                        .flatMap(branch -> getUsedFiles(branch, missingManifest).stream())
                         .collect(Collectors.toSet());
 
         if (usedFiles.isEmpty()) {
-            LOG.warn(
-                    "Collected used files is empty while {} candidates are present, "
-                            + "aborting orphan files clean to prevent data loss.",
-                    candidateDeletes.size());
+            LOG.warn("Collected used files is empty, aborting orphan files clean.");
             return new CleanOrphanFilesResult(
                     deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
         }
 
-        if (missingManifestListCount.get() > 0 || missingManifestCount.get() > 0) {
-            LOG.warn(
-                    "Detected {} missing manifest-list/index-manifest and {} missing manifest "
-                            + "file(s) during used-files collection while {} candidates are "
-                            + "present; this indicates a concurrent snapshot expiration. "
-                            + "Aborting orphan files clean to prevent data loss.",
-                    missingManifestListCount.get(),
-                    missingManifestCount.get(),
-                    candidateDeletes.size());
+        if (missingManifest.get()) {
+            LOG.warn("Detected missing manifest during used-files collection, aborting clean.");
             return new CleanOrphanFilesResult(
                     deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
         }
@@ -192,7 +175,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             String branch,
             Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer,
-            Consumer<String> missingManifestListConsumer)
+            AtomicBoolean missingManifest)
             throws IOException {
         randomlyOnlyExecute(
                 executor,
@@ -203,7 +186,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                                 snapshot,
                                 usedFileConsumer,
                                 manifestConsumer,
-                                missingManifestListConsumer);
+                                missingManifest);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -211,29 +194,21 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                 safelyGetAllSnapshots(branch));
     }
 
-    private Set<String> getUsedFiles(
-            String branch,
-            AtomicLong missingManifestListCount,
-            AtomicLong missingManifestCount) {
+    private Set<String> getUsedFiles(String branch, AtomicBoolean missingManifest) {
         Set<String> usedFiles = ConcurrentHashMap.newKeySet();
         ManifestFile manifestFile =
                 table.switchToBranch(branch).store().manifestFileFactory().create();
         try {
             Set<String> manifests = ConcurrentHashMap.newKeySet();
-            collectWithoutDataFile(
-                    branch,
-                    usedFiles::add,
-                    manifests::add,
-                    name -> missingManifestListCount.incrementAndGet());
+            collectWithoutDataFile(branch, usedFiles::add, manifests::add, missingManifest);
             randomlyOnlyExecute(
                     executor,
                     manifestName -> {
                         try {
-                            AtomicBoolean manifestMissing = new AtomicBoolean(false);
                             retryReadingFiles(
                                             () -> manifestFile.readWithIOException(manifestName),
                                             Collections.<ManifestEntry>emptyList(),
-                                            manifestMissing)
+                                            missingManifest)
                                     .stream()
                                     .map(ManifestEntry::file)
                                     .forEach(
@@ -245,9 +220,6 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                                                         .filter(candidateDeletes::contains)
                                                         .forEach(usedFiles::add);
                                             });
-                            if (manifestMissing.get()) {
-                                missingManifestCount.incrementAndGet();
-                            }
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileStatus;
@@ -53,6 +54,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.FileStorePathFactory.BUCKET_PATH_PREFIX;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
@@ -175,18 +177,34 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             String branch,
             Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer,
+            Consumer<String> liveManifestConsumer,
             AtomicBoolean missingManifest)
             throws IOException {
+        Set<Snapshot> liveSnapshots =
+                DEFAULT_MAIN_BRANCH.equals(branch)
+                        ? new HashSet<>(
+                                table.switchToBranch(branch)
+                                        .snapshotManager()
+                                        .safelyGetAllSnapshots())
+                        : Collections.emptySet();
         randomlyOnlyExecute(
                 executor,
                 snapshot -> {
                     try {
+                        boolean live = liveSnapshots.contains(snapshot);
+                        Consumer<String> perSnapshotManifestConsumer =
+                                live
+                                        ? manifest -> {
+                                            manifestConsumer.accept(manifest);
+                                            liveManifestConsumer.accept(manifest);
+                                        }
+                                        : manifestConsumer;
                         collectWithoutDataFile(
                                 branch,
                                 snapshot,
                                 usedFileConsumer,
-                                manifestConsumer,
-                                missingManifest);
+                                perSnapshotManifestConsumer,
+                                live ? missingManifest : null);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -200,15 +218,19 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                 table.switchToBranch(branch).store().manifestFileFactory().create();
         try {
             Set<String> manifests = ConcurrentHashMap.newKeySet();
-            collectWithoutDataFile(branch, usedFiles::add, manifests::add, missingManifest);
+            Set<String> liveManifests = ConcurrentHashMap.newKeySet();
+            collectWithoutDataFile(
+                    branch, usedFiles::add, manifests::add, liveManifests::add, missingManifest);
             randomlyOnlyExecute(
                     executor,
                     manifestName -> {
                         try {
+                            AtomicBoolean fnfFallback =
+                                    liveManifests.contains(manifestName) ? missingManifest : null;
                             retryReadingFiles(
                                             () -> manifestFile.readWithIOException(manifestName),
                                             Collections.<ManifestEntry>emptyList(),
-                                            missingManifest)
+                                            fnfFallback)
                                     .stream()
                                     .map(ManifestEntry::file)
                                     .forEach(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -179,9 +179,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             Consumer<String> liveManifestConsumer,
             AtomicBoolean missingManifest)
             throws IOException {
-        Set<Snapshot> liveSnapshots =
-                new HashSet<>(
-                        table.switchToBranch(branch).snapshotManager().safelyGetAllSnapshots());
+        Set<Snapshot> liveSnapshots = safelyGetLiveSnapshots(branch);
+        Set<Snapshot> snapshots = snapshotsIncludingTagsAndChangelogs(branch, liveSnapshots);
         randomlyOnlyExecute(
                 executor,
                 snapshot -> {
@@ -204,7 +203,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                         throw new RuntimeException(e);
                     }
                 },
-                safelyGetAllSnapshots(branch));
+                snapshots);
     }
 
     private Set<String> getUsedFiles(String branch, AtomicBoolean missingManifest) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -118,12 +118,6 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
                         .flatMap(branch -> getUsedFiles(branch, missingManifest).stream())
                         .collect(Collectors.toSet());
 
-        if (usedFiles.isEmpty()) {
-            LOG.warn("Collected used files is empty, aborting orphan files clean.");
-            return new CleanOrphanFilesResult(
-                    deleteFiles.size(), deletedFilesLenInBytes.get(), deleteFiles);
-        }
-
         if (missingManifest.get()) {
             LOG.warn("Detected missing manifest during used-files collection, aborting clean.");
             return new CleanOrphanFilesResult(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -54,7 +54,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.FileStorePathFactory.BUCKET_PATH_PREFIX;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
@@ -181,12 +180,8 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             AtomicBoolean missingManifest)
             throws IOException {
         Set<Snapshot> liveSnapshots =
-                DEFAULT_MAIN_BRANCH.equals(branch)
-                        ? new HashSet<>(
-                                table.switchToBranch(branch)
-                                        .snapshotManager()
-                                        .safelyGetAllSnapshots())
-                        : Collections.emptySet();
+                new HashSet<>(
+                        table.switchToBranch(branch).snapshotManager().safelyGetAllSnapshots());
         randomlyOnlyExecute(
                 executor,
                 snapshot -> {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -260,6 +261,16 @@ public abstract class OrphanFilesClean implements Serializable {
             Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer)
             throws IOException {
+        collectWithoutDataFile(branch, snapshot, usedFileConsumer, manifestConsumer, name -> {});
+    }
+
+    protected void collectWithoutDataFile(
+            String branch,
+            Snapshot snapshot,
+            Consumer<String> usedFileConsumer,
+            Consumer<String> manifestConsumer,
+            Consumer<String> missingManifestListConsumer)
+            throws IOException {
         Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer =
                 fileAndFlag -> {
                     if (fileAndFlag.getRight()) {
@@ -267,7 +278,8 @@ public abstract class OrphanFilesClean implements Serializable {
                     }
                     usedFileConsumer.accept(fileAndFlag.getLeft());
                 };
-        collectWithoutDataFileWithManifestFlag(branch, snapshot, usedFileWithFlagConsumer);
+        collectWithoutDataFileWithManifestFlag(
+                branch, snapshot, usedFileWithFlagConsumer, missingManifestListConsumer);
     }
 
     protected void collectWithoutDataFileWithManifestFlag(
@@ -275,36 +287,47 @@ public abstract class OrphanFilesClean implements Serializable {
             Snapshot snapshot,
             Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer)
             throws IOException {
+        collectWithoutDataFileWithManifestFlag(
+                branch, snapshot, usedFileWithFlagConsumer, name -> {});
+    }
+
+    protected void collectWithoutDataFileWithManifestFlag(
+            String branch,
+            Snapshot snapshot,
+            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
+            Consumer<String> missingManifestListConsumer)
+            throws IOException {
         FileStoreTable branchTable = table.switchToBranch(branch);
         ManifestList manifestList = branchTable.store().manifestListFactory().create();
         IndexFileHandler indexFileHandler = branchTable.store().newIndexFileHandler();
         List<ManifestFileMeta> manifestFileMetas = new ArrayList<>();
         // changelog manifest
         if (snapshot.changelogManifestList() != null) {
-            usedFileWithFlagConsumer.accept(Pair.of(snapshot.changelogManifestList(), false));
-            manifestFileMetas.addAll(
-                    retryReadingFiles(
-                            () ->
-                                    manifestList.readWithIOException(
-                                            snapshot.changelogManifestList()),
-                            emptyList()));
+            collectManifestList(
+                    manifestList,
+                    snapshot.changelogManifestList(),
+                    manifestFileMetas,
+                    usedFileWithFlagConsumer,
+                    missingManifestListConsumer);
         }
 
         // delta manifest
         if (snapshot.deltaManifestList() != null) {
-            usedFileWithFlagConsumer.accept(Pair.of(snapshot.deltaManifestList(), false));
-            manifestFileMetas.addAll(
-                    retryReadingFiles(
-                            () -> manifestList.readWithIOException(snapshot.deltaManifestList()),
-                            emptyList()));
+            collectManifestList(
+                    manifestList,
+                    snapshot.deltaManifestList(),
+                    manifestFileMetas,
+                    usedFileWithFlagConsumer,
+                    missingManifestListConsumer);
         }
 
         // base manifest
-        usedFileWithFlagConsumer.accept(Pair.of(snapshot.baseManifestList(), false));
-        manifestFileMetas.addAll(
-                retryReadingFiles(
-                        () -> manifestList.readWithIOException(snapshot.baseManifestList()),
-                        emptyList()));
+        collectManifestList(
+                manifestList,
+                snapshot.baseManifestList(),
+                manifestFileMetas,
+                usedFileWithFlagConsumer,
+                missingManifestListConsumer);
 
         // collect manifests
         for (ManifestFileMeta manifest : manifestFileMetas) {
@@ -314,20 +337,48 @@ public abstract class OrphanFilesClean implements Serializable {
         // index files
         String indexManifest = snapshot.indexManifest();
         if (indexManifest != null && indexFileHandler.existsManifest(indexManifest)) {
-            usedFileWithFlagConsumer.accept(Pair.of(indexManifest, false));
-            retryReadingFiles(
+            AtomicBoolean indexManifestMissing = new AtomicBoolean(false);
+            List<IndexManifestEntry> indexEntries =
+                    retryReadingFiles(
                             () -> indexFileHandler.readManifestWithIOException(indexManifest),
-                            Collections.<IndexManifestEntry>emptyList())
-                    .stream()
-                    .map(IndexManifestEntry::indexFile)
-                    .map(IndexFileMeta::fileName)
-                    .forEach(name -> usedFileWithFlagConsumer.accept(Pair.of(name, false)));
+                            Collections.<IndexManifestEntry>emptyList(),
+                            indexManifestMissing);
+            if (indexManifestMissing.get()) {
+                missingManifestListConsumer.accept(indexManifest);
+            } else {
+                usedFileWithFlagConsumer.accept(Pair.of(indexManifest, false));
+                indexEntries.stream()
+                        .map(IndexManifestEntry::indexFile)
+                        .map(IndexFileMeta::fileName)
+                        .forEach(name -> usedFileWithFlagConsumer.accept(Pair.of(name, false)));
+            }
         }
 
         // statistic file
         if (snapshot.statistics() != null) {
             usedFileWithFlagConsumer.accept(Pair.of(snapshot.statistics(), false));
         }
+    }
+
+    private static void collectManifestList(
+            ManifestList manifestList,
+            String manifestListName,
+            List<ManifestFileMeta> manifestFileMetas,
+            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
+            Consumer<String> missingManifestListConsumer)
+            throws IOException {
+        AtomicBoolean missing = new AtomicBoolean(false);
+        List<ManifestFileMeta> metas =
+                retryReadingFiles(
+                        () -> manifestList.readWithIOException(manifestListName),
+                        emptyList(),
+                        missing);
+        if (missing.get()) {
+            missingManifestListConsumer.accept(manifestListName);
+            return;
+        }
+        usedFileWithFlagConsumer.accept(Pair.of(manifestListName, false));
+        manifestFileMetas.addAll(metas);
     }
 
     /** List directories that contains data files and manifest files. */
@@ -444,12 +495,23 @@ public abstract class OrphanFilesClean implements Serializable {
      */
     protected static <T> T retryReadingFiles(SupplierWithIOException<T> reader, T defaultValue)
             throws IOException {
+        return retryReadingFiles(reader, defaultValue, null);
+    }
+
+    protected static <T> T retryReadingFiles(
+            SupplierWithIOException<T> reader,
+            T defaultValue,
+            @Nullable AtomicBoolean fnfFallback)
+            throws IOException {
         int retryNumber = 0;
         IOException caught = null;
         while (retryNumber++ < READ_FILE_RETRY_NUM) {
             try {
                 return reader.get();
             } catch (FileNotFoundException e) {
+                if (fnfFallback != null) {
+                    fnfFallback.set(true);
+                }
                 return defaultValue;
             } catch (IOException e) {
                 caught = e;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -260,7 +260,7 @@ public abstract class OrphanFilesClean implements Serializable {
             Snapshot snapshot,
             Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer,
-            AtomicBoolean missingManifest)
+            @Nullable AtomicBoolean missingManifest)
             throws IOException {
         Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer =
                 fileAndFlag -> {
@@ -277,7 +277,7 @@ public abstract class OrphanFilesClean implements Serializable {
             String branch,
             Snapshot snapshot,
             Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
-            AtomicBoolean missingManifest)
+            @Nullable AtomicBoolean missingManifest)
             throws IOException {
         FileStoreTable branchTable = table.switchToBranch(branch);
         ManifestList manifestList = branchTable.store().manifestListFactory().create();
@@ -300,7 +300,7 @@ public abstract class OrphanFilesClean implements Serializable {
                             emptyList(),
                             missingManifest);
             // A missing manifest list means we cannot determine all used files, so abort.
-            if (missingManifest.get()) {
+            if (missingManifest != null && missingManifest.get()) {
                 return;
             }
             usedFileWithFlagConsumer.accept(Pair.of(manifestListName, false));
@@ -320,7 +320,7 @@ public abstract class OrphanFilesClean implements Serializable {
                             () -> indexFileHandler.readManifestWithIOException(indexManifest),
                             Collections.<IndexManifestEntry>emptyList(),
                             missingManifest);
-            if (!missingManifest.get()) {
+            if (missingManifest == null || !missingManifest.get()) {
                 usedFileWithFlagConsumer.accept(Pair.of(indexManifest, false));
                 indexEntries.stream()
                         .map(IndexManifestEntry::indexFile)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -259,17 +259,8 @@ public abstract class OrphanFilesClean implements Serializable {
             String branch,
             Snapshot snapshot,
             Consumer<String> usedFileConsumer,
-            Consumer<String> manifestConsumer)
-            throws IOException {
-        collectWithoutDataFile(branch, snapshot, usedFileConsumer, manifestConsumer, name -> {});
-    }
-
-    protected void collectWithoutDataFile(
-            String branch,
-            Snapshot snapshot,
-            Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer,
-            Consumer<String> missingManifestListConsumer)
+            AtomicBoolean missingManifest)
             throws IOException {
         Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer =
                 fileAndFlag -> {
@@ -279,55 +270,42 @@ public abstract class OrphanFilesClean implements Serializable {
                     usedFileConsumer.accept(fileAndFlag.getLeft());
                 };
         collectWithoutDataFileWithManifestFlag(
-                branch, snapshot, usedFileWithFlagConsumer, missingManifestListConsumer);
-    }
-
-    protected void collectWithoutDataFileWithManifestFlag(
-            String branch,
-            Snapshot snapshot,
-            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer)
-            throws IOException {
-        collectWithoutDataFileWithManifestFlag(
-                branch, snapshot, usedFileWithFlagConsumer, name -> {});
+                branch, snapshot, usedFileWithFlagConsumer, missingManifest);
     }
 
     protected void collectWithoutDataFileWithManifestFlag(
             String branch,
             Snapshot snapshot,
             Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
-            Consumer<String> missingManifestListConsumer)
+            AtomicBoolean missingManifest)
             throws IOException {
         FileStoreTable branchTable = table.switchToBranch(branch);
         ManifestList manifestList = branchTable.store().manifestListFactory().create();
         IndexFileHandler indexFileHandler = branchTable.store().newIndexFileHandler();
         List<ManifestFileMeta> manifestFileMetas = new ArrayList<>();
-        // changelog manifest
+        // collect changelog, delta and base manifest lists
+        List<String> manifestListNames = new ArrayList<>();
         if (snapshot.changelogManifestList() != null) {
-            collectManifestList(
-                    manifestList,
-                    snapshot.changelogManifestList(),
-                    manifestFileMetas,
-                    usedFileWithFlagConsumer,
-                    missingManifestListConsumer);
+            manifestListNames.add(snapshot.changelogManifestList());
         }
-
-        // delta manifest
         if (snapshot.deltaManifestList() != null) {
-            collectManifestList(
-                    manifestList,
-                    snapshot.deltaManifestList(),
-                    manifestFileMetas,
-                    usedFileWithFlagConsumer,
-                    missingManifestListConsumer);
+            manifestListNames.add(snapshot.deltaManifestList());
         }
+        manifestListNames.add(snapshot.baseManifestList());
 
-        // base manifest
-        collectManifestList(
-                manifestList,
-                snapshot.baseManifestList(),
-                manifestFileMetas,
-                usedFileWithFlagConsumer,
-                missingManifestListConsumer);
+        for (String manifestListName : manifestListNames) {
+            List<ManifestFileMeta> metas =
+                    retryReadingFiles(
+                            () -> manifestList.readWithIOException(manifestListName),
+                            emptyList(),
+                            missingManifest);
+            // A missing manifest list means we cannot determine all used files, so abort.
+            if (missingManifest.get()) {
+                return;
+            }
+            usedFileWithFlagConsumer.accept(Pair.of(manifestListName, false));
+            manifestFileMetas.addAll(metas);
+        }
 
         // collect manifests
         for (ManifestFileMeta manifest : manifestFileMetas) {
@@ -337,15 +315,12 @@ public abstract class OrphanFilesClean implements Serializable {
         // index files
         String indexManifest = snapshot.indexManifest();
         if (indexManifest != null && indexFileHandler.existsManifest(indexManifest)) {
-            AtomicBoolean indexManifestMissing = new AtomicBoolean(false);
             List<IndexManifestEntry> indexEntries =
                     retryReadingFiles(
                             () -> indexFileHandler.readManifestWithIOException(indexManifest),
                             Collections.<IndexManifestEntry>emptyList(),
-                            indexManifestMissing);
-            if (indexManifestMissing.get()) {
-                missingManifestListConsumer.accept(indexManifest);
-            } else {
+                            missingManifest);
+            if (!missingManifest.get()) {
                 usedFileWithFlagConsumer.accept(Pair.of(indexManifest, false));
                 indexEntries.stream()
                         .map(IndexManifestEntry::indexFile)
@@ -358,27 +333,6 @@ public abstract class OrphanFilesClean implements Serializable {
         if (snapshot.statistics() != null) {
             usedFileWithFlagConsumer.accept(Pair.of(snapshot.statistics(), false));
         }
-    }
-
-    private static void collectManifestList(
-            ManifestList manifestList,
-            String manifestListName,
-            List<ManifestFileMeta> manifestFileMetas,
-            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
-            Consumer<String> missingManifestListConsumer)
-            throws IOException {
-        AtomicBoolean missing = new AtomicBoolean(false);
-        List<ManifestFileMeta> metas =
-                retryReadingFiles(
-                        () -> manifestList.readWithIOException(manifestListName),
-                        emptyList(),
-                        missing);
-        if (missing.get()) {
-            missingManifestListConsumer.accept(manifestListName);
-            return;
-        }
-        usedFileWithFlagConsumer.accept(Pair.of(manifestListName, false));
-        manifestFileMetas.addAll(metas);
     }
 
     /** List directories that contains data files and manifest files. */
@@ -499,9 +453,7 @@ public abstract class OrphanFilesClean implements Serializable {
     }
 
     protected static <T> T retryReadingFiles(
-            SupplierWithIOException<T> reader,
-            T defaultValue,
-            @Nullable AtomicBoolean fnfFallback)
+            SupplierWithIOException<T> reader, T defaultValue, @Nullable AtomicBoolean fnfFallback)
             throws IOException {
         int retryNumber = 0;
         IOException caught = null;
@@ -511,6 +463,9 @@ public abstract class OrphanFilesClean implements Serializable {
             } catch (FileNotFoundException e) {
                 if (fnfFallback != null) {
                     fnfFallback.set(true);
+                    LOG.warn(
+                            "File not found while collecting used files, aborting orphan files clean.",
+                            e);
                 }
                 return defaultValue;
             } catch (IOException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -38,7 +38,6 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SupplierWithIOException;
-import org.apache.paimon.utils.TagManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,15 +243,18 @@ public abstract class OrphanFilesClean implements Serializable {
         return path.getName().endsWith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX);
     }
 
-    protected Set<Snapshot> safelyGetAllSnapshots(String branch) throws IOException {
+    protected Set<Snapshot> safelyGetLiveSnapshots(String branch) throws IOException {
         FileStoreTable branchTable = table.switchToBranch(branch);
-        SnapshotManager snapshotManager = branchTable.snapshotManager();
-        ChangelogManager changelogManager = branchTable.changelogManager();
-        TagManager tagManager = branchTable.tagManager();
-        Set<Snapshot> readSnapshots = new HashSet<>(snapshotManager.safelyGetAllSnapshots());
-        readSnapshots.addAll(tagManager.taggedSnapshots());
-        readSnapshots.addAll(changelogManager.safelyGetAllChangelogs());
-        return readSnapshots;
+        return new HashSet<>(branchTable.snapshotManager().safelyGetAllSnapshots());
+    }
+
+    protected Set<Snapshot> snapshotsIncludingTagsAndChangelogs(
+            String branch, Set<Snapshot> liveSnapshots) throws IOException {
+        FileStoreTable branchTable = table.switchToBranch(branch);
+        Set<Snapshot> snapshots = new HashSet<>(liveSnapshots);
+        snapshots.addAll(branchTable.tagManager().taggedSnapshots());
+        snapshots.addAll(branchTable.changelogManager().safelyGetAllChangelogs());
+        return snapshots;
     }
 
     protected void collectWithoutDataFile(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -704,6 +704,46 @@ public class LocalOrphanFilesCleanTest {
         assertThat(fileIO.exists(unknownDir)).isTrue();
     }
 
+    @Test
+    void testAbortWhenManifestListMissingDuringConcurrentExpiration() throws Exception {
+        commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
+        commit(Collections.singletonList(new TestPojo(2, 0, "b", "v2")));
+        commit(Collections.singletonList(new TestPojo(3, 1, "c", "v3")));
+
+        List<Path> dataFilesBefore = new ArrayList<>();
+        collectDataFiles(tablePath, dataFilesBefore);
+        assertThat(dataFilesBefore).isNotEmpty();
+
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        Path missingManifestList = new Path(manifestDir, latest.baseManifestList());
+        assertThat(fileIO.exists(missingManifestList)).isTrue();
+        fileIO.deleteQuietly(missingManifestList);
+
+        LocalOrphanFilesClean orphanFilesClean =
+                new LocalOrphanFilesClean(
+                        table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFileCount()).isEqualTo(0);
+        for (Path dataFile : dataFilesBefore) {
+            assertThat(fileIO.exists(dataFile)).isTrue();
+        }
+    }
+
+    private void collectDataFiles(Path dir, List<Path> result) throws IOException {
+        FileStatus[] statuses = fileIO.listStatus(dir);
+        if (statuses == null) {
+            return;
+        }
+        for (FileStatus status : statuses) {
+            if (status.isDir()) {
+                collectDataFiles(status.getPath(), result);
+            } else if (status.getPath().getParent().getName().startsWith(BUCKET_PATH_PREFIX)) {
+                result.add(status.getPath());
+            }
+        }
+    }
+
     private void writeData(
             SnapshotManager snapshotManager,
             List<List<TestPojo>> committedData,

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -550,6 +550,10 @@ public class LocalOrphanFilesCleanTest {
             commit(generateData());
         }
 
+        List<Path> dataFilesBefore = new ArrayList<>();
+        collectDataFiles(tablePath, dataFilesBefore);
+        assertThat(dataFilesBefore).isNotEmpty();
+
         // randomly delete a manifest file of snapshot 1
         SnapshotManager snapshotManager = table.snapshotManager();
         Snapshot snapshot1 = snapshotManager.snapshot(1);
@@ -567,7 +571,12 @@ public class LocalOrphanFilesCleanTest {
         LocalOrphanFilesClean orphanFilesClean =
                 new LocalOrphanFilesClean(
                         table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
-        assertThat(orphanFilesClean.clean().getDeletedFilesPath().size()).isGreaterThan(0);
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFileCount()).isEqualTo(0);
+        for (Path dataFile : dataFilesBefore) {
+            assertThat(fileIO.exists(dataFile)).isTrue();
+        }
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -83,6 +83,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
 import static org.apache.paimon.utils.BranchManager.branchPath;
 import static org.apache.paimon.utils.FileStorePathFactory.BUCKET_PATH_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -779,6 +780,49 @@ public class LocalOrphanFilesCleanTest {
         LocalOrphanFilesClean orphanFilesClean =
                 new LocalOrphanFilesClean(
                         table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFileCount()).isEqualTo(0);
+        for (Path dataFile : dataFilesBefore) {
+            assertThat(fileIO.exists(dataFile)).isTrue();
+        }
+    }
+
+    @Test
+    void testReuseCapturedLiveSnapshots() throws Exception {
+        commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
+        Snapshot mainSnapshot = table.snapshotManager().latestSnapshot();
+
+        String branchName = "branch1";
+        table.createBranch(branchName);
+        FileStoreTable branchTable = table.switchToBranch(branchName);
+        String branchCommitUser = UUID.randomUUID().toString();
+        try (TableWriteImpl<?> branchWrite = branchTable.newWrite(branchCommitUser);
+                TableCommitImpl branchCommit = branchTable.newCommit(branchCommitUser)) {
+            branchWrite.write(new TestPojo(2, 0, "b", "v2").toRow(RowKind.INSERT));
+            branchCommit.commit(0, branchWrite.prepareCommit(true, 0));
+        }
+
+        List<Path> dataFilesBefore = new ArrayList<>();
+        collectDataFiles(tablePath, dataFilesBefore);
+        assertThat(dataFilesBefore).isNotEmpty();
+
+        LocalOrphanFilesClean orphanFilesClean =
+                new LocalOrphanFilesClean(
+                        table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2)) {
+                    @Override
+                    protected Set<Snapshot> snapshotsIncludingTagsAndChangelogs(
+                            String branch, Set<Snapshot> liveSnapshots) throws IOException {
+                        if (DEFAULT_MAIN_BRANCH.equals(branch)) {
+                            fileIO.deleteQuietly(
+                                    table.snapshotManager().snapshotPath(mainSnapshot.id()));
+                            fileIO.deleteQuietly(
+                                    new Path(manifestDir, mainSnapshot.baseManifestList()));
+                        }
+                        return super.snapshotsIncludingTagsAndChangelogs(branch, liveSnapshots);
+                    }
+                };
+
         CleanOrphanFilesResult result = orphanFilesClean.clean();
 
         assertThat(result.getDeletedFileCount()).isEqualTo(0);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -212,8 +212,13 @@ public class LocalOrphanFilesCleanTest {
         table.copy(expireOptions.toMap()).newCommit("").expireSnapshots();
 
         // randomly delete tags
-        List<String> deleteTags = Collections.emptyList();
-        deleteTags = randomlyPick(allTags);
+        String branchBaseTag = allTags.get(0);
+        List<String> deletableTags =
+                allTags.stream()
+                        .filter(tag -> !tag.equals(branchBaseTag))
+                        .collect(Collectors.toList());
+        List<String> deleteTags =
+                deletableTags.isEmpty() ? Collections.emptyList() : randomlyPick(deletableTags);
         for (String tagName : deleteTags) {
             table.deleteTag(tagName);
         }
@@ -315,8 +320,13 @@ public class LocalOrphanFilesCleanTest {
         table.copy(expireOptions.toMap()).newCommit("").expireSnapshots();
 
         // randomly delete tags
-        List<String> deleteTags = Collections.emptyList();
-        deleteTags = randomlyPick(allTags);
+        String branchBaseTag = allTags.get(0);
+        List<String> deletableTags =
+                allTags.stream()
+                        .filter(tag -> !tag.equals(branchBaseTag))
+                        .collect(Collectors.toList());
+        List<String> deleteTags =
+                deletableTags.isEmpty() ? Collections.emptyList() : randomlyPick(deletableTags);
         for (String tagName : deleteTags) {
             table.deleteTag(tagName);
         }
@@ -725,6 +735,44 @@ public class LocalOrphanFilesCleanTest {
 
         Snapshot latest = table.snapshotManager().latestSnapshot();
         Path missingManifestList = new Path(manifestDir, latest.baseManifestList());
+        assertThat(fileIO.exists(missingManifestList)).isTrue();
+        fileIO.deleteQuietly(missingManifestList);
+
+        LocalOrphanFilesClean orphanFilesClean =
+                new LocalOrphanFilesClean(
+                        table, System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(2));
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFileCount()).isEqualTo(0);
+        for (Path dataFile : dataFilesBefore) {
+            assertThat(fileIO.exists(dataFile)).isTrue();
+        }
+    }
+
+    @Test
+    void testAbortWhenBranchManifestListMissingDuringConcurrentExpiration() throws Exception {
+        commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
+
+        String branchName = "branch1";
+        table.createBranch(branchName);
+        FileStoreTable branchTable = table.switchToBranch(branchName);
+        String branchCommitUser = UUID.randomUUID().toString();
+        try (TableWriteImpl<?> branchWrite = branchTable.newWrite(branchCommitUser);
+                TableCommitImpl branchCommit = branchTable.newCommit(branchCommitUser)) {
+            branchWrite.write(new TestPojo(2, 0, "a", "v2").toRow(RowKind.INSERT));
+            branchCommit.commit(0, branchWrite.prepareCommit(true, 0));
+            branchWrite.write(new TestPojo(3, 0, "b", "v3").toRow(RowKind.INSERT));
+            branchCommit.commit(1, branchWrite.prepareCommit(true, 1));
+            branchWrite.write(new TestPojo(4, 1, "c", "v4").toRow(RowKind.INSERT));
+            branchCommit.commit(2, branchWrite.prepareCommit(true, 2));
+        }
+
+        List<Path> dataFilesBefore = new ArrayList<>();
+        collectDataFiles(tablePath, dataFilesBefore);
+        assertThat(dataFilesBefore).isNotEmpty();
+
+        Snapshot branchLatest = branchTable.snapshotManager().latestSnapshot();
+        Path missingManifestList = new Path(manifestDir, branchLatest.baseManifestList());
         assertThat(fileIO.exists(missingManifestList)).isTrue();
         fileIO.deleteQuietly(missingManifestList);
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -37,6 +37,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -66,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -147,54 +149,73 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                         .name("branch-snapshot-deletion-result");
 
         // branch and manifest file
-        final OutputTag<Tuple2<String, String>> manifestOutputTag =
-                new OutputTag<Tuple2<String, String>>("manifest-output") {};
+        final OutputTag<Tuple3<String, String, Boolean>> manifestOutputTag =
+                new OutputTag<Tuple3<String, String, Boolean>>("manifest-output") {};
 
         SingleOutputStreamOperator<String> usedManifestFiles =
                 env.fromCollection(branches)
                         .name("branch-source")
                         .process(
-                                new ProcessFunction<String, Tuple2<String, String>>() {
+                                new ProcessFunction<String, Tuple3<String, String, Boolean>>() {
                                     @Override
                                     public void processElement(
                                             String branch,
-                                            ProcessFunction<String, Tuple2<String, String>>.Context
+                                            ProcessFunction<String, Tuple3<String, String, Boolean>>
+                                                            .Context
                                                     ctx,
-                                            Collector<Tuple2<String, String>> out)
+                                            Collector<Tuple3<String, String, Boolean>> out)
                                             throws Exception {
+                                        Set<Long> liveSnapshotIds =
+                                                Identifier.DEFAULT_MAIN_BRANCH.equals(branch)
+                                                        ? table.switchToBranch(branch)
+                                                                .snapshotManager()
+                                                                .safelyGetAllSnapshots().stream()
+                                                                .map(Snapshot::id)
+                                                                .collect(Collectors.toSet())
+                                                        : Collections.emptySet();
                                         for (Snapshot snapshot : safelyGetAllSnapshots(branch)) {
-                                            out.collect(new Tuple2<>(branch, snapshot.toJson()));
+                                            out.collect(
+                                                    new Tuple3<>(
+                                                            branch,
+                                                            snapshot.toJson(),
+                                                            liveSnapshotIds.contains(
+                                                                    snapshot.id())));
                                         }
                                     }
                                 })
                         .name("collect-snapshots")
                         .rebalance()
                         .process(
-                                new ProcessFunction<Tuple2<String, String>, String>() {
+                                new ProcessFunction<Tuple3<String, String, Boolean>, String>() {
 
                                     @Override
                                     public void processElement(
-                                            Tuple2<String, String> branchAndSnapshot,
-                                            ProcessFunction<Tuple2<String, String>, String>.Context
+                                            Tuple3<String, String, Boolean> branchAndSnapshot,
+                                            ProcessFunction<Tuple3<String, String, Boolean>, String>
+                                                            .Context
                                                     ctx,
                                             Collector<String> out)
                                             throws Exception {
                                         String branch = branchAndSnapshot.f0;
                                         Snapshot snapshot = Snapshot.fromJson(branchAndSnapshot.f1);
+                                        boolean liveOnMainBranch = branchAndSnapshot.f2;
                                         Consumer<String> manifestConsumer =
-                                                manifest -> {
-                                                    Tuple2<String, String> tuple2 =
-                                                            new Tuple2<>(branch, manifest);
-                                                    ctx.output(manifestOutputTag, tuple2);
-                                                };
-                                        AtomicBoolean missingManifest = new AtomicBoolean(false);
+                                                manifest ->
+                                                        ctx.output(
+                                                                manifestOutputTag,
+                                                                new Tuple3<>(
+                                                                        branch,
+                                                                        manifest,
+                                                                        liveOnMainBranch));
+                                        AtomicBoolean missingManifest =
+                                                liveOnMainBranch ? new AtomicBoolean(false) : null;
                                         collectWithoutDataFile(
                                                 branch,
                                                 snapshot,
                                                 out::collect,
                                                 manifestConsumer,
                                                 missingManifest);
-                                        if (missingManifest.get()) {
+                                        if (missingManifest != null && missingManifest.get()) {
                                             out.collect(MISSING_MANIFEST_SENTINEL);
                                         }
                                     }
@@ -204,40 +225,46 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
         DataStream<String> usedFiles =
                 usedManifestFiles
                         .getSideOutput(manifestOutputTag)
-                        .keyBy(tuple2 -> tuple2.f0 + ":" + tuple2.f1)
+                        .keyBy(tuple3 -> tuple3.f0 + ":" + tuple3.f1)
                         .transform(
                                 "collect-used-files",
                                 STRING_TYPE_INFO,
-                                new BoundedOneInputOperator<Tuple2<String, String>, String>() {
+                                new BoundedOneInputOperator<
+                                        Tuple3<String, String, Boolean>, String>() {
 
-                                    private final Set<Tuple2<String, String>> manifests =
-                                            new HashSet<>();
+                                    private final Map<String, Tuple3<String, String, Boolean>>
+                                            manifests = new HashMap<>();
 
                                     @Override
                                     public void processElement(
-                                            StreamRecord<Tuple2<String, String>> element) {
-                                        manifests.add(element.getValue());
+                                            StreamRecord<Tuple3<String, String, Boolean>> element) {
+                                        Tuple3<String, String, Boolean> value = element.getValue();
+                                        manifests.merge(
+                                                value.f0 + ":" + value.f1,
+                                                value,
+                                                (a, b) -> new Tuple3<>(a.f0, a.f1, a.f2 || b.f2));
                                     }
 
                                     @Override
                                     public void endInput() throws IOException {
                                         Map<String, ManifestFile> branchManifests = new HashMap<>();
-                                        for (Tuple2<String, String> tuple2 : manifests) {
+                                        for (Tuple3<String, String, Boolean> tuple :
+                                                manifests.values()) {
                                             ManifestFile manifestFile =
                                                     branchManifests.computeIfAbsent(
-                                                            tuple2.f0,
+                                                            tuple.f0,
                                                             key ->
                                                                     table.switchToBranch(key)
                                                                             .store()
                                                                             .manifestFileFactory()
                                                                             .create());
                                             AtomicBoolean manifestMissing =
-                                                    new AtomicBoolean(false);
+                                                    tuple.f2 ? new AtomicBoolean(false) : null;
                                             retryReadingFiles(
                                                             () ->
                                                                     manifestFile
                                                                             .readWithIOException(
-                                                                                    tuple2.f1),
+                                                                                    tuple.f1),
                                                             Collections.<ManifestEntry>emptyList(),
                                                             manifestMissing)
                                                     .forEach(
@@ -252,7 +279,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                                                         new StreamRecord<>(
                                                                                                 file)));
                                                             });
-                                            if (manifestMissing.get()) {
+                                            if (manifestMissing != null && manifestMissing.get()) {
                                                 output.collect(
                                                         new StreamRecord<>(
                                                                 MISSING_MANIFEST_SENTINEL));

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -63,6 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
@@ -74,6 +75,9 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class FlinkOrphanFilesClean extends OrphanFilesClean {
 
     protected static final Logger LOG = LoggerFactory.getLogger(FlinkOrphanFilesClean.class);
+
+    private static final String MISSING_MANIFEST_SENTINEL =
+            "__PAIMON_ORPHAN_CLEAN_MISSING_MANIFEST__";
 
     @Nullable protected final Integer parallelism;
 
@@ -183,8 +187,14 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                             new Tuple2<>(branch, manifest);
                                                     ctx.output(manifestOutputTag, tuple2);
                                                 };
+                                        Consumer<String> missingManifestListConsumer =
+                                                name -> out.collect(MISSING_MANIFEST_SENTINEL);
                                         collectWithoutDataFile(
-                                                branch, snapshot, out::collect, manifestConsumer);
+                                                branch,
+                                                snapshot,
+                                                out::collect,
+                                                manifestConsumer,
+                                                missingManifestListConsumer);
                                     }
                                 })
                         .name("collect-manifests");
@@ -219,12 +229,15 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                                             .store()
                                                                             .manifestFileFactory()
                                                                             .create());
+                                            AtomicBoolean manifestMissing =
+                                                    new AtomicBoolean(false);
                                             retryReadingFiles(
                                                             () ->
                                                                     manifestFile
                                                                             .readWithIOException(
                                                                                     tuple2.f1),
-                                                            Collections.<ManifestEntry>emptyList())
+                                                            Collections.<ManifestEntry>emptyList(),
+                                                            manifestMissing)
                                                     .forEach(
                                                             f -> {
                                                                 List<String> files =
@@ -237,6 +250,11 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                                                         new StreamRecord<>(
                                                                                                 file)));
                                                             });
+                                            if (manifestMissing.get()) {
+                                                output.collect(
+                                                        new StreamRecord<>(
+                                                                MISSING_MANIFEST_SENTINEL));
+                                            }
                                         }
                                     }
                                 });
@@ -369,6 +387,8 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                     private long emittedFilesCount;
                                     private long emittedFilesLen;
 
+                                    private boolean abortDeletion;
+
                                     private final Set<String> used = new HashSet<>();
 
                                     @Override
@@ -385,6 +405,15 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                 checkState(!buildEnd, "Should not build ended.");
                                                 LOG.info("Finish build phase.");
                                                 buildEnd = true;
+                                                if (abortDeletion) {
+                                                    LOG.warn(
+                                                            "Detected missing manifest-list/manifest "
+                                                                    + "during used-files collection; "
+                                                                    + "this indicates a concurrent "
+                                                                    + "snapshot expiration. Aborting "
+                                                                    + "orphan files clean to prevent "
+                                                                    + "data loss.");
+                                                }
                                                 break;
                                             case 2:
                                                 checkState(buildEnd, "Should build ended.");
@@ -404,13 +433,21 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
 
                                     @Override
                                     public void processElement1(StreamRecord<String> element) {
-                                        used.add(element.getValue());
+                                        String value = element.getValue();
+                                        if (MISSING_MANIFEST_SENTINEL.equals(value)) {
+                                            abortDeletion = true;
+                                            return;
+                                        }
+                                        used.add(value);
                                     }
 
                                     @Override
                                     public void processElement2(
                                             StreamRecord<Tuple2<String, Long>> element) {
                                         checkState(buildEnd, "Should build ended.");
+                                        if (abortDeletion) {
+                                            return;
+                                        }
                                         Tuple2<String, Long> fileInfo = element.getValue();
                                         String value = fileInfo.f0;
                                         Path path = new Path(value);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -187,14 +187,16 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                             new Tuple2<>(branch, manifest);
                                                     ctx.output(manifestOutputTag, tuple2);
                                                 };
-                                        Consumer<String> missingManifestListConsumer =
-                                                name -> out.collect(MISSING_MANIFEST_SENTINEL);
+                                        AtomicBoolean missingManifest = new AtomicBoolean(false);
                                         collectWithoutDataFile(
                                                 branch,
                                                 snapshot,
                                                 out::collect,
                                                 manifestConsumer,
-                                                missingManifestListConsumer);
+                                                missingManifest);
+                                        if (missingManifest.get()) {
+                                            out.collect(MISSING_MANIFEST_SENTINEL);
+                                        }
                                     }
                                 })
                         .name("collect-manifests");
@@ -407,12 +409,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                 buildEnd = true;
                                                 if (abortDeletion) {
                                                     LOG.warn(
-                                                            "Detected missing manifest-list/manifest "
-                                                                    + "during used-files collection; "
-                                                                    + "this indicates a concurrent "
-                                                                    + "snapshot expiration. Aborting "
-                                                                    + "orphan files clean to prevent "
-                                                                    + "data loss.");
+                                                            "Detected missing manifest, aborting clean.");
                                                 }
                                                 break;
                                             case 2:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -67,7 +67,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -165,18 +164,16 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                     ctx,
                                             Collector<Tuple3<String, String, Boolean>> out)
                                             throws Exception {
-                                        Set<Long> liveSnapshotIds =
-                                                table.switchToBranch(branch).snapshotManager()
-                                                        .safelyGetAllSnapshots().stream()
-                                                        .map(Snapshot::id)
-                                                        .collect(Collectors.toSet());
-                                        for (Snapshot snapshot : safelyGetAllSnapshots(branch)) {
+                                        Set<Snapshot> liveSnapshots =
+                                                safelyGetLiveSnapshots(branch);
+                                        for (Snapshot snapshot :
+                                                snapshotsIncludingTagsAndChangelogs(
+                                                        branch, liveSnapshots)) {
                                             out.collect(
                                                     new Tuple3<>(
                                                             branch,
                                                             snapshot.toJson(),
-                                                            liveSnapshotIds.contains(
-                                                                    snapshot.id())));
+                                                            liveSnapshots.contains(snapshot)));
                                         }
                                     }
                                 })

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -398,11 +398,74 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                 .setParallelism(1)
                 .setMaxParallelism(1);
 
-        DataStream<CleanOrphanFilesResult> deleted =
+        DataStream<String> missingManifestSignals =
                 usedFiles
+                        .filter(MISSING_MANIFEST_SENTINEL::equals)
+                        .name("missing-manifest-signals");
+        DataStream<String> normalUsedFiles =
+                usedFiles
+                        .filter(file -> !MISSING_MANIFEST_SENTINEL.equals(file))
+                        .name("normal-used-files");
+
+        DataStream<Tuple2<String, Long>> candidatesAfterGlobalAbort =
+                missingManifestSignals
+                        .broadcast()
+                        .connect(candidates)
+                        .transform(
+                                "abort-candidates-on-missing-manifest",
+                                candidates.getType(),
+                                new BoundedTwoInputOperator<
+                                        String, Tuple2<String, Long>, Tuple2<String, Long>>() {
+
+                                    private boolean signalEnd;
+                                    private boolean abortDeletion;
+
+                                    @Override
+                                    public InputSelection nextSelection() {
+                                        return signalEnd
+                                                ? InputSelection.SECOND
+                                                : InputSelection.FIRST;
+                                    }
+
+                                    @Override
+                                    public void endInput(int inputId) {
+                                        if (inputId == 1) {
+                                            checkState(!signalEnd, "Signal input already ended.");
+                                            signalEnd = true;
+                                            if (abortDeletion) {
+                                                LOG.warn(
+                                                        "Detected missing manifest, aborting clean globally.");
+                                            }
+                                        } else {
+                                            checkState(signalEnd, "Signal input should end first.");
+                                        }
+                                    }
+
+                                    @Override
+                                    public void processElement1(StreamRecord<String> element) {
+                                        checkState(
+                                                MISSING_MANIFEST_SENTINEL.equals(
+                                                        element.getValue()),
+                                                "Unexpected global abort signal.");
+                                        abortDeletion = true;
+                                    }
+
+                                    @Override
+                                    public void processElement2(
+                                            StreamRecord<Tuple2<String, Long>> element) {
+                                        checkState(signalEnd, "Signal input should end first.");
+                                        if (!abortDeletion) {
+                                            output.collect(element);
+                                        }
+                                    }
+                                });
+
+        DataStream<CleanOrphanFilesResult> deleted =
+                normalUsedFiles
                         .keyBy(f -> f)
                         .connect(
-                                candidates.keyBy(pathAndSize -> new Path(pathAndSize.f0).getName()))
+                                candidatesAfterGlobalAbort.keyBy(
+                                        pathAndSize -> new Path(pathAndSize.f0).getName()))
                         .transform(
                                 "join-used-and-candidate-files",
                                 TypeInformation.of(CleanOrphanFilesResult.class),
@@ -412,8 +475,6 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                     private boolean buildEnd;
                                     private long emittedFilesCount;
                                     private long emittedFilesLen;
-
-                                    private boolean abortDeletion;
 
                                     private final Set<String> used = new HashSet<>();
 
@@ -431,10 +492,6 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                 checkState(!buildEnd, "Should not build ended.");
                                                 LOG.info("Finish build phase.");
                                                 buildEnd = true;
-                                                if (abortDeletion) {
-                                                    LOG.warn(
-                                                            "Detected missing manifest, aborting clean.");
-                                                }
                                                 break;
                                             case 2:
                                                 checkState(buildEnd, "Should build ended.");
@@ -454,21 +511,13 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
 
                                     @Override
                                     public void processElement1(StreamRecord<String> element) {
-                                        String value = element.getValue();
-                                        if (MISSING_MANIFEST_SENTINEL.equals(value)) {
-                                            abortDeletion = true;
-                                            return;
-                                        }
-                                        used.add(value);
+                                        used.add(element.getValue());
                                     }
 
                                     @Override
                                     public void processElement2(
                                             StreamRecord<Tuple2<String, Long>> element) {
                                         checkState(buildEnd, "Should build ended.");
-                                        if (abortDeletion) {
-                                            return;
-                                        }
                                         Tuple2<String, Long> fileInfo = element.getValue();
                                         String value = fileInfo.f0;
                                         Path path = new Path(value);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -166,13 +166,10 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                             Collector<Tuple3<String, String, Boolean>> out)
                                             throws Exception {
                                         Set<Long> liveSnapshotIds =
-                                                Identifier.DEFAULT_MAIN_BRANCH.equals(branch)
-                                                        ? table.switchToBranch(branch)
-                                                                .snapshotManager()
-                                                                .safelyGetAllSnapshots().stream()
-                                                                .map(Snapshot::id)
-                                                                .collect(Collectors.toSet())
-                                                        : Collections.emptySet();
+                                                table.switchToBranch(branch).snapshotManager()
+                                                        .safelyGetAllSnapshots().stream()
+                                                        .map(Snapshot::id)
+                                                        .collect(Collectors.toSet());
                                         for (Snapshot snapshot : safelyGetAllSnapshots(branch)) {
                                             out.collect(
                                                     new Tuple3<>(
@@ -198,7 +195,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                             throws Exception {
                                         String branch = branchAndSnapshot.f0;
                                         Snapshot snapshot = Snapshot.fromJson(branchAndSnapshot.f1);
-                                        boolean liveOnMainBranch = branchAndSnapshot.f2;
+                                        boolean isLiveSnapshot = branchAndSnapshot.f2;
                                         Consumer<String> manifestConsumer =
                                                 manifest ->
                                                         ctx.output(
@@ -206,9 +203,9 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                                 new Tuple3<>(
                                                                         branch,
                                                                         manifest,
-                                                                        liveOnMainBranch));
+                                                                        isLiveSnapshot));
                                         AtomicBoolean missingManifest =
-                                                liveOnMainBranch ? new AtomicBoolean(false) : null;
+                                                isLiveSnapshot ? new AtomicBoolean(false) : null;
                                         collectWithoutDataFile(
                                                 branch,
                                                 snapshot,

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/RemoveOrphanFilesActionITCaseBase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.action;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.FileIO;
@@ -400,6 +401,40 @@ public abstract class RemoveOrphanFilesActionITCaseBase extends ActionITCaseBase
         assertThatCode(() -> executeSQL(withInvalidMode))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Unknown mode");
+    }
+
+    @Test
+    public void testDistributedCleanAbortsGloballyWhenManifestListIsMissing() throws Exception {
+        FileStoreTable table = createTableAndWriteData(tableName);
+        FileIO fileIO = table.fileIO();
+
+        List<Path> orphanFiles = new ArrayList<>();
+        for (int i = 0; i < 32; i++) {
+            Path orphanFile = getOrphanFilePath(table, "bucket-0/global-abort-orphan-" + i);
+            fileIO.writeFile(orphanFile, "orphan", true);
+            orphanFiles.add(orphanFile);
+        }
+        Thread.sleep(2000);
+
+        Snapshot latestSnapshot = table.snapshotManager().latestSnapshot();
+        Path manifestList =
+                table.store().pathFactory().toManifestListPath(latestSnapshot.baseManifestList());
+        assertThat(fileIO.exists(manifestList)).isTrue();
+        fileIO.deleteQuietly(manifestList);
+
+        String olderThan =
+                DateTimeUtils.formatLocalDateTime(
+                        DateTimeUtils.toLocalDateTime(System.currentTimeMillis()), 3);
+        String procedure =
+                String.format(
+                        "CALL sys.remove_orphan_files('%s.%s', '%s', false, 5, 'distributed')",
+                        database, tableName, olderThan);
+        ImmutableList<Row> result = ImmutableList.copyOf(executeSQL(procedure));
+
+        assertThat(result).containsOnly(Row.of("0"));
+        for (Path orphanFile : orphanFiles) {
+            assertThat(fileIO.exists(orphanFile)).isTrue();
+        }
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -69,27 +69,46 @@ case class SparkOrphanFilesClean(
     val usedManifestFiles = spark.sparkContext
       .parallelize(branches.asScala.toSeq, maxBranchParallelism)
       .mapPartitions(_.flatMap {
-        branch => safelyGetAllSnapshots(branch).asScala.map(snapshot => (branch, snapshot.toJson))
+        branch =>
+          val liveSnapshotIds =
+            if (Identifier.DEFAULT_MAIN_BRANCH.equals(branch)) {
+              specifiedTable
+                .switchToBranch(branch)
+                .snapshotManager()
+                .safelyGetAllSnapshots()
+                .asScala
+                .map(_.id())
+                .toSet
+            } else {
+              Set.empty[Long]
+            }
+          safelyGetAllSnapshots(branch).asScala.map(
+            snapshot => (branch, snapshot.toJson, liveSnapshotIds.contains(snapshot.id())))
       })
       .repartition(parallelism)
       .flatMap {
-        case (branch, snapshotJson) =>
+        case (branch, snapshotJson, liveOnMainBranch) =>
           val usedFileBuffer = new ArrayBuffer[BranchAndManifestFile]()
           val usedFileConsumer =
             new Consumer[org.apache.paimon.utils.Pair[String, java.lang.Boolean]] {
               override def accept(pair: utils.Pair[String, java.lang.Boolean]): Unit = {
                 usedFileBuffer.append(
-                  BranchAndManifestFile(branch, pair.getLeft, pair.getRight, isMissing = false))
+                  BranchAndManifestFile(
+                    branch,
+                    pair.getLeft,
+                    pair.getRight,
+                    isMissing = false,
+                    isLiveSnapshot = liveOnMainBranch))
               }
             }
-          val missingManifest = new AtomicBoolean(false)
+          val missingManifest = if (liveOnMainBranch) new AtomicBoolean(false) else null
           val snapshot = Snapshot.fromJson(snapshotJson)
           collectWithoutDataFileWithManifestFlag(
             branch,
             snapshot,
             usedFileConsumer,
             missingManifest)
-          if (missingManifest.get()) {
+          if (missingManifest != null && missingManifest.get()) {
             usedFileBuffer.append(
               BranchAndManifestFile(branch, "", isManifestFile = false, isMissing = true))
           }
@@ -108,7 +127,9 @@ case class SparkOrphanFilesClean(
 
     val dataFilesWithFlag = usedManifestFiles
       .filter(f => f.isManifestFile && !f.isMissing)
-      .distinct()
+      .groupByKey(f => (f.branch, f.manifestName))
+      .reduceGroups((a, b) => a.copy(isLiveSnapshot = a.isLiveSnapshot || b.isLiveSnapshot))
+      .map(_._2)
       .mapPartitions {
         it =>
           val branchManifests = new util.HashMap[String, ManifestFile]
@@ -119,13 +140,14 @@ case class SparkOrphanFilesClean(
                 (key: String) =>
                   specifiedTable.switchToBranch(key).store.manifestFileFactory.create)
 
-              val manifestMissing = new AtomicBoolean(false)
+              val manifestMissing =
+                if (branchAndManifestFile.isLiveSnapshot) new AtomicBoolean(false) else null
               val entries = retryReadingFiles(
                 () => manifestFile.readWithIOException(branchAndManifestFile.manifestName),
                 Collections.emptyList[ManifestEntry],
                 manifestMissing
               ).asScala
-              if (manifestMissing.get()) {
+              if (manifestMissing != null && manifestMissing.get()) {
                 Iterator.single(("", true))
               } else {
                 entries
@@ -236,7 +258,8 @@ case class BranchAndManifestFile(
     branch: String,
     manifestName: String,
     isManifestFile: Boolean,
-    isMissing: Boolean = false)
+    isMissing: Boolean = false,
+    isLiveSnapshot: Boolean = false)
 
 object SparkOrphanFilesClean extends SQLConfHelper {
   def executeDatabaseOrphanFiles(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.SQLConfHelper
 
 import java.util
 import java.util.Collections
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import java.util.function.Consumer
 
 import scala.collection.JavaConverters._
@@ -78,19 +78,40 @@ case class SparkOrphanFilesClean(
           val usedFileConsumer =
             new Consumer[org.apache.paimon.utils.Pair[String, java.lang.Boolean]] {
               override def accept(pair: utils.Pair[String, java.lang.Boolean]): Unit = {
-                usedFileBuffer.append(BranchAndManifestFile(branch, pair.getLeft, pair.getRight))
+                usedFileBuffer.append(
+                  BranchAndManifestFile(branch, pair.getLeft, pair.getRight, isMissing = false))
               }
             }
+          val missingConsumer = new Consumer[String] {
+            override def accept(name: String): Unit = {
+              usedFileBuffer.append(
+                BranchAndManifestFile(branch, name, isManifestFile = false, isMissing = true))
+            }
+          }
           val snapshot = Snapshot.fromJson(snapshotJson)
-          collectWithoutDataFileWithManifestFlag(branch, snapshot, usedFileConsumer)
+          collectWithoutDataFileWithManifestFlag(
+            branch,
+            snapshot,
+            usedFileConsumer,
+            missingConsumer)
           usedFileBuffer
       }
       .toDS()
       .cache()
 
-    // find all data files
-    val dataFiles = usedManifestFiles
-      .filter(_.isManifestFile)
+    if (!usedManifestFiles.filter(_.isMissing).isEmpty) {
+      logWarning(
+        "Detected missing manifest-list/index-manifest during used-files collection; this " +
+          "indicates a concurrent snapshot expiration. Aborting orphan files clean to prevent " +
+          "data loss.")
+      return (
+        spark.createDataset(
+          Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),
+        usedManifestFiles)
+    }
+
+    val dataFilesWithFlag = usedManifestFiles
+      .filter(f => f.isManifestFile && !f.isMissing)
       .distinct()
       .mapPartitions {
         it =>
@@ -102,18 +123,42 @@ case class SparkOrphanFilesClean(
                 (key: String) =>
                   specifiedTable.switchToBranch(key).store.manifestFileFactory.create)
 
-              retryReadingFiles(
+              val manifestMissing = new AtomicBoolean(false)
+              val entries = retryReadingFiles(
                 () => manifestFile.readWithIOException(branchAndManifestFile.manifestName),
-                Collections.emptyList[ManifestEntry]
-              ).asScala.flatMap {
-                manifestEntry =>
-                  manifestEntry.fileName() +: manifestEntry.file().extraFiles().asScala
+                Collections.emptyList[ManifestEntry],
+                manifestMissing
+              ).asScala
+              if (manifestMissing.get()) {
+                Iterator.single(("", true))
+              } else {
+                entries
+                  .flatMap {
+                    manifestEntry =>
+                      manifestEntry.fileName() +: manifestEntry.file().extraFiles().asScala
+                  }
+                  .map(name => (name, false))
+                  .iterator
               }
           }
       }
+      .cache()
+
+    if (!dataFilesWithFlag.filter(_._2).isEmpty) {
+      logWarning(
+        "Detected missing manifest file(s) while collecting data files; this indicates a " +
+          "concurrent snapshot expiration. Aborting orphan files clean to prevent data loss.")
+      return (
+        spark.createDataset(
+          Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),
+        usedManifestFiles)
+    }
+
+    val dataFiles = dataFilesWithFlag.filter(!_._2).map(_._1)
 
     // union manifest and data files
     val usedFiles = usedManifestFiles
+      .filter(!_.isMissing)
       .map(_.manifestName)
       .union(dataFiles)
       .toDF("used_name")
@@ -193,7 +238,11 @@ case class SparkOrphanFilesClean(
  * @param isManifestFile
  *   If it is the manifest file
  */
-case class BranchAndManifestFile(branch: String, manifestName: String, isManifestFile: Boolean)
+case class BranchAndManifestFile(
+    branch: String,
+    manifestName: String,
+    isManifestFile: Boolean,
+    isMissing: Boolean = false)
 
 object SparkOrphanFilesClean extends SQLConfHelper {
   def executeDatabaseOrphanFiles(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -82,28 +82,24 @@ case class SparkOrphanFilesClean(
                   BranchAndManifestFile(branch, pair.getLeft, pair.getRight, isMissing = false))
               }
             }
-          val missingConsumer = new Consumer[String] {
-            override def accept(name: String): Unit = {
-              usedFileBuffer.append(
-                BranchAndManifestFile(branch, name, isManifestFile = false, isMissing = true))
-            }
-          }
+          val missingManifest = new AtomicBoolean(false)
           val snapshot = Snapshot.fromJson(snapshotJson)
           collectWithoutDataFileWithManifestFlag(
             branch,
             snapshot,
             usedFileConsumer,
-            missingConsumer)
+            missingManifest)
+          if (missingManifest.get()) {
+            usedFileBuffer.append(
+              BranchAndManifestFile(branch, "", isManifestFile = false, isMissing = true))
+          }
           usedFileBuffer
       }
       .toDS()
       .cache()
 
     if (!usedManifestFiles.filter(_.isMissing).isEmpty) {
-      logWarning(
-        "Detected missing manifest-list/index-manifest during used-files collection; this " +
-          "indicates a concurrent snapshot expiration. Aborting orphan files clean to prevent " +
-          "data loss.")
+      logWarning("Detected missing manifest during used-files collection, aborting clean.")
       return (
         spark.createDataset(
           Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),
@@ -145,9 +141,7 @@ case class SparkOrphanFilesClean(
       .cache()
 
     if (!dataFilesWithFlag.filter(_._2).isEmpty) {
-      logWarning(
-        "Detected missing manifest file(s) while collecting data files; this indicates a " +
-          "concurrent snapshot expiration. Aborting orphan files clean to prevent data loss.")
+      logWarning("Detected missing manifest while collecting data files, aborting clean.")
       return (
         spark.createDataset(
           Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -70,16 +70,9 @@ case class SparkOrphanFilesClean(
       .parallelize(branches.asScala.toSeq, maxBranchParallelism)
       .mapPartitions(_.flatMap {
         branch =>
-          val liveSnapshotIds =
-            specifiedTable
-              .switchToBranch(branch)
-              .snapshotManager()
-              .safelyGetAllSnapshots()
-              .asScala
-              .map(_.id())
-              .toSet
-          safelyGetAllSnapshots(branch).asScala.map(
-            snapshot => (branch, snapshot.toJson, liveSnapshotIds.contains(snapshot.id())))
+          val liveSnapshots = safelyGetLiveSnapshots(branch)
+          snapshotsIncludingTagsAndChangelogs(branch, liveSnapshots).asScala.map(
+            snapshot => (branch, snapshot.toJson, liveSnapshots.contains(snapshot)))
       })
       .repartition(parallelism)
       .flatMap {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -40,6 +40,7 @@ import java.util.function.Consumer
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
 case class SparkOrphanFilesClean(
     specifiedTable: FileStoreTable,
@@ -51,7 +52,19 @@ case class SparkOrphanFilesClean(
   with SQLConfHelper
   with Logging {
 
-  def doOrphanClean(): (Dataset[(Long, Long)], Dataset[BranchAndManifestFile]) = {
+  def doOrphanClean(): (Dataset[(Long, Long)], Seq[Dataset[_]]) = {
+    val cachedDatasets = new ArrayBuffer[Dataset[_]]()
+    try {
+      doOrphanClean(cachedDatasets)
+    } catch {
+      case NonFatal(t) =>
+        cachedDatasets.foreach(_.unpersist())
+        throw t
+    }
+  }
+
+  private def doOrphanClean(
+      cachedDatasets: ArrayBuffer[Dataset[_]]): (Dataset[(Long, Long)], Seq[Dataset[_]]) = {
     import spark.implicits._
 
     val branches = validBranches()
@@ -105,13 +118,14 @@ case class SparkOrphanFilesClean(
       }
       .toDS()
       .cache()
+    cachedDatasets += usedManifestFiles
 
     if (!usedManifestFiles.filter(_.isMissing).isEmpty) {
       logWarning("Detected missing manifest during used-files collection, aborting clean.")
       return (
         spark.createDataset(
           Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),
-        usedManifestFiles)
+        cachedDatasets.toSeq)
     }
 
     val dataFilesWithFlag = usedManifestFiles
@@ -150,13 +164,14 @@ case class SparkOrphanFilesClean(
           }
       }
       .cache()
+    cachedDatasets += dataFilesWithFlag
 
     if (!dataFilesWithFlag.filter(_._2).isEmpty) {
       logWarning("Detected missing manifest while collecting data files, aborting clean.")
       return (
         spark.createDataset(
           Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get()))),
-        usedManifestFiles)
+        cachedDatasets.toSeq)
     }
 
     val dataFiles = dataFilesWithFlag.filter(!_._2).map(_._1)
@@ -231,7 +246,7 @@ case class SparkOrphanFilesClean(
         deleted
       }
 
-    (finalDeletedDataset, usedManifestFiles)
+    (finalDeletedDataset, cachedDatasets.toSeq)
   }
 }
 
@@ -282,17 +297,22 @@ object SparkOrphanFilesClean extends SQLConfHelper {
     if (tables.isEmpty) {
       return new CleanOrphanFilesResult(0, 0)
     }
-    val (deleted, waitToRelease) = tables.map {
-      table =>
-        new SparkOrphanFilesClean(
-          table,
-          olderThanMillis,
-          parallelism,
-          dryRun,
-          spark
-        ).doOrphanClean()
-    }.unzip
+    val deleted = new ArrayBuffer[Dataset[(Long, Long)]]()
+    val waitToRelease = new ArrayBuffer[Dataset[_]]()
     try {
+      tables.foreach {
+        table =>
+          val (deletedDataset, cachedDatasets) = new SparkOrphanFilesClean(
+            table,
+            olderThanMillis,
+            parallelism,
+            dryRun,
+            spark
+          ).doOrphanClean()
+          deleted += deletedDataset
+          waitToRelease ++= cachedDatasets
+      }
+
       val result = deleted
         .reduce((l, r) => l.union(r))
         .toDF("deletedFilesCount", "deletedFilesLenInBytes")

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -71,23 +71,19 @@ case class SparkOrphanFilesClean(
       .mapPartitions(_.flatMap {
         branch =>
           val liveSnapshotIds =
-            if (Identifier.DEFAULT_MAIN_BRANCH.equals(branch)) {
-              specifiedTable
-                .switchToBranch(branch)
-                .snapshotManager()
-                .safelyGetAllSnapshots()
-                .asScala
-                .map(_.id())
-                .toSet
-            } else {
-              Set.empty[Long]
-            }
+            specifiedTable
+              .switchToBranch(branch)
+              .snapshotManager()
+              .safelyGetAllSnapshots()
+              .asScala
+              .map(_.id())
+              .toSet
           safelyGetAllSnapshots(branch).asScala.map(
             snapshot => (branch, snapshot.toJson, liveSnapshotIds.contains(snapshot.id())))
       })
       .repartition(parallelism)
       .flatMap {
-        case (branch, snapshotJson, liveOnMainBranch) =>
+        case (branch, snapshotJson, isLive) =>
           val usedFileBuffer = new ArrayBuffer[BranchAndManifestFile]()
           val usedFileConsumer =
             new Consumer[org.apache.paimon.utils.Pair[String, java.lang.Boolean]] {
@@ -98,10 +94,10 @@ case class SparkOrphanFilesClean(
                     pair.getLeft,
                     pair.getRight,
                     isMissing = false,
-                    isLiveSnapshot = liveOnMainBranch))
+                    isLiveSnapshot = isLive))
               }
             }
-          val missingManifest = if (liveOnMainBranch) new AtomicBoolean(false) else null
+          val missingManifest = if (isLive) new AtomicBoolean(false) else null
           val snapshot = Snapshot.fromJson(snapshotJson)
           collectWithoutDataFileWithManifestFlag(
             branch,


### PR DESCRIPTION
### Purpose

Fix #7710. 

`LocalOrphanFilesClean.clean()` collects used files by reading all snapshots via `safelyGetAllSnapshots()`. However, this method silently catches `FileNotFoundException` — if concurrent snapshot expiration deletes all snapshots between listing and reading, `usedFiles` ends up empty, and all candidate data files get deleted as orphans.

This patch skips orphan file deletion when `usedFiles` is empty to prevent accidental data loss.

### Tests

Added `LocalOrphanFilesCleanTest#testSkipCleaningWhenAllSnapshotsDeleted`.
