### PR TITLE
[core] Add commit-snapshot-id field to DataFileMeta

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
+++ b/paimon-api/src/main/java/org/apache/paimon/table/SpecialFields.java
@@ -93,13 +93,17 @@ public class SpecialFields {
     public static final DataField ROW_ID =
             new DataField(Integer.MAX_VALUE - 5, "_ROW_ID", DataTypes.BIGINT().notNull());
 
+    public static final DataField COMMIT_SNAPSHOT_ID =
+            new DataField(Integer.MAX_VALUE - 6, "_COMMIT_SNAPSHOT_ID", DataTypes.BIGINT());
+
     public static final Set<String> SYSTEM_FIELD_NAMES =
             Stream.of(
                             SEQUENCE_NUMBER.name(),
                             VALUE_KIND.name(),
                             LEVEL.name(),
                             ROW_KIND.name(),
-                            ROW_ID.name())
+                            ROW_ID.name(),
+                            COMMIT_SNAPSHOT_ID.name())
                     .collect(Collectors.toSet());
 
     public static boolean isSystemField(int fieldId) {

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValue.java
@@ -43,6 +43,8 @@ public class KeyValue {
 
     public static final long UNKNOWN_SEQUENCE = -1;
     public static final int UNKNOWN_LEVEL = -1;
+    // Paimon snapshot ids are always >= 1, so -1 is a safe sentinel for "unstamped".
+    public static final long UNKNOWN_SNAPSHOT_ID = -1;
 
     private InternalRow key;
     // determined after written into memory table or read from file
@@ -51,6 +53,9 @@ public class KeyValue {
     private InternalRow value;
     // determined after read from file
     private int level;
+    // determined after read from file; UNKNOWN_SNAPSHOT_ID if the source data file is not stamped
+    // with a commit snapshot id (snapshot-ordering disabled, or pre-existing data file)
+    private long snapshotId;
 
     public KeyValue replace(InternalRow key, RowKind valueKind, InternalRow value) {
         return replace(key, UNKNOWN_SEQUENCE, valueKind, value);
@@ -63,6 +68,7 @@ public class KeyValue {
         this.valueKind = valueKind;
         this.value = value;
         this.level = UNKNOWN_LEVEL;
+        this.snapshotId = UNKNOWN_SNAPSHOT_ID;
         return this;
     }
 
@@ -108,6 +114,26 @@ public class KeyValue {
     public KeyValue setLevel(int level) {
         this.level = level;
         return this;
+    }
+
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    public KeyValue setSnapshotId(long snapshotId) {
+        this.snapshotId = snapshotId;
+        return this;
+    }
+
+    /**
+     * Compare two KeyValues by their commit snapshot id. {@link #UNKNOWN_SNAPSHOT_ID} is treated as
+     * {@link Long#MIN_VALUE} so that stamped records always beat unstamped ones, preserving
+     * comparator transitivity.
+     */
+    public static int compareSnapshotId(KeyValue a, KeyValue b) {
+        long sa = a.snapshotId == UNKNOWN_SNAPSHOT_ID ? Long.MIN_VALUE : a.snapshotId;
+        long sb = b.snapshotId == UNKNOWN_SNAPSHOT_ID ? Long.MIN_VALUE : b.snapshotId;
+        return Long.compare(sa, sb);
     }
 
     public static RowType schema(RowType keyType, RowType valueType) {
@@ -173,7 +199,8 @@ public class KeyValue {
                         sequenceNumber,
                         valueKind,
                         valueSerializer.copy(value))
-                .setLevel(level);
+                .setLevel(level)
+                .setSnapshotId(snapshotId);
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMeta.java
@@ -87,7 +87,8 @@ public interface DataFileMeta {
                             new DataField(17, "_EXTERNAL_PATH", newStringType(true)),
                             new DataField(18, "_FIRST_ROW_ID", new BigIntType(true)),
                             new DataField(
-                                    19, "_WRITE_COLS", new ArrayType(true, newStringType(false)))));
+                                    19, "_WRITE_COLS", new ArrayType(true, newStringType(false))),
+                            new DataField(20, "_COMMIT_SNAPSHOT_ID", new BigIntType(true))));
 
     BinaryRow EMPTY_MIN_KEY = EMPTY_ROW;
     BinaryRow EMPTY_MAX_KEY = EMPTY_ROW;
@@ -328,6 +329,17 @@ public interface DataFileMeta {
     DataFileMeta assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber);
 
     DataFileMeta assignFirstRowId(long firstRowId);
+
+    /**
+     * Snapshot id at which this file was committed (or the source snapshot id stamped by a
+     * compaction rewriter). Null when the table does not enable {@code sequence.snapshot-ordering}
+     * or when this file pre-dates the feature.
+     */
+    @Nullable
+    Long commitSnapshotId();
+
+    /** Returns a copy of this file with the given commit snapshot id stamped on it. */
+    DataFileMeta assignCommitSnapshotId(long snapshotId);
 
     default List<Path> collectFiles(DataFilePathFactory pathFactory) {
         List<Path> paths = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaSerializer.java
@@ -61,31 +61,40 @@ public class DataFileMetaSerializer extends ObjectSerializer<DataFileMeta> {
                 toStringArrayData(meta.valueStatsCols()),
                 meta.externalPath().map(BinaryString::fromString).orElse(null),
                 meta.firstRowId(),
-                meta.writeCols() == null ? null : toStringArrayData(meta.writeCols()));
+                meta.writeCols() == null ? null : toStringArrayData(meta.writeCols()),
+                meta.commitSnapshotId());
     }
 
     @Override
     public DataFileMeta fromRow(InternalRow row) {
-        return DataFileMeta.create(
-                row.getString(0).toString(),
-                row.getLong(1),
-                row.getLong(2),
-                deserializeBinaryRow(row.getBinary(3)),
-                deserializeBinaryRow(row.getBinary(4)),
-                SimpleStats.fromRow(row.getRow(5, 3)),
-                SimpleStats.fromRow(row.getRow(6, 3)),
-                row.getLong(7),
-                row.getLong(8),
-                row.getLong(9),
-                row.getInt(10),
-                fromStringArrayData(row.getArray(11)),
-                row.getTimestamp(12, 3),
-                row.isNullAt(13) ? null : row.getLong(13),
-                row.isNullAt(14) ? null : row.getBinary(14),
-                row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
-                row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
-                row.isNullAt(17) ? null : row.getString(17).toString(),
-                row.isNullAt(18) ? null : row.getLong(18),
-                row.isNullAt(19) ? null : fromStringArrayData(row.getArray(19)));
+        DataFileMeta meta =
+                DataFileMeta.create(
+                        row.getString(0).toString(),
+                        row.getLong(1),
+                        row.getLong(2),
+                        deserializeBinaryRow(row.getBinary(3)),
+                        deserializeBinaryRow(row.getBinary(4)),
+                        SimpleStats.fromRow(row.getRow(5, 3)),
+                        SimpleStats.fromRow(row.getRow(6, 3)),
+                        row.getLong(7),
+                        row.getLong(8),
+                        row.getLong(9),
+                        row.getInt(10),
+                        fromStringArrayData(row.getArray(11)),
+                        row.getTimestamp(12, 3),
+                        row.isNullAt(13) ? null : row.getLong(13),
+                        row.isNullAt(14) ? null : row.getBinary(14),
+                        row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
+                        row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
+                        row.isNullAt(17) ? null : row.getString(17).toString(),
+                        row.isNullAt(18) ? null : row.getLong(18),
+                        row.isNullAt(19) ? null : fromStringArrayData(row.getArray(19)));
+        // Field 20 (_COMMIT_SNAPSHOT_ID) was added in a later version and is nullable. Rows read
+        // through Avro from older manifests will have this position filled with null, so a simple
+        // null-check is sufficient for backwards compatibility.
+        if (!row.isNullAt(20)) {
+            meta = meta.assignCommitSnapshotId(row.getLong(20));
+        }
+        return meta;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaWriteColsLegacySerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/DataFileMetaWriteColsLegacySerializer.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.safe.SafeBinaryRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.data.serializer.InternalSerializers;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BigIntType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.TinyIntType;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.paimon.utils.InternalRowUtils.fromStringArrayData;
+import static org.apache.paimon.utils.InternalRowUtils.toStringArrayData;
+import static org.apache.paimon.utils.SerializationUtils.deserializeBinaryRow;
+import static org.apache.paimon.utils.SerializationUtils.newBytesType;
+import static org.apache.paimon.utils.SerializationUtils.newStringType;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/**
+ * Legacy serializer for {@link DataFileMeta} with 20 fields (before {@code _COMMIT_SNAPSHOT_ID} was
+ * added at field 20). Used to deserialize DataSplit v8 and CommitMessage v9-v11.
+ */
+public class DataFileMetaWriteColsLegacySerializer implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final RowType SCHEMA =
+            new RowType(
+                    false,
+                    Arrays.asList(
+                            new DataField(0, "_FILE_NAME", newStringType(false)),
+                            new DataField(1, "_FILE_SIZE", new BigIntType(false)),
+                            new DataField(2, "_ROW_COUNT", new BigIntType(false)),
+                            new DataField(3, "_MIN_KEY", newBytesType(false)),
+                            new DataField(4, "_MAX_KEY", newBytesType(false)),
+                            new DataField(5, "_KEY_STATS", SimpleStats.SCHEMA),
+                            new DataField(6, "_VALUE_STATS", SimpleStats.SCHEMA),
+                            new DataField(7, "_MIN_SEQUENCE_NUMBER", new BigIntType(false)),
+                            new DataField(8, "_MAX_SEQUENCE_NUMBER", new BigIntType(false)),
+                            new DataField(9, "_SCHEMA_ID", new BigIntType(false)),
+                            new DataField(10, "_LEVEL", new IntType(false)),
+                            new DataField(
+                                    11, "_EXTRA_FILES", new ArrayType(false, newStringType(false))),
+                            new DataField(12, "_CREATION_TIME", DataTypes.TIMESTAMP_MILLIS()),
+                            new DataField(13, "_DELETE_ROW_COUNT", new BigIntType(true)),
+                            new DataField(14, "_EMBEDDED_FILE_INDEX", newBytesType(true)),
+                            new DataField(15, "_FILE_SOURCE", new TinyIntType(true)),
+                            new DataField(
+                                    16,
+                                    "_VALUE_STATS_COLS",
+                                    DataTypes.ARRAY(DataTypes.STRING().notNull())),
+                            new DataField(17, "_EXTERNAL_PATH", newStringType(true)),
+                            new DataField(18, "_FIRST_ROW_ID", new BigIntType(true)),
+                            new DataField(
+                                    19, "_WRITE_COLS", new ArrayType(true, newStringType(false)))));
+
+    protected final InternalRowSerializer rowSerializer;
+
+    public DataFileMetaWriteColsLegacySerializer() {
+        this.rowSerializer = InternalSerializers.create(SCHEMA);
+    }
+
+    public final void serializeList(List<DataFileMeta> records, DataOutputView target)
+            throws IOException {
+        target.writeInt(records.size());
+        for (DataFileMeta t : records) {
+            serialize(t, target);
+        }
+    }
+
+    public void serialize(DataFileMeta meta, DataOutputView target) throws IOException {
+        GenericRow row =
+                GenericRow.of(
+                        BinaryString.fromString(meta.fileName()),
+                        meta.fileSize(),
+                        meta.rowCount(),
+                        serializeBinaryRow(meta.minKey()),
+                        serializeBinaryRow(meta.maxKey()),
+                        meta.keyStats().toRow(),
+                        meta.valueStats().toRow(),
+                        meta.minSequenceNumber(),
+                        meta.maxSequenceNumber(),
+                        meta.schemaId(),
+                        meta.level(),
+                        toStringArrayData(meta.extraFiles()),
+                        meta.creationTime(),
+                        meta.deleteRowCount().orElse(null),
+                        meta.embeddedIndex(),
+                        meta.fileSource().map(FileSource::toByteValue).orElse(null),
+                        toStringArrayData(meta.valueStatsCols()),
+                        meta.externalPath().map(BinaryString::fromString).orElse(null),
+                        meta.firstRowId(),
+                        meta.writeCols() == null ? null : toStringArrayData(meta.writeCols()));
+        rowSerializer.serialize(row, target);
+    }
+
+    public final List<DataFileMeta> deserializeList(DataInputView source) throws IOException {
+        int size = source.readInt();
+        List<DataFileMeta> records = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            records.add(deserialize(source));
+        }
+        return records;
+    }
+
+    public DataFileMeta deserialize(DataInputView in) throws IOException {
+        byte[] bytes = new byte[in.readInt()];
+        in.readFully(bytes);
+        SafeBinaryRow row = new SafeBinaryRow(rowSerializer.getArity(), bytes, 0);
+        return DataFileMeta.create(
+                row.getString(0).toString(),
+                row.getLong(1),
+                row.getLong(2),
+                deserializeBinaryRow(row.getBinary(3)),
+                deserializeBinaryRow(row.getBinary(4)),
+                SimpleStats.fromRow(row.getRow(5, 3)),
+                SimpleStats.fromRow(row.getRow(6, 3)),
+                row.getLong(7),
+                row.getLong(8),
+                row.getLong(9),
+                row.getInt(10),
+                fromStringArrayData(row.getArray(11)),
+                row.getTimestamp(12, 3),
+                row.isNullAt(13) ? null : row.getLong(13),
+                row.isNullAt(14) ? null : row.getBinary(14),
+                row.isNullAt(15) ? null : FileSource.fromByteValue(row.getByte(15)),
+                row.isNullAt(16) ? null : fromStringArrayData(row.getArray(16)),
+                row.isNullAt(17) ? null : row.getString(17).toString(),
+                row.isNullAt(18) ? null : row.getLong(18),
+                row.isNullAt(19) ? null : fromStringArrayData(row.getArray(19)));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/io/PojoDataFileMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/PojoDataFileMeta.java
@@ -82,6 +82,14 @@ public class PojoDataFileMeta implements DataFileMeta {
 
     private final @Nullable List<String> writeCols;
 
+    /**
+     * Commit snapshot id stamped on this file. Non-null only when the table has {@code
+     * sequence.snapshot-ordering} enabled and the file has been assigned a snapshot id either at
+     * commit time or by a compaction rewriter. Null for files written before the feature was
+     * enabled or for tables that do not use snapshot-based ordering.
+     */
+    private final @Nullable Long commitSnapshotId;
+
     public PojoDataFileMeta(
             String fileName,
             long fileSize,
@@ -103,6 +111,52 @@ public class PojoDataFileMeta implements DataFileMeta {
             @Nullable String externalPath,
             @Nullable Long firstRowId,
             @Nullable List<String> writeCols) {
+        this(
+                fileName,
+                fileSize,
+                rowCount,
+                minKey,
+                maxKey,
+                keyStats,
+                valueStats,
+                minSequenceNumber,
+                maxSequenceNumber,
+                schemaId,
+                level,
+                extraFiles,
+                creationTime,
+                deleteRowCount,
+                embeddedIndex,
+                fileSource,
+                valueStatsCols,
+                externalPath,
+                firstRowId,
+                writeCols,
+                null);
+    }
+
+    public PojoDataFileMeta(
+            String fileName,
+            long fileSize,
+            long rowCount,
+            BinaryRow minKey,
+            BinaryRow maxKey,
+            SimpleStats keyStats,
+            SimpleStats valueStats,
+            long minSequenceNumber,
+            long maxSequenceNumber,
+            long schemaId,
+            int level,
+            List<String> extraFiles,
+            Timestamp creationTime,
+            @Nullable Long deleteRowCount,
+            @Nullable byte[] embeddedIndex,
+            @Nullable FileSource fileSource,
+            @Nullable List<String> valueStatsCols,
+            @Nullable String externalPath,
+            @Nullable Long firstRowId,
+            @Nullable List<String> writeCols,
+            @Nullable Long commitSnapshotId) {
         this.fileName = fileName;
         this.fileSize = fileSize;
 
@@ -127,6 +181,7 @@ public class PojoDataFileMeta implements DataFileMeta {
         this.externalPath = externalPath;
         this.firstRowId = firstRowId;
         this.writeCols = writeCols;
+        this.commitSnapshotId = commitSnapshotId;
     }
 
     @Override
@@ -253,205 +308,238 @@ public class PojoDataFileMeta implements DataFileMeta {
     }
 
     @Override
+    @Nullable
+    public Long commitSnapshotId() {
+        return commitSnapshotId;
+    }
+
+    @Override
+    public PojoDataFileMeta assignCommitSnapshotId(long snapshotId) {
+        return toBuilder().commitSnapshotId(snapshotId).build();
+    }
+
+    @Override
     public PojoDataFileMeta upgrade(int newLevel) {
         checkArgument(newLevel > this.level);
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                newLevel,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().level(newLevel).build();
     }
 
     @Override
     public PojoDataFileMeta rename(String newFileName) {
         String newExternalPath = externalPathDir().map(dir -> dir + "/" + newFileName).orElse(null);
-        return new PojoDataFileMeta(
-                newFileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                newExternalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().fileName(newFileName).externalPath(newExternalPath).build();
     }
 
     @Override
     public PojoDataFileMeta copyWithoutStats() {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                EMPTY_STATS,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                Collections.emptyList(),
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().valueStats(EMPTY_STATS).valueStatsCols(Collections.emptyList()).build();
     }
 
     @Override
     public PojoDataFileMeta assignSequenceNumber(long minSequenceNumber, long maxSequenceNumber) {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder()
+                .minSequenceNumber(minSequenceNumber)
+                .maxSequenceNumber(maxSequenceNumber)
+                .build();
     }
 
     @Override
     public PojoDataFileMeta assignFirstRowId(long firstRowId) {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().firstRowId(firstRowId).build();
     }
 
     @Override
     public PojoDataFileMeta copy(List<String> newExtraFiles) {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                newExtraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().extraFiles(newExtraFiles).build();
     }
 
     @Override
     public PojoDataFileMeta newExternalPath(String newExternalPath) {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                embeddedIndex,
-                fileSource,
-                valueStatsCols,
-                newExternalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().externalPath(newExternalPath).build();
     }
 
     @Override
     public PojoDataFileMeta copy(byte[] newEmbeddedIndex) {
-        return new PojoDataFileMeta(
-                fileName,
-                fileSize,
-                rowCount,
-                minKey,
-                maxKey,
-                keyStats,
-                valueStats,
-                minSequenceNumber,
-                maxSequenceNumber,
-                schemaId,
-                level,
-                extraFiles,
-                creationTime,
-                deleteRowCount,
-                newEmbeddedIndex,
-                fileSource,
-                valueStatsCols,
-                externalPath,
-                firstRowId,
-                writeCols);
+        return toBuilder().embeddedIndex(newEmbeddedIndex).build();
+    }
+
+    private Builder toBuilder() {
+        return new Builder()
+                .fileName(fileName)
+                .fileSize(fileSize)
+                .rowCount(rowCount)
+                .minKey(minKey)
+                .maxKey(maxKey)
+                .keyStats(keyStats)
+                .valueStats(valueStats)
+                .minSequenceNumber(minSequenceNumber)
+                .maxSequenceNumber(maxSequenceNumber)
+                .schemaId(schemaId)
+                .level(level)
+                .extraFiles(extraFiles)
+                .creationTime(creationTime)
+                .deleteRowCount(deleteRowCount)
+                .embeddedIndex(embeddedIndex)
+                .fileSource(fileSource)
+                .valueStatsCols(valueStatsCols)
+                .externalPath(externalPath)
+                .firstRowId(firstRowId)
+                .writeCols(writeCols)
+                .commitSnapshotId(commitSnapshotId);
+    }
+
+    private static class Builder {
+        private String fileName;
+        private long fileSize;
+        private long rowCount;
+        private BinaryRow minKey;
+        private BinaryRow maxKey;
+        private SimpleStats keyStats;
+        private SimpleStats valueStats;
+        private long minSequenceNumber;
+        private long maxSequenceNumber;
+        private long schemaId;
+        private int level;
+        private List<String> extraFiles;
+        private Timestamp creationTime;
+        private @Nullable Long deleteRowCount;
+        private @Nullable byte[] embeddedIndex;
+        private @Nullable FileSource fileSource;
+        private @Nullable List<String> valueStatsCols;
+        private @Nullable String externalPath;
+        private @Nullable Long firstRowId;
+        private @Nullable List<String> writeCols;
+        private @Nullable Long commitSnapshotId;
+
+        Builder fileName(String v) {
+            this.fileName = v;
+            return this;
+        }
+
+        Builder fileSize(long v) {
+            this.fileSize = v;
+            return this;
+        }
+
+        Builder rowCount(long v) {
+            this.rowCount = v;
+            return this;
+        }
+
+        Builder minKey(BinaryRow v) {
+            this.minKey = v;
+            return this;
+        }
+
+        Builder maxKey(BinaryRow v) {
+            this.maxKey = v;
+            return this;
+        }
+
+        Builder keyStats(SimpleStats v) {
+            this.keyStats = v;
+            return this;
+        }
+
+        Builder valueStats(SimpleStats v) {
+            this.valueStats = v;
+            return this;
+        }
+
+        Builder minSequenceNumber(long v) {
+            this.minSequenceNumber = v;
+            return this;
+        }
+
+        Builder maxSequenceNumber(long v) {
+            this.maxSequenceNumber = v;
+            return this;
+        }
+
+        Builder schemaId(long v) {
+            this.schemaId = v;
+            return this;
+        }
+
+        Builder level(int v) {
+            this.level = v;
+            return this;
+        }
+
+        Builder extraFiles(List<String> v) {
+            this.extraFiles = v;
+            return this;
+        }
+
+        Builder creationTime(Timestamp v) {
+            this.creationTime = v;
+            return this;
+        }
+
+        Builder deleteRowCount(@Nullable Long v) {
+            this.deleteRowCount = v;
+            return this;
+        }
+
+        Builder embeddedIndex(@Nullable byte[] v) {
+            this.embeddedIndex = v;
+            return this;
+        }
+
+        Builder fileSource(@Nullable FileSource v) {
+            this.fileSource = v;
+            return this;
+        }
+
+        Builder valueStatsCols(@Nullable List<String> v) {
+            this.valueStatsCols = v;
+            return this;
+        }
+
+        Builder externalPath(@Nullable String v) {
+            this.externalPath = v;
+            return this;
+        }
+
+        Builder firstRowId(@Nullable Long v) {
+            this.firstRowId = v;
+            return this;
+        }
+
+        Builder writeCols(@Nullable List<String> v) {
+            this.writeCols = v;
+            return this;
+        }
+
+        Builder commitSnapshotId(@Nullable Long v) {
+            this.commitSnapshotId = v;
+            return this;
+        }
+
+        PojoDataFileMeta build() {
+            return new PojoDataFileMeta(
+                    fileName,
+                    fileSize,
+                    rowCount,
+                    minKey,
+                    maxKey,
+                    keyStats,
+                    valueStats,
+                    minSequenceNumber,
+                    maxSequenceNumber,
+                    schemaId,
+                    level,
+                    extraFiles,
+                    creationTime,
+                    deleteRowCount,
+                    embeddedIndex,
+                    fileSource,
+                    valueStatsCols,
+                    externalPath,
+                    firstRowId,
+                    writeCols,
+                    commitSnapshotId);
+        }
     }
 
     @Override
@@ -513,7 +601,8 @@ public class PojoDataFileMeta implements DataFileMeta {
                 && Objects.equals(valueStatsCols, that.valueStatsCols())
                 && Objects.equals(externalPath, that.externalPath().orElse(null))
                 && Objects.equals(firstRowId, that.firstRowId())
-                && Objects.equals(writeCols, that.writeCols());
+                && Objects.equals(writeCols, that.writeCols())
+                && Objects.equals(commitSnapshotId, that.commitSnapshotId());
     }
 
     @Override
@@ -538,7 +627,8 @@ public class PojoDataFileMeta implements DataFileMeta {
                 valueStatsCols,
                 externalPath,
                 firstRowId,
-                writeCols);
+                writeCols,
+                commitSnapshotId);
     }
 
     @Override
@@ -548,7 +638,7 @@ public class PojoDataFileMeta implements DataFileMeta {
                         + "minKey: %s, maxKey: %s, keyStats: %s, valueStats: %s, "
                         + "minSequenceNumber: %d, maxSequenceNumber: %d, "
                         + "schemaId: %d, level: %d, extraFiles: %s, creationTime: %s, "
-                        + "deleteRowCount: %d, fileSource: %s, valueStatsCols: %s, externalPath: %s, firstRowId: %s, writeCols: %s}",
+                        + "deleteRowCount: %d, fileSource: %s, valueStatsCols: %s, externalPath: %s, firstRowId: %s, writeCols: %s, commitSnapshotId: %s}",
                 fileName,
                 fileSize,
                 rowCount,
@@ -568,6 +658,7 @@ public class PojoDataFileMeta implements DataFileMeta {
                 valueStatsCols,
                 externalPath,
                 firstRowId,
-                writeCols);
+                writeCols,
+                commitSnapshotId);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/ManifestEntry.java
@@ -64,6 +64,8 @@ public interface ManifestEntry extends FileEntry {
 
     ManifestEntry assignFirstRowId(long firstRowId);
 
+    ManifestEntry assignCommitSnapshotId(long snapshotId);
+
     ManifestEntry upgrade(int newLevel);
 
     static long recordCount(List<ManifestEntry> manifestEntries) {

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/PojoManifestEntry.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/PojoManifestEntry.java
@@ -146,6 +146,12 @@ public class PojoManifestEntry implements ManifestEntry {
     }
 
     @Override
+    public PojoManifestEntry assignCommitSnapshotId(long snapshotId) {
+        return new PojoManifestEntry(
+                kind, partition, bucket, totalBuckets, file.assignCommitSnapshotId(snapshotId));
+    }
+
+    @Override
     public ManifestEntry upgrade(int newLevel) {
         return new PojoManifestEntry(kind, partition, bucket, totalBuckets, file.upgrade(newLevel));
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/CommitMessageSerializer.java
@@ -33,6 +33,7 @@ import org.apache.paimon.io.DataFileMeta10LegacySerializer;
 import org.apache.paimon.io.DataFileMeta12LegacySerializer;
 import org.apache.paimon.io.DataFileMetaFirstRowIdLegacySerializer;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.io.DataFileMetaWriteColsLegacySerializer;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataInputView;
@@ -51,11 +52,12 @@ import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 /** {@link VersionedSerializer} for {@link CommitMessage}. */
 public class CommitMessageSerializer implements VersionedSerializer<CommitMessage> {
 
-    public static final int CURRENT_VERSION = 11;
+    public static final int CURRENT_VERSION = 12;
 
     private final DataFileMetaSerializer dataFileSerializer;
     private final IndexFileMetaSerializer indexEntrySerializer;
 
+    private DataFileMetaWriteColsLegacySerializer dataFileMetaWriteColsLegacySerializer;
     private DataFileMetaFirstRowIdLegacySerializer dataFileMetaFirstRowIdLegacySerializer;
     private DataFileMeta12LegacySerializer dataFileMeta12LegacySerializer;
     private DataFileMeta10LegacySerializer dataFileMeta10LegacySerializer;
@@ -184,8 +186,13 @@ public class CommitMessageSerializer implements VersionedSerializer<CommitMessag
 
     private IOExceptionSupplier<List<DataFileMeta>> fileDeserializer(
             int version, DataInputView view) {
-        if (version >= 9) {
+        if (version >= 12) {
             return () -> dataFileSerializer.deserializeList(view);
+        } else if (version >= 9) {
+            if (dataFileMetaWriteColsLegacySerializer == null) {
+                dataFileMetaWriteColsLegacySerializer = new DataFileMetaWriteColsLegacySerializer();
+            }
+            return () -> dataFileMetaWriteColsLegacySerializer.deserializeList(view);
         } else if (version == 8) {
             if (dataFileMetaFirstRowIdLegacySerializer == null) {
                 dataFileMetaFirstRowIdLegacySerializer =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataSplit.java
@@ -28,6 +28,7 @@ import org.apache.paimon.io.DataFileMeta10LegacySerializer;
 import org.apache.paimon.io.DataFileMeta12LegacySerializer;
 import org.apache.paimon.io.DataFileMetaFirstRowIdLegacySerializer;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.io.DataFileMetaWriteColsLegacySerializer;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataInputViewStreamWrapper;
 import org.apache.paimon.io.DataOutputView;
@@ -63,7 +64,7 @@ public class DataSplit implements Split {
 
     private static final long serialVersionUID = 7L;
     private static final long MAGIC = -2394839472490812314L;
-    private static final int VERSION = 8;
+    private static final int VERSION = 9;
 
     private long snapshotId = 0;
     private BinaryRow partition;
@@ -489,6 +490,10 @@ public class DataSplit implements Split {
                     new DataFileMetaFirstRowIdLegacySerializer();
             return serializer::deserialize;
         } else if (version == 8) {
+            DataFileMetaWriteColsLegacySerializer serializer =
+                    new DataFileMetaWriteColsLegacySerializer();
+            return serializer::deserialize;
+        } else if (version == 9) {
             DataFileMetaSerializer serializer = new DataFileMetaSerializer();
             return serializer::deserialize;
         } else {

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileMetaCommitSnapshotIdTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileMetaCommitSnapshotIdTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@code commitSnapshotId} field on {@link DataFileMeta}. */
+public class DataFileMetaCommitSnapshotIdTest {
+
+    private final DataFileTestDataGenerator gen = DataFileTestDataGenerator.builder().build();
+
+    @Test
+    public void testDefaultIsNull() {
+        DataFileMeta meta = gen.next().meta;
+        assertThat(meta.commitSnapshotId()).isNull();
+    }
+
+    @Test
+    public void testAssignAndPreserve() {
+        DataFileMeta original = gen.next().meta;
+        DataFileMeta stamped = original.assignCommitSnapshotId(42L);
+        assertThat(stamped.commitSnapshotId()).isEqualTo(42L);
+
+        // Copy methods should preserve the stamp.
+        assertThat(stamped.upgrade(stamped.level() + 1).commitSnapshotId()).isEqualTo(42L);
+        assertThat(stamped.assignSequenceNumber(1L, 2L).commitSnapshotId()).isEqualTo(42L);
+        assertThat(stamped.copyWithoutStats().commitSnapshotId()).isEqualTo(42L);
+        assertThat(stamped.rename("renamed").commitSnapshotId()).isEqualTo(42L);
+    }
+
+    @Test
+    public void testSerializerRoundTripStamped() {
+        DataFileMeta stamped = gen.next().meta.assignCommitSnapshotId(1234L);
+        DataFileMeta restored =
+                new DataFileMetaSerializer().fromRow(new DataFileMetaSerializer().toRow(stamped));
+        assertThat(restored.commitSnapshotId()).isEqualTo(1234L);
+        assertThat(restored).isEqualTo(stamped);
+    }
+
+    @Test
+    public void testSerializerRoundTripUnstamped() {
+        DataFileMeta meta = gen.next().meta;
+        DataFileMeta restored =
+                new DataFileMetaSerializer().fromRow(new DataFileMetaSerializer().toRow(meta));
+        assertThat(restored.commitSnapshotId()).isNull();
+        assertThat(restored).isEqualTo(meta);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/io/DataFileMetaSerializerCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/io/DataFileMetaSerializerCompatibilityTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that old 20-field binary data (written before {@code _COMMIT_SNAPSHOT_ID} was added) can be
+ * deserialized by the legacy serializer with {@code commitSnapshotId == null}.
+ */
+public class DataFileMetaSerializerCompatibilityTest {
+
+    private final DataFileTestDataGenerator gen = DataFileTestDataGenerator.builder().build();
+
+    @Test
+    public void testLegacyRoundTripPreservesNullCommitSnapshotId() throws Exception {
+        DataFileMeta original = gen.next().meta;
+        assertThat(original.commitSnapshotId()).isNull();
+
+        DataFileMetaWriteColsLegacySerializer legacySerializer =
+                new DataFileMetaWriteColsLegacySerializer();
+        DataOutputSerializer output = new DataOutputSerializer(1024);
+        legacySerializer.serialize(original, output);
+
+        DataInputDeserializer input = new DataInputDeserializer(output.getCopyOfBuffer());
+        DataFileMeta restored = legacySerializer.deserialize(input);
+
+        assertThat(restored.commitSnapshotId()).isNull();
+        assertThat(restored.fileName()).isEqualTo(original.fileName());
+        assertThat(restored.fileSize()).isEqualTo(original.fileSize());
+        assertThat(restored.rowCount()).isEqualTo(original.rowCount());
+        assertThat(restored.level()).isEqualTo(original.level());
+    }
+
+    @Test
+    public void testCurrentSerializerThenLegacyDeserializerDropsSnapshotId() throws Exception {
+        DataFileMeta stamped = gen.next().meta.assignCommitSnapshotId(42L);
+
+        DataFileMetaWriteColsLegacySerializer legacySerializer =
+                new DataFileMetaWriteColsLegacySerializer();
+        DataOutputSerializer output = new DataOutputSerializer(1024);
+        legacySerializer.serialize(stamped, output);
+
+        DataInputDeserializer input = new DataInputDeserializer(output.getCopyOfBuffer());
+        DataFileMeta restored = legacySerializer.deserialize(input);
+
+        assertThat(restored.commitSnapshotId()).isNull();
+        assertThat(restored.fileName()).isEqualTo(stamped.fileName());
+    }
+
+    @Test
+    public void testCurrentSerializerRoundTripPreservesSnapshotId() throws Exception {
+        DataFileMeta stamped = gen.next().meta.assignCommitSnapshotId(99L);
+
+        DataFileMetaSerializer currentSerializer = new DataFileMetaSerializer();
+        DataOutputSerializer output = new DataOutputSerializer(1024);
+        currentSerializer.serialize(stamped, output);
+
+        DataInputDeserializer input = new DataInputDeserializer(output.getCopyOfBuffer());
+        DataFileMeta restored = currentSerializer.deserialize(input);
+
+        assertThat(restored.commitSnapshotId()).isEqualTo(99L);
+        assertThat(restored.fileName()).isEqualTo(stamped.fileName());
+    }
+}


### PR DESCRIPTION
### Purpose

  Part 1/3 of https://github.com/apache/paimon/issues/7806

  Add the infrastructure for snapshot-based sequence ordering:
  - Reserve `_COMMIT_SNAPSHOT_ID` special field and add `snapshotId` attribute on `KeyValue`.
  - Add nullable `commitSnapshotId` field to `DataFileMeta` with builder-based copy methods.
  - Bump `DataSplit` version 8→9 and `CommitMessageSerializer` version 11→12 with legacy serializer for backward-compatible deserialization.

  Pure plumbing — no behavior change. The field is always null until the write-path PR stamps it.

  ### Tests
  - `DataFileMetaCommitSnapshotIdTest`: field default null, assign/preserve across copy methods, serializer round-trip.
  - `DataFileMetaSerializerCompatibilityTest`: legacy 20-field serialize → deserialize produces `commitSnapshotId == null`.
