### PR TITLE
[core] Add manifest sort compaction

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -469,6 +469,21 @@ public class CoreOptions implements Serializable {
                             "To avoid frequent manifest merges, this parameter specifies the minimum number "
                                     + "of ManifestFileMeta to merge.");
 
+    public static final ConfigOption<Boolean> MANIFEST_SORT_ENABLED =
+            key("manifest-sort.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to rewrite part of manifest files by partition range during commit.");
+
+    public static final ConfigOption<Integer> MANIFEST_SORT_REWRITE_MANIFEST_COUNT =
+            key("manifest-sort.rewrite-manifest-count")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The maximum number of manifest files picked from sorted runs for "
+                                    + "manifest sort compaction.");
+
     public static final ConfigOption<String> UPSERT_KEY =
             key("upsert-key")
                     .stringType()
@@ -2809,6 +2824,14 @@ public class CoreOptions implements Serializable {
 
     public int manifestMergeMinCount() {
         return options.get(MANIFEST_MERGE_MIN_COUNT);
+    }
+
+    public boolean manifestSortEnabled() {
+        return options.get(MANIFEST_SORT_ENABLED);
+    }
+
+    public int manifestSortRewriteManifestCount() {
+        return options.get(MANIFEST_SORT_REWRITE_MANIFEST_COUNT);
     }
 
     public MergeEngine mergeEngine() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -895,6 +895,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         String indexManifest = null;
         List<ManifestFileMeta> mergeBeforeManifests = new ArrayList<>();
         List<ManifestFileMeta> mergeAfterManifests = new ArrayList<>();
+        List<ManifestFileMeta> createdManifestsForAbort = new ArrayList<>();
         long nextRowIdStart = firstRowIdStart;
         try {
             long previousTotalRecordCount = 0L;
@@ -915,14 +916,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             // try to merge old manifest files to create base manifest list
             mergeAfterManifests =
-                    ManifestFileMerger.merge(
+                    mergeManifests(
                             mergeBeforeManifests,
-                            manifestFile,
-                            options.manifestTargetSize().getBytes(),
                             options.manifestMergeMinCount(),
                             options.manifestFullCompactionThresholdSize().getBytes(),
-                            partitionType,
-                            options.scanManifestParallelism());
+                            createdManifestsForAbort);
             baseManifestList = manifestList.write(mergeAfterManifests);
 
             if (options.rowTrackingEnabled()) {
@@ -997,7 +995,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             commitCleaner.cleanUpReuseTmpManifests(
                     deltaManifestList, changelogManifestList, oldIndexManifest, indexManifest);
             commitCleaner.cleanUpNoReuseTmpManifests(
-                    baseManifestList, mergeBeforeManifests, mergeAfterManifests);
+                    baseManifestList, mergeBeforeManifests, createdManifestsForAbort);
             throw new RuntimeException(
                     String.format(
                             "Exception occurs when preparing snapshot #%d by user %s "
@@ -1117,16 +1115,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 manifestList.readDataManifests(latestSnapshot);
         List<ManifestFileMeta> mergeAfterManifests;
 
-        // the fist trial
-        mergeAfterManifests =
-                ManifestFileMerger.merge(
-                        mergeBeforeManifests,
-                        manifestFile,
-                        options.manifestTargetSize().getBytes(),
-                        1,
-                        1,
-                        partitionType,
-                        options.scanManifestParallelism());
+        // the first trial
+        mergeAfterManifests = mergeManifests(mergeBeforeManifests, 1, 1);
 
         if (new HashSet<>(mergeBeforeManifests).equals(new HashSet<>(mergeAfterManifests))) {
             // no need to commit this snapshot, because no compact were happened
@@ -1161,6 +1151,87 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.nextRowId());
 
         return commitSnapshotImpl(newSnapshot, emptyList());
+    }
+
+    private List<ManifestFileMeta> mergeManifests(
+            List<ManifestFileMeta> input,
+            int suggestedMinMetaCount,
+            long manifestFullCompactionSize) {
+        List<ManifestFileMeta> newFilesForAbort = new ArrayList<>();
+        try {
+            return mergeManifests(
+                    input, suggestedMinMetaCount, manifestFullCompactionSize, newFilesForAbort);
+        } catch (Throwable e) {
+            for (ManifestFileMeta manifest : newFilesForAbort) {
+                manifestFile.delete(manifest.fileName());
+            }
+            if (e instanceof Error) {
+                throw (Error) e;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<ManifestFileMeta> mergeManifests(
+            List<ManifestFileMeta> input,
+            int suggestedMinMetaCount,
+            long manifestFullCompactionSize,
+            List<ManifestFileMeta> newFilesForAbort)
+            throws Exception {
+        List<ManifestFileMeta> merged =
+                ManifestFileMerger.merge(
+                        input,
+                        manifestFile,
+                        options.manifestTargetSize().getBytes(),
+                        suggestedMinMetaCount,
+                        manifestFullCompactionSize,
+                        partitionType,
+                        options.scanManifestParallelism());
+        addCreatedManifestFiles(input, merged, newFilesForAbort);
+        if (options.manifestSortEnabled()) {
+            Optional<List<ManifestFileMeta>> sorted =
+                    ManifestFileMerger.trySortCompaction(
+                            merged,
+                            newFilesForAbort,
+                            manifestFile,
+                            partitionType,
+                            options.manifestSortRewriteManifestCount(),
+                            options.scanManifestParallelism());
+            if (sorted.isPresent()) {
+                merged = sorted.get();
+                cleanUnusedCreatedManifestFiles(merged, newFilesForAbort);
+            }
+        }
+        return merged;
+    }
+
+    private static void addCreatedManifestFiles(
+            List<ManifestFileMeta> input,
+            List<ManifestFileMeta> output,
+            List<ManifestFileMeta> newFilesForAbort) {
+        Set<String> inputFileNames =
+                input.stream().map(ManifestFileMeta::fileName).collect(Collectors.toSet());
+        Set<String> knownNewFileNames =
+                newFilesForAbort.stream()
+                        .map(ManifestFileMeta::fileName)
+                        .collect(Collectors.toSet());
+        for (ManifestFileMeta manifest : output) {
+            if (!inputFileNames.contains(manifest.fileName())
+                    && knownNewFileNames.add(manifest.fileName())) {
+                newFilesForAbort.add(manifest);
+            }
+        }
+    }
+
+    private void cleanUnusedCreatedManifestFiles(
+            List<ManifestFileMeta> output, List<ManifestFileMeta> createdManifestFiles) {
+        Set<String> outputFileNames =
+                output.stream().map(ManifestFileMeta::fileName).collect(Collectors.toSet());
+        for (ManifestFileMeta manifest : createdManifestFiles) {
+            if (!outputFileNames.contains(manifest.fileName())) {
+                manifestFile.delete(manifest.fileName());
+            }
+        }
     }
 
     private boolean commitSnapshotImpl(Snapshot newSnapshot, List<PartitionEntry> deltaStatistics) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -177,6 +177,9 @@ public class ManifestFileMerger {
             return Optional.empty();
         }
 
+        // Sort compaction may move a rewritten group before non-rewritten manifests. Even though
+        // rewriteGroups keeps the input order inside each group, it cannot preserve ordering
+        // dependencies between a DELETE entry and an ADD entry in manifests outside the group.
         for (ManifestFileMeta file : input) {
             if (file.numDeletedFiles() > 0) {
                 return Optional.empty();
@@ -224,9 +227,8 @@ public class ManifestFileMerger {
         for (int i = 0; i < input.size(); i++) {
             ManifestFileMeta file = input.get(i);
             if (rewriteFileNames.contains(file.fileName())) {
-                if (insertPos < 0) {
-                    insertPos = i;
-                }
+                insertPos = i;
+                break;
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.codegen.CodeGenUtils;
+import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.manifest.FileEntry;
@@ -34,13 +36,17 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -152,6 +158,274 @@ public class ManifestFileMerger {
             List<ManifestFileMeta> merged = manifestFile.write(new ArrayList<>(map.values()));
             result.addAll(merged);
             newMetas.addAll(merged);
+        }
+    }
+
+    public static Optional<List<ManifestFileMeta>> trySortCompaction(
+            List<ManifestFileMeta> input,
+            List<ManifestFileMeta> newFilesForAbort,
+            ManifestFile manifestFile,
+            RowType partitionType,
+            int rewriteManifestCount,
+            @Nullable Integer manifestReadParallelism)
+            throws Exception {
+        checkArgument(
+                rewriteManifestCount > 0,
+                "Manifest sort rewrite manifest count must be greater than 0.");
+
+        if (partitionType.getFieldCount() == 0 || input.size() <= 1) {
+            return Optional.empty();
+        }
+
+        for (ManifestFileMeta file : input) {
+            if (file.numDeletedFiles() > 0) {
+                return Optional.empty();
+            }
+        }
+
+        RecordComparator partitionComparator =
+                CodeGenUtils.newRecordComparator(partitionType.getFieldTypes());
+        List<ManifestFileMeta> compactCandidates = compactCandidates(input, partitionComparator);
+        if (compactCandidates.size() <= 1) {
+            return Optional.empty();
+        }
+
+        List<ManifestSortedRun> runs = partitionSortedRuns(compactCandidates, partitionComparator);
+        if (runs.size() <= 1) {
+            return Optional.empty();
+        }
+
+        List<ManifestSortedRun> pickedRuns = pickRuns(runs, rewriteManifestCount);
+        if (pickedRuns.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ManifestFileMeta> pickedFiles = new ArrayList<>();
+        for (ManifestSortedRun run : pickedRuns) {
+            pickedFiles.addAll(run.files);
+        }
+        List<List<ManifestFileMeta>> rewriteGroups =
+                rewriteGroups(pickedFiles, input, partitionComparator);
+        LinkedHashSet<String> rewriteFileNames = new LinkedHashSet<>();
+        for (List<ManifestFileMeta> rewriteGroup : rewriteGroups) {
+            addFileNames(rewriteGroup, rewriteFileNames);
+        }
+        if (rewriteFileNames.size() <= 1) {
+            return Optional.empty();
+        }
+
+        LOG.info(
+                "Start Manifest File Sort Compaction: sortedRuns: {}, pickedRuns: {}, pickedFiles: {}",
+                runs.size(),
+                pickedRuns.size(),
+                pickedFiles.size());
+
+        int insertPos = -1;
+        for (int i = 0; i < input.size(); i++) {
+            ManifestFileMeta file = input.get(i);
+            if (rewriteFileNames.contains(file.fileName())) {
+                if (insertPos < 0) {
+                    insertPos = i;
+                }
+            }
+        }
+
+        List<ManifestFileMeta> rewritten = new ArrayList<>();
+        for (List<ManifestFileMeta> rewriteGroup : rewriteGroups) {
+            Map<FileEntry.Identifier, ManifestEntry> map = new LinkedHashMap<>();
+            FileEntry.mergeEntries(manifestFile, rewriteGroup, map, manifestReadParallelism);
+            List<ManifestEntry> entries = new ArrayList<>(map.values());
+            sortEntriesByPartition(entries, partitionComparator);
+            if (!entries.isEmpty()) {
+                List<ManifestFileMeta> groupRewritten = manifestFile.write(entries);
+                rewritten.addAll(groupRewritten);
+                newFilesForAbort.addAll(groupRewritten);
+            }
+        }
+
+        List<ManifestFileMeta> result = new ArrayList<>();
+        for (int i = 0; i < input.size(); i++) {
+            if (i == insertPos) {
+                result.addAll(rewritten);
+            }
+            ManifestFileMeta file = input.get(i);
+            if (!rewriteFileNames.contains(file.fileName())) {
+                result.add(file);
+            }
+        }
+        return Optional.of(result);
+    }
+
+    private static List<ManifestFileMeta> compactCandidates(
+            List<ManifestFileMeta> input, RecordComparator partitionComparator) {
+        List<ManifestFileMeta> result = new ArrayList<>();
+        for (ManifestFileMeta file : input) {
+            if (hasMultiplePartitions(file, partitionComparator)) {
+                result.add(file);
+            }
+        }
+        return result;
+    }
+
+    private static List<ManifestSortedRun> partitionSortedRuns(
+            List<ManifestFileMeta> input, RecordComparator partitionComparator) {
+        List<ManifestFileMeta> files = new ArrayList<>(input);
+        files.sort(
+                (left, right) -> {
+                    int result =
+                            partitionComparator.compare(minPartition(left), minPartition(right));
+                    return result == 0
+                            ? partitionComparator.compare(maxPartition(left), maxPartition(right))
+                            : result;
+                });
+
+        PriorityQueue<ManifestSortedRunBuilder> queue =
+                new PriorityQueue<>(
+                        (left, right) ->
+                                partitionComparator.compare(
+                                        maxPartition(left.last()), maxPartition(right.last())));
+        for (ManifestFileMeta file : files) {
+            ManifestSortedRunBuilder run = queue.poll();
+            if (run == null) {
+                queue.add(new ManifestSortedRunBuilder(file));
+            } else if (partitionComparator.compare(minPartition(file), maxPartition(run.last()))
+                    > 0) {
+                run.add(file);
+                queue.add(run);
+            } else {
+                queue.add(new ManifestSortedRunBuilder(file));
+                queue.add(run);
+            }
+        }
+
+        List<ManifestSortedRun> runs = new ArrayList<>();
+        for (ManifestSortedRunBuilder builder : queue) {
+            runs.add(builder.toRun());
+        }
+        runs.sort(
+                (left, right) ->
+                        partitionComparator.compare(
+                                minPartition(left.files.get(0)), minPartition(right.files.get(0))));
+        return runs;
+    }
+
+    private static List<ManifestSortedRun> pickRuns(
+            List<ManifestSortedRun> runs, int rewriteManifestCount) {
+        List<ManifestSortedRun> sortedRuns = new ArrayList<>(runs);
+        sortedRuns.sort(
+                Comparator.comparingLong(ManifestSortedRun::totalFileSize)
+                        .thenComparingInt(ManifestSortedRun::fileCount));
+
+        ManifestSortedRun firstRun = sortedRuns.get(0);
+        if (firstRun.fileCount() > rewriteManifestCount) {
+            return Collections.emptyList();
+        }
+
+        List<ManifestSortedRun> result = new ArrayList<>();
+        result.add(firstRun);
+        long candidateSize = firstRun.totalFileSize();
+        int candidateFileCount = firstRun.fileCount();
+        for (int i = 1; i < sortedRuns.size(); i++) {
+            ManifestSortedRun next = sortedRuns.get(i);
+            if (candidateSize < next.totalFileSize()
+                    || candidateFileCount + next.fileCount() > rewriteManifestCount) {
+                break;
+            }
+            result.add(next);
+            candidateSize += next.totalFileSize();
+            candidateFileCount += next.fileCount();
+        }
+        return result.size() > 1 ? result : Collections.emptyList();
+    }
+
+    private static List<List<ManifestFileMeta>> rewriteGroups(
+            List<ManifestFileMeta> rewriteFiles,
+            List<ManifestFileMeta> input,
+            RecordComparator partitionComparator) {
+        rewriteFiles = new ArrayList<>(rewriteFiles);
+        rewriteFiles.sort(
+                (left, right) -> {
+                    int result =
+                            partitionComparator.compare(minPartition(left), minPartition(right));
+                    return result == 0
+                            ? partitionComparator.compare(maxPartition(left), maxPartition(right))
+                            : result;
+                });
+
+        List<Set<String>> groupNames = new ArrayList<>();
+        LinkedHashSet<String> currentNames = new LinkedHashSet<>();
+        BinaryRow currentMax = null;
+        for (ManifestFileMeta file : rewriteFiles) {
+            if (!currentNames.isEmpty()
+                    && partitionComparator.compare(minPartition(file), currentMax) > 0) {
+                groupNames.add(currentNames);
+                currentNames = new LinkedHashSet<>();
+                currentMax = null;
+            }
+            currentNames.add(file.fileName());
+            if (currentMax == null
+                    || partitionComparator.compare(maxPartition(file), currentMax) > 0) {
+                currentMax = maxPartition(file);
+            }
+        }
+        if (!currentNames.isEmpty()) {
+            groupNames.add(currentNames);
+        }
+
+        List<List<ManifestFileMeta>> result = new ArrayList<>();
+        for (Set<String> names : groupNames) {
+            List<ManifestFileMeta> group = new ArrayList<>();
+            for (ManifestFileMeta file : input) {
+                if (names.contains(file.fileName())) {
+                    group.add(file);
+                }
+            }
+            if (group.size() > 1) {
+                result.add(group);
+            }
+        }
+        return result;
+    }
+
+    private static void sortEntriesByPartition(
+            List<ManifestEntry> entries, RecordComparator partitionComparator) {
+        entries.sort(
+                (left, right) -> {
+                    int result = partitionComparator.compare(left.partition(), right.partition());
+                    if (result != 0) {
+                        return result;
+                    }
+
+                    result = Integer.compare(left.bucket(), right.bucket());
+                    if (result != 0) {
+                        return result;
+                    }
+
+                    result = Integer.compare(left.level(), right.level());
+                    if (result != 0) {
+                        return result;
+                    }
+
+                    return left.fileName().compareTo(right.fileName());
+                });
+    }
+
+    private static boolean hasMultiplePartitions(
+            ManifestFileMeta file, RecordComparator partitionComparator) {
+        return partitionComparator.compare(minPartition(file), maxPartition(file)) < 0;
+    }
+
+    private static BinaryRow minPartition(ManifestFileMeta file) {
+        return file.partitionStats().minValues();
+    }
+
+    private static BinaryRow maxPartition(ManifestFileMeta file) {
+        return file.partitionStats().maxValues();
+    }
+
+    private static void addFileNames(List<ManifestFileMeta> files, Set<String> names) {
+        for (ManifestFileMeta file : files) {
+            names.add(file.fileName());
         }
     }
 
@@ -314,6 +588,51 @@ public class ManifestFileMerger {
             this.file = file;
             this.requireChange = requireChange;
             this.entries = entries;
+        }
+    }
+
+    private static class ManifestSortedRun {
+
+        private final List<ManifestFileMeta> files;
+        private final long totalFileSize;
+
+        private ManifestSortedRun(List<ManifestFileMeta> files) {
+            this.files = files;
+            long totalFileSize = 0;
+            for (ManifestFileMeta file : files) {
+                totalFileSize += file.fileSize();
+            }
+            this.totalFileSize = totalFileSize;
+        }
+
+        private int fileCount() {
+            return files.size();
+        }
+
+        private long totalFileSize() {
+            return totalFileSize;
+        }
+    }
+
+    private static class ManifestSortedRunBuilder {
+
+        private final List<ManifestFileMeta> files;
+
+        private ManifestSortedRunBuilder(ManifestFileMeta file) {
+            this.files = new ArrayList<>();
+            this.files.add(file);
+        }
+
+        private void add(ManifestFileMeta file) {
+            files.add(file);
+        }
+
+        private ManifestFileMeta last() {
+            return files.get(files.size() - 1);
+        }
+
+        private ManifestSortedRun toRun() {
+            return new ManifestSortedRun(files);
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -75,6 +75,18 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         manifestFile = createManifestFile(tempDir.toString());
     }
 
+    private ManifestFileMeta makeRangeManifest(String fileNamePrefix, int minPartition) {
+        return makeManifest(
+                makeEntry(true, fileNamePrefix + "-" + minPartition, minPartition),
+                makeEntry(true, fileNamePrefix + "-" + (minPartition + 1), minPartition + 1));
+    }
+
+    private Set<String> entryFileNames(ManifestFileMeta manifest) {
+        return manifestFile.read(manifest.fileName(), manifest.fileSize()).stream()
+                .map(entry -> entry.file().fileName())
+                .collect(Collectors.toSet());
+    }
+
     @Disabled // TODO wrong test to rely on self-defined file size
     @ParameterizedTest
     @ValueSource(ints = {2, 3, 4})
@@ -229,6 +241,169 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
                 ManifestFileMerger.merge(
                         input, manifestFile, 500, 3, 200, getPartitionType(), null);
         assertEquivalentEntries(input, merged);
+    }
+
+    @Test
+    public void testSortCompactionPicksRunsByRecursiveSize() throws Exception {
+        ManifestFileMeta run0Partition0 = makeRangeManifest("run0", 0);
+        ManifestFileMeta run1Partition0 = makeRangeManifest("run1", 0);
+        ManifestFileMeta run2Partition0 = makeRangeManifest("run2", 0);
+        ManifestFileMeta run0Partition3 = makeRangeManifest("run0", 3);
+        ManifestFileMeta run1Partition3 = makeRangeManifest("run1", 3);
+        ManifestFileMeta run2Partition3 = makeRangeManifest("run2", 3);
+        ManifestFileMeta run0Partition6 = makeRangeManifest("run0", 6);
+        ManifestFileMeta run1Partition6 = makeRangeManifest("run1", 6);
+        ManifestFileMeta run2Partition6 = makeRangeManifest("run2", 6);
+        List<ManifestFileMeta> input =
+                Arrays.asList(
+                        run0Partition0,
+                        run1Partition0,
+                        run2Partition0,
+                        run0Partition3,
+                        run1Partition3,
+                        run2Partition3,
+                        run0Partition6,
+                        run1Partition6,
+                        run2Partition6);
+
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 9, null);
+
+        assertThat(sorted).isPresent();
+        List<ManifestFileMeta> result = sorted.get();
+        assertEquivalentEntries(input, result);
+        assertThat(result).hasSize(3);
+        assertThat(result).doesNotContainAnyElementsOf(input);
+        assertThat(newMetas).hasSize(3);
+        assertThat(newMetas.stream().map(this::entryFileNames).collect(Collectors.toList()))
+                .containsExactlyInAnyOrder(
+                        new HashSet<>(
+                                Arrays.asList(
+                                        "run0-0", "run0-1", "run1-0", "run1-1", "run2-0",
+                                        "run2-1")),
+                        new HashSet<>(
+                                Arrays.asList(
+                                        "run0-3", "run0-4", "run1-3", "run1-4", "run2-3",
+                                        "run2-4")),
+                        new HashSet<>(
+                                Arrays.asList(
+                                        "run0-6", "run0-7", "run1-6", "run1-7", "run2-6",
+                                        "run2-7")));
+    }
+
+    @Test
+    public void testSortCompactionRegistersEveryRewrittenManifestForAbort() throws Exception {
+        ManifestFileMeta run0Partition0 = makeRangeManifest("run0", 0);
+        ManifestFileMeta run1Partition0 = makeRangeManifest("run1", 0);
+        ManifestFileMeta run2Partition0 = makeRangeManifest("run2", 0);
+        ManifestFileMeta run0Partition3 = makeRangeManifest("run0", 3);
+        ManifestFileMeta run1Partition3 = makeRangeManifest("run1", 3);
+        ManifestFileMeta run2Partition3 = makeRangeManifest("run2", 3);
+        ManifestFileMeta run0Partition6 = makeRangeManifest("run0", 6);
+        ManifestFileMeta run1Partition6 = makeRangeManifest("run1", 6);
+        ManifestFileMeta run2Partition6 = makeRangeManifest("run2", 6);
+        List<ManifestFileMeta> input =
+                Arrays.asList(
+                        run0Partition0,
+                        run1Partition0,
+                        run2Partition0,
+                        run0Partition3,
+                        run1Partition3,
+                        run2Partition3,
+                        run0Partition6,
+                        run1Partition6,
+                        run2Partition6);
+
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 6, null);
+
+        assertThat(sorted).isPresent();
+        assertEquivalentEntries(input, sorted.get());
+        assertThat(sorted.get()).hasSize(6);
+        assertThat(newMetas).hasSize(3);
+        assertThat(newMetas).allMatch(meta -> sorted.get().contains(meta));
+        assertThat(newMetas.stream().map(this::entryFileNames).collect(Collectors.toList()))
+                .allMatch(names -> names.size() == 4);
+    }
+
+    @Test
+    public void testSortCompactionCanRewriteSingleFileRuns() throws Exception {
+        List<ManifestFileMeta> input =
+                Arrays.asList(makeRangeManifest("run0", 0), makeRangeManifest("run1", 0));
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 2, null);
+
+        assertThat(sorted).isPresent();
+        assertEquivalentEntries(input, sorted.get());
+        assertThat(sorted.get()).hasSize(1);
+        assertThat(newMetas).hasSize(1);
+        assertThat(entryFileNames(newMetas.get(0)))
+                .containsExactlyInAnyOrder("run0-0", "run0-1", "run1-0", "run1-1");
+    }
+
+    @Test
+    public void testSortCompactionSkipsWhenOnlyOneRunFitsRewriteCount() throws Exception {
+        List<ManifestFileMeta> input =
+                Arrays.asList(
+                        makeRangeManifest("target-0", 0),
+                        makeRangeManifest("target-3", 3),
+                        makeRangeManifest("source-3", 3),
+                        makeRangeManifest("target-6", 6),
+                        makeRangeManifest("source-6", 6));
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 2, null);
+
+        assertThat(sorted).isEmpty();
+        assertThat(newMetas).isEmpty();
+    }
+
+    @Test
+    public void testSortCompactionSkipsSinglePartitionManifests() throws Exception {
+        List<ManifestFileMeta> input =
+                Arrays.asList(
+                        makeManifest(makeEntry(true, "target-0", 0)),
+                        makeManifest(makeEntry(true, "target-2", 2)),
+                        makeManifest(makeEntry(true, "target-4", 4)),
+                        makeManifest(makeEntry(true, "source-4", 4)),
+                        makeManifest(makeEntry(true, "target-6", 6)),
+                        makeManifest(makeEntry(true, "source-6", 6)),
+                        makeManifest(makeEntry(true, "target-8", 8)),
+                        makeManifest(makeEntry(true, "source-8", 8)));
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 3, null);
+
+        assertThat(sorted).isEmpty();
+        assertThat(newMetas).isEmpty();
+    }
+
+    @Test
+    public void testSortCompactionSkipsDeleteManifests() throws Exception {
+        List<ManifestFileMeta> input =
+                Arrays.asList(
+                        makeManifest(makeEntry(true, "target-0", 0)),
+                        makeManifest(makeEntry(false, "target-0", 0)),
+                        makeManifest(makeEntry(true, "target-2", 2)));
+        List<ManifestFileMeta> newMetas = new ArrayList<>();
+
+        Optional<List<ManifestFileMeta>> sorted =
+                ManifestFileMerger.trySortCompaction(
+                        input, newMetas, manifestFile, getPartitionType(), 1, null);
+
+        assertThat(sorted).isEmpty();
+        assertThat(newMetas).isEmpty();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1015,9 +1015,7 @@ public class FileStoreCommitTest {
                         .collect(Collectors.toList());
 
         store.options().toConfiguration().set(CoreOptions.MANIFEST_SORT_ENABLED, true);
-        store.options()
-                .toConfiguration()
-                .set(CoreOptions.MANIFEST_SORT_REWRITE_MANIFEST_COUNT, 4);
+        store.options().toConfiguration().set(CoreOptions.MANIFEST_SORT_REWRITE_MANIFEST_COUNT, 4);
 
         List<KeyValue> finalKvs = partitionRangeData(6, 4);
         expected.addAll(finalKvs);

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -27,6 +27,9 @@ import org.apache.paimon.TestKeyValueGenerator;
 import org.apache.paimon.catalog.RenamingSnapshotCommit;
 import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.deletionvectors.BucketedDvMaintainer;
 import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.fs.Path;
@@ -42,6 +45,7 @@ import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.operation.commit.ConflictDetection;
 import org.apache.paimon.operation.commit.RetryCommitResult;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -981,6 +985,56 @@ public class FileStoreCommitTest {
     }
 
     @Test
+    public void testManifestSortCompactionInCommit() throws Exception {
+        TestFileStore store = createStore(false);
+        store.options()
+                .toConfiguration()
+                .set(CoreOptions.MANIFEST_TARGET_FILE_SIZE, MemorySize.parse("1 gb"));
+        store.options().toConfiguration().set(CoreOptions.MANIFEST_MERGE_MIN_COUNT, 100);
+        store.options()
+                .toConfiguration()
+                .set(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE, MemorySize.parse("1 gb"));
+        store.options().toConfiguration().set(CoreOptions.FILE_COMPRESSION, "null");
+        store.options().toConfiguration().set(CoreOptions.MANIFEST_COMPRESSION, "null");
+
+        List<KeyValue> expected = new ArrayList<>();
+        int[] minHrs = new int[] {0, 3, 0, 3};
+        for (int fileId = 0; fileId < minHrs.length; fileId++) {
+            List<KeyValue> kvs = partitionRangeData(minHrs[fileId], fileId % 2);
+            expected.addAll(kvs);
+            store.commitData(kvs, gen::getPartition, kv -> 0);
+        }
+
+        Snapshot beforeSort = store.snapshotManager().latestSnapshot();
+        List<ManifestFileMeta> beforeSortManifests =
+                store.manifestListFactory().create().readDataManifests(beforeSort);
+        assertThat(beforeSortManifests).hasSize(4);
+        List<String> beforeSortManifestNames =
+                beforeSortManifests.stream()
+                        .map(ManifestFileMeta::fileName)
+                        .collect(Collectors.toList());
+
+        store.options().toConfiguration().set(CoreOptions.MANIFEST_SORT_ENABLED, true);
+        store.options()
+                .toConfiguration()
+                .set(CoreOptions.MANIFEST_SORT_REWRITE_MANIFEST_COUNT, 4);
+
+        List<KeyValue> finalKvs = partitionRangeData(6, 4);
+        expected.addAll(finalKvs);
+        Snapshot sorted = store.commitData(finalKvs, gen::getPartition, kv -> 0).get(0);
+        List<ManifestFileMeta> sortedManifests =
+                store.manifestListFactory().create().readDataManifests(sorted);
+
+        assertThat(sortedManifests).hasSize(3);
+        assertThat(sortedManifests.stream().map(ManifestFileMeta::fileName))
+                .doesNotContainAnyElementsOf(beforeSortManifestNames);
+        assertThat(sortedManifests.stream().map(this::partitionRange).collect(Collectors.toList()))
+                .containsExactly("20211110:0-1", "20211110:3-4", "20211110:6-7");
+        assertThat(store.toKvMap(store.readKvsFromSnapshot(sorted.id())))
+                .isEqualTo(store.toKvMap(expected));
+    }
+
+    @Test
     public void testCommitManifestWithProperties() throws Exception {
         TestFileStore store = createStore(false);
 
@@ -1207,6 +1261,43 @@ public class FileStoreCommitTest {
         return generateData(numRecords).values().stream()
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
+    }
+
+    private List<KeyValue> partitionRangeData(int minHr, int fileId) {
+        return Arrays.asList(
+                sortCompactionKv(minHr, fileId, 0), sortCompactionKv(minHr + 1, fileId, 1));
+    }
+
+    private KeyValue sortCompactionKv(int hr, int fileId, int rowId) {
+        int shopId = 1;
+        long orderId = 1_000_000L + fileId * 10L + rowId;
+        long itemId = 2_000_000L + fileId * 10L + rowId;
+        return new KeyValue()
+                .replace(
+                        TestKeyValueGenerator.KEY_SERIALIZER
+                                .toBinaryRow(GenericRow.of(shopId, orderId))
+                                .copy(),
+                        orderId,
+                        RowKind.INSERT,
+                        TestKeyValueGenerator.DEFAULT_ROW_SERIALIZER
+                                .toBinaryRow(
+                                        GenericRow.of(
+                                                BinaryString.fromString("20211110"),
+                                                hr,
+                                                shopId,
+                                                orderId,
+                                                itemId,
+                                                new GenericArray(new int[] {1, 1}),
+                                                BinaryString.fromString(
+                                                        "manifest-sort-compaction")))
+                                .copy());
+    }
+
+    private String partitionRange(ManifestFileMeta manifest) {
+        BinaryRow min = manifest.partitionStats().minValues();
+        BinaryRow max = manifest.partitionStats().maxValues();
+        assertThat(min.getString(0)).isEqualTo(max.getString(0));
+        return min.getString(0) + ":" + min.getInt(1) + "-" + max.getInt(1);
     }
 
     private Map<BinaryRow, List<KeyValue>> generateData(int numRecords) {


### PR DESCRIPTION
## Summary
- add manifest-sort.enabled and manifest-sort.rewrite-manifest-count options
- add independent manifest sort compaction that groups ManifestFileMeta by partition-range sorted runs
- wire the sort compaction after existing manifest merge during snapshot/manifest compact commits
- add focused manifest metadata tests for partial target-run rewrite and delete-manifest skip behavior

## Validation
- mvn -pl paimon-core -am -DfailIfNoTests=false -Dtest=ManifestFileMetaTest test
- mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=FileStoreCommitTest#testManifestCompact test