### PR TITLE
[iceberg] Fix UnsupportedOperationException reading tinyint and smallint columns

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergConversions.java
@@ -142,6 +142,10 @@ public class IcebergConversions {
             case INTEGER:
             case DATE:
                 return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
+            case TINYINT:
+                return (byte) ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
+            case SMALLINT:
+                return (short) ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getInt();
             case BIGINT:
                 return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).getLong();
             case FLOAT:

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergConversionsIntegerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/manifest/IcebergConversionsIntegerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg.manifest;
+
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IcebergConversionsIntegerTest {
+
+    @Test
+    void testTinyIntRoundTrip() {
+        byte value = (byte) 42;
+        ByteBuffer buffer = IcebergConversions.toByteBuffer(DataTypes.TINYINT(), value);
+        Object decoded = IcebergConversions.toPaimonObject(DataTypes.TINYINT(), buffer.array());
+        assertThat(decoded).isEqualTo(value);
+    }
+
+    @Test
+    void testTinyIntRoundTripNegative() {
+        byte value = (byte) -7;
+        ByteBuffer buffer = IcebergConversions.toByteBuffer(DataTypes.TINYINT(), value);
+        Object decoded = IcebergConversions.toPaimonObject(DataTypes.TINYINT(), buffer.array());
+        assertThat(decoded).isEqualTo(value);
+    }
+
+    @Test
+    void testSmallIntRoundTrip() {
+        short value = (short) 12345;
+        ByteBuffer buffer = IcebergConversions.toByteBuffer(DataTypes.SMALLINT(), value);
+        Object decoded = IcebergConversions.toPaimonObject(DataTypes.SMALLINT(), buffer.array());
+        assertThat(decoded).isEqualTo(value);
+    }
+
+    @Test
+    void testSmallIntRoundTripNegative() {
+        short value = (short) -1234;
+        ByteBuffer buffer = IcebergConversions.toByteBuffer(DataTypes.SMALLINT(), value);
+        Object decoded = IcebergConversions.toPaimonObject(DataTypes.SMALLINT(), buffer.array());
+        assertThat(decoded).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
### Purpose
   - Iceberg toByteBuffer encodes tiny and small int as 4 byte little endian int, but IcebergConversions.toPaimonObject has no matching case and throws UnsupportedOperationException.
   - Occurs when the type is used as a partition column and decoded back into Paimon objects.
   - Add support for the same.

### Tests
 - Unit tests