### PR TITLE
[iceberg] Support timestamp conversion for IcebergDataField

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DecimalType;
 import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.utils.Preconditions;
 
@@ -109,6 +110,8 @@ public class IcebergConversions {
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                 return timestampToByteBuffer(
                         (Timestamp) value, ((LocalZonedTimestampType) type).getPrecision());
+            case TIME_WITHOUT_TIME_ZONE:
+                return timeToByteBuffer((Integer) value, ((TimeType) type).getPrecision());
             default:
                 throw new UnsupportedOperationException("Cannot serialize type: " + type);
         }
@@ -121,6 +124,15 @@ public class IcebergConversions {
         return ByteBuffer.allocate(8)
                 .order(ByteOrder.LITTLE_ENDIAN)
                 .putLong(0, timestamp.toMicros());
+    }
+
+    private static ByteBuffer timeToByteBuffer(int millisOfDay, int precision) {
+        Preconditions.checkArgument(
+                precision >= 0 && precision <= 3,
+                "Paimon Iceberg compatibility only support time type with precision from 0 to 3.");
+        return ByteBuffer.allocate(8)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(0, millisOfDay * 1000L);
     }
 
     public static Object toPaimonObject(DataType type, byte[] bytes) {
@@ -163,6 +175,13 @@ public class IcebergConversions {
                     return Timestamp.fromEpochMillis(timestampLong);
                 }
                 return Timestamp.fromMicros(timestampLong);
+            case TIME_WITHOUT_TIME_ZONE:
+                int timePrecision = ((TimeType) type).getPrecision();
+                Preconditions.checkArgument(
+                        timePrecision >= 0 && timePrecision <= 3,
+                        "Paimon Iceberg compatibility only support time type with precision from 0 to 3.");
+                long timeMicros = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getLong();
+                return (int) (timeMicros / 1000L);
             default:
                 throw new UnsupportedOperationException("Cannot deserialize type: " + type);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -33,6 +33,7 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
@@ -163,6 +164,12 @@ public class IcebergDataField {
                 return "double";
             case DATE:
                 return "date";
+            case TIME_WITHOUT_TIME_ZONE:
+                int timePrecision = ((TimeType) dataType).getPrecision();
+                Preconditions.checkArgument(
+                        timePrecision >= 0 && timePrecision <= 3,
+                        "Paimon Iceberg compatibility only support time type with precision from 0 to 3.");
+                return "time";
             case CHAR:
             case VARCHAR:
                 return "string";
@@ -235,6 +242,8 @@ public class IcebergDataField {
                     return new DoubleType(!isRequired);
                 case "date":
                     return new DateType(!isRequired);
+                case "time":
+                    return new TimeType(!isRequired, 3);
                 case "string":
                     return new VarCharType(!isRequired, VarCharType.MAX_LENGTH);
                 case "binary":

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergConversionsTimeTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergConversionsTimeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.manifest;
+
+import org.apache.paimon.iceberg.metadata.IcebergDataField;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.TimeType;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IcebergConversionsTimeTest {
+
+    private static final int MIDDAY_MS = 47_003_524; // 13:03:03.524
+
+    @Test
+    void testTimeToByteBuffer() {
+        ByteBuffer buffer = IcebergConversions.toByteBuffer(DataTypes.TIME(3), MIDDAY_MS);
+        assertThat(buffer.order()).isEqualTo(ByteOrder.LITTLE_ENDIAN);
+        assertThat(buffer.getLong(0)).isEqualTo(MIDDAY_MS * 1000L);
+    }
+
+    @Test
+    void testToPaimonObjectForTime() {
+        byte[] bytes = new byte[8];
+        ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putLong(MIDDAY_MS * 1000L);
+
+        Object actual = IcebergConversions.toPaimonObject(DataTypes.TIME(3), bytes);
+
+        assertThat(actual).isEqualTo(MIDDAY_MS);
+    }
+
+    @Test
+    void testIcebergDataFieldToTypeObjectForTime() {
+        DataField field = new DataField(0, "event_time", DataTypes.TIME(3));
+        IcebergDataField icebergField = new IcebergDataField(field);
+
+        assertThat(icebergField.type()).isEqualTo("time");
+    }
+
+    @Test
+    void testIcebergDataFieldFromTypeForTime() {
+        IcebergDataField field = new IcebergDataField(0, "event_time", false, "time", null);
+
+        assertThat(field.dataType()).isInstanceOf(TimeType.class);
+    }
+}


### PR DESCRIPTION
### Purpose
 - Paimon table containing a TIME column fails when Iceberg is enabled.
 - Support TIME_WITHOUT_TIME_ZONE case, all values are scaled by 1000 since Paimon stores milliseconds internally.
 - Output follows Iceberg convention for storing timestamp type.

### Tests
 - Unit tests