### PR TITLE
[python] Implement branch CRUD on FileSystemCatalog

### DIFF
--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -22,6 +22,8 @@ from pypaimon.api.api_response import GetTagResponse, PagedList
 from pypaimon.catalog.catalog import Catalog
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
 from pypaimon.catalog.catalog_exception import (
+    BranchAlreadyExistException,
+    BranchNotExistException,
     DatabaseAlreadyExistException,
     DatabaseNotExistException,
     TableAlreadyExistException,
@@ -448,3 +450,95 @@ class FileSystemCatalog(Catalog):
             page = tags
             next_token = None
         return PagedList(elements=page, next_page_token=next_token)
+
+    # ===================== Branch CRUD =====================
+    # Thin wrappers that delegate to FileSystemBranchManager (returned by
+    # FileStoreTable.branch_manager() in the local-catalog case). Mirrors
+    # the RESTCatalog branch overrides added in #7747; the only difference
+    # is that the manager raises ValueError / RuntimeError instead of REST
+    # exceptions, so the catalog layer translates the messages back into
+    # the typed Catalog exception hierarchy.
+
+    def create_branch(
+            self,
+            identifier: Union[str, Identifier],
+            branch_name: str,
+            tag_name: Optional[str] = None,
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        try:
+            table.branch_manager().create_branch(branch_name, tag_name)
+        except ValueError as e:
+            msg = str(e)
+            # ``tag_manager.get_or_throw`` raises ValueError("Tag '...' doesn't exist.")
+            if tag_name is not None and "Tag" in msg and "doesn't exist" in msg:
+                raise TagNotExistException(tag_name) from e
+            # ``_validate_branch`` raises ValueError("Branch name '...' already exists.")
+            if "already exists" in msg:
+                raise BranchAlreadyExistException(branch_name) from e
+            raise
+
+    def drop_branch(
+            self,
+            identifier: Union[str, Identifier],
+            branch_name: str,
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        try:
+            table.branch_manager().drop_branch(branch_name)
+        except ValueError as e:
+            # FileSystemBranchManager.drop_branch raises
+            # ValueError("Branch name '...' doesn't exist.") when missing.
+            if "doesn't exist" in str(e):
+                raise BranchNotExistException(branch_name) from e
+            raise
+
+    def rename_branch(
+            self,
+            identifier: Union[str, Identifier],
+            from_branch: str,
+            to_branch: str,
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        try:
+            table.branch_manager().rename_branch(from_branch, to_branch)
+        except ValueError as e:
+            msg = str(e)
+            if "Source branch" in msg and "doesn't exist" in msg:
+                raise BranchNotExistException(from_branch) from e
+            if "Target branch" in msg and "already exists" in msg:
+                raise BranchAlreadyExistException(to_branch) from e
+            # Other ValueErrors (rename-main rejection, blank/invalid names)
+            # propagate as-is — they are user-facing argument errors that
+            # the catalog API does not have a typed equivalent for.
+            raise
+
+    def fast_forward(
+            self,
+            identifier: Union[str, Identifier],
+            branch_name: str,
+    ) -> None:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        try:
+            table.branch_manager().fast_forward(branch_name)
+        except ValueError as e:
+            if "doesn't exist" in str(e):
+                raise BranchNotExistException(branch_name) from e
+            raise
+
+    def list_branches(
+            self,
+            identifier: Union[str, Identifier],
+    ) -> List[str]:
+        if not isinstance(identifier, Identifier):
+            identifier = Identifier.from_string(identifier)
+        table = self.get_table(identifier)
+        return table.branch_manager().branches()

--- a/paimon-python/pypaimon/tests/filesystem_catalog_branch_test.py
+++ b/paimon-python/pypaimon/tests/filesystem_catalog_branch_test.py
@@ -1,0 +1,177 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""End-to-end tests for branch CRUD on ``FileSystemCatalog``.
+
+Mirrors the ``RESTCatalogBranchCRUDTest`` matrix from the REST branch
+tests but exercises the local filesystem path. Pins down the exception
+types and return shapes the catalog layer must produce regardless of
+which catalog implementation is in use.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.catalog.catalog_exception import (BranchAlreadyExistException,
+                                                BranchNotExistException,
+                                                TableNotExistException,
+                                                TagNotExistException)
+from pypaimon.common.identifier import Identifier
+
+
+class FileSystemCatalogBranchCRUDTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="unittest_fs_branch_")
+        warehouse = os.path.join(self.temp_dir, "warehouse")
+        os.makedirs(warehouse, exist_ok=True)
+        self.catalog = CatalogFactory.create({"warehouse": warehouse})
+        self.catalog.create_database("default", True)
+
+        self.pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("value", pa.string()),
+        ])
+        self.identifier = Identifier.from_string("default.test_branch_table")
+        self.catalog.create_table(
+            self.identifier,
+            Schema.from_pyarrow_schema(self.pa_schema),
+            False,
+        )
+        # Commit one batch so the table has a snapshot to base branches on.
+        table = self.catalog.get_table(self.identifier)
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(pa.Table.from_pydict(
+            {"id": [1, 2, 3], "value": ["a", "b", "c"]},
+            schema=self.pa_schema,
+        ))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # -- create + list --------------------------------------------------------
+
+    def test_create_branch_without_from_tag(self):
+        self.catalog.create_branch(self.identifier, "b1")
+        self.assertEqual(self.catalog.list_branches(self.identifier), ["b1"])
+
+    def test_create_branch_duplicate_raises(self):
+        self.catalog.create_branch(self.identifier, "b1")
+        with self.assertRaises(BranchAlreadyExistException) as cm:
+            self.catalog.create_branch(self.identifier, "b1")
+        self.assertEqual(cm.exception.branch, "b1")
+
+    def test_create_branch_table_not_exists(self):
+        with self.assertRaises(TableNotExistException):
+            self.catalog.create_branch(
+                Identifier.from_string("default.no_such_table"), "b1")
+
+    def test_create_branch_from_nonexistent_tag_raises(self):
+        with self.assertRaises(TagNotExistException) as cm:
+            self.catalog.create_branch(
+                self.identifier, "b1", tag_name="absent_tag")
+        self.assertEqual(cm.exception.tag, "absent_tag")
+
+    # NOTE: ``test_create_branch_from_existing_tag`` (a true happy-path
+    # ``create_branch(tag_name=...)``) is not included here. The
+    # ``FileSystemBranchManager`` "from-tag" path has a pre-existing bug
+    # (``branch_snapshot_manager`` is constructed without switching to
+    # the new branch's path, so ``copy_file(src, dst)`` ends up with
+    # ``src == dst`` and raises ``SameFileError``). That's a manager-
+    # level fix, not in the scope of this catalog-layer thin wrapper.
+    # Catalog-layer error translation for the from-tag path is still
+    # covered by ``test_create_branch_from_nonexistent_tag_raises``.
+
+    # -- list -----------------------------------------------------------------
+
+    def test_list_branches_returns_created(self):
+        for name in ("b1", "b2", "b3"):
+            self.catalog.create_branch(self.identifier, name)
+        self.assertEqual(
+            sorted(self.catalog.list_branches(self.identifier)),
+            ["b1", "b2", "b3"],
+        )
+
+    def test_list_branches_empty(self):
+        # Fresh table with no branches created.
+        self.assertEqual(self.catalog.list_branches(self.identifier), [])
+
+    def test_list_branches_table_not_exists(self):
+        with self.assertRaises(TableNotExistException):
+            self.catalog.list_branches(
+                Identifier.from_string("default.no_such_table"))
+
+    # -- rename ---------------------------------------------------------------
+
+    def test_rename_branch_happy(self):
+        self.catalog.create_branch(self.identifier, "b1")
+        self.catalog.rename_branch(self.identifier, "b1", "b2")
+        listed = self.catalog.list_branches(self.identifier)
+        self.assertNotIn("b1", listed)
+        self.assertIn("b2", listed)
+
+    def test_rename_branch_to_existing_raises(self):
+        self.catalog.create_branch(self.identifier, "b1")
+        self.catalog.create_branch(self.identifier, "b2")
+        with self.assertRaises(BranchAlreadyExistException) as cm:
+            self.catalog.rename_branch(self.identifier, "b1", "b2")
+        self.assertEqual(cm.exception.branch, "b2")
+
+    def test_rename_branch_from_missing_raises(self):
+        with self.assertRaises(BranchNotExistException) as cm:
+            self.catalog.rename_branch(self.identifier, "absent", "b2")
+        self.assertEqual(cm.exception.branch, "absent")
+
+    # -- drop -----------------------------------------------------------------
+
+    def test_drop_branch_happy(self):
+        self.catalog.create_branch(self.identifier, "b1")
+        self.catalog.drop_branch(self.identifier, "b1")
+        self.assertNotIn(
+            "b1", self.catalog.list_branches(self.identifier))
+
+    def test_drop_branch_missing_raises(self):
+        with self.assertRaises(BranchNotExistException) as cm:
+            self.catalog.drop_branch(self.identifier, "absent")
+        self.assertEqual(cm.exception.branch, "absent")
+
+    # -- fast_forward ---------------------------------------------------------
+
+    def test_fast_forward_missing_raises(self):
+        with self.assertRaises(BranchNotExistException) as cm:
+            self.catalog.fast_forward(self.identifier, "absent")
+        self.assertEqual(cm.exception.branch, "absent")
+
+    # NOTE: a true happy-path ``fast_forward`` end-to-end test is not
+    # included here for the same reason as the create-branch-from-tag
+    # case above — it requires the manager-level fix to the from-tag
+    # path (so the branch carries a snapshot for fast-forward to move).
+    # Catalog-layer error translation is covered by the missing-branch
+    # case above.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/rest/rest_branch_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_branch_test.py
@@ -16,12 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
-import shutil
-import tempfile
 import unittest
 
-from pypaimon import CatalogFactory
 from pypaimon.catalog.catalog_exception import (BranchAlreadyExistException,
                                                 BranchNotExistException,
                                                 TableNotExistException)
@@ -117,30 +113,10 @@ class RESTCatalogBranchCRUDTest(RESTBaseTest):
         self.rest_catalog.fast_forward(identifier, "b1")
 
 
-class FilesystemCatalogBranchInheritsNotImplementedTest(unittest.TestCase):
-    """The filesystem catalog inherits the abstract ``NotImplementedError`` stubs.
-
-    A concrete filesystem branch implementation requires a Python-side
-    BranchManager and is tracked separately. The point of this test is to
-    confirm the new ``rename_branch`` abstract stub closes the API gap:
-    on master ``Catalog.rename_branch`` did not exist (AttributeError),
-    after this PR it raises ``NotImplementedError``.
-    """
-
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp(prefix="unittest_branch_")
-        warehouse = os.path.join(self.temp_dir, "warehouse")
-        os.makedirs(warehouse, exist_ok=True)
-        self.catalog = CatalogFactory.create({"warehouse": warehouse})
-
-    def tearDown(self):
-        shutil.rmtree(self.temp_dir, ignore_errors=True)
-
-    def test_rename_branch_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError) as cm:
-            self.catalog.rename_branch(
-                Identifier.from_string("default.tbl"), "b1", "b2")
-        self.assertIn("rename_branch", str(cm.exception))
+# Note: the previous ``FilesystemCatalogBranchInheritsNotImplementedTest``
+# class has been removed because FileSystemCatalog now overrides the
+# branch CRUD methods (no longer raises NotImplementedError). The new
+# behavior is covered by ``pypaimon/tests/filesystem_catalog_branch_test.py``.
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

Override the five branch CRUD methods on `FileSystemCatalog` so Python users on the local-catalog path get the same typed behavior as `RESTCatalog` (added in #7747). Sister PR to #7751 (FileSystemCatalog Tag CRUD); follow-up to #7747.

`FileSystemCatalog` previously inherited the `Catalog` ABC `NotImplementedError` stubs because the original PR (#7747) did not port the manager-layer wiring. The Python `FileSystemBranchManager` already exists at `pypaimon/branch/filesystem_branch_manager.py` and is reachable via `FileStoreTable.branch_manager()`, so this PR is a thin wrapper: each catalog method delegates to the manager and translates `ValueError` messages back into the typed catalog exception hierarchy (`BranchAlreadyExistException`, `BranchNotExistException`, `TagNotExistException`).

## In scope

- 5 method overrides on `FileSystemCatalog`: `create_branch` / `drop_branch` / `rename_branch` / `fast_forward` / `list_branches`.
- New end-to-end test suite `tests/filesystem_catalog_branch_test.py` covering the same matrix as `RESTCatalogBranchCRUDTest` from #7747 (create / list / rename / drop / fast_forward — happy paths plus all typed-exception paths).
- Removal of the now-stale `FilesystemCatalogBranchInheritsNotImplementedTest` class from `rest/rest_branch_test.py` (it asserted `NotImplementedError`, which no longer holds).

## Out of scope

- The `FileSystemBranchManager` "from-tag" path has a pre-existing bug: `_copy_with_branch` returns a `SnapshotManager` that doesn't switch to the new branch's path, so `copy_file(src, dst)` ends up with `src == dst` and raises `SameFileError`. That's a manager-level fix. The catalog-layer error translation for the from-tag path is still covered by `test_create_branch_from_nonexistent_tag_raises`. Two corresponding happy-path tests (`test_create_branch_from_existing_tag` and `test_fast_forward_happy`) are intentionally omitted with NOTE comments pointing at the bug.
- `ignore_if_exists` parameter on `create_branch` — Java `Catalog.createBranch` does not expose it, and the manager-layer default (`False`) is sufficient.

## Tests

Local run from `paimon-python/`:

```
pytest pypaimon/tests/filesystem_catalog_branch_test.py -v   # 13 passed
pytest pypaimon/tests/rest/rest_branch_test.py \
       pypaimon/tests/api/test_branch_dto_serde.py \
       pypaimon/tests/filesystem_catalog_tag_test.py \
       pypaimon/tests/branch_manager_test.py -v               # 59 passed
flake8 --config=dev/cfg.ini <touched files>                   # clean
```

## Anti-divergence checklist

- Method signatures match the `Catalog` ABC (`identifier: Union[str, Identifier]`, `tag_name=None`).
- Typed exceptions match those raised by `RESTCatalog` (`BranchAlreadyExistException` / `BranchNotExistException` / `TagNotExistException` / `TableNotExistException`).
- `list_branches` returns `List[str]` (not `PagedList`), matching the strict Java alignment from #7747.
- Substring matches verified against `pypaimon/branch/filesystem_branch_manager.py` master HEAD.

## Generative AI disclosure

Drafted with assistance from a generative AI tool. All code, tests, and exception-translation logic were reviewed and validated by the contributor.