### PR TITLE
[common] Avoid secured Hadoop FileSystem without Kerberos config

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
+++ b/paimon-common/src/main/java/org/apache/paimon/security/SecurityConfiguration.java
@@ -84,15 +84,11 @@ public class SecurityConfiguration {
 
     public boolean isLegal() {
         if (StringUtils.isNullOrWhitespaceOnly(keytab)
-                != StringUtils.isNullOrWhitespaceOnly(principal)) {
+                || StringUtils.isNullOrWhitespaceOnly(principal)) {
             return false;
         }
 
-        if (!StringUtils.isNullOrWhitespaceOnly(keytab)) {
-            File keytabFile = new File(keytab);
-            return keytabFile.exists() && keytabFile.isFile() && keytabFile.canRead();
-        }
-
-        return true;
+        File keytabFile = new File(keytab);
+        return keytabFile.exists() && keytabFile.isFile() && keytabFile.canRead();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystemTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystemTest.java
@@ -34,7 +34,15 @@ public class HadoopSecuredFileSystemTest {
     @TempDir private java.nio.file.Path tmp;
 
     @Test
-    public void test() throws Exception {
+    public void testEmptySecurityConfigurationDoesNotWrapFileSystem() throws Exception {
+        HadoopFileIO fileIO = createFileIO(new Options());
+
+        assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
+                .isNotInstanceOf(HadoopSecuredFileSystem.class);
+    }
+
+    @Test
+    public void testValidKeytabAndPrincipalWrapsFileSystem() throws Exception {
         File keytabFile = new File(tmp.toFile(), "test-keytab.keytab");
         assertThat(keytabFile.createNewFile()).isTrue();
 
@@ -42,8 +50,8 @@ public class HadoopSecuredFileSystemTest {
         options.set("security.kerberos.login.principal", "test-user");
         options.set("security.kerberos.login.keytab", keytabFile.getAbsolutePath());
 
-        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
-        fileIO.configure(CatalogContext.create(options));
+        HadoopFileIO fileIO = createFileIO(options);
+
         assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
                 .isInstanceOf(HadoopSecuredFileSystem.class);
     }
@@ -52,8 +60,7 @@ public class HadoopSecuredFileSystemTest {
     public void testPreserveExternalUgiWhenNoKerberosCredentials() throws Exception {
         Options options = new Options();
 
-        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
-        fileIO.configure(CatalogContext.create(options));
+        HadoopFileIO fileIO = createFileIO(options);
         assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
                 .isNotInstanceOf(HadoopSecuredFileSystem.class);
     }
@@ -66,9 +73,14 @@ public class HadoopSecuredFileSystemTest {
         Options options = new Options();
         options.set("security.kerberos.login.keytab", keytabFile.getAbsolutePath());
 
-        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
-        fileIO.configure(CatalogContext.create(options));
+        HadoopFileIO fileIO = createFileIO(options);
         assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
                 .isNotInstanceOf(HadoopSecuredFileSystem.class);
+    }
+
+    private HadoopFileIO createFileIO(Options options) {
+        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
+        fileIO.configure(CatalogContext.create(options));
+        return fileIO;
     }
 }


### PR DESCRIPTION
### Purpose

Fixes #7146.

`SecurityConfiguration#isLegal` now returns false when either Kerberos keytab or principal is missing. This prevents `HadoopFileIO` from wrapping the native Hadoop `FileSystem` in `HadoopSecuredFileSystem` for catalogs without Kerberos configuration, while keeping valid keytab/principal configurations on the secured path.

### Tests

- `mvn -pl paimon-common -Pfast-build -Dtest=HadoopSecuredFileSystemTest test`
- `mvn -pl paimon-common spotless:check`