### PR TITLE
[infra] Add stale PR policy via GitHub Actions

### DIFF
--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Posts a single reminder comment on pull requests that have seen no
+# activity for 90 days. No auto-close; a maintainer decides whether to
+# close, ping again, or leave the PR open. Issues are not in scope.
+#
+# See dev@paimon.apache.org "Stale PR cleanup for Paimon" thread.
+
+name: Stale PR reminder
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PRs: nudge once at 90 days of inactivity, never auto-close.
+          days-before-pr-stale: 90
+          days-before-pr-close: -1
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has had no activity for 90 days. If you'd
+            like to keep it open, please push a new commit or leave a
+            comment. Thanks for the contribution.
+          remove-stale-when-updated: true
+
+          # Issues are not in scope for this workflow.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          operations-per-run: 100


### PR DESCRIPTION
### Purpose
 - Adds an actions/stale workflow, give warning and mark stale after 60d of inactivity.
 - Currently only a comment is applied and PR marked as stale, does not auto close, can be considered in future.
 - Runs every 1 day.

### Tests
 - N/A