### PR TITLE
[core] fix NPE in BTreeFileMetaSelector when btree index contains empty string key.

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeFileMetaSelector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeFileMetaSelector.java
@@ -233,6 +233,9 @@ public class BTreeFileMetaSelector implements FunctionVisitor<Optional<List<Glob
     }
 
     private Object deserialize(byte[] valueBytes) {
+        if (valueBytes == null) {
+            return null; // defensive: V0 data may have null for empty string
+        }
         return keySerializer.deserialize(MemorySlice.wrap(valueBytes));
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
@@ -70,13 +70,13 @@ public class BTreeIndexMeta {
             sliceOutput.writeInt(firstKey.length);
             sliceOutput.writeBytes(firstKey);
         } else {
-            sliceOutput.writeInt(0);
+            sliceOutput.writeInt(-1);
         }
         if (lastKey != null) {
             sliceOutput.writeInt(lastKey.length);
             sliceOutput.writeBytes(lastKey);
         } else {
-            sliceOutput.writeInt(0);
+            sliceOutput.writeInt(-1);
         }
         sliceOutput.writeByte(hasNulls ? 1 : 0);
         return sliceOutput.toSlice().getHeapMemory();
@@ -86,10 +86,18 @@ public class BTreeIndexMeta {
         MemorySliceInput sliceInput = MemorySlice.wrap(data).toInput();
         int firstKeyLength = sliceInput.readInt();
         byte[] firstKey =
-                firstKeyLength == 0 ? null : sliceInput.readSlice(firstKeyLength).copyBytes();
+                firstKeyLength < 0
+                        ? null
+                        : firstKeyLength == 0
+                                ? new byte[0]
+                                : sliceInput.readSlice(firstKeyLength).copyBytes();
         int lastKeyLength = sliceInput.readInt();
         byte[] lastKey =
-                lastKeyLength == 0 ? null : sliceInput.readSlice(lastKeyLength).copyBytes();
+                lastKeyLength < 0
+                        ? null
+                        : lastKeyLength == 0
+                                ? new byte[0]
+                                : sliceInput.readSlice(lastKeyLength).copyBytes();
         boolean hasNulls = sliceInput.readByte() == 1;
         return new BTreeIndexMeta(firstKey, lastKey, hasNulls);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
@@ -108,7 +108,7 @@ public class BTreeIndexMeta {
         // V0 format ends with hasNulls (0 or 1), V1 format ends with VERSION (>= 2).
         byte lastByte = data[data.length - 1];
 
-        if (lastByte >= VERSION) {
+        if (lastByte == VERSION) {
             // V1 format: -1 means null, 0 means empty byte array, version byte at the end
             MemorySliceInput sliceInput = MemorySlice.wrap(data).toInput();
             int firstKeyLength = sliceInput.readInt();

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexMeta.java
@@ -27,8 +27,25 @@ import javax.annotation.Nullable;
 /**
  * Index Meta of each BTree index file. The first key and last key of this meta could be null if the
  * entire btree index file only contains nulls.
+ *
+ * <h3>Serialization format versions:</h3>
+ *
+ * <p>V0 (legacy): {@code [firstKeyLength(4)] [firstKey] [lastKeyLength(4)] [lastKey] [hasNulls(1)]}
+ *
+ * <p>V0 uses 0 to represent null key length, which cannot distinguish null from empty byte array
+ * (e.g. empty string key). The last byte is hasNulls (0 or 1).
+ *
+ * <p>V1: {@code [firstKeyLength(4)] [firstKey] [lastKeyLength(4)] [lastKey] [hasNulls(1)]
+ * [VERSION(1)]}
+ *
+ * <p>V1 uses -1 to represent null key length and 0 for empty byte array. A version byte is appended
+ * at the end. The version value must be >= 2 to avoid conflict with V0's hasNulls byte (0 or 1), so
+ * that the format can be detected by reading the last byte.
  */
 public class BTreeIndexMeta {
+
+    // Must be >= 2 to distinguish from V0's hasNulls byte (0 or 1).
+    private static final byte VERSION = 2;
 
     @Nullable private final byte[] firstKey;
     @Nullable private final byte[] lastKey;
@@ -61,7 +78,7 @@ public class BTreeIndexMeta {
     private int memorySize() {
         return (firstKey == null ? 0 : firstKey.length)
                 + (lastKey == null ? 0 : lastKey.length)
-                + 9;
+                + 10; // 4 (firstKeyLength) + 4 (lastKeyLength) + 1 (hasNulls) + 1 (version)
     }
 
     public byte[] serialize() {
@@ -70,35 +87,59 @@ public class BTreeIndexMeta {
             sliceOutput.writeInt(firstKey.length);
             sliceOutput.writeBytes(firstKey);
         } else {
+            // -1 represents null in V1 format
             sliceOutput.writeInt(-1);
         }
         if (lastKey != null) {
             sliceOutput.writeInt(lastKey.length);
             sliceOutput.writeBytes(lastKey);
         } else {
+            // -1 represents null in V1 format
             sliceOutput.writeInt(-1);
         }
         sliceOutput.writeByte(hasNulls ? 1 : 0);
+        // Append version byte at the end. Must be >= 2 to distinguish from V0's hasNulls (0 or 1).
+        sliceOutput.writeByte(VERSION);
         return sliceOutput.toSlice().getHeapMemory();
     }
 
     public static BTreeIndexMeta deserialize(byte[] data) {
-        MemorySliceInput sliceInput = MemorySlice.wrap(data).toInput();
-        int firstKeyLength = sliceInput.readInt();
-        byte[] firstKey =
-                firstKeyLength < 0
-                        ? null
-                        : firstKeyLength == 0
-                                ? new byte[0]
-                                : sliceInput.readSlice(firstKeyLength).copyBytes();
-        int lastKeyLength = sliceInput.readInt();
-        byte[] lastKey =
-                lastKeyLength < 0
-                        ? null
-                        : lastKeyLength == 0
-                                ? new byte[0]
-                                : sliceInput.readSlice(lastKeyLength).copyBytes();
-        boolean hasNulls = sliceInput.readByte() == 1;
-        return new BTreeIndexMeta(firstKey, lastKey, hasNulls);
+        // Detect format version by reading the last byte.
+        // V0 format ends with hasNulls (0 or 1), V1 format ends with VERSION (>= 2).
+        byte lastByte = data[data.length - 1];
+
+        if (lastByte >= VERSION) {
+            // V1 format: -1 means null, 0 means empty byte array, version byte at the end
+            MemorySliceInput sliceInput = MemorySlice.wrap(data).toInput();
+            int firstKeyLength = sliceInput.readInt();
+            byte[] firstKey =
+                    firstKeyLength < 0
+                            ? null
+                            : firstKeyLength == 0
+                                    ? new byte[0]
+                                    : sliceInput.readSlice(firstKeyLength).copyBytes();
+            int lastKeyLength = sliceInput.readInt();
+            byte[] lastKey =
+                    lastKeyLength < 0
+                            ? null
+                            : lastKeyLength == 0
+                                    ? new byte[0]
+                                    : sliceInput.readSlice(lastKeyLength).copyBytes();
+            boolean hasNulls = sliceInput.readByte() == 1;
+            // Skip the version byte at the end, it has already been read.
+            return new BTreeIndexMeta(firstKey, lastKey, hasNulls);
+        } else {
+            // V0 format (legacy): no version byte, 0 means null, positive means key length.
+            // The last byte is hasNulls (0 or 1), not a version byte.
+            MemorySliceInput sliceInput = MemorySlice.wrap(data).toInput();
+            int firstKeyLength = sliceInput.readInt();
+            byte[] firstKey =
+                    firstKeyLength == 0 ? null : sliceInput.readSlice(firstKeyLength).copyBytes();
+            int lastKeyLength = sliceInput.readInt();
+            byte[] lastKey =
+                    lastKeyLength == 0 ? null : sliceInput.readSlice(lastKeyLength).copyBytes();
+            boolean hasNulls = sliceInput.readByte() == 1;
+            return new BTreeIndexMeta(firstKey, lastKey, hasNulls);
+        }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeFileMetaSelectorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeFileMetaSelectorTest.java
@@ -18,12 +18,14 @@
 
 package org.apache.paimon.globalindex.btree;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.memory.MemorySliceOutput;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.VarCharType;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -171,5 +173,63 @@ public class BTreeFileMetaSelectorTest {
         sliceOutput.reset();
         sliceOutput.writeInt(value);
         return sliceOutput.toSlice().copyBytes();
+    }
+
+    @Test
+    public void testMetaSelectorWithEmptyStringKey() {
+        // Simulate the real NPE scenario: btree index file with empty string as firstKey
+        KeySerializer stringSerializer = KeySerializer.create(new VarCharType());
+        byte[] emptyKey = stringSerializer.serialize(BinaryString.EMPTY_UTF8);
+        byte[] normalKey = stringSerializer.serialize(BinaryString.fromString("www.example.com"));
+
+        BTreeIndexMeta metaWithEmptyFirstKey = new BTreeIndexMeta(emptyKey, normalKey, false);
+        BTreeIndexMeta metaWithNormalKeys =
+                new BTreeIndexMeta(
+                        stringSerializer.serialize(BinaryString.fromString("aaa.com")),
+                        stringSerializer.serialize(BinaryString.fromString("zzz.com")),
+                        false);
+        BTreeIndexMeta metaOnlyNulls = new BTreeIndexMeta(null, null, true);
+
+        List<GlobalIndexIOMeta> files =
+                Arrays.asList(
+                        new GlobalIndexIOMeta(
+                                new Path("file_empty"), 1, metaWithEmptyFirstKey.serialize()),
+                        new GlobalIndexIOMeta(
+                                new Path("file_normal"), 1, metaWithNormalKeys.serialize()),
+                        new GlobalIndexIOMeta(
+                                new Path("file_nulls"), 1, metaOnlyNulls.serialize()));
+
+        FieldRef ref = new FieldRef(1, "page_host", new VarCharType());
+        BTreeFileMetaSelector selector = new BTreeFileMetaSelector(files, stringSerializer);
+
+        // visitEqual should not throw NPE
+        Optional<List<GlobalIndexIOMeta>> result =
+                selector.visitEqual(ref, BinaryString.fromString("www.example.com"));
+        Assertions.assertThat(result).isNotEmpty();
+        assertFiles(result.get(), Arrays.asList("file_empty", "file_normal"));
+
+        // visitLessThan should not throw NPE
+        result = selector.visitLessThan(ref, BinaryString.fromString("bbb.com"));
+        Assertions.assertThat(result).isNotEmpty();
+        assertFiles(result.get(), Arrays.asList("file_empty", "file_normal"));
+
+        // visitGreaterThan should not throw NPE
+        result = selector.visitGreaterThan(ref, BinaryString.fromString("www.example.com"));
+        Assertions.assertThat(result).isNotEmpty();
+
+        // visitIn should not throw NPE
+        result =
+                selector.visitIn(
+                        ref,
+                        Arrays.asList(
+                                BinaryString.fromString("www.example.com"),
+                                BinaryString.fromString("zzz.com")));
+        Assertions.assertThat(result).isNotEmpty();
+
+        // visitBetween should not throw NPE
+        result =
+                selector.visitBetween(
+                        ref, BinaryString.EMPTY_UTF8, BinaryString.fromString("zzz.com"));
+        Assertions.assertThat(result).isNotEmpty();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex.btree;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Test for {@link BTreeIndexMeta} serialization/deserialization. */
+public class BTreeIndexMetaTest {
+
+    @Test
+    public void testSerializeDeserializeNormal() {
+        byte[] firstKey = new byte[] {1, 2, 3};
+        byte[] lastKey = new byte[] {4, 5, 6};
+        BTreeIndexMeta meta = new BTreeIndexMeta(firstKey, lastKey, true);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isEqualTo(firstKey);
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(lastKey);
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeNullKeys() {
+        BTreeIndexMeta meta = new BTreeIndexMeta(null, null, true);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isNull();
+        Assertions.assertThat(deserialized.getLastKey()).isNull();
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isTrue();
+    }
+
+    @Test
+    public void testSerializeDeserializeEmptyKey() {
+        // This is the core bug scenario: empty byte array (e.g. from empty string)
+        // should NOT be confused with null
+        byte[] emptyKey = new byte[0];
+        byte[] lastKey = new byte[] {4, 5, 6};
+        BTreeIndexMeta meta = new BTreeIndexMeta(emptyKey, lastKey, false);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isNotNull();
+        Assertions.assertThat(deserialized.getFirstKey()).isEmpty();
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(lastKey);
+        Assertions.assertThat(deserialized.hasNulls()).isFalse();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeBothEmptyKeys() {
+        byte[] emptyKey = new byte[0];
+        BTreeIndexMeta meta = new BTreeIndexMeta(emptyKey, emptyKey, false);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isNotNull();
+        Assertions.assertThat(deserialized.getFirstKey()).isEmpty();
+        Assertions.assertThat(deserialized.getLastKey()).isNotNull();
+        Assertions.assertThat(deserialized.getLastKey()).isEmpty();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeFirstKeyNull() {
+        byte[] lastKey = new byte[] {4, 5, 6};
+        BTreeIndexMeta meta = new BTreeIndexMeta(null, lastKey, true);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isNull();
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(lastKey);
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeLastKeyNull() {
+        byte[] firstKey = new byte[] {1, 2, 3};
+        BTreeIndexMeta meta = new BTreeIndexMeta(firstKey, null, true);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isEqualTo(firstKey);
+        Assertions.assertThat(deserialized.getLastKey()).isNull();
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testRoundTripWithStringSerializer() {
+        // Simulate the real scenario: StringSerializer.serialize(BinaryString.EMPTY_UTF8)
+        // returns byte[0], which must survive the BTreeIndexMeta round-trip
+        KeySerializer serializer = KeySerializer.create(new org.apache.paimon.types.VarCharType());
+        byte[] emptyStrKey = serializer.serialize(org.apache.paimon.data.BinaryString.EMPTY_UTF8);
+        Assertions.assertThat(emptyStrKey).isEmpty();
+
+        byte[] normalKey =
+                serializer.serialize(org.apache.paimon.data.BinaryString.fromString("abc"));
+        BTreeIndexMeta meta = new BTreeIndexMeta(emptyStrKey, normalKey, false);
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(meta.serialize());
+        Assertions.assertThat(deserialized.getFirstKey()).isNotNull();
+        Assertions.assertThat(deserialized.getFirstKey()).isEmpty();
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(normalKey);
+
+        // Verify the deserialized keys can be read back by KeySerializer
+        Object firstKeyObj =
+                serializer.deserialize(
+                        org.apache.paimon.memory.MemorySlice.wrap(deserialized.getFirstKey()));
+        Object lastKeyObj =
+                serializer.deserialize(
+                        org.apache.paimon.memory.MemorySlice.wrap(deserialized.getLastKey()));
+        Assertions.assertThat(firstKeyObj)
+                .isEqualTo(org.apache.paimon.data.BinaryString.EMPTY_UTF8);
+        Assertions.assertThat(lastKeyObj)
+                .isEqualTo(org.apache.paimon.data.BinaryString.fromString("abc"));
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
@@ -18,11 +18,15 @@
 
 package org.apache.paimon.globalindex.btree;
 
+import org.apache.paimon.memory.MemorySliceOutput;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /** Test for {@link BTreeIndexMeta} serialization/deserialization. */
 public class BTreeIndexMetaTest {
+
+    // ---- V1 format tests (current version) ----
 
     @Test
     public void testSerializeDeserializeNormal() {
@@ -50,7 +54,7 @@ public class BTreeIndexMetaTest {
 
     @Test
     public void testSerializeDeserializeEmptyKey() {
-        // This is the core bug scenario: empty byte array (e.g. from empty string)
+        // Core bug scenario: empty byte array (e.g. from empty string key)
         // should NOT be confused with null
         byte[] emptyKey = new byte[0];
         byte[] lastKey = new byte[] {4, 5, 6};
@@ -129,5 +133,84 @@ public class BTreeIndexMetaTest {
                 .isEqualTo(org.apache.paimon.data.BinaryString.EMPTY_UTF8);
         Assertions.assertThat(lastKeyObj)
                 .isEqualTo(org.apache.paimon.data.BinaryString.fromString("abc"));
+    }
+
+    @Test
+    public void testV1SerializedEndsWithVersionByte() {
+        // Verify that V1 serialized data ends with the VERSION byte (>= 2)
+        BTreeIndexMeta meta = new BTreeIndexMeta(new byte[] {1}, new byte[] {2}, false);
+        byte[] data = meta.serialize();
+        Assertions.assertThat(data[data.length - 1]).isEqualTo(2);
+    }
+
+    // ---- V0 format backward compatibility tests ----
+
+    @Test
+    public void testDeserializeV0FormatAllNullKeys() {
+        // V0 format: no version byte, 0 means null
+        // firstKey=null (int 0), lastKey=null (int 0), hasNulls=true (byte 1)
+        MemorySliceOutput out = new MemorySliceOutput(9);
+        out.writeInt(0); // firstKeyLength = 0 means null in V0
+        out.writeInt(0); // lastKeyLength = 0 means null in V0
+        out.writeByte(1); // hasNulls = true, also serves as last byte (1 < VERSION)
+        byte[] v0Data = out.toSlice().copyBytes();
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(v0Data);
+        Assertions.assertThat(deserialized.getFirstKey()).isNull();
+        Assertions.assertThat(deserialized.getLastKey()).isNull();
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isTrue();
+    }
+
+    @Test
+    public void testDeserializeV0FormatAllNullKeysHasNullsFalse() {
+        // V0 format: all null keys with hasNulls=false (last byte is 0, still < VERSION)
+        MemorySliceOutput out = new MemorySliceOutput(9);
+        out.writeInt(0);
+        out.writeInt(0);
+        out.writeByte(0); // hasNulls = false, last byte is 0 < VERSION
+        byte[] v0Data = out.toSlice().copyBytes();
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(v0Data);
+        Assertions.assertThat(deserialized.getFirstKey()).isNull();
+        Assertions.assertThat(deserialized.getLastKey()).isNull();
+        Assertions.assertThat(deserialized.hasNulls()).isFalse();
+        Assertions.assertThat(deserialized.onlyNulls()).isTrue();
+    }
+
+    @Test
+    public void testDeserializeV0FormatNormalKeys() {
+        // V0 format: positive length means key data
+        // firstKey=[1,2,3] (length=3), lastKey=[4,5,6] (length=3), hasNulls=false (byte 0)
+        MemorySliceOutput out = new MemorySliceOutput(15);
+        out.writeInt(3);
+        out.writeBytes(new byte[] {1, 2, 3});
+        out.writeInt(3);
+        out.writeBytes(new byte[] {4, 5, 6});
+        out.writeByte(0);
+        byte[] v0Data = out.toSlice().copyBytes();
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(v0Data);
+        Assertions.assertThat(deserialized.getFirstKey()).isEqualTo(new byte[] {1, 2, 3});
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(new byte[] {4, 5, 6});
+        Assertions.assertThat(deserialized.hasNulls()).isFalse();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
+    }
+
+    @Test
+    public void testDeserializeV0FormatFirstKeyNullLastKeyNormal() {
+        // V0 format: firstKey=null (int 0), lastKey=[4,5,6] (length=3)
+        MemorySliceOutput out = new MemorySliceOutput(12);
+        out.writeInt(0);
+        out.writeInt(3);
+        out.writeBytes(new byte[] {4, 5, 6});
+        out.writeByte(1);
+        byte[] v0Data = out.toSlice().copyBytes();
+
+        BTreeIndexMeta deserialized = BTreeIndexMeta.deserialize(v0Data);
+        Assertions.assertThat(deserialized.getFirstKey()).isNull();
+        Assertions.assertThat(deserialized.getLastKey()).isEqualTo(new byte[] {4, 5, 6});
+        Assertions.assertThat(deserialized.hasNulls()).isTrue();
+        Assertions.assertThat(deserialized.onlyNulls()).isFalse();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
@@ -140,7 +140,7 @@ public class BTreeIndexMetaTest {
         // Verify that V1 serialized data ends with the VERSION byte (>= 2)
         BTreeIndexMeta meta = new BTreeIndexMeta(new byte[] {1}, new byte[] {2}, false);
         byte[] data = meta.serialize();
-        Assertions.assertThat(data[data.length - 1]).isEqualTo(2);
+        Assertions.assertThat(data[data.length - 1]).isEqualTo((byte) 2);
     }
 
     // ---- V0 format backward compatibility tests ----


### PR DESCRIPTION
### Purpose

close #7811 

### Tests
