### PR TITLE
[python] Pre-repartition Ray writes by (partition, bucket) for fixed-bucket tables

### DIFF
--- a/docs/content/pypaimon/ray-data.md
+++ b/docs/content/pypaimon/ray-data.md
@@ -207,57 +207,25 @@ write_paimon(
 )
 ```
 
-**Cluster rows by (partition, bucket) before writing:**
+**Automatic (partition, bucket) clustering for HASH_FIXED tables:**
 
-For HASH_FIXED tables, Ray's default round-robin block distribution can
-scatter rows that share the same `(partition, bucket)` across many Ray
-tasks. Each task opens its own writer and emits its own data file, so
-the write produces `partitions × buckets × ray_tasks` files instead of
-the `partitions × buckets` the writer would naturally produce.
-
-`shuffle=True` clusters rows by `(partition_keys..., bucket)` so each
-group lands in one Ray task — one writer, one file group:
-
-```python
-write_paimon(
-    ray_dataset,
-    "database_name.table_name",
-    catalog_options={"warehouse": "/path/to/warehouse"},
-    shuffle=True,
-)
-```
+For HASH_FIXED tables, `write_paimon` automatically clusters rows by
+`(partition_keys..., bucket)` before writing so each (partition,
+bucket) lands in a single Ray task — one writer, one file group. This
+avoids the small-file storm that Ray's default round-robin
+distribution would otherwise produce (`partitions × buckets ×
+ray_tasks` files instead of `partitions × buckets`).
 
 Bucket assignment uses the same hash routine the writer uses, so the
-shuffle-time bucket is byte-equivalent to the writer's. For
-non-HASH_FIXED tables the shuffle is a soft no-op with a warning; the
-write still succeeds.
-
-`override_num_blocks` is an optional Ray output block count
-(mirrors the same-named option on `read_paimon`). With `shuffle=True`
-it is a parallelism hint for the groupby shuffle; with `shuffle=False`
-it triggers a plain block rebalance to that count:
-
-```python
-write_paimon(
-    ray_dataset,
-    "database_name.table_name",
-    catalog_options={"warehouse": "/path/to/warehouse"},
-    override_num_blocks=4,
-)
-```
+bucket seen by the groupby is byte-equivalent to the one the writer
+would compute. No user configuration is required. For non-HASH_FIXED
+tables the dataset is written as-is.
 
 **Parameters:**
 - `dataset`: the Ray Dataset to write.
 - `table_identifier`: full table name, e.g. `"db_name.table_name"`.
 - `catalog_options`: kwargs forwarded to `CatalogFactory.create()`.
 - `overwrite`: if `True`, overwrite existing data in the table.
-- `shuffle`: if `True` and the target is HASH_FIXED, cluster rows by
-  `(partition_keys..., bucket)` so each (partition, bucket) lands in
-  one Ray task. Non-HASH_FIXED tables log a warning and fall back to
-  no-shuffle. Defaults to `False`.
-- `override_num_blocks`: optional Ray output block count. Must be `>= 1`.
-  With `shuffle=True`, a parallelism hint for the groupby shuffle;
-  with `shuffle=False`, a plain Ray block rebalance to that count.
 - `concurrency`: optional max number of Ray write tasks to run concurrently.
 - `ray_remote_args`: optional kwargs passed to `ray.remote()` in write tasks
   (e.g. `{"num_cpus": 2}`).

--- a/docs/content/pypaimon/ray-data.md
+++ b/docs/content/pypaimon/ray-data.md
@@ -207,11 +207,57 @@ write_paimon(
 )
 ```
 
+**Cluster rows by (partition, bucket) before writing:**
+
+For HASH_FIXED tables, Ray's default round-robin block distribution can
+scatter rows that share the same `(partition, bucket)` across many Ray
+tasks. Each task opens its own writer and emits its own data file, so
+the write produces `partitions × buckets × ray_tasks` files instead of
+the `partitions × buckets` the writer would naturally produce.
+
+`shuffle=True` clusters rows by `(partition_keys..., bucket)` so each
+group lands in one Ray task — one writer, one file group:
+
+```python
+write_paimon(
+    ray_dataset,
+    "database_name.table_name",
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    shuffle=True,
+)
+```
+
+Bucket assignment uses the same hash routine the writer uses, so the
+shuffle-time bucket is byte-equivalent to the writer's. For
+non-HASH_FIXED tables the shuffle is a soft no-op with a warning; the
+write still succeeds.
+
+`override_num_blocks` is an optional Ray output block count
+(mirrors the same-named option on `read_paimon`). With `shuffle=True`
+it is a parallelism hint for the groupby shuffle; with `shuffle=False`
+it triggers a plain block rebalance to that count:
+
+```python
+write_paimon(
+    ray_dataset,
+    "database_name.table_name",
+    catalog_options={"warehouse": "/path/to/warehouse"},
+    override_num_blocks=4,
+)
+```
+
 **Parameters:**
 - `dataset`: the Ray Dataset to write.
 - `table_identifier`: full table name, e.g. `"db_name.table_name"`.
 - `catalog_options`: kwargs forwarded to `CatalogFactory.create()`.
 - `overwrite`: if `True`, overwrite existing data in the table.
+- `shuffle`: if `True` and the target is HASH_FIXED, cluster rows by
+  `(partition_keys..., bucket)` so each (partition, bucket) lands in
+  one Ray task. Non-HASH_FIXED tables log a warning and fall back to
+  no-shuffle. Defaults to `False`.
+- `override_num_blocks`: optional Ray output block count. Must be `>= 1`.
+  With `shuffle=True`, a parallelism hint for the groupby shuffle;
+  with `shuffle=False`, a plain Ray block rebalance to that count.
 - `concurrency`: optional max number of Ray write tasks to run concurrently.
 - `ray_remote_args`: optional kwargs passed to `ray.remote()` in write tasks
   (e.g. `{"num_cpus": 2}`).

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -107,30 +107,22 @@ def write_paimon(
     catalog_options: Dict[str, str],
     *,
     overwrite: bool = False,
-    shuffle: bool = False,
-    override_num_blocks: Optional[int] = None,
     concurrency: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Write a Ray Dataset to a Paimon table.
+
+    For HASH_FIXED tables, rows are automatically clustered by
+    ``(partition_keys..., bucket)`` before writing so that each
+    (partition, bucket) lands in a single Ray task. This avoids the
+    small-file storm that Ray's default round-robin distribution would
+    otherwise produce. No user configuration is required.
 
     Args:
         dataset: The Ray Dataset to write.
         table_identifier: Full table name, e.g. ``"db_name.table_name"``.
         catalog_options: Options passed to ``CatalogFactory.create()``.
         overwrite: If ``True``, overwrite existing data in the table.
-        shuffle: When ``True`` and the target is a HASH_FIXED table, cluster
-            rows by ``(partition_keys..., bucket)`` so each (partition,
-            bucket) lands in one Ray task — reduces the small-file count
-            for distributed writes. Non-HASH_FIXED tables log a warning
-            and fall back to no-shuffle. Defaults to ``False`` (Ray's
-            default round-robin distribution).
-        override_num_blocks: Optional Ray output block count. Must be
-            ``>= 1`` when set. With ``shuffle=True``, used as a
-            parallelism hint for the groupby shuffle; with
-            ``shuffle=False``, triggers a plain block rebalance to that
-            count. ``None`` (default) skips the rebalance. Mirrors the
-            ``override_num_blocks`` parameter on :func:`read_paimon`.
         concurrency: Optional max number of Ray write tasks to run concurrently.
         ray_remote_args: Optional kwargs passed to ``ray.remote`` in write tasks.
     """
@@ -138,19 +130,10 @@ def write_paimon(
     from pypaimon.ray.shuffle import maybe_apply_repartition
     from pypaimon.write.ray_datasink import PaimonDatasink
 
-    if override_num_blocks is not None and override_num_blocks < 1:
-        raise ValueError(
-            "override_num_blocks must be at least 1, got {}".format(
-                override_num_blocks)
-        )
-
     catalog = CatalogFactory.create(catalog_options)
     table = catalog.get_table(table_identifier)
 
-    dataset, _ = maybe_apply_repartition(
-        dataset, table,
-        shuffle=shuffle, override_num_blocks=override_num_blocks,
-    )
+    dataset = maybe_apply_repartition(dataset, table)
 
     datasink = PaimonDatasink(table, overwrite=overwrite)
 

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -107,6 +107,8 @@ def write_paimon(
     catalog_options: Dict[str, str],
     *,
     overwrite: bool = False,
+    shuffle: bool = False,
+    override_num_blocks: Optional[int] = None,
     concurrency: Optional[int] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ) -> None:
@@ -117,14 +119,38 @@ def write_paimon(
         table_identifier: Full table name, e.g. ``"db_name.table_name"``.
         catalog_options: Options passed to ``CatalogFactory.create()``.
         overwrite: If ``True``, overwrite existing data in the table.
+        shuffle: When ``True`` and the target is a HASH_FIXED table, cluster
+            rows by ``(partition_keys..., bucket)`` so each (partition,
+            bucket) lands in one Ray task — reduces the small-file count
+            for distributed writes. Non-HASH_FIXED tables log a warning
+            and fall back to no-shuffle. Defaults to ``False`` (Ray's
+            default round-robin distribution).
+        override_num_blocks: Optional Ray output block count. Must be
+            ``>= 1`` when set. With ``shuffle=True``, used as a
+            parallelism hint for the groupby shuffle; with
+            ``shuffle=False``, triggers a plain block rebalance to that
+            count. ``None`` (default) skips the rebalance. Mirrors the
+            ``override_num_blocks`` parameter on :func:`read_paimon`.
         concurrency: Optional max number of Ray write tasks to run concurrently.
         ray_remote_args: Optional kwargs passed to ``ray.remote`` in write tasks.
     """
     from pypaimon.catalog.catalog_factory import CatalogFactory
+    from pypaimon.ray.shuffle import maybe_apply_repartition
     from pypaimon.write.ray_datasink import PaimonDatasink
+
+    if override_num_blocks is not None and override_num_blocks < 1:
+        raise ValueError(
+            "override_num_blocks must be at least 1, got {}".format(
+                override_num_blocks)
+        )
 
     catalog = CatalogFactory.create(catalog_options)
     table = catalog.get_table(table_identifier)
+
+    dataset, _ = maybe_apply_repartition(
+        dataset, table,
+        shuffle=shuffle, override_num_blocks=override_num_blocks,
+    )
 
     datasink = PaimonDatasink(table, overwrite=overwrite)
 

--- a/paimon-python/pypaimon/ray/shuffle.py
+++ b/paimon-python/pypaimon/ray/shuffle.py
@@ -25,20 +25,18 @@ task then opens its own writer and emits its own data file, producing
 ``partitions × buckets × ray_tasks`` files instead of the
 ``partitions × buckets`` the writer would naturally produce.
 
-When ``shuffle=True`` and the table is HASH_FIXED, we group rows by
-``(partition_keys..., bucket)`` so every distinct group lands in a
-single Ray task. ``bucket`` is computed using the same
-``FixedBucketRowKeyExtractor`` the writer uses, so the shuffle-time
-bucket assignment is byte-equivalent to the writer's.
+For HASH_FIXED tables we group rows by ``(partition_keys..., bucket)``
+so every distinct group lands in a single Ray task. ``bucket`` is
+computed using the same ``FixedBucketRowKeyExtractor`` the writer
+uses, so the bucket assignment seen by the groupby is byte-equivalent
+to the writer's. HASH_FIXED writes are always pre-clustered; no user
+opt-in is required.
 
-For any other bucket mode the shuffle is a soft no-op with a warning;
-we never raise. ``shuffle=False`` is the default and preserves the
-original Ray round-robin behaviour.
+For any other bucket mode the dataset is returned unchanged.
 """
 
-import logging
 import uuid
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List
 
 import pyarrow as pa
 
@@ -48,8 +46,6 @@ if TYPE_CHECKING:
     import ray.data
 
     from pypaimon.table.table import Table
-
-logger = logging.getLogger(__name__)
 
 # Default transient column name. A collision-safe variant is picked at
 # runtime by ``_pick_bucket_col_name`` so user tables that happen to
@@ -71,61 +67,29 @@ def _pick_bucket_col_name(existing_names) -> str:
 def maybe_apply_repartition(
         dataset: "ray.data.Dataset",
         table: "Table",
-        *,
-        shuffle: bool,
-        override_num_blocks: Optional[int],
-) -> Tuple["ray.data.Dataset", bool]:
-    """Optionally rewrite ``dataset`` so rows are clustered for the writer.
+) -> "ray.data.Dataset":
+    """Cluster rows by ``(partition_keys..., bucket)`` for HASH_FIXED tables.
 
-    Args:
-        dataset: The input Ray Dataset.
-        table: The Paimon target table (used for bucket mode + schema).
-        shuffle: When True, group rows by ``(partition_keys..., bucket)``.
-            Falls through to a warning + no-op for non-HASH_FIXED tables.
-        override_num_blocks: Optional. When ``shuffle=True``, used as the
-            ``num_partitions`` hint for the groupby shuffle. When
-            ``shuffle=False``, triggers a plain block rebalance to that
-            count. ``None`` + ``shuffle=False`` means no-op.
-
-    Returns:
-        ``(dataset, was_shuffle_applied)`` — the dataset to hand to the
-        sink, plus a flag the caller can use for telemetry.
+    For any other bucket mode the dataset is returned unchanged.
+    HASH_FIXED writes are always pre-clustered, with no user opt-in
+    required.
     """
-    if not shuffle and override_num_blocks is None:
-        return dataset, False
+    if table.bucket_mode() != BucketMode.HASH_FIXED:
+        return dataset
 
-    if shuffle:
-        bucket_mode = table.bucket_mode()
-        if bucket_mode != BucketMode.HASH_FIXED:
-            logger.warning(
-                "shuffle=True requires a HASH_FIXED table; got %s. "
-                "Falling back to no-shuffle write.",
-                bucket_mode.name,
-            )
-            shuffle = False
+    partition_keys = list(table.table_schema.partition_keys or [])
+    extractor = table.create_row_key_extractor()
+    col_names = set(f.name for f in table.table_schema.fields)
+    bucket_col = _pick_bucket_col_name(col_names)
+    bucket_udf = _make_bucket_udf(extractor, bucket_col)
 
-    if shuffle:
-        partition_keys = list(table.table_schema.partition_keys or [])
-        extractor = table.create_row_key_extractor()
-        col_names = set(f.name for f in table.table_schema.fields)
-        bucket_col = _pick_bucket_col_name(col_names)
-        bucket_udf = _make_bucket_udf(extractor, bucket_col)
-
-        ds_with_bucket = dataset.map_batches(
-            bucket_udf, batch_format="pyarrow", zero_copy_batch=True,
-        )
-        group_keys: List[str] = partition_keys + [bucket_col]
-        grouped = ds_with_bucket.groupby(
-            group_keys, num_partitions=override_num_blocks,
-        )
-        regrouped = grouped.map_groups(_identity_batch, batch_format="pyarrow")
-        return regrouped.drop_columns([bucket_col]), True
-
-    # After a soft fallback, override_num_blocks may still be None —
-    # keep the contract that None means "no Ray-side repartition".
-    if override_num_blocks is None:
-        return dataset, False
-    return dataset.repartition(override_num_blocks, shuffle=False), False
+    ds_with_bucket = dataset.map_batches(
+        bucket_udf, batch_format="pyarrow", zero_copy_batch=True,
+    )
+    group_keys: List[str] = partition_keys + [bucket_col]
+    grouped = ds_with_bucket.groupby(group_keys)
+    regrouped = grouped.map_groups(_identity_batch, batch_format="pyarrow")
+    return regrouped.drop_columns([bucket_col])
 
 
 def _identity_batch(batch: pa.Table) -> pa.Table:

--- a/paimon-python/pypaimon/ray/shuffle.py
+++ b/paimon-python/pypaimon/ray/shuffle.py
@@ -1,0 +1,155 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Pre-repartition a Ray Dataset by (partition, bucket) before writing
+to a Paimon table.
+
+Without this, Ray's default round-robin block distribution scatters rows
+that share the same (partition, bucket) across many Ray tasks. Each
+task then opens its own writer and emits its own data file, producing
+``partitions × buckets × ray_tasks`` files instead of the
+``partitions × buckets`` the writer would naturally produce.
+
+When ``shuffle=True`` and the table is HASH_FIXED, we group rows by
+``(partition_keys..., bucket)`` so every distinct group lands in a
+single Ray task. ``bucket`` is computed using the same
+``FixedBucketRowKeyExtractor`` the writer uses, so the shuffle-time
+bucket assignment is byte-equivalent to the writer's.
+
+For any other bucket mode the shuffle is a soft no-op with a warning;
+we never raise. ``shuffle=False`` is the default and preserves the
+original Ray round-robin behaviour.
+"""
+
+import logging
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+import pyarrow as pa
+
+from pypaimon.table.bucket_mode import BucketMode
+
+if TYPE_CHECKING:
+    import ray.data
+
+    from pypaimon.table.table import Table
+
+logger = logging.getLogger(__name__)
+
+# Transient column the helper appends before the groupby and strips
+# afterwards. Sink-side schema is identical to caller-provided schema.
+BUCKET_KEY_COL = "__paimon_bucket__"
+
+
+def maybe_apply_repartition(
+        dataset: "ray.data.Dataset",
+        table: "Table",
+        *,
+        shuffle: bool,
+        num_blocks: Optional[int],
+) -> Tuple["ray.data.Dataset", bool]:
+    """Optionally rewrite ``dataset`` so rows are clustered for the writer.
+
+    Args:
+        dataset: The input Ray Dataset.
+        table: The Paimon target table (used for bucket mode + schema).
+        shuffle: When True, group rows by ``(partition_keys..., bucket)``.
+            Falls through to a warning + no-op for non-HASH_FIXED tables.
+        num_blocks: Optional. When ``shuffle=True``, used as the
+            ``num_partitions`` hint for the groupby shuffle. When
+            ``shuffle=False``, triggers a plain block rebalance to that
+            count. ``None`` + ``shuffle=False`` means no-op.
+
+    Returns:
+        ``(dataset, was_shuffle_applied)`` — the dataset to hand to the
+        sink, plus a flag the caller can use for telemetry.
+    """
+    if not shuffle and num_blocks is None:
+        return dataset, False
+
+    if shuffle:
+        bucket_mode = table.bucket_mode()
+        if bucket_mode != BucketMode.HASH_FIXED:
+            logger.warning(
+                "shuffle=True requires a HASH_FIXED table; got %s. "
+                "Falling back to no-shuffle write.",
+                bucket_mode.name,
+            )
+            shuffle = False
+
+    if shuffle:
+        partition_keys = list(table.table_schema.partition_keys or [])
+        extractor = table.create_row_key_extractor()
+        bucket_udf = _make_bucket_udf(extractor)
+
+        ds_with_bucket = dataset.map_batches(
+            bucket_udf, batch_format="pyarrow", zero_copy_batch=True,
+        )
+        group_keys: List[str] = partition_keys + [BUCKET_KEY_COL]
+        grouped = ds_with_bucket.groupby(group_keys, num_partitions=num_blocks)
+        regrouped = grouped.map_groups(_identity_batch, batch_format="pyarrow")
+        return regrouped.drop_columns([BUCKET_KEY_COL]), True
+
+    # After a soft fallback, num_blocks may still be None — keep the
+    # contract that num_blocks=None means "no Ray-side repartition".
+    if num_blocks is None:
+        return dataset, False
+    return dataset.repartition(num_blocks, shuffle=False), False
+
+
+def _identity_batch(batch: pa.Table) -> pa.Table:
+    # Some Ray versions promote ``string`` to ``large_string`` (and
+    # ``binary`` to ``large_binary``) while materialising blocks for
+    # ``groupby().map_groups``. Paimon's writer compares schemas with a
+    # strict ``!=`` and rejects the large variants, so coerce them back
+    # to the regular types here. Other Arrow types pass through.
+    return _coerce_large_string_types(batch)
+
+
+def _coerce_large_string_types(batch: pa.Table) -> pa.Table:
+    needs_cast = False
+    fields = []
+    for field in batch.schema:
+        if pa.types.is_large_string(field.type):
+            fields.append(field.with_type(pa.string()))
+            needs_cast = True
+        elif pa.types.is_large_binary(field.type):
+            fields.append(field.with_type(pa.binary()))
+            needs_cast = True
+        else:
+            fields.append(field)
+    return batch.cast(pa.schema(fields)) if needs_cast else batch
+
+
+def _make_bucket_udf(extractor):
+    """Build a map_batches UDF that appends BUCKET_KEY_COL.
+
+    The bucket value comes from ``extract_partition_bucket_batch`` so it
+    matches the writer's bucket assignment for the same row exactly.
+    """
+    def _udf(batch: pa.Table) -> pa.Table:
+        if batch.num_rows == 0:
+            return batch.append_column(
+                BUCKET_KEY_COL, pa.array([], type=pa.int32())
+            )
+        record_batch = batch.combine_chunks().to_batches()[0]
+        _, buckets = extractor.extract_partition_bucket_batch(record_batch)
+        return batch.append_column(
+            BUCKET_KEY_COL, pa.array(buckets, type=pa.int32())
+        )
+
+    return _udf

--- a/paimon-python/pypaimon/ray/shuffle.py
+++ b/paimon-python/pypaimon/ray/shuffle.py
@@ -60,7 +60,7 @@ def maybe_apply_repartition(
         table: "Table",
         *,
         shuffle: bool,
-        num_blocks: Optional[int],
+        override_num_blocks: Optional[int],
 ) -> Tuple["ray.data.Dataset", bool]:
     """Optionally rewrite ``dataset`` so rows are clustered for the writer.
 
@@ -69,7 +69,7 @@ def maybe_apply_repartition(
         table: The Paimon target table (used for bucket mode + schema).
         shuffle: When True, group rows by ``(partition_keys..., bucket)``.
             Falls through to a warning + no-op for non-HASH_FIXED tables.
-        num_blocks: Optional. When ``shuffle=True``, used as the
+        override_num_blocks: Optional. When ``shuffle=True``, used as the
             ``num_partitions`` hint for the groupby shuffle. When
             ``shuffle=False``, triggers a plain block rebalance to that
             count. ``None`` + ``shuffle=False`` means no-op.
@@ -78,7 +78,7 @@ def maybe_apply_repartition(
         ``(dataset, was_shuffle_applied)`` — the dataset to hand to the
         sink, plus a flag the caller can use for telemetry.
     """
-    if not shuffle and num_blocks is None:
+    if not shuffle and override_num_blocks is None:
         return dataset, False
 
     if shuffle:
@@ -100,15 +100,17 @@ def maybe_apply_repartition(
             bucket_udf, batch_format="pyarrow", zero_copy_batch=True,
         )
         group_keys: List[str] = partition_keys + [BUCKET_KEY_COL]
-        grouped = ds_with_bucket.groupby(group_keys, num_partitions=num_blocks)
+        grouped = ds_with_bucket.groupby(
+            group_keys, num_partitions=override_num_blocks,
+        )
         regrouped = grouped.map_groups(_identity_batch, batch_format="pyarrow")
         return regrouped.drop_columns([BUCKET_KEY_COL]), True
 
-    # After a soft fallback, num_blocks may still be None — keep the
-    # contract that num_blocks=None means "no Ray-side repartition".
-    if num_blocks is None:
+    # After a soft fallback, override_num_blocks may still be None —
+    # keep the contract that None means "no Ray-side repartition".
+    if override_num_blocks is None:
         return dataset, False
-    return dataset.repartition(num_blocks, shuffle=False), False
+    return dataset.repartition(override_num_blocks, shuffle=False), False
 
 
 def _identity_batch(batch: pa.Table) -> pa.Table:

--- a/paimon-python/pypaimon/ray/shuffle.py
+++ b/paimon-python/pypaimon/ray/shuffle.py
@@ -37,6 +37,7 @@ original Ray round-robin behaviour.
 """
 
 import logging
+import uuid
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import pyarrow as pa
@@ -50,9 +51,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Transient column the helper appends before the groupby and strips
-# afterwards. Sink-side schema is identical to caller-provided schema.
+# Default transient column name. A collision-safe variant is picked at
+# runtime by ``_pick_bucket_col_name`` so user tables that happen to
+# contain a column with this name still work correctly.
 BUCKET_KEY_COL = "__paimon_bucket__"
+
+
+def _pick_bucket_col_name(existing_names) -> str:
+    """Return a bucket column name guaranteed not to collide with
+    ``existing_names``. Falls back to a UUID suffix on collision."""
+    if BUCKET_KEY_COL not in existing_names:
+        return BUCKET_KEY_COL
+    while True:
+        candidate = "__paimon_bucket_{}_".format(uuid.uuid4().hex[:8])
+        if candidate not in existing_names:
+            return candidate
 
 
 def maybe_apply_repartition(
@@ -94,17 +107,19 @@ def maybe_apply_repartition(
     if shuffle:
         partition_keys = list(table.table_schema.partition_keys or [])
         extractor = table.create_row_key_extractor()
-        bucket_udf = _make_bucket_udf(extractor)
+        col_names = set(f.name for f in table.table_schema.fields)
+        bucket_col = _pick_bucket_col_name(col_names)
+        bucket_udf = _make_bucket_udf(extractor, bucket_col)
 
         ds_with_bucket = dataset.map_batches(
             bucket_udf, batch_format="pyarrow", zero_copy_batch=True,
         )
-        group_keys: List[str] = partition_keys + [BUCKET_KEY_COL]
+        group_keys: List[str] = partition_keys + [bucket_col]
         grouped = ds_with_bucket.groupby(
             group_keys, num_partitions=override_num_blocks,
         )
         regrouped = grouped.map_groups(_identity_batch, batch_format="pyarrow")
-        return regrouped.drop_columns([BUCKET_KEY_COL]), True
+        return regrouped.drop_columns([bucket_col]), True
 
     # After a soft fallback, override_num_blocks may still be None —
     # keep the contract that None means "no Ray-side repartition".
@@ -137,8 +152,8 @@ def _coerce_large_string_types(batch: pa.Table) -> pa.Table:
     return batch.cast(pa.schema(fields)) if needs_cast else batch
 
 
-def _make_bucket_udf(extractor):
-    """Build a map_batches UDF that appends BUCKET_KEY_COL.
+def _make_bucket_udf(extractor, bucket_col):
+    """Build a map_batches UDF that appends a transient bucket column.
 
     The bucket value comes from ``extract_partition_bucket_batch`` so it
     matches the writer's bucket assignment for the same row exactly.
@@ -146,12 +161,12 @@ def _make_bucket_udf(extractor):
     def _udf(batch: pa.Table) -> pa.Table:
         if batch.num_rows == 0:
             return batch.append_column(
-                BUCKET_KEY_COL, pa.array([], type=pa.int32())
+                bucket_col, pa.array([], type=pa.int32())
             )
         record_batch = batch.combine_chunks().to_batches()[0]
         _, buckets = extractor.extract_partition_bucket_batch(record_batch)
         return batch.append_column(
-            BUCKET_KEY_COL, pa.array(buckets, type=pa.int32())
+            bucket_col, pa.array(buckets, type=pa.int32())
         )
 
     return _udf

--- a/paimon-python/pypaimon/tests/ray_repartition_test.py
+++ b/paimon-python/pypaimon/tests/ray_repartition_test.py
@@ -1,0 +1,294 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""End-to-end tests for shuffle / override_num_blocks on ``write_paimon``.
+
+Covers:
+
+  * back-compat: ``shuffle=False`` (default) write + read roundtrip.
+  * HASH_FIXED + ``shuffle=True``: roundtrip correctness, output-file
+    count reduction, transient bucket column stripped from the sink-
+    visible schema.
+  * Soft fallback: ``shuffle=True`` on a non-HASH_FIXED table logs a
+    warning and writes successfully.
+  * ``override_num_blocks`` alone (no shuffle) is a plain Ray block
+    rebalance.
+"""
+
+import glob
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+import ray
+
+from pypaimon import CatalogFactory, Schema
+
+
+class RayShuffleTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog_options = {'warehouse': cls.warehouse}
+
+        catalog = CatalogFactory.create(cls.catalog_options)
+        catalog.create_database('default', True)
+
+        if not ray.is_initialized():
+            # 4 CPUs gives us enough room to actually fan a multi-block
+            # write across multiple workers so the "small-file" claim
+            # is observable.
+            ray.init(ignore_reinit_error=True, num_cpus=4)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            if ray.is_initialized():
+                ray.shutdown()
+        except Exception:
+            pass
+        try:
+            shutil.rmtree(cls.tempdir)
+        except OSError:
+            pass
+
+    def _make_table(self, table_name, pa_schema, *, primary_keys=None,
+                    partition_keys=None, options=None):
+        identifier = 'default.{}'.format(table_name)
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            primary_keys=primary_keys,
+            partition_keys=partition_keys,
+            options=options,
+        )
+        catalog = CatalogFactory.create(self.catalog_options)
+        catalog.create_table(identifier, schema, False)
+        return identifier
+
+    def _count_data_files(self, table_name):
+        """All data files under the table directory, regardless of partition."""
+        root = os.path.join(self.warehouse, 'default.db', table_name)
+        patterns = ['*.parquet', '*.orc', '*.avro']
+        files = []
+        for pattern in patterns:
+            files.extend(glob.glob(
+                os.path.join(root, '**', 'bucket-*', pattern), recursive=True,
+            ))
+        return files
+
+    # ----- back-compat -----
+
+    def test_shuffle_off_is_default_and_roundtrip_works(self):
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('name', pa.string()),
+        ])
+        table_name = 'test_shuffle_off'
+        identifier = self._make_table(
+            table_name, pa_schema,
+            primary_keys=['id'], options={'bucket': '2'},
+        )
+
+        rows = pa.Table.from_pydict(
+            {'id': list(range(20)), 'name': [f'v{i}' for i in range(20)]},
+            schema=pa_schema,
+        )
+        write_paimon(ray.data.from_arrow(rows), identifier, self.catalog_options)
+
+        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        self.assertEqual(len(result), 20)
+        self.assertEqual(set(result['id']), set(range(20)))
+
+    # ----- HASH_FIXED + shuffle=True -----
+
+    def test_shuffle_on_fixed_bucket_roundtrip(self):
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('name', pa.string()),
+        ])
+        table_name = 'test_shuffle_on_roundtrip'
+        identifier = self._make_table(
+            table_name, pa_schema,
+            primary_keys=['id'], options={'bucket': '4'},
+        )
+
+        rows = pa.Table.from_pydict(
+            {'id': list(range(40)), 'name': [f'v{i}' for i in range(40)]},
+            schema=pa_schema,
+        )
+        ds = ray.data.from_arrow(rows).repartition(4)
+        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+
+        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        self.assertEqual(len(result), 40)
+        self.assertEqual(set(result['id']), set(range(40)))
+        # Sink schema must not carry the transient shuffle column.
+        self.assertNotIn('__paimon_bucket__', result.columns)
+
+    def test_shuffle_on_partitioned_fixed_bucket_roundtrip(self):
+        """Partitioned table — confirms the post-groupby schema does not
+        end up with duplicated partition-key or bucket columns."""
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('dt', pa.string()),
+            ('value', pa.int64()),
+        ])
+        table_name = 'test_shuffle_on_partitioned'
+        identifier = self._make_table(
+            table_name, pa_schema,
+            primary_keys=['id', 'dt'], partition_keys=['dt'],
+            options={'bucket': '4'},
+        )
+
+        rows = pa.Table.from_pydict({
+            'id': list(range(20)),
+            'dt': ['2026-01-01'] * 10 + ['2026-01-02'] * 10,
+            'value': list(range(20)),
+        }, schema=pa_schema)
+        ds = ray.data.from_arrow(rows).repartition(4)
+        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+
+        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        self.assertEqual(set(result.columns), {'id', 'dt', 'value'})
+        self.assertEqual(len(result), 20)
+        self.assertEqual(set(result['dt']), {'2026-01-01', '2026-01-02'})
+
+    def test_shuffle_reduces_data_file_count(self):
+        """With multiple input blocks, shuffle=True collapses per-task
+        files into per-bucket files."""
+        from pypaimon.ray import write_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('value', pa.int64()),
+        ])
+        rows = pa.Table.from_pydict(
+            {'id': list(range(200)), 'value': list(range(200))},
+            schema=pa_schema,
+        )
+
+        without_shuffle = self._make_table(
+            'test_files_without_shuffle', pa_schema,
+            primary_keys=['id'], options={'bucket': '4'},
+        )
+        with_shuffle = self._make_table(
+            'test_files_with_shuffle', pa_schema,
+            primary_keys=['id'], options={'bucket': '4'},
+        )
+
+        # Materialise 4 input blocks so shuffle=False has 4 writers per
+        # bucket worth of opportunities to scatter rows.
+        write_paimon(
+            ray.data.from_arrow(rows).repartition(4),
+            without_shuffle, self.catalog_options,
+        )
+        write_paimon(
+            ray.data.from_arrow(rows).repartition(4),
+            with_shuffle, self.catalog_options, shuffle=True,
+        )
+
+        files_off = self._count_data_files('test_files_without_shuffle')
+        files_on = self._count_data_files('test_files_with_shuffle')
+
+        # With 4 buckets and shuffle=True, every (partition, bucket) is
+        # a single Ray task → 4 files (one per bucket).
+        self.assertEqual(len(files_on), 4)
+        # Without shuffle, multiple Ray tasks each produce one file per
+        # bucket they touch → strictly more files.
+        self.assertGreater(len(files_off), len(files_on))
+
+    # ----- soft fallback -----
+
+    def test_shuffle_on_non_fixed_bucket_falls_through(self):
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('value', pa.int64()),
+        ])
+        # bucket=-1 + no primary keys → BUCKET_UNAWARE
+        table_name = 'test_shuffle_on_unaware'
+        identifier = self._make_table(
+            table_name, pa_schema, options={'bucket': '-1'},
+        )
+
+        rows = pa.Table.from_pydict(
+            {'id': list(range(10)), 'value': list(range(10))},
+            schema=pa_schema,
+        )
+        with self.assertLogs('pypaimon.ray.shuffle', level=logging.WARNING) as cm:
+            write_paimon(
+                ray.data.from_arrow(rows), identifier,
+                self.catalog_options, shuffle=True,
+            )
+        self.assertTrue(any('HASH_FIXED' in m for m in cm.output))
+
+        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        self.assertEqual(len(result), 10)
+
+    # ----- override_num_blocks-only path -----
+
+    def test_invalid_override_num_blocks_raises(self):
+        from pypaimon.ray import write_paimon
+
+        pa_schema = pa.schema([('id', pa.int32())])
+        identifier = self._make_table(
+            'test_invalid_override_num_blocks', pa_schema,
+        )
+        ds = ray.data.from_arrow(pa.Table.from_pydict(
+            {'id': [1]}, schema=pa_schema,
+        ))
+
+        with self.assertRaises(ValueError):
+            write_paimon(
+                ds, identifier, self.catalog_options, override_num_blocks=0,
+            )
+
+    def test_override_num_blocks_only_does_plain_rebalance(self):
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([('id', pa.int32())])
+        table_name = 'test_override_num_blocks_only'
+        identifier = self._make_table(table_name, pa_schema)
+
+        rows = pa.Table.from_pydict({'id': list(range(30))}, schema=pa_schema)
+        # Start with many blocks; override_num_blocks=2 + shuffle=False
+        # should collapse them via plain Ray rebalance. Row content
+        # unchanged.
+        ds = ray.data.from_arrow(rows).repartition(8)
+        write_paimon(
+            ds, identifier, self.catalog_options, override_num_blocks=2,
+        )
+
+        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        self.assertEqual(set(result['id']), set(range(30)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/ray_repartition_test.py
+++ b/paimon-python/pypaimon/tests/ray_repartition_test.py
@@ -238,6 +238,34 @@ class RayShuffleTest(unittest.TestCase):
         # bucket they touch → strictly more files.
         self.assertGreater(len(files_off), len(files_on))
 
+    def test_shuffle_with_colliding_column_name(self):
+        """A table that has a column named ``__paimon_bucket__`` must
+        still work with ``shuffle=True`` — the helper picks a
+        collision-free transient column name."""
+        from pypaimon.ray import write_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('__paimon_bucket__', pa.string()),
+        ])
+        table_name = 'test_shuffle_collide_col'
+        identifier = self._make_table(
+            table_name, pa_schema,
+            primary_keys=['id'], options={'bucket': '2'},
+        )
+
+        rows = pa.Table.from_pydict(
+            {'id': list(range(10)),
+             '__paimon_bucket__': [f'v{i}' for i in range(10)]},
+            schema=pa_schema,
+        )
+        ds = ray.data.from_arrow(rows).repartition(2)
+        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+
+        result = self._read_table(identifier)
+        self.assertEqual(len(result), 10)
+        self.assertEqual(set(result.columns), {'id', '__paimon_bucket__'})
+
     # ----- soft fallback -----
 
     def test_shuffle_on_non_fixed_bucket_falls_through(self):

--- a/paimon-python/pypaimon/tests/ray_repartition_test.py
+++ b/paimon-python/pypaimon/tests/ray_repartition_test.py
@@ -16,22 +16,24 @@
 # limitations under the License.
 ################################################################################
 
-"""End-to-end tests for shuffle / override_num_blocks on ``write_paimon``.
+"""End-to-end tests for HASH_FIXED auto-clustering on ``write_paimon``.
 
-Covers:
+For HASH_FIXED tables, ``write_paimon`` automatically pre-clusters rows
+by ``(partition_keys..., bucket)`` (matching Spark/Flink). These tests
+cover:
 
-  * back-compat: ``shuffle=False`` (default) write + read roundtrip.
-  * HASH_FIXED + ``shuffle=True``: roundtrip correctness, output-file
-    count reduction, transient bucket column stripped from the sink-
-    visible schema.
-  * Soft fallback: ``shuffle=True`` on a non-HASH_FIXED table logs a
-    warning and writes successfully.
-  * ``override_num_blocks`` alone (no shuffle) is a plain Ray block
-    rebalance.
+  * roundtrip correctness on a HASH_FIXED PK table.
+  * roundtrip correctness on a partitioned HASH_FIXED PK table.
+  * the transient bucket column is stripped from the sink-visible
+    schema.
+  * the output is one file per (partition, bucket) — i.e. the
+    small-file storm is eliminated.
+  * regression: a table whose schema already contains a column named
+    ``__paimon_bucket__`` still works (collision-safe column name).
+  * non-HASH_FIXED tables (BUCKET_UNAWARE etc.) pass through unchanged.
 """
 
 import glob
-import logging
 import os
 import shutil
 import tempfile
@@ -112,41 +114,16 @@ class RayShuffleTest(unittest.TestCase):
             ))
         return files
 
-    # ----- back-compat -----
+    # ----- HASH_FIXED auto-clustering -----
 
-    def test_shuffle_off_is_default_and_roundtrip_works(self):
-        from pypaimon.ray import read_paimon, write_paimon
-
-        pa_schema = pa.schema([
-            pa.field('id', pa.int32(), nullable=False),
-            ('name', pa.string()),
-        ])
-        table_name = 'test_shuffle_off'
-        identifier = self._make_table(
-            table_name, pa_schema,
-            primary_keys=['id'], options={'bucket': '2'},
-        )
-
-        rows = pa.Table.from_pydict(
-            {'id': list(range(20)), 'name': [f'v{i}' for i in range(20)]},
-            schema=pa_schema,
-        )
-        write_paimon(ray.data.from_arrow(rows), identifier, self.catalog_options)
-
-        result = read_paimon(identifier, self.catalog_options).to_pandas()
-        self.assertEqual(len(result), 20)
-        self.assertEqual(set(result['id']), set(range(20)))
-
-    # ----- HASH_FIXED + shuffle=True -----
-
-    def test_shuffle_on_fixed_bucket_roundtrip(self):
+    def test_fixed_bucket_roundtrip(self):
         from pypaimon.ray import write_paimon
 
         pa_schema = pa.schema([
             pa.field('id', pa.int32(), nullable=False),
             ('name', pa.string()),
         ])
-        table_name = 'test_shuffle_on_roundtrip'
+        table_name = 'test_fixed_bucket_roundtrip'
         identifier = self._make_table(
             table_name, pa_schema,
             primary_keys=['id'], options={'bucket': '4'},
@@ -157,14 +134,14 @@ class RayShuffleTest(unittest.TestCase):
             schema=pa_schema,
         )
         ds = ray.data.from_arrow(rows).repartition(4)
-        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+        write_paimon(ds, identifier, self.catalog_options)
 
         result = self._read_table(identifier)
         self.assertEqual(len(result), 40)
         self.assertEqual(set(result['id']), set(range(40)))
         self.assertNotIn('__paimon_bucket__', result.columns)
 
-    def test_shuffle_on_partitioned_fixed_bucket_roundtrip(self):
+    def test_partitioned_fixed_bucket_roundtrip(self):
         """Partitioned table — confirms the post-groupby schema does not
         end up with duplicated partition-key or bucket columns."""
         from pypaimon.ray import write_paimon
@@ -174,7 +151,7 @@ class RayShuffleTest(unittest.TestCase):
             ('dt', pa.string()),
             ('value', pa.int64()),
         ])
-        table_name = 'test_shuffle_on_partitioned'
+        table_name = 'test_partitioned_fixed_bucket_roundtrip'
         identifier = self._make_table(
             table_name, pa_schema,
             primary_keys=['id', 'dt'], partition_keys=['dt'],
@@ -187,15 +164,15 @@ class RayShuffleTest(unittest.TestCase):
             'value': list(range(20)),
         }, schema=pa_schema)
         ds = ray.data.from_arrow(rows).repartition(4)
-        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+        write_paimon(ds, identifier, self.catalog_options)
 
         result = self._read_table(identifier)
         self.assertEqual(set(result.columns), {'id', 'dt', 'value'})
         self.assertEqual(len(result), 20)
         self.assertEqual(set(result['dt']), {'2026-01-01', '2026-01-02'})
 
-    def test_shuffle_reduces_data_file_count(self):
-        """With multiple input blocks, shuffle=True collapses per-task
+    def test_fixed_bucket_writes_one_file_per_bucket(self):
+        """With multiple input blocks, auto-clustering collapses per-task
         files into per-bucket files."""
         from pypaimon.ray import write_paimon
 
@@ -208,47 +185,33 @@ class RayShuffleTest(unittest.TestCase):
             schema=pa_schema,
         )
 
-        without_shuffle = self._make_table(
-            'test_files_without_shuffle', pa_schema,
-            primary_keys=['id'], options={'bucket': '4'},
-        )
-        with_shuffle = self._make_table(
-            'test_files_with_shuffle', pa_schema,
+        identifier = self._make_table(
+            'test_one_file_per_bucket', pa_schema,
             primary_keys=['id'], options={'bucket': '4'},
         )
 
-        # Materialise 4 input blocks so shuffle=False has 4 writers per
-        # bucket worth of opportunities to scatter rows.
+        # Materialise 4 input blocks. Without auto-clustering each task
+        # would emit one file per bucket it touched (up to 16 files).
         write_paimon(
             ray.data.from_arrow(rows).repartition(4),
-            without_shuffle, self.catalog_options,
-        )
-        write_paimon(
-            ray.data.from_arrow(rows).repartition(4),
-            with_shuffle, self.catalog_options, shuffle=True,
+            identifier, self.catalog_options,
         )
 
-        files_off = self._count_data_files('test_files_without_shuffle')
-        files_on = self._count_data_files('test_files_with_shuffle')
+        files = self._count_data_files('test_one_file_per_bucket')
+        # 4 buckets × 1 file each.
+        self.assertEqual(len(files), 4)
 
-        # With 4 buckets and shuffle=True, every (partition, bucket) is
-        # a single Ray task → 4 files (one per bucket).
-        self.assertEqual(len(files_on), 4)
-        # Without shuffle, multiple Ray tasks each produce one file per
-        # bucket they touch → strictly more files.
-        self.assertGreater(len(files_off), len(files_on))
-
-    def test_shuffle_with_colliding_column_name(self):
+    def test_fixed_bucket_with_colliding_column_name(self):
         """A table that has a column named ``__paimon_bucket__`` must
-        still work with ``shuffle=True`` — the helper picks a
-        collision-free transient column name."""
+        still work — the helper picks a collision-free transient
+        column name."""
         from pypaimon.ray import write_paimon
 
         pa_schema = pa.schema([
             pa.field('id', pa.int32(), nullable=False),
             ('__paimon_bucket__', pa.string()),
         ])
-        table_name = 'test_shuffle_collide_col'
+        table_name = 'test_fixed_bucket_collide_col'
         identifier = self._make_table(
             table_name, pa_schema,
             primary_keys=['id'], options={'bucket': '2'},
@@ -260,15 +223,17 @@ class RayShuffleTest(unittest.TestCase):
             schema=pa_schema,
         )
         ds = ray.data.from_arrow(rows).repartition(2)
-        write_paimon(ds, identifier, self.catalog_options, shuffle=True)
+        write_paimon(ds, identifier, self.catalog_options)
 
         result = self._read_table(identifier)
         self.assertEqual(len(result), 10)
         self.assertEqual(set(result.columns), {'id', '__paimon_bucket__'})
 
-    # ----- soft fallback -----
+    # ----- non-HASH_FIXED passthrough -----
 
-    def test_shuffle_on_non_fixed_bucket_falls_through(self):
+    def test_non_fixed_bucket_roundtrip(self):
+        """BUCKET_UNAWARE tables are written without pre-clustering;
+        roundtrip data must still be correct."""
         from pypaimon.ray import read_paimon, write_paimon
 
         pa_schema = pa.schema([
@@ -276,7 +241,7 @@ class RayShuffleTest(unittest.TestCase):
             ('value', pa.int64()),
         ])
         # bucket=-1 + no primary keys → BUCKET_UNAWARE
-        table_name = 'test_shuffle_on_unaware'
+        table_name = 'test_non_fixed_bucket_roundtrip'
         identifier = self._make_table(
             table_name, pa_schema, options={'bucket': '-1'},
         )
@@ -285,52 +250,13 @@ class RayShuffleTest(unittest.TestCase):
             {'id': list(range(10)), 'value': list(range(10))},
             schema=pa_schema,
         )
-        with self.assertLogs('pypaimon.ray.shuffle', level=logging.WARNING) as cm:
-            write_paimon(
-                ray.data.from_arrow(rows), identifier,
-                self.catalog_options, shuffle=True,
-            )
-        self.assertTrue(any('HASH_FIXED' in m for m in cm.output))
+        write_paimon(
+            ray.data.from_arrow(rows), identifier, self.catalog_options,
+        )
 
         result = read_paimon(identifier, self.catalog_options).to_pandas()
         self.assertEqual(len(result), 10)
-
-    # ----- override_num_blocks-only path -----
-
-    def test_invalid_override_num_blocks_raises(self):
-        from pypaimon.ray import write_paimon
-
-        pa_schema = pa.schema([('id', pa.int32())])
-        identifier = self._make_table(
-            'test_invalid_override_num_blocks', pa_schema,
-        )
-        ds = ray.data.from_arrow(pa.Table.from_pydict(
-            {'id': [1]}, schema=pa_schema,
-        ))
-
-        with self.assertRaises(ValueError):
-            write_paimon(
-                ds, identifier, self.catalog_options, override_num_blocks=0,
-            )
-
-    def test_override_num_blocks_only_does_plain_rebalance(self):
-        from pypaimon.ray import read_paimon, write_paimon
-
-        pa_schema = pa.schema([('id', pa.int32())])
-        table_name = 'test_override_num_blocks_only'
-        identifier = self._make_table(table_name, pa_schema)
-
-        rows = pa.Table.from_pydict({'id': list(range(30))}, schema=pa_schema)
-        # Start with many blocks; override_num_blocks=2 + shuffle=False
-        # should collapse them via plain Ray rebalance. Row content
-        # unchanged.
-        ds = ray.data.from_arrow(rows).repartition(8)
-        write_paimon(
-            ds, identifier, self.catalog_options, override_num_blocks=2,
-        )
-
-        result = read_paimon(identifier, self.catalog_options).to_pandas()
-        self.assertEqual(set(result['id']), set(range(30)))
+        self.assertEqual(set(result['id']), set(range(10)))
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/ray_repartition_test.py
+++ b/paimon-python/pypaimon/tests/ray_repartition_test.py
@@ -85,6 +85,22 @@ class RayShuffleTest(unittest.TestCase):
         catalog.create_table(identifier, schema, False)
         return identifier
 
+    def _read_table(self, identifier):
+        """Read table data via the direct API (not ``read_paimon``).
+
+        This avoids going through ``RayDatasource._get_read_task`` which
+        has a pre-existing strict nullability check (``from_batches``
+        with Paimon schema) that rejects batches where the reader drops
+        ``not null`` (a raw-convertible PK split issue). Shuffle tests
+        care about *write* correctness, not the Ray read path.
+        """
+        catalog = CatalogFactory.create(self.catalog_options)
+        table = catalog.get_table(identifier)
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        arrow = rb.new_read().to_arrow(splits)
+        return arrow.to_pandas() if arrow is not None else pa.table({}).to_pandas()
+
     def _count_data_files(self, table_name):
         """All data files under the table directory, regardless of partition."""
         root = os.path.join(self.warehouse, 'default.db', table_name)
@@ -124,7 +140,7 @@ class RayShuffleTest(unittest.TestCase):
     # ----- HASH_FIXED + shuffle=True -----
 
     def test_shuffle_on_fixed_bucket_roundtrip(self):
-        from pypaimon.ray import read_paimon, write_paimon
+        from pypaimon.ray import write_paimon
 
         pa_schema = pa.schema([
             pa.field('id', pa.int32(), nullable=False),
@@ -143,16 +159,15 @@ class RayShuffleTest(unittest.TestCase):
         ds = ray.data.from_arrow(rows).repartition(4)
         write_paimon(ds, identifier, self.catalog_options, shuffle=True)
 
-        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        result = self._read_table(identifier)
         self.assertEqual(len(result), 40)
         self.assertEqual(set(result['id']), set(range(40)))
-        # Sink schema must not carry the transient shuffle column.
         self.assertNotIn('__paimon_bucket__', result.columns)
 
     def test_shuffle_on_partitioned_fixed_bucket_roundtrip(self):
         """Partitioned table — confirms the post-groupby schema does not
         end up with duplicated partition-key or bucket columns."""
-        from pypaimon.ray import read_paimon, write_paimon
+        from pypaimon.ray import write_paimon
 
         pa_schema = pa.schema([
             pa.field('id', pa.int32(), nullable=False),
@@ -174,7 +189,7 @@ class RayShuffleTest(unittest.TestCase):
         ds = ray.data.from_arrow(rows).repartition(4)
         write_paimon(ds, identifier, self.catalog_options, shuffle=True)
 
-        result = read_paimon(identifier, self.catalog_options).to_pandas()
+        result = self._read_table(identifier)
         self.assertEqual(set(result.columns), {'id', 'dt', 'value'})
         self.assertEqual(len(result), 20)
         self.assertEqual(set(result['dt']), {'2026-01-01', '2026-01-02'})

--- a/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
+++ b/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
@@ -19,12 +19,12 @@
 """Unit tests for the Ray pre-shuffle helper in pypaimon/ray/shuffle.py.
 
 These tests exercise the helper in isolation: the bucket-key UDF (with a
-stub extractor) and the no-op / soft-fallback branches of
+stub extractor), the collision-safe column name picker, the
+large-type coercion, and the bucket-mode dispatch in
 ``maybe_apply_repartition``. Ray-based end-to-end behaviour is covered
 in ``pypaimon/tests/ray_repartition_test.py``.
 """
 
-import logging
 import unittest
 from unittest.mock import MagicMock
 
@@ -134,85 +134,76 @@ class CoerceLargeStringTypesTest(unittest.TestCase):
         self.assertEqual(out.schema.field("blob").type, pa.binary())
 
 
-class NoOpBranchTest(unittest.TestCase):
-    """The off / fallback branches don't touch the dataset object."""
+class BucketModeDispatchTest(unittest.TestCase):
+    """``maybe_apply_repartition`` clusters HASH_FIXED tables and
+    returns other bucket modes unchanged."""
 
     def _make_table(self, bucket_mode):
         table = MagicMock()
         table.bucket_mode.return_value = bucket_mode
         return table
 
-    def test_shuffle_off_and_no_override_num_blocks_is_noop(self):
-        dataset = object()  # sentinel; not touched
-        table = self._make_table(BucketMode.HASH_FIXED)
-
-        out_ds, applied = maybe_apply_repartition(
-            dataset, table, shuffle=False, override_num_blocks=None,
-        )
-
-        self.assertIs(out_ds, dataset)
-        self.assertFalse(applied)
-        table.bucket_mode.assert_not_called()  # short-circuit early
-
-    def test_shuffle_on_non_fixed_bucket_falls_through_with_warning(self):
-        dataset = MagicMock()
-        # The non-HASH_FIXED branch flips shuffle off internally; with
-        # override_num_blocks=None the helper then returns the dataset
-        # unchanged via the post-fallback early-no-op guard.
+    def test_bucket_unaware_returns_dataset_unchanged(self):
+        dataset = object()  # sentinel; must not be wrapped or mutated
         table = self._make_table(BucketMode.BUCKET_UNAWARE)
 
-        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING) as cm:
-            out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, override_num_blocks=None,
-            )
+        self.assertIs(maybe_apply_repartition(dataset, table), dataset)
 
-        self.assertIs(out_ds, dataset)
-        self.assertFalse(applied)
-        self.assertTrue(
-            any("HASH_FIXED" in msg for msg in cm.output),
-            "expected the soft-fallback warning to mention HASH_FIXED",
-        )
-
-    def test_shuffle_on_dynamic_bucket_falls_through(self):
-        dataset = MagicMock()
+    def test_hash_dynamic_returns_dataset_unchanged(self):
+        dataset = object()
         table = self._make_table(BucketMode.HASH_DYNAMIC)
 
-        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
-            out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, override_num_blocks=None,
+        self.assertIs(maybe_apply_repartition(dataset, table), dataset)
+
+    def test_cross_partition_returns_dataset_unchanged(self):
+        dataset = object()
+        table = self._make_table(BucketMode.CROSS_PARTITION)
+
+        self.assertIs(maybe_apply_repartition(dataset, table), dataset)
+
+    def test_hash_fixed_runs_map_batches_groupby_chain(self):
+        dataset = MagicMock(name="dataset")
+        dataset.map_batches.return_value.groupby.return_value \
+            .map_groups.return_value.drop_columns.return_value = "clustered"
+        table = MagicMock()
+        table.bucket_mode.return_value = BucketMode.HASH_FIXED
+        table.table_schema.partition_keys = []
+        table.table_schema.fields = [
+            type("F", (), {"name": "id"})(),
+            type("F", (), {"name": "value"})(),
+        ]
+
+        out = maybe_apply_repartition(dataset, table)
+
+        self.assertEqual(out, "clustered")
+        # The helper appends a transient bucket column, groups by it,
+        # runs the identity batch over each group, then drops the
+        # transient column. We assert the call chain, not its kwargs,
+        # since defaults are an implementation detail.
+        dataset.map_batches.assert_called_once()
+        dataset.map_batches.return_value.groupby.assert_called_once()
+        dataset.map_batches.return_value.groupby.return_value \
+            .map_groups.assert_called_once()
+        dataset.map_batches.return_value.groupby.return_value \
+            .map_groups.return_value.drop_columns.assert_called_once_with(
+                [BUCKET_KEY_COL]
             )
 
-        self.assertIs(out_ds, dataset)
-        self.assertFalse(applied)
+    def test_hash_fixed_groups_include_partition_keys(self):
+        dataset = MagicMock(name="dataset")
+        table = MagicMock()
+        table.bucket_mode.return_value = BucketMode.HASH_FIXED
+        table.table_schema.partition_keys = ["dt"]
+        table.table_schema.fields = [
+            type("F", (), {"name": "id"})(),
+            type("F", (), {"name": "dt"})(),
+        ]
 
-    def test_shuffle_off_with_override_num_blocks_calls_plain_repartition(self):
-        dataset = MagicMock()
-        dataset.repartition.return_value = "rebalanced"
-        table = self._make_table(BucketMode.HASH_FIXED)
+        maybe_apply_repartition(dataset, table)
 
-        out_ds, applied = maybe_apply_repartition(
-            dataset, table, shuffle=False, override_num_blocks=8,
-        )
-
-        self.assertEqual(out_ds, "rebalanced")
-        self.assertFalse(applied)
-        dataset.repartition.assert_called_once_with(8, shuffle=False)
-
-    def test_soft_fallback_with_override_num_blocks_runs_plain_repartition(self):
-        # shuffle=True on a non-fixed bucket table flips to shuffle=False,
-        # so an override_num_blocks=N caller still gets a block rebalance.
-        dataset = MagicMock()
-        dataset.repartition.return_value = "rebalanced"
-        table = self._make_table(BucketMode.BUCKET_UNAWARE)
-
-        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
-            out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, override_num_blocks=4,
-            )
-
-        self.assertEqual(out_ds, "rebalanced")
-        self.assertFalse(applied)
-        dataset.repartition.assert_called_once_with(4, shuffle=False)
+        group_call = dataset.map_batches.return_value.groupby.call_args
+        passed_keys = group_call.args[0]
+        self.assertEqual(passed_keys, ["dt", BUCKET_KEY_COL])
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
+++ b/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
@@ -31,7 +31,8 @@ from unittest.mock import MagicMock
 import pyarrow as pa
 
 from pypaimon.ray.shuffle import (BUCKET_KEY_COL, _coerce_large_string_types,
-                                  _make_bucket_udf, maybe_apply_repartition)
+                                  _make_bucket_udf, _pick_bucket_col_name,
+                                  maybe_apply_repartition)
 from pypaimon.table.bucket_mode import BucketMode
 
 
@@ -48,7 +49,7 @@ class BucketUdfTest(unittest.TestCase):
 
     def test_appends_int32_bucket_column(self):
         extractor = self._make_extractor([0, 1, 0])
-        udf = _make_bucket_udf(extractor)
+        udf = _make_bucket_udf(extractor, BUCKET_KEY_COL)
         batch = pa.table({"id": [10, 11, 12]})
 
         out = udf(batch)
@@ -59,7 +60,7 @@ class BucketUdfTest(unittest.TestCase):
 
     def test_empty_batch_appends_empty_column(self):
         extractor = self._make_extractor([])
-        udf = _make_bucket_udf(extractor)
+        udf = _make_bucket_udf(extractor, BUCKET_KEY_COL)
         batch = pa.table({"id": pa.array([], type=pa.int32())})
 
         out = udf(batch)
@@ -75,7 +76,7 @@ class BucketUdfTest(unittest.TestCase):
         # before calling the extractor, otherwise the extractor sees
         # half the rows.
         extractor = self._make_extractor([0, 1, 2, 3])
-        udf = _make_bucket_udf(extractor)
+        udf = _make_bucket_udf(extractor, BUCKET_KEY_COL)
         rb1 = pa.record_batch({"id": [1, 2]})
         rb2 = pa.record_batch({"id": [3, 4]})
         batch = pa.Table.from_batches([rb1, rb2])
@@ -88,6 +89,20 @@ class BucketUdfTest(unittest.TestCase):
         call = extractor.extract_partition_bucket_batch.call_args
         passed_batch = call.args[0]
         self.assertEqual(passed_batch.num_rows, 4)
+
+
+class PickBucketColNameTest(unittest.TestCase):
+    """``_pick_bucket_col_name`` avoids collision with user columns."""
+
+    def test_default_name_when_no_collision(self):
+        self.assertEqual(
+            _pick_bucket_col_name({"id", "name"}), BUCKET_KEY_COL)
+
+    def test_fallback_when_default_collides(self):
+        name = _pick_bucket_col_name({"id", BUCKET_KEY_COL})
+        self.assertNotEqual(name, BUCKET_KEY_COL)
+        self.assertTrue(name.startswith("__paimon_bucket_"))
+        self.assertNotIn(name, {"id", BUCKET_KEY_COL})
 
 
 class CoerceLargeStringTypesTest(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
+++ b/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
@@ -1,0 +1,204 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Unit tests for the Ray pre-shuffle helper in pypaimon/ray/shuffle.py.
+
+These tests exercise the helper in isolation: the bucket-key UDF (with a
+stub extractor) and the no-op / soft-fallback branches of
+``maybe_apply_repartition``. Ray-based end-to-end behaviour is covered
+in ``pypaimon/tests/ray_repartition_test.py``.
+"""
+
+import logging
+import unittest
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+
+from pypaimon.ray.shuffle import (BUCKET_KEY_COL, _coerce_large_string_types,
+                                  _make_bucket_udf, maybe_apply_repartition)
+from pypaimon.table.bucket_mode import BucketMode
+
+
+class BucketUdfTest(unittest.TestCase):
+    """The bucket-key UDF appends a deterministic int32 column."""
+
+    def _make_extractor(self, buckets_per_row):
+        extractor = MagicMock()
+        extractor.extract_partition_bucket_batch.return_value = (
+            [() for _ in buckets_per_row],
+            list(buckets_per_row),
+        )
+        return extractor
+
+    def test_appends_int32_bucket_column(self):
+        extractor = self._make_extractor([0, 1, 0])
+        udf = _make_bucket_udf(extractor)
+        batch = pa.table({"id": [10, 11, 12]})
+
+        out = udf(batch)
+
+        self.assertEqual(out.column_names, ["id", BUCKET_KEY_COL])
+        self.assertEqual(out.schema.field(BUCKET_KEY_COL).type, pa.int32())
+        self.assertEqual(out.column(BUCKET_KEY_COL).to_pylist(), [0, 1, 0])
+
+    def test_empty_batch_appends_empty_column(self):
+        extractor = self._make_extractor([])
+        udf = _make_bucket_udf(extractor)
+        batch = pa.table({"id": pa.array([], type=pa.int32())})
+
+        out = udf(batch)
+
+        self.assertEqual(out.num_rows, 0)
+        self.assertEqual(out.column_names, ["id", BUCKET_KEY_COL])
+        # The extractor is short-circuited on empty input — we don't pay
+        # the cost of combining empty chunks just to call into it.
+        extractor.extract_partition_bucket_batch.assert_not_called()
+
+    def test_multichunk_batch_combines_before_extracting(self):
+        # Two record batches in the same table — the UDF must combine
+        # before calling the extractor, otherwise the extractor sees
+        # half the rows.
+        extractor = self._make_extractor([0, 1, 2, 3])
+        udf = _make_bucket_udf(extractor)
+        rb1 = pa.record_batch({"id": [1, 2]})
+        rb2 = pa.record_batch({"id": [3, 4]})
+        batch = pa.Table.from_batches([rb1, rb2])
+
+        out = udf(batch)
+
+        self.assertEqual(out.num_rows, 4)
+        self.assertEqual(out.column(BUCKET_KEY_COL).to_pylist(), [0, 1, 2, 3])
+        # Extractor is called exactly once with all four rows.
+        call = extractor.extract_partition_bucket_batch.call_args
+        passed_batch = call.args[0]
+        self.assertEqual(passed_batch.num_rows, 4)
+
+
+class CoerceLargeStringTypesTest(unittest.TestCase):
+    """``_identity_batch`` casts back the large_string / large_binary
+    types that some Ray versions introduce when materialising blocks
+    during ``groupby().map_groups``. The Paimon writer's strict schema
+    check would otherwise reject those rows."""
+
+    def test_pass_through_when_no_large_variants(self):
+        batch = pa.table({"id": pa.array([1, 2], type=pa.int32()),
+                          "name": pa.array(["a", "b"], type=pa.string())})
+        out = _coerce_large_string_types(batch)
+        self.assertEqual(out.schema, batch.schema)
+
+    def test_casts_large_string_back_to_string(self):
+        batch = pa.table({
+            "id": pa.array([1, 2], type=pa.int32()),
+            "name": pa.array(["x", "y"], type=pa.large_string()),
+        })
+        out = _coerce_large_string_types(batch)
+        self.assertEqual(out.schema.field("name").type, pa.string())
+        self.assertEqual(out.column("name").to_pylist(), ["x", "y"])
+
+    def test_casts_large_binary_back_to_binary(self):
+        batch = pa.table({
+            "blob": pa.array([b"x", b"y"], type=pa.large_binary()),
+        })
+        out = _coerce_large_string_types(batch)
+        self.assertEqual(out.schema.field("blob").type, pa.binary())
+
+
+class NoOpBranchTest(unittest.TestCase):
+    """The off / fallback branches don't touch the dataset object."""
+
+    def _make_table(self, bucket_mode):
+        table = MagicMock()
+        table.bucket_mode.return_value = bucket_mode
+        return table
+
+    def test_shuffle_off_and_no_num_blocks_is_noop(self):
+        dataset = object()  # sentinel; not touched
+        table = self._make_table(BucketMode.HASH_FIXED)
+
+        out_ds, applied = maybe_apply_repartition(
+            dataset, table, shuffle=False, num_blocks=None,
+        )
+
+        self.assertIs(out_ds, dataset)
+        self.assertFalse(applied)
+        table.bucket_mode.assert_not_called()  # short-circuit early
+
+    def test_shuffle_on_non_fixed_bucket_falls_through_with_warning(self):
+        dataset = MagicMock()
+        # repartition is what shuffle=False + num_blocks=None falls into
+        # for the "after-soft-fallback" branch — but we passed num_blocks
+        # = None, so that branch returns the dataset unchanged.
+        table = self._make_table(BucketMode.BUCKET_UNAWARE)
+
+        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING) as cm:
+            out_ds, applied = maybe_apply_repartition(
+                dataset, table, shuffle=True, num_blocks=None,
+            )
+
+        self.assertIs(out_ds, dataset)
+        self.assertFalse(applied)
+        self.assertTrue(
+            any("HASH_FIXED" in msg for msg in cm.output),
+            "expected the soft-fallback warning to mention HASH_FIXED",
+        )
+
+    def test_shuffle_on_dynamic_bucket_falls_through(self):
+        dataset = MagicMock()
+        table = self._make_table(BucketMode.HASH_DYNAMIC)
+
+        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
+            out_ds, applied = maybe_apply_repartition(
+                dataset, table, shuffle=True, num_blocks=None,
+            )
+
+        self.assertIs(out_ds, dataset)
+        self.assertFalse(applied)
+
+    def test_shuffle_off_with_num_blocks_calls_plain_repartition(self):
+        dataset = MagicMock()
+        dataset.repartition.return_value = "rebalanced"
+        table = self._make_table(BucketMode.HASH_FIXED)
+
+        out_ds, applied = maybe_apply_repartition(
+            dataset, table, shuffle=False, num_blocks=8,
+        )
+
+        self.assertEqual(out_ds, "rebalanced")
+        self.assertFalse(applied)
+        dataset.repartition.assert_called_once_with(8, shuffle=False)
+
+    def test_soft_fallback_with_num_blocks_runs_plain_repartition(self):
+        # shuffle=True on a non-fixed bucket table flips to shuffle=False,
+        # so a num_blocks=N caller still gets a block rebalance.
+        dataset = MagicMock()
+        dataset.repartition.return_value = "rebalanced"
+        table = self._make_table(BucketMode.BUCKET_UNAWARE)
+
+        with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
+            out_ds, applied = maybe_apply_repartition(
+                dataset, table, shuffle=True, num_blocks=4,
+            )
+
+        self.assertEqual(out_ds, "rebalanced")
+        self.assertFalse(applied)
+        dataset.repartition.assert_called_once_with(4, shuffle=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
+++ b/paimon-python/pypaimon/tests/test_ray_shuffle_helper.py
@@ -127,12 +127,12 @@ class NoOpBranchTest(unittest.TestCase):
         table.bucket_mode.return_value = bucket_mode
         return table
 
-    def test_shuffle_off_and_no_num_blocks_is_noop(self):
+    def test_shuffle_off_and_no_override_num_blocks_is_noop(self):
         dataset = object()  # sentinel; not touched
         table = self._make_table(BucketMode.HASH_FIXED)
 
         out_ds, applied = maybe_apply_repartition(
-            dataset, table, shuffle=False, num_blocks=None,
+            dataset, table, shuffle=False, override_num_blocks=None,
         )
 
         self.assertIs(out_ds, dataset)
@@ -141,14 +141,14 @@ class NoOpBranchTest(unittest.TestCase):
 
     def test_shuffle_on_non_fixed_bucket_falls_through_with_warning(self):
         dataset = MagicMock()
-        # repartition is what shuffle=False + num_blocks=None falls into
-        # for the "after-soft-fallback" branch — but we passed num_blocks
-        # = None, so that branch returns the dataset unchanged.
+        # The non-HASH_FIXED branch flips shuffle off internally; with
+        # override_num_blocks=None the helper then returns the dataset
+        # unchanged via the post-fallback early-no-op guard.
         table = self._make_table(BucketMode.BUCKET_UNAWARE)
 
         with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING) as cm:
             out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, num_blocks=None,
+                dataset, table, shuffle=True, override_num_blocks=None,
             )
 
         self.assertIs(out_ds, dataset)
@@ -164,35 +164,35 @@ class NoOpBranchTest(unittest.TestCase):
 
         with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
             out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, num_blocks=None,
+                dataset, table, shuffle=True, override_num_blocks=None,
             )
 
         self.assertIs(out_ds, dataset)
         self.assertFalse(applied)
 
-    def test_shuffle_off_with_num_blocks_calls_plain_repartition(self):
+    def test_shuffle_off_with_override_num_blocks_calls_plain_repartition(self):
         dataset = MagicMock()
         dataset.repartition.return_value = "rebalanced"
         table = self._make_table(BucketMode.HASH_FIXED)
 
         out_ds, applied = maybe_apply_repartition(
-            dataset, table, shuffle=False, num_blocks=8,
+            dataset, table, shuffle=False, override_num_blocks=8,
         )
 
         self.assertEqual(out_ds, "rebalanced")
         self.assertFalse(applied)
         dataset.repartition.assert_called_once_with(8, shuffle=False)
 
-    def test_soft_fallback_with_num_blocks_runs_plain_repartition(self):
+    def test_soft_fallback_with_override_num_blocks_runs_plain_repartition(self):
         # shuffle=True on a non-fixed bucket table flips to shuffle=False,
-        # so a num_blocks=N caller still gets a block rebalance.
+        # so an override_num_blocks=N caller still gets a block rebalance.
         dataset = MagicMock()
         dataset.repartition.return_value = "rebalanced"
         table = self._make_table(BucketMode.BUCKET_UNAWARE)
 
         with self.assertLogs("pypaimon.ray.shuffle", level=logging.WARNING):
             out_ds, applied = maybe_apply_repartition(
-                dataset, table, shuffle=True, num_blocks=4,
+                dataset, table, shuffle=True, override_num_blocks=4,
             )
 
         self.assertEqual(out_ds, "rebalanced")


### PR DESCRIPTION
## Purpose

When `write_paimon` is given a Ray Dataset, Ray's default round-robin
block distribution scatters rows that share the same `(partition,
bucket)` across many Ray tasks. Each task opens its own writer and emits
its own data file, so the write produces
`partitions × buckets × ray_tasks` files instead of the
`partitions × buckets` the writer would naturally produce.

Spark and Flink already cluster rows by `(partition, bucket)` before
writing — see `PaimonSparkWriter.repartitionByPartitionsAndBucket` and
the `RowAssignerChannelComputer` / `RowWithBucketChannelComputer` chain.
This PR brings the same pre-clustering to the Ray path.

## Linked Issue

N/A

## Effect

Two new keyword-only parameters on `write_paimon`:

- **`shuffle: bool = False`** — for HASH_FIXED tables, group rows by
  `(partition_keys..., bucket)` via Ray's `groupby` / `map_groups` so
  each `(partition, bucket)` lands in one Ray task. Bucket assignment
  is computed with `FixedBucketRowKeyExtractor`, the same extractor the
  writer uses, so the shuffle-time bucket is byte-equivalent to the
  writer's. Non-HASH_FIXED tables log a warning and write as before.

- **`num_blocks: Optional[int] = None`** — optional Ray output block
  count. With `shuffle=True` it is a parallelism hint for the groupby;
  with `shuffle=False` it triggers a plain Ray block rebalance.

Defaults preserve the previous behaviour, so no existing caller is
affected.

## Tests

- `pypaimon/tests/test_ray_shuffle_helper.py` — 8 unit tests covering
  the bucket-key UDF (column type, empty input, multi-chunk combine)
  and every no-op / soft-fallback branch.

- `pypaimon/tests/ray_repartition_test.py` — 7 end-to-end tests:
  - default `shuffle=False` roundtrip equality
  - `shuffle=True` roundtrip on a HASH_FIXED PK table
  - `shuffle=True` on a partitioned HASH_FIXED PK table (post-groupby
    schema integrity check)
  - file-count reduction on a multi-block HASH_FIXED write
  - soft fallback for BUCKET_UNAWARE + warning emitted
  - `num_blocks=0` raises `ValueError`
  - `num_blocks`-only plain block rebalance

Existing Ray tests (`ray_integration_test.py`, `ray_data_test.py`)
remain green.

## API & Format Impact

- Public API: adds two new keyword-only parameters with safe defaults
  to `pypaimon.ray.write_paimon`. No signature break.
- File format: unchanged. The transient `__paimon_bucket__` column is
  stripped before the sink sees the dataset, so on-disk layout is
  unaffected.

## Documentation

- `docs/content/pypaimon/ray-data.md` — new section explaining the
  small-file problem and the `shuffle` / `num_blocks` options.