### PR TITLE
[core] Validate page size for wide write buffer rows

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -120,6 +120,7 @@ public class SortBufferWriteBuffer implements WriteBuffer {
             throw new IllegalArgumentException(
                     "Write buffer requires a minimum of 3 page memory, please increase write buffer memory size.");
         }
+        validatePageSizeForFixedLengthPart(fieldTypes.size(), memoryPool.pageSize());
         InternalRowSerializer serializer =
                 InternalSerializers.create(KeyValue.schema(keyType, valueType));
         BinaryInMemorySortBuffer inMemorySortBuffer =
@@ -137,6 +138,20 @@ public class SortBufferWriteBuffer implements WriteBuffer {
                                 compression,
                                 maxDiskSize)
                         : inMemorySortBuffer;
+    }
+
+    private static void validatePageSizeForFixedLengthPart(int fieldCount, int pageSize) {
+        int fixedLengthPartSize = BinaryRow.calculateFixPartSizeInBytes(fieldCount);
+        if (fixedLengthPartSize > pageSize) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "BinaryRow fixed-length part size %s for %s fields exceeds current page-size %s. "
+                                    + "Please increase the 'page-size' table option to at least %s bytes.",
+                            new MemorySize(fixedLengthPartSize).toHumanReadableString(),
+                            fieldCount,
+                            new MemorySize(pageSize).toHumanReadableString(),
+                            fixedLengthPartSize));
+        }
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferValidationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree;
+
+import org.apache.paimon.compression.CompressOptions;
+import org.apache.paimon.memory.HeapMemorySegmentPool;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link SortBufferWriteBuffer} validation. */
+public class SortBufferWriteBufferValidationTest {
+
+    @Test
+    public void testRejectWideRowsWhenPageSizeCannotHoldFixedPart() {
+        RowType.Builder valueType = RowType.builder();
+        for (int i = 0; i < 9000; i++) {
+            valueType.field("f" + i, DataTypes.STRING());
+        }
+
+        assertThatThrownBy(
+                        () ->
+                                new SortBufferWriteBuffer(
+                                        RowType.builder().field("key", DataTypes.INT()).build(),
+                                        valueType.build(),
+                                        null,
+                                        new HeapMemorySegmentPool(64 * 1024 * 3L, 64 * 1024),
+                                        false,
+                                        MemorySize.MAX_VALUE,
+                                        128,
+                                        CompressOptions.defaultOptions(),
+                                        null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("BinaryRow fixed-length part")
+                .hasMessageContaining("page-size")
+                .hasMessageContaining("at least")
+                .hasMessageContaining("73152 bytes");
+    }
+}


### PR DESCRIPTION
### Purpose

When writing a very wide primary-key table, the write path may fail during commit with an unclear `NegativeArraySizeException`:

```text
26/05/13 09:08:37 WARN TaskSetManager: Lost task 1.0 in stage 6.0 (TID 160) (10.166.23.92 executor 12): java.lang.NegativeArraySizeException
    at org.apache.paimon.memory.MemorySegmentUtils.getBytes(MemorySegmentUtils.java:191)
    at org.apache.paimon.data.BinarySection.toBytes(BinarySection.java:101)
    at org.apache.paimon.format.parquet.writer.ParquetRowDataWriter$StringWriter.writeString(ParquetRowDataWriter.java:299)
    at org.apache.paimon.mergetree.SortBufferWriteBuffer.forEach(SortBufferWriteBuffer.java:162)
    at org.apache.paimon.mergetree.MergeTreeWriter.flushWriteBuffer(MergeTreeWriter.java:224)
    at org.apache.paimon.mergetree.MergeTreeWriter.prepareCommit(MergeTreeWriter.java:253)
    .....
```
One root cause is that the table schema is too wide for the configured page-size. BinaryRow requires its fixed-length part to fit into one memory segment. If the fixed-length part is larger than page-size, later write/flush code can read invalid string offsets or lengths and surface a misleading low-level exception.


### Tests
paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferValidationTest.java