### PR TITLE
[spark] Fix merge into update columns detection

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
@@ -735,6 +735,7 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
                                 put(DATA_EVOLUTION_ENABLED.key(), "true");
                                 put("blob-field", "picture");
                                 put(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "1 b");
+                                put("sink.parallelism", "1");
                             }
                         }));
         insertInto(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -619,8 +619,7 @@ object MergeIntoPaimonDataEvolutionTable {
   final private val FIRST_ROW_ID_NAME = "_FIRST_ROW_ID";
 
   private[commands] def isModifiedAssignment(assignment: Assignment): Boolean = {
-    !(assignment.key.equals(assignment.value) ||
-      sameAttributeReference(assignment.key, assignment.value))
+    !sameAttributeReference(assignment.key, assignment.value)
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -87,8 +87,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         case updateAction: UpdateAction =>
           for (assignment <- updateAction.assignments) {
             if (isModifiedAssignment(assignment)) {
-              val key = assignment.key.asInstanceOf[AttributeReference]
-              columns ++= Seq(key)
+              columns += assignmentKeyAttribute(assignment)
             }
           }
       }
@@ -281,9 +280,7 @@ case class MergeIntoPaimonDataEvolutionTable(
           UpdateAction.apply(
             update.condition,
             update.assignments.filter(
-              a =>
-                updateColumnsSorted.contains(
-                  a.key.asInstanceOf[AttributeReference])) ++ assignments))
+              a => updateColumnsSorted.contains(assignmentKeyAttribute(a))) ++ assignments))
 
     for (action <- realUpdateActions) {
       allFields ++= action.references.flatMap(r => extractFields(r)).seq
@@ -620,6 +617,15 @@ object MergeIntoPaimonDataEvolutionTable {
 
   private[commands] def isModifiedAssignment(assignment: Assignment): Boolean = {
     !sameAttributeReference(assignment.key, assignment.value)
+  }
+
+  private[commands] def assignmentKeyAttribute(assignment: Assignment): AttributeReference = {
+    assignment.key match {
+      case key: AttributeReference => key
+      case other =>
+        throw new UnsupportedOperationException(
+          s"Unsupported update assignment key: $other. Only top-level attributes are supported.")
+    }
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -34,7 +34,6 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
@@ -62,8 +61,7 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedActions: Seq[MergeAction],
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
-  with WithFileStoreTable
-  with Logging {
+  with WithFileStoreTable {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -88,22 +86,14 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case updateAction: UpdateAction =>
           for (assignment <- updateAction.assignments) {
-            val keyEqualsValue = assignment.key.equals(assignment.value)
-            val keySameRefValue = sameAttributeReference(assignment.key, assignment.value)
-            val includeColumn = !(keyEqualsValue || keySameRefValue)
-
-            if (includeColumn) {
+            if (isModifiedAssignment(assignment)) {
               val key = assignment.key.asInstanceOf[AttributeReference]
               columns ++= Seq(key)
             }
           }
       }
     }
-    val result = columns.toSet
-    logInfo(
-      s"MergeIntoPaimonDataEvolutionTable update columns: " +
-        s"${result.map(_.name).toSeq.sorted.mkString("[", ", ", "]")}.")
-    result
+    columns.toSet
   }
 
   /**
@@ -610,14 +600,6 @@ case class MergeIntoPaimonDataEvolutionTable(
   private def attribute(name: String, plan: LogicalPlan) =
     plan.output.find(attr => resolver(name, attr.name)).get
 
-  private def sameAttributeReference(left: Expression, right: Expression): Boolean = {
-    (left, right) match {
-      case (leftAttr: AttributeReference, rightAttr: AttributeReference) =>
-        leftAttr.sameRef(rightAttr)
-      case _ => false
-    }
-  }
-
   private def addFirstRowId(
       sparkSession: SparkSession,
       plan: LogicalPlan,
@@ -635,6 +617,19 @@ object MergeIntoPaimonDataEvolutionTable {
   final private val ROW_FROM_TARGET = "__row_from_target"
   final private val ROW_ID_NAME = "_ROW_ID"
   final private val FIRST_ROW_ID_NAME = "_FIRST_ROW_ID";
+
+  private[commands] def isModifiedAssignment(assignment: Assignment): Boolean = {
+    !(assignment.key.equals(assignment.value) ||
+      sameAttributeReference(assignment.key, assignment.value))
+  }
+
+  private def sameAttributeReference(left: Expression, right: Expression): Boolean = {
+    (left, right) match {
+      case (leftAttr: AttributeReference, rightAttr: AttributeReference) =>
+        leftAttr.sameRef(rightAttr)
+      case _ => false
+    }
+  }
 
   private def floorBinarySearch(indexed: immutable.IndexedSeq[Long], value: Long): Long = {
     if (indexed.isEmpty) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -34,6 +34,7 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
@@ -61,7 +62,8 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedActions: Seq[MergeAction],
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
-  with WithFileStoreTable {
+  with WithFileStoreTable
+  with Logging {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -86,14 +88,22 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case updateAction: UpdateAction =>
           for (assignment <- updateAction.assignments) {
-            if (!assignment.key.equals(assignment.value)) {
+            val keyEqualsValue = assignment.key.equals(assignment.value)
+            val keySameRefValue = sameAttributeReference(assignment.key, assignment.value)
+            val includeColumn = !(keyEqualsValue || keySameRefValue)
+
+            if (includeColumn) {
               val key = assignment.key.asInstanceOf[AttributeReference]
               columns ++= Seq(key)
             }
           }
       }
     }
-    columns.toSet
+    val result = columns.toSet
+    logInfo(
+      s"MergeIntoPaimonDataEvolutionTable update columns: " +
+        s"${result.map(_.name).toSeq.sorted.mkString("[", ", ", "]")}.")
+    result
   }
 
   /**
@@ -599,6 +609,14 @@ case class MergeIntoPaimonDataEvolutionTable(
 
   private def attribute(name: String, plan: LogicalPlan) =
     plan.output.find(attr => resolver(name, attr.name)).get
+
+  private def sameAttributeReference(left: Expression, right: Expression): Boolean = {
+    (left, right) match {
+      case (leftAttr: AttributeReference, rightAttr: AttributeReference) =>
+        leftAttr.sameRef(rightAttr)
+      case _ => false
+    }
+  }
 
   private def addFirstRowId(
       sparkSession: SparkSession,

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.commands
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.logical.Assignment
+import org.apache.spark.sql.types.{BinaryType, StringType}
+
+class MergeIntoPaimonDataEvolutionTableTest extends SparkFunSuite {
+
+  test("update column detection ignores target self-assignment with different qualifiers") {
+    val targetPicture = AttributeReference("picture", BinaryType)()
+    val qualifiedTargetPicture = targetPicture.withQualifier(Seq("t"))
+
+    assert(!targetPicture.equals(qualifiedTargetPicture))
+    assert(targetPicture.sameRef(qualifiedTargetPicture))
+    assert(
+      !MergeIntoPaimonDataEvolutionTable.isModifiedAssignment(
+        Assignment(targetPicture, qualifiedTargetPicture)))
+  }
+
+  test("update column detection includes source assignment with same column name") {
+    val targetFileType = AttributeReference("file_type", StringType)()
+    val sourceFileType = AttributeReference("file_type", StringType)().withQualifier(Seq("s"))
+
+    assert(!targetFileType.sameRef(sourceFileType))
+    assert(
+      MergeIntoPaimonDataEvolutionTable.isModifiedAssignment(
+        Assignment(targetFileType, sourceFileType)))
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
@@ -19,9 +19,9 @@
 package org.apache.paimon.spark.commands
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GetStructField, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Assignment
-import org.apache.spark.sql.types.{BinaryType, StringType}
+import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}
 
 class MergeIntoPaimonDataEvolutionTableTest extends SparkFunSuite {
 
@@ -44,5 +44,16 @@ class MergeIntoPaimonDataEvolutionTableTest extends SparkFunSuite {
     assert(
       MergeIntoPaimonDataEvolutionTable.isModifiedAssignment(
         Assignment(targetFileType, sourceFileType)))
+  }
+
+  test("update column detection rejects non top-level assignment key") {
+    val targetStruct =
+      AttributeReference("metadata", StructType(Seq(StructField("name", StringType))))()
+    val nestedKey = GetStructField(targetStruct, 0, Some("name"))
+
+    intercept[UnsupportedOperationException] {
+      MergeIntoPaimonDataEvolutionTable.assignmentKeyAttribute(
+        Assignment(nestedKey, Literal("new-name")))
+    }
   }
 }


### PR DESCRIPTION
## What changed

This updates Spark merge-into data evolution update column detection so target self-assignments are not treated as modified columns when Spark adds or changes qualifiers. The logic now treats matching AttributeReference exprIds as the same target column, while still including source-side assignments such as target_col = source_col.

## Why

Spark AttributeReference.equals also compares qualifiers, so the same target field can compare unequal as file_name#2 versus t.file_name#2. That made updateColumns include unchanged fields and caused partial updates to rewrite more columns than expected.

## Validation

- mvn -pl paimon-spark/paimon-spark-common -DskipTests -Dcheckstyle.skip -Drat.skip -Dspotless.check.skip=true compile
- mvn -pl paimon-spark/paimon-spark-common -DskipTests -Dcheckstyle.skip -Drat.skip spotless:check