### PR TITLE
[python] Support StreamTableUpdate of data evolution for StreamWriteBuilder

### DIFF
--- a/docs/content/pypaimon/data-evolution.md
+++ b/docs/content/pypaimon/data-evolution.md
@@ -36,16 +36,40 @@ To use partial updates / data evolution, enable both options when creating the t
 - **`row-tracking.enabled`**: `true`
 - **`data-evolution.enabled`**: `true`
 
+## Batch vs Stream
+
+Data evolution supports both batch and stream modes. The API differs as follows:
+
+|                     | Batch                                        | Stream                                         |
+|---------------------|----------------------------------------------|------------------------------------------------|
+| Builder             | `table.new_batch_write_builder()`            | `table.new_stream_write_builder()`             |
+| Write               | `BatchTableWrite`                            | `StreamTableWrite`                             |
+| Update              | `BatchTableUpdate`                           | `StreamTableUpdate`                            |
+| Commit              | `BatchTableCommit`                           | `StreamTableCommit`                            |
+| `commit_identifier` | Not required                                 | Required (monotonically increasing integer)    |
+| Lifecycle           | One-shot: each instance can commit only once | Reusable: same instance can commit many rounds |
+
+Method signatures that differ between modes:
+
+| Method                          | Batch                                          | Stream                                                            |
+|---------------------------------|------------------------------------------------|-------------------------------------------------------------------|
+| `prepare_commit()`              | `write.prepare_commit()`                       | `write.prepare_commit(commit_identifier)`                         |
+| `update_by_arrow_with_row_id()` | `update.update_by_arrow_with_row_id(table)`    | `update.update_by_arrow_with_row_id(table, commit_identifier)`    |
+| `upsert_by_arrow_with_key()`    | `update.upsert_by_arrow_with_key(table, keys)` | `update.upsert_by_arrow_with_key(table, keys, commit_identifier)` |
+| `commit()`                      | `commit.commit(messages)`                      | `commit.commit(messages, commit_identifier)`                      |
+
 ## Update Columns By Row ID
 
-You can create `TableUpdate.update_by_arrow_with_row_id` to update columns to data evolution tables.
+You can use `update_by_arrow_with_row_id` to update columns in data evolution tables.
 
-The input data should include the `_ROW_ID` column, update operation will automatically sort and match each `_ROW_ID` to
-its corresponding `first_row_id`, then groups rows with the same `first_row_id` and writes them to a separate file.
+The input data should include the `_ROW_ID` column. The update operation will automatically sort and match each `_ROW_ID`
+to its corresponding `first_row_id`, then group rows with the same `first_row_id` and write them to a separate file.
 
 **Requirements for `_ROW_ID` updates**
 
 - **Update columns only**: include `_ROW_ID` plus the columns you want to update (partial schema is OK).
+
+### Batch Mode
 
 ```python
 import pyarrow as pa
@@ -96,6 +120,58 @@ table_commit.close()
 #   'f1': [-1001, 1002]
 ```
 
+### Stream Mode
+
+```python
+import pyarrow as pa
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/warehouse'})
+catalog.create_database('default', False)
+
+simple_pa_schema = pa.schema([
+  ('f0', pa.int8()),
+  ('f1', pa.int16()),
+])
+schema = Schema.from_pyarrow_schema(simple_pa_schema,
+                                    options={'row-tracking.enabled': 'true', 'data-evolution.enabled': 'true'})
+catalog.create_table('default.test_stream', schema, False)
+table = catalog.get_table('default.test_stream')
+
+# write initial data
+write_builder = table.new_batch_write_builder()
+table_write = write_builder.new_write()
+table_commit = write_builder.new_commit()
+table_write.write_arrow(pa.Table.from_pydict({
+  'f0': [-1, 2],
+  'f1': [-1001, 1002]
+}, schema=simple_pa_schema))
+table_commit.commit(table_write.prepare_commit())
+table_write.close()
+table_commit.close()
+
+# stream update: each round uses a new commit_identifier
+stream_builder = table.new_stream_write_builder()
+table_update = stream_builder.new_update().with_update_type(['f0'])
+table_commit = stream_builder.new_commit()
+
+data1 = pa.Table.from_pydict({
+  '_ROW_ID': [0],
+  'f0': [5],
+}, schema=pa.schema([('_ROW_ID', pa.int64()), ('f0', pa.int8())]))
+cmts1 = table_update.update_by_arrow_with_row_id(data1, commit_identifier=1)
+table_commit.commit(cmts1, commit_identifier=1)
+
+data2 = pa.Table.from_pydict({
+  '_ROW_ID': [1],
+  'f0': [6],
+}, schema=pa.schema([('_ROW_ID', pa.int64()), ('f0', pa.int8())]))
+cmts2 = table_update.update_by_arrow_with_row_id(data2, commit_identifier=2)
+table_commit.commit(cmts2, commit_identifier=2)
+
+table_commit.close()
+```
+
 ## Filter by _ROW_ID
 
 Requires the same [Prerequisites](#prerequisites) (row-tracking and data-evolution enabled). On such tables you can filter by `_ROW_ID` to prune files at scan time. Supported: `equal('_ROW_ID', id)`, `is_in('_ROW_ID', [id1, ...])`, `between('_ROW_ID', low, high)`.
@@ -121,6 +197,8 @@ If you want to **upsert** (update-or-insert) rows by one or more business key co
 - For **partitioned tables**, the input data must contain all partition key columns. Partition keys are
   **automatically stripped** from `upsert_keys` during matching (since each partition is processed independently),
   so you do **not** need to include them in `upsert_keys`.
+
+### Batch Mode
 
 **Example: basic upsert**
 
@@ -234,6 +312,63 @@ table_commit.close()
 - Duplicate keys in the input data are automatically deduplicated — the **last occurrence** is kept.
 - The upsert is atomic per commit — all matched updates and new appends are included in the same commit.
 
+### Stream Mode
+
+```python
+import pyarrow as pa
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/warehouse'})
+catalog.create_database('default', False)
+
+pa_schema = pa.schema([
+    ('id', pa.int32()),
+    ('name', pa.string()),
+    ('age', pa.int32()),
+])
+schema = Schema.from_pyarrow_schema(
+    pa_schema,
+    options={'row-tracking.enabled': 'true', 'data-evolution.enabled': 'true'},
+)
+catalog.create_table('default.users_stream', schema, False)
+table = catalog.get_table('default.users_stream')
+
+# write initial data
+write_builder = table.new_batch_write_builder()
+write = write_builder.new_write()
+commit = write_builder.new_commit()
+write.write_arrow(pa.Table.from_pydict(
+    {'id': [1, 2], 'name': ['Alice', 'Bob'], 'age': [30, 25]},
+    schema=pa_schema,
+))
+commit.commit(write.prepare_commit())
+write.close()
+commit.close()
+
+# stream upsert: each round uses a new commit_identifier
+stream_builder = table.new_stream_write_builder()
+table_update = stream_builder.new_update()
+table_commit = stream_builder.new_commit()
+
+upsert_data1 = pa.Table.from_pydict(
+    {'id': [1, 3], 'name': ['Alice_v2', 'Charlie'], 'age': [31, 28]},
+    schema=pa_schema,
+)
+cmts1 = table_update.upsert_by_arrow_with_key(upsert_data1, upsert_keys=['id'], commit_identifier=1)
+table_commit.commit(cmts1, commit_identifier=1)
+
+upsert_data2 = pa.Table.from_pydict(
+    {'id': [2, 4], 'name': ['Bob_v2', 'David'], 'age': [26, 40]},
+    schema=pa_schema,
+)
+cmts2 = table_update.upsert_by_arrow_with_key(upsert_data2, upsert_keys=['id'], commit_identifier=2)
+table_commit.commit(cmts2, commit_identifier=2)
+
+table_commit.close()
+```
+
+The `with_update_type` and partitioned table patterns shown in Batch Mode also work in Stream Mode — just add `commit_identifier` to the `upsert_by_arrow_with_key` and `commit` calls.
+
 ## Update Columns By Shards
 
 If you want to **compute a derived column** (or **update an existing column based on other columns**) without providing
@@ -245,6 +380,8 @@ If you want to **compute a derived column** (or **update an existing column base
 - Commit per shard
 
 This is useful for backfilling a newly added column, or recomputing a column from other columns.
+
+### Batch Mode
 
 **Example: compute `d = c + b - a`**
 
@@ -325,6 +462,62 @@ commit_messages = upd.prepare_commit()
 commit = write_builder.new_commit()
 commit.commit(commit_messages)
 commit.close()
+```
+
+### Stream Mode
+
+```python
+import pyarrow as pa
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/warehouse'})
+catalog.create_database('default', False)
+
+table_schema = pa.schema([
+    ('a', pa.int32()),
+    ('b', pa.int32()),
+    ('c', pa.int32()),
+    ('d', pa.int32()),
+])
+
+schema = Schema.from_pyarrow_schema(
+    table_schema,
+    options={'row-tracking.enabled': 'true', 'data-evolution.enabled': 'true'},
+)
+catalog.create_table('default.t_stream', schema, False)
+table = catalog.get_table('default.t_stream')
+
+# write initial data (a, b, c only)
+write_builder = table.new_batch_write_builder()
+write = write_builder.new_write().with_write_type(['a', 'b', 'c'])
+commit = write_builder.new_commit()
+write.write_arrow(pa.Table.from_pydict({'a': [1, 2], 'b': [10, 20], 'c': [100, 200]}))
+commit.commit(write.prepare_commit())
+write.close()
+commit.close()
+
+# stream shard update: each round uses a new commit_identifier
+stream_builder = table.new_stream_write_builder()
+table_update = stream_builder.new_update()
+table_update.with_read_projection(['a', 'b', 'c'])
+table_update.with_update_type(['d'])
+table_commit = stream_builder.new_commit()
+
+upd = table_update.new_shard_updator(0, 1)
+reader = upd.arrow_reader()
+
+for batch in iter(reader.read_next_batch, None):
+    a = batch.column('a').to_pylist()
+    b = batch.column('b').to_pylist()
+    c = batch.column('c').to_pylist()
+    d = [ci + bi - ai for ai, bi, ci in zip(a, b, c)]
+
+    upd.update_by_arrow_batch(
+        pa.RecordBatch.from_pydict({'d': d}, schema=pa.schema([('d', pa.int32())]))
+    )
+
+commit_messages = upd.prepare_commit()
+table_commit.commit(commit_messages, commit_identifier=1)
 ```
 
 **Notes**

--- a/paimon-python/pypaimon/tests/data_evolution_test_helpers.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test_helpers.py
@@ -1,0 +1,269 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+"""Helpers shared between the test suites that exercise
+``StreamTableUpdate`` / ``BatchTableUpdate``
+(``table_update_test.py``, ``table_upsert_by_key_test.py``).
+
+Two distinct contracts are factored out here:
+
+1. :class:`DataEvolutionTestBase` — table lifecycle, schema, and helpers
+   common to every data-evolution table-modification test.
+2. :class:`BatchModeMixin` / :class:`StreamModeMixin` — the
+   write-builder-agnostic primitives that drive a test either through
+   ``BatchWriteBuilder`` or ``StreamWriteBuilder``. Each suite only has
+   to add its own one-line API-call primitive (e.g. ``_apply_update``).
+3. :class:`StreamSnapshotAssertions` — snapshot-level assertions plus
+   :meth:`StreamSnapshotAssertions._stream_commit_session` for opening a
+   reusable ``StreamWriteBuilder`` / ``StreamTableCommit`` pair (shared by
+   ``table_update_test`` / ``table_upsert_by_key_test`` stream-only cases).
+"""
+
+import itertools
+import os
+import shutil
+import tempfile
+import threading
+import uuid
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+
+
+# ======================================================================
+# Snapshot assertions for stream-mode tests
+# ======================================================================
+
+class StreamSnapshotAssertions:
+    """Mixin providing snapshot-level assertions for stream-mode tests.
+
+    Designed to be mixed into a :class:`StreamModeMixin` whose concrete test
+    classes also inherit from :class:`unittest.TestCase` (so ``self`` exposes
+    ``assertEqual``).
+
+    The single contract these assertions enforce is the one that
+    distinguishes stream mode from batch mode: every commit lands on its
+    own snapshot tagged with the caller-supplied ``commit_identifier``
+    under a stable ``commit_user``.
+
+    Tests that drive a single :class:`StreamWriteBuilder` should prefer
+    :meth:`_stream_commit_session` plus :meth:`_assert_stream_builder_snapshots`
+    over repeating ``new_stream_write_builder`` /
+    ``_latest_snapshot_id`` boilerplate.
+    """
+
+    @staticmethod
+    def _latest_snapshot_id(table) -> int:
+        """Latest snapshot id, or ``0`` for an empty table."""
+        latest = table.snapshot_manager().get_latest_snapshot()
+        return latest.id if latest is not None else 0
+
+    def _stream_commit_session(self, table):
+        """Open one ``StreamWriteBuilder`` + ``StreamTableCommit`` pair.
+
+        Returns ``(write_builder, commit, base_snapshot_id)``. Caller must
+        invoke ``commit.close()`` after finishing commits.
+        """
+        base_snapshot_id = self._latest_snapshot_id(table)
+        wb = table.new_stream_write_builder()
+        tc = wb.new_commit()
+        return wb, tc, base_snapshot_id
+
+    def _assert_snapshots_carry(
+            self, table, base_snapshot_id, commit_user, commit_identifiers,
+    ):
+        """Assert that the snapshots produced after ``base_snapshot_id`` are
+        tagged with the given ``commit_identifiers`` in order, all under
+        ``commit_user``.
+
+        Asserted snapshot-by-snapshot so failures pinpoint the exact
+        mismatching snapshot id.
+        """
+        snap_mgr = table.snapshot_manager()
+        for offset, expected_cid in enumerate(commit_identifiers, start=1):
+            snap_id = base_snapshot_id + offset
+            snap = snap_mgr.get_snapshot_by_id(snap_id)
+            self.assertEqual(
+                (commit_user, expected_cid),
+                (snap.commit_user, snap.commit_identifier),
+                msg=f"snapshot {snap_id}: expected "
+                    f"(user={commit_user!r}, identifier={expected_cid})",
+            )
+
+    def _assert_stream_builder_snapshots(
+            self, table, write_builder, base_snapshot_id, commit_identifiers,
+    ):
+        """Assert snapshots after ``base_snapshot_id`` carry
+        ``commit_identifiers`` in order under ``write_builder.commit_user``.
+
+        Convenience wrapper so stream tests do not repeat
+        ``write_builder.commit_user`` at every call site.
+        """
+        self._assert_snapshots_carry(
+            table,
+            base_snapshot_id,
+            write_builder.commit_user,
+            commit_identifiers,
+        )
+
+
+# ======================================================================
+# Shared test-class base
+# ======================================================================
+
+class DataEvolutionTestBase:
+    """Shared lifecycle, schema, and helpers for data-evolution
+    table-modification tests (update-by-row-id, upsert-by-key).
+
+    Concrete subclasses must also inherit from :class:`unittest.TestCase`
+    *and* one of :class:`BatchModeMixin` / :class:`StreamModeMixin`, which
+    provide the mode-specific write/commit primitives.
+    """
+
+    # The canonical 4-column schema used by both suites.
+    pa_schema = pa.schema([
+        ('id', pa.int32()),
+        ('name', pa.string()),
+        ('age', pa.int32()),
+        ('city', pa.string()),
+    ])
+
+    table_options = {
+        'row-tracking.enabled': 'true',
+        'data-evolution.enabled': 'true',
+    }
+
+    # ------------------------------------------------------------------
+    # Class-level fixtures
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({'warehouse': cls.warehouse})
+        cls.catalog.create_database('default', True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Common helpers
+    # ------------------------------------------------------------------
+
+    def _unique_name(self, prefix='tbl'):
+        return f'default.{prefix}_{uuid.uuid4().hex[:8]}'
+
+    def _create_table(self, pa_schema=None, partition_keys=None, options=None):
+        pa_schema = pa_schema if pa_schema is not None else self.pa_schema
+        opts = options if options is not None else self.table_options
+        s = Schema.from_pyarrow_schema(
+            pa_schema, partition_keys=partition_keys, options=opts
+        )
+        name = self._unique_name()
+        self.catalog.create_table(name, s, False)
+        return self.catalog.get_table(name)
+
+    def _write_arrow(self, table, data):
+        """Write a single Arrow table and commit as one snapshot."""
+        wb = self._make_write_builder(table)
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_arrow(data)
+        cid = self._next_commit_id()
+        msgs = self._prepare_write_commit(tw, cid)
+        self._apply_commit(tc, msgs, cid)
+        tw.close()
+        tc.close()
+
+    def _read_all(self, table):
+        rb = table.new_read_builder()
+        return rb.new_read().to_arrow(rb.new_scan().plan().splits())
+
+    # ------------------------------------------------------------------
+    # Mode-specific primitives (overridden by mixins)
+    # ------------------------------------------------------------------
+
+    def _make_write_builder(self, table):
+        raise NotImplementedError
+
+    def _next_commit_id(self):
+        """Next ``commit_identifier`` for stream mode, or ``None`` for batch."""
+        raise NotImplementedError
+
+    def _prepare_write_commit(self, table_write, cid):
+        """Invoke ``table_write.prepare_commit`` with the appropriate
+        signature for this mode (stream takes ``cid``; batch takes nothing)."""
+        raise NotImplementedError
+
+    def _apply_commit(self, commit, msgs, cid):
+        raise NotImplementedError
+
+
+# ======================================================================
+# Mode-specific mixins (write-builder + commit framework only)
+# ======================================================================
+
+class BatchModeMixin:
+    """Drive shared tests through ``BatchWriteBuilder``.
+
+    Each suite layers its own one-line API-call primitive on top
+    (e.g. ``_apply_update``, ``_apply_upsert``).
+    """
+
+    def _make_write_builder(self, table):
+        return table.new_batch_write_builder()
+
+    def _next_commit_id(self):
+        return None  # batch APIs do not take a commit_identifier
+
+    def _prepare_write_commit(self, table_write, cid):
+        return table_write.prepare_commit()
+
+    def _apply_commit(self, commit, msgs, cid):
+        commit.commit(msgs)
+
+
+class StreamModeMixin(StreamSnapshotAssertions):
+    """Drive shared tests through ``StreamWriteBuilder``.
+
+    Owns a thread-safe monotonically-increasing counter so concurrent
+    tests still get unique, well-ordered ``commit_identifier`` values.
+    Inherits the stream-mode snapshot assertions from
+    :class:`StreamSnapshotAssertions`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self._stream_id_counter = itertools.count(1)
+        self._stream_id_lock = threading.Lock()
+
+    def _make_write_builder(self, table):
+        return table.new_stream_write_builder()
+
+    def _next_commit_id(self):
+        with self._stream_id_lock:
+            return next(self._stream_id_counter)
+
+    def _prepare_write_commit(self, table_write, cid):
+        return table_write.prepare_commit(cid)
+
+    def _apply_commit(self, commit, msgs, cid):
+        commit.commit(msgs, cid)

--- a/paimon-python/pypaimon/tests/table_commit_test.py
+++ b/paimon-python/pypaimon/tests/table_commit_test.py
@@ -1,20 +1,21 @@
-"""
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 import unittest
 from unittest.mock import Mock
 

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -1,1123 +1,659 @@
-"""
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
-import os
-import shutil
-import tempfile
+import random
+import string
+import threading
 import unittest
 
 import pyarrow as pa
 
-from pypaimon import CatalogFactory, Schema
+from pypaimon.tests.data_evolution_test_helpers import (
+    BatchModeMixin,
+    DataEvolutionTestBase,
+    StreamModeMixin,
+)
 
 
-class TableUpdateTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.tempdir = tempfile.mkdtemp()
-        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
-        cls.catalog = CatalogFactory.create({
-            'warehouse': cls.warehouse
-        })
-        cls.catalog.create_database('default', True)
+# ======================================================================
+# Shared base for batch & stream table-update tests
+# ======================================================================
 
-        # Define table schema for testing
-        cls.pa_schema = pa.schema([
-            ('id', pa.int32()),
-            ('name', pa.string()),
-            ('age', pa.int32()),
-            ('city', pa.string()),
-        ])
+class _TableUpdateTestBase(DataEvolutionTestBase):
+    """Shared tests for ``TableUpdate.update_by_arrow_with_row_id``.
 
-        # Define options for data evolution
-        cls.table_options = {
-            'row-tracking.enabled': 'true',
-            'data-evolution.enabled': 'true'
-        }
+    Concrete subclasses must inherit from :class:`unittest.TestCase` AND one
+    of :class:`_BatchModeMixin` / :class:`_StreamModeMixin`, which add the
+    operation-specific primitive ``_apply_update(tu, data, cid)`` on top of
+    the framework primitives provided by
+    :class:`DataEvolutionTestBase`/:class:`BatchModeMixin`/:class:`StreamModeMixin`.
+    """
 
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tempdir, ignore_errors=True)
+    # ------------------------------------------------------------------
+    # Operation-specific primitive (overridden by mixins)
+    # ------------------------------------------------------------------
 
-    def _create_table(self):
-        """Helper method to create a table with initial data."""
-        # Generate unique table name for each test
-        import uuid
-        table_name = f'test_data_evolution_{uuid.uuid4().hex[:8]}'
-        schema = Schema.from_pyarrow_schema(self.pa_schema, options=self.table_options)
-        self.catalog.create_table(f'default.{table_name}', schema, False)
-        table = self.catalog.get_table(f'default.{table_name}')
+    def _apply_update(self, table_update, data, cid):
+        raise NotImplementedError
 
-        # Write batch-1
-        write_builder = table.new_batch_write_builder()
+    # ------------------------------------------------------------------
+    # Helpers built on the primitives
+    # ------------------------------------------------------------------
 
-        initial_data = pa.Table.from_pydict({
+    def _create_seeded_table(self, partition_keys=None):
+        """Create the canonical 5-row / 2-file table used by most tests.
+
+        Layout (row_id → row):
+            0: (1, Alice,   25, NYC)
+            1: (2, Bob,     30, LA)
+            2: (3, Charlie, 35, Chicago)
+            3: (4, David,   40, Houston)
+            4: (5, Eve,     45, Phoenix)
+        """
+        table = self._create_table(partition_keys=partition_keys)
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
-            'city': ['NYC', 'LA']
-        }, schema=self.pa_schema)
-
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(initial_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # Write batch-2
-        following_data = pa.Table.from_pydict({
+            'city': ['NYC', 'LA'],
+        }, schema=self.pa_schema))
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [3, 4, 5],
             'name': ['Charlie', 'David', 'Eve'],
             'age': [35, 40, 45],
-            'city': ['Chicago', 'Houston', 'Phoenix']
-        }, schema=self.pa_schema)
-
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(following_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
+            'city': ['Chicago', 'Houston', 'Phoenix'],
+        }, schema=self.pa_schema))
         return table
 
+    def _do_update(self, table, data, columns):
+        """End-to-end ``update_by_arrow_with_row_id`` + commit. Returns the
+        commit messages so callers can inspect produced files."""
+        wb = self._make_write_builder(table)
+        tu = wb.new_update().with_update_type(columns)
+        cid = self._next_commit_id()
+        msgs = self._apply_update(tu, data, cid)
+        tc = wb.new_commit()
+        self._apply_commit(tc, msgs, cid)
+        tc.close()
+        return msgs
+
+    # ==================================================================
+    # Shared tests (run under both batch and stream modes)
+    # ==================================================================
+
     def test_update_existing_column(self):
-        """Test updating an existing column using data evolution."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        batch_write = write_builder.new_write()
-
-        # Prepare update data (sorted by row_id)
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [1, 0, 2, 3, 4],
-            'age': [31, 26, 36, 39, 42]
-        })
-
-        # Update the age column
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-        batch_write.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that ages were updated for rows 0-2
-        ages = result['age'].to_pylist()
-        expected_ages = [26, 31, 36, 39, 42]
-        self.assertEqual(ages, expected_ages)
-
-    def test_update_multiple_columns(self):
-        """Test updating multiple columns at once."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        batch_write = write_builder.new_write()
-
-        # Prepare update data (sorted by row_id)
-        update_data = pa.Table.from_pydict({
+        """Update a single column across both files (row_ids unordered)."""
+        table = self._create_seeded_table()
+        self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': [1, 0, 2, 3, 4],
             'age': [31, 26, 36, 39, 42],
-            'city': ['Los Angeles', 'New York', 'Chicago', 'Phoenix', 'Houston']
-        })
+        }), ['age'])
+        self.assertEqual(
+            [26, 31, 36, 39, 42],
+            self._read_all(table)['age'].to_pylist(),
+        )
 
-        # Update multiple columns
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age', 'city'])
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
+    def test_update_multiple_columns(self):
+        """Update ``age`` + ``city`` together; other columns are untouched."""
+        table = self._create_seeded_table()
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [1, 0, 2, 3, 4],
+            'age': [31, 26, 36, 39, 42],
+            'city': ['Los Angeles', 'New York', 'Chicago', 'Phoenix', 'Houston'],
+        }), ['age', 'city'])
 
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-        batch_write.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that both age and city were updated for rows 0-2
-        ages = result['age'].to_pylist()
-        cities = result['city'].to_pylist()
-
-        expected_ages = [26, 31, 36, 39, 42]
-        expected_cities = ['New York', 'Los Angeles', 'Chicago', 'Phoenix', 'Houston']
-
-        self.assertEqual(ages, expected_ages)
-        self.assertEqual(cities, expected_cities)
-
-    def test_nonexistent_column(self):
-        """Test that updating a non-existent column raises an error."""
-        table = self._create_table()
-
-        # Try to update a non-existent column
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0, 1, 2, 3, 4],
-            'nonexistent_column': [100, 200, 300, 400, 500]
-        })
-
-        # Should raise ValueError
-        with self.assertRaises(ValueError) as context:
-            write_builder = table.new_batch_write_builder()
-            table_update = write_builder.new_update().with_update_type(['nonexistent_column'])
-            table_update.update_by_arrow_with_row_id(update_data)
-
-        self.assertIn('not in table schema', str(context.exception))
-
-    def test_missing_row_id_column(self):
-        """Test that missing row_id column raises an error."""
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        batch_write = write_builder.new_write()
-
-        # Prepare update data without row_id column
-        update_data = pa.Table.from_pydict({
-            'age': [26, 27, 28, 29, 30]
-        })
-
-        # Should raise ValueError
-        with self.assertRaises(ValueError) as context:
-            write_builder = table.new_batch_write_builder()
-            table_update = write_builder.new_update().with_update_type(['age'])
-            table_update.update_by_arrow_with_row_id(update_data)
-
-        self.assertIn("Input data must contain _ROW_ID column", str(context.exception))
-        batch_write.close()
+        result = self._read_all(table)
+        self.assertEqual([26, 31, 36, 39, 42], result['age'].to_pylist())
+        self.assertEqual(
+            ['New York', 'Los Angeles', 'Chicago', 'Phoenix', 'Houston'],
+            result['city'].to_pylist(),
+        )
 
     def test_partitioned_table_update(self):
-        """Test updating columns in a partitioned table."""
-        # Create partitioned table
-        schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['city'], options=self.table_options)
-        self.catalog.create_table('default.test_partitioned_evolution', schema, False)
-        table = self.catalog.get_table('default.test_partitioned_evolution')
-
-        # Write initial data
-        write_builder = table.new_batch_write_builder()
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-
-        initial_data = pa.Table.from_pydict({
+        """Updates work on a partitioned table the same as a flat one."""
+        table = self._create_table(partition_keys=['city'])
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2, 3, 4, 5],
             'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             'age': [25, 30, 35, 40, 45],
-            'city': ['NYC', 'NYC', 'LA', 'LA', 'Chicago']
-        }, schema=self.pa_schema)
+            'city': ['NYC', 'NYC', 'LA', 'LA', 'Chicago'],
+        }, schema=self.pa_schema))
 
-        table_write.write_arrow(initial_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Update ages
-        update_data = pa.Table.from_pydict({
+        self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': [1, 0, 2, 3, 4],
-            'age': [31, 26, 36, 41, 46]
-        })
+            'age': [31, 26, 36, 41, 46],
+        }), ['age'])
 
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check ages were updated
-        ages = result['age'].to_pylist()
-        expected_ages = [26, 31, 36, 41, 46]
-        self.assertEqual(ages, expected_ages)
-
-    def test_multiple_calls(self):
-        """Test multiple calls to update_columns, each updating a single column."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # First update: Update age column
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_age_data = pa.Table.from_pydict({
-            '_ROW_ID': [1, 0, 2, 3, 4],
-            'age': [31, 26, 36, 41, 46]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_age_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Second update: Update city column
-        update_city_data = pa.Table.from_pydict({
-            '_ROW_ID': [1, 0, 2, 3, 4],
-            'city': ['Los Angeles', 'New York', 'Chicago', 'Phoenix', 'Houston']
-        })
-        table_update.with_update_type(['city'])
-        commit_messages = table_update.update_by_arrow_with_row_id(update_city_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify both columns were updated correctly
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        ages = result['age'].to_pylist()
-        cities = result['city'].to_pylist()
-
-        expected_ages = [26, 31, 36, 41, 46]
-        expected_cities = ['New York', 'Los Angeles', 'Chicago', 'Phoenix', 'Houston']
-
-        self.assertEqual(ages, expected_ages, "Age column was not updated correctly")
-        self.assertEqual(cities, expected_cities, "City column was not updated correctly")
-
-    def test_update_partial_file(self):
-        """Test updating an existing column using data evolution."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        batch_write = write_builder.new_write()
-
-        # Prepare update data (sorted by row_id)
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [1],
-            'age': [31]
-        })
-
-        # Update the age column
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-        batch_write.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that ages were updated for rows 0-2
-        ages = result['age'].to_pylist()
-        expected_ages = [25, 31, 35, 40, 45]
-        self.assertEqual(ages, expected_ages)
-
-    def test_partial_rows_update_single_file(self):
-        """Test updating only some rows within a single file."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Update only row 0 in the first file (which contains rows 0-1)
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0],
-            'age': [100]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that only row 0 was updated, others remain unchanged
-        ages = result['age'].to_pylist()
-        expected_ages = [100, 30, 35, 40, 45]  # Only first row updated
-        self.assertEqual(ages, expected_ages)
-
-    def test_partial_rows_update_multiple_files(self):
-        """Test updating partial rows across multiple files."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Update row 1 from first file and row 2 from second file
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [1, 2],
-            'age': [200, 300]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that only specified rows were updated
-        ages = result['age'].to_pylist()
-        expected_ages = [25, 200, 300, 40, 45]  # Rows 1 and 2 updated
-        self.assertEqual(ages, expected_ages)
-
-    def test_partial_rows_non_consecutive(self):
-        """Test updating non-consecutive rows."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Update rows 0, 2, 4 (non-consecutive)
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0, 2, 4],
-            'age': [100, 300, 500]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that only specified rows were updated
-        ages = result['age'].to_pylist()
-        expected_ages = [100, 30, 300, 40, 500]  # Rows 0, 2, 4 updated
-        self.assertEqual(ages, expected_ages)
+        self.assertEqual(
+            [26, 31, 36, 41, 46],
+            self._read_all(table)['age'].to_pylist(),
+        )
 
     def test_update_preserves_other_columns(self):
-        """Test that updating one column preserves other columns."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Update only row 1
-        update_data = pa.Table.from_pydict({
+        """Updating ``age`` leaves all other columns untouched."""
+        table = self._create_seeded_table()
+        self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': [1],
-            'age': [999]
-        })
+            'age': [999],
+        }), ['age'])
 
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
+        result = self._read_all(table)
+        self.assertEqual([25, 999, 35, 40, 45], result['age'].to_pylist())
+        self.assertEqual(
+            ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            result['name'].to_pylist(),
+        )
+        self.assertEqual(
+            ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+            result['city'].to_pylist(),
+        )
 
-        # Commit the changes
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
+    def test_partial_row_updates(self):
+        """All partial-row patterns share one parameterised test."""
+        cases = [
+            # name, row_ids, ages, expected ages after update
+            ('single_first_file',  [0],       [100],            [100, 30,  35,  40, 45]),
+            ('single_second_file', [1],       [31],             [25,  31,  35,  40, 45]),
+            ('one_per_file',       [1, 2],    [200, 300],       [25,  200, 300, 40, 45]),
+            ('non_consecutive',    [0, 2, 4], [100, 300, 500],  [100, 30,  300, 40, 500]),
+        ]
+        for name, row_ids, ages, expected in cases:
+            with self.subTest(case=name):
+                table = self._create_seeded_table()
+                self._do_update(table, pa.Table.from_pydict({
+                    '_ROW_ID': row_ids,
+                    'age': ages,
+                }), ['age'])
+                self.assertEqual(
+                    expected,
+                    self._read_all(table)['age'].to_pylist(),
+                )
 
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
+    def test_multiple_sequential_single_column_updates(self):
+        """Two sequential updates on different single columns compose."""
+        table = self._create_seeded_table()
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [1, 0, 2, 3, 4],
+            'age': [31, 26, 36, 41, 46],
+        }), ['age'])
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [1, 0, 2, 3, 4],
+            'city': ['Los Angeles', 'New York', 'Chicago', 'Phoenix', 'Houston'],
+        }), ['city'])
 
-        # Check that age was updated for row 1
-        ages = result['age'].to_pylist()
-        expected_ages = [25, 999, 35, 40, 45]
-        self.assertEqual(ages, expected_ages)
-
-        # Check that other columns remain unchanged
-        names = result['name'].to_pylist()
-        expected_names = ['Alice', 'Bob', 'Charlie', 'David', 'Eve']
-        self.assertEqual(names, expected_names)
-
-        cities = result['city'].to_pylist()
-        expected_cities = ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix']
-        self.assertEqual(cities, expected_cities)
+        result = self._read_all(table)
+        self.assertEqual([26, 31, 36, 41, 46], result['age'].to_pylist())
+        self.assertEqual(
+            ['New York', 'Los Angeles', 'Chicago', 'Phoenix', 'Houston'],
+            result['city'].to_pylist(),
+        )
 
     def test_sequential_partial_updates(self):
-        """Test multiple sequential partial updates on the same table."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # First update: Update row 0
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_data_1 = pa.Table.from_pydict({
-            '_ROW_ID': [0],
-            'age': [100]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data_1)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Second update: Update row 2
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_data_2 = pa.Table.from_pydict({
-            '_ROW_ID': [2],
-            'age': [300]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data_2)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Third update: Update row 4
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_data_3 = pa.Table.from_pydict({
-            '_ROW_ID': [4],
-            'age': [500]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data_3)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the final data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Check that all updates were applied correctly
-        ages = result['age'].to_pylist()
-        expected_ages = [100, 30, 300, 40, 500]
-        self.assertEqual(expected_ages, ages)
-
-    def test_row_id_out_of_range(self):
-        """Test that row_id out of valid range raises an error."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Prepare update data with row_id out of range (table has 5 rows: 0-4)
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0, 10],  # 10 is out of range
-            'age': [26, 100]
-        })
-
-        # Should raise ValueError for row_id out of range
-        with self.assertRaises(ValueError) as context:
-            table_update.update_by_arrow_with_row_id(update_data)
-
-        self.assertIn("out of valid range", str(context.exception))
-
-    def test_negative_row_id(self):
-        """Test that negative row_id raises an error."""
-        # Create table with initial data
-        table = self._create_table()
-
-        # Create data evolution table update
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        # Prepare update data with negative row_id
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [-1, 0],
-            'age': [100, 26]
-        })
-
-        # Should raise ValueError for negative row_id
-        with self.assertRaises(ValueError) as context:
-            table_update.update_by_arrow_with_row_id(update_data)
-
-        self.assertIn("out of valid range", str(context.exception))
-
-    def test_duplicate_row_id(self):
-        """Test that duplicate _ROW_ID values raise an error."""
-        table = self._create_table()
-
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0, 0, 1],
-            'age': [100, 200, 300]
-        })
-
-        with self.assertRaises(ValueError) as context:
-            table_update.update_by_arrow_with_row_id(update_data)
-
-        self.assertIn("duplicate _ROW_ID values", str(context.exception))
-
-    def test_large_table_partial_column_updates(self):
-        """Test partial column updates on a large table with 4 columns.
-
-        This test covers:
-        1. Update first column (id), update 1 row, verify result
-        2. Update first and second columns (id, name), update 2 rows, verify result
-        3. Update second column (name), update 1 row, verify result
-        4. Update third column (age), verify result
-        """
-        import uuid
-
-        # Create table with 4 columns and 20 rows in 2 files
-        table_name = f'test_large_table_{uuid.uuid4().hex[:8]}'
-        schema = Schema.from_pyarrow_schema(self.pa_schema, options=self.table_options)
-        self.catalog.create_table(f'default.{table_name}', schema, False)
-        table = self.catalog.get_table(f'default.{table_name}')
-
-        # Write batch-1
-        num_row = 1000
-        write_builder = table.new_batch_write_builder()
-        batch1_data = pa.Table.from_pydict({
-            'id': list(range(num_row)),
-            'name': [f'Name_{i}' for i in range(num_row)],
-            'age': [20 + i for i in range(num_row)],
-            'city': [f'City_{i}' for i in range(num_row)]
-        }, schema=self.pa_schema)
-
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(batch1_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # Write batch-2
-        batch2_data = pa.Table.from_pydict({
-            'id': list(range(num_row, num_row * 2)),
-            'name': [f'Name_{i}' for i in range(num_row, num_row * 2)],
-            'age': [20 + num_row + i for i in range(num_row)],
-            'city': [f'City_{i}' for i in range(num_row, num_row * 2)]
-        }, schema=self.pa_schema)
-
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(batch2_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # --- Test 1: Update first column (id), update 1 row ---
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['id'])
-
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [5],
-            'id': [999]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify Test 1
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        ids = result['id'].to_pylist()
-        expected_ids = list(range(num_row * 2))
-        expected_ids[5] = 999
-        self.assertEqual(expected_ids, ids, "Test 1 failed: Update first column for 1 row")
-
-        # --- Test 2: Update first and second columns (id, name), update 2 rows ---
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['id', 'name'])
-
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [3, 15],
-            'id': [888, 777],
-            'name': ['Updated_Name_3', 'Updated_Name_15']
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify Test 2
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        ids = result['id'].to_pylist()
-        expected_ids[3] = 888
-        expected_ids[15] = 777
-        self.assertEqual(expected_ids, ids, "Test 2 failed: Update id column for 2 rows")
-
-        names = result['name'].to_pylist()
-        expected_names = [f'Name_{i}' for i in range(num_row * 2)]
-        expected_names[3] = 'Updated_Name_3'
-        expected_names[15] = 'Updated_Name_15'
-        self.assertEqual(expected_names, names, "Test 2 failed: Update name column for 2 rows")
-
-        # --- Test 3: Update second column (name), update 1 row ---
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['name'])
-
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [12],
-            'name': ['NewName_12']
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify Test 3
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        names = result['name'].to_pylist()
-        expected_names[12] = 'NewName_12'
-        self.assertEqual(expected_names, names, "Test 3 failed: Update name column for 1 row")
-
-        # --- Test 4: Update third column (age), update multiple rows across both files ---
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age'])
-
-        update_data = pa.Table.from_pydict({
-            '_ROW_ID': [0, 5, 10, 15],
-            'age': [100, 105, 110, 115]
-        })
-
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify Test 4
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        ages = result['age'].to_pylist()
-        expected_ages = [20 + i for i in range(num_row)] + [20 + num_row + i for i in range(num_row)]
-        expected_ages[0] = 100
-        expected_ages[5] = 105
-        expected_ages[10] = 110
-        expected_ages[15] = 115
-        self.assertEqual(expected_ages, ages, "Test 4 failed: Update age column for multiple rows")
-
-        # Verify other columns remain unchanged after all updates
-        cities = result['city'].to_pylist()
-        expected_cities = [f'City_{i}' for i in range(num_row * 2)]
-        self.assertEqual(expected_cities, cities, "City column should remain unchanged")
+        """Sequential single-row updates accumulate correctly."""
+        table = self._create_seeded_table()
+        for row_id, age in [(0, 100), (2, 300), (4, 500)]:
+            self._do_update(table, pa.Table.from_pydict({
+                '_ROW_ID': [row_id],
+                'age': [age],
+            }), ['age'])
+        self.assertEqual(
+            [100, 30, 300, 40, 500],
+            self._read_all(table)['age'].to_pylist(),
+        )
 
     def test_update_partial_rows_across_two_files(self):
-        """Test updating partial rows across two data files in a single update operation.
-
-        This test creates a table with 2 commits (2 data files), then performs a single update
-        that modifies partial rows from both files simultaneously.
-        """
-        import uuid
-
-        # Create table
-        table_name = f'test_two_files_{uuid.uuid4().hex[:8]}'
-        schema = Schema.from_pyarrow_schema(self.pa_schema, options=self.table_options)
-        self.catalog.create_table(f'default.{table_name}', schema, False)
-        table = self.catalog.get_table(f'default.{table_name}')
-
-        # Commit 1: Write first batch of data (row_id 0-4)
-        write_builder = table.new_batch_write_builder()
-        batch1_data = pa.Table.from_pydict({
+        """A single update modifies partial rows from both data files."""
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2, 3, 4, 5],
             'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             'age': [20, 25, 30, 35, 40],
-            'city': ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix']
-        }, schema=self.pa_schema)
-
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(batch1_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # Commit 2: Write second batch of data (row_id 5-9)
-        batch2_data = pa.Table.from_pydict({
+            'city': ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+        }, schema=self.pa_schema))
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [6, 7, 8, 9, 10],
             'name': ['Frank', 'Grace', 'Henry', 'Ivy', 'Jack'],
             'age': [45, 50, 55, 60, 65],
-            'city': ['Seattle', 'Boston', 'Denver', 'Miami', 'Atlanta']
-        }, schema=self.pa_schema)
+            'city': ['Seattle', 'Boston', 'Denver', 'Miami', 'Atlanta'],
+        }, schema=self.pa_schema))
 
-        table_write = write_builder.new_write()
-        table_commit = write_builder.new_commit()
-        table_write.write_arrow(batch2_data)
-        table_commit.commit(table_write.prepare_commit())
-        table_write.close()
-        table_commit.close()
-
-        # Single update: Update partial rows from both files
-        # Update rows 1, 3 from file 1 and rows 6, 8 from file 2
-        write_builder = table.new_batch_write_builder()
-        table_update = write_builder.new_update().with_update_type(['age', 'name'])
-
-        update_data = pa.Table.from_pydict({
+        self._do_update(table, pa.Table.from_pydict({
             '_ROW_ID': [1, 3, 6, 8],
             'age': [100, 200, 300, 400],
-            'name': ['Updated_Bob', 'Updated_David', 'Updated_Grace', 'Updated_Ivy']
-        })
+            'name': ['Updated_Bob', 'Updated_David', 'Updated_Grace', 'Updated_Ivy'],
+        }), ['age', 'name'])
 
-        commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-        table_commit = write_builder.new_commit()
-        table_commit.commit(commit_messages)
-        table_commit.close()
-
-        # Verify the updated data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        # Verify ages: rows 1, 3, 6, 8 should be updated
-        ages = result['age'].to_pylist()
-        expected_ages = [20, 100, 30, 200, 40, 45, 300, 55, 400, 65]
-        self.assertEqual(expected_ages, ages, "Ages not updated correctly across two files")
-
-        # Verify names: rows 1, 3, 6, 8 should be updated
-        names = result['name'].to_pylist()
-        expected_names = ['Alice', 'Updated_Bob', 'Charlie', 'Updated_David', 'Eve',
-                          'Frank', 'Updated_Grace', 'Henry', 'Updated_Ivy', 'Jack']
-        self.assertEqual(expected_names, names, "Names not updated correctly across two files")
-
-        # Verify other columns remain unchanged
-        ids = result['id'].to_pylist()
-        expected_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        self.assertEqual(expected_ids, ids, "IDs should remain unchanged")
-
-        cities = result['city'].to_pylist()
-        expected_cities = ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix',
-                           'Seattle', 'Boston', 'Denver', 'Miami', 'Atlanta']
-        self.assertEqual(expected_cities, cities, "Cities should remain unchanged")
-
-    def test_concurrent_updates_with_retry(self):
-        """Test data evolution with multiple threads performing concurrent updates.
-
-        Each thread updates different rows of the same column. If a conflict occurs,
-        the thread retries until the update succeeds. After all threads complete,
-        the final result is verified to ensure all updates were applied correctly.
-        """
-        import threading
-        table = self._create_table()
-
-        # Table has 5 rows (row_id 0-4) after _create_table:
-        #   row 0: age=25, row 1: age=30, row 2: age=35, row 3: age=40, row 4: age=45
-
-        # Thread 1 updates rows 0 and 1
-        # Thread 2 updates rows 2 and 3
-        # Thread 3 updates row 4
-        thread_updates = [
-            {'row_ids': [0, 1], 'ages': [100, 200]},
-            {'row_ids': [2, 3], 'ages': [300, 400]},
-            {'row_ids': [4], 'ages': [500]},
-        ]
-
-        errors = []
-        success_counts = [0] * len(thread_updates)
-
-        def update_worker(thread_index, update_spec):
-            max_retries = 20
-            for attempt in range(max_retries):
-                try:
-                    write_builder = table.new_batch_write_builder()
-                    table_update = write_builder.new_update().with_update_type(['age'])
-
-                    update_data = pa.Table.from_pydict({
-                        '_ROW_ID': update_spec['row_ids'],
-                        'age': update_spec['ages'],
-                    })
-
-                    commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-                    table_commit = write_builder.new_commit()
-                    table_commit.commit(commit_messages)
-                    table_commit.close()
-
-                    success_counts[thread_index] = attempt + 1
-                    return
-                except Exception as e:
-                    import traceback
-                    self.assertIn(
-                        "For Data Evolution table, multiple 'MERGE INTO' operations have encountered conflicts",
-                        str(e),
-                        "Thread-{} attempt {} unexpected error: {}\n{}".format(
-                            thread_index, attempt + 1, e, traceback.format_exc()
-                        )
-                    )
-                    if attempt == max_retries - 1:
-                        errors.append(
-                            "Thread-{} failed after {} retries: {}".format(
-                                thread_index, max_retries, e
-                            )
-                        )
-
-        threads = []
-        for idx, spec in enumerate(thread_updates):
-            thread = threading.Thread(target=update_worker, args=(idx, spec))
-            threads.append(thread)
-
-        for thread in threads:
-            thread.start()
-
-        for thread in threads:
-            thread.join(timeout=120)
-
-        if errors:
-            self.fail("Some threads failed:\n" + "\n".join(errors))
-
-        for idx, count in enumerate(success_counts):
-            self.assertGreater(
-                count, 0,
-                "Thread-{} did not succeed".format(idx)
-            )
-
-        # Verify the final data
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
-
-        ages = result['age'].to_pylist()
-        expected_ages = [100, 200, 300, 400, 500]
-        self.assertEqual(expected_ages, ages,
-                         "Concurrent updates did not produce correct final result")
-
-    def test_concurrent_updates_same_rows_with_retry(self):
-        """Test data evolution with multiple threads updating overlapping rows.
-
-        Multiple threads compete to update the same rows. Each thread retries
-        on conflict until success. The final result should reflect one of the
-        successful updates for each row (last-writer-wins).
-        """
-        import threading
-
-        table = self._create_table()
-
-        # All threads update the same rows but with different values
-        thread_updates = [
-            {'row_ids': [0, 1, 2], 'ages': [101, 201, 301], 'thread_name': 'A'},
-            {'row_ids': [0, 1, 2], 'ages': [102, 202, 302], 'thread_name': 'B'},
-            {'row_ids': [0, 1, 2], 'ages': [103, 203, 303], 'thread_name': 'C'},
-        ]
-
-        errors = []
-        completion_order = []
-        order_lock = threading.Lock()
-
-        def update_worker(thread_index, update_spec):
-            max_retries = 30
-            for attempt in range(max_retries):
-                try:
-                    write_builder = table.new_batch_write_builder()
-                    table_update = write_builder.new_update().with_update_type(['age'])
-
-                    update_data = pa.Table.from_pydict({
-                        '_ROW_ID': update_spec['row_ids'],
-                        'age': update_spec['ages'],
-                    })
-
-                    commit_messages = table_update.update_by_arrow_with_row_id(update_data)
-
-                    table_commit = write_builder.new_commit()
-                    table_commit.commit(commit_messages)
-                    table_commit.close()
-
-                    with order_lock:
-                        completion_order.append(thread_index)
-                    return
-                except Exception as e:
-                    import traceback
-                    self.assertIn(
-                        "For Data Evolution table, multiple 'MERGE INTO' operations have encountered conflicts",
-                        str(e),
-                        "Thread-{} attempt {} unexpected error: {}\n{}".format(
-                            thread_index, attempt + 1, e, traceback.format_exc()
-                        )
-                    )
-                    if attempt == max_retries - 1:
-                        errors.append(
-                            "Thread-{} ({}) failed after {} retries: {}".format(
-                                thread_index, update_spec['thread_name'],
-                                max_retries, e
-                            )
-                        )
-
-        threads = []
-        for idx, spec in enumerate(thread_updates):
-            thread = threading.Thread(target=update_worker, args=(idx, spec))
-            threads.append(thread)
-
-        for thread in threads:
-            thread.start()
-
-        for thread in threads:
-            thread.join(timeout=120)
-
-        if errors:
-            self.fail("Some threads failed:\n" + "\n".join(errors))
-
+        result = self._read_all(table)
         self.assertEqual(
-            len(completion_order), len(thread_updates),
-            "Not all threads completed successfully"
+            [20, 100, 30, 200, 40, 45, 300, 55, 400, 65],
+            result['age'].to_pylist(),
+        )
+        self.assertEqual(
+            ['Alice', 'Updated_Bob', 'Charlie', 'Updated_David', 'Eve',
+             'Frank', 'Updated_Grace', 'Henry', 'Updated_Ivy', 'Jack'],
+            result['name'].to_pylist(),
+        )
+        # Untouched columns
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                         result['id'].to_pylist())
+        self.assertEqual(
+            ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix',
+             'Seattle', 'Boston', 'Denver', 'Miami', 'Atlanta'],
+            result['city'].to_pylist(),
         )
 
-        # Verify the final data: the last thread to commit wins
-        read_builder = table.new_read_builder()
-        table_read = read_builder.new_read()
-        splits = read_builder.new_scan().plan().splits()
-        result = table_read.to_arrow(splits)
+    def test_large_table_partial_column_updates(self):
+        """4-step update sequence on a 2000-row / 2-file table.
 
-        ages = result['age'].to_pylist()
+        Covers: single-column / multi-column / both-files updates while
+        verifying that untouched columns stay intact.
+        """
+        num_row = 1000
+        table = self._create_table()
 
-        # The last thread to successfully commit determines rows 0-2
-        last_winner = completion_order[-1]
-        winner_ages = thread_updates[last_winner]['ages']
-        self.assertEqual(winner_ages[0], ages[0],
-                         "Row 0 should reflect last writer's value")
-        self.assertEqual(winner_ages[1], ages[1],
-                         "Row 1 should reflect last writer's value")
-        self.assertEqual(winner_ages[2], ages[2],
-                         "Row 2 should reflect last writer's value")
+        # 2 commits, num_row rows each
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': list(range(num_row)),
+            'name': [f'Name_{i}' for i in range(num_row)],
+            'age': [20 + i for i in range(num_row)],
+            'city': [f'City_{i}' for i in range(num_row)],
+        }, schema=self.pa_schema))
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': list(range(num_row, num_row * 2)),
+            'name': [f'Name_{i}' for i in range(num_row, num_row * 2)],
+            'age': [20 + num_row + i for i in range(num_row)],
+            'city': [f'City_{i}' for i in range(num_row, num_row * 2)],
+        }, schema=self.pa_schema))
 
-        # Rows 3 and 4 should remain unchanged
-        self.assertEqual(40, ages[3], "Row 3 should remain unchanged")
-        self.assertEqual(45, ages[4], "Row 4 should remain unchanged")
+        expected_ids = list(range(num_row * 2))
+        expected_names = [f'Name_{i}' for i in range(num_row * 2)]
+        expected_ages = ([20 + i for i in range(num_row)]
+                         + [20 + num_row + i for i in range(num_row)])
+
+        # 1) update id col, 1 row
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [5], 'id': [999],
+        }), ['id'])
+        expected_ids[5] = 999
+
+        # 2) update id+name cols, 2 rows
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [3, 15],
+            'id': [888, 777],
+            'name': ['Updated_Name_3', 'Updated_Name_15'],
+        }), ['id', 'name'])
+        expected_ids[3], expected_ids[15] = 888, 777
+        expected_names[3] = 'Updated_Name_3'
+        expected_names[15] = 'Updated_Name_15'
+
+        # 3) update name col, 1 row
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [12], 'name': ['NewName_12'],
+        }), ['name'])
+        expected_names[12] = 'NewName_12'
+
+        # 4) update age col, 4 rows across both files
+        self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [0, 5, 10, 15],
+            'age': [100, 105, 110, 115],
+        }), ['age'])
+        for r, a in [(0, 100), (5, 105), (10, 110), (15, 115)]:
+            expected_ages[r] = a
+
+        result = self._read_all(table)
+        self.assertEqual(expected_ids, result['id'].to_pylist())
+        self.assertEqual(expected_names, result['name'].to_pylist())
+        self.assertEqual(expected_ages, result['age'].to_pylist())
+        # city was never touched
+        self.assertEqual(
+            [f'City_{i}' for i in range(num_row * 2)],
+            result['city'].to_pylist(),
+        )
 
     def test_update_with_large_file(self):
-        import uuid
-        import random
-        import string
-
-        table_name = f'test_row_id_split_{uuid.uuid4().hex[:8]}'
-        schema = Schema.from_pyarrow_schema(
-            pa.schema([('id', pa.int64()), ('name', pa.string())]),
-            options={
-                'row-tracking.enabled': 'true',
-                'data-evolution.enabled': 'true',
-                'write-only': 'true',
-            }
-        )
-        self.catalog.create_table(
-            f'default.{table_name}', schema, False)
-        table = self.catalog.get_table(f'default.{table_name}')
+        """Even with a tiny ``target-file-size`` the update produces one
+        output file per first_row_id group (rolling is disabled internally)."""
+        from pypaimon.schema.schema_change import SetOption
 
         N = 5000
-        data = pa.table({
+        schema = pa.schema([('id', pa.int64()), ('name', pa.string())])
+        opts = {
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'write-only': 'true',
+        }
+        table = self._create_table(pa_schema=schema, options=opts)
+        table_identifier = table.identifier
+
+        self._write_arrow(table, pa.table({
             'id': list(range(N)),
-            'name': [
-                ''.join(random.choices(
-                    string.ascii_letters, k=200))
-                for _ in range(N)],
-        })
-        wb = table.new_batch_write_builder()
-        tw = wb.new_write()
-        tc = wb.new_commit()
-        tw.write_arrow(data)
-        tc.commit(tw.prepare_commit())
-        tw.close()
-        tc.close()
+            'name': [''.join(random.choices(string.ascii_letters, k=200))
+                     for _ in range(N)],
+        }))
 
-        from pypaimon.schema.schema_change import SetOption
         self.catalog.alter_table(
-            f'default.{table_name}',
-            [SetOption('target-file-size', '10kb')])
-        table = self.catalog.get_table(f'default.{table_name}')
+            table_identifier, [SetOption('target-file-size', '10kb')]
+        )
+        table = self.catalog.get_table(table_identifier)
 
-        wb = table.new_batch_write_builder()
-        updator = wb.new_update()
-        updator.with_update_type(['name'])
-        update_data = pa.table({
-            '_ROW_ID': pa.array(
-                list(range(N)), type=pa.int64()),
-            'name': [
-                ''.join(random.choices(
-                    string.ascii_letters, k=200))
-                for _ in range(N)],
+        msgs = self._do_update(table, pa.table({
+            '_ROW_ID': pa.array(list(range(N)), type=pa.int64()),
+            'name': [''.join(random.choices(string.ascii_letters, k=200))
+                     for _ in range(N)],
+        }), ['name'])
+
+        all_files = [f for m in msgs for f in m.new_files]
+        self.assertEqual(1, len(all_files),
+                         "Update should produce exactly one file per group")
+        self.assertEqual(0, all_files[0].first_row_id)
+        self.assertEqual(N, all_files[0].row_count)
+
+    # ------------------------------------------------------------------
+    # Validation tests
+    # ------------------------------------------------------------------
+
+    def test_nonexistent_column_raises(self):
+        table = self._create_seeded_table()
+        bad = pa.Table.from_pydict({
+            '_ROW_ID': [0, 1, 2, 3, 4],
+            'nonexistent_column': [100, 200, 300, 400, 500],
         })
-        msgs = updator.update_by_arrow_with_row_id(update_data)
+        with self.assertRaises(ValueError) as ctx:
+            wb = self._make_write_builder(table)
+            tu = wb.new_update().with_update_type(['nonexistent_column'])
+            self._apply_update(tu, bad, self._next_commit_id())
+        self.assertIn('not in table schema', str(ctx.exception))
 
-        all_files = []
-        for msg in msgs:
-            all_files.extend(msg.new_files)
+    def test_missing_row_id_column_raises(self):
+        table = self._create_seeded_table()
+        bad = pa.Table.from_pydict({'age': [26, 27, 28, 29, 30]})
+        with self.assertRaises(ValueError) as ctx:
+            wb = self._make_write_builder(table)
+            tu = wb.new_update().with_update_type(['age'])
+            self._apply_update(tu, bad, self._next_commit_id())
+        self.assertIn('_ROW_ID column', str(ctx.exception))
 
+    def test_invalid_row_id_raises(self):
+        """row_id outside [0, total_row_count) (both directions) raises."""
+        table = self._create_seeded_table()
+        cases = [
+            ('out_of_range_high', [0, 10], [26, 100]),
+            ('negative',          [-1, 0], [100, 26]),
+        ]
+        for name, row_ids, ages in cases:
+            with self.subTest(case=name):
+                wb = self._make_write_builder(table)
+                tu = wb.new_update().with_update_type(['age'])
+                bad = pa.Table.from_pydict({'_ROW_ID': row_ids, 'age': ages})
+                with self.assertRaises(ValueError) as ctx:
+                    self._apply_update(tu, bad, self._next_commit_id())
+                self.assertIn('out of valid range', str(ctx.exception))
+
+    def test_duplicate_row_id_raises(self):
+        table = self._create_seeded_table()
+        wb = self._make_write_builder(table)
+        tu = wb.new_update().with_update_type(['age'])
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_update(
+                tu,
+                pa.Table.from_pydict({
+                    '_ROW_ID': [0, 0, 1],
+                    'age': [100, 200, 300],
+                }),
+                self._next_commit_id(),
+            )
+        self.assertIn('duplicate _ROW_ID', str(ctx.exception))
+
+    # ------------------------------------------------------------------
+    # Concurrency tests
+    # ------------------------------------------------------------------
+
+    def _run_concurrent_updates(self, table, thread_specs, max_retries):
+        """Run a batch of concurrent updates with conflict-retry; return the
+        commit order (``thread_index`` of the winning commit appended last)."""
+        errors = []
+        completion_order = []
+        lock = threading.Lock()
+        retry_marker = (
+            "multiple 'MERGE INTO' operations have encountered conflicts"
+        )
+
+        def worker(idx, spec):
+            for _ in range(max_retries):
+                try:
+                    self._do_update(table, pa.Table.from_pydict({
+                        '_ROW_ID': spec['row_ids'],
+                        'age': spec['ages'],
+                    }), ['age'])
+                    with lock:
+                        completion_order.append(idx)
+                    return
+                except Exception as e:
+                    if retry_marker not in str(e):
+                        errors.append(f"Thread-{idx} unexpected error: {e}")
+                        return
+            errors.append(f"Thread-{idx} did not succeed in {max_retries} retries")
+
+        threads = [threading.Thread(target=worker, args=(i, s))
+                   for i, s in enumerate(thread_specs)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+
+        self.assertEqual([], errors)
+        self.assertEqual(len(thread_specs), len(completion_order),
+                         "Not all threads committed successfully")
+        return completion_order
+
+    def test_concurrent_updates_disjoint_rows(self):
+        """Disjoint per-thread updates all materialise into the final state."""
+        table = self._create_seeded_table()
+        specs = [
+            {'row_ids': [0, 1], 'ages': [100, 200]},
+            {'row_ids': [2, 3], 'ages': [300, 400]},
+            {'row_ids': [4],    'ages': [500]},
+        ]
+        self._run_concurrent_updates(table, specs, max_retries=20)
         self.assertEqual(
-            len(all_files), 1,
-            "Update should produce exactly one file per group")
-        self.assertEqual(all_files[0].first_row_id, 0)
-        self.assertEqual(all_files[0].row_count, N)
+            [100, 200, 300, 400, 500],
+            self._read_all(table)['age'].to_pylist(),
+        )
 
-        tc = wb.new_commit()
-        tc.commit(msgs)
+    def test_concurrent_updates_overlapping_rows_last_writer_wins(self):
+        """When threads compete on the same rows, the final commit wins."""
+        table = self._create_seeded_table()
+        specs = [
+            {'row_ids': [0, 1, 2], 'ages': [101, 201, 301]},
+            {'row_ids': [0, 1, 2], 'ages': [102, 202, 302]},
+            {'row_ids': [0, 1, 2], 'ages': [103, 203, 303]},
+        ]
+        completion_order = self._run_concurrent_updates(
+            table, specs, max_retries=30
+        )
+        winner = specs[completion_order[-1]]['ages']
+        ages = self._read_all(table)['age'].to_pylist()
+        self.assertEqual(winner, ages[:3])
+        # Rows 3 & 4 must remain at seed values
+        self.assertEqual([40, 45], ages[3:])
+
+
+# ======================================================================
+# Mode-specific mixins (add the ``update_by_arrow_with_row_id`` primitive)
+# ======================================================================
+
+class _BatchModeMixin(BatchModeMixin):
+    def _apply_update(self, table_update, data, cid):
+        return table_update.update_by_arrow_with_row_id(data)
+
+
+class _StreamModeMixin(StreamModeMixin):
+    def _apply_update(self, table_update, data, cid):
+        return table_update.update_by_arrow_with_row_id(data, cid)
+
+
+# ======================================================================
+# Concrete test classes
+# ======================================================================
+
+class TableUpdateBatchTest(_BatchModeMixin, _TableUpdateTestBase, unittest.TestCase):
+    """All shared update tests under batch (``BatchWriteBuilder``) semantics."""
+
+
+class TableUpdateStreamTest(_StreamModeMixin, _TableUpdateTestBase, unittest.TestCase):
+    """All shared update tests under stream (``StreamWriteBuilder``) semantics,
+    plus stream-only multi-commit scenarios that are impossible to express
+    under :class:`BatchTableCommit` (which forbids re-committing).
+    """
+
+    # ------------------------------------------------------------------
+    # Stream-only helpers
+    # ------------------------------------------------------------------
+
+    def _stream_commit_age_updates_by_row_id(self, tu, tc, commit_ids, row_age_pairs):
+        """Apply one ``age`` update per ``commit_id``; ``tu`` is already
+        ``with_update_type(['age'])``."""
+        for cid, (row_id, age) in zip(commit_ids, row_age_pairs):
+            msgs = tu.update_by_arrow_with_row_id(
+                pa.Table.from_pydict({'_ROW_ID': [row_id], 'age': [age]}),
+                cid,
+            )
+            tc.commit(msgs, cid)
+
+    # ------------------------------------------------------------------
+    # Stream-only tests
+    # ------------------------------------------------------------------
+
+    def test_stream_multi_commit_on_one_write_builder(self):
+        """A single ``StreamWriteBuilder`` drives many update+commit cycles
+        with reused ``tu`` and ``tc`` instances. Each commit produces its own
+        snapshot tagged with the caller-supplied ``commit_identifier`` under
+        a stable ``commit_user`` — the core contract distinguishing stream
+        from batch mode.
+
+        Parameterised over both contiguous and sparse identifier sequences
+        to catch any accidental coupling between ``commit_identifier`` and
+        ``snapshot_id`` ordering.
+        """
+        # (row_id, age) for each of the 3 commits — same triplet for both runs.
+        per_commit_rows = [(0, 100), (2, 300), (4, 500)]
+        expected_ages = [100, 30, 300, 40, 500]
+
+        for case_name, commit_ids in [
+            ('contiguous', [1, 2, 3]),
+            ('sparse',     [42, 100, 1000]),
+        ]:
+            with self.subTest(case=case_name):
+                table = self._create_seeded_table()
+                wb, tc, base_snapshot_id = self._stream_commit_session(table)
+                tu = wb.new_update().with_update_type(['age'])
+                self._stream_commit_age_updates_by_row_id(
+                    tu, tc, commit_ids, per_commit_rows,
+                )
+                tc.close()
+
+                result = self._read_all(table)
+                self.assertEqual(expected_ages, result['age'].to_pylist())
+                self.assertEqual([1, 2, 3, 4, 5], result['id'].to_pylist())
+                self.assertEqual(
+                    ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+                    result['name'].to_pylist(),
+                )
+                self.assertEqual(
+                    ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+                    result['city'].to_pylist(),
+                )
+                self._assert_stream_builder_snapshots(
+                    table, wb, base_snapshot_id, commit_ids,
+                )
+
+    def test_stream_commit_instance_accepts_messages_from_different_updates(self):
+        """``StreamTableCommit`` may be committed many times, and each
+        commit may carry messages from a *different* ``StreamTableUpdate``
+        instance (different ``update_cols``). The one-shot restriction
+        that applies to :class:`BatchTableCommit` does not apply here.
+        """
+        table = self._create_seeded_table()
+        wb, tc, base_snapshot_id = self._stream_commit_session(table)
+
+        # First update: only 'age' projection, fresh tu.
+        tu1 = wb.new_update().with_update_type(['age'])
+        msgs1 = tu1.update_by_arrow_with_row_id(
+            pa.Table.from_pydict({'_ROW_ID': [0], 'age': [111]}), 1,
+        )
+        tc.commit(msgs1, 1)
+
+        # Second update: different 'city' projection, fresh tu, same tc.
+        tu2 = wb.new_update().with_update_type(['city'])
+        msgs2 = tu2.update_by_arrow_with_row_id(
+            pa.Table.from_pydict({'_ROW_ID': [0], 'city': ['Beijing']}), 2,
+        )
+        tc.commit(msgs2, 2)
         tc.close()
+
+        result = self._read_all(table)
+        self.assertEqual([111, 30, 35, 40, 45], result['age'].to_pylist())
+        self.assertEqual(
+            ['Beijing', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+            result['city'].to_pylist(),
+        )
+        self.assertEqual([1, 2, 3, 4, 5], result['id'].to_pylist())
+        self.assertEqual(
+            ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            result['name'].to_pylist(),
+        )
+        self._assert_stream_builder_snapshots(
+            table, wb, base_snapshot_id, [1, 2],
+        )
+
+    def test_stream_interleaved_write_and_update_on_same_builder(self):
+        """A single stream builder may perform an initial write followed by
+        an update on the same ``tc``, each tagged with its own
+        ``commit_identifier`` that propagates to its own snapshot.
+        """
+        table = self._create_table()
+        wb, tc, base_snapshot_id = self._stream_commit_session(table)
+        tw = wb.new_write()
+
+        tw.write_arrow(pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['A', 'B', 'C'],
+            'age': [10, 20, 30],
+            'city': ['X', 'Y', 'Z'],
+        }, schema=self.pa_schema))
+        tc.commit(tw.prepare_commit(1), 1)
+        tw.close()
+
+        tu = wb.new_update().with_update_type(['age'])
+        msgs = tu.update_by_arrow_with_row_id(
+            pa.Table.from_pydict({'_ROW_ID': [0, 2], 'age': [111, 333]}), 2,
+        )
+        tc.commit(msgs, 2)
+        tc.close()
+
+        result = self._read_all(table)
+        self.assertEqual([111, 20, 333], result['age'].to_pylist())
+        self.assertEqual([1, 2, 3], result['id'].to_pylist())
+        self.assertEqual(['A', 'B', 'C'], result['name'].to_pylist())
+        self.assertEqual(['X', 'Y', 'Z'], result['city'].to_pylist())
+        self._assert_stream_builder_snapshots(
+            table, wb, base_snapshot_id, [1, 2],
+        )
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/table_upsert_by_key_test.py
+++ b/paimon-python/pypaimon/tests/table_upsert_by_key_test.py
@@ -1,122 +1,84 @@
-"""
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
-import os
-import shutil
-import tempfile
 import unittest
-import uuid
 
 import pyarrow as pa
 
-from pypaimon import CatalogFactory, Schema
+from pypaimon.tests.data_evolution_test_helpers import (
+    BatchModeMixin,
+    DataEvolutionTestBase,
+    StreamModeMixin,
+)
 
 
-class TableUpsertByKeyTest(unittest.TestCase):
-    """Tests for TableUpsertByKey (upsert_by_arrow_with_key)."""
+# ======================================================================
+# Shared base for batch & stream upsert-by-key tests
+# ======================================================================
 
-    @classmethod
-    def setUpClass(cls):
-        cls.tempdir = tempfile.mkdtemp()
-        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
-        cls.catalog = CatalogFactory.create({
-            'warehouse': cls.warehouse
-        })
-        cls.catalog.create_database('default', True)
+class _TableUpsertByKeyTestBase(DataEvolutionTestBase):
+    """Shared tests for ``TableUpdate.upsert_by_arrow_with_key``.
 
-        # Schema for non-partitioned table
-        cls.pa_schema = pa.schema([
-            ('id', pa.int32()),
-            ('name', pa.string()),
-            ('age', pa.int32()),
-            ('city', pa.string()),
-        ])
+    Concrete subclasses must inherit from :class:`unittest.TestCase` AND one
+    of :class:`_BatchModeMixin` / :class:`_StreamModeMixin`, which add the
+    operation-specific primitive ``_apply_upsert(tu, data, upsert_keys, cid)``
+    on top of the framework primitives provided by
+    :class:`DataEvolutionTestBase`/:class:`BatchModeMixin`/:class:`StreamModeMixin`.
+    """
 
-        # Schema for partitioned table
-        cls.partitioned_pa_schema = pa.schema([
-            ('id', pa.int32()),
-            ('name', pa.string()),
-            ('age', pa.int32()),
-            ('region', pa.string()),
-        ])
-
-        cls.table_options = {
-            'row-tracking.enabled': 'true',
-            'data-evolution.enabled': 'true',
-        }
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tempdir, ignore_errors=True)
+    # Partitioned variant of the base schema (city → region).
+    partitioned_pa_schema = pa.schema([
+        ('id', pa.int32()),
+        ('name', pa.string()),
+        ('age', pa.int32()),
+        ('region', pa.string()),
+    ])
 
     # ------------------------------------------------------------------
-    # helpers
+    # Operation-specific primitive (overridden by mixins)
     # ------------------------------------------------------------------
 
-    def _unique_name(self, prefix='upsert'):
-        return f'default.{prefix}_{uuid.uuid4().hex[:8]}'
+    def _apply_upsert(self, table_update, data, upsert_keys, cid):
+        raise NotImplementedError
 
-    def _create_table(self, pa_schema=None, partition_keys=None):
-        """Create a table and return the table object."""
-        pa_schema = pa_schema or self.pa_schema
-        name = self._unique_name()
-        if partition_keys:
-            schema = Schema.from_pyarrow_schema(
-                pa_schema, partition_keys=partition_keys, options=self.table_options
-            )
-        else:
-            schema = Schema.from_pyarrow_schema(pa_schema, options=self.table_options)
-        self.catalog.create_table(name, schema, False)
-        return self.catalog.get_table(name)
-
-    def _write(self, table, data):
-        """Write an Arrow table and commit."""
-        wb = table.new_batch_write_builder()
-        tw = wb.new_write()
-        tc = wb.new_commit()
-        tw.write_arrow(data)
-        tc.commit(tw.prepare_commit())
-        tw.close()
-        tc.close()
-
-    def _read_all(self, table):
-        """Read the full table and return as Arrow table."""
-        rb = table.new_read_builder()
-        tr = rb.new_read()
-        splits = rb.new_scan().plan().splits()
-        return tr.to_arrow(splits)
+    # ------------------------------------------------------------------
+    # Helpers built on the primitives
+    # ------------------------------------------------------------------
 
     def _upsert(self, table, data, upsert_keys, update_cols=None):
-        """Run upsert_by_arrow_with_key and commit."""
-        wb = table.new_batch_write_builder()
+        """End-to-end upsert + commit."""
+        wb = self._make_write_builder(table)
         tu = wb.new_update()
         if update_cols:
             tu.with_update_type(update_cols)
-        msgs = tu.upsert_by_arrow_with_key(data, upsert_keys)
+        cid = self._next_commit_id()
+        msgs = self._apply_upsert(tu, data, upsert_keys, cid)
         tc = wb.new_commit()
-        tc.commit(msgs)
+        self._apply_commit(tc, msgs, cid)
         tc.close()
+        return msgs
 
     # ==================================================================
     # Basic upsert tests (non-partitioned)
     # ==================================================================
 
     def test_all_new_rows(self):
-        """Upsert into an empty table – every row is new."""
+        """Upsert into an empty table – every row is appended."""
         table = self._create_table()
         data = pa.Table.from_pydict({
             'id': [1, 2, 3],
@@ -128,140 +90,95 @@ class TableUpsertByKeyTest(unittest.TestCase):
         self._upsert(table, data, upsert_keys=['id'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 3)
-        self.assertEqual(sorted(result['id'].to_pylist()), [1, 2, 3])
+        self.assertEqual(3, result.num_rows)
+        self.assertEqual([1, 2, 3], sorted(result['id'].to_pylist()))
 
     def test_all_matched_rows(self):
-        """Upsert where every row matches an existing key – pure update."""
+        """Upsert where every row matches existing keys – pure update path."""
         table = self._create_table()
-        initial = pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Carol'],
             'age': [25, 30, 35],
             'city': ['NYC', 'LA', 'Chicago'],
-        }, schema=self.pa_schema)
-        self._write(table, initial)
+        }, schema=self.pa_schema))
 
-        update = pa.Table.from_pydict({
+        self._upsert(table, pa.Table.from_pydict({
             'id': [1, 2, 3],
             'name': ['Alice2', 'Bob2', 'Carol2'],
             'age': [26, 31, 36],
             'city': ['NYC2', 'LA2', 'Chicago2'],
-        }, schema=self.pa_schema)
-        self._upsert(table, update, upsert_keys=['id'])
+        }, schema=self.pa_schema), upsert_keys=['id'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 3)
+        self.assertEqual(3, result.num_rows)
         names = sorted(zip(result['id'].to_pylist(), result['name'].to_pylist()))
-        self.assertEqual(names, [(1, 'Alice2'), (2, 'Bob2'), (3, 'Carol2')])
+        self.assertEqual([(1, 'Alice2'), (2, 'Bob2'), (3, 'Carol2')], names)
 
     def test_mixed_update_and_append(self):
-        """Upsert where some rows match and some are new."""
+        """Upsert with some matched + some new rows."""
         table = self._create_table()
-        initial = pa.Table.from_pydict({
-            'id': [1, 2],
-            'name': ['Alice', 'Bob'],
-            'age': [25, 30],
-            'city': ['NYC', 'LA'],
-        }, schema=self.pa_schema)
-        self._write(table, initial)
-
-        upsert_data = pa.Table.from_pydict({
-            'id': [2, 3],
-            'name': ['Bob_new', 'Carol'],
-            'age': [31, 35],
-            'city': ['LA_new', 'Chicago'],
-        }, schema=self.pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, 3)
-        rows = sorted(
-            zip(result['id'].to_pylist(), result['name'].to_pylist()),
-            key=lambda x: x[0],
-        )
-        self.assertEqual(rows, [(1, 'Alice'), (2, 'Bob_new'), (3, 'Carol')])
-
-    def test_upsert_preserves_untouched_columns(self):
-        """Columns not listed in update_cols remain unchanged after upsert."""
-        table = self._create_table()
-        initial = pa.Table.from_pydict({
-            'id': [1, 2],
-            'name': ['Alice', 'Bob'],
-            'age': [25, 30],
-            'city': ['NYC', 'LA'],
-        }, schema=self.pa_schema)
-        self._write(table, initial)
-
-        # Only update 'age' for matched row (id=1)
-        upsert_data = pa.Table.from_pydict({
-            'id': [1],
-            'name': ['_ignored_'],
-            'age': [99],
-            'city': ['_ignored_'],
-        }, schema=self.pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'], update_cols=['age'])
-
-        result = self._read_all(table)
-        row = {k: result[k].to_pylist() for k in result.column_names}
-        idx = row['id'].index(1)
-        self.assertEqual(row['age'][idx], 99)
-        self.assertEqual(row['name'][idx], 'Alice')  # unchanged
-        self.assertEqual(row['city'][idx], 'NYC')  # unchanged
-
-    # ==================================================================
-    # Composite key tests
-    # ==================================================================
-
-    def test_composite_key_upsert(self):
-        """Upsert using two columns as composite key."""
-        table = self._create_table()
-        initial = pa.Table.from_pydict({
-            'id': [1, 1, 2],
-            'name': ['Alice', 'Alice', 'Bob'],
-            'age': [25, 30, 35],
-            'city': ['NYC', 'LA', 'Chicago'],
-        }, schema=self.pa_schema)
-        self._write(table, initial)
-
-        # (id=1, name='Alice') matches two existing rows with different cities;
-        # since keys contain (id, name) the match is unique per key column combo.
-        # But our data has (1, 'Alice') twice in initial → validation should still
-        # pass because we check input data, not table data.
-        upsert_data = pa.Table.from_pydict({
-            'id': [1, 2],
-            'name': ['Alice', 'Carol'],
-            'age': [99, 40],
-            'city': ['Updated', 'Dallas'],
-        }, schema=self.pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id', 'name'])
-
-        result = self._read_all(table)
-        # 3 original + 1 new (2, Carol) = 4 rows; (1, Alice) matched the first occurrence
-        self.assertEqual(result.num_rows, 4)
-        ids = sorted(zip(
-            result['id'].to_pylist(),
-            result['name'].to_pylist(),
-            result['city'].to_pylist(),
-        ))
-        # (1,'Alice','LA') row should remain; (1,'Alice','NYC')-keyed row updated; (2,'Bob') unchanged; (2,'Carol') new
-        self.assertIn((2, 'Carol', 'Dallas'), ids)
-
-    # ==================================================================
-    # Sequential upsert tests
-    # ==================================================================
-
-    def test_sequential_upserts(self):
-        """Two sequential upserts: second upsert sees results of the first."""
-        table = self._create_table()
-        self._write(table, pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
             'city': ['NYC', 'LA'],
         }, schema=self.pa_schema))
 
-        # First upsert: update id=1, add id=3
+        self._upsert(table, pa.Table.from_pydict({
+            'id': [2, 3],
+            'name': ['Bob_new', 'Carol'],
+            'age': [31, 35],
+            'city': ['LA_new', 'Chicago'],
+        }, schema=self.pa_schema), upsert_keys=['id'])
+
+        result = self._read_all(table)
+        self.assertEqual(3, result.num_rows)
+        rows = sorted(
+            zip(result['id'].to_pylist(), result['name'].to_pylist()),
+            key=lambda x: x[0],
+        )
+        self.assertEqual([(1, 'Alice'), (2, 'Bob_new'), (3, 'Carol')], rows)
+
+    def test_composite_key_upsert(self):
+        """Upsert with a multi-column composite key."""
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 1, 2],
+            'name': ['Alice', 'Alice', 'Bob'],
+            'age': [25, 30, 35],
+            'city': ['NYC', 'LA', 'Chicago'],
+        }, schema=self.pa_schema))
+
+        # (id, name) = (1, Alice) appears twice in the table → matches the
+        # first occurrence; (2, Carol) is new.
+        self._upsert(table, pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['Alice', 'Carol'],
+            'age': [99, 40],
+            'city': ['Updated', 'Dallas'],
+        }, schema=self.pa_schema), upsert_keys=['id', 'name'])
+
+        result = self._read_all(table)
+        self.assertEqual(4, result.num_rows)
+        rows = sorted(zip(
+            result['id'].to_pylist(),
+            result['name'].to_pylist(),
+            result['city'].to_pylist(),
+        ))
+        self.assertIn((2, 'Carol', 'Dallas'), rows)
+
+    def test_sequential_upserts(self):
+        """A second upsert sees the rows inserted by the first."""
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['Alice', 'Bob'],
+            'age': [25, 30],
+            'city': ['NYC', 'LA'],
+        }, schema=self.pa_schema))
+
+        # First upsert: update id=1, insert id=3
         self._upsert(table, pa.Table.from_pydict({
             'id': [1, 3],
             'name': ['Alice_v2', 'Carol'],
@@ -269,7 +186,7 @@ class TableUpsertByKeyTest(unittest.TestCase):
             'city': ['NYC', 'Chicago'],
         }, schema=self.pa_schema), upsert_keys=['id'])
 
-        # Second upsert: update id=3 (just inserted), add id=4
+        # Second upsert: update id=3 (just inserted), insert id=4
         self._upsert(table, pa.Table.from_pydict({
             'id': [3, 4],
             'name': ['Carol_v2', 'Dave'],
@@ -278,81 +195,146 @@ class TableUpsertByKeyTest(unittest.TestCase):
         }, schema=self.pa_schema), upsert_keys=['id'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 4)
-        rows = {r: v for r, v in zip(result['id'].to_pylist(), result['name'].to_pylist())}
-        self.assertEqual(rows[1], 'Alice_v2')
-        self.assertEqual(rows[3], 'Carol_v2')
-        self.assertEqual(rows[4], 'Dave')
+        self.assertEqual(4, result.num_rows)
+        rows = {r: v for r, v in zip(
+            result['id'].to_pylist(), result['name'].to_pylist()
+        )}
+        self.assertEqual('Alice_v2', rows[1])
+        self.assertEqual('Carol_v2', rows[3])
+        self.assertEqual('Dave',     rows[4])
+
+    def test_upsert_across_multiple_data_files(self):
+        """Upsert hits rows that live in different snapshots/files."""
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['Alice', 'Bob'],
+            'age': [25, 30],
+            'city': ['NYC', 'LA'],
+        }, schema=self.pa_schema))
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [3, 4],
+            'name': ['Carol', 'Dave'],
+            'age': [35, 40],
+            'city': ['Chicago', 'Houston'],
+        }, schema=self.pa_schema))
+
+        self._upsert(table, pa.Table.from_pydict({
+            'id': [2, 3, 5],
+            'name': ['Bob_v2', 'Carol_v2', 'Eve'],
+            'age': [31, 36, 45],
+            'city': ['LA2', 'Chicago2', 'Phoenix'],
+        }, schema=self.pa_schema), upsert_keys=['id'])
+
+        result = self._read_all(table)
+        self.assertEqual(5, result.num_rows)
+        rows = {r: v for r, v in zip(
+            result['id'].to_pylist(), result['name'].to_pylist()
+        )}
+        self.assertEqual('Alice',    rows[1])
+        self.assertEqual('Bob_v2',   rows[2])
+        self.assertEqual('Carol_v2', rows[3])
+        self.assertEqual('Dave',     rows[4])
+        self.assertEqual('Eve',      rows[5])
+
+    def test_large_table_upsert(self):
+        """Upsert that touches a wide selection of rows in a 200-row table."""
+        table = self._create_table()
+        n = 200
+
+        for half in (0, 1):
+            rng = range(half * n // 2, (half + 1) * n // 2)
+            self._write_arrow(table, pa.Table.from_pydict({
+                'id':   list(rng),
+                'name': [f'Name_{i}' for i in rng],
+                'age':  [20 + i for i in rng],
+                'city': [f'City_{i}' for i in rng],
+            }, schema=self.pa_schema))
+
+        update_ids = list(range(0, n, 10))
+        new_ids = list(range(n, n + 10))
+        all_ids = update_ids + new_ids
+
+        self._upsert(table, pa.Table.from_pydict({
+            'id':   all_ids,
+            'name': [f'Upserted_{i}' for i in all_ids],
+            'age':  [1000 + i for i in all_ids],
+            'city': [f'UCity_{i}' for i in all_ids],
+        }, schema=self.pa_schema), upsert_keys=['id'])
+
+        result = self._read_all(table)
+        self.assertEqual(n + 10, result.num_rows)
+
+        m = {r: nm for r, nm in zip(
+            result['id'].to_pylist(), result['name'].to_pylist()
+        )}
+        for uid in update_ids:
+            self.assertEqual(f'Upserted_{uid}', m[uid])
+        for nid in new_ids:
+            self.assertEqual(f'Upserted_{nid}', m[nid])
+        for i in range(n):
+            if i not in update_ids:
+                self.assertEqual(f'Name_{i}', m[i])
 
     # ==================================================================
     # Partitioned table tests
     # ==================================================================
 
     def test_partitioned_table_upsert(self):
-        """Upsert on a partitioned table with data in multiple partitions."""
+        """Upsert touching multiple partitions: match in each + 1 new row."""
         table = self._create_table(
             pa_schema=self.partitioned_pa_schema,
             partition_keys=['region'],
         )
-
-        # Write initial data across two partitions
-        initial = pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2, 3, 4],
             'name': ['Alice', 'Bob', 'Carol', 'Dave'],
             'age': [25, 30, 35, 40],
             'region': ['US', 'US', 'EU', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._write(table, initial)
+        }, schema=self.partitioned_pa_schema))
 
-        # Upsert: update one row per partition, add one new
-        upsert_data = pa.Table.from_pydict({
+        # Partition key 'region' is auto-stripped from upsert keys
+        self._upsert(table, pa.Table.from_pydict({
             'id': [1, 3, 5],
             'name': ['Alice_v2', 'Carol_v2', 'Eve'],
             'age': [26, 36, 45],
             'region': ['US', 'EU', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        # upsert_keys=['id'] only – partition key 'region' is auto-stripped
-        self._upsert(table, upsert_data, upsert_keys=['id'])
+        }, schema=self.partitioned_pa_schema), upsert_keys=['id'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 5)
+        self.assertEqual(5, result.num_rows)
         rows = sorted(zip(
             result['id'].to_pylist(),
             result['name'].to_pylist(),
             result['region'].to_pylist(),
         ))
-        self.assertIn((1, 'Alice_v2', 'US'), rows)
-        self.assertIn((2, 'Bob', 'US'), rows)
-        self.assertIn((3, 'Carol_v2', 'EU'), rows)
-        self.assertIn((4, 'Dave', 'EU'), rows)
-        self.assertIn((5, 'Eve', 'EU'), rows)
+        for expected in [(1, 'Alice_v2', 'US'), (2, 'Bob', 'US'),
+                         (3, 'Carol_v2', 'EU'), (4, 'Dave', 'EU'),
+                         (5, 'Eve', 'EU')]:
+            self.assertIn(expected, rows)
 
-    def test_partitioned_upsert_single_partition(self):
-        """Upsert targeting only one partition does not affect the other."""
+    def test_partitioned_upsert_single_partition_leaves_others_unchanged(self):
+        """Touching only one partition does not affect any other partition."""
         table = self._create_table(
             pa_schema=self.partitioned_pa_schema,
             partition_keys=['region'],
         )
-
-        initial = pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2, 3],
             'name': ['Alice', 'Bob', 'Carol'],
             'age': [25, 30, 35],
             'region': ['US', 'US', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._write(table, initial)
+        }, schema=self.partitioned_pa_schema))
 
-        # Only touch US partition
-        upsert_data = pa.Table.from_pydict({
+        self._upsert(table, pa.Table.from_pydict({
             'id': [1, 4],
             'name': ['Alice_v2', 'Dave'],
             'age': [26, 40],
             'region': ['US', 'US'],
-        }, schema=self.partitioned_pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'])
+        }, schema=self.partitioned_pa_schema), upsert_keys=['id'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 4)
+        self.assertEqual(4, result.num_rows)
         eu_rows = [
             (i, n) for i, n, r in zip(
                 result['id'].to_pylist(),
@@ -360,314 +342,121 @@ class TableUpsertByKeyTest(unittest.TestCase):
                 result['region'].to_pylist(),
             ) if r == 'EU'
         ]
-        # EU partition unchanged
-        self.assertEqual(eu_rows, [(3, 'Carol')])
+        self.assertEqual([(3, 'Carol')], eu_rows)
 
     def test_partitioned_all_new_rows(self):
-        """Upsert into an empty partitioned table – all new."""
+        """Upsert into an empty partitioned table – pure append per partition."""
         table = self._create_table(
             pa_schema=self.partitioned_pa_schema,
             partition_keys=['region'],
         )
-
-        data = pa.Table.from_pydict({
+        self._upsert(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
             'region': ['US', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._upsert(table, data, upsert_keys=['id'])
+        }, schema=self.partitioned_pa_schema), upsert_keys=['id'])
 
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, 2)
+        self.assertEqual(2, self._read_all(table).num_rows)
 
-    # ==================================================================
-    # Multiple data files
-    # ==================================================================
-
-    def test_upsert_across_multiple_data_files(self):
-        """Upsert matches rows that live in different data files (commits)."""
-        table = self._create_table()
-        # First commit
-        self._write(table, pa.Table.from_pydict({
-            'id': [1, 2],
-            'name': ['Alice', 'Bob'],
-            'age': [25, 30],
-            'city': ['NYC', 'LA'],
-        }, schema=self.pa_schema))
-        # Second commit
-        self._write(table, pa.Table.from_pydict({
-            'id': [3, 4],
-            'name': ['Carol', 'Dave'],
-            'age': [35, 40],
-            'city': ['Chicago', 'Houston'],
-        }, schema=self.pa_schema))
-
-        # Upsert hits both files: update id=2 (file1) and id=3 (file2), add id=5
-        upsert_data = pa.Table.from_pydict({
-            'id': [2, 3, 5],
-            'name': ['Bob_v2', 'Carol_v2', 'Eve'],
-            'age': [31, 36, 45],
-            'city': ['LA2', 'Chicago2', 'Phoenix'],
-        }, schema=self.pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, 5)
-        rows = {r: v for r, v in zip(result['id'].to_pylist(), result['name'].to_pylist())}
-        self.assertEqual(rows[1], 'Alice')
-        self.assertEqual(rows[2], 'Bob_v2')
-        self.assertEqual(rows[3], 'Carol_v2')
-        self.assertEqual(rows[4], 'Dave')
-        self.assertEqual(rows[5], 'Eve')
-
-    # ==================================================================
-    # Validation / error tests
-    # ==================================================================
-
-    def test_empty_upsert_keys_raises(self):
-        """Empty upsert_keys list should raise ValueError."""
-        table = self._create_table()
-        self._write(table, pa.Table.from_pydict({
-            'id': [1], 'name': ['A'], 'age': [1], 'city': ['X'],
-        }, schema=self.pa_schema))
-
-        data = pa.Table.from_pydict({
-            'id': [1], 'name': ['B'], 'age': [2], 'city': ['Y'],
-        }, schema=self.pa_schema)
-
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=[])
-        self.assertIn('must not be empty', str(ctx.exception))
-
-    def test_upsert_key_not_in_schema_raises(self):
-        """upsert_key not present in table schema should raise ValueError."""
-        table = self._create_table()
-        self._write(table, pa.Table.from_pydict({
-            'id': [1], 'name': ['A'], 'age': [1], 'city': ['X'],
-        }, schema=self.pa_schema))
-
-        data = pa.Table.from_pydict({
-            'id': [1], 'name': ['B'], 'age': [2], 'city': ['Y'],
-        }, schema=self.pa_schema)
-
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['nonexistent'])
-        self.assertIn('not in table schema', str(ctx.exception))
-
-    def test_upsert_key_not_in_data_raises(self):
-        """upsert_key not present in input data should raise ValueError."""
-        table = self._create_table()
-        self._write(table, pa.Table.from_pydict({
-            'id': [1], 'name': ['A'], 'age': [1], 'city': ['X'],
-        }, schema=self.pa_schema))
-
-        # Input data missing 'city' column but upsert_keys=['city']
-        data = pa.Table.from_pydict({
-            'id': [1], 'name': ['B'], 'age': [2],
-        })
-
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['city'])
-        self.assertIn('not in input data', str(ctx.exception))
-
-    def test_empty_data_raises(self):
-        """Empty input data should raise ValueError."""
-        table = self._create_table()
-        data = pa.Table.from_pydict({
-            'id': pa.array([], type=pa.int32()),
-            'name': pa.array([], type=pa.string()),
-            'age': pa.array([], type=pa.int32()),
-            'city': pa.array([], type=pa.string()),
-        })
-
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['id'])
-        self.assertIn('empty', str(ctx.exception))
-
-    def test_duplicate_keys_in_input_keeps_last(self):
-        """Duplicate keys in input data should keep the last occurrence."""
-        table = self._create_table()
-        self._write(table, pa.Table.from_pydict({
-            'id': [1, 2],
-            'name': ['Alice', 'Bob'],
-            'age': [25, 30],
-            'city': ['NYC', 'LA'],
-        }, schema=self.pa_schema))
-
-        # id=1 appears twice; the second row (name='A_last') should win
-        data = pa.Table.from_pydict({
-            'id': [1, 1],
-            'name': ['A_first', 'A_last'],
-            'age': [90, 91],
-            'city': ['X', 'Y'],
-        }, schema=self.pa_schema)
-        self._upsert(table, data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        rows = {r: (n, a, c) for r, n, a, c in zip(
-            result['id'].to_pylist(),
-            result['name'].to_pylist(),
-            result['age'].to_pylist(),
-            result['city'].to_pylist(),
-        )}
-        # id=1 updated with last duplicate row
-        self.assertEqual(rows[1], ('A_last', 91, 'Y'))
-        # id=2 unchanged
-        self.assertEqual(rows[2], ('Bob', 30, 'LA'))
-
-    def test_duplicate_keys_all_new_keeps_last(self):
-        """Duplicate keys in input on empty table keeps the last occurrence."""
-        table = self._create_table()
-
-        # id=1 appears three times; last row should win
-        data = pa.Table.from_pydict({
-            'id': [1, 1, 1, 2],
-            'name': ['A1', 'A2', 'A3', 'B'],
-            'age': [10, 20, 30, 40],
-            'city': ['X1', 'X2', 'X3', 'Y'],
-        }, schema=self.pa_schema)
-        self._upsert(table, data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, 2)
-        rows = {r: (n, a, c) for r, n, a, c in zip(
-            result['id'].to_pylist(),
-            result['name'].to_pylist(),
-            result['age'].to_pylist(),
-            result['city'].to_pylist(),
-        )}
-        self.assertEqual(rows[1], ('A3', 30, 'X3'))
-        self.assertEqual(rows[2], ('B', 40, 'Y'))
-
-    def test_duplicate_keys_partitioned_keeps_last(self):
-        """Duplicate keys in a partitioned table keep the last per partition."""
+    def test_same_key_in_different_partitions(self):
+        """The same upsert-key value in different partitions stays distinct."""
         table = self._create_table(
             pa_schema=self.partitioned_pa_schema,
             partition_keys=['region'],
         )
-        self._write(table, pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 1],
+            'name': ['Alice_US', 'Alice_EU'],
+            'age': [25, 30],
+            'region': ['US', 'EU'],
+        }, schema=self.partitioned_pa_schema))
+
+        self._upsert(table, pa.Table.from_pydict({
+            'id': [1, 1],
+            'name': ['Alice_US_v2', 'Alice_EU_v2'],
+            'age': [26, 31],
+            'region': ['US', 'EU'],
+        }, schema=self.partitioned_pa_schema), upsert_keys=['id'])
+
+        result = self._read_all(table)
+        self.assertEqual(2, result.num_rows)
+        rows = sorted(zip(
+            result['id'].to_pylist(),
+            result['name'].to_pylist(),
+            result['region'].to_pylist(),
+        ), key=lambda x: x[2])
+        self.assertEqual((1, 'Alice_EU_v2', 'EU'), rows[0])
+        self.assertEqual((1, 'Alice_US_v2', 'US'), rows[1])
+
+    def test_partitioned_update_cols_with_new_rows(self):
+        """``update_cols`` only constrains matched rows; new rows still get
+        every column written via the regular write path."""
+        table = self._create_table(
+            pa_schema=self.partitioned_pa_schema,
+            partition_keys=['region'],
+        )
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
             'region': ['US', 'EU'],
         }, schema=self.partitioned_pa_schema))
 
-        # id=1 duplicated in US partition; id=2 duplicated in EU partition
-        data = pa.Table.from_pydict({
-            'id': [1, 1, 2, 2],
-            'name': ['A_first', 'A_last', 'B_first', 'B_last'],
-            'age': [50, 51, 60, 61],
-            'region': ['US', 'US', 'EU', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._upsert(table, data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, 2)
-        rows = {(r, reg): (n, a) for r, n, a, reg in zip(
-            result['id'].to_pylist(),
-            result['name'].to_pylist(),
-            result['age'].to_pylist(),
-            result['region'].to_pylist(),
-        )}
-        self.assertEqual(rows[(1, 'US')], ('A_last', 51))
-        self.assertEqual(rows[(2, 'EU')], ('B_last', 61))
-
-    def test_partitioned_table_missing_partition_col_in_data_raises(self):
-        """Input data missing partition column should raise ValueError."""
-        table = self._create_table(
-            pa_schema=self.partitioned_pa_schema,
-            partition_keys=['region'],
-        )
-
-        # Input data does NOT include the 'region' partition column
-        data = pa.Table.from_pydict({
-            'id': [1], 'name': ['A'], 'age': [25],
-        })
-
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['id'])
-        self.assertIn('partition key', str(ctx.exception).lower())
-
-    def test_same_key_in_different_partitions(self):
-        """Same upsert key value in different partitions is valid."""
-        table = self._create_table(
-            pa_schema=self.partitioned_pa_schema,
-            partition_keys=['region'],
-        )
-
-        initial = pa.Table.from_pydict({
-            'id': [1, 1],
-            'name': ['Alice_US', 'Alice_EU'],
-            'age': [25, 30],
-            'region': ['US', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._write(table, initial)
-
-        # Upsert id=1 in both partitions (same key, different partitions)
         upsert_data = pa.Table.from_pydict({
-            'id': [1, 1],
-            'name': ['Alice_US_v2', 'Alice_EU_v2'],
-            'age': [26, 31],
-            'region': ['US', 'EU'],
+            'id': [1, 3],
+            'name': ['Alice_v2', 'Carol'],
+            'age': [99, 50],
+            'region': ['US', 'US'],
         }, schema=self.partitioned_pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'])
+        self._upsert(table, upsert_data,
+                     upsert_keys=['id'], update_cols=['age'])
 
         result = self._read_all(table)
-        self.assertEqual(result.num_rows, 2)
-        rows = sorted(zip(
-            result['id'].to_pylist(),
-            result['name'].to_pylist(),
-            result['region'].to_pylist(),
-        ), key=lambda x: x[2])
-        self.assertEqual(rows[0], (1, 'Alice_EU_v2', 'EU'))
-        self.assertEqual(rows[1], (1, 'Alice_US_v2', 'US'))
+        self.assertEqual(3, result.num_rows)
 
-    def test_invalid_update_cols_raises(self):
-        """update_cols referencing non-existent column should raise."""
-        table = self._create_table()
-        data = pa.Table.from_pydict({
-            'id': [1], 'name': ['A'], 'age': [25], 'city': ['NYC'],
-        }, schema=self.pa_schema)
+        ids = result['id'].to_pylist()
+        names = result['name'].to_pylist()
+        ages = result['age'].to_pylist()
+        regions = result['region'].to_pylist()
 
-        with self.assertRaises(ValueError):
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update().with_update_type(['nonexistent_col'])
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['id'])
+        # id=1 was matched: only 'age' should change
+        idx1 = ids.index(1)
+        self.assertEqual(99,      ages[idx1])
+        self.assertEqual('Alice', names[idx1])
+        self.assertEqual('US',    regions[idx1])
+
+        # id=2 untouched
+        idx2 = ids.index(2)
+        self.assertEqual(30,   ages[idx2])
+        self.assertEqual('EU', regions[idx2])
+
+        # id=3 is new — all columns from the input land in the table
+        idx3 = ids.index(3)
+        self.assertEqual(50,      ages[idx3])
+        self.assertEqual('Carol', names[idx3])
+        self.assertEqual('US',    regions[idx3])
 
     # ==================================================================
-    # update_cols (partial column update) tests
+    # update_cols partial update (non-partitioned)
     # ==================================================================
 
     def test_update_cols_partial_update(self):
-        """update_cols limits which columns are updated for matched rows."""
+        """``update_cols`` limits which columns are touched for matched rows."""
         table = self._create_table()
-        initial = pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
             'city': ['NYC', 'LA'],
-        }, schema=self.pa_schema)
-        self._write(table, initial)
+        }, schema=self.pa_schema))
 
-        upsert_data = pa.Table.from_pydict({
+        self._upsert(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['_X_', '_Y_'],
             'age': [99, 88],
             'city': ['_X_', '_Y_'],
-        }, schema=self.pa_schema)
-        # Only update 'age'
-        self._upsert(table, upsert_data, upsert_keys=['id'], update_cols=['age'])
+        }, schema=self.pa_schema), upsert_keys=['id'], update_cols=['age'])
 
         result = self._read_all(table)
         rows = sorted(zip(
@@ -676,135 +465,408 @@ class TableUpsertByKeyTest(unittest.TestCase):
             result['age'].to_pylist(),
             result['city'].to_pylist(),
         ))
-        # name and city should be unchanged; age updated
-        self.assertEqual(rows[0], (1, 'Alice', 99, 'NYC'))
-        self.assertEqual(rows[1], (2, 'Bob', 88, 'LA'))
+        self.assertEqual((1, 'Alice', 99, 'NYC'), rows[0])
+        self.assertEqual((2, 'Bob',   88, 'LA'),  rows[1])
 
     # ==================================================================
-    # Large data test
+    # Duplicate-key dedup tests — parametrised
     # ==================================================================
 
-    def test_large_table_upsert(self):
-        """Upsert on a table with many rows spread across multiple commits."""
-        table = self._create_table()
-        n = 200
+    def test_duplicate_keys_in_input_keeps_last(self):
+        """Duplicate keys in input always keep the *last* occurrence."""
+        cases = [
+            ('empty_table_non_partitioned', False, {
+                'data': pa.Table.from_pydict({
+                    'id': [1, 1, 1, 2],
+                    'name': ['A1', 'A2', 'A3', 'B'],
+                    'age': [10, 20, 30, 40],
+                    'city': ['X1', 'X2', 'X3', 'Y'],
+                }, schema=self.pa_schema),
+                'expected_rows': {
+                    1: ('A3', 30, 'X3'),
+                    2: ('B',  40, 'Y'),
+                },
+                'expected_num_rows': 2,
+            }),
+            ('with_existing_rows_non_partitioned', True, {
+                'data': pa.Table.from_pydict({
+                    'id': [1, 1],
+                    'name': ['A_first', 'A_last'],
+                    'age': [90, 91],
+                    'city': ['X', 'Y'],
+                }, schema=self.pa_schema),
+                'expected_rows': {
+                    1: ('A_last', 91, 'Y'),
+                    2: ('Bob',    30, 'LA'),   # untouched
+                },
+                'expected_num_rows': 2,
+            }),
+        ]
 
-        # Write 200 rows in 2 commits
-        self._write(table, pa.Table.from_pydict({
-            'id': list(range(n // 2)),
-            'name': [f'Name_{i}' for i in range(n // 2)],
-            'age': [20 + i for i in range(n // 2)],
-            'city': [f'City_{i}' for i in range(n // 2)],
-        }, schema=self.pa_schema))
-        self._write(table, pa.Table.from_pydict({
-            'id': list(range(n // 2, n)),
-            'name': [f'Name_{i}' for i in range(n // 2, n)],
-            'age': [20 + i for i in range(n // 2, n)],
-            'city': [f'City_{i}' for i in range(n // 2, n)],
-        }, schema=self.pa_schema))
+        for name, prefill, spec in cases:
+            with self.subTest(case=name):
+                table = self._create_table()
+                if prefill:
+                    self._write_arrow(table, pa.Table.from_pydict({
+                        'id': [1, 2],
+                        'name': ['Alice', 'Bob'],
+                        'age': [25, 30],
+                        'city': ['NYC', 'LA'],
+                    }, schema=self.pa_schema))
 
-        # Upsert: update every 10th row, add 10 new rows
-        update_ids = list(range(0, n, 10))
-        new_ids = list(range(n, n + 10))
-        all_ids = update_ids + new_ids
+                self._upsert(table, spec['data'], upsert_keys=['id'])
+                result = self._read_all(table)
+                self.assertEqual(spec['expected_num_rows'], result.num_rows)
+                actual = {r: (n, a, c) for r, n, a, c in zip(
+                    result['id'].to_pylist(),
+                    result['name'].to_pylist(),
+                    result['age'].to_pylist(),
+                    result['city'].to_pylist(),
+                )}
+                for k, v in spec['expected_rows'].items():
+                    self.assertEqual(v, actual[k])
 
-        upsert_data = pa.Table.from_pydict({
-            'id': all_ids,
-            'name': [f'Upserted_{i}' for i in all_ids],
-            'age': [1000 + i for i in all_ids],
-            'city': [f'UCity_{i}' for i in all_ids],
-        }, schema=self.pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'])
-
-        result = self._read_all(table)
-        self.assertEqual(result.num_rows, n + 10)
-
-        result_map = {
-            rid: rname
-            for rid, rname in zip(result['id'].to_pylist(), result['name'].to_pylist())
-        }
-        # Verify updated rows
-        for uid in update_ids:
-            self.assertEqual(result_map[uid], f'Upserted_{uid}')
-        # Verify new rows
-        for nid in new_ids:
-            self.assertEqual(result_map[nid], f'Upserted_{nid}')
-        # Verify untouched rows
-        for i in range(n):
-            if i not in update_ids:
-                self.assertEqual(result_map[i], f'Name_{i}')
-
-    def test_non_data_evolution_table_raises(self):
-        """Upsert on a table without data-evolution enabled should raise."""
-        pa_schema = pa.schema([
-            ('id', pa.int32()),
-            ('name', pa.string()),
-        ])
-        name = self._unique_name()
-        # No data-evolution option
-        schema = Schema.from_pyarrow_schema(pa_schema)
-        self.catalog.create_table(name, schema, False)
-        table = self.catalog.get_table(name)
-
-        data = pa.Table.from_pydict({'id': [1], 'name': ['A']}, schema=pa_schema)
-        with self.assertRaises(ValueError) as ctx:
-            wb = table.new_batch_write_builder()
-            tu = wb.new_update()
-            tu.upsert_by_arrow_with_key(data, upsert_keys=['id'])
-        self.assertIn('data-evolution.enabled', str(ctx.exception))
-
-    def test_partitioned_update_cols_with_new_rows(self):
-        """When update_cols is set, matched rows update only those columns,
-        but new rows are appended with ALL columns via the standard write path."""
+    def test_duplicate_keys_in_input_partitioned_keeps_last(self):
+        """Duplicate keys in a partitioned table keep the last *per partition*."""
         table = self._create_table(
             pa_schema=self.partitioned_pa_schema,
             partition_keys=['region'],
         )
-
-        initial = pa.Table.from_pydict({
+        self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
             'age': [25, 30],
             'region': ['US', 'EU'],
-        }, schema=self.partitioned_pa_schema)
-        self._write(table, initial)
+        }, schema=self.partitioned_pa_schema))
 
-        # Upsert with update_cols=['age'] -- the partition key 'region' is NOT
-        # in update_cols.  id=1 matches (update), id=3 is new (append).
-        upsert_data = pa.Table.from_pydict({
-            'id': [1, 3],
-            'name': ['Alice_v2', 'Carol'],
-            'age': [99, 50],
-            'region': ['US', 'US'],
-        }, schema=self.partitioned_pa_schema)
-        self._upsert(table, upsert_data, upsert_keys=['id'],
-                     update_cols=['age'])
+        self._upsert(table, pa.Table.from_pydict({
+            'id': [1, 1, 2, 2],
+            'name': ['A_first', 'A_last', 'B_first', 'B_last'],
+            'age': [50, 51, 60, 61],
+            'region': ['US', 'US', 'EU', 'EU'],
+        }, schema=self.partitioned_pa_schema), upsert_keys=['id'])
 
         result = self._read_all(table)
-        # 2 original + 1 new = 3
-        self.assertEqual(result.num_rows, 3)
+        self.assertEqual(2, result.num_rows)
+        rows = {(r, reg): (n, a) for r, n, a, reg in zip(
+            result['id'].to_pylist(),
+            result['name'].to_pylist(),
+            result['age'].to_pylist(),
+            result['region'].to_pylist(),
+        )}
+        self.assertEqual(('A_last', 51), rows[(1, 'US')])
+        self.assertEqual(('B_last', 61), rows[(2, 'EU')])
 
-        ids = result['id'].to_pylist()
-        names = result['name'].to_pylist()
-        ages = result['age'].to_pylist()
-        regions = result['region'].to_pylist()
+    # ==================================================================
+    # Validation tests
+    # ==================================================================
 
-        # id=1 was updated: only age changed
-        idx1 = ids.index(1)
-        self.assertEqual(ages[idx1], 99)
-        self.assertEqual(names[idx1], 'Alice')  # unchanged
-        self.assertEqual(regions[idx1], 'US')
+    def _seed_simple_table(self):
+        """A 1-row non-partitioned table used by most validation tests."""
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1], 'name': ['A'], 'age': [1], 'city': ['X'],
+        }, schema=self.pa_schema))
+        return table
 
-        # id=2 was untouched
-        idx2 = ids.index(2)
-        self.assertEqual(ages[idx2], 30)
-        self.assertEqual(regions[idx2], 'EU')
+    def _expect_upsert_value_error(self, table, data, upsert_keys,
+                                   update_cols=None, expected_substring=''):
+        """Build update + invoke upsert (no commit) and assert it raises."""
+        with self.assertRaises(ValueError) as ctx:
+            wb = self._make_write_builder(table)
+            tu = wb.new_update()
+            if update_cols:
+                tu.with_update_type(update_cols)
+            self._apply_upsert(tu, data, upsert_keys, self._next_commit_id())
+        if expected_substring:
+            self.assertIn(expected_substring, str(ctx.exception))
 
-        # id=3 is new — all columns written (not partial)
-        idx3 = ids.index(3)
-        self.assertEqual(ages[idx3], 50)
-        self.assertEqual(names[idx3], 'Carol')
-        self.assertEqual(regions[idx3], 'US')
+    def test_empty_upsert_keys_raises(self):
+        table = self._seed_simple_table()
+        data = pa.Table.from_pydict({
+            'id': [1], 'name': ['B'], 'age': [2], 'city': ['Y'],
+        }, schema=self.pa_schema)
+        self._expect_upsert_value_error(
+            table, data, upsert_keys=[], expected_substring='must not be empty'
+        )
+
+    def test_upsert_key_not_in_schema_raises(self):
+        table = self._seed_simple_table()
+        data = pa.Table.from_pydict({
+            'id': [1], 'name': ['B'], 'age': [2], 'city': ['Y'],
+        }, schema=self.pa_schema)
+        self._expect_upsert_value_error(
+            table, data, upsert_keys=['nonexistent'],
+            expected_substring='not in table schema',
+        )
+
+    def test_upsert_key_not_in_data_raises(self):
+        table = self._seed_simple_table()
+        # 'city' is missing from the input
+        data = pa.Table.from_pydict({
+            'id': [1], 'name': ['B'], 'age': [2],
+        })
+        self._expect_upsert_value_error(
+            table, data, upsert_keys=['city'],
+            expected_substring='not in input data',
+        )
+
+    def test_empty_data_raises(self):
+        table = self._create_table()
+        empty = pa.Table.from_pydict({
+            'id':   pa.array([], type=pa.int32()),
+            'name': pa.array([], type=pa.string()),
+            'age':  pa.array([], type=pa.int32()),
+            'city': pa.array([], type=pa.string()),
+        })
+        self._expect_upsert_value_error(
+            table, empty, upsert_keys=['id'], expected_substring='empty'
+        )
+
+    def test_invalid_update_cols_raises(self):
+        table = self._create_table()
+        # ``with_update_type`` raises eagerly before upsert is called
+        with self.assertRaises(ValueError):
+            wb = self._make_write_builder(table)
+            wb.new_update().with_update_type(['nonexistent_col'])
+
+    def test_partitioned_missing_partition_col_in_data_raises(self):
+        table = self._create_table(
+            pa_schema=self.partitioned_pa_schema,
+            partition_keys=['region'],
+        )
+        # Input data does NOT contain the 'region' partition column
+        data = pa.Table.from_pydict({
+            'id': [1], 'name': ['A'], 'age': [25],
+        })
+        with self.assertRaises(ValueError) as ctx:
+            wb = self._make_write_builder(table)
+            tu = wb.new_update()
+            self._apply_upsert(tu, data, ['id'], self._next_commit_id())
+        self.assertIn('partition key', str(ctx.exception).lower())
+
+    def test_non_data_evolution_table_raises(self):
+        """Upsert on a table without data-evolution enabled is rejected."""
+        plain = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+        ])
+        # No data-evolution / row-tracking options
+        table = self._create_table(pa_schema=plain, options={})
+        data = pa.Table.from_pydict({'id': [1], 'name': ['A']}, schema=plain)
+        with self.assertRaises(ValueError) as ctx:
+            wb = self._make_write_builder(table)
+            tu = wb.new_update()
+            self._apply_upsert(tu, data, ['id'], self._next_commit_id())
+        self.assertIn('data-evolution.enabled', str(ctx.exception))
+
+
+# ======================================================================
+# Mode-specific mixins (add the ``upsert_by_arrow_with_key`` primitive)
+# ======================================================================
+
+class _BatchModeMixin(BatchModeMixin):
+    def _apply_upsert(self, table_update, data, upsert_keys, cid):
+        return table_update.upsert_by_arrow_with_key(data, upsert_keys)
+
+
+class _StreamModeMixin(StreamModeMixin):
+    def _apply_upsert(self, table_update, data, upsert_keys, cid):
+        return table_update.upsert_by_arrow_with_key(data, upsert_keys, cid)
+
+
+# ======================================================================
+# Concrete test classes
+# ======================================================================
+
+class TableUpsertByKeyBatchTest(
+    _BatchModeMixin, _TableUpsertByKeyTestBase, unittest.TestCase
+):
+    """All shared upsert tests under batch (``BatchWriteBuilder``) semantics."""
+
+
+class TableUpsertByKeyStreamTest(
+    _StreamModeMixin, _TableUpsertByKeyTestBase, unittest.TestCase
+):
+    """All shared upsert tests under stream (``StreamWriteBuilder``) semantics,
+    plus stream-only multi-commit scenarios."""
+
+    # ------------------------------------------------------------------
+    # Stream-only helpers
+    # ------------------------------------------------------------------
+
+    def _stream_commit_upserts_by_key(
+            self, tu, tc, commit_ids, tables, upsert_keys):
+        """One upsert + commit per ``(cid, arrow_table)`` pair.
+
+        Reuses the same ``StreamTableUpdate`` instance ``tu`` across commits.
+        """
+        for cid, data in zip(commit_ids, tables):
+            msgs = tu.upsert_by_arrow_with_key(data, upsert_keys, cid)
+            tc.commit(msgs, cid)
+
+    # ------------------------------------------------------------------
+    # Stream-only tests
+    # ------------------------------------------------------------------
+
+    def test_stream_multi_upsert_on_one_write_builder(self):
+        """A single ``StreamWriteBuilder`` drives many upsert+commit cycles
+        with reused ``tu`` and ``tc`` instances. Each commit produces its own
+        snapshot tagged with the caller-supplied ``commit_identifier`` under
+        a stable ``commit_user`` — the core contract distinguishing stream
+        from batch mode.
+
+        Parameterised over both contiguous and sparse identifier sequences
+        to catch any accidental coupling between ``commit_identifier`` and
+        ``snapshot_id`` ordering.
+        """
+        upserts = [
+            # First upsert: all new
+            pa.Table.from_pydict({
+                'id': [1, 2],
+                'name': ['Alice', 'Bob'],
+                'age': [25, 30],
+                'city': ['NYC', 'LA'],
+            }, schema=self.pa_schema),
+            # Second upsert: update id=1 + append id=3
+            pa.Table.from_pydict({
+                'id': [1, 3],
+                'name': ['Alice_v2', 'Carol'],
+                'age': [26, 35],
+                'city': ['NYC2', 'Chicago'],
+            }, schema=self.pa_schema),
+        ]
+        expected_by_id = {
+            1: ('Alice_v2', 26, 'NYC2'),
+            2: ('Bob', 30, 'LA'),
+            3: ('Carol', 35, 'Chicago'),
+        }
+
+        for case_name, commit_ids in [
+            ('contiguous', [1, 2]),
+            ('sparse',     [42, 1000]),
+        ]:
+            with self.subTest(case=case_name):
+                table = self._create_table()
+                wb, tc, base_snapshot_id = self._stream_commit_session(table)
+                tu = wb.new_update()
+                self._stream_commit_upserts_by_key(
+                    tu, tc, commit_ids, upserts, ['id'],
+                )
+                tc.close()
+
+                result = self._read_all(table)
+                self.assertEqual(3, result.num_rows)
+                actual = {
+                    i: (n, a, c) for i, n, a, c in zip(
+                        result['id'].to_pylist(),
+                        result['name'].to_pylist(),
+                        result['age'].to_pylist(),
+                        result['city'].to_pylist(),
+                    )
+                }
+                self.assertEqual(expected_by_id, actual)
+                self._assert_stream_builder_snapshots(
+                    table, wb, base_snapshot_id, commit_ids,
+                )
+
+    def test_stream_commit_same_tc_different_update_projections(self):
+        """``StreamTableCommit`` may carry commits from distinct
+        :class:`StreamTableUpdate` instances — e.g. full upsert followed by a
+        projection-limited upsert on the same ``tc``.
+        """
+        table = self._create_table()
+        wb, tc, base_snapshot_id = self._stream_commit_session(table)
+
+        tu1 = wb.new_update()
+        msgs1 = tu1.upsert_by_arrow_with_key(
+            pa.Table.from_pydict({
+                'id': [1],
+                'name': ['Alice'],
+                'age': [25],
+                'city': ['NYC'],
+            }, schema=self.pa_schema),
+            ['id'],
+            1,
+        )
+        tc.commit(msgs1, 1)
+
+        tu2 = wb.new_update().with_update_type(['city'])
+        msgs2 = tu2.upsert_by_arrow_with_key(
+            pa.Table.from_pydict({
+                'id': [1],
+                'name': ['ShouldIgnore'],
+                'age': [99],
+                'city': ['Boston'],
+            }, schema=self.pa_schema),
+            ['id'],
+            2,
+        )
+        tc.commit(msgs2, 2)
+        tc.close()
+
+        result = self._read_all(table)
+        self.assertEqual(1, result.num_rows)
+        self.assertEqual(1, result['id'].to_pylist()[0])
+        self.assertEqual('Alice', result['name'].to_pylist()[0])
+        self.assertEqual(25, result['age'].to_pylist()[0])
+        self.assertEqual('Boston', result['city'].to_pylist()[0])
+        self._assert_stream_builder_snapshots(
+            table, wb, base_snapshot_id, [1, 2],
+        )
+
+    def test_stream_interleaved_write_and_upsert_on_same_builder(self):
+        """A single stream builder may perform an initial write followed by
+        an upsert on the same ``tc``, each tagged with its own
+        ``commit_identifier`` that propagates to its own snapshot.
+        """
+        table = self._create_table()
+        wb, tc, base_snapshot_id = self._stream_commit_session(table)
+        tw = wb.new_write()
+        tu = wb.new_update()
+
+        # Phase 1: initial write
+        tw.write_arrow(pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['Alice', 'Bob'],
+            'age': [25, 30],
+            'city': ['NYC', 'LA'],
+        }, schema=self.pa_schema))
+        tc.commit(tw.prepare_commit(1), 1)
+        tw.close()
+
+        # Phase 2: upsert overlapping + new rows
+        msgs = tu.upsert_by_arrow_with_key(
+            pa.Table.from_pydict({
+                'id': [2, 3],
+                'name': ['Bob_v2', 'Carol'],
+                'age': [31, 35],
+                'city': ['LA2', 'Chicago'],
+            }, schema=self.pa_schema),
+            ['id'],
+            2,
+        )
+        tc.commit(msgs, 2)
+        tc.close()
+
+        result = self._read_all(table)
+        self.assertEqual(3, result.num_rows)
+        actual = {
+            i: (n, a, c) for i, n, a, c in zip(
+                result['id'].to_pylist(),
+                result['name'].to_pylist(),
+                result['age'].to_pylist(),
+                result['city'].to_pylist(),
+            )
+        }
+        self.assertEqual({
+            1: ('Alice', 25, 'NYC'),
+            2: ('Bob_v2', 31, 'LA2'),
+            3: ('Carol', 35, 'Chicago'),
+        }, actual)
+        self._assert_stream_builder_snapshots(
+            table, wb, base_snapshot_id, [1, 2],
+        )
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -27,7 +27,17 @@ from pypaimon.write.file_store_commit import FileStoreCommit
 
 
 class TableCommit:
-    """Python implementation of BatchTableCommit for batch writing scenarios."""
+    """Common base for batch and stream table commits.
+
+    Owns the underlying :class:`FileStoreCommit` and provides the shared
+    :meth:`_commit` implementation. The concrete subclasses differ only in
+    their public ``commit`` signature and lifecycle constraints:
+
+    * :class:`BatchTableCommit` accepts no ``commit_identifier`` and may be
+      committed at most once.
+    * :class:`StreamTableCommit` requires an explicit ``commit_identifier``
+      on every call and may be reused for many commits.
+    """
 
     def __init__(self, table, commit_user: str, static_partition: Optional[dict]):
         from pypaimon.table.file_store_table import FileStoreTable
@@ -42,11 +52,8 @@ class TableCommit:
             raise RuntimeError("Table does not provide a SnapshotCommit instance")
 
         self.file_store_commit = FileStoreCommit(snapshot_commit, table, commit_user)
-        self.batch_committed = False
 
     def _commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
-        self._check_committed()
-
         non_empty_messages = [msg for msg in commit_messages if not msg.is_empty()]
 
         if self.overwrite_partition is not None:
@@ -66,7 +73,7 @@ class TableCommit:
             if not non_empty_messages:
                 return
             logger.info(
-                "Committing batch table %s, %d non-empty messages",
+                "Committing table %s, %d non-empty messages",
                 self.table.identifier, len(non_empty_messages)
             )
             self.file_store_commit.commit(
@@ -80,14 +87,16 @@ class TableCommit:
     def close(self):
         self.file_store_commit.close()
 
-    def _check_committed(self):
-        if self.batch_committed:
-            raise RuntimeError("BatchTableCommit only supports one-time committing.")
-        self.batch_committed = True
-
 
 class BatchTableCommit(TableCommit):
+    """Batch-mode commit; supports at most one commit per instance."""
+
+    def __init__(self, table, commit_user: str, static_partition: Optional[dict]):
+        super().__init__(table, commit_user, static_partition)
+        self.batch_committed = False
+
     def commit(self, commit_messages: List[CommitMessage]):
+        self._check_committed()
         self._commit(commit_messages, BATCH_COMMIT_IDENTIFIER)
 
     def truncate_table(self) -> None:
@@ -99,8 +108,19 @@ class BatchTableCommit(TableCommit):
         self._check_committed()
         self.file_store_commit.drop_partitions(partitions, BATCH_COMMIT_IDENTIFIER)
 
+    def _check_committed(self):
+        if self.batch_committed:
+            raise RuntimeError("BatchTableCommit only supports one-time committing.")
+        self.batch_committed = True
+
 
 class StreamTableCommit(TableCommit):
+    """Stream-mode commit; reusable across many commit rounds.
+
+    Each call must be tagged with a monotonically increasing
+    ``commit_identifier`` — analogous to
+    :meth:`StreamTableWrite.prepare_commit`.
+    """
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
         self._commit(commit_messages, commit_identifier)

--- a/paimon-python/pypaimon/write/table_commit.py
+++ b/paimon-python/pypaimon/write/table_commit.py
@@ -122,5 +122,5 @@ class StreamTableCommit(TableCommit):
     :meth:`StreamTableWrite.prepare_commit`.
     """
 
-    def commit(self, commit_messages: List[CommitMessage], commit_identifier: int = BATCH_COMMIT_IDENTIFIER):
+    def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
         self._commit(commit_messages, commit_identifier)

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
 from collections import defaultdict
 from typing import List, Optional, Tuple
 
@@ -25,6 +26,7 @@ from pypaimon.common.memory_size import MemorySize
 from pypaimon.globalindex import Range
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.split import DataSplit
+from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 from pypaimon.write.table_upsert_by_key import TableUpsertByKey
@@ -87,6 +89,15 @@ def _divide_ranges(
 
 
 class TableUpdate:
+    """Common base for batch and stream table-update builders.
+
+    Holds the shared configuration (``update_cols``, ``projection``) and the
+    canonical ``commit_identifier``-aware implementations of the update /
+    upsert operations. The concrete subclasses
+    :class:`BatchTableUpdate` and :class:`StreamTableUpdate` expose
+    mode-specific public method signatures.
+    """
+
     def __init__(self, table, commit_user):
         from pypaimon.table.file_store_table import FileStoreTable
 
@@ -123,28 +134,88 @@ class TableUpdate:
             total_shard_count,
         )
 
-    def update_by_arrow_with_row_id(self, table: pa.Table) -> List[CommitMessage]:
-        update_by_row_id = TableUpdateByRowId(self.table, self.commit_user)
-        update_by_row_id.update_columns(table, self.update_cols)
-        return update_by_row_id.commit_messages
+    def _update_by_arrow_with_row_id(
+            self, table: pa.Table, commit_identifier: int
+    ) -> List[CommitMessage]:
+        """Shared implementation for ``update_by_arrow_with_row_id``.
 
-    def upsert_by_arrow_with_key(self, table: pa.Table, upsert_keys: List[str]) -> List[CommitMessage]:
-        """Upsert rows into an append-only table by one or more key columns.
+        The public method lives on the concrete subclasses so each can
+        expose the signature appropriate to its mode (batch vs stream).
+        Produced commit messages are tagged with ``commit_identifier``.
+        """
+        return TableUpdateByRowId(
+            self.table, self.commit_user, commit_identifier,
+        ).update_columns(table, self.update_cols)
+
+    def _upsert_by_arrow_with_key(
+            self,
+            table: pa.Table,
+            upsert_keys: List[str],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        """Shared implementation for ``upsert_by_arrow_with_key``.
 
         For each row in the input Arrow table:
-        - If a row with the same composite upsert_keys value already exists -> update that row
-          in-place.
-        - If no matching row exists -> append as a new row.
+
+        * If a row with the same composite ``upsert_keys`` value already
+          exists → update that row in-place.
+        * Otherwise → append as a new row.
+
+        The public method lives on the concrete subclasses so each can
+        expose the signature appropriate to its mode (batch vs stream).
 
         Args:
             table: Input Arrow table containing rows to upsert.
-            upsert_keys: One or more column names used together as a composite match key.
+            upsert_keys: One or more column names forming the composite match key.
+            commit_identifier: Identifier to tag the produced commit messages with.
 
         Returns:
-            List of CommitMessages to be committed.
+            List of :class:`CommitMessage` objects to be committed.
         """
-        upsert = TableUpsertByKey(self.table, self.commit_user)
-        return upsert.upsert(table, upsert_keys, self.update_cols)
+        return TableUpsertByKey(
+            self.table, self.commit_user, commit_identifier
+        ).upsert(table, upsert_keys, self.update_cols)
+
+
+class BatchTableUpdate(TableUpdate):
+    """Batch-mode table update; commit messages always use
+    :data:`BATCH_COMMIT_IDENTIFIER`."""
+
+    def update_by_arrow_with_row_id(self, table: pa.Table) -> List[CommitMessage]:
+        """Apply column updates keyed by ``_ROW_ID`` to existing rows."""
+        return self._update_by_arrow_with_row_id(table, BATCH_COMMIT_IDENTIFIER)
+
+    def upsert_by_arrow_with_key(
+            self, table: pa.Table, upsert_keys: List[str]
+    ) -> List[CommitMessage]:
+        """Upsert rows into an append-only table by one or more key columns."""
+        return self._upsert_by_arrow_with_key(
+            table, upsert_keys, BATCH_COMMIT_IDENTIFIER
+        )
+
+
+class StreamTableUpdate(TableUpdate):
+    """Stream-mode table update; the same instance may drive many rounds,
+    each tagged with its own ``commit_identifier``."""
+
+    def update_by_arrow_with_row_id(
+            self, table: pa.Table, commit_identifier: int
+    ) -> List[CommitMessage]:
+        """Apply column updates keyed by ``_ROW_ID`` to existing rows,
+        tagging the produced commit messages with ``commit_identifier``."""
+        return self._update_by_arrow_with_row_id(table, commit_identifier)
+
+    def upsert_by_arrow_with_key(
+            self,
+            table: pa.Table,
+            upsert_keys: List[str],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        """Upsert rows into an append-only table by one or more key columns,
+        tagging the produced commit messages with ``commit_identifier``."""
+        return self._upsert_by_arrow_with_key(
+            table, upsert_keys, commit_identifier
+        )
 
 
 class ShardTableUpdator:

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -15,18 +15,21 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
 import bisect
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import pyarrow as pa
 import pyarrow.compute as pc
 
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.split import DataSplit
 from pypaimon.read.table_read import TableRead
+from pypaimon.utils.range import Range
 from pypaimon.schema.data_types import DataField
-from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.special_fields import SpecialFields
+from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_write import FileStoreWrite
 
 
@@ -40,53 +43,62 @@ class TableUpdateByRowId:
 
     FIRST_ROW_ID_COLUMN = '_FIRST_ROW_ID'
 
-    def __init__(self, table, commit_user: str):
+    def __init__(self, table, commit_user: str, commit_identifier: int):
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
         self.commit_user = commit_user
+        self.commit_identifier = commit_identifier
 
-        # Load existing first_row_ids and build partition map
+        # Snapshot the current state once: a single ``first_row_id -> (split, files)``
+        # map is enough to drive every downstream lookup (partition, row-count, read).
         (self.snapshot_id,
          self.first_row_ids,
-         self.first_row_id_to_partition_map,
-         self.first_row_id_to_row_count_map,
-         self.total_row_count,
-         self.splits) = self._load_existing_files_info()
+         self._first_row_id_index,
+         self.total_row_count) = self._load_existing_files_info()
 
-        # Collect commit messages
-        self.commit_messages = []
+        self.commit_messages: List[CommitMessage] = []
 
-    def _load_existing_files_info(self):
-        """Load existing first_row_ids and build partition map for efficient lookup."""
-        first_row_ids = []
-        first_row_id_to_partition_map: Dict[int, GenericRow] = {}
-        first_row_id_to_row_count_map: Dict[int, int] = {}
+    def _load_existing_files_info(
+            self,
+    ) -> Tuple[int, List[int], Dict[int, Tuple[DataSplit, List[DataFileMeta]]], int]:
+        """Scan the latest snapshot once and index files by ``first_row_id``.
 
-        read_builder = self.table.new_read_builder()
-        scan = read_builder.new_scan()
-        plan = scan.plan()
+        Returns:
+            A 4-tuple of ``(snapshot_id, sorted_unique_first_row_ids, index, total_row_count)``
+            where ``index`` maps each ``first_row_id`` to the owning split and
+            the list of files with that id (a single id may belong to multiple
+            files when data evolution has split a logical row range).
+        """
+        plan = self.table.new_read_builder().new_scan().plan()
         splits = plan.splits()
 
+        index: Dict[int, Tuple[DataSplit, List[DataFileMeta]]] = {}
+        row_id_ranges: List[Range] = []
         for split in splits:
             for file in split.files:
-                if file.first_row_id is not None and not file.file_name.endswith('.blob'):
-                    first_row_id = file.first_row_id
-                    first_row_ids.append(first_row_id)
-                    first_row_id_to_partition_map[first_row_id] = split.partition
-                    first_row_id_to_row_count_map[first_row_id] = file.row_count
+                if file.first_row_id is None or file.file_name.endswith('.blob'):
+                    continue
+                row_id_ranges.append(file.row_id_range())
+                entry = index.get(file.first_row_id)
+                if entry is None:
+                    index[file.first_row_id] = (split, [file])
+                else:
+                    entry[1].append(file)
 
-        total_row_count = sum(first_row_id_to_row_count_map.values())
+        # Multiple physical files may share the same first_row_id (data evolution);
+        # summing row_count per file would over-count logical rows and widen
+        # the _ROW_ID validation range incorrectly.
+        if row_id_ranges:
+            merged = Range.sort_and_merge_overlap(row_id_ranges, True, True)
+            total_row_count = sum(r.count() for r in merged)
+        else:
+            total_row_count = 0
 
         snapshot_id = plan.snapshot_id if plan.snapshot_id is not None else -1
-        return (snapshot_id,
-                sorted(list(set(first_row_ids))),
-                first_row_id_to_partition_map,
-                first_row_id_to_row_count_map,
-                total_row_count,
-                splits)
+        return snapshot_id, sorted(index.keys()), index, total_row_count
 
-    def update_columns(self, data: pa.Table, column_names: List[str]) -> List:
+    def update_columns(self, data: pa.Table, column_names: List[str]) -> List[CommitMessage]:
         """
         Add or update columns in the table.
 
@@ -98,90 +110,76 @@ class TableUpdateByRowId:
             List of commit messages
         """
 
-        # Validate column_names is not empty
         if not column_names:
             raise ValueError("column_names cannot be empty")
 
-        # Validate input data has row_id column
         if SpecialFields.ROW_ID.name not in data.column_names:
             raise ValueError(f"Input data must contain {SpecialFields.ROW_ID.name} column")
 
-        # Validate all update columns exist in the schema
         for col_name in column_names:
             if col_name not in self.table.field_names:
                 raise ValueError(f"Column {col_name} not found in table schema")
 
-        # Sort data by _ROW_ID column
         sorted_data = data.sort_by([(SpecialFields.ROW_ID.name, "ascending")])
-
-        # Calculate first_row_id for each row
         data_with_first_row_id = self._calculate_first_row_id(sorted_data)
-
-        # Group by first_row_id and write each group
         self._write_by_first_row_id(data_with_first_row_id, column_names)
 
         return self.commit_messages
 
     def _calculate_first_row_id(self, data: pa.Table) -> pa.Table:
-        """Calculate _first_row_id for each row based on _ROW_ID.
+        """Append ``_FIRST_ROW_ID`` to *data* by looking up each ``_ROW_ID``.
 
-        Supports partial row updates - row_ids don't need to be consecutive.
+        Validates that every input ``_ROW_ID`` is unique and falls in
+        ``[0, total_row_count)``. Supports partial / non-consecutive updates.
         """
-        row_ids = data[SpecialFields.ROW_ID.name].to_pylist()
+        row_id_arr = data[SpecialFields.ROW_ID.name]
+        row_ids = row_id_arr.to_pylist()
 
-        # Validate row_ids have no duplicates
         if len(row_ids) != len(set(row_ids)):
             raise ValueError("Input data contains duplicate _ROW_ID values")
 
-        # Validate row_ids are within valid range
-        for row_id in row_ids:
-            if row_id < 0 or row_id >= self.total_row_count:
-                raise ValueError(f"Row ID {row_id} is out of valid range [0, {self.total_row_count})")
+        if not row_ids:
+            return data.append_column(
+                self.FIRST_ROW_ID_COLUMN, pa.array([], type=pa.int64()),
+            )
 
-        # Calculate first_row_id for each row_id
-        first_row_id_values = []
-        for row_id in row_ids:
-            first_row_id = self._floor_binary_search(self.first_row_ids, row_id)
-            first_row_id_values.append(first_row_id)
+        # Vectorised range check (avoids a Python-level per-row loop).
+        min_id = pc.min(row_id_arr).as_py()
+        max_id = pc.max(row_id_arr).as_py()
+        if min_id < 0 or max_id >= self.total_row_count:
+            offending = min_id if min_id < 0 else max_id
+            raise ValueError(
+                f"Row ID {offending} is out of valid range "
+                f"[0, {self.total_row_count})"
+            )
 
-        # Add first_row_id column to the table
-        first_row_id_array = pa.array(first_row_id_values, type=pa.int64())
-        return data.append_column(self.FIRST_ROW_ID_COLUMN, first_row_id_array)
-
-    def _floor_binary_search(self, sorted_seq: List[int], value: int) -> int:
-        """Binary search to find the floor value in sorted sequence."""
-        if not sorted_seq:
+        if not self.first_row_ids:
             raise ValueError("The input sorted sequence is empty.")
 
-        idx = bisect.bisect_right(sorted_seq, value) - 1
-        if idx < 0:
-            raise ValueError(f"Value {value} is less than the first element in the sorted sequence.")
-
-        return sorted_seq[idx]
+        sorted_seq = self.first_row_ids
+        bisect_right = bisect.bisect_right
+        first_row_id_values = [
+            sorted_seq[bisect_right(sorted_seq, row_id) - 1]
+            for row_id in row_ids
+        ]
+        return data.append_column(
+            self.FIRST_ROW_ID_COLUMN,
+            pa.array(first_row_id_values, type=pa.int64()),
+        )
 
     def _write_by_first_row_id(self, data: pa.Table, column_names: List[str]):
         """Write data grouped by first_row_id."""
-        # Extract unique first_row_id values
         first_row_id_array = data[self.FIRST_ROW_ID_COLUMN]
         unique_first_row_ids = pc.unique(first_row_id_array).to_pylist()
 
         for first_row_id in unique_first_row_ids:
-            # Filter rows for this first_row_id
-            mask = pc.equal(first_row_id_array, first_row_id)
-            group_data = data.filter(mask)
-
-            # Get partition for this first_row_id
-            partition = self._find_partition_by_first_row_id(first_row_id)
-
-            if partition is None:
+            entry = self._first_row_id_index.get(first_row_id)
+            if entry is None:
                 raise ValueError(f"No existing file found for first_row_id {first_row_id}")
+            split, _files = entry
 
-            # Write this group
-            self._write_group(partition, first_row_id, group_data, column_names)
-
-    def _find_partition_by_first_row_id(self, first_row_id: int) -> Optional[GenericRow]:
-        """Find the partition for a given first_row_id using pre-built partition map."""
-        return self.first_row_id_to_partition_map.get(first_row_id)
+            group_data = data.filter(pc.equal(first_row_id_array, first_row_id))
+            self._write_group(split.partition, first_row_id, group_data, column_names)
 
     def _read_original_file_data(self, first_row_id: int, column_names: List[str]) -> Optional[pa.Table]:
         """Read original file data for the given first_row_id.
@@ -198,44 +196,26 @@ class TableUpdateByRowId:
             PyArrow Table containing the original data for columns that exist in the file,
             or None if no columns need to be read from the original file.
         """
-
-        # Build read type for the columns we need to read
-        read_fields: List[DataField] = []
-        for field in self.table.fields:
-            if field.name in column_names:
-                read_fields.append(field)
-
+        wanted = set(column_names)
+        read_fields: List[DataField] = [
+            field for field in self.table.fields if field.name in wanted
+        ]
         if not read_fields:
             return None
 
-        # Find the split that contains files with this first_row_id
-        target_split = None
-        target_files = []
-        for split in self.splits:
-            for file_idx, file in enumerate(split.files):
-                if file.first_row_id == first_row_id:
-                    target_files.append(file)
-                    if target_split is None:
-                        target_split = split
-            if target_split is not None:
-                break
-
-        if not target_files:
+        entry = self._first_row_id_index.get(first_row_id)
+        if entry is None:
             raise ValueError(f"No file found for first_row_id {first_row_id}")
+        owning_split, target_files = entry
 
-        # Create a DataSplit containing all files with this first_row_id
         origin_split = DataSplit(
             files=target_files,
-            partition=target_split.partition,
-            bucket=target_split.bucket,
-            raw_convertible=True
+            partition=owning_split.partition,
+            bucket=owning_split.bucket,
+            raw_convertible=True,
         )
-
-        # Create TableRead and read the data
         table_read = TableRead(self.table, predicate=None, read_type=read_fields)
-        origin_data = table_read.to_arrow([origin_split])
-
-        return origin_data
+        return table_read.to_arrow([origin_split])
 
     def _merge_update_with_original(self, original_data: Optional[pa.Table], update_data: pa.Table,
                                     column_names: List[str], first_row_id: int) -> pa.Table:
@@ -283,43 +263,29 @@ class TableUpdateByRowId:
                      data: pa.Table, column_names: List[str]):
         """Write a group of data with the same first_row_id.
 
-        This method reads the original file data, merges it with the update data,
-        and writes out the complete merged data. Supports partial row updates.
+        Reads the original file data, merges in the update values, and
+        writes a single output file (rolling disabled) for the group.
         """
-
-        # Read original file data for the columns being updated
         original_data = self._read_original_file_data(first_row_id, column_names)
+        merged_data = self._merge_update_with_original(
+            original_data, data, column_names, first_row_id,
+        )
 
-        # Merge update data with original data
-        merged_data = self._merge_update_with_original(original_data, data, column_names, first_row_id)
-
-        # Create a file store write for this partition
-        # Disable rolling to ensure one output file per first_row_id group,
         file_store_write = FileStoreWrite(self.table, self.commit_user)
-        file_store_write.disable_rolling()
+        try:
+            file_store_write.disable_rolling()
+            file_store_write.write_cols = column_names
 
-        # Set write columns to only update specific columns
-        write_cols = column_names
-        file_store_write.write_cols = write_cols
+            partition_tuple = tuple(partition.values)
+            for batch in merged_data.to_batches():
+                file_store_write.write(partition_tuple, 0, batch)
 
-        # Convert partition to tuple for hashing
-        partition_tuple = tuple(partition.values)
-
-        # Write merged data - convert Table to RecordBatch
-        for batch in merged_data.to_batches():
-            file_store_write.write(partition_tuple, 0, batch)
-
-        # Prepare commit and assign first_row_id
-        commit_messages = file_store_write.prepare_commit(BATCH_COMMIT_IDENTIFIER)
-
-        # Assign first_row_id to the new files
-        for msg in commit_messages:
-            msg.check_from_snapshot = self.snapshot_id
-            for file in msg.new_files:
-                file.first_row_id = first_row_id
-                file.write_cols = write_cols
-
-        self.commit_messages.extend(commit_messages)
-
-        # Close the writer
-        file_store_write.close()
+            new_messages = file_store_write.prepare_commit(self.commit_identifier)
+            for msg in new_messages:
+                msg.check_from_snapshot = self.snapshot_id
+                for file in msg.new_files:
+                    file.first_row_id = first_row_id
+                    file.write_cols = column_names
+            self.commit_messages.extend(new_messages)
+        finally:
+            file_store_write.close()

--- a/paimon-python/pypaimon/write/table_upsert_by_key.py
+++ b/paimon-python/pypaimon/write/table_upsert_by_key.py
@@ -15,16 +15,17 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
+import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 import pyarrow as pa
-import logging
 
 from pypaimon.read.table_read import TableRead
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
-from pypaimon.write.table_write import BatchTableWrite
+from pypaimon.write.table_write import StreamTableWrite
 
 # Composite key is represented as a tuple of values
 _KeyTuple = Tuple[Any, ...]
@@ -44,11 +45,12 @@ class TableUpsertByKey:
     All upsert_keys must be columns present in both the input data and the table schema.
     """
 
-    def __init__(self, table, commit_user: str):
+    def __init__(self, table, commit_user: str, commit_identifier: int):
         from pypaimon.table.file_store_table import FileStoreTable
 
         self.table: FileStoreTable = table
         self.commit_user = commit_user
+        self.commit_identifier = commit_identifier
 
     def upsert(self, data: pa.Table, upsert_keys: List[str],
                update_cols: Optional[List[str]] = None) -> List[CommitMessage]:
@@ -107,30 +109,27 @@ class TableUpsertByKey:
         Split *data* into ``(partition_spec, partition_rows)`` pairs.
 
         For non-partitioned tables a single pair ``({}, data)`` is returned.
+        Iteration order matches first-appearance order of each partition value
+        in the input — dict preserves insertion order on Python 3.7+.
         """
         partition_keys = self.table.partition_keys
         if not partition_keys:
             return [({}, data)]
 
-        # Materialise partition columns once
         part_columns = [data[k].to_pylist() for k in partition_keys]
 
-        # Discover unique partitions and collect row indices
-        seen_order: List[Tuple[Any, ...]] = []  # preserves insertion order
         partition_to_indices: Dict[Tuple[Any, ...], List[int]] = {}
         for i in range(data.num_rows):
             part_tuple = tuple(col[i] for col in part_columns)
-            if part_tuple not in partition_to_indices:
-                seen_order.append(part_tuple)
-                partition_to_indices[part_tuple] = []
-            partition_to_indices[part_tuple].append(i)
+            partition_to_indices.setdefault(part_tuple, []).append(i)
 
-        result: List[Tuple[Dict[str, Any], pa.Table]] = []
-        for part_tuple in seen_order:
-            spec = dict(zip(partition_keys, part_tuple))
-            indices = pa.array(partition_to_indices[part_tuple], type=pa.int64())
-            result.append((spec, data.take(indices)))
-        return result
+        return [
+            (
+                dict(zip(partition_keys, part_tuple)),
+                data.take(pa.array(indices, type=pa.int64())),
+            )
+            for part_tuple, indices in partition_to_indices.items()
+        ]
 
     # ------------------------------------------------------------------
     # Per-partition upsert
@@ -153,72 +152,77 @@ class TableUpsertByKey:
         key set on-the-fly, so only matching key → _ROW_ID pairs are kept in
         memory (instead of the entire partition's key set).
         """
-        # Strip partition columns – they are constant inside one partition
+        # Partition columns are constant inside one partition – drop them
+        # from the key set used for matching.
         partition_key_set = set(self.table.partition_keys)
         match_keys = [k for k in upsert_keys if k not in partition_key_set]
 
-        # 1. Build input key tuples and a lookup set
+        # 1. Build the composite key tuple for every input row.
         key_columns = [partition_data[k].to_pylist() for k in match_keys]
-        input_key_tuples = [
+        input_key_tuples: List[_KeyTuple] = [
             tuple(col[i] for col in key_columns)
             for i in range(partition_data.num_rows)
         ]
 
-        # 2. Deduplicate: keep last occurrence of each key
+        # 2. Deduplicate – keep the LAST occurrence of every repeated key.
+        partition_data, input_key_tuples = self._dedup_last_write_wins(
+            partition_data, input_key_tuples, partition_spec,
+        )
+
+        # 3. Scan partition once, keeping only key → _ROW_ID pairs that
+        #    appear in the input (memory ∝ |input|, not |partition|).
+        key_to_row_id = self._build_key_to_row_id_map(
+            match_keys, partition_spec, set(input_key_tuples),
+        )
+
+        # 4. Partition input rows into matched (update) vs unmatched (append).
+        matched_indices: List[int] = []
+        new_indices: List[int] = []
+        for i, key_tuple in enumerate(input_key_tuples):
+            (matched_indices if key_tuple in key_to_row_id else new_indices).append(i)
+
+        logger.info(
+            "Upserting partition %s: %d matched, %d new",
+            partition_spec, len(matched_indices), len(new_indices),
+        )
+
+        commit_messages: List[CommitMessage] = []
+        if matched_indices:
+            commit_messages.extend(self._do_updates(
+                partition_data, matched_indices,
+                input_key_tuples, key_to_row_id, update_cols,
+            ))
+        if new_indices:
+            commit_messages.extend(self._do_appends(partition_data, new_indices))
+        return commit_messages
+
+    @staticmethod
+    def _dedup_last_write_wins(
+            partition_data: pa.Table,
+            input_key_tuples: List[_KeyTuple],
+            partition_spec: Dict[str, Any],
+    ) -> Tuple[pa.Table, List[_KeyTuple]]:
+        """Collapse duplicate-key rows in ``partition_data`` to the last
+        occurrence of each key, preserving relative order. No-op when the
+        input has no duplicates."""
         key_to_last_idx: Dict[_KeyTuple, int] = {}
         for i, key_tuple in enumerate(input_key_tuples):
             key_to_last_idx[key_tuple] = i  # last write wins
 
-        if len(input_key_tuples) != len(key_to_last_idx):
-            original_count = len(input_key_tuples)
-            dedup_indices = sorted(key_to_last_idx.values())
-            partition_data = partition_data.take(dedup_indices)
-            input_key_tuples = [input_key_tuples[i] for i in dedup_indices]
-            logger.warning(
-                "Deduplicated input from %d to %d rows in partition %s "
-                "(kept last occurrence).",
-                original_count, len(input_key_tuples), partition_spec,
-            )
+        if len(key_to_last_idx) == len(input_key_tuples):
+            return partition_data, input_key_tuples
 
-        # 3. Scan partition in batches, build key → _ROW_ID only for
-        #    keys present in the input (avoids full-partition materialisation).
-        input_key_set = set(key_to_last_idx.keys())
-        key_to_row_id = self._build_key_to_row_id_map(
-            match_keys, partition_spec, input_key_set
+        original_count = len(input_key_tuples)
+        dedup_indices = sorted(key_to_last_idx.values())
+        logger.warning(
+            "Deduplicated input from %d to %d rows in partition %s "
+            "(kept last occurrence).",
+            original_count, len(dedup_indices), partition_spec,
         )
-
-        # 4. Split into matched (update) vs unmatched (append)
-        matched_indices: List[int] = []
-        new_indices: List[int] = []
-        for i, key_tuple in enumerate(input_key_tuples):
-            if key_tuple in key_to_row_id:
-                matched_indices.append(i)
-            else:
-                new_indices.append(i)
-
-        commit_messages: List[CommitMessage] = []
-
-        logger.info(
-            f"Upserting partition {partition_spec}: "
-            f"{len(matched_indices)} matched, {len(new_indices)} new"
+        return (
+            partition_data.take(dedup_indices),
+            [input_key_tuples[i] for i in dedup_indices],
         )
-
-        # 5. In-place updates
-        if matched_indices:
-            commit_messages.extend(
-                self._do_updates(
-                    partition_data, matched_indices,
-                    input_key_tuples, key_to_row_id, update_cols
-                )
-            )
-
-        # 6. Appends
-        if new_indices:
-            commit_messages.extend(
-                self._do_appends(partition_data, new_indices)
-            )
-
-        return commit_messages
 
     def _validate_inputs(self, data: pa.Table, upsert_keys: List[str],
                          update_cols: Optional[List[str]]):
@@ -281,9 +285,11 @@ class TableUpsertByKey:
         Scan the partition in batches and collect key → _ROW_ID only for
         rows whose composite key is in *input_key_set*.
 
-        ``is_in`` predicates on each key column are pushed to the scan so
-        that files whose stats do not overlap the input values are pruned
-        entirely.
+        The partition spec (if any) is pushed down as an ``and`` of per-key
+        equality predicates so non-matching partitions are pruned by the
+        scanner. The match-key filter itself is applied in Python on each
+        batch — this keeps memory proportional to the input key set rather
+        than the entire partition.
 
         Args:
             match_keys:     Column names used as the composite match key
@@ -337,27 +343,21 @@ class TableUpsertByKey:
             key_to_row_id: Dict[_KeyTuple, int],
             update_cols: Optional[List[str]]
     ) -> List[CommitMessage]:
-        """
-        Update rows that have matching upsert keys by rewriting them in-place.
-        """
+        """Update matched rows by rewriting them in-place via
+        :class:`TableUpdateByRowId`."""
         matched_data = data.take(matched_indices)
+        row_id_array = pa.array(
+            [key_to_row_id[input_key_tuples[i]] for i in matched_indices],
+            type=pa.int64(),
+        )
+        update_data = matched_data.append_column(
+            SpecialFields.ROW_ID.name, row_id_array,
+        )
 
-        # Build _ROW_ID values for matched rows
-        row_id_values = [key_to_row_id[input_key_tuples[i]] for i in matched_indices]
-        row_id_array = pa.array(row_id_values, type=pa.int64())
-
-        # Add _ROW_ID column
-        update_data = matched_data.append_column(SpecialFields.ROW_ID.name, row_id_array)
-
-        # Determine which columns to update
-        if update_cols is None:
-            cols_to_update = list(self.table.field_names)
-        else:
-            cols_to_update = list(update_cols)
-
-        # Use TableUpdateByRowId to do the actual in-place update
-        updater = TableUpdateByRowId(self.table, self.commit_user)
-        return updater.update_columns(update_data, cols_to_update)
+        cols_to_update = list(update_cols) if update_cols else list(self.table.field_names)
+        return TableUpdateByRowId(
+            self.table, self.commit_user, self.commit_identifier,
+        ).update_columns(update_data, cols_to_update)
 
     def _do_appends(
             self,
@@ -367,10 +367,13 @@ class TableUpsertByKey:
         """
         Append rows that have no matching upsert key.
 
-        New rows are written with all columns via the standard
-        BatchTableWrite API, which handles partition/bucket routing
-        automatically.  ``update_cols`` only restricts which columns
-        are rewritten for *matched* rows.
+        New rows are always written with *all* columns — ``update_cols``
+        only restricts which columns are rewritten for *matched* rows.
+
+        :class:`StreamTableWrite` is used so the produced commit messages
+        carry this upsert's ``commit_identifier``; in batch mode the
+        identifier is :data:`BATCH_COMMIT_IDENTIFIER`, so the on-disk
+        result is identical to using :class:`BatchTableWrite`.
         """
         new_data = data.take(new_indices)
 
@@ -378,10 +381,10 @@ class TableUpsertByKey:
         all_ordered_cols = [c for c in self.table.field_names if c in new_data.column_names]
         new_data = new_data.select(all_ordered_cols)
 
-        table_write = BatchTableWrite(self.table, self.commit_user)
+        table_write = StreamTableWrite(self.table, self.commit_user)
         try:
             table_write.with_write_type(all_ordered_cols)
             table_write.write_arrow(new_data)
-            return table_write.prepare_commit()
+            return table_write.prepare_commit(self.commit_identifier)
         finally:
             table_write.close()

--- a/paimon-python/pypaimon/write/write_builder.py
+++ b/paimon-python/pypaimon/write/write_builder.py
@@ -22,7 +22,8 @@ from typing import Optional
 
 from pypaimon.write.table_commit import (BatchTableCommit, StreamTableCommit,
                                          TableCommit)
-from pypaimon.write.table_update import TableUpdate
+from pypaimon.write.table_update import (BatchTableUpdate, StreamTableUpdate,
+                                         TableUpdate)
 from pypaimon.write.table_write import (BatchTableWrite, StreamTableWrite,
                                         TableWrite)
 
@@ -61,8 +62,8 @@ class BatchWriteBuilder(WriteBuilder):
     def new_write(self) -> BatchTableWrite:
         return BatchTableWrite(self.table, self.commit_user)
 
-    def new_update(self) -> TableUpdate:
-        return TableUpdate(self.table, self.commit_user)
+    def new_update(self) -> BatchTableUpdate:
+        return BatchTableUpdate(self.table, self.commit_user)
 
     def new_commit(self) -> BatchTableCommit:
         commit = BatchTableCommit(self.table, self.commit_user, self.static_partition)
@@ -74,8 +75,8 @@ class StreamWriteBuilder(WriteBuilder):
     def new_write(self) -> StreamTableWrite:
         return StreamTableWrite(self.table, self.commit_user)
 
-    def new_update(self) -> TableUpdate:
-        raise ValueError("StreamWriteBuilder.new_update() not supported.")
+    def new_update(self) -> StreamTableUpdate:
+        return StreamTableUpdate(self.table, self.commit_user)
 
     def new_commit(self) -> StreamTableCommit:
         commit = StreamTableCommit(self.table, self.commit_user, self.static_partition)


### PR DESCRIPTION
### Purpose                                                               

Support data evolution for `StreamWriteBuilder` by introducing `StreamTableUpdate` that exposes `update_by_arrow_with_row_id` and `upsert_by_arrow_with_key` APIs with `commit_identifier` support. Previously, `StreamWriteBuilder.new_update()` raised `ValueError("StreamWriteBuilder.new_update() not supported.")`, making data-evolution table-update operations unavailable in streaming mode.

Key changes:

- `TableUpdate` → `BatchTableUpdate` / `StreamTableUpdate` split: Refactored `TableUpdate` into a shared base with `_update_by_arrow_with_row_id` and `_upsert_by_arrow_with_key` internals that accept a `commit_identifier`. `BatchTableUpdate` delegates to `BATCH_COMMIT_IDENTIFIER` (no commit_identifier parameter); `StreamTableUpdate` requires an explicit commit_identifier per call — mirroring the existing `TableWrite` / `TableCommit` batch/stream pattern.
- `TableCommit` cleanup: Moved `_check_committed` / `batch_committed` guard down from the shared `TableCommit` base into `BatchTableCommit`, since stream-mode commits are reusable by design. Improved log message and docstrings.
- `TableUpdateByRowId` / `TableUpsertByKey`: Both now accept `commit_identifier` via constructor instead of hard-coding `BATCH_COMMIT_IDENTIFIER` internally. `TableUpsertByKey._do_appends` switched from `BatchTableWrite` to `StreamTableWrite` so that appended commit messages carry the correct identifier.
- `WriteBuilder`: `StreamWriteBuilder.new_update()` returns `StreamTableUpdate` instead of raising.                                                                                          

### Tests

Stream-mode tests in `table_update_test.py` and `table_upsert_by_key_test.py` cover `update_by_arrow_with_row_id` and `upsert_by_arrow_with_key` under streaming, including: single-column update, multi-column update, partial-row update, partitioned tables, consecutive commits with correct snapshot identifiers, and concurrent stream commits.