### PR TITLE
[core] Optimize overwrite retry with incremental scan

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -780,13 +780,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             @Nullable Long watermark,
             Map<String, String> properties) {
         return tryCommit(
-                latestSnapshot ->
-                        scanner.readOverwriteChanges(
-                                options.bucket(),
-                                changes,
-                                indexFiles,
-                                latestSnapshot,
-                                partitionFilter),
+                scanner.overwriteChangesProvider(
+                        options.bucket(), changes, indexFiles, partitionFilter),
                 identifier,
                 watermark,
                 properties,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/CommitScanner.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation.commit;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.IndexManifestFile;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -136,39 +138,180 @@ public class CommitScanner {
             @Nullable Snapshot latestSnapshot,
             @Nullable PartitionPredicate partitionFilter) {
         List<ManifestEntry> changesWithOverwrite = new ArrayList<>();
-        List<IndexManifestEntry> indexChangesWithOverwrite = new ArrayList<>();
         if (latestSnapshot != null) {
-            scan.withSnapshot(latestSnapshot)
-                    .withPartitionFilter(partitionFilter)
-                    .withKind(ScanMode.ALL);
-            if (numBucket != BucketMode.POSTPONE_BUCKET) {
-                // bucket = -2 can only be overwritten in postpone bucket tables
-                scan.withBucketFilter(bucket -> bucket >= 0);
+            appendDeleteEntries(
+                    changesWithOverwrite,
+                    readOverwriteBaseEntries(numBucket, latestSnapshot, partitionFilter).values());
+        }
+        changesWithOverwrite.addAll(changes);
+        return new CommitChanges(
+                changesWithOverwrite,
+                emptyList(),
+                readOverwriteIndexChanges(indexFiles, latestSnapshot, partitionFilter));
+    }
+
+    public CommitChangesProvider overwriteChangesProvider(
+            int numBucket,
+            List<ManifestEntry> changes,
+            List<IndexManifestEntry> indexFiles,
+            @Nullable PartitionPredicate partitionFilter) {
+        return new OverwriteChangesProvider(numBucket, changes, indexFiles, partitionFilter);
+    }
+
+    private Map<FileEntry.Identifier, ManifestEntry> readOverwriteBaseEntries(
+            int numBucket, Snapshot latestSnapshot, @Nullable PartitionPredicate partitionFilter) {
+        Map<FileEntry.Identifier, ManifestEntry> currentEntries = new LinkedHashMap<>();
+        for (ManifestEntry entry :
+                readOverwriteEntries(numBucket, latestSnapshot, ScanMode.ALL, partitionFilter)) {
+            currentEntries.put(entry.identifier(), entry);
+        }
+        return currentEntries;
+    }
+
+    private List<ManifestEntry> readOverwriteEntries(
+            int numBucket,
+            Snapshot snapshot,
+            ScanMode scanMode,
+            @Nullable PartitionPredicate partitionFilter) {
+        FileStoreScan freshScan = freshScan();
+        freshScan.withSnapshot(snapshot).withPartitionFilter(partitionFilter).withKind(scanMode);
+        if (numBucket != BucketMode.POSTPONE_BUCKET) {
+            // bucket = -2 can only be overwritten in postpone bucket tables
+            freshScan.withBucketFilter(bucket -> bucket >= 0);
+        }
+        return freshScan.plan().files();
+    }
+
+    private List<IndexManifestEntry> readOverwriteIndexChanges(
+            List<IndexManifestEntry> indexFiles,
+            @Nullable Snapshot latestSnapshot,
+            @Nullable PartitionPredicate partitionFilter) {
+        List<IndexManifestEntry> indexChangesWithOverwrite = new ArrayList<>();
+        if (latestSnapshot != null && latestSnapshot.indexManifest() != null) {
+            List<IndexManifestEntry> entries =
+                    indexManifestFile.read(latestSnapshot.indexManifest());
+            for (IndexManifestEntry entry : entries) {
+                if (partitionFilter == null || partitionFilter.test(entry.partition())) {
+                    indexChangesWithOverwrite.add(entry.toDeleteEntry());
+                }
             }
-            List<ManifestEntry> currentEntries = scan.plan().files();
-            for (ManifestEntry entry : currentEntries) {
-                changesWithOverwrite.add(
-                        ManifestEntry.create(
-                                FileKind.DELETE,
-                                entry.partition(),
-                                entry.bucket(),
-                                entry.totalBuckets(),
-                                entry.file()));
+        }
+        indexChangesWithOverwrite.addAll(indexFiles);
+        return indexChangesWithOverwrite;
+    }
+
+    private FileStoreScan freshScan() {
+        FileStoreScan freshScan = scanSupplier.get();
+        if (dropStats) {
+            freshScan.dropStats();
+        }
+        return freshScan;
+    }
+
+    private void appendDeleteEntries(
+            List<ManifestEntry> changesWithOverwrite, Iterable<ManifestEntry> currentEntries) {
+        for (ManifestEntry entry : currentEntries) {
+            changesWithOverwrite.add(
+                    ManifestEntry.create(
+                            FileKind.DELETE,
+                            entry.partition(),
+                            entry.bucket(),
+                            entry.totalBuckets(),
+                            entry.file()));
+        }
+    }
+
+    private class OverwriteChangesProvider implements CommitChangesProvider {
+
+        private final int numBucket;
+        private final List<ManifestEntry> changes;
+        private final List<IndexManifestEntry> indexFiles;
+        @Nullable private final PartitionPredicate partitionFilter;
+
+        @Nullable private Snapshot cachedSnapshot;
+        @Nullable private Map<FileEntry.Identifier, ManifestEntry> currentEntries;
+
+        private OverwriteChangesProvider(
+                int numBucket,
+                List<ManifestEntry> changes,
+                List<IndexManifestEntry> indexFiles,
+                @Nullable PartitionPredicate partitionFilter) {
+            this.numBucket = numBucket;
+            this.changes = changes;
+            this.indexFiles = indexFiles;
+            this.partitionFilter = partitionFilter;
+        }
+
+        @Override
+        public CommitChanges provide(@Nullable Snapshot latestSnapshot) {
+            if (latestSnapshot == null) {
+                return new CommitChanges(
+                        new ArrayList<>(changes), emptyList(), new ArrayList<>(indexFiles));
             }
 
-            // collect index files
-            if (latestSnapshot.indexManifest() != null) {
-                List<IndexManifestEntry> entries =
-                        indexManifestFile.read(latestSnapshot.indexManifest());
-                for (IndexManifestEntry entry : entries) {
-                    if (partitionFilter == null || partitionFilter.test(entry.partition())) {
-                        indexChangesWithOverwrite.add(entry.toDeleteEntry());
+            updateCurrentEntries(latestSnapshot);
+
+            List<ManifestEntry> changesWithOverwrite = new ArrayList<>();
+            appendDeleteEntries(changesWithOverwrite, currentEntries.values());
+            changesWithOverwrite.addAll(changes);
+            return new CommitChanges(
+                    changesWithOverwrite,
+                    emptyList(),
+                    readOverwriteIndexChanges(indexFiles, latestSnapshot, partitionFilter));
+        }
+
+        private void updateCurrentEntries(Snapshot latestSnapshot) {
+            if (cachedSnapshot == null || latestSnapshot.id() < cachedSnapshot.id()) {
+                currentEntries =
+                        readOverwriteBaseEntries(numBucket, latestSnapshot, partitionFilter);
+            } else if (latestSnapshot.id() > cachedSnapshot.id()) {
+                try {
+                    updateCurrentEntriesFromDelta(latestSnapshot);
+                } catch (RuntimeException e) {
+                    currentEntries =
+                            readOverwriteBaseEntries(numBucket, latestSnapshot, partitionFilter);
+                }
+            }
+            cachedSnapshot = latestSnapshot;
+        }
+
+        private void updateCurrentEntriesFromDelta(Snapshot latestSnapshot) {
+            for (long snapshotId = cachedSnapshot.id() + 1;
+                    snapshotId <= latestSnapshot.id();
+                    snapshotId++) {
+                for (ManifestEntry entry :
+                        readOverwriteEntries(
+                                numBucket, snapshotId, ScanMode.DELTA, partitionFilter)) {
+                    FileEntry.Identifier identifier = entry.identifier();
+                    switch (entry.kind()) {
+                        case ADD:
+                            currentEntries.put(identifier, entry);
+                            break;
+                        case DELETE:
+                            currentEntries.remove(identifier);
+                            break;
+                        default:
+                            throw new UnsupportedOperationException(
+                                    "Unsupported file kind: " + entry.kind());
                     }
                 }
             }
         }
-        changesWithOverwrite.addAll(changes);
-        indexChangesWithOverwrite.addAll(indexFiles);
-        return new CommitChanges(changesWithOverwrite, emptyList(), indexChangesWithOverwrite);
+
+        private List<ManifestEntry> readOverwriteEntries(
+                int numBucket,
+                long snapshotId,
+                ScanMode scanMode,
+                @Nullable PartitionPredicate partitionFilter) {
+            FileStoreScan freshScan = freshScan();
+            freshScan
+                    .withSnapshot(snapshotId)
+                    .withPartitionFilter(partitionFilter)
+                    .withKind(scanMode);
+            if (numBucket != BucketMode.POSTPONE_BUCKET) {
+                freshScan.withBucketFilter(bucket -> bucket >= 0);
+            }
+            return freshScan.plan().files();
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -82,6 +82,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -946,6 +947,67 @@ public class FileStoreCommitTest {
     }
 
     @Test
+    public void testOverwriteRetryUpdatesCurrentFilesWithDelta() throws Exception {
+        TestFileStore store = createStore(false);
+        List<KeyValue> base =
+                Arrays.asList(
+                        gen.nextPartitionedData(RowKind.INSERT, "20211110", 8),
+                        gen.nextPartitionedData(RowKind.INSERT, "20211110", 9),
+                        gen.nextPartitionedData(RowKind.INSERT, "20211111", 8));
+        store.commitData(base, gen::getPartition, kv -> 0);
+
+        KeyValue overwriteRecord = gen.nextPartitionedData(RowKind.INSERT, "20211110", 8);
+        AtomicReference<ManifestCommittable> committableRef = new AtomicReference<>();
+        store.commitDataImpl(
+                Collections.singletonList(overwriteRecord),
+                gen::getPartition,
+                kv -> 0,
+                true,
+                17L,
+                null,
+                Collections.emptyList(),
+                (commit, committable) -> committableRef.set(committable));
+
+        KeyValue concurrentRecord = gen.nextPartitionedData(RowKind.INSERT, "20211110", 9);
+        AtomicInteger retries = new AtomicInteger();
+        try (FileStoreCommitImpl commit =
+                newCommitWithSnapshotCommit(
+                        store,
+                        "overwrite-retry",
+                        new CommitFailOnceSnapshotCommit(
+                                new RenamingSnapshotCommit(store.snapshotManager(), Lock.empty()),
+                                retries,
+                                () -> {
+                                    try {
+                                        store.commitData(
+                                                Collections.singletonList(concurrentRecord),
+                                                gen::getPartition,
+                                                kv -> 0);
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                }))) {
+            commit.overwritePartition(
+                    Collections.singletonMap("dt", "20211110"),
+                    checkNotNull(committableRef.get()),
+                    Collections.emptyMap());
+        }
+
+        assertThat(retries.get()).isEqualTo(2);
+
+        List<KeyValue> expected = new ArrayList<>();
+        expected.add(overwriteRecord);
+        expected.add(base.get(2));
+        gen.sort(expected);
+        Map<BinaryRow, BinaryRow> expectedMap = store.toKvMap(expected);
+
+        List<KeyValue> actual =
+                store.readKvsFromSnapshot(checkNotNull(store.snapshotManager().latestSnapshotId()));
+        gen.sort(actual);
+        assertThat(store.toKvMap(actual)).isEqualTo(expectedMap);
+    }
+
+    @Test
     public void testManifestCompactFull() throws Exception {
         // Disable full compaction by options.
         TestFileStore store =
@@ -1140,6 +1202,38 @@ public class FileStoreCommitTest {
                 return false;
             }
             return committed;
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.close();
+        }
+    }
+
+    private static class CommitFailOnceSnapshotCommit implements SnapshotCommit {
+
+        private final SnapshotCommit delegate;
+        private final AtomicInteger attempts;
+        private final Runnable beforeFirstFailure;
+
+        private CommitFailOnceSnapshotCommit(
+                SnapshotCommit delegate, AtomicInteger attempts, Runnable beforeFirstFailure) {
+            this.delegate = delegate;
+            this.attempts = attempts;
+            this.beforeFirstFailure = beforeFirstFailure;
+        }
+
+        @Override
+        public boolean commit(
+                Snapshot snapshot,
+                String branch,
+                List<org.apache.paimon.partition.PartitionStatistics> statistics)
+                throws Exception {
+            if (attempts.getAndIncrement() == 0) {
+                beforeFirstFailure.run();
+                return false;
+            }
+            return delegate.commit(snapshot, branch, statistics);
         }
 
         @Override


### PR DESCRIPTION
### Purpose

Overwrite commits rebuild the target partition file set before every atomic commit retry. For large partitions this repeatedly performs a full manifest scan after commit conflicts, which can make retries very expensive.

### Changes

- Add a stateful overwrite `CommitChangesProvider` in `CommitScanner`.
- Keep the first overwrite attempt behavior as a full target scan.
- On later retries, update the cached target file set from snapshot `DELTA` manifests between the previous checked snapshot and the latest snapshot.
- Use the provider from the common overwrite path, so both normal insert overwrite and drop/truncate partition paths are covered.
- Keep index overwrite changes based on the latest index manifest on each retry.
- Add a retry test for partial-partition insert overwrite with a concurrent commit between attempts.

### Tests

- `mvn -pl paimon-api,paimon-test-utils,paimon-common,paimon-codegen,paimon-codegen-loader,paimon-arrow,paimon-format -DskipTests install`
- `mvn -pl paimon-core -DskipITs -Dtest=FileStoreCommitTest#testOverwriteRetryUpdatesCurrentFilesWithDelta test`
- `mvn -pl paimon-core -DskipITs -Dtest=FileStoreCommitTest#testOverwritePartialCommit+testDropPartitions+testIndexFiles+testDropStatsForOverwrite+testOverwriteRetryUpdatesCurrentFilesWithDelta test`
- `mvn -pl paimon-core -DskipITs -Dtest=FileStoreCommitTest test`
