### PR TITLE
[core] Drop global index external path with table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.DATA_FILE_EXTERNAL_PATHS;
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_EXTERNAL_PATH;
 import static org.apache.paimon.CoreOptions.PATH;
 import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.catalog.CatalogUtils.checkNotBranch;
@@ -387,7 +388,15 @@ public abstract class AbstractCatalog implements Catalog {
             return Collections.emptyList();
         }
         return schemas.stream()
-                .map(schema -> schema.toSchema().options().get(DATA_FILE_EXTERNAL_PATHS.key()))
+                .flatMap(
+                        schema -> {
+                            Map<String, String> options = schema.toSchema().options();
+                            return Arrays.stream(
+                                    new String[] {
+                                        options.get(DATA_FILE_EXTERNAL_PATHS.key()),
+                                        options.get(GLOBAL_INDEX_EXTERNAL_PATH.key())
+                                    });
+                        })
                 .filter(Objects::nonNull)
                 .flatMap(externalPath -> Arrays.stream(externalPath.split(",")))
                 .map(Path::new)

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -68,6 +68,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.annotation.Nullable;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1079,6 +1080,38 @@ public abstract class CatalogTestBase {
         // Drop table does not throw exception when table does not exist and ignoreIfNotExists is
         // true
         assertThatCode(() -> catalog.dropTable(nonExistingTable, true)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testDropTableWithExternalPaths() throws Exception {
+        catalog.createDatabase("test_db", false);
+        Identifier identifier = Identifier.create("test_db", "table_with_external_paths");
+        java.nio.file.Path dataExternalPath = tempFile.resolve("data-external-path");
+        java.nio.file.Path globalIndexExternalPath = tempFile.resolve("global-index-external-path");
+        Files.createDirectories(dataExternalPath.resolve("data"));
+        Files.createDirectories(globalIndexExternalPath.resolve("index"));
+
+        Map<String, String> options = new HashMap<>();
+        options.put(
+                CoreOptions.DATA_FILE_EXTERNAL_PATHS.key(), dataExternalPath.toUri().toString());
+        options.put(
+                CoreOptions.GLOBAL_INDEX_EXTERNAL_PATH.key(),
+                globalIndexExternalPath.toUri().toString());
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "col", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+
+        catalog.createTable(identifier, schema, false);
+        catalog.dropTable(identifier, false);
+
+        assertThat(Files.exists(dataExternalPath)).isFalse();
+        assertThat(Files.exists(globalIndexExternalPath)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

When dropping a table, Paimon already collects and deletes paths from `data-file.external-paths`. However, it missed `global-index.external-path`, so global index files could be left behind after `dropTable`.

### Changes

- Include `GLOBAL_INDEX_EXTERNAL_PATH` when collecting schema external paths during table drop.
- Add catalog coverage verifying both data file external paths and global index external paths are removed.

### Tests

- `mvn -pl paimon-core -Pfast-build -Dtest=FileSystemCatalogTest#testDropTableWithExternalPaths,CachingCatalogTest#testDropTableWithExternalPaths test`
- `mvn -pl paimon-core -DskipTests spotless:check`
