### PR TITLE
[deploy] Fix empty javadoc jar when building with JDK 8 (#7658)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,6 +492,31 @@ under the License.
                 <jdk>11</jdk>
             </activation>
         </profile>
+
+        <profile>
+            <!-- JDK 9+ supports the ignore-source-errors flag for javadoc -->
+            <id>javadoc-jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <release>8</release>
+                                <additionalJOptions combine.children="append">
+                                    <!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
+                                    <additionalJOption>--ignore-source-errors</additionalJOption>
+                                </additionalJOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -1012,12 +1037,10 @@ under the License.
                     <configuration>
                         <quiet>true</quiet>
                         <detectOfflineLinks>false</detectOfflineLinks>
-                        <release>8</release>
+                        <source>8</source>
                         <failOnError>false</failOnError>
                         <additionalJOptions>
                             <additionalJOption>-Xdoclint:none</additionalJOption>
-                            <!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
-                            <additionalJOption>--ignore-source-errors</additionalJOption>
                         </additionalJOptions>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
### Purpose

Cherry-picks cf96eed0d70b88a877bd999f422499ec64d30ee3(https://github.com/apache/paimon/pull/7658) to release-1.3 branch.

### Tests
