### PR TITLE
[python] Fix FileSystemBranchManager from-tag and fast-forward path computation

### DIFF
--- a/paimon-python/pypaimon/branch/filesystem_branch_manager.py
+++ b/paimon-python/pypaimon/branch/filesystem_branch_manager.py
@@ -83,22 +83,21 @@ class FileSystemBranchManager(BranchManager):
 
     def _copy_with_branch(self, manager, branch: str):
         """
-        Create a copy of the manager for a different branch.
+        Return a new manager whose path accessors land under
+        ``{table_path}/branch/branch-{name}``.
 
-        Args:
-            manager: The manager to copy (TagManager, SnapshotManager, etc.)
-            branch: The target branch name
-
-        Returns:
-            A new manager instance for the specified branch
+        Equivalent to the per-manager rebranch calls inlined in Java
+        ``FileSystemBranchManager.createBranch(name, tagName)`` (e.g.
+        ``snapshotManager.copyWithBranch(branchName)``). ``TagManager``
+        is rebuilt directly because the Python ``TagManager`` has no
+        ``copy_with_branch`` factory yet.
         """
         if isinstance(manager, TagManager):
             return TagManager(self.file_io, self.table_path, branch)
         elif isinstance(manager, SchemaManager):
-            # SchemaManager doesn't support branch parameter, use branch path instead
-            return SchemaManager(self.file_io, self.branch_path(branch))
+            return manager.copy_with_branch(branch)
         elif isinstance(manager, SnapshotManager):
-            return SnapshotManager(self.snapshot_manager.table)
+            return manager.copy_with_branch(branch)
         else:
             return manager
 

--- a/paimon-python/pypaimon/snapshot/snapshot_loader.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_loader.py
@@ -36,6 +36,20 @@ class SnapshotLoader:
         self.catalog_loader = catalog_loader
         self.identifier = identifier
 
+    def copy_with_branch(self, branch: str) -> 'SnapshotLoader':
+        """Return a new loader whose identifier carries ``branch``.
+
+        Mirrors Java ``SnapshotLoaderImpl.copyWithBranch``
+        (tag/SnapshotLoaderImpl.java).
+        """
+        from pypaimon.common.identifier import Identifier
+        rebranched = Identifier(
+            database=self.identifier.database,
+            object=self.identifier.object,
+            branch=branch,
+        )
+        return SnapshotLoader(self.catalog_loader, rebranched)
+
     def load(self) -> Optional[str]:
         """Load the latest snapshot from the catalog.
         

--- a/paimon-python/pypaimon/snapshot/snapshot_loader.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_loader.py
@@ -44,8 +44,8 @@ class SnapshotLoader:
         """
         from pypaimon.common.identifier import Identifier
         rebranched = Identifier(
-            database=self.identifier.database,
-            object=self.identifier.object,
+            database=self.identifier.get_database_name(),
+            object=self.identifier.get_table_name(),
             branch=branch,
         )
         return SnapshotLoader(self.catalog_loader, rebranched)

--- a/paimon-python/pypaimon/snapshot/snapshot_manager.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_manager.py
@@ -51,12 +51,14 @@ class SnapshotManager:
         self.latest_file = f"{self.snapshot_dir}/LATEST"
 
     def copy_with_branch(self, branch_name: str) -> 'SnapshotManager':
-        # Mirrors Java SnapshotManager.copyWithBranch for the local
-        # filesystem path. SnapshotLoader rebranching (REST path) is
-        # not implemented yet -- the new manager re-fetches a loader
-        # from catalog_environment, which on the FileSystemCatalog
-        # path is None and therefore inert.
-        return SnapshotManager(self.table, branch_name)
+        # Mirrors Java SnapshotManager.copyWithBranch: the new manager
+        # carries a SnapshotLoader rebranched to ``branch_name`` so REST
+        # loads target the correct branch instead of falling back to the
+        # main-branch identifier.
+        new_manager = SnapshotManager(self.table, branch_name)
+        if self.snapshot_loader is not None:
+            new_manager.snapshot_loader = self.snapshot_loader.copy_with_branch(branch_name)
+        return new_manager
 
     def get_latest_snapshot(self) -> Optional[Snapshot]:
         """

--- a/paimon-python/pypaimon/snapshot/snapshot_manager.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_manager.py
@@ -29,16 +29,34 @@ from pypaimon.snapshot.snapshot_loader import SnapshotLoader
 class SnapshotManager:
     """Manager for snapshot files using unified FileIO."""
 
-    def __init__(self, table):
+    def __init__(self, table, branch: Optional[str] = None):
+        # Lazy imports to avoid a cycle: pypaimon.branch.__init__
+        # eagerly loads FileSystemBranchManager, which imports
+        # SnapshotManager.
+        from pypaimon.branch.branch_manager import BranchManager
+        from pypaimon.common.identifier import DEFAULT_MAIN_BRANCH
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
         self.file_io: FileIO = self.table.file_io
         self.snapshot_loader: Optional[SnapshotLoader] = self.table.catalog_environment.snapshot_loader()
 
-        snapshot_path = self.table.table_path.rstrip('/')
-        self.snapshot_dir = f"{snapshot_path}/snapshot"
+        if branch is None:
+            branch = self.table.current_branch() or DEFAULT_MAIN_BRANCH
+        self.branch = BranchManager.normalize_branch(branch)
+
+        table_root = self.table.table_path.rstrip('/')
+        branch_root = BranchManager.branch_path(table_root, self.branch)
+        self.snapshot_dir = f"{branch_root}/snapshot"
         self.latest_file = f"{self.snapshot_dir}/LATEST"
+
+    def copy_with_branch(self, branch_name: str) -> 'SnapshotManager':
+        # Mirrors Java SnapshotManager.copyWithBranch for the local
+        # filesystem path. SnapshotLoader rebranching (REST path) is
+        # not implemented yet -- the new manager re-fetches a loader
+        # from catalog_environment, which on the FileSystemCatalog
+        # path is None and therefore inert.
+        return SnapshotManager(self.table, branch_name)
 
     def get_latest_snapshot(self) -> Optional[Snapshot]:
         """

--- a/paimon-python/pypaimon/tests/branch_manager_test.py
+++ b/paimon-python/pypaimon/tests/branch_manager_test.py
@@ -20,8 +20,12 @@ import shutil
 import tempfile
 import unittest
 
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
 from pypaimon.branch.branch_manager import BranchManager, DEFAULT_MAIN_BRANCH
 from pypaimon.branch.filesystem_branch_manager import FileSystemBranchManager
+from pypaimon.common.identifier import Identifier
 
 
 class BranchManagerTest(unittest.TestCase):
@@ -177,6 +181,116 @@ class FileSystemBranchManagerTest(unittest.TestCase):
 
         self.assertTrue(manager.branch_exists("feature"))
         self.assertFalse(manager.branch_exists("develop"))
+
+
+class SnapshotManagerBranchAwarenessTest(unittest.TestCase):
+    """Pin down SnapshotManager's branch-aware path computation.
+
+    Mirrors Java ``SnapshotManager.copyWithBranch`` (utils/SnapshotManager.java):
+    a non-main branch must produce paths under
+    ``{table_path}/branch/branch-{name}/snapshot/...``.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="unittest_snapshot_branch_")
+        warehouse = os.path.join(self.temp_dir, "warehouse")
+        os.makedirs(warehouse, exist_ok=True)
+        self.catalog = CatalogFactory.create({"warehouse": warehouse})
+        self.catalog.create_database("default", True)
+
+        self.pa_schema = pa.schema([("id", pa.int64()), ("value", pa.string())])
+        self.identifier = Identifier.from_string("default.snapshot_branch_table")
+        self.catalog.create_table(
+            self.identifier, Schema.from_pyarrow_schema(self.pa_schema), False)
+        self.table = self.catalog.get_table(self.identifier)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_default_constructor_targets_main_branch(self):
+        sm = self.table.snapshot_manager()
+        self.assertEqual(sm.branch, "main")
+        self.assertEqual(sm.snapshot_dir, f"{self.table.table_path.rstrip('/')}/snapshot")
+
+    def test_copy_with_branch_returns_branch_aware_paths(self):
+        sm = self.table.snapshot_manager()
+        branch_sm = sm.copy_with_branch("b1")
+
+        self.assertIsNot(branch_sm, sm)
+        self.assertEqual(branch_sm.branch, "b1")
+
+        expected_dir = f"{self.table.table_path.rstrip('/')}/branch/branch-b1/snapshot"
+        self.assertEqual(branch_sm.snapshot_dir, expected_dir)
+        self.assertEqual(branch_sm.get_snapshot_path(7), f"{expected_dir}/snapshot-7")
+        self.assertNotEqual(sm.get_snapshot_path(7), branch_sm.get_snapshot_path(7))
+
+
+class FileSystemBranchManagerEndToEndTest(unittest.TestCase):
+    """Catalog-driven end-to-end tests that exercise ``_copy_with_branch``.
+
+    These regress the from-tag and fast-forward paths that previously
+    raised ``SameFileError``: the SnapshotManager produced by
+    ``_copy_with_branch`` still pointed at the main-branch snapshot dir,
+    so ``copy_file(src, dst)`` collapsed to ``src == dst``.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="unittest_fs_branch_e2e_")
+        warehouse = os.path.join(self.temp_dir, "warehouse")
+        os.makedirs(warehouse, exist_ok=True)
+        self.catalog = CatalogFactory.create({"warehouse": warehouse})
+        self.catalog.create_database("default", True)
+
+        self.pa_schema = pa.schema([("id", pa.int64()), ("value", pa.string())])
+        self.identifier = Identifier.from_string("default.fs_branch_e2e_table")
+        self.catalog.create_table(
+            self.identifier, Schema.from_pyarrow_schema(self.pa_schema), False)
+
+        table = self.catalog.get_table(self.identifier)
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        w.write_arrow(pa.Table.from_pydict(
+            {"id": [1, 2, 3], "value": ["a", "b", "c"]}, schema=self.pa_schema))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+        self.table = self.catalog.get_table(self.identifier)
+        self.table_root = self.table.table_path.rstrip('/')
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _latest_snapshot_id(self) -> int:
+        latest = self.table.snapshot_manager().get_latest_snapshot()
+        self.assertIsNotNone(latest)
+        return latest.id
+
+    def test_create_branch_from_tag_lands_files_under_branch_dir(self):
+        snapshot_id = self._latest_snapshot_id()
+
+        self.table.create_tag("t1")
+        bm = self.table.branch_manager()
+        bm.create_branch("b1", tag_name="t1")
+
+        branch_root = f"{self.table_root}/branch/branch-b1"
+        self.assertTrue(os.path.isdir(branch_root))
+        self.assertTrue(
+            os.path.isfile(f"{branch_root}/snapshot/snapshot-{snapshot_id}"))
+        self.assertTrue(os.path.isfile(f"{branch_root}/tag/tag-t1"))
+        # At least one schema file (schema-0) must have been copied.
+        schema_dir = f"{branch_root}/schema"
+        self.assertTrue(os.path.isdir(schema_dir))
+        self.assertTrue(
+            any(name.startswith("schema-") for name in os.listdir(schema_dir)))
+
+    def test_fast_forward_after_create_branch_from_tag(self):
+        self.table.create_tag("t1")
+        bm = self.table.branch_manager()
+        bm.create_branch("b1", tag_name="t1")
+        # Must not raise: previously fast_forward's copy_files(src=branch_dir,
+        # dst=main_dir) collapsed to src == dst because the branch-side
+        # SnapshotManager still pointed at the main snapshot dir.
+        bm.fast_forward("b1")
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/branch_manager_test.py
+++ b/paimon-python/pypaimon/tests/branch_manager_test.py
@@ -224,6 +224,33 @@ class SnapshotManagerBranchAwarenessTest(unittest.TestCase):
         self.assertEqual(branch_sm.get_snapshot_path(7), f"{expected_dir}/snapshot-7")
         self.assertNotEqual(sm.get_snapshot_path(7), branch_sm.get_snapshot_path(7))
 
+    def test_copy_with_branch_rebranches_snapshot_loader(self):
+        from pypaimon.common.identifier import Identifier
+        from pypaimon.snapshot.snapshot_loader import SnapshotLoader
+
+        sm = self.table.snapshot_manager()
+        # FileSystem path has no loader; inject one to exercise the
+        # rebranch code path. Mirrors Java SnapshotLoaderImpl.copyWithBranch.
+        sm.snapshot_loader = SnapshotLoader(
+            catalog_loader=object(),
+            identifier=Identifier(database="default",
+                                  object="snapshot_branch_table"),
+        )
+
+        branch_sm = sm.copy_with_branch("b1")
+
+        self.assertIsNotNone(branch_sm.snapshot_loader)
+        self.assertIsNot(branch_sm.snapshot_loader, sm.snapshot_loader)
+        self.assertEqual(branch_sm.snapshot_loader.identifier.branch, "b1")
+        self.assertEqual(
+            branch_sm.snapshot_loader.identifier.database,
+            sm.snapshot_loader.identifier.database)
+        self.assertEqual(
+            branch_sm.snapshot_loader.identifier.object,
+            sm.snapshot_loader.identifier.object)
+        # Original loader's identifier untouched.
+        self.assertIsNone(sm.snapshot_loader.identifier.branch)
+
 
 class FileSystemBranchManagerEndToEndTest(unittest.TestCase):
     """Catalog-driven end-to-end tests that exercise ``_copy_with_branch``.

--- a/paimon-python/pypaimon/tests/snapshot_manager_test.py
+++ b/paimon-python/pypaimon/tests/snapshot_manager_test.py
@@ -42,6 +42,7 @@ class SnapshotManagerTest(unittest.TestCase):
 
         table = Mock()
         table.table_path = "/tmp/test_table"
+        table.current_branch.return_value = "main"
         table.file_io = Mock()
         table.file_io.exists_batch.return_value = {
             "/tmp/test_table/snapshot/snapshot-5": True,
@@ -82,6 +83,7 @@ class SnapshotManagerTest(unittest.TestCase):
 
         table = Mock()
         table.table_path = "/tmp/test_table"
+        table.current_branch.return_value = "main"
         table.file_io = Mock()
         # All paths return False (no files exist)
         table.file_io.exists_batch.return_value = {}
@@ -105,6 +107,7 @@ class SnapshotManagerTest(unittest.TestCase):
 
         table = Mock()
         table.table_path = "/tmp/test_table"
+        table.current_branch.return_value = "main"
         table.file_io = Mock()
 
         # All 3 snapshots exist but are COMPACT (will be skipped)


### PR DESCRIPTION
## Purpose

Fix a pre-existing bug in `FileSystemBranchManager._copy_with_branch` that made `create_branch(tag_name=...)` and `fast_forward` raise `SameFileError`: the `SnapshotManager` it produced still pointed at the main-branch snapshot directory, so `copy_file(src, dst)` collapsed to `src == dst`.

The fix mirrors Java `SnapshotManager.copyWithBranch` (paimon-core/.../utils/SnapshotManager.java:89-95): the Python `SnapshotManager` now carries an explicit `branch` field and a `copy_with_branch(branch_name)` factory, so its `snapshot_dir` / `get_snapshot_path(...)` resolve to `{table_path}/branch/branch-{name}/snapshot/...` for non-main branches. `FileSystemBranchManager._copy_with_branch` then dispatches to the per-manager factories (`SnapshotManager.copy_with_branch` / `SchemaManager.copy_with_branch`) instead of blindly reconstructing a main-branch `SnapshotManager`.

`SnapshotLoader` is rebranched in lockstep so REST-path catalog loads target the requested branch rather than falling back to the main-branch identifier (mirrors Java `SnapshotLoaderImpl.copyWithBranch`).

## In scope

- `pypaimon/snapshot/snapshot_manager.py`: constructor accepts an optional `branch` argument (defaults to inheriting `table.current_branch()`); new `branch` field; branch-aware `snapshot_dir` / `latest_file`; new `copy_with_branch(branch_name)` factory that also rebranches the snapshot loader.
- `pypaimon/snapshot/snapshot_loader.py`: new `copy_with_branch(branch)` returning a loader whose `Identifier` carries the new branch (mirrors Java `SnapshotLoaderImpl.copyWithBranch`).
- `pypaimon/branch/filesystem_branch_manager.py`: `_copy_with_branch` dispatches to `manager.copy_with_branch(branch)` for `SnapshotManager` / `SchemaManager` (the latter already had the factory). `TagManager` is still rebuilt directly because the Python `TagManager` has no `copy_with_branch` factory yet.
- `pypaimon/tests/branch_manager_test.py`: two new test classes -- `SnapshotManagerBranchAwarenessTest` pins down the branch-aware path computation and the loader rebranching, and `FileSystemBranchManagerEndToEndTest` regresses both the from-tag happy path and the fast-forward happy path that previously raised `SameFileError`.
- `pypaimon/tests/snapshot_manager_test.py`: existing `Mock()` tables now explicitly set `current_branch.return_value = "main"`, since the constructor now calls `table.current_branch()` for the default branch.

## Out of scope

- Re-enabling the two from-tag / fast-forward happy-path tests skipped in #7755 (`filesystem_catalog_branch_test.py`). That file is only on the #7755 branch; once #7755 merges, the skipped tests can be re-enabled in a follow-up.
- Consolidating `FileSystemBranchManager._normalize_branch` with `BranchManager.normalize_branch` -- out of diff, separate cleanup.

## Tests

From `paimon-python/`:

```
pytest pypaimon/tests/branch_manager_test.py -v             # 19 passed (14 existing + 5 new)
pytest pypaimon/tests/snapshot_manager_test.py -v           # 3 passed (mock fixture fix)
pytest pypaimon/tests/branch/ pypaimon/tests/rest/rest_branch_test.py \
       pypaimon/tests/api/test_branch_dto_serde.py \
       pypaimon/tests/filesystem_catalog_tag_test.py -q     # 87 passed
flake8 --config=dev/cfg.ini <touched files>                  # clean
```

The two new end-to-end tests in `FileSystemBranchManagerEndToEndTest` (`test_create_branch_from_tag_lands_files_under_branch_dir` and `test_fast_forward_after_create_branch_from_tag`) deterministically reproduce the `SameFileError` on master and pass on this branch. `test_copy_with_branch_rebranches_snapshot_loader` covers the new loader rebranching.

## Anti-divergence checklist

- `SnapshotManager.copy_with_branch` matches Java `SnapshotManager.copyWithBranch` semantics: a fresh manager whose path accessors flow through `BranchManager.branch_path(table_root, branch)`, plus a snapshot loader rebranched via `SnapshotLoader.copy_with_branch(branch)` when one is present.
- `SnapshotLoader.copy_with_branch` matches Java `SnapshotLoaderImpl.copyWithBranch`: same `catalog_loader`, new `Identifier(database, object, branch)`.
- `branch == "main"` keeps existing paths bit-identical (`branch_path(p, "main") == p`), so all current `SnapshotManager(table)` call sites stay zero-regression.
- `FileStoreTable.snapshot_manager()` is unchanged; the new optional `branch` parameter defaults to `table.current_branch()` which is already the production behavior.

## Generative AI disclosure

Drafted with assistance from a generative AI tool. All code, tests, and Java alignment were reviewed and validated by the contributor.