### PR TITLE
[arrow] Replace System.out.println with LOG.debug in ArrowBundleWriter

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowBundleWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowBundleWriter.java
@@ -134,8 +134,8 @@ public class ArrowBundleWriter implements BundleFormatWriter {
     @Override
     public void close() throws IOException {
         flush();
-        System.out.println("Serialize vsr cost: " + serializeCost + "ms");
-        System.out.println("Jni cost: " + jniCost + "ms");
+        LOG.debug("Serialize vsr cost: {}ms", serializeCost);
+        LOG.debug("Jni cost: {}ms", jniCost);
         this.nativeWriter.close();
         this.arrowFormatWriter.close();
     }


### PR DESCRIPTION
### Purpose
Linked issue: N/A

Production code in ArrowBundleWriter.close() contains two System.out.println debug output statements that should use proper logging. This is a code quality fix to ensure debug output goes through SLF4J logging framework instead of stdout.

### Brief change log
- Replace `System.out.println("Serialize vsr cost: " + serializeCost + "ms")` with `LOG.debug("Serialize vsr cost: {}ms", serializeCost)`
- Replace `System.out.println("Jni cost: " + jniCost + "ms")` with `LOG.debug("Jni cost: {}ms", jniCost)`

### Tests
Existing tests pass. The change is trivial (println to LOG.debug) and doesn't affect behavior.

### API and Format
No

### Documentation
No