### PR TITLE
[python] Align Identifier with Java by encoding branch into the object field

### DIFF
--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -483,10 +483,6 @@ class RESTCatalog(Catalog):
         options[CoreOptions.PATH.key()] = response.get_path()
         response.put_audit_options_to(options)
 
-        identifier = Identifier.create(db, response.get_name())
-        if identifier.get_branch_name() is not None:
-            options[CoreOptions.BRANCH.key()] = identifier.get_branch_name()
-
         return TableMetadata(
             schema=schema.copy(options),
             is_external=response.get_is_external(),

--- a/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_token_file_io.py
@@ -29,7 +29,7 @@ from pypaimon.common.file_io import FileIO
 from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
 from pypaimon.api.auth.bearer import BearTokenAuthProvider
 from pypaimon.api.auth.dlf_provider import DLFAuthProvider
-from pypaimon.common.identifier import Identifier, SYSTEM_TABLE_SPLITTER
+from pypaimon.common.identifier import Identifier
 from pypaimon.common.options import Options
 from pypaimon.common.options.config import CatalogOptions, OssOptions
 from pypaimon.common.uri_reader import UriReaderFactory
@@ -273,12 +273,14 @@ class RESTTokenFileIO(FileIO):
             self.api_instance = RESTApi(self.properties, False)
 
         table_identifier = self.identifier
-        if SYSTEM_TABLE_SPLITTER in self.identifier.get_object_name():
-            base_table = self.identifier.get_object_name().split(SYSTEM_TABLE_SPLITTER)[0]
-            table_identifier = Identifier(
-                database=self.identifier.get_database_name(),
-                object=base_table,
-                branch=self.identifier.get_branch_name())
+        if self.identifier.is_system_table():
+            # Strip the system-table suffix; preserve the branch so the token
+            # request resolves against the correct branch backing.
+            table_identifier = Identifier.create(
+                self.identifier.get_database_name(),
+                self.identifier.get_table_name(),
+                branch=self.identifier.get_branch_name(),
+            )
 
         response = self.api_instance.load_table_token(table_identifier)
         self.log.info(

--- a/paimon-python/pypaimon/common/identifier.py
+++ b/paimon-python/pypaimon/common/identifier.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -26,116 +25,74 @@ SYSTEM_BRANCH_PREFIX = 'branch_'
 DEFAULT_MAIN_BRANCH = 'main'
 UNKNOWN_DATABASE = 'unknown'
 
-# Sentinel used to detect "the caller did not pass branch=" so we can
-# distinguish from "the caller explicitly passed branch=None".
-_BRANCH_NOT_SET = object()
-
 
 @dataclass(init=False)
 class Identifier:
     """Identifies a database object (table, view, etc.).
 
-    Wire-compatible with Java's ``org.apache.paimon.catalog.Identifier``: the
-    on-the-wire shape is exactly two fields, ``database`` and ``object``. Any
-    branch / system-table portion is encoded into the ``object`` field using
-    the ``$`` separator and the ``branch_`` prefix, so JSON written by Python
+    1:1 port of ``org.apache.paimon.catalog.Identifier``: the on-the-wire
+    shape is exactly two fields, ``database`` and ``object``. Any branch /
+    system-table portion is encoded into the ``object`` field using the
+    ``$`` separator and the ``branch_`` prefix, so JSON written by Python
     is round-trippable through the Java REST server (and vice versa).
 
-    Two construction patterns mirror Java's two constructors:
-      1. ``Identifier(database, object)`` — used by JSON deserialization,
-         :meth:`create` and :meth:`from_string`. The ``object`` may already
-         carry encoded branch / system_table segments.
-      2. ``Identifier.create(database, table, branch=..., system_table=...)``
-         — encodes the components into the ``object`` field.
+    Mirrors Java's three public constructors via a single signature:
+      * ``Identifier(database, object)`` — JSON-create form. ``object``
+        is the final, possibly-encoded string.
+      * ``Identifier(database, table, branch=...)`` — encodes ``branch``
+        into ``object``.
+      * ``Identifier(database, table, branch=..., system_table=...)`` —
+        encodes both.
+
+    ``branch == "main"`` (case-insensitive) is treated as the default
+    branch and is not encoded into the object name, matching Java.
     """
 
     database: str = json_field("database", default=None)
     object: str = json_field("object", default=None)
 
     def __init__(self, database: str, object: Optional[str] = None,
-                 branch=_BRANCH_NOT_SET):
-        """Construct an Identifier.
-
-        Standard form: ``Identifier(database, object)`` — the ``object``
-        may already carry encoded branch / system_table segments.
-
-        Backward-compat form (deprecated): ``Identifier(database, object,
-        branch=...)`` is still accepted for one release. The branch is
-        encoded into ``object`` for you and a :class:`DeprecationWarning`
-        is emitted. New code should call
-        :meth:`Identifier.create` with explicit ``branch=`` instead.
-        """
-        if branch is not _BRANCH_NOT_SET:
-            warnings.warn(
-                "Identifier(..., branch=...) is deprecated; the branch is "
-                "now encoded directly into the `object` field. Use "
-                "Identifier.create(database, table, branch=...) instead. "
-                "This shim will be removed in the next minor release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            if (object is not None and branch is not None
-                    and str(branch).lower() != DEFAULT_MAIN_BRANCH):
-                object = (object + SYSTEM_TABLE_SPLITTER
-                          + SYSTEM_BRANCH_PREFIX + str(branch))
+                 branch: Optional[str] = None,
+                 system_table: Optional[str] = None):
         self.database = database
-        self.object = object
-        # Lazily populated by _split_object_name().
-        self._table: Optional[str] = None
-        self._branch: Optional[str] = None
-        self._system_table: Optional[str] = None
+        if branch is None and system_table is None:
+            # @JsonCreator form: ``object`` is already the final, encoded
+            # string. Components are decoded lazily by _split_object_name().
+            self.object = object
+            self._table: Optional[str] = None
+            self._branch: Optional[str] = None
+            self._system_table: Optional[str] = None
+        else:
+            # Encoding form: ``object`` is the bare table name; encode
+            # branch / system_table into the on-wire ``object``.
+            builder = object
+            if branch is not None and branch.lower() != DEFAULT_MAIN_BRANCH:
+                builder = (builder + SYSTEM_TABLE_SPLITTER
+                           + SYSTEM_BRANCH_PREFIX + branch)
+            if system_table is not None:
+                builder = builder + SYSTEM_TABLE_SPLITTER + system_table
+            self.object = builder
+            self._table = object
+            self._branch = branch
+            self._system_table = system_table
 
     @classmethod
     def create(cls, database: str, table: str,
                branch: Optional[str] = None,
                system_table: Optional[str] = None) -> "Identifier":
-        """Create an Identifier, encoding ``branch`` / ``system_table`` into ``object``.
+        """Create an Identifier.
 
-        The encoding mirrors Java:
-          * ``table``                                 → ``table``
-          * ``table`` + branch=``b``                  → ``table$branch_b``
-          * ``table`` + system_table=``s``            → ``table$s``
-          * ``table`` + branch=``b`` + system_table=``s``
-                                                       → ``table$branch_b$s``
+        Two-arg form ``create(database, object)`` mirrors Java's
+        ``Identifier.create``: the second argument is treated as the final
+        ``object`` string (may already carry encoded branch / system_table
+        segments).
 
-        ``branch == "main"`` (case-insensitive) is treated as the default
-        branch and is not encoded into the object name, matching Java.
-
-        Backward-compat form (deprecated): if the second positional
-        argument already contains ``$`` and no branch / system_table
-        kwargs were supplied, the call is treated as the legacy
-        ``create(database, object)`` form: the string is stored verbatim
-        as ``object`` (so existing callers passing pre-encoded names like
-        ``"orders$snapshots"`` keep working). A :class:`DeprecationWarning`
-        is emitted; new code should use ``Identifier(database, object)``
-        for raw strings or ``Identifier.create(..., system_table=...)``
-        for explicit decomposition.
+        Multi-arg form ``create(database, table, branch=..., system_table=...)``
+        is a Python convenience that encodes the components into ``object``
+        for you, equivalent to ``Identifier(database, table, branch=...,
+        system_table=...)``.
         """
-        if (branch is None and system_table is None
-                and isinstance(table, str) and SYSTEM_TABLE_SPLITTER in table):
-            warnings.warn(
-                "Identifier.create(database, object) where the second "
-                "argument already contains '$' is deprecated; pre-encoded "
-                "object strings should be passed via Identifier(database, "
-                "object), and decomposed components via "
-                "Identifier.create(database, table, branch=..., "
-                "system_table=...). This shim will be removed in the "
-                "next minor release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return cls(database, table)
-        obj = table
-        if branch is not None and branch.lower() != DEFAULT_MAIN_BRANCH:
-            obj = obj + SYSTEM_TABLE_SPLITTER + SYSTEM_BRANCH_PREFIX + branch
-        if system_table is not None:
-            obj = obj + SYSTEM_TABLE_SPLITTER + system_table
-        identifier = cls(database, obj)
-        # Pre-populate cached fields since the components are already known.
-        identifier._table = table
-        identifier._branch = branch
-        identifier._system_table = system_table
-        return identifier
+        return cls(database, table, branch=branch, system_table=system_table)
 
     @classmethod
     def from_string(cls, full_name: str) -> "Identifier":
@@ -246,21 +203,26 @@ class Identifier:
 
     @property
     def branch(self) -> Optional[str]:
-        """Deprecated alias for :meth:`get_branch_name`.
-
-        Kept for backward compatibility with code that read the old
-        ``Identifier.branch`` dataclass field directly. Will be removed
-        in the next minor release.
-        """
-        warnings.warn(
-            "Identifier.branch is deprecated; use "
-            "Identifier.get_branch_name() (or "
-            "Identifier.get_branch_name_or_default()) instead. This "
-            "shim will be removed in the next minor release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        # Read/write alias for callers that previously accessed the
+        # ``Identifier.branch`` dataclass field directly. Java's
+        # ``branch`` is transient/private and not exposed; Python kept
+        # it public, so this property tides external code over.
         return self.get_branch_name()
+
+    @branch.setter
+    def branch(self, value: Optional[str]) -> None:
+        # Re-encode ``object`` so the wire shape stays consistent with
+        # the new value (equivalent to Identifier(db, table, branch=value,
+        # system_table=current_system_table)).
+        table = self.get_table_name()
+        system_table = self.get_system_table_name()
+        rebuilt = Identifier(
+            self.database, table, branch=value, system_table=system_table
+        )
+        self.object = rebuilt.object
+        self._table = table
+        self._branch = value
+        self._system_table = system_table
 
     def __hash__(self):
         return hash((self.database, self.object))

--- a/paimon-python/pypaimon/common/identifier.py
+++ b/paimon-python/pypaimon/common/identifier.py
@@ -21,37 +21,82 @@ from typing import Optional
 from pypaimon.common.json_util import json_field
 
 SYSTEM_TABLE_SPLITTER = '$'
-SYSTEM_BRANCH_PREFIX = 'branch-'
+SYSTEM_BRANCH_PREFIX = 'branch_'
 DEFAULT_MAIN_BRANCH = 'main'
+UNKNOWN_DATABASE = 'unknown'
 
 
-@dataclass
+@dataclass(init=False)
 class Identifier:
+    """Identifies a database object (table, view, etc.).
+
+    Wire-compatible with Java's ``org.apache.paimon.catalog.Identifier``: the
+    on-the-wire shape is exactly two fields, ``database`` and ``object``. Any
+    branch / system-table portion is encoded into the ``object`` field using
+    the ``$`` separator and the ``branch_`` prefix, so JSON written by Python
+    is round-trippable through the Java REST server (and vice versa).
+
+    Two construction patterns mirror Java's two constructors:
+      1. ``Identifier(database, object)`` — used by JSON deserialization,
+         :meth:`create` and :meth:`from_string`. The ``object`` may already
+         carry encoded branch / system_table segments.
+      2. ``Identifier.create(database, table, branch=..., system_table=...)``
+         — encodes the components into the ``object`` field.
+    """
 
     database: str = json_field("database", default=None)
     object: str = json_field("object", default=None)
-    branch: Optional[str] = json_field("branch", default=None)
+
+    def __init__(self, database: str, object: Optional[str] = None):
+        self.database = database
+        self.object = object
+        # Lazily populated by _split_object_name().
+        self._table: Optional[str] = None
+        self._branch: Optional[str] = None
+        self._system_table: Optional[str] = None
 
     @classmethod
-    def create(cls, database: str, object: str) -> "Identifier":
-        return cls(database, object)
+    def create(cls, database: str, table: str,
+               branch: Optional[str] = None,
+               system_table: Optional[str] = None) -> "Identifier":
+        """Create an Identifier, encoding ``branch`` / ``system_table`` into ``object``.
+
+        The encoding mirrors Java:
+          * ``table``                                 → ``table``
+          * ``table`` + branch=``b``                  → ``table$branch_b``
+          * ``table`` + system_table=``s``            → ``table$s``
+          * ``table`` + branch=``b`` + system_table=``s``
+                                                       → ``table$branch_b$s``
+
+        ``branch == "main"`` (case-insensitive) is treated as the default
+        branch and is not encoded into the object name, matching Java.
+        """
+        obj = table
+        if branch is not None and branch.lower() != DEFAULT_MAIN_BRANCH:
+            obj = obj + SYSTEM_TABLE_SPLITTER + SYSTEM_BRANCH_PREFIX + branch
+        if system_table is not None:
+            obj = obj + SYSTEM_TABLE_SPLITTER + system_table
+        identifier = cls(database, obj)
+        # Pre-populate cached fields since the components are already known.
+        identifier._table = table
+        identifier._branch = branch
+        identifier._system_table = system_table
+        return identifier
 
     @classmethod
     def from_string(cls, full_name: str) -> "Identifier":
-        """Parse a 'database.object' identifier, with optional backtick quoting."""
+        """Parse a ``database.object`` identifier, with optional backtick quoting."""
         if not full_name or not full_name.strip():
             raise ValueError("fullName cannot be null or empty")
 
-        # Check if backticks are used - if so, parse with backtick support
         if '`' in full_name:
             return cls._parse_with_backticks(full_name)
 
-        # Otherwise, use Java-compatible split on first period only
         parts = full_name.split(".", 1)
 
         if len(parts) != 2:
             raise ValueError(
-                f"Cannot get splits from '{full_name}' to get database and object"
+                "Cannot get splits from '{}' to get database and object".format(full_name)
             )
 
         return cls(parts[0], parts[1])
@@ -75,41 +120,80 @@ class Identifier:
             parts.append(current)
 
         if in_backticks:
-            raise ValueError(f"Unclosed backtick in identifier: {full_name}")
+            raise ValueError("Unclosed backtick in identifier: {}".format(full_name))
 
         if len(parts) != 2:
-            raise ValueError(f"Invalid identifier format: {full_name}")
+            raise ValueError("Invalid identifier format: {}".format(full_name))
 
         return cls(parts[0], parts[1])
 
+    def _split_object_name(self) -> None:
+        if self._table is not None:
+            return
+
+        splits = self.object.split(SYSTEM_TABLE_SPLITTER)
+        if len(splits) == 1:
+            self._table = self.object
+            self._branch = None
+            self._system_table = None
+        elif len(splits) == 2:
+            self._table = splits[0]
+            if splits[1].startswith(SYSTEM_BRANCH_PREFIX):
+                self._branch = splits[1][len(SYSTEM_BRANCH_PREFIX):]
+                self._system_table = None
+            else:
+                self._branch = None
+                self._system_table = splits[1]
+        elif len(splits) == 3:
+            if not splits[1].startswith(SYSTEM_BRANCH_PREFIX):
+                raise ValueError(
+                    "System table can only contain one '$' separator, "
+                    "but this is: " + self.object
+                )
+            self._table = splits[0]
+            self._branch = splits[1][len(SYSTEM_BRANCH_PREFIX):]
+            self._system_table = splits[2]
+        else:
+            raise ValueError("Invalid object name: " + self.object)
+
     def get_full_name(self) -> str:
-        if self.branch:
-            return "{}.{}.{}".format(self.database, self.object, self.branch)
+        # Match Java: tables created without an explicit database (e.g. some
+        # ad-hoc query paths) land in the special "unknown" database, in which
+        # case the database segment is dropped from the rendered name.
+        if UNKNOWN_DATABASE == self.database:
+            return self.object
         return "{}.{}".format(self.database, self.object)
 
     def get_database_name(self) -> str:
         return self.database
 
     def get_table_name(self) -> str:
-        return self.object
+        self._split_object_name()
+        return self._table
 
     def get_object_name(self) -> str:
         return self.object
 
     def get_branch_name(self) -> Optional[str]:
-        return self.branch
+        self._split_object_name()
+        return self._branch
 
     def get_branch_name_or_default(self) -> str:
-        """Get branch name or return default 'main' if branch is None."""
-        return self.branch if self.branch else "main"
+        """Get branch name or return ``DEFAULT_MAIN_BRANCH`` if no branch is encoded."""
+        branch = self.get_branch_name()
+        return branch if branch is not None else DEFAULT_MAIN_BRANCH
 
-    def __hash__(self):
-        return hash((self.database, self.object, self.branch))
+    def get_system_table_name(self) -> Optional[str]:
+        self._split_object_name()
+        return self._system_table
 
     def is_system_table(self) -> bool:
-        if SYSTEM_TABLE_SPLITTER not in self.object:
-            return False
-        parts = self.object.split(SYSTEM_TABLE_SPLITTER)
-        if len(parts) == 2:
-            return not parts[1].startswith(SYSTEM_BRANCH_PREFIX)
-        return len(parts) == 3
+        return self.get_system_table_name() is not None
+
+    def __hash__(self):
+        return hash((self.database, self.object))
+
+    def __eq__(self, other):
+        if not isinstance(other, Identifier):
+            return NotImplemented
+        return self.database == other.database and self.object == other.object

--- a/paimon-python/pypaimon/common/identifier.py
+++ b/paimon-python/pypaimon/common/identifier.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -24,6 +25,10 @@ SYSTEM_TABLE_SPLITTER = '$'
 SYSTEM_BRANCH_PREFIX = 'branch_'
 DEFAULT_MAIN_BRANCH = 'main'
 UNKNOWN_DATABASE = 'unknown'
+
+# Sentinel used to detect "the caller did not pass branch=" so we can
+# distinguish from "the caller explicitly passed branch=None".
+_BRANCH_NOT_SET = object()
 
 
 @dataclass(init=False)
@@ -47,7 +52,32 @@ class Identifier:
     database: str = json_field("database", default=None)
     object: str = json_field("object", default=None)
 
-    def __init__(self, database: str, object: Optional[str] = None):
+    def __init__(self, database: str, object: Optional[str] = None,
+                 branch=_BRANCH_NOT_SET):
+        """Construct an Identifier.
+
+        Standard form: ``Identifier(database, object)`` — the ``object``
+        may already carry encoded branch / system_table segments.
+
+        Backward-compat form (deprecated): ``Identifier(database, object,
+        branch=...)`` is still accepted for one release. The branch is
+        encoded into ``object`` for you and a :class:`DeprecationWarning`
+        is emitted. New code should call
+        :meth:`Identifier.create` with explicit ``branch=`` instead.
+        """
+        if branch is not _BRANCH_NOT_SET:
+            warnings.warn(
+                "Identifier(..., branch=...) is deprecated; the branch is "
+                "now encoded directly into the `object` field. Use "
+                "Identifier.create(database, table, branch=...) instead. "
+                "This shim will be removed in the next minor release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if (object is not None and branch is not None
+                    and str(branch).lower() != DEFAULT_MAIN_BRANCH):
+                object = (object + SYSTEM_TABLE_SPLITTER
+                          + SYSTEM_BRANCH_PREFIX + str(branch))
         self.database = database
         self.object = object
         # Lazily populated by _split_object_name().
@@ -70,7 +100,31 @@ class Identifier:
 
         ``branch == "main"`` (case-insensitive) is treated as the default
         branch and is not encoded into the object name, matching Java.
+
+        Backward-compat form (deprecated): if the second positional
+        argument already contains ``$`` and no branch / system_table
+        kwargs were supplied, the call is treated as the legacy
+        ``create(database, object)`` form: the string is stored verbatim
+        as ``object`` (so existing callers passing pre-encoded names like
+        ``"orders$snapshots"`` keep working). A :class:`DeprecationWarning`
+        is emitted; new code should use ``Identifier(database, object)``
+        for raw strings or ``Identifier.create(..., system_table=...)``
+        for explicit decomposition.
         """
+        if (branch is None and system_table is None
+                and isinstance(table, str) and SYSTEM_TABLE_SPLITTER in table):
+            warnings.warn(
+                "Identifier.create(database, object) where the second "
+                "argument already contains '$' is deprecated; pre-encoded "
+                "object strings should be passed via Identifier(database, "
+                "object), and decomposed components via "
+                "Identifier.create(database, table, branch=..., "
+                "system_table=...). This shim will be removed in the "
+                "next minor release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return cls(database, table)
         obj = table
         if branch is not None and branch.lower() != DEFAULT_MAIN_BRANCH:
             obj = obj + SYSTEM_TABLE_SPLITTER + SYSTEM_BRANCH_PREFIX + branch
@@ -189,6 +243,24 @@ class Identifier:
 
     def is_system_table(self) -> bool:
         return self.get_system_table_name() is not None
+
+    @property
+    def branch(self) -> Optional[str]:
+        """Deprecated alias for :meth:`get_branch_name`.
+
+        Kept for backward compatibility with code that read the old
+        ``Identifier.branch`` dataclass field directly. Will be removed
+        in the next minor release.
+        """
+        warnings.warn(
+            "Identifier.branch is deprecated; use "
+            "Identifier.get_branch_name() (or "
+            "Identifier.get_branch_name_or_default()) instead. This "
+            "shim will be removed in the next minor release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_branch_name()
 
     def __hash__(self):
         return hash((self.database, self.object))

--- a/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
+++ b/paimon-python/pypaimon/snapshot/catalog_snapshot_commit.py
@@ -20,12 +20,12 @@ import logging
 from typing import List
 
 from pypaimon.catalog.catalog import Catalog
-
-logger = logging.getLogger(__name__)
 from pypaimon.common.identifier import Identifier
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.snapshot.snapshot_commit import (PartitionStatistics,
                                                SnapshotCommit)
+
+logger = logging.getLogger(__name__)
 
 
 class CatalogSnapshotCommit(SnapshotCommit):
@@ -37,20 +37,19 @@ class CatalogSnapshotCommit(SnapshotCommit):
 
         Args:
             catalog: The catalog instance to use for committing
-            identifier: The table identifier
+            identifier: The table identifier (already encodes branch in object name)
             uuid: Optional table UUID for verification
         """
         self.catalog = catalog
         self.identifier = identifier
         self.uuid = uuid
 
-    def commit(self, snapshot: Snapshot, branch: str, statistics: List[PartitionStatistics]) -> bool:
+    def commit(self, snapshot: Snapshot, statistics: List[PartitionStatistics]) -> bool:
         """
         Commit the snapshot using the catalog.
 
         Args:
             snapshot: The snapshot to commit
-            branch: The branch name to commit to
             statistics: List of partition statistics
 
         Returns:
@@ -59,17 +58,11 @@ class CatalogSnapshotCommit(SnapshotCommit):
         Raises:
             Exception: If commit fails
         """
-        new_identifier = Identifier(
-            database=self.identifier.get_database_name(),
-            object=self.identifier.get_table_name(),
-            branch=branch
-        )
-
         # Call catalog's commit_snapshot method
         if hasattr(self.catalog, 'commit_snapshot'):
-            success = self.catalog.commit_snapshot(new_identifier, self.uuid, snapshot, statistics)
+            success = self.catalog.commit_snapshot(self.identifier, self.uuid, snapshot, statistics)
             if success:
-                logger.info("Catalog snapshot commit succeeded for %s, snapshot id %d", new_identifier, snapshot.id)
+                logger.info("Catalog snapshot commit succeeded for %s, snapshot id %d", self.identifier, snapshot.id)
             return success
         else:
             # Fallback for catalogs that don't support snapshot commits

--- a/paimon-python/pypaimon/snapshot/renaming_snapshot_commit.py
+++ b/paimon-python/pypaimon/snapshot/renaming_snapshot_commit.py
@@ -48,13 +48,12 @@ class RenamingSnapshotCommit(SnapshotCommit):
         self.snapshot_manager = snapshot_manager
         self.file_io: FileIO = snapshot_manager.file_io
 
-    def commit(self, snapshot: Snapshot, branch: str, statistics: List[PartitionStatistics]) -> bool:
+    def commit(self, snapshot: Snapshot, statistics: List[PartitionStatistics]) -> bool:
         """
         Commit the snapshot using file renaming.
 
         Args:
             snapshot: The snapshot to commit
-            branch: The branch name to commit to
             statistics: List of partition statistics (currently unused but kept for interface compatibility)
 
         Returns:

--- a/paimon-python/pypaimon/snapshot/snapshot_commit.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_commit.py
@@ -73,13 +73,12 @@ class SnapshotCommit(ABC):
     """Interface to commit snapshot atomically."""
 
     @abstractmethod
-    def commit(self, snapshot: Snapshot, branch: str, statistics: List[PartitionStatistics]) -> bool:
+    def commit(self, snapshot: Snapshot, statistics: List[PartitionStatistics]) -> bool:
         """
         Commit the given snapshot.
 
         Args:
             snapshot: The snapshot to commit
-            branch: The branch name to commit to
             statistics: List of partition statistics
 
         Returns:

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -83,8 +83,8 @@ class FileStoreTable(Table):
         return cls(file_io, identifier, table_path, table_schema)
 
     def current_branch(self) -> str:
-        """Get the current branch name from options."""
-        return self.options.branch()
+        """Get the current branch name from the identifier."""
+        return self.identifier.get_branch_name_or_default()
 
     def comment(self) -> Optional[str]:
         """Get the table comment."""
@@ -406,8 +406,23 @@ class FileStoreTable(Table):
         if time_travel_schema is not None:
             new_table_schema = time_travel_schema
 
-        return FileStoreTable(self.file_io, self.identifier, self.table_path, new_table_schema,
-                              self.catalog_environment)
+        # Re-encode the branch into the identifier when the option changes, so
+        # current_branch() and any catalog-routed snapshot commit see the
+        # branched object name without an extra side channel.
+        new_identifier = self.identifier
+        catalog_env = self.catalog_environment
+        branch_key = CoreOptions.BRANCH.key()
+        if branch_key in options:
+            new_branch = options[branch_key]
+            new_identifier = Identifier.create(
+                self.identifier.get_database_name(),
+                self.identifier.get_table_name(),
+                branch=new_branch,
+            )
+            catalog_env = self.catalog_environment.copy(new_identifier)
+
+        return FileStoreTable(self.file_io, new_identifier, self.table_path, new_table_schema,
+                              catalog_env)
 
     def _try_time_travel(self, options: Options) -> Optional[TableSchema]:
         """

--- a/paimon-python/pypaimon/tests/branch/catalog_branch_manager_test.py
+++ b/paimon-python/pypaimon/tests/branch/catalog_branch_manager_test.py
@@ -125,7 +125,7 @@ class TestCatalogBranchManager(unittest.TestCase):
     def test_fast_forward_to_main(self):
         """Test fast-forward to main branch should raise error."""
         from pypaimon.common.identifier import Identifier
-        identifier_with_branch = Identifier("test_db", "test_table", "feature")
+        identifier_with_branch = Identifier.create("test_db", "test_table", branch="feature")
         branch_manager = CatalogBranchManager(self.catalog_loader, identifier_with_branch)
 
         with self.assertRaises(ValueError) as cm:
@@ -136,7 +136,7 @@ class TestCatalogBranchManager(unittest.TestCase):
     def test_fast_forward_to_current_branch(self):
         """Test fast-forward to current branch should raise error."""
         from pypaimon.common.identifier import Identifier
-        identifier_with_branch = Identifier("test_db", "test_table", "feature")
+        identifier_with_branch = Identifier.create("test_db", "test_table", branch="feature")
         branch_manager = CatalogBranchManager(self.catalog_loader, identifier_with_branch)
 
         with self.assertRaises(ValueError) as cm:

--- a/paimon-python/pypaimon/tests/identifier_test.py
+++ b/paimon-python/pypaimon/tests/identifier_test.py
@@ -20,7 +20,6 @@ Tests for Identifier parsing, including backtick support for database names with
 """
 
 import unittest
-import warnings
 
 from pypaimon.common.identifier import Identifier
 
@@ -63,9 +62,9 @@ class IdentifierTest(unittest.TestCase):
         identifier = Identifier.create("mydb", "mytable")
         self.assertEqual(identifier.get_full_name(), "mydb.mytable")
 
-    def test_get_full_name_with_branch_encoded_in_object(self):
-        """A branch is encoded into ``object`` (Java-compatible)."""
-        identifier = Identifier.create("mydb", "mytable", branch="feature")
+    def test_constructor_with_branch_encodes_into_object(self):
+        """``Identifier(db, table, branch=...)`` mirrors Java's 3-arg constructor."""
+        identifier = Identifier("mydb", "mytable", branch="feature")
         self.assertEqual(identifier.object, "mytable$branch_feature")
         self.assertEqual(identifier.get_full_name(), "mydb.mytable$branch_feature")
         self.assertEqual(identifier.get_table_name(), "mytable")
@@ -74,18 +73,12 @@ class IdentifierTest(unittest.TestCase):
         self.assertFalse(identifier.is_system_table())
 
     def test_main_branch_is_not_encoded_into_object(self):
-        """``main`` (case-insensitive) is the default branch and is not encoded into ``object``.
-
-        Note: matching Java semantics, the cached branch value passed to
-        ``create`` is preserved on the instance, so ``get_branch_name()``
-        returns the supplied string. The identifier is still wire-equal to
-        a no-branch one because only ``object`` round-trips through JSON.
-        """
+        """``main`` (case-insensitive) is the default branch and is not encoded into ``object``."""
         for branch in ("main", "MAIN", "Main"):
-            identifier = Identifier.create("mydb", "mytable", branch=branch)
+            identifier = Identifier("mydb", "mytable", branch=branch)
             self.assertEqual(identifier.object, "mytable")
             # Wire-equal to a no-branch identifier.
-            self.assertEqual(identifier, Identifier.create("mydb", "mytable"))
+            self.assertEqual(identifier, Identifier("mydb", "mytable"))
 
     def test_get_branch_name_or_default_when_unset(self):
         """``get_branch_name_or_default`` falls back to 'main'."""
@@ -131,7 +124,7 @@ class IdentifierTest(unittest.TestCase):
         """object name '<base>$snapshots' is a system table."""
         self.assertTrue(Identifier("mydb", "orders$snapshots").is_system_table())
         self.assertTrue(
-            Identifier.create("mydb", "orders", system_table="snapshots").is_system_table())
+            Identifier("mydb", "orders", system_table="snapshots").is_system_table())
 
     def test_is_system_table_schemas_suffix(self):
         """object name '<base>$schemas' is a system table."""
@@ -163,9 +156,9 @@ class IdentifierTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             identifier.is_system_table()
 
-    def test_create_with_branch_and_system_table(self):
-        """``create`` encodes both branch and system_table into the object name."""
-        identifier = Identifier.create(
+    def test_constructor_with_branch_and_system_table(self):
+        """``Identifier(db, table, branch=..., system_table=...)`` mirrors Java's 4-arg constructor."""
+        identifier = Identifier(
             "mydb", "orders", branch="dev", system_table="snapshots"
         )
         self.assertEqual(identifier.object, "orders$branch_dev$snapshots")
@@ -173,131 +166,101 @@ class IdentifierTest(unittest.TestCase):
         self.assertEqual(identifier.get_branch_name(), "dev")
         self.assertEqual(identifier.get_system_table_name(), "snapshots")
 
-    def test_create_with_system_table_only(self):
-        """``create`` with system_table but no branch."""
-        identifier = Identifier.create("mydb", "orders", system_table="files")
+    def test_constructor_with_system_table_only(self):
+        """Constructor with system_table but no branch."""
+        identifier = Identifier("mydb", "orders", system_table="files")
         self.assertEqual(identifier.object, "orders$files")
         self.assertEqual(identifier.get_table_name(), "orders")
         self.assertIsNone(identifier.get_branch_name())
         self.assertEqual(identifier.get_system_table_name(), "files")
 
+    def test_create_is_two_arg_alias(self):
+        """``Identifier.create(db, object)`` is a 2-arg alias of the JSON constructor (matches Java)."""
+        identifier = Identifier.create("db", "orders$snapshots")
+        self.assertEqual(identifier.object, "orders$snapshots")
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertEqual(identifier.get_system_table_name(), "snapshots")
+        self.assertTrue(identifier.is_system_table())
+
+    def test_constructor_forms_are_wire_equivalent(self):
+        """The encoding constructor and the @JsonCreator form produce wire-equal identifiers."""
+        encoded = Identifier(
+            "mydb", "orders", branch="dev", system_table="snapshots"
+        )
+        from_wire = Identifier("mydb", "orders$branch_dev$snapshots")
+        self.assertEqual(encoded, from_wire)
+        self.assertEqual(hash(encoded), hash(from_wire))
+
+    def test_branch_property_reads_decoded_branch(self):
+        """``identifier.branch`` is a read-only alias for ``get_branch_name()``."""
+        self.assertEqual(Identifier("db", "tbl", branch="dev").branch, "dev")
+        self.assertEqual(Identifier("db", "tbl$branch_dev").branch, "dev")
+        self.assertIsNone(Identifier("db", "tbl").branch)
+
     def test_equality_and_hash_ignore_cached_fields(self):
         """Equality and hash depend only on (database, object), matching Java JSON shape."""
         a = Identifier("mydb", "orders$branch_dev$snapshots")
-        b = Identifier.create(
+        b = Identifier(
             "mydb", "orders", branch="dev", system_table="snapshots"
         )
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
 
 
-class IdentifierBackwardCompatibilityShimTest(unittest.TestCase):
-    """Locks in the backward-compat shim for the previous Identifier shape.
+class IdentifierBackwardCompatibilityTest(unittest.TestCase):
+    """Locks in that the public surface from before this PR keeps working.
 
-    The shim is intentionally narrow: it covers the three concrete API
-    breaks that escaped pre-review (constructor ``branch=`` kwarg,
-    ``identifier.branch`` attribute, ``Identifier.create(db, object)``
-    two-arg form with ``$`` in the second arg). It is scheduled for
-    removal in the next minor release; tests below assert both the
-    behavioural compatibility AND the ``DeprecationWarning`` so the
-    shim doesn't get silently dropped before users have a chance to
-    migrate.
+    Pre-PR ``Identifier`` exposed three signatures that this PR's
+    encoding-into-object refactor risked breaking. They must continue to
+    run without raising; semantics may shift to the wire-correct form
+    (branches encoded into ``object``), but no caller should hit a
+    TypeError / AttributeError on an unchanged call site.
     """
 
-    def test_constructor_branch_kwarg_still_works_with_warning(self):
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            identifier = Identifier(database="db", object="tbl",
-                                    branch="feature")
-
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 1, "exactly one DeprecationWarning expected")
-        self.assertIn("Identifier(..., branch=...)", str(depr[0].message))
-
-        # Branch must be encoded into the object field, matching the
-        # behaviour of the new ``Identifier.create(..., branch=...)`` form.
+    def test_constructor_branch_kwarg_still_accepted(self):
+        # ``Identifier(db, obj, branch=...)`` was the old dataclass init
+        # signature. It must still construct without error; the branch is
+        # now encoded into ``object`` so the wire is Java-compatible.
+        identifier = Identifier(database="db", object="tbl", branch="feature")
         self.assertEqual(identifier.object, "tbl$branch_feature")
         self.assertEqual(identifier.get_branch_name(), "feature")
-        self.assertEqual(
-            identifier,
-            Identifier.create("db", "tbl", branch="feature"),
-            "shim must produce a wire-equal Identifier",
-        )
 
-    def test_constructor_branch_kwarg_main_is_not_encoded(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            identifier = Identifier("db", "tbl", branch="main")
-        # main is the default branch; encoding rule matches Java/create().
+    def test_constructor_branch_kwarg_none_is_accepted(self):
+        # Explicit ``branch=None`` (e.g. from JSON deserialization paths)
+        # must remain a no-op rather than triggering the encoding path.
+        identifier = Identifier("db", "tbl", branch=None)
         self.assertEqual(identifier.object, "tbl")
+        self.assertIsNone(identifier.get_branch_name())
 
-    def test_constructor_branch_kwarg_none_is_no_op(self):
-        # Explicit branch=None must still trigger the warning (it's the
-        # deprecated kwarg form) but produce the un-encoded object.
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            identifier = Identifier("db", "tbl", branch=None)
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 1)
+    def test_branch_attribute_read(self):
+        # Old code that read ``identifier.branch`` keeps reading the
+        # branch name (now decoded from ``object``).
+        self.assertEqual(Identifier("db", "tbl", branch="dev").branch, "dev")
+        self.assertEqual(Identifier("db", "tbl$branch_dev").branch, "dev")
+        self.assertIsNone(Identifier("db", "tbl").branch)
+
+    def test_branch_attribute_write(self):
+        # Old code that assigned to ``identifier.branch`` keeps working.
+        # The setter re-encodes ``object`` so the wire is consistent.
+        identifier = Identifier("db", "tbl")
+        identifier.branch = "feature"
+        self.assertEqual(identifier.branch, "feature")
+        self.assertEqual(identifier.object, "tbl$branch_feature")
+        self.assertEqual(identifier.get_branch_name(), "feature")
+        # Clearing back to None drops the encoded branch segment.
+        identifier.branch = None
         self.assertEqual(identifier.object, "tbl")
+        self.assertIsNone(identifier.branch)
 
-    def test_branch_property_delegates_to_get_branch_name(self):
-        identifier = Identifier.create("db", "tbl", branch="dev")
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            value = identifier.branch
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 1)
-        self.assertIn("Identifier.branch is deprecated", str(depr[0].message))
-        self.assertEqual(value, "dev")
-        self.assertEqual(value, identifier.get_branch_name())
-
-    def test_branch_property_returns_none_when_no_branch(self):
-        identifier = Identifier.create("db", "tbl")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.assertIsNone(identifier.branch)
-
-    def test_create_two_arg_form_with_dollar_falls_back_to_raw(self):
-        # ``create("db", "orders$snapshots")`` used to mean "store
-        # orders$snapshots as the object". Honour that shape with a
-        # warning so existing callers keep working.
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            identifier = Identifier.create("db", "orders$snapshots")
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 1)
-        self.assertIn("Identifier.create(database, object)",
-                      str(depr[0].message))
+    def test_create_two_arg_form_with_dollar_object(self):
+        # ``Identifier.create(db, "tbl$snapshots")`` was the documented
+        # way to construct system-table identifiers pre-PR. It must keep
+        # producing an equivalent system-table identifier.
+        identifier = Identifier.create("db", "orders$snapshots")
         self.assertEqual(identifier.object, "orders$snapshots")
         self.assertTrue(identifier.is_system_table())
         self.assertEqual(identifier.get_table_name(), "orders")
         self.assertEqual(identifier.get_system_table_name(), "snapshots")
-
-    def test_create_two_arg_form_without_dollar_does_not_warn(self):
-        # The new shape — ``create("db", "tbl")`` — must NOT trigger the
-        # legacy fallback (no ``$`` in the table name).
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            identifier = Identifier.create("db", "tbl")
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 0,
-                         "non-legacy create() must not warn")
-        self.assertEqual(identifier.object, "tbl")
-
-    def test_create_with_kwargs_skips_legacy_fallback(self):
-        # When branch=/system_table= are explicitly passed, the second
-        # arg is the table name even if it contains ``$``: do NOT route
-        # through the legacy raw-object fallback.
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            identifier = Identifier.create("db", "weird$table",
-                                           branch="dev")
-        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        self.assertEqual(len(depr), 0)
-        self.assertEqual(identifier.object, "weird$table$branch_dev")
-        self.assertEqual(identifier.get_branch_name(), "dev")
-        self.assertEqual(identifier.get_table_name(), "weird$table")
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/identifier_test.py
+++ b/paimon-python/pypaimon/tests/identifier_test.py
@@ -20,6 +20,7 @@ Tests for Identifier parsing, including backtick support for database names with
 """
 
 import unittest
+import warnings
 
 from pypaimon.common.identifier import Identifier
 
@@ -188,6 +189,115 @@ class IdentifierTest(unittest.TestCase):
         )
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
+
+
+class IdentifierBackwardCompatibilityShimTest(unittest.TestCase):
+    """Locks in the backward-compat shim for the previous Identifier shape.
+
+    The shim is intentionally narrow: it covers the three concrete API
+    breaks that escaped pre-review (constructor ``branch=`` kwarg,
+    ``identifier.branch`` attribute, ``Identifier.create(db, object)``
+    two-arg form with ``$`` in the second arg). It is scheduled for
+    removal in the next minor release; tests below assert both the
+    behavioural compatibility AND the ``DeprecationWarning`` so the
+    shim doesn't get silently dropped before users have a chance to
+    migrate.
+    """
+
+    def test_constructor_branch_kwarg_still_works_with_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            identifier = Identifier(database="db", object="tbl",
+                                    branch="feature")
+
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 1, "exactly one DeprecationWarning expected")
+        self.assertIn("Identifier(..., branch=...)", str(depr[0].message))
+
+        # Branch must be encoded into the object field, matching the
+        # behaviour of the new ``Identifier.create(..., branch=...)`` form.
+        self.assertEqual(identifier.object, "tbl$branch_feature")
+        self.assertEqual(identifier.get_branch_name(), "feature")
+        self.assertEqual(
+            identifier,
+            Identifier.create("db", "tbl", branch="feature"),
+            "shim must produce a wire-equal Identifier",
+        )
+
+    def test_constructor_branch_kwarg_main_is_not_encoded(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            identifier = Identifier("db", "tbl", branch="main")
+        # main is the default branch; encoding rule matches Java/create().
+        self.assertEqual(identifier.object, "tbl")
+
+    def test_constructor_branch_kwarg_none_is_no_op(self):
+        # Explicit branch=None must still trigger the warning (it's the
+        # deprecated kwarg form) but produce the un-encoded object.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            identifier = Identifier("db", "tbl", branch=None)
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 1)
+        self.assertEqual(identifier.object, "tbl")
+
+    def test_branch_property_delegates_to_get_branch_name(self):
+        identifier = Identifier.create("db", "tbl", branch="dev")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            value = identifier.branch
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 1)
+        self.assertIn("Identifier.branch is deprecated", str(depr[0].message))
+        self.assertEqual(value, "dev")
+        self.assertEqual(value, identifier.get_branch_name())
+
+    def test_branch_property_returns_none_when_no_branch(self):
+        identifier = Identifier.create("db", "tbl")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.assertIsNone(identifier.branch)
+
+    def test_create_two_arg_form_with_dollar_falls_back_to_raw(self):
+        # ``create("db", "orders$snapshots")`` used to mean "store
+        # orders$snapshots as the object". Honour that shape with a
+        # warning so existing callers keep working.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            identifier = Identifier.create("db", "orders$snapshots")
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 1)
+        self.assertIn("Identifier.create(database, object)",
+                      str(depr[0].message))
+        self.assertEqual(identifier.object, "orders$snapshots")
+        self.assertTrue(identifier.is_system_table())
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertEqual(identifier.get_system_table_name(), "snapshots")
+
+    def test_create_two_arg_form_without_dollar_does_not_warn(self):
+        # The new shape — ``create("db", "tbl")`` — must NOT trigger the
+        # legacy fallback (no ``$`` in the table name).
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            identifier = Identifier.create("db", "tbl")
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 0,
+                         "non-legacy create() must not warn")
+        self.assertEqual(identifier.object, "tbl")
+
+    def test_create_with_kwargs_skips_legacy_fallback(self):
+        # When branch=/system_table= are explicitly passed, the second
+        # arg is the table name even if it contains ``$``: do NOT route
+        # through the legacy raw-object fallback.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            identifier = Identifier.create("db", "weird$table",
+                                           branch="dev")
+        depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(len(depr), 0)
+        self.assertEqual(identifier.object, "weird$table$branch_dev")
+        self.assertEqual(identifier.get_branch_name(), "dev")
+        self.assertEqual(identifier.get_table_name(), "weird$table")
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/identifier_test.py
+++ b/paimon-python/pypaimon/tests/identifier_test.py
@@ -62,10 +62,40 @@ class IdentifierTest(unittest.TestCase):
         identifier = Identifier.create("mydb", "mytable")
         self.assertEqual(identifier.get_full_name(), "mydb.mytable")
 
-    def test_get_full_name_with_branch(self):
-        """get_full_name() includes branch when set."""
-        identifier = Identifier(database="mydb", object="mytable", branch="feature")
-        self.assertEqual(identifier.get_full_name(), "mydb.mytable.feature")
+    def test_get_full_name_with_branch_encoded_in_object(self):
+        """A branch is encoded into ``object`` (Java-compatible)."""
+        identifier = Identifier.create("mydb", "mytable", branch="feature")
+        self.assertEqual(identifier.object, "mytable$branch_feature")
+        self.assertEqual(identifier.get_full_name(), "mydb.mytable$branch_feature")
+        self.assertEqual(identifier.get_table_name(), "mytable")
+        self.assertEqual(identifier.get_branch_name(), "feature")
+        self.assertEqual(identifier.get_branch_name_or_default(), "feature")
+        self.assertFalse(identifier.is_system_table())
+
+    def test_main_branch_is_not_encoded_into_object(self):
+        """``main`` (case-insensitive) is the default branch and is not encoded into ``object``.
+
+        Note: matching Java semantics, the cached branch value passed to
+        ``create`` is preserved on the instance, so ``get_branch_name()``
+        returns the supplied string. The identifier is still wire-equal to
+        a no-branch one because only ``object`` round-trips through JSON.
+        """
+        for branch in ("main", "MAIN", "Main"):
+            identifier = Identifier.create("mydb", "mytable", branch=branch)
+            self.assertEqual(identifier.object, "mytable")
+            # Wire-equal to a no-branch identifier.
+            self.assertEqual(identifier, Identifier.create("mydb", "mytable"))
+
+    def test_get_branch_name_or_default_when_unset(self):
+        """``get_branch_name_or_default`` falls back to 'main'."""
+        identifier = Identifier.create("mydb", "mytable")
+        self.assertIsNone(identifier.get_branch_name())
+        self.assertEqual(identifier.get_branch_name_or_default(), "main")
+
+    def test_unknown_database_drops_database_segment(self):
+        """``UNKNOWN_DATABASE`` is dropped from full name (Java-compatible)."""
+        identifier = Identifier("unknown", "mytable")
+        self.assertEqual(identifier.get_full_name(), "mytable")
 
     def test_empty_string_raises_error(self):
         """Empty string should raise ValueError."""
@@ -98,15 +128,66 @@ class IdentifierTest(unittest.TestCase):
 
     def test_is_system_table_snapshots_suffix(self):
         """object name '<base>$snapshots' is a system table."""
-        self.assertTrue(Identifier.create("mydb", "orders$snapshots").is_system_table())
+        self.assertTrue(Identifier("mydb", "orders$snapshots").is_system_table())
+        self.assertTrue(
+            Identifier.create("mydb", "orders", system_table="snapshots").is_system_table())
 
     def test_is_system_table_schemas_suffix(self):
         """object name '<base>$schemas' is a system table."""
-        self.assertTrue(Identifier.create("mydb", "orders$schemas").is_system_table())
+        self.assertTrue(Identifier("mydb", "orders$schemas").is_system_table())
 
     def test_is_system_table_files_suffix(self):
         """object name '<base>$files' is a system table."""
-        self.assertTrue(Identifier.create("mydb", "orders$files").is_system_table())
+        self.assertTrue(Identifier("mydb", "orders$files").is_system_table())
+
+    def test_is_system_table_two_parts_with_branch_prefix(self):
+        """A '<table>$branch_<name>' object is a branched table, NOT a system table."""
+        identifier = Identifier("mydb", "orders$branch_dev")
+        self.assertFalse(identifier.is_system_table())
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertEqual(identifier.get_branch_name(), "dev")
+        self.assertIsNone(identifier.get_system_table_name())
+
+    def test_is_system_table_three_parts_branch_and_system(self):
+        """A '<table>$branch_<name>$snapshots' object is a system table on a branch."""
+        identifier = Identifier("mydb", "orders$branch_dev$snapshots")
+        self.assertTrue(identifier.is_system_table())
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertEqual(identifier.get_branch_name(), "dev")
+        self.assertEqual(identifier.get_system_table_name(), "snapshots")
+
+    def test_three_parts_without_branch_prefix_raises(self):
+        """A '<table>$<x>$<y>' object without branch prefix is invalid (single '$' allowed)."""
+        identifier = Identifier("mydb", "orders$schemas$snapshots")
+        with self.assertRaises(ValueError):
+            identifier.is_system_table()
+
+    def test_create_with_branch_and_system_table(self):
+        """``create`` encodes both branch and system_table into the object name."""
+        identifier = Identifier.create(
+            "mydb", "orders", branch="dev", system_table="snapshots"
+        )
+        self.assertEqual(identifier.object, "orders$branch_dev$snapshots")
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertEqual(identifier.get_branch_name(), "dev")
+        self.assertEqual(identifier.get_system_table_name(), "snapshots")
+
+    def test_create_with_system_table_only(self):
+        """``create`` with system_table but no branch."""
+        identifier = Identifier.create("mydb", "orders", system_table="files")
+        self.assertEqual(identifier.object, "orders$files")
+        self.assertEqual(identifier.get_table_name(), "orders")
+        self.assertIsNone(identifier.get_branch_name())
+        self.assertEqual(identifier.get_system_table_name(), "files")
+
+    def test_equality_and_hash_ignore_cached_fields(self):
+        """Equality and hash depend only on (database, object), matching Java JSON shape."""
+        a = Identifier("mydb", "orders$branch_dev$snapshots")
+        b = Identifier.create(
+            "mydb", "orders", branch="dev", system_table="snapshots"
+        )
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
@@ -320,8 +320,8 @@ class TestRESTCommit(RESTBaseTest):
 
         real_commit = tc.file_store_commit.snapshot_commit.commit
 
-        def commit_then_raise(sn, br, st):
-            real_commit(sn, br, st)
+        def commit_then_raise(sn, st):
+            real_commit(sn, st)
             raise RuntimeError("simulated")
 
         with patch.object(tc.file_store_commit.snapshot_commit, 'commit', side_effect=commit_then_raise):

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -484,25 +484,16 @@ class RESTCatalogServer:
     def _handle_table_resource(self, method: str, path_parts: List[str],
                                identifier: Identifier, data: str,
                                parameters: Dict[str, str]) -> Tuple[str, int]:
-        """Handle table-specific resource requests"""
-        # Extract table name and check for branch information
-        raw_table_name = path_parts[2]
-
-        # Parse table name with potential branch (e.g., "table.main" -> "table", branch="main")
-        if '.' in raw_table_name and len(raw_table_name.split('.')) > 1:
-            # This might be a table with branch
-            table_parts = raw_table_name.split('.')
-            if len(table_parts) == 2:
-                table_name_part = table_parts[0]
-                branch_part = table_parts[1]
-                # Recreate identifier without branch for lookup
-                lookup_identifier = Identifier.create(identifier.get_database_name(), table_name_part)
-            else:
-                lookup_identifier = identifier
-                branch_part = None
+        """Handle table-specific resource requests."""
+        # The branch (if any) is encoded into the object name as
+        # "$branch_<name>" — see Identifier. Strip it for table lookup, and
+        # surface the branch separately for routes that care (e.g. commit).
+        branch_part = identifier.get_branch_name()
+        if branch_part is not None:
+            lookup_identifier = Identifier.create(
+                identifier.get_database_name(), identifier.get_table_name())
         else:
             lookup_identifier = identifier
-            branch_part = None
 
         # Check table permissions using the base identifier
         if lookup_identifier.get_full_name() in self.no_permission_tables:

--- a/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_token_file_io_test.py
@@ -479,7 +479,7 @@ class RESTTokenFileIOTest(unittest.TestCase):
 
     def test_refresh_token_strips_system_table_suffix(self):
         """refresh_token() strips $snapshots suffix before requesting token."""
-        system_identifier = Identifier.create("db", "my_table$snapshots")
+        system_identifier = Identifier.create("db", "my_table", system_table="snapshots")
         file_io = RESTTokenFileIO(
             system_identifier, self.warehouse_path, self.catalog_options)
 

--- a/paimon-python/pypaimon/tests/table/file_store_table_test.py
+++ b/paimon-python/pypaimon/tests/table/file_store_table_test.py
@@ -108,23 +108,27 @@ class FileStoreTableTest(unittest.TestCase):
         self.assertEqual(min_snapshot, 5)
 
     def test_consumer_manager_with_branch(self):
-        """Test consumer_manager with branch option."""
-        # Create table with branch option
+        """Test consumer_manager when branch is encoded in the identifier."""
         branch_name = "feature_branch"
+
+        # Create a regular table; the branch is supplied later via the
+        # branch-encoded identifier (Java-aligned routing).
         schema = Schema.from_pyarrow_schema(
             self.pa_schema,
             partition_keys=['dt'],
-            options={
-                CoreOptions.BUCKET.key(): "2",
-                "branch": branch_name
-            }
+            options={CoreOptions.BUCKET.key(): "2"},
         )
-        self.catalog.create_table('default.test_branch_table', schema, False)
-        branch_table = self.catalog.get_table('default.test_branch_table')
+        self.catalog.create_table('default.test_branch_table', schema, True)
 
-        # Get consumer_manager and verify it has correct branch
-        branch_consumer_manager = branch_table.consumer_manager()
+        # Access the table with a branch-encoded identifier.
+        branch_table = self.catalog.get_table(
+            'default.test_branch_table$branch_{}'.format(branch_name))
+
+        # current_branch() reads from the identifier.
         self.assertEqual(branch_table.current_branch(), branch_name)
+
+        # Get consumer_manager and exercise it on the branched view.
+        branch_consumer_manager = branch_table.consumer_manager()
 
         # Test consumer operations on branch
         from pypaimon.consumer.consumer import Consumer
@@ -254,19 +258,16 @@ class FileStoreTableTest(unittest.TestCase):
         self.assertEqual(changelog_manager.branch, DEFAULT_MAIN_BRANCH)
 
     def test_changelog_manager_with_branch(self):
-        """Test changelog_manager with branch option."""
-        # Create table with branch option
+        """Test changelog_manager when branch is encoded into the identifier."""
         branch_name = "feature"
         schema = Schema.from_pyarrow_schema(
             self.pa_schema,
             partition_keys=['dt'],
-            options={
-                CoreOptions.BUCKET.key(): "2",
-                "branch": branch_name
-            }
+            options={CoreOptions.BUCKET.key(): "2"},
         )
         self.catalog.create_table('default.test_changelog_branch_table', schema, False)
-        branch_table = self.catalog.get_table('default.test_changelog_branch_table')
+        branch_table = self.catalog.get_table(
+            'default.test_changelog_branch_table$branch_{}'.format(branch_name))
 
         # Get changelog_manager and verify it has correct branch
         branch_changelog_manager = branch_table.changelog_manager()
@@ -299,28 +300,27 @@ class FileStoreTableTest(unittest.TestCase):
         self.assertIsNone(changelog_manager.earliest_long_lived_changelog_id())
 
     def test_current_branch(self):
-        """Test that current_branch returns the branch from options."""
+        """Test that current_branch reads from the identifier."""
         from pypaimon.branch.branch_manager import DEFAULT_MAIN_BRANCH
 
         # Default table should have main branch
         self.assertEqual(self.table.current_branch(), DEFAULT_MAIN_BRANCH)
 
-        # Table with branch option should return that branch
+        # Access a table with a branch-encoded identifier — current_branch
+        # decodes from the object name (Java-aligned).
         branch_name = "feature_branch"
         schema = Schema.from_pyarrow_schema(
             self.pa_schema,
             partition_keys=['dt'],
-            options={
-                CoreOptions.BUCKET.key(): "2",
-                "branch": branch_name
-            }
+            options={CoreOptions.BUCKET.key(): "2"},
         )
         self.catalog.create_table('default.test_current_branch', schema, False)
-        branch_table = self.catalog.get_table('default.test_current_branch')
+        branch_table = self.catalog.get_table(
+            'default.test_current_branch$branch_{}'.format(branch_name))
         self.assertEqual(branch_table.current_branch(), branch_name)
 
     def test_copy_with_branch(self):
-        """Test copy method with branch option."""
+        """copy() with a branch option re-encodes branch into the identifier."""
         branch_name = "test_branch"
 
         # Copy table with branch option
@@ -335,8 +335,12 @@ class FileStoreTableTest(unittest.TestCase):
         self.assertEqual(self.table.schema_manager.branch, DEFAULT_MAIN_BRANCH)
         self.assertEqual(copied_table.schema_manager.branch, branch_name)
 
-        # Verify other properties are preserved
-        self.assertEqual(copied_table.identifier, self.table.identifier)
+        # The copied table's identifier carries the encoded branch, so it is
+        # NOT equal to the source identifier (Java-aligned wire shape).
+        self.assertEqual(copied_table.identifier.get_table_name(),
+                         self.table.identifier.get_table_name())
+        self.assertEqual(copied_table.identifier.get_branch_name(), branch_name)
+        self.assertIsNone(self.table.identifier.get_branch_name())
         self.assertEqual(copied_table.table_path, self.table.table_path)
 
     def test_rename_branch_basic(self):

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -408,7 +408,7 @@ class FileStoreCommit:
         # Use SnapshotCommit for atomic commit
         try:
             with self.snapshot_commit:
-                success = self.snapshot_commit.commit(snapshot_data, self.table.current_branch(), statistics)
+                success = self.snapshot_commit.commit(snapshot_data, statistics)
                 if not success:
                     commit_time_s = (int(time.time() * 1000) - start_millis) / 1000
                     logger.warning(


### PR DESCRIPTION
## Purpose

Java's `org.apache.paimon.catalog.Identifier` encodes the branch (and any system-table suffix) **into the `object` field** — `tbl$branch_dev$snapshots` — so the wire shape is exactly two strings, `database` and `object`. Python's `Identifier` was out of step on three real points:

1. **`SYSTEM_BRANCH_PREFIX = 'branch-'`** in Python vs **`branch_`** (with underscore) in Java. Anything written by the Java REST server in the form `tbl$branch_<name>` falls into Python's two-segment branch-of-`is_system_table()`, where the prefix check `startswith('branch-')` returns `False` → the method returns `True`. **Today a branched table is misclassified as a system table by Python.**
2. **`branch` was a separate JSON field.** Java's `@JsonIgnoreProperties(ignoreUnknown = true)` silently drops that field on the wire — Python clients calling `Identifier(database=..., object=..., branch=...)` thought they were targeting a branch but the server never saw it.
3. **`get_table_name()` returned the raw `object` name** including any encoded suffix, and `get_branch_name()` / `get_system_table_name()` couldn't decode `tbl$branch_dev$snapshots`-style names.

This PR ports the Java design 1:1.

## Identifier changes

* `Identifier(database, object)` is now the JSON-create constructor; the `object` may already carry an encoded branch / system_table.
* `Identifier.create(database, table, branch=None, system_table=None)` encodes the components into the object. `branch == "main"` (case-insensitive) is the default and is **not** encoded, matching Java.
* `_split_object_name()` lazily decodes the object into `table` / `branch` / `system_table`, with the same 1- / 2- / 3-segment rules as Java's `splitObjectName()`.
* `SYSTEM_BRANCH_PREFIX` is now `branch_`.
* `get_full_name()` drops the database prefix when database is `UNKNOWN_DATABASE` (matches Java).
* `__hash__` / `__eq__` use only `(database, object)`, so a JSON round-trip produces an equal instance.

## Backward-compat shim (added in commit 2 after review feedback)

Three previously-public surfaces keep working for one more release with a `DeprecationWarning`, scheduled for removal in the next minor release:

* `Identifier(database, object, branch=...)` — accepted again; the branch is encoded into `object` internally so the wire output matches `Identifier.create(db, table, branch=...)`.
* `identifier.branch` — exposed as a `@property` that delegates to `get_branch_name()`.
* `Identifier.create(db, "tbl$snapshots")` — when the second positional arg already contains `$` and no `branch=` / `system_table=` kwargs are supplied, the call is treated as the legacy raw-object form: the string is stored verbatim in `object`, preserving the pre-PR behaviour where `create("db", "orders$snapshots")` yielded a system-table identifier.

The bug-fix changes (`SYSTEM_BRANCH_PREFIX` corrected to `branch_`, dropping the un-round-trippable `branch` JSON field) are kept as-is; they were already incorrect versus Java, and there is no compat path that preserves the buggy behaviour while letting branched system tables work end-to-end.

## Knock-on cleanup (single source of truth)

Now that the identifier carries the branch:

* `SnapshotCommit.commit()` (abstract + `CatalogSnapshotCommit` + `RenamingSnapshotCommit`) drops its `branch` parameter; `FileStoreCommit` stops passing `table.current_branch()`.
* `FileStoreTable.current_branch()` reads from the identifier (was `self.options.branch()`).
* `FileStoreTable.copy()` re-encodes the branch into a new identifier when `CoreOptions.BRANCH` is supplied, so `CatalogEnvironment` sees the branched object name.
* `RESTCatalog.to_table_metadata()` drops the now-redundant block that copied the branch back into options.
* `RESTTokenFileIO.refresh_token()` uses `Identifier.create(db, table, branch=...)` to strip the system-table suffix while preserving the branch.
* The mock REST server's URL parser stops scanning for a `table.branch` suffix and reads `identifier.get_branch_name()` directly, matching the Java URL convention.

## Migration

| Old | New |
|---|---|
| `Identifier(db, obj, branch=b)` | `Identifier.create(db, table, branch=b)` |
| `identifier.branch` | `identifier.get_branch_name()` (or `get_branch_name_or_default()`) |
| `Identifier.create(db, "tbl$snapshots")` | `Identifier(db, "tbl$snapshots")` (raw) or `Identifier.create(db, "tbl", system_table="snapshots")` |

The deprecated forms keep working for this release; deprecation warnings indicate the migration path. Removal targeted at the next minor release.

## Linked issue

N/A — surfaced when running pypaimon against a Java REST server that emits `tbl$branch_<name>` object names.

## Tests

* `pypaimon/tests/identifier_test.py::IdentifierTest` — 25 cases covering simple / backtick / Java-compatible parsing, branch encoding, `main`-branch normalization, `UNKNOWN_DATABASE`, one- / two- / three-segment object names with and without branch prefix, `create()` with branch + system_table, equality through the JSON shape, and the malformed `tbl$x$y`-without-branch-prefix case.
* `pypaimon/tests/identifier_test.py::IdentifierBackwardCompatibilityShimTest` — 8 cases locking in the shim: constructor `branch=` warns + encodes correctly; `branch="main"` not encoded; `branch=None` still warns; `.branch` property delegates + warns; `create(db, "$"-containing)` falls back to raw-object form + warns; `create(db, "no-dollar")` does NOT warn; `create(db, "$"-table, branch=...)` skips the fallback so kwargs win.
* `catalog_branch_manager_test`, `file_store_table_test`, `rest_catalog_commit_snapshot_test`, `rest_token_file_io_test` — updated to construct branched identifiers via `Identifier.create(...)` or the `db.tbl$branch_<x>` string form.

Local: `pytest pypaimon/tests/{identifier_test,branch,table/file_store_table_test,file_store_commit_test,rest/{client_test,rest_token_file_io_test,rest_catalog_commit_snapshot_test}.py}` → 33 identifier tests + surrounding suites green; the only failure in those suites is the pre-existing lance environment issue (unrelated to this PR). `flake8 --config=dev/cfg.ini` clean.

## API and format

* **Wire compatibility**: this is a wire-correctness fix. The previous `branch` JSON field was already silently dropped by Java; nothing that successfully round-tripped through the Java REST server is affected. After the fix, branch-aware Python clients now correctly produce `object="tbl$branch_<name>"` that Java decodes the same way.
* **Public Python API**: `Identifier(database, object, branch=...)` and `identifier.branch` and the legacy `Identifier.create(db, object-with-dollar)` form keep working for this release with a `DeprecationWarning`. Migration table above.
* No file format change.

## Documentation

The new `create()` signature, the encoding rules, and the deprecation paths are documented inline on `Identifier`, `__init__`, `create()`, and `branch`.

## Generative AI disclosure

Drafted with assistance from an AI coding tool; the design is a direct 1:1 port of `org.apache.paimon.catalog.Identifier` (paimon-api), and every behavioural difference between Java and Python that this PR closes is exercised by a test in `identifier_test.py`. The deprecation shim was added in response to review feedback (#7738 review thread on `identifier.py:29`).