### PR TITLE
[core] Introduce Catalog#loadTableMetadata

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -668,7 +668,8 @@ public abstract class AbstractCatalog implements Catalog {
         return newDatabasePath(warehouse(), database);
     }
 
-    protected TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
+    @Override
+    public TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
         return new TableMetadata(loadTableSchema(identifier), false, null);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -167,6 +167,15 @@ public interface Catalog extends AutoCloseable {
     Table getTableById(String tableId) throws TableIdNotExistException;
 
     /**
+     * Return a {@link TableMetadata} identified by the given {@link Identifier}.
+     *
+     * @param identifier Path of the table
+     * @return The requested table metadata
+     * @throws TableNotExistException if the target does not exist
+     */
+    TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException;
+
+    /**
      * Get names of all tables under this database. An empty list is returned if none exists.
      *
      * <p>NOTE: System tables will not be listed.

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -159,6 +159,11 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
+        return wrapped.loadTableMetadata(identifier);
+    }
+
+    @Override
     public void renameTable(Identifier fromTable, Identifier toTable, boolean ignoreIfNotExists)
             throws TableNotExistException, TableAlreadyExistException {
         wrapped.renameTable(fromTable, toTable, ignoreIfNotExists);

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -453,7 +453,8 @@ public class RESTCatalog implements Catalog {
         }
     }
 
-    private TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
+    @Override
+    public TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
         // if the table is system table, we need to load table metadata from the system table's data
         // table
         Identifier loadTableIdentifier =

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTableFactory.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -192,17 +194,31 @@ public class FileStoreTableFactory {
             CatalogEnvironment catalogEnvironment) {
         Options branchOptions = new Options(dynamicOptions.toMap());
         branchOptions.set(CoreOptions.BRANCH, branchName);
-        Optional<TableSchema> schema = new SchemaManager(fileIO, tablePath, branchName).latest();
+
+        Identifier identifier = catalogEnvironment.identifier();
+        Identifier branchIdentifier = null;
+        if (identifier != null) {
+            branchIdentifier =
+                    new Identifier(
+                            identifier.getDatabaseName(), identifier.getObjectName(), branchName);
+        }
+        CatalogLoader catalogLoader = catalogEnvironment.catalogLoader();
+
+        Optional<TableSchema> schema;
+        if (branchIdentifier != null && catalogLoader != null) {
+            try (Catalog catalog = catalogLoader.load()) {
+                schema = Optional.of(catalog.loadTableMetadata(branchIdentifier).schema());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            schema = new SchemaManager(fileIO, tablePath, branchName).latest();
+        }
+
         if (schema.isPresent()) {
-            Identifier identifier = catalogEnvironment.identifier();
             CatalogEnvironment branchCatalogEnvironment = catalogEnvironment;
-            if (identifier != null) {
-                branchCatalogEnvironment =
-                        catalogEnvironment.copy(
-                                new Identifier(
-                                        identifier.getDatabaseName(),
-                                        identifier.getObjectName(),
-                                        branchName));
+            if (branchIdentifier != null) {
+                branchCatalogEnvironment = catalogEnvironment.copy(branchIdentifier);
             }
             return createWithoutFallbackBranch(
                     fileIO, tablePath, schema.get(), branchOptions, branchCatalogEnvironment);

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -770,7 +770,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    protected TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
+    public TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
         return loadTableMetadata(identifier, getHmsTable(identifier));
     }
 


### PR DESCRIPTION
### Purpose

All catalogs have implemented the `loadTableMetadata` method. In this PR we move this method into the interface, so we can use it if we only want to get some metadata like schemas from tables and don't want the table object itself.

### Tests

This is a refactor. Existing tests should cover this change.