### PR TITLE
[python] Fix broken test `branch_manager_test`

### DIFF
--- a/paimon-python/pypaimon/tests/branch_manager_test.py
+++ b/paimon-python/pypaimon/tests/branch_manager_test.py
@@ -246,8 +246,8 @@ class SnapshotManagerBranchAwarenessTest(unittest.TestCase):
             branch_sm.snapshot_loader.identifier.database,
             sm.snapshot_loader.identifier.database)
         self.assertEqual(
-            branch_sm.snapshot_loader.identifier.object,
-            sm.snapshot_loader.identifier.object)
+            branch_sm.snapshot_loader.identifier.get_table_name(),
+            sm.snapshot_loader.identifier.get_table_name())
         # Original loader's identifier untouched.
         self.assertIsNone(sm.snapshot_loader.identifier.branch)
 


### PR DESCRIPTION
### Purpose

All PRs are failing lint-python (3.10/3.11) on `test_copy_with_branch_rebranches_snapshot_loader` since `#7738` and `#7756` were merged.

`#7738` encodes branch into `Identifier.object`, but `#7756`'s test compares `.object` directly. Use `.get_table_name()` instead.

### Tests
paimon-python/pypaimon/tests/branch_manager_test.py