### PR TITLE
[python] Fix read_paimon ArrowInvalid on PK tables with single-snapshot data

### DIFF
--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -157,7 +157,10 @@ class RayDatasource(Datasource):
                 if batch.num_rows == 0:
                     continue
                 has_data = True
-                yield pyarrow.Table.from_batches([batch], schema=schema)
+                table = pyarrow.Table.from_batches([batch])
+                if table.schema != schema:
+                    table = table.cast(schema)
+                yield table
 
             if not has_data:
                 yield pyarrow.Table.from_arrays(

--- a/paimon-python/pypaimon/tests/ray_integration_test.py
+++ b/paimon-python/pypaimon/tests/ray_integration_test.py
@@ -345,6 +345,32 @@ class RayIntegrationTest(unittest.TestCase):
             read_paimon('default.does_not_matter', self.catalog_options,
                         override_num_blocks=0)
 
+    def test_read_paimon_pk_single_snapshot(self):
+        """read_paimon on a PK table with a single snapshot (raw-convertible
+        splits) must not raise ArrowInvalid on schema nullability mismatch.
+
+        The Paimon table schema marks PK columns as NOT NULL, but the
+        Parquet reader may produce nullable fields. The RayDatasource
+        read task must cast the batch to align the schema rather than
+        rejecting it via strict from_batches equality.
+        """
+        from pypaimon.ray import read_paimon
+
+        pa_schema = pa.schema([
+            pa.field('id', pa.int32(), nullable=False),
+            ('name', pa.string()),
+        ])
+        identifier = self._create_and_populate_table(
+            'test_read_pk_single_snap', pa_schema,
+            {'id': [1, 2, 3], 'name': ['a', 'b', 'c']},
+            primary_keys=['id'], options={'bucket': '2'},
+        )
+
+        ds = read_paimon(identifier, self.catalog_options)
+        self.assertEqual(ds.count(), 3)
+        df = ds.to_pandas().sort_values('id').reset_index(drop=True)
+        self.assertEqual(list(df['id']), [1, 2, 3])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Purpose

`read_paimon()` crashes with `pyarrow.lib.ArrowInvalid` when reading
a primary-key table whose data consists of a single snapshot (all
splits are raw-convertible). The issue is in
`RayDatasource._get_read_task`:

```python
yield pyarrow.Table.from_batches([batch], schema=schema)
```

`schema` comes from `PyarrowFieldParser.from_paimon_schema` and marks
PK columns as `NOT NULL`. The `batch` from the Parquet reader may have
those columns as nullable — `from_batches` does a strict schema equality
check (including the nullable bit) and rejects the mismatch.

This is a pre-existing issue on master. It was never triggered by
existing tests because they all write multiple snapshots (creating
non-raw-convertible splits that go through the merge-read path, which
preserves nullability).

## Linked Issue

Discovered while testing PR #7813 on CI (Python 3.10 / pyarrow in the
CI container triggers the strict check; newer pyarrow on local dev
machines is more lenient).

## Fix

Replace the strict `from_batches([batch], schema=schema)` with:

```python
table = pyarrow.Table.from_batches([batch])
if table.schema != schema:
    table = table.cast(schema)
yield table
```

`Table.cast(target_schema)` is a zero-copy metadata-only operation for
nullable→not-null diffs. It also handles other type promotions (e.g.
`large_string → string`) that may occur on some Ray versions.

When schemas already match, the `if` branch is skipped — zero overhead.

## Tests

Added `test_read_paimon_pk_single_snapshot`: PK table + single write +
`read_paimon()` — verifies no ArrowInvalid on raw-convertible splits.

All existing `ray_integration_test.py` tests remain green.

## API & Format Impact

None. Pure internal fix in the Ray read task function.

## Documentation Impact

None.

## Generative AI Disclosure

Drafted with Claude Code assistance, reviewed and tested by the author.