### PR TITLE
[core] Skip tag copy in fastForward when branch has no tags

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileSystemBranchManager.java
@@ -195,10 +195,11 @@ public class FileSystemBranchManager implements BranchManager {
                     schemaManager.copyWithBranch(branchName).schemaDirectory(),
                     schemaManager.schemaDirectory(),
                     true);
-            fileIO.copyFiles(
-                    tagManager.copyWithBranch(branchName).tagDirectory(),
-                    tagManager.tagDirectory(),
-                    true);
+            // Continue fast-forward even without tags.
+            Path branchTagDirectory = tagManager.copyWithBranch(branchName).tagDirectory();
+            if (fileIO.exists(branchTagDirectory)) {
+                fileIO.copyFiles(branchTagDirectory, tagManager.tagDirectory(), true);
+            }
             snapshotManager.invalidateCache();
         } catch (IOException e) {
             throw new RuntimeException(

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -1357,6 +1357,35 @@ public abstract class SimpleTableTestBase {
     }
 
     @Test
+    public void testFastForwardWithoutTag() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+
+        try (StreamTableWrite write = table.newWrite(commitUser);
+                StreamTableCommit commit = table.newCommit(commitUser)) {
+            write.write(rowData(0, 0, 0L));
+            commit.commit(0, write.prepareCommit(false, 1));
+        }
+
+        table.createBranch(BRANCH_NAME);
+        FileStoreTable tableBranch = createBranchTable(BRANCH_NAME);
+
+        try (StreamTableWrite write = tableBranch.newWrite(commitUser);
+                StreamTableCommit commit = tableBranch.newCommit(commitUser)) {
+            write.write(rowData(2, 20, 200L));
+            commit.commit(1, write.prepareCommit(false, 2));
+        }
+
+        table.fastForward(BRANCH_NAME);
+
+        assertThat(
+                        getResult(
+                                table.newRead(),
+                                toSplits(table.newSnapshotReader().read().dataSplits()),
+                                BATCH_ROW_TO_STRING))
+                .contains("2|20|200|binary|varbinary|mapKey:mapVal|multiset");
+    }
+
+    @Test
     public void testUnsupportedTagName() throws Exception {
         FileStoreTable table = createFileStoreTable();
 


### PR DESCRIPTION
### Purpose
  - fastForward copies the tag directory to main, even when the branch did not have a tag created.
  - On object store,`listStatus` on the missing directory throws FNF exception, causing failure for fastforward for branch without tags.
  - Add a guard to check that the tag dir exists before the copy operation.
  - Closes user reported bug #7781
### Tests
 - UT