### PR TITLE
[core] Preserve external UGI when paimon has no kerberos credentials

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystem.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystem.java
@@ -21,6 +21,7 @@ package org.apache.paimon.fs.hadoop;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.security.HadoopModule;
 import org.apache.paimon.security.SecurityConfiguration;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -200,6 +201,14 @@ public class HadoopSecuredFileSystem extends FileSystem {
             throws IOException {
         SecurityConfiguration config = new SecurityConfiguration(options);
         if (config.isLegal()) {
+            if (StringUtils.isNullOrWhitespaceOnly(config.getKeytab())
+                    && StringUtils.isNullOrWhitespaceOnly(config.getPrincipal())) {
+                LOG.info(
+                        "No paimon Kerberos credentials configured "
+                                + "(security.kerberos.login.keytab/principal); "
+                                + "skip HadoopModule.install() to preserve externally-established UGI.");
+                return fileSystem;
+            }
             LOG.info("Hadoop security configuration is legal, use the secured FileSystem.");
             HadoopModule module = new HadoopModule(config, configuration);
             module.install();

--- a/paimon-common/src/test/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystemTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/hadoop/HadoopSecuredFileSystemTest.java
@@ -47,4 +47,28 @@ public class HadoopSecuredFileSystemTest {
         assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
                 .isInstanceOf(HadoopSecuredFileSystem.class);
     }
+
+    @Test
+    public void testPreserveExternalUgiWhenNoKerberosCredentials() throws Exception {
+        Options options = new Options();
+
+        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
+        fileIO.configure(CatalogContext.create(options));
+        assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
+                .isNotInstanceOf(HadoopSecuredFileSystem.class);
+    }
+
+    @Test
+    public void testReturnOriginalFileSystemWhenSecurityConfigIsIllegal() throws Exception {
+        File keytabFile = new File(tmp.toFile(), "test-keytab.keytab");
+        assertThat(keytabFile.createNewFile()).isTrue();
+
+        Options options = new Options();
+        options.set("security.kerberos.login.keytab", keytabFile.getAbsolutePath());
+
+        HadoopFileIO fileIO = new HadoopFileIO(new Path("file:///tmp/test"));
+        fileIO.configure(CatalogContext.create(options));
+        assertThat(fileIO.getFileSystem(new org.apache.hadoop.fs.Path("file:///tmp/test")))
+                .isNotInstanceOf(HadoopSecuredFileSystem.class);
+    }
 }


### PR DESCRIPTION
### Purpose
  When no explicit Kerberos credentials (`security.kerberos.login.keytab` / `security.kerberos.login.principal`) are provided in catalog options, `HadoopModule.install()` calls
  `UserGroupInformation.setConfiguration()` and **resets the JVM-global UGI auth method**.

  This can wipe out a Kerberos TGT already established by the host process — e.g. by Spark via `spark.kerberos.principal` / `spark.kerberos.keytab` — and cause downstream SASL / HMS calls
  to fail with:

  > `GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)`

 Therefore, preserve the externally-established UGI when paimon has no credentials to install.

### Tests
CI