### PR TITLE
[python] Use pypaimon with Google Cloud Storage

### DIFF
--- a/paimon-python/pypaimon/common/options/config.py
+++ b/paimon-python/pypaimon/common/options/config.py
@@ -43,6 +43,15 @@ class S3Options:
     S3_REGION = ConfigOptions.key("fs.s3.region").string_type().no_default_value().with_description("S3 region")
 
 
+class GcsOptions:
+    GCS_ACCESS_TOKEN = ConfigOptions.key("gcs.access-token").string_type().no_default_value().with_description(
+        "GCS access token. If not set, ADC (Application Default Credentials) is used automatically.")
+    GCS_ACCESS_TOKEN_EXPIRATION = ConfigOptions.key("gcs.access-token.expiration").string_type().no_default_value().with_description(
+        "ISO 8601 expiration datetime for the GCS access token. Required when gcs.access-token is set.")
+    GCS_PROJECT_ID = ConfigOptions.key("gcs.project-id").string_type().no_default_value().with_description(
+        "GCP project ID for GCS requests.")
+
+
 class PVFSOptions:
     CACHE_ENABLED = ConfigOptions.key("cache-enabled").boolean_type().default_value("true").with_description(
         "Enable cache")

--- a/paimon-python/pypaimon/common/options/config.py
+++ b/paimon-python/pypaimon/common/options/config.py
@@ -44,12 +44,19 @@ class S3Options:
 
 
 class GcsOptions:
-    GCS_ACCESS_TOKEN = ConfigOptions.key("gcs.access-token").string_type().no_default_value().with_description(
-        "GCS access token. If not set, ADC (Application Default Credentials) is used automatically.")
-    GCS_ACCESS_TOKEN_EXPIRATION = ConfigOptions.key("gcs.access-token.expiration").string_type().no_default_value().with_description(
-        "ISO 8601 expiration datetime for the GCS access token. Required when gcs.access-token is set.")
-    GCS_PROJECT_ID = ConfigOptions.key("gcs.project-id").string_type().no_default_value().with_description(
-        "GCP project ID for GCS requests.")
+    GCS_ACCESS_TOKEN = (
+        ConfigOptions.key("gcs.access-token").string_type().no_default_value()
+        .with_description(
+            "GCS access token. If not set, ADC (Application Default Credentials) is used "
+            "automatically."))
+    GCS_ACCESS_TOKEN_EXPIRATION = (
+        ConfigOptions.key("gcs.access-token.expiration").string_type().no_default_value()
+        .with_description(
+            "ISO 8601 expiration datetime for the GCS access token. "
+            "Required when gcs.access-token is set."))
+    GCS_PROJECT_ID = (
+        ConfigOptions.key("gcs.project-id").string_type().no_default_value()
+        .with_description("GCP project ID for GCS requests."))
 
 
 class PVFSOptions:

--- a/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
+++ b/paimon-python/pypaimon/filesystem/pyarrow_file_io.py
@@ -78,6 +78,8 @@ class PyArrowFileIO(FileIO):
             self.filesystem = self._initialize_s3_fs()
         elif scheme in {"hdfs", "viewfs"}:
             self.filesystem = self._initialize_hdfs_fs(scheme, netloc)
+        elif scheme == "gs":
+            self.filesystem = self._initialize_gcs_fs()
         else:
             raise ValueError(f"Unrecognized filesystem type in URI: {scheme}")
 
@@ -300,6 +302,26 @@ class PyArrowFileIO(FileIO):
                 port=port,
                 user=os.environ.get('HADOOP_USER_NAME', 'hadoop')
             )
+
+    def _initialize_gcs_fs(self) -> FileSystem:
+        access_token = self._get_property("gcs.access-token")
+        token_expiry = self._get_property("gcs.access-token.expiration")
+        project_id = self._get_property("gcs.project-id")
+
+        kwargs = {}
+        if access_token:
+            from datetime import datetime
+            kwargs["access_token"] = access_token
+            kwargs["credential_token_expiration"] = (
+                datetime.fromisoformat(token_expiry) if token_expiry
+                else datetime(9999, 12, 31)
+            )
+        if project_id:
+            kwargs["project_id"] = project_id
+
+        # With no kwargs, GcsFileSystem uses ADC automatically
+        # (GOOGLE_APPLICATION_CREDENTIALS or GCP metadata server / Workload Identity)
+        return pafs.GcsFileSystem(**kwargs)
 
     @staticmethod
     def _kerberos_login_from_keytab(principal: str, keytab: str):
@@ -705,6 +727,13 @@ class PyArrowFileIO(FileIO):
                     return result if result else '.'
             else:
                 return str(path)
+
+        from pyarrow.fs import GcsFileSystem
+        if isinstance(self.filesystem, GcsFileSystem):
+            if parsed.scheme and parsed.netloc:
+                path_part = normalized_path.lstrip('/')
+                return f"{parsed.netloc}/{path_part}" if path_part else parsed.netloc
+            return str(path)
 
         if parsed.scheme:
             if not normalized_path:

--- a/paimon-python/pypaimon/tests/file_io_test.py
+++ b/paimon-python/pypaimon/tests/file_io_test.py
@@ -562,5 +562,62 @@ class HdfsFileIOTest(unittest.TestCase):
             self.assertIn('HADOOP_CONF_DIR', str(ctx.exception))
 
 
+class GCSFileIOPathTest(unittest.TestCase):
+    """Unit tests for PyArrowFileIO.to_filesystem_path with GCS (no credentials required)."""
+
+    def setUp(self):
+        self.file_io = PyArrowFileIO("gs://my-bucket/warehouse", Options({}))
+
+    def test_gcs_filesystem_type(self):
+        """GCS warehouse path should produce a GcsFileSystem."""
+        self.assertIsInstance(self.file_io.filesystem, pafs.GcsFileSystem)
+
+    def test_gcs_path_conversion(self):
+        """gs://bucket/key should map to bucket/key (no leading slash)."""
+        self.assertEqual(
+            self.file_io.to_filesystem_path("gs://my-bucket/path/to/file.parquet"),
+            "my-bucket/path/to/file.parquet"
+        )
+        self.assertEqual(
+            self.file_io.to_filesystem_path("gs://my-bucket/warehouse/db.db/tbl/data-0.parquet"),
+            "my-bucket/warehouse/db.db/tbl/data-0.parquet"
+        )
+
+    def test_gcs_path_bucket_only(self):
+        """gs://bucket with no path should return just the bucket name."""
+        self.assertEqual(
+            self.file_io.to_filesystem_path("gs://my-bucket"),
+            "my-bucket"
+        )
+
+    def test_gcs_path_normalization(self):
+        """Multiple consecutive slashes in the path should be collapsed."""
+        self.assertEqual(
+            self.file_io.to_filesystem_path("gs://my-bucket///path///to///file.parquet"),
+            "my-bucket/path/to/file.parquet"
+        )
+
+    def test_gcs_path_idempotency(self):
+        """Already-converted bucket/key paths should pass through unchanged."""
+        converted = "my-bucket/path/to/file.parquet"
+        self.assertEqual(self.file_io.to_filesystem_path(converted), converted)
+        parent = str(Path(converted).parent)
+        self.assertEqual(self.file_io.to_filesystem_path(parent), parent)
+
+    def test_gcs_path_no_leading_slash(self):
+        """to_filesystem_path must never return a path starting with '/'."""
+        cases = [
+            "gs://my-bucket/path/to/file.parquet",
+            "gs://my-bucket",
+            "gs://my-bucket///path",
+        ]
+        for uri in cases:
+            result = self.file_io.to_filesystem_path(uri)
+            self.assertFalse(
+                result.startswith("/"),
+                f"Path must not start with '/' for GcsFileSystem, got: {result!r} (input: {uri!r})"
+            )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/gcs_file_io_test.py
+++ b/paimon-python/pypaimon/tests/gcs_file_io_test.py
@@ -1,0 +1,184 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import os
+import unittest
+import uuid
+
+import pyarrow.fs as pafs
+
+from pypaimon.common.options import Options
+from pypaimon.filesystem.pyarrow_file_io import PyArrowFileIO
+
+
+class GCSFileIOTest(unittest.TestCase):
+    """Integration tests for PyArrowFileIO with GCS.
+
+    Requires the following environment variable to be set:
+      GCS_TEST_BUCKET  — name of the GCS bucket to use (without gs:// prefix)
+
+    Credentials are picked up automatically via Application Default Credentials
+    (GOOGLE_APPLICATION_CREDENTIALS, GCP metadata server, or Workload Identity).
+    All tests are skipped when GCS_TEST_BUCKET is not configured.
+    """
+
+    def setUp(self):
+        self.bucket = os.environ.get("GCS_TEST_BUCKET")
+        if not self.bucket:
+            self.skipTest("GCS_TEST_BUCKET is not configured")
+            return
+
+        self.root_path = f"gs://{self.bucket}/"
+        self.file_io = PyArrowFileIO(self.root_path, Options({}))
+        self.test_prefix = f"test-{uuid.uuid4().hex[:8]}/"
+
+    def tearDown(self):
+        if not hasattr(self, 'file_io'):
+            return
+        test_dir = f"{self.root_path}{self.test_prefix}"
+        try:
+            if self.file_io.exists(test_dir):
+                self.file_io.delete(test_dir, recursive=True)
+        except Exception:
+            pass
+
+    def _path(self, name: str) -> str:
+        return f"{self.root_path}{self.test_prefix}{name}"
+
+    def test_gcs_filesystem_type(self):
+        """PyArrowFileIO with gs:// should use GcsFileSystem."""
+        self.assertIsInstance(self.file_io.filesystem, pafs.GcsFileSystem)
+
+    def test_exists(self):
+        """exists() returns False for non-existent paths."""
+        self.assertFalse(self.file_io.exists(self._path("nonexistent.txt")))
+        with self.assertRaises(FileNotFoundError):
+            self.file_io.get_file_status(self._path("nonexistent.txt"))
+
+    def test_write_and_read_file(self):
+        """write_file() and read_file_utf8() round-trip."""
+        test_file = self._path("write_read_test.txt")
+
+        self.file_io.write_file(test_file, "hello gcs")
+        self.assertTrue(self.file_io.exists(test_file))
+        self.assertEqual(self.file_io.read_file_utf8(test_file), "hello gcs")
+
+    def test_write_file_overwrite(self):
+        """write_file() respects the overwrite flag."""
+        test_file = self._path("overwrite_test.txt")
+
+        self.file_io.write_file(test_file, "first")
+        with self.assertRaises(FileExistsError):
+            self.file_io.write_file(test_file, "second", overwrite=False)
+        self.assertEqual(self.file_io.read_file_utf8(test_file), "first")
+
+        self.file_io.write_file(test_file, "overwritten", overwrite=True)
+        self.assertEqual(self.file_io.read_file_utf8(test_file), "overwritten")
+
+    def test_new_input_stream_read(self):
+        """new_output_stream() / new_input_stream() round-trip."""
+        test_data = b"Hello, GCS! This is a test file."
+        test_file = self._path("input_stream_test.bin")
+
+        with self.file_io.new_output_stream(test_file) as out:
+            out.write(test_data)
+
+        with self.file_io.new_input_stream(test_file) as inp:
+            self.assertEqual(inp.read(), test_data)
+
+        with self.assertRaises(FileNotFoundError):
+            self.file_io.new_input_stream(self._path("nonexistent.bin"))
+
+    def test_get_file_status_directory(self):
+        """get_file_status() returns Directory type for a directory."""
+        test_dir = self._path("test-dir/")
+        self.file_io.mkdirs(test_dir)
+        status = self.file_io.get_file_status(test_dir)
+        self.assertIsNotNone(status)
+        self.assertEqual(status.type, pafs.FileType.Directory)
+
+    def test_get_file_status_file(self):
+        """get_file_status() returns File type and non-None size for a file."""
+        test_file = self._path("status_test.txt")
+        self.file_io.write_file(test_file, "content")
+        status = self.file_io.get_file_status(test_file)
+        self.assertEqual(status.type, pafs.FileType.File)
+        self.assertIsNotNone(status.size)
+
+    def test_delete_returns_false_when_not_exists(self):
+        """delete() returns False when the path does not exist."""
+        self.assertFalse(self.file_io.delete(self._path("nonexistent.txt")))
+        self.assertFalse(self.file_io.delete(self._path("nonexistent_dir"), recursive=False))
+
+    def test_delete_non_empty_directory_raises_error(self):
+        """delete() without recursive=True raises OSError for non-empty directory."""
+        test_dir = self._path("nonempty-dir/")
+        test_file = self._path("nonempty-dir/file.txt")
+        self.file_io.mkdirs(test_dir)
+        with self.file_io.new_output_stream(test_file) as out:
+            out.write(b"data")
+
+        with self.assertRaises(OSError) as ctx:
+            self.file_io.delete(test_dir, recursive=False)
+        self.assertIn("is not empty", str(ctx.exception))
+
+    def test_rename_returns_false_when_dst_exists(self):
+        """rename() returns False when the destination already exists."""
+        src = self._path("src.txt")
+        dst = self._path("dst.txt")
+        with self.file_io.new_output_stream(src) as out:
+            out.write(b"src")
+        with self.file_io.new_output_stream(dst) as out:
+            out.write(b"dst")
+
+        self.assertFalse(self.file_io.rename(src, dst))
+
+    def test_copy_file(self):
+        """copy_file() copies content and respects the overwrite flag."""
+        src = self._path("copy_src.txt")
+        dst = self._path("copy_dst.txt")
+        with self.file_io.new_output_stream(src) as out:
+            out.write(b"source content")
+        with self.file_io.new_output_stream(dst) as out:
+            out.write(b"target content")
+
+        with self.assertRaises(FileExistsError) as ctx:
+            self.file_io.copy_file(src, dst, overwrite=False)
+        self.assertIn("already exists", str(ctx.exception))
+
+        self.file_io.copy_file(src, dst, overwrite=True)
+        with self.file_io.new_input_stream(dst) as inp:
+            self.assertEqual(inp.read(), b"source content")
+
+    def test_try_to_write_atomic(self):
+        """try_to_write_atomic() writes a file and returns True on success."""
+        normal_file = self._path("atomic_file.txt")
+        self.assertTrue(self.file_io.try_to_write_atomic(normal_file, "atomic content"))
+        self.assertEqual(self.file_io.read_file_utf8(normal_file), "atomic content")
+
+    def test_mkdirs_raises_error_when_path_is_file(self):
+        """mkdirs() raises FileExistsError when the path is an existing file."""
+        test_file = self._path("existing_file.txt")
+        self.file_io.write_file(test_file, "data")
+
+        with self.assertRaises(FileExistsError) as ctx:
+            self.file_io.mkdirs(test_file)
+        self.assertIn("is not a directory", str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Purpose

Use Google Cloud Storage (GCS) as warehouse / object storage for pypaimon (without java dependencies). This PR adds PyArrowFileIO handling for GCS.

### Changes

#### 1. Scheme dispatch (`pyarrow_file_io.py`)

Added a `gs` branch in `__init__` alongside the existing `s3` and `hdfs` branches:

```python
elif scheme == "gs":
    self.filesystem = self._initialize_gcs_fs()
```

#### 2. `_initialize_gcs_fs()` method (`pyarrow_file_io.py`)

Uses `pyarrow.fs.GcsFileSystem`, which is already available via `pyarrow[gcs]`.

With no arguments, `GcsFileSystem` picks up credentials automatically via Application Default Credentials (ADC): `GOOGLE_APPLICATION_CREDENTIALS`, the GCP metadata server, or Workload Identity on GKE/GCE. Three optional properties allow explicit credential passing:

| Property | Description |
|---|---|
| `gcs.access-token` | OAuth2 access token. If unset, ADC is used. |
| `gcs.access-token.expiration` | ISO 8601 expiry datetime for the token. |
| `gcs.project-id` | GCP project ID for billing/quota. |

```python
def _initialize_gcs_fs(self) -> FileSystem:
    access_token = self._get_property("gcs.access-token")
    token_expiry = self._get_property("gcs.access-token.expiration")
    project_id = self._get_property("gcs.project-id")

    kwargs = {}
    if access_token:
        from datetime import datetime
        kwargs["access_token"] = access_token
        kwargs["credential_token_expiration"] = (
            datetime.fromisoformat(token_expiry) if token_expiry
            else datetime(9999, 12, 31)
        )
    if project_id:
        kwargs["project_id"] = project_id

    # With no kwargs, GcsFileSystem uses ADC automatically
    return pafs.GcsFileSystem(**kwargs)
```

#### 3. Path fix in `to_filesystem_path()` (`pyarrow_file_io.py`)

`to_filesystem_path()` had a catch-all for non-S3/non-HDFS schemes that returned only `uri.path` — e.g. for `gs://my-bucket/data/table` it returned `/data/table`, stripping the bucket name. `GcsFileSystem` (like `S3FileSystem`) expects paths in `bucket/key` form without a leading slash.

Added a `GcsFileSystem` branch mirroring the existing S3 logic:

```python
from pyarrow.fs import GcsFileSystem
if isinstance(self.filesystem, GcsFileSystem):
    if parsed.scheme and parsed.netloc:
        path_part = normalized_path.lstrip('/')
        return f"{parsed.netloc}/{path_part}" if path_part else parsed.netloc
    return str(path)
```

#### 4. `GcsOptions` class (`config.py`)

Added a `GcsOptions` class alongside the existing `S3Options` documenting the three new properties.

```
class GcsOptions:
    GCS_ACCESS_TOKEN = ConfigOptions.key("gcs.access-token").string_type().no_default_value().with_description(
        "GCS access token. If not set, ADC (Application Default Credentials) is used automatically.")
    ...
```

### Linked issue

https://github.com/apache/paimon/issues/7768

### Tests

#### Unit tests — `pypaimon/tests/file_io_test.py`

A new `GCSFileIOPathTest` class is added to the existing `file_io_test.py`, following the same pattern as the existing S3/OSS path conversion tests. These tests require no GCS credentials.

| Test | What it checks |
|---|---|
| `test_gcs_filesystem_type` | `PyArrowFileIO("gs://...")` produces a `pafs.GcsFileSystem` instance |
| `test_gcs_path_conversion` | `gs://bucket/key` maps to `bucket/key` (bucket prepended, no leading slash) |
| `test_gcs_path_bucket_only` | `gs://bucket` with no path component maps to `bucket` |
| `test_gcs_path_normalization` | Consecutive slashes in the path are collapsed (e.g. `gs://bucket///a///b` → `bucket/a/b`) |
| `test_gcs_path_idempotency` | Already-converted `bucket/key` paths pass through unchanged |
| `test_gcs_path_no_leading_slash` | `to_filesystem_path` never returns a path starting with `/` for any GCS URI |

```bash
python -m pytest pypaimon/tests/file_io_test.py::GCSFileIOPathTest -v
```

#### Integration tests — `pypaimon/tests/gcs_file_io_test.py`

A new `GCSFileIOTest` class is added following the pattern of `oss_file_io_test.py`. All tests are skipped automatically when `GCS_TEST_BUCKET` is not set. Credentials are picked up via ADC — no explicit credential properties are required.

| Test | What it checks |
|---|---|
| `test_gcs_filesystem_type` | Live `PyArrowFileIO` with `gs://` uses `GcsFileSystem` |
| `test_exists` | `exists()` returns `False` for non-existent paths; `get_file_status()` raises `FileNotFoundError` |
| `test_write_and_read_file` | `write_file()` / `read_file_utf8()` round-trip |
| `test_write_file_overwrite` | `write_file(..., overwrite=False)` raises `FileExistsError`; `overwrite=True` replaces content |
| `test_new_input_stream_read` | `new_output_stream()` / `new_input_stream()` binary round-trip; `FileNotFoundError` for missing file |
| `test_get_file_status_directory` | `get_file_status()` returns `FileType.Directory` for a directory |
| `test_get_file_status_file` | `get_file_status()` returns `FileType.File` with non-None size |
| `test_delete_returns_false_when_not_exists` | `delete()` returns `False` for non-existent file/directory |
| `test_delete_non_empty_directory_raises_error` | `delete(..., recursive=False)` raises `OSError` for non-empty directory |
| `test_rename_returns_false_when_dst_exists` | `rename()` returns `False` when destination already exists |
| `test_copy_file` | `copy_file(..., overwrite=False)` raises `FileExistsError`; `overwrite=True` replaces content |
| `test_try_to_write_atomic` | `try_to_write_atomic()` writes content and returns `True` on success |
| `test_mkdirs_raises_error_when_path_is_file` | `mkdirs()` raises `FileExistsError` when path is an existing file |

```bash
# Skips all tests (no bucket configured)
python -m pytest pypaimon/tests/gcs_file_io_test.py -v

# Runs all tests against a real GCS bucket using ADC
GCS_TEST_BUCKET=my-bucket python -m pytest pypaimon/tests/gcs_file_io_test.py -v
```

