### PR TITLE
[python] Support Kerberos authentication for HDFS

### DIFF
--- a/docs/content/pypaimon/python-api.md
+++ b/docs/content/pypaimon/python-api.md
@@ -62,6 +62,43 @@ catalog_options = {
 catalog = CatalogFactory.create(catalog_options)
 ```
 
+For an HDFS warehouse with Kerberos authentication:
+
+```python
+from pypaimon import CatalogFactory
+
+catalog_options = {
+    'warehouse': 'hdfs://namenode:8020/path/to/warehouse',
+    # Keytab mode: automatic kinit
+    'security.kerberos.login.principal': 'user@YOUR.REALM',
+    'security.kerberos.login.keytab': '/path/to/user.keytab',
+}
+catalog = CatalogFactory.create(catalog_options)
+```
+
+If you have already run `kinit` externally, you can omit `principal` and `keytab`.
+PyPaimon will automatically pick up the ticket from `KRB5CCNAME` environment variable
+or the default `/tmp/krb5cc_<uid>`:
+
+```python
+from pypaimon import CatalogFactory
+
+catalog_options = {
+    'warehouse': 'hdfs://namenode:8020/path/to/warehouse',
+    # Ticket cache mode: uses existing Kerberos ticket
+}
+catalog = CatalogFactory.create(catalog_options)
+```
+
+To disable ticket cache auto-detection and force SIMPLE authentication, set:
+
+```python
+catalog_options = {
+    'warehouse': 'hdfs://namenode:8020/path/to/warehouse',
+    'security.kerberos.login.use-ticket-cache': 'false',
+}
+```
+
 {{< /tab >}}
 {{< tab "rest catalog" >}}
 The sample code is as follows. The detailed meaning of option can be found in [REST]({{< ref "concepts/rest/overview" >}}).
@@ -984,6 +1021,14 @@ The following shows the supported features of Python Paimon compared to Java Pai
 
 - FileSystemCatalog
 - RestCatalog
+
+**Filesystem & Security**
+
+- Local filesystem (`file://`)
+- HDFS (`hdfs://`) with SIMPLE authentication
+- HDFS (`hdfs://`) with Kerberos authentication (keytab or ticket cache)
+- Aliyun OSS (`oss://`)
+- S3 (`s3://`)
 
 **Table Level**
 

--- a/paimon-python/pypaimon/common/options/config.py
+++ b/paimon-python/pypaimon/common/options/config.py
@@ -87,6 +87,27 @@ class CatalogOptions:
     BLOB_FILE_IO_DEFAULT_CACHE_SIZE = 2 ** 31 - 1
 
 
+class SecurityOptions:
+    KERBEROS_PRINCIPAL = (
+        ConfigOptions.key("security.kerberos.login.principal")
+        .string_type()
+        .no_default_value()
+        .with_description("Kerberos principal name associated with the keytab")
+    )
+    KERBEROS_KEYTAB = (
+        ConfigOptions.key("security.kerberos.login.keytab")
+        .string_type()
+        .no_default_value()
+        .with_description("Absolute path to a Kerberos keytab file that contains the user credentials")
+    )
+    KERBEROS_USE_TICKET_CACHE = (
+        ConfigOptions.key("security.kerberos.login.use-ticket-cache")
+        .boolean_type()
+        .default_value(True)
+        .with_description("Whether to read from the Kerberos ticket cache")
+    )
+
+
 class FuseOptions:
     """FUSE configuration options."""
 

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -32,7 +32,7 @@ from pyarrow._fs import FileSystem
 
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.options import Options
-from pypaimon.common.options.config import OssOptions, S3Options
+from pypaimon.common.options.config import OssOptions, S3Options, SecurityOptions
 from pypaimon.common.options.options_utils import OptionsUtils
 from pypaimon.common.uri_reader import UriReaderFactory
 from pypaimon.filesystem.jindo_file_system_handler import JindoFileSystemHandler, JINDO_AVAILABLE
@@ -256,12 +256,60 @@ class PyArrowFileIO(FileIO):
         )
         os.environ['CLASSPATH'] = class_paths.stdout.strip()
 
+        principal = (self.properties.get(SecurityOptions.KERBEROS_PRINCIPAL)
+                     or self._get_property("security.principal"))
+        keytab = (self.properties.get(SecurityOptions.KERBEROS_KEYTAB)
+                  or self._get_property("security.keytab"))
+        use_ticket_cache = self.properties.get(SecurityOptions.KERBEROS_USE_TICKET_CACHE)
+
+        if bool(principal) != bool(keytab):
+            raise ValueError(
+                "security.kerberos.login.principal and security.kerberos.login.keytab "
+                "must be both set or both unset")
+
         host, port_str = splitport(netloc)
-        return pafs.HadoopFileSystem(
-            host=host,
-            port=int(port_str),
-            user=os.environ.get('HADOOP_USER_NAME', 'hadoop')
+        port = int(port_str) if port_str else 0
+
+        kerb_ticket = None
+        if principal and keytab:
+            self._kerberos_login_from_keytab(principal, keytab)
+            kerb_ticket = self._get_ticket_cache_path()
+        elif use_ticket_cache:
+            cache_path = self._get_ticket_cache_path()
+            if cache_path and os.path.exists(cache_path):
+                kerb_ticket = cache_path
+
+        if kerb_ticket:
+            return pafs.HadoopFileSystem(host=host, port=port, kerb_ticket=kerb_ticket)
+        else:
+            return pafs.HadoopFileSystem(
+                host=host,
+                port=port,
+                user=os.environ.get('HADOOP_USER_NAME', 'hadoop')
+            )
+
+    @staticmethod
+    def _kerberos_login_from_keytab(principal: str, keytab: str):
+        if not os.path.isfile(keytab):
+            raise FileNotFoundError(f"Kerberos keytab file not found: {keytab}")
+        if not os.access(keytab, os.R_OK):
+            raise PermissionError(f"Kerberos keytab file is not readable: {keytab}")
+        subprocess.run(
+            ['kinit', '-kt', keytab, principal],
+            check=True, capture_output=True, text=True
         )
+
+    @staticmethod
+    def _get_ticket_cache_path() -> Optional[str]:
+        cc = os.environ.get('KRB5CCNAME')
+        if cc:
+            if cc.startswith('FILE:'):
+                return cc[5:]
+            return cc
+        default_path = f'/tmp/krb5cc_{os.getuid()}'
+        if os.path.exists(default_path):
+            return default_path
+        return None
 
     def new_input_stream(self, path: str):
         path_str = self.to_filesystem_path(path)

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -274,6 +274,10 @@ class PyArrowFileIO(FileIO):
         if principal and keytab:
             self._kerberos_login_from_keytab(principal, keytab)
             kerb_ticket = self._get_ticket_cache_path()
+            if not kerb_ticket:
+                raise RuntimeError(
+                    "kinit succeeded but no ticket cache path could be determined. "
+                    "Set the KRB5CCNAME environment variable to specify the cache location.")
         elif use_ticket_cache:
             cache_path = self._get_ticket_cache_path()
             if cache_path and os.path.exists(cache_path):

--- a/paimon-python/pypaimon/tests/kerberos_test.py
+++ b/paimon-python/pypaimon/tests/kerberos_test.py
@@ -1,0 +1,282 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pypaimon.common.options import Options
+from pypaimon.common.options.config import SecurityOptions
+
+
+class SecurityOptionsTest(unittest.TestCase):
+
+    def test_parse_principal_and_keytab(self):
+        opts = Options({
+            "security.kerberos.login.principal": "user@REALM",
+            "security.kerberos.login.keytab": "/path/to/user.keytab",
+        })
+        self.assertEqual(opts.get(SecurityOptions.KERBEROS_PRINCIPAL), "user@REALM")
+        self.assertEqual(opts.get(SecurityOptions.KERBEROS_KEYTAB), "/path/to/user.keytab")
+
+    def test_use_ticket_cache_default_true(self):
+        opts = Options({})
+        self.assertTrue(opts.get(SecurityOptions.KERBEROS_USE_TICKET_CACHE))
+
+    def test_use_ticket_cache_explicit_false(self):
+        opts = Options({"security.kerberos.login.use-ticket-cache": "false"})
+        self.assertFalse(opts.get(SecurityOptions.KERBEROS_USE_TICKET_CACHE))
+
+    def test_principal_and_keytab_default_none(self):
+        opts = Options({})
+        self.assertIsNone(opts.get(SecurityOptions.KERBEROS_PRINCIPAL))
+        self.assertIsNone(opts.get(SecurityOptions.KERBEROS_KEYTAB))
+
+
+class KerberosHdfsTest(unittest.TestCase):
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    @patch("pypaimon.filesystem.pyarrow_file_io.pafs.HadoopFileSystem")
+    def test_hdfs_with_keytab_calls_kinit(self, mock_hdfs_fs, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        with tempfile.NamedTemporaryFile(suffix=".keytab") as keytab_file:
+            from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+            with patch.dict(os.environ, {
+                "HADOOP_HOME": "/opt/hadoop",
+                "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+                "KRB5CCNAME": "/tmp/krb5cc_test",
+            }):
+                opts = Options({
+                    "security.kerberos.login.principal": "hdfs/nn@REALM",
+                    "security.kerberos.login.keytab": keytab_file.name,
+                })
+
+                with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+
+            kinit_calls = [
+                c for c in mock_subprocess_run.call_args_list
+                if c[0][0][0] == 'kinit'
+            ]
+            self.assertEqual(len(kinit_calls), 1)
+            self.assertEqual(kinit_calls[0][0][0], ['kinit', '-kt', keytab_file.name, 'hdfs/nn@REALM'])
+
+            hdfs_kwargs = mock_hdfs_fs.call_args[1]
+            self.assertEqual(hdfs_kwargs["host"], "namenode")
+            self.assertEqual(hdfs_kwargs["port"], 8020)
+            self.assertEqual(hdfs_kwargs["kerb_ticket"], "/tmp/krb5cc_test")
+            self.assertNotIn("user", hdfs_kwargs)
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    @patch("pypaimon.filesystem.pyarrow_file_io.pafs.HadoopFileSystem")
+    def test_hdfs_with_ticket_cache(self, mock_hdfs_fs, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with patch.dict(os.environ, {
+            "HADOOP_HOME": "/opt/hadoop",
+            "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+            "KRB5CCNAME": "/tmp/krb5cc_existing",
+        }):
+            with patch("os.path.exists", return_value=True):
+                opts = Options({})
+
+                with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+
+        hdfs_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(hdfs_kwargs["kerb_ticket"], "/tmp/krb5cc_existing")
+        self.assertNotIn("user", hdfs_kwargs)
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    @patch("pypaimon.filesystem.pyarrow_file_io.pafs.HadoopFileSystem")
+    def test_hdfs_without_kerberos_uses_simple_auth(self, mock_hdfs_fs, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        env = {
+            "HADOOP_HOME": "/opt/hadoop",
+            "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+            "HADOOP_USER_NAME": "testuser",
+        }
+        env_remove = {k: v for k, v in os.environ.items()}
+        env_remove.pop("KRB5CCNAME", None)
+        env_remove.update(env)
+
+        with patch.dict(os.environ, env_remove, clear=True):
+            with patch("os.path.exists", return_value=False):
+                opts = Options({"security.kerberos.login.use-ticket-cache": "false"})
+
+                with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+
+        hdfs_kwargs = mock_hdfs_fs.call_args[1]
+        self.assertEqual(hdfs_kwargs["user"], "testuser")
+        self.assertNotIn("kerb_ticket", hdfs_kwargs)
+
+    def test_keytab_not_found_raises_error(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+        with self.assertRaises(FileNotFoundError):
+            PyArrowFileIO._kerberos_login_from_keytab("user@REALM", "/nonexistent/path.keytab")
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    def test_principal_without_keytab_raises_error(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with patch.dict(os.environ, {
+            "HADOOP_HOME": "/opt/hadoop",
+            "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+        }):
+            opts = Options({
+                "security.kerberos.login.principal": "user@REALM",
+            })
+
+            with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                file_io.properties = opts
+                file_io.logger = MagicMock()
+
+                with self.assertRaises(ValueError) as ctx:
+                    file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+                self.assertIn("must be both set or both unset", str(ctx.exception))
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    def test_keytab_without_principal_raises_error(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with tempfile.NamedTemporaryFile(suffix=".keytab") as keytab_file:
+            with patch.dict(os.environ, {
+                "HADOOP_HOME": "/opt/hadoop",
+                "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+            }):
+                opts = Options({
+                    "security.kerberos.login.keytab": keytab_file.name,
+                })
+
+                with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    with self.assertRaises(ValueError) as ctx:
+                        file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+                    self.assertIn("must be both set or both unset", str(ctx.exception))
+
+    def test_get_ticket_cache_from_krb5ccname(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with patch.dict(os.environ, {"KRB5CCNAME": "/tmp/custom_cc"}):
+            path = PyArrowFileIO._get_ticket_cache_path()
+            self.assertEqual(path, "/tmp/custom_cc")
+
+    def test_get_ticket_cache_from_krb5ccname_file_prefix(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with patch.dict(os.environ, {"KRB5CCNAME": "FILE:/tmp/custom_cc"}):
+            path = PyArrowFileIO._get_ticket_cache_path()
+            self.assertEqual(path, "/tmp/custom_cc")
+
+    def test_get_ticket_cache_default_path(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        env = dict(os.environ)
+        env.pop("KRB5CCNAME", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("os.path.exists", return_value=True):
+                with patch("os.getuid", return_value=1000):
+                    path = PyArrowFileIO._get_ticket_cache_path()
+                    self.assertEqual(path, "/tmp/krb5cc_1000")
+
+    def test_get_ticket_cache_no_cache(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        env = dict(os.environ)
+        env.pop("KRB5CCNAME", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch("os.path.exists", return_value=False):
+                path = PyArrowFileIO._get_ticket_cache_path()
+                self.assertIsNone(path)
+
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    @patch("pypaimon.filesystem.pyarrow_file_io.pafs.HadoopFileSystem")
+    def test_hdfs_with_fallback_keys(self, mock_hdfs_fs, mock_subprocess_run):
+        """Verify that Java-compatible fallback keys security.principal / security.keytab work."""
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        with tempfile.NamedTemporaryFile(suffix=".keytab") as keytab_file:
+            from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+            with patch.dict(os.environ, {
+                "HADOOP_HOME": "/opt/hadoop",
+                "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+                "KRB5CCNAME": "/tmp/krb5cc_test",
+            }):
+                opts = Options({
+                    "security.principal": "hdfs/nn@REALM",
+                    "security.keytab": keytab_file.name,
+                })
+
+                with patch.object(PyArrowFileIO, '__init__', lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+
+            kinit_calls = [
+                c for c in mock_subprocess_run.call_args_list
+                if c[0][0][0] == 'kinit'
+            ]
+            self.assertEqual(len(kinit_calls), 1)
+            self.assertEqual(kinit_calls[0][0][0],
+                             ['kinit', '-kt', keytab_file.name, 'hdfs/nn@REALM'])
+
+            hdfs_kwargs = mock_hdfs_fs.call_args[1]
+            self.assertEqual(hdfs_kwargs["kerb_ticket"], "/tmp/krb5cc_test")
+            self.assertNotIn("user", hdfs_kwargs)
+
+    def test_keytab_not_readable_raises_error(self):
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with tempfile.NamedTemporaryFile(suffix=".keytab") as keytab_file:
+            with patch("os.access", return_value=False):
+                with self.assertRaises(PermissionError) as ctx:
+                    PyArrowFileIO._kerberos_login_from_keytab("user@REALM", keytab_file.name)
+                self.assertIn("not readable", str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/kerberos_test.py
+++ b/paimon-python/pypaimon/tests/kerberos_test.py
@@ -277,6 +277,36 @@ class KerberosHdfsTest(unittest.TestCase):
                     PyArrowFileIO._kerberos_login_from_keytab("user@REALM", keytab_file.name)
                 self.assertIn("not readable", str(ctx.exception))
 
+    @patch("pypaimon.filesystem.pyarrow_file_io.subprocess.run")
+    def test_kinit_success_but_no_cache_raises_error(self, mock_subprocess_run):
+        mock_subprocess_run.return_value = MagicMock(stdout="/some/classpath")
+
+        from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+        with tempfile.NamedTemporaryFile(suffix=".keytab") as keytab_file:
+            with patch.dict(os.environ, {
+                "HADOOP_HOME": "/opt/hadoop",
+                "HADOOP_CONF_DIR": "/opt/hadoop/etc/hadoop",
+            }):
+                opts = Options({
+                    "security.kerberos.login.principal": "user@REALM",
+                    "security.kerberos.login.keytab": keytab_file.name,
+                })
+
+                with patch.object(PyArrowFileIO, '__init__',
+                                  lambda self, *a, **kw: None):
+                    file_io = PyArrowFileIO.__new__(PyArrowFileIO)
+                    file_io.properties = opts
+                    file_io.logger = MagicMock()
+
+                    with patch.object(PyArrowFileIO,
+                                      '_get_ticket_cache_path',
+                                      return_value=None):
+                        with self.assertRaises(RuntimeError) as ctx:
+                            file_io._initialize_hdfs_fs("hdfs", "namenode:8020")
+                        self.assertIn("no ticket cache path",
+                                      str(ctx.exception))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Purpose
Add Kerberos support for HDFS in PyPaimon, aligned with Java Paimon's `SecurityConfiguration`. Supports keytab login (automatic `kinit`) and existing ticket cache mode, with fallback keys `security.principal` / `security.keytab` for Java compatibility.

Includes `SecurityOptions` config class, unit tests, sample script, and documentation.

### Tests
- pypaimon/tests/kerberos_test.py
- **Manually E2E tested on Aliyun EMR**