### PR TITLE
[python] Implement tag CRUD on FileSystemCatalog

### DIFF
--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -18,13 +18,16 @@
 
 from typing import List, Optional, Union
 
+from pypaimon.api.api_response import GetTagResponse, PagedList
 from pypaimon.catalog.catalog import Catalog
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
 from pypaimon.catalog.catalog_exception import (
     DatabaseAlreadyExistException,
     DatabaseNotExistException,
     TableAlreadyExistException,
-    TableNotExistException
+    TableNotExistException,
+    TagAlreadyExistException,
+    TagNotExistException,
 )
 from pypaimon.catalog.database import Database
 from pypaimon.common.options import Options
@@ -343,3 +346,105 @@ class FileSystemCatalog(Catalog):
             next_page_token = str(end_index)
 
         return PagedList(elements=result_partitions, next_page_token=next_page_token)
+
+    # ===================== Tag CRUD =====================
+    # Thin wrappers that delegate to FileStoreTable's existing tag helpers
+    # (which in turn use the Python-side TagManager). The catalog layer is
+    # responsible for translating ValueError messages from TagManager into
+    # the typed Catalog exceptions used by the rest of the API.
+
+    def create_tag(
+            self,
+            identifier: Union[str, Identifier],
+            tag_name: str,
+            snapshot_id: Optional[int] = None,
+            time_retained: Optional[str] = None,
+            ignore_if_exists: bool = False,
+    ) -> None:
+        if time_retained is not None:
+            # Python's Tag dataclass does not yet carry tag_create_time /
+            # tag_time_retained fields; supporting TTL on FileSystemCatalog
+            # requires extending Tag + TagManager and is tracked as a
+            # follow-up. Raise here instead of silently dropping the option,
+            # so callers cannot mistakenly believe the TTL took effect.
+            raise NotImplementedError(
+                "FileSystemCatalog does not yet support `time_retained` on "
+                "create_tag (requires extending the Python Tag dataclass + "
+                "TagManager).")
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        try:
+            table.create_tag(tag_name, snapshot_id, ignore_if_exists)
+        except ValueError as e:
+            # ``table.create_tag`` honors ``ignore_if_exists`` internally, so
+            # any "already exists" message that bubbles up here means the
+            # caller asked us to fail on conflict.
+            if "already exists" in str(e):
+                raise TagAlreadyExistException(tag_name) from e
+            raise
+
+    def delete_tag(
+            self,
+            identifier: Union[str, Identifier],
+            tag_name: str,
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        # ``table.delete_tag`` returns False (no exception) when the tag is
+        # missing — surface that as a typed catalog exception to match the
+        # RESTCatalog behavior.
+        if not table.delete_tag(tag_name):
+            raise TagNotExistException(tag_name)
+
+    def get_tag(
+            self,
+            identifier: Union[str, Identifier],
+            tag_name: str,
+    ) -> GetTagResponse:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        tag = table.tag_manager().get(tag_name)
+        if tag is None:
+            raise TagNotExistException(tag_name)
+        # tag_create_time / tag_time_retained are not tracked on the
+        # filesystem side yet — the Python Tag dataclass inherits only
+        # Snapshot fields. Returning ``None`` for both keeps the response
+        # shape compatible with the Java contract while making the gap
+        # visible to callers.
+        return GetTagResponse(
+            tag_name=tag_name,
+            snapshot=tag.trim_to_snapshot(),
+            tag_create_time=None,
+            tag_time_retained=None,
+        )
+
+    def list_tags_paged(
+            self,
+            identifier: Union[str, Identifier],
+            max_results: Optional[int] = None,
+            page_token: Optional[str] = None,
+            tag_name_prefix: Optional[str] = None,
+    ) -> PagedList:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+
+        # TagManager.list_tags() returns the full list with no built-in
+        # pagination, so we filter + paginate client-side. Sort
+        # lexicographically so ``page_token`` (the previous page's last
+        # entry) gives a stable continuation cursor.
+        tags = sorted(table.list_tags())
+        if tag_name_prefix:
+            tags = [t for t in tags if t.startswith(tag_name_prefix)]
+        if page_token:
+            tags = [t for t in tags if t > page_token]
+        if max_results is not None and max_results > 0 and len(tags) > max_results:
+            page = tags[:max_results]
+            next_token = page[-1]
+        else:
+            page = tags
+            next_token = None
+        return PagedList(elements=page, next_page_token=next_token)

--- a/paimon-python/pypaimon/tests/filesystem_catalog_tag_test.py
+++ b/paimon-python/pypaimon/tests/filesystem_catalog_tag_test.py
@@ -1,0 +1,184 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""End-to-end tests for tag CRUD on ``FileSystemCatalog``.
+
+Mirrors the ``RESTCatalogTagCRUDTest`` matrix from the REST tag tests
+but exercises the local filesystem path. The tests pin down the
+exception types and the ``GetTagResponse`` / ``PagedList`` return shapes
+that the catalog layer must produce regardless of which catalog
+implementation is in use.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.api.api_response import GetTagResponse, PagedList
+from pypaimon.catalog.catalog_exception import (TableNotExistException,
+                                                TagAlreadyExistException,
+                                                TagNotExistException)
+from pypaimon.common.identifier import Identifier
+from pypaimon.snapshot.snapshot import Snapshot
+
+
+class FileSystemCatalogTagCRUDTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="unittest_fs_tag_")
+        warehouse = os.path.join(self.temp_dir, "warehouse")
+        os.makedirs(warehouse, exist_ok=True)
+        self.catalog = CatalogFactory.create({"warehouse": warehouse})
+        self.catalog.create_database("default", True)
+
+        self.pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("value", pa.string()),
+        ])
+        self.identifier = Identifier.from_string("default.test_tag_table")
+        self.catalog.create_table(
+            self.identifier,
+            Schema.from_pyarrow_schema(self.pa_schema),
+            False,
+        )
+        # Commit one batch so the table has a snapshot to tag.
+        table = self.catalog.get_table(self.identifier)
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(pa.Table.from_pydict(
+            {"id": [1, 2, 3], "value": ["a", "b", "c"]},
+            schema=self.pa_schema,
+        ))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # -- create + get --------------------------------------------------------
+
+    def test_create_and_get_tag(self):
+        self.catalog.create_tag(self.identifier, "t1")
+        response = self.catalog.get_tag(self.identifier, "t1")
+        self.assertIsInstance(response, GetTagResponse)
+        self.assertEqual(response.tag_name, "t1")
+        self.assertIsInstance(response.snapshot, Snapshot)
+        # FileSystemCatalog does not yet track tag_create_time /
+        # tag_time_retained — both must be None until the underlying Tag
+        # dataclass is extended.
+        self.assertIsNone(response.tag_create_time)
+        self.assertIsNone(response.tag_time_retained)
+
+    def test_create_tag_with_snapshot_id(self):
+        self.catalog.create_tag(self.identifier, "t1", snapshot_id=1)
+        response = self.catalog.get_tag(self.identifier, "t1")
+        self.assertIsNotNone(response.snapshot)
+        self.assertEqual(response.snapshot.id, 1)
+
+    # -- create error paths --------------------------------------------------
+
+    def test_create_tag_already_exists_raises(self):
+        self.catalog.create_tag(self.identifier, "t1")
+        with self.assertRaises(TagAlreadyExistException) as cm:
+            self.catalog.create_tag(self.identifier, "t1")
+        self.assertEqual(cm.exception.tag, "t1")
+
+    def test_create_tag_already_exists_ignore(self):
+        self.catalog.create_tag(self.identifier, "t1")
+        # ignore_if_exists=True must swallow the conflict, leaving the
+        # original tag in place.
+        self.catalog.create_tag(self.identifier, "t1", ignore_if_exists=True)
+        result = self.catalog.list_tags_paged(self.identifier)
+        self.assertEqual(result.elements, ["t1"])
+
+    def test_create_tag_with_time_retained_raises_not_implemented(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            self.catalog.create_tag(
+                self.identifier, "t1", time_retained="1d")
+        self.assertIn("time_retained", str(cm.exception))
+
+    def test_create_tag_table_not_exists(self):
+        with self.assertRaises(TableNotExistException):
+            self.catalog.create_tag(
+                Identifier.from_string("default.no_such_table"), "t1")
+
+    # -- get error paths -----------------------------------------------------
+
+    def test_get_tag_not_exists(self):
+        with self.assertRaises(TagNotExistException) as cm:
+            self.catalog.get_tag(self.identifier, "absent")
+        self.assertEqual(cm.exception.tag, "absent")
+
+    # -- delete --------------------------------------------------------------
+
+    def test_delete_tag_happy(self):
+        self.catalog.create_tag(self.identifier, "t1")
+        self.catalog.delete_tag(self.identifier, "t1")
+        self.assertNotIn(
+            "t1", self.catalog.list_tags_paged(self.identifier).elements)
+
+    def test_delete_tag_not_exists(self):
+        with self.assertRaises(TagNotExistException) as cm:
+            self.catalog.delete_tag(self.identifier, "absent")
+        self.assertEqual(cm.exception.tag, "absent")
+
+    # -- list_tags_paged -----------------------------------------------------
+
+    def test_list_tags_paged_basic(self):
+        for name in ("t1", "t2", "t3"):
+            self.catalog.create_tag(self.identifier, name)
+
+        all_tags = self.catalog.list_tags_paged(self.identifier)
+        self.assertIsInstance(all_tags, PagedList)
+        self.assertEqual(sorted(all_tags.elements), ["t1", "t2", "t3"])
+        self.assertIsNone(all_tags.next_page_token)
+
+        first_page = self.catalog.list_tags_paged(
+            self.identifier, max_results=2)
+        self.assertEqual(len(first_page.elements), 2)
+        self.assertIsNotNone(first_page.next_page_token)
+
+        second_page = self.catalog.list_tags_paged(
+            self.identifier,
+            max_results=2,
+            page_token=first_page.next_page_token,
+        )
+        self.assertEqual(len(second_page.elements), 1)
+        self.assertIsNone(second_page.next_page_token)
+
+    def test_list_tags_paged_with_prefix(self):
+        for name in ("prod_v1", "prod_v2", "dev_v1"):
+            self.catalog.create_tag(self.identifier, name)
+
+        result = self.catalog.list_tags_paged(
+            self.identifier, tag_name_prefix="prod_")
+        self.assertEqual(sorted(result.elements), ["prod_v1", "prod_v2"])
+
+    def test_list_tags_paged_empty_table(self):
+        # Fresh table with no tags created.
+        result = self.catalog.list_tags_paged(self.identifier)
+        self.assertEqual(result.elements, [])
+        self.assertIsNone(result.next_page_token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/rest/rest_tag_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_tag_test.py
@@ -16,6 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import unittest
+
 from pypaimon.api.api_response import GetTagResponse
 from pypaimon.catalog.catalog_exception import (TableNotExistException,
                                                 TagAlreadyExistException,

--- a/paimon-python/pypaimon/tests/rest/rest_tag_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_tag_test.py
@@ -16,16 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
-import shutil
-import tempfile
-import unittest
-
 from pypaimon.api.api_response import GetTagResponse
 from pypaimon.catalog.catalog_exception import (TableNotExistException,
                                                 TagAlreadyExistException,
                                                 TagNotExistException)
-from pypaimon import CatalogFactory
 from pypaimon.common.identifier import Identifier
 from pypaimon.snapshot.snapshot import Snapshot
 from pypaimon.tests.rest.rest_base_test import RESTBaseTest
@@ -128,47 +122,10 @@ class RESTCatalogTagCRUDTest(RESTBaseTest):
             self.rest_catalog.delete_tag(identifier, "absent")
 
 
-class FilesystemCatalogTagInheritsNotImplementedTest(unittest.TestCase):
-    """The filesystem catalog inherits the abstract NotImplementedError stubs.
-
-    A concrete tag implementation requires a Python-side TagManager port and
-    is tracked separately. The point of this test is to confirm the
-    abstract API gap is closed: ``FileSystemCatalog().create_tag(...)``
-    raises ``NotImplementedError`` rather than ``AttributeError``.
-    """
-
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp(prefix="unittest_tag_")
-        warehouse = os.path.join(self.temp_dir, "warehouse")
-        os.makedirs(warehouse, exist_ok=True)
-        # Use the default (filesystem) catalog. Without a ``metastore`` option
-        # CatalogFactory returns FileSystemCatalog, which inherits the abstract
-        # ``NotImplementedError`` tag stubs.
-        self.catalog = CatalogFactory.create({"warehouse": warehouse})
-
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    def test_create_tag_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError) as cm:
-            self.catalog.create_tag(
-                Identifier.from_string("default.tbl"), "t1")
-        self.assertIn("create_tag", str(cm.exception))
-
-    def test_delete_tag_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError):
-            self.catalog.delete_tag(
-                Identifier.from_string("default.tbl"), "t1")
-
-    def test_get_tag_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError):
-            self.catalog.get_tag(
-                Identifier.from_string("default.tbl"), "t1")
-
-    def test_list_tags_paged_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError):
-            self.catalog.list_tags_paged(
-                Identifier.from_string("default.tbl"))
+# Note: the previous ``FilesystemCatalogTagInheritsNotImplementedTest`` class
+# has been removed because FileSystemCatalog now overrides the tag CRUD
+# methods (no longer raises NotImplementedError). The new behavior is
+# covered by ``pypaimon/tests/filesystem_catalog_tag_test.py``.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

PR #7746 added abstract tag stubs to `Catalog` and a complete `RESTCatalog` implementation, but left `FileSystemCatalog` inheriting `NotImplementedError`. The merge note said implementing filesystem tag CRUD required porting a Python `TagManager`. As it turns out, `pypaimon/tag/tag_manager.py::TagManager` and `FileStoreTable.create_tag` / `delete_tag` / `list_tags` / `tag_manager()` **already exist on master**, so this PR is a thin catalog-layer wrapper that delegates to those helpers and translates `ValueError` / return-value-`False` into the typed catalog exceptions used by the rest of the API.

## Linked issue

Follow-up to #7746 — closes the FileSystemCatalog gap noted in that PR's "Out of scope" section.

## Tests

- **`pypaimon/tests/filesystem_catalog_tag_test.py`** (12 new cases) — mirrors `RESTCatalogTagCRUDTest` on the local filesystem path:
  - `test_create_and_get_tag`, `test_create_tag_with_snapshot_id`
  - `test_create_tag_already_exists_raises`, `test_create_tag_already_exists_ignore`
  - `test_create_tag_with_time_retained_raises_not_implemented` (filesystem-only)
  - `test_create_tag_table_not_exists`
  - `test_get_tag_not_exists`
  - `test_delete_tag_happy`, `test_delete_tag_not_exists`
  - `test_list_tags_paged_basic` (paging via `max_results` + `next_page_token`)
  - `test_list_tags_paged_with_prefix`, `test_list_tags_paged_empty_table`
- **`pypaimon/tests/rest/rest_tag_test.py`** — removed the now-stale `FilesystemCatalogTagInheritsNotImplementedTest` class (its assertions no longer hold; new behavior is covered by the new file). Cleaned up unused imports left behind.
- Regression: `pypaimon/tests/api/test_tag_dto_serde.py` (8 cases) and the REST tag test matrix (11 cases) all still pass.
- All edited files pass `flake8 --config=dev/cfg.ini`.

## API and format

No new public Catalog method or wire format. This PR only **overrides** the four existing abstract stubs in `FileSystemCatalog`:

| Method | Delegate / behavior |
|---|---|
| `create_tag` | `table.create_tag(tag_name, snapshot_id, ignore_if_exists)`. `ValueError("...already exists.")` → `TagAlreadyExistException` (only when `not ignore_if_exists`). |
| `delete_tag` | `table.delete_tag(tag_name) -> bool`. `False` → `TagNotExistException`. |
| `get_tag` | `table.tag_manager().get(tag_name) -> Optional[Tag]`. `None` → `TagNotExistException`. Result wrapped in `GetTagResponse` with `snapshot=tag.trim_to_snapshot()`. |
| `list_tags_paged` | `table.list_tags() -> List[str]`. Client-side lexicographic sort + prefix filter + `page_token` continuation cursor (no Java equivalent of paged listing exists in `TagManager` itself). |

## Documentation

n/a — this is a parity fix for an existing public API.

## Out of scope (separate PRs)

- **`time_retained` real support** — Python's `Tag` dataclass currently inherits only `Snapshot` fields and has no place to store `tag_create_time` / `tag_time_retained`. This PR rejects `time_retained != None` with `NotImplementedError` rather than silently dropping it (which would mislead callers about TTL effects). Extending `Tag` + `TagManager.create_tag` to carry these fields requires a coordinated change to the on-disk tag JSON format and is tracked as a follow-up.
- **`GetTagResponse.tag_create_time`** — for the same reason, this catalog returns `None` for `tag_create_time` and `tag_time_retained`. Cross-`FileIO` mtime extraction is not reliable (different `FileIO` implementations expose different metadata).
- **Branch CRUD on FileSystemCatalog** — branch CRUD requires the abstract `rename_branch` stub and `BranchAlreadyExistException` handling introduced by #7747 (still under review). The sister PR for FileSystemCatalog branch CRUD will follow once #7747 lands.
- **Tag callbacks** — Java has them; Python doesn't, and they're not needed for filesystem semantics.

## Verification

```bash
# Targeted
pytest pypaimon/tests/filesystem_catalog_tag_test.py -v

# Regression
pytest pypaimon/tests/rest/rest_tag_test.py pypaimon/tests/api/test_tag_dto_serde.py -v

# Master-vs-fix
git stash
python -c "from pypaimon.catalog.filesystem_catalog import FileSystemCatalog; \
           print('create_tag in __dict__:', 'create_tag' in FileSystemCatalog.__dict__)"
# Expected: False (master inherits NotImplementedError)
git stash pop
python -c "..."  # Expected: True (PR adds the override)

# Lint
flake8 --config=dev/cfg.ini pypaimon/catalog/filesystem_catalog.py \
                            pypaimon/tests/filesystem_catalog_tag_test.py \
                            pypaimon/tests/rest/rest_tag_test.py
```

## Generative AI disclosure

Implementation, tests, and PR description were drafted with the assistance of Claude (Anthropic). Claude was supplied with the existing pypaimon helpers (`TagManager`, `FileStoreTable.create_tag` / `delete_tag` / `list_tags`, `RESTCatalog.create_tag`'s exception mapping pattern from #7746) and the REST tag test matrix; the design plan and code were reviewed and integrated by the author.