### PR TITLE
[deploy] Move extensions to root pom

### DIFF
--- a/paimon-vortex/paimon-vortex-jni/pom.xml
+++ b/paimon-vortex/paimon-vortex-jni/pom.xml
@@ -145,13 +145,5 @@ under the License.
                 </configuration>
             </plugin>
         </plugins>
-
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.1</version>
-            </extension>
-        </extensions>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1159,6 +1159,14 @@ under the License.
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
     </build>
 
     <!--


### PR DESCRIPTION
### Purpose

Currently, Paimon cannot be deployed with Maven's `deployAtEnd` parameter. This is because some extensions are placed in the submodules of this project and caused individual plugin classloaders. As stated in [Maven classloading](https://svn.apache.org/repos/infra/websites/production/maven/content/reference/maven-classloading.html):

> For projects that use build extensions, plugin classloaders are wired to project classloaders. This gives plugin code access to both Maven API packages and packages exported by the project build extensions. Maven will create one and only one classloader for each unique plugin+dependencies+build-extensions combination.

> Maven guarantees there will be one and only one project classloader for each unique set of project build extensions and the same classloader will be used by all projects that have the set of build extensions.

The workaround is to declare all extension plugins, with all their extra <dependencies>, in the parent project. This assures that the same classloader is used for loading plugin in all modules.

Reference: https://stackoverflow.com/questions/36328154/maven-deploy-plugin-deployatend-not-working

### Tests
