### PR TITLE
[python] Extend commit protocol for compaction (DataIncrement/CompactIncrement)

### DIFF
--- a/paimon-python/pypaimon/globalindex/create_global_index.py
+++ b/paimon-python/pypaimon/globalindex/create_global_index.py
@@ -258,7 +258,6 @@ class GlobalIndexBuilder:
                     CommitMessage(
                         partition=tuple(split.partition.values),
                         bucket=0,
-                        new_files=[],
                         index_adds=index_adds,
                     )
                 )
@@ -325,7 +324,6 @@ class GlobalIndexBuilder:
                     CommitMessage(
                         partition=tuple(index_split.partition.values),
                         bucket=0,
-                        new_files=[],
                         index_adds=index_adds,
                     )
                 )

--- a/paimon-python/pypaimon/globalindex/drop_global_index.py
+++ b/paimon-python/pypaimon/globalindex/drop_global_index.py
@@ -127,7 +127,6 @@ class GlobalIndexDropper:
             CommitMessage(
                 partition=partition,
                 bucket=0,
-                new_files=[],
                 index_deletes=deletes,
             )
             for partition, deletes in by_partition.items()

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -16,15 +16,19 @@
 # under the License.
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import List, Optional
+from datetime import date, datetime, time as dt_time
+from decimal import Decimal
+from base64 import b64decode, b64encode
+from typing import Any, Dict, List, Optional
 import time
 
 from pypaimon.utils.range import Range
 from pypaimon.data.timestamp import Timestamp
 from pypaimon.manifest.schema.simple_stats import (KEY_STATS_SCHEMA, VALUE_STATS_SCHEMA,
                                                    SimpleStats)
+from pypaimon.schema.data_types import DataField
 from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.row.internal_row import RowKind
 from pypaimon.utils.file_store_path_factory import _is_null_or_whitespace_only
 
 
@@ -226,6 +230,188 @@ class DataFileMeta:
             write_cols=self.write_cols,
             file_path=self.file_path
         )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-friendly dict for cross-process transport (e.g. Ray task payloads).
+
+        Field types preserved via tagged objects (see encode_value/decode_value).
+        """
+        return {
+            "file_name": self.file_name,
+            "file_size": self.file_size,
+            "row_count": self.row_count,
+            "min_key": _generic_row_to_dict(self.min_key),
+            "max_key": _generic_row_to_dict(self.max_key),
+            "key_stats": _simple_stats_to_dict(self.key_stats),
+            "value_stats": _simple_stats_to_dict(self.value_stats),
+            "min_sequence_number": self.min_sequence_number,
+            "max_sequence_number": self.max_sequence_number,
+            "schema_id": self.schema_id,
+            "level": self.level,
+            "extra_files": list(self.extra_files) if self.extra_files is not None else [],
+            "creation_time": _timestamp_to_dict(self.creation_time),
+            "delete_row_count": self.delete_row_count,
+            "embedded_index": _bytes_to_str(self.embedded_index),
+            "file_source": self.file_source,
+            "value_stats_cols": list(self.value_stats_cols) if self.value_stats_cols is not None else None,
+            "external_path": self.external_path,
+            "first_row_id": self.first_row_id,
+            "write_cols": list(self.write_cols) if self.write_cols is not None else None,
+            "file_path": self.file_path,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DataFileMeta":
+        return cls(
+            file_name=data["file_name"],
+            file_size=data["file_size"],
+            row_count=data["row_count"],
+            min_key=_generic_row_from_dict(data.get("min_key")),
+            max_key=_generic_row_from_dict(data.get("max_key")),
+            key_stats=_simple_stats_from_dict(data.get("key_stats")),
+            value_stats=_simple_stats_from_dict(data.get("value_stats")),
+            min_sequence_number=data["min_sequence_number"],
+            max_sequence_number=data["max_sequence_number"],
+            schema_id=data["schema_id"],
+            level=data["level"],
+            extra_files=list(data.get("extra_files") or []),
+            creation_time=_timestamp_from_dict(data.get("creation_time")),
+            delete_row_count=data.get("delete_row_count"),
+            embedded_index=_bytes_from_str(data.get("embedded_index")),
+            file_source=data.get("file_source"),
+            value_stats_cols=list(data["value_stats_cols"]) if data.get("value_stats_cols") is not None else None,
+            external_path=data.get("external_path"),
+            first_row_id=data.get("first_row_id"),
+            write_cols=list(data["write_cols"]) if data.get("write_cols") is not None else None,
+            file_path=data.get("file_path"),
+        )
+
+
+def _bytes_to_str(value: Optional[bytes]) -> Optional[str]:
+    if value is None:
+        return None
+    return b64encode(value).decode("ascii")
+
+
+def _bytes_from_str(value: Optional[str]) -> Optional[bytes]:
+    if value is None:
+        return None
+    return b64decode(value.encode("ascii"))
+
+
+def _timestamp_to_dict(ts: Optional[Timestamp]) -> Optional[Dict[str, int]]:
+    if ts is None:
+        return None
+    return {"ms": ts.get_millisecond(), "ns": ts.get_nano_of_millisecond()}
+
+
+def _timestamp_from_dict(data: Optional[Dict[str, int]]) -> Optional[Timestamp]:
+    if data is None:
+        return None
+    return Timestamp(data["ms"], data.get("ns", 0))
+
+
+def encode_value(value: Any) -> Any:
+    """Encode a GenericRow / SimpleStats / partition field value into a JSON-friendly form.
+
+    Tagged dicts mark non-JSON-native types so decode_value can round-trip them.
+    Public so that callers serializing other field-bearing structures (e.g. partitions
+    in CommitMessage) can reuse the same tagged encoding.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return {"__t__": "bytes", "v": b64encode(value).decode("ascii")}
+    if isinstance(value, Decimal):
+        return {"__t__": "decimal", "v": str(value)}
+    if isinstance(value, Timestamp):
+        return {"__t__": "ts", "ms": value.get_millisecond(), "ns": value.get_nano_of_millisecond()}
+    if isinstance(value, datetime):
+        return {"__t__": "datetime", "v": value.isoformat()}
+    if isinstance(value, date):
+        return {"__t__": "date", "v": value.isoformat()}
+    if isinstance(value, dt_time):
+        return {"__t__": "time", "v": value.isoformat()}
+    raise TypeError(
+        f"Unsupported value type for DataFileMeta serialization: {type(value).__name__}. "
+        "ARRAY-typed (list/tuple) partition or field values are not yet supported."
+    )
+
+
+def decode_value(value: Any) -> Any:
+    if not isinstance(value, dict) or "__t__" not in value:
+        return value
+    tag = value["__t__"]
+    if tag == "bytes":
+        return b64decode(value["v"].encode("ascii"))
+    if tag == "decimal":
+        return Decimal(value["v"])
+    if tag == "ts":
+        return Timestamp(value["ms"], value.get("ns", 0))
+    if tag == "datetime":
+        return datetime.fromisoformat(value["v"])
+    if tag == "date":
+        return date.fromisoformat(value["v"])
+    if tag == "time":
+        return dt_time.fromisoformat(value["v"])
+    raise ValueError(f"Unknown tagged value type: {tag}")
+
+
+def _generic_row_to_dict(row) -> Optional[Dict[str, Any]]:
+    if row is None:
+        return None
+    # GenericRow exposes .values directly; BinaryRow lazily decodes per field
+    # via get_field(i). Normalize both into a list of decoded Python values
+    # so the dict format stays uniform. The fallback targets InternalRow-style
+    # rows (e.g. BinaryRow) that expose __len__ + get_field(i) but no .values.
+    if hasattr(row, "values"):
+        values = row.values
+    else:
+        values = [row.get_field(i) for i in range(len(row))]
+    fields = getattr(row, "fields", None)
+    return {
+        "values": [encode_value(v) for v in values],
+        "fields": [f.to_dict() for f in fields] if fields else [],
+        "row_kind": row.get_row_kind().value if hasattr(row, "get_row_kind") else 0,
+    }
+
+
+def _generic_row_from_dict(data: Optional[Dict[str, Any]]) -> Optional[GenericRow]:
+    if data is None:
+        return None
+    fields = [DataField.from_dict(f) for f in data.get("fields", [])]
+    values = [decode_value(v) for v in data.get("values", [])]
+    row_kind = RowKind(data.get("row_kind", RowKind.INSERT.value))
+    return GenericRow(values, fields, row_kind)
+
+
+def _simple_stats_to_dict(stats: Optional[SimpleStats]) -> Optional[Dict[str, Any]]:
+    if stats is None:
+        return None
+    # null_counts may be a Python list (writer path) or a pyarrow Array-like
+    # (manifest reader path). Normalize to a plain list of ints.
+    nc = stats.null_counts
+    if nc is None:
+        null_counts = []
+    elif hasattr(nc, "to_pylist"):
+        null_counts = nc.to_pylist()
+    else:
+        null_counts = list(nc)
+    return {
+        "min_values": _generic_row_to_dict(stats.min_values),
+        "max_values": _generic_row_to_dict(stats.max_values),
+        "null_counts": null_counts,
+    }
+
+
+def _simple_stats_from_dict(data: Optional[Dict[str, Any]]) -> Optional[SimpleStats]:
+    if data is None:
+        return None
+    return SimpleStats(
+        min_values=_generic_row_from_dict(data.get("min_values")),
+        max_values=_generic_row_from_dict(data.get("max_values")),
+        null_counts=list(data.get("null_counts") or []),
+    )
 
 
 DATA_FILE_META_SCHEMA = {

--- a/paimon-python/pypaimon/tests/commit_message_serializer_test.py
+++ b/paimon-python/pypaimon/tests/commit_message_serializer_test.py
@@ -1,0 +1,341 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import unittest
+from datetime import date, datetime, time as dt_time
+from decimal import Decimal
+
+from pypaimon.data.timestamp import Timestamp
+from pypaimon.globalindex.global_index_meta import GlobalIndexMeta
+from pypaimon.index.deletion_vector_meta import DeletionVectorMeta
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.row.internal_row import RowKind
+from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.commit_message_serializer import CommitMessageSerializer
+from pypaimon.write.compact_increment import CompactIncrement
+from pypaimon.write.data_increment import DataIncrement
+
+
+def _key_field(idx: int, name: str, type_str: str) -> DataField:
+    return DataField(idx, name, AtomicType(type_str))
+
+
+def _build_data_file_meta(file_name: str = "data-1.parquet") -> DataFileMeta:
+    pk_fields = [_key_field(0, "id", "BIGINT"), _key_field(1, "name", "STRING")]
+    min_key = GenericRow([1, "alice"], pk_fields)
+    max_key = GenericRow([99, "zoe"], pk_fields)
+    key_stats = SimpleStats(
+        min_values=GenericRow([1, "alice"], pk_fields),
+        max_values=GenericRow([99, "zoe"], pk_fields),
+        null_counts=[0, 0],
+    )
+    value_stats = SimpleStats(
+        min_values=GenericRow([], []),
+        max_values=GenericRow([], []),
+        null_counts=[],
+    )
+    return DataFileMeta.create(
+        file_name=file_name,
+        file_size=4096,
+        row_count=99,
+        min_key=min_key,
+        max_key=max_key,
+        key_stats=key_stats,
+        value_stats=value_stats,
+        min_sequence_number=10,
+        max_sequence_number=200,
+        schema_id=0,
+        level=0,
+        extra_files=["index-1.idx"],
+        creation_time=Timestamp.from_epoch_millis(1_700_000_000_000, 123_456),
+        delete_row_count=2,
+        embedded_index=b"\x00\x01\x02\x03embedded",
+        file_source=1,
+        value_stats_cols=["c1"],
+        external_path="oss://bucket/path/to/file",
+        first_row_id=1000,
+        write_cols=["id", "name"],
+        file_path="/abs/path/data-1.parquet",
+    )
+
+
+def _build_index_manifest_entry(
+    file_name: str = "index-1.gidx",
+    with_dv_ranges: bool = False,
+) -> IndexManifestEntry:
+    part_fields = [_key_field(0, "dt", "STRING")]
+    partition = GenericRow(["2024-01-01"], part_fields)
+    dv_ranges = None
+    if with_dv_ranges:
+        dv_ranges = {
+            "data-1.parquet": DeletionVectorMeta(
+                data_file_name="data-1.parquet", offset=16, length=128, cardinality=5
+            ),
+        }
+    index_file = IndexFileMeta(
+        index_type="GLOBAL_INDEX",
+        file_name=file_name,
+        file_size=512,
+        row_count=20,
+        dv_ranges=dv_ranges,
+        external_path="oss://bucket/index/" + file_name,
+        global_index_meta=GlobalIndexMeta(
+            row_range_start=0,
+            row_range_end=20,
+            index_field_id=3,
+            extra_field_ids=[4, 5],
+            index_meta=b"\x00\x01global-index-meta",
+        ),
+    )
+    # kind=1 (DELETE) mirrors build_index_delete_msgs.
+    return IndexManifestEntry(kind=1, partition=partition, bucket=0, index_file=index_file)
+
+
+class DataFileMetaSerdeTest(unittest.TestCase):
+
+    def test_to_from_dict_roundtrip(self):
+        original = _build_data_file_meta()
+        rebuilt = DataFileMeta.from_dict(original.to_dict())
+
+        self.assertEqual(original, rebuilt)
+        # spot check of complex sub-fields that use tagged encoding
+        self.assertEqual(original.embedded_index, rebuilt.embedded_index)
+        self.assertEqual(original.creation_time, rebuilt.creation_time)
+        self.assertEqual(original.min_key.values, rebuilt.min_key.values)
+        self.assertEqual(original.min_key.row_kind, rebuilt.min_key.row_kind)
+        self.assertEqual(
+            [f.to_dict() for f in original.min_key.fields],
+            [f.to_dict() for f in rebuilt.min_key.fields],
+        )
+
+    def test_value_encoding_supports_decimal_and_temporal_types(self):
+        fields = [
+            _key_field(0, "amount", "DECIMAL(10, 2)"),
+            _key_field(1, "ts", "TIMESTAMP(6)"),
+            _key_field(2, "d", "DATE"),
+            _key_field(3, "t", "TIME"),
+            _key_field(4, "blob", "BYTES"),
+        ]
+        row = GenericRow(
+            values=[
+                Decimal("12.34"),
+                datetime(2024, 1, 2, 3, 4, 5, 678901),
+                date(2024, 1, 2),
+                dt_time(13, 45, 30, 250000),
+                b"binary-payload",
+            ],
+            fields=fields,
+            row_kind=RowKind.UPDATE_AFTER,
+        )
+        # Reuse the GenericRow encode path through SimpleStats
+        stats = SimpleStats(min_values=row, max_values=row, null_counts=[0, 0, 0, 0, 0])
+        meta = _build_data_file_meta()
+        meta.key_stats = stats
+
+        rebuilt = DataFileMeta.from_dict(meta.to_dict())
+
+        self.assertEqual(rebuilt.key_stats.min_values.values[0], Decimal("12.34"))
+        self.assertEqual(rebuilt.key_stats.min_values.values[1], datetime(2024, 1, 2, 3, 4, 5, 678901))
+        self.assertEqual(rebuilt.key_stats.min_values.values[2], date(2024, 1, 2))
+        self.assertEqual(rebuilt.key_stats.min_values.values[3], dt_time(13, 45, 30, 250000))
+        self.assertEqual(rebuilt.key_stats.min_values.values[4], b"binary-payload")
+        self.assertEqual(rebuilt.key_stats.min_values.row_kind, RowKind.UPDATE_AFTER)
+
+
+class CommitMessageSerializerTest(unittest.TestCase):
+
+    def test_serialize_deserialize_roundtrip_for_compact_message(self):
+        before_files = [_build_data_file_meta(f"old-{i}.parquet") for i in range(3)]
+        after_files = [_build_data_file_meta("new-merged.parquet")]
+        message = CommitMessage(
+            partition=("2024-01-01", "us"),
+            bucket=2,
+            total_buckets=8,
+            compact_increment=CompactIncrement(
+                compact_before=before_files,
+                compact_after=after_files,
+            ),
+            check_from_snapshot=42,
+        )
+
+        payload = CommitMessageSerializer.serialize(message)
+        rebuilt = CommitMessageSerializer.deserialize(payload)
+
+        self.assertIsInstance(payload, bytes)
+        self.assertEqual(message.partition, rebuilt.partition)
+        self.assertEqual(message.bucket, rebuilt.bucket)
+        self.assertEqual(message.total_buckets, rebuilt.total_buckets)
+        self.assertEqual(message.new_files, rebuilt.new_files)
+        self.assertEqual(message.compact_before, rebuilt.compact_before)
+        self.assertEqual(message.compact_after, rebuilt.compact_after)
+        self.assertEqual(message.check_from_snapshot, rebuilt.check_from_snapshot)
+
+    def test_serialize_deserialize_roundtrip_for_append_message(self):
+        message = CommitMessage(
+            partition=(),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_build_data_file_meta("append-1.parquet")]),
+        )
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        self.assertEqual(message.partition, rebuilt.partition)
+        self.assertEqual(message.bucket, rebuilt.bucket)
+        self.assertEqual(message.new_files, rebuilt.new_files)
+        self.assertEqual([], rebuilt.compact_before)
+        self.assertEqual([], rebuilt.compact_after)
+
+    def test_unsupported_version_is_rejected(self):
+        message = CommitMessage(
+            partition=(),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_build_data_file_meta()]),
+        )
+        payload_dict = CommitMessageSerializer.to_dict(message)
+        payload_dict["version"] = CommitMessageSerializer.VERSION + 1
+
+        with self.assertRaises(ValueError):
+            CommitMessageSerializer.from_dict(payload_dict)
+
+    def test_serialize_supports_partition_with_non_json_native_types(self):
+        # Partitions can carry DATE/DECIMAL/bytes columns; serializer must round-trip them.
+        message = CommitMessage(
+            partition=(date(2024, 1, 2), Decimal("99.50"), b"raw"),
+            bucket=0,
+            compact_increment=CompactIncrement(compact_after=[_build_data_file_meta()]),
+        )
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        self.assertEqual((date(2024, 1, 2), Decimal("99.50"), b"raw"), rebuilt.partition)
+
+    def test_serialize_supports_timestamp_partition(self):
+        ts = Timestamp.from_epoch_millis(1_700_000_000_000, 500_000)
+        message = CommitMessage(
+            partition=(ts,),
+            bucket=0,
+            compact_increment=CompactIncrement(compact_after=[_build_data_file_meta()]),
+        )
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        self.assertEqual((ts,), rebuilt.partition)
+
+    def test_roundtrip_for_index_deletes_only_message(self):
+        # A global-index update can build a message whose ONLY content is
+        # index_deletes; the serializer must not drop it.
+        entry = _build_index_manifest_entry(with_dv_ranges=True)
+        message = CommitMessage(
+            partition=("2024-01-01",),
+            bucket=0,
+            index_deletes=[entry],
+        )
+        self.assertFalse(message.is_empty())
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        # The deletions survive the round-trip.
+        self.assertFalse(rebuilt.is_empty())
+        self.assertEqual(1, len(rebuilt.index_deletes))
+        rebuilt_entry = rebuilt.index_deletes[0]
+        self.assertEqual(entry.kind, rebuilt_entry.kind)
+        self.assertEqual(entry.bucket, rebuilt_entry.bucket)
+        self.assertEqual(entry.partition.values, rebuilt_entry.partition.values)
+        self.assertEqual(
+            [f.to_dict() for f in entry.partition.fields],
+            [f.to_dict() for f in rebuilt_entry.partition.fields],
+        )
+
+        original_file = entry.index_file
+        rebuilt_file = rebuilt_entry.index_file
+        self.assertEqual(original_file.index_type, rebuilt_file.index_type)
+        self.assertEqual(original_file.file_name, rebuilt_file.file_name)
+        self.assertEqual(original_file.file_size, rebuilt_file.file_size)
+        self.assertEqual(original_file.row_count, rebuilt_file.row_count)
+        self.assertEqual(original_file.external_path, rebuilt_file.external_path)
+
+        # IndexFileMeta.__eq__ only compares scalar identity fields, so assert
+        # the richer payloads explicitly to catch silent global_index/dv loss.
+        self.assertEqual(original_file.global_index_meta, rebuilt_file.global_index_meta)
+        self.assertEqual(
+            original_file.global_index_meta.index_meta,
+            rebuilt_file.global_index_meta.index_meta,
+        )
+        self.assertEqual(original_file.dv_ranges, rebuilt_file.dv_ranges)
+
+    def test_roundtrip_for_index_adds_only_message(self):
+        # A global-index creation builds a message whose ONLY content is
+        # index_adds (e.g. globalindex/create_global_index); the serializer must
+        # round-trip them just like index_deletes.
+        entry = _build_index_manifest_entry(with_dv_ranges=True)
+        message = CommitMessage(
+            partition=("2024-01-01",),
+            bucket=0,
+            index_adds=[entry],
+        )
+        self.assertFalse(message.is_empty())
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        self.assertFalse(rebuilt.is_empty())
+        self.assertEqual(1, len(rebuilt.index_adds))
+        self.assertEqual([], rebuilt.index_deletes)
+        rebuilt_entry = rebuilt.index_adds[0]
+        self.assertEqual(entry.kind, rebuilt_entry.kind)
+        self.assertEqual(entry.partition.values, rebuilt_entry.partition.values)
+        self.assertEqual(entry.index_file.file_name, rebuilt_entry.index_file.file_name)
+        self.assertEqual(
+            entry.index_file.global_index_meta, rebuilt_entry.index_file.global_index_meta)
+
+    def test_roundtrip_preserves_index_file_without_dv_or_global_index(self):
+        entry = _build_index_manifest_entry(with_dv_ranges=False)
+        entry.index_file.global_index_meta = None
+        message = CommitMessage(partition=("2024-01-01",), bucket=0, index_deletes=[entry])
+
+        rebuilt = CommitMessageSerializer.deserialize(CommitMessageSerializer.serialize(message))
+
+        rebuilt_file = rebuilt.index_deletes[0].index_file
+        self.assertIsNone(rebuilt_file.dv_ranges)
+        self.assertIsNone(rebuilt_file.global_index_meta)
+
+    def test_serialize_list_round_trip(self):
+        messages = [
+            CommitMessage(
+                partition=(f"p{i}",),
+                bucket=i,
+                data_increment=DataIncrement(new_files=[_build_data_file_meta(f"f{i}.parquet")]),
+            )
+            for i in range(3)
+        ]
+        payloads = CommitMessageSerializer.serialize_list(messages)
+        rebuilt = CommitMessageSerializer.deserialize_list(payloads)
+
+        self.assertEqual(len(messages), len(rebuilt))
+        for original, copy in zip(messages, rebuilt):
+            self.assertEqual(original.partition, copy.partition)
+            self.assertEqual(original.bucket, copy.bucket)
+            self.assertEqual(original.new_files, copy.new_files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/file_store_commit_compact_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_compact_test.py
@@ -1,0 +1,430 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import unittest
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+from pypaimon.data.timestamp import Timestamp
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.compact_increment import CompactIncrement
+from pypaimon.write.data_increment import DataIncrement
+from pypaimon.write.file_store_commit import FileStoreCommit
+
+
+def _make_index_delete(name: str) -> IndexManifestEntry:
+    return IndexManifestEntry(
+        kind=1,  # DELETE
+        partition=GenericRow([], []),
+        bucket=0,
+        index_file=IndexFileMeta(
+            index_type='HASH',
+            file_name=name,
+            file_size=64,
+            row_count=1,
+        ),
+    )
+
+
+def _make_file(name: str, *, first_row_id=None) -> DataFileMeta:
+    return DataFileMeta.create(
+        file_name=name,
+        file_size=4096,
+        row_count=10,
+        min_key=GenericRow([], []),
+        max_key=GenericRow([], []),
+        key_stats=SimpleStats.empty_stats(),
+        value_stats=SimpleStats.empty_stats(),
+        min_sequence_number=1,
+        max_sequence_number=10,
+        schema_id=0,
+        level=0,
+        extra_files=[],
+        creation_time=Timestamp.from_local_date_time(datetime(2024, 1, 15, 10, 30, 0)),
+        first_row_id=first_row_id,
+    )
+
+
+@patch('pypaimon.write.file_store_commit.ManifestFileManager')
+@patch('pypaimon.write.file_store_commit.ManifestListManager')
+class TestFileStoreCommitCompact(unittest.TestCase):
+    """Phase 1 protocol-level tests: verify data / compaction increments flow
+    correctly through the single public commit() entry.
+
+    commit() splits each batch into an APPEND (or OVERWRITE) snapshot for the
+    data increments and a separate COMPACT snapshot for the compact increments,
+    mirroring Java's FileStoreCommitImpl (one commit may produce up to two
+    snapshots). These tests stub _try_commit so we only verify entry
+    construction and commit_kind selection. Full e2e (with real manifest writes
+    / scans) is covered in Phase 2 once the rewriter exists.
+    """
+
+    def setUp(self):
+        self.mock_table = Mock()
+        self.mock_table.partition_keys = ['dt']
+        self.mock_table.partition_keys_fields = [DataField(0, 'dt', AtomicType('STRING'))]
+        self.mock_table.total_buckets = 4
+        self.mock_table.current_branch.return_value = 'main'
+        self.mock_table.identifier = 'default.t'
+        self.mock_snapshot_commit = Mock()
+
+    def _create_commit(self):
+        return FileStoreCommit(
+            snapshot_commit=self.mock_snapshot_commit,
+            table=self.mock_table,
+            commit_user='test_user',
+        )
+
+    # ---- entry construction -------------------------------------------------
+
+    def test_build_data_entries_emits_add_for_new_files(self, *_):
+        commit = self._create_commit()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=2,
+            data_increment=DataIncrement(new_files=[_make_file('a.parquet')]),
+        )
+
+        entries = commit._build_data_entries([msg])
+
+        self.assertEqual(1, len(entries))
+        self.assertEqual(0, entries[0].kind)
+        self.assertEqual(2, entries[0].bucket)
+        self.assertEqual('a.parquet', entries[0].file.file_name)
+        self.assertEqual(['2024-01-15'], list(entries[0].partition.values))
+
+    def test_build_compact_entries_emits_delete_before_and_add_after(self, *_):
+        commit = self._create_commit()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=1,
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old-1.parquet'), _make_file('old-2.parquet')],
+                compact_after=[_make_file('merged.parquet')],
+            ),
+        )
+
+        entries = commit._build_compact_entries([msg])
+
+        kinds = [e.kind for e in entries]
+        names = [e.file.file_name for e in entries]
+        self.assertEqual([1, 1, 0], kinds)
+        self.assertEqual(['old-1.parquet', 'old-2.parquet', 'merged.parquet'], names)
+        self.assertTrue(all(e.bucket == 1 for e in entries))
+
+    def test_build_data_entries_ignores_compact_increment(self, *_):
+        # _build_data_entries only reads new_files; compact files belong to the
+        # compact side and must not leak into the APPEND snapshot.
+        commit = self._create_commit()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            compact_increment=CompactIncrement(compact_after=[_make_file('m.parquet')]),
+        )
+        self.assertEqual([], commit._build_data_entries([msg]))
+
+    def test_build_data_entries_ignores_changelog_files(self, *_):
+        # changelog_files are committed to the changelog manifest via
+        # _collect_changelog_entries, not as delta entries.
+        commit = self._create_commit()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            data_increment=DataIncrement(changelog_files=[_make_file('c.parquet')]),
+        )
+        self.assertEqual([], commit._build_data_entries([msg]))
+
+    def test_build_data_entries_uses_message_total_buckets_when_set(self, *_):
+        """A stale plan whose bucket count has been rescaled should keep the
+        message's own total_buckets, not be silently overwritten with the
+        table's current value.
+        """
+        commit = self._create_commit()
+        # Table claims 4 buckets; message was planned when there were 8.
+        self.mock_table.total_buckets = 4
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            total_buckets=8,
+            data_increment=DataIncrement(new_files=[_make_file('a.parquet')]),
+        )
+
+        entries = commit._build_data_entries([msg])
+
+        self.assertEqual(1, len(entries))
+        self.assertEqual(8, entries[0].total_buckets)
+
+    def test_build_data_entries_falls_back_to_table_total_buckets(self, *_):
+        commit = self._create_commit()
+        self.mock_table.total_buckets = 4
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            total_buckets=None,
+            data_increment=DataIncrement(new_files=[_make_file('a.parquet')]),
+        )
+
+        entries = commit._build_data_entries([msg])
+
+        self.assertEqual(4, entries[0].total_buckets)
+
+    # ---- unwired-slot rejection --------------------------------------------
+
+    def test_commit_emits_delete_entry_for_data_increment_deleted_files(self, *_):
+        # deleted_files (e.g. a partition/row DELETE in data-evolution tables)
+        # become kind=1 DELETE entries on the data side.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            data_increment=DataIncrement(deleted_files=[_make_file('d.parquet')]),
+        )
+
+        commit.commit([msg], commit_identifier=100)
+
+        commit._try_commit.assert_called_once()
+        entries = commit._try_commit.call_args.kwargs['commit_entries_plan'](None)
+        self.assertEqual([1], [e.kind for e in entries])
+        self.assertEqual('d.parquet', entries[0].file.file_name)
+
+    def test_commit_rejects_compact_increment_changelog_files(self, *_):
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('2024-01-15',),
+            bucket=0,
+            compact_increment=CompactIncrement(changelog_files=[_make_file('c.parquet')]),
+        )
+        with self.assertRaises(NotImplementedError):
+            commit.commit([msg], commit_identifier=110)
+        commit._try_commit.assert_not_called()
+
+    # ---- compaction through the public commit() ----------------------------
+
+    def test_commit_compact_uses_compact_kind_and_no_conflict_detection(self, *_):
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=3,
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old.parquet')],
+                compact_after=[_make_file('new.parquet')],
+            ),
+        )
+
+        commit.commit([msg], commit_identifier=300)
+
+        # Data side is empty, so only the COMPACT snapshot is committed.
+        commit._try_commit.assert_called_once()
+        kwargs = commit._try_commit.call_args.kwargs
+        self.assertEqual('COMPACT', kwargs['commit_kind'])
+        self.assertEqual(300, kwargs['commit_identifier'])
+        self.assertFalse(kwargs['detect_conflicts'])
+        self.assertFalse(kwargs['allow_rollback'])
+
+    def test_commit_skips_when_no_messages(self, *_):
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+
+        commit.commit([], commit_identifier=500)
+
+        commit._try_commit.assert_not_called()
+
+    def test_commit_skips_when_messages_have_no_files(self, *_):
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        empty_msg = CommitMessage(partition=('p1',), bucket=0)
+
+        commit.commit([empty_msg], commit_identifier=600)
+
+        commit._try_commit.assert_not_called()
+
+    def test_commit_changelog_only_message_produces_no_snapshot(self, *_):
+        # A message whose only data content is a changelog file produces no delta
+        # entry and no index deletes, so neither side commits a snapshot.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(changelog_files=[_make_file('c.parquet')]),
+        )
+
+        commit.commit([msg], commit_identifier=650)
+
+        commit._try_commit.assert_not_called()
+
+    def test_commit_compact_forwards_index_deletes(self, *_):
+        # A compaction that also removes index manifest entries (e.g. a
+        # global-index update) must forward those deletes to _try_commit;
+        # otherwise the old index entries are left behind.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        deletes = [_make_index_delete('idx-old-1'), _make_index_delete('idx-old-2')]
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=3,
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old.parquet')],
+                compact_after=[_make_file('new.parquet')],
+            ),
+            index_deletes=deletes,
+        )
+
+        commit.commit([msg], commit_identifier=610)
+
+        commit._try_commit.assert_called_once()
+        self.assertEqual(deletes, commit._try_commit.call_args.kwargs['index_deletes'])
+
+    def test_commit_message_with_only_index_deletes(self, *_):
+        # A message whose only content is index_deletes (no data, no compact
+        # files) still carries meaningful state. With no compact increment it
+        # rides the APPEND snapshot, matching how pure global-index update
+        # messages have always committed.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        deletes = [_make_index_delete('idx-only')]
+        msg = CommitMessage(partition=('p1',), bucket=0, index_deletes=deletes)
+
+        commit.commit([msg], commit_identifier=620)
+
+        commit._try_commit.assert_called_once()
+        kwargs = commit._try_commit.call_args.kwargs
+        self.assertEqual('APPEND', kwargs['commit_kind'])
+        self.assertEqual(deletes, kwargs['index_deletes'])
+
+    # ---- data + compaction in one batch: up to two snapshots ----------------
+
+    def test_mixed_batch_produces_append_then_compact_snapshots(self, *_):
+        # A batch mixing a data-only message and a compact-only message produces
+        # two snapshots: APPEND for the writes, then COMPACT for the compaction.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        data_msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_make_file('append.parquet')]),
+        )
+        compact_msg = CommitMessage(
+            partition=('p1',),
+            bucket=1,
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old.parquet')],
+                compact_after=[_make_file('merged.parquet')],
+            ),
+        )
+
+        commit.commit([data_msg, compact_msg], commit_identifier=700)
+
+        self.assertEqual(2, commit._try_commit.call_count)
+        kinds = [c.kwargs['commit_kind'] for c in commit._try_commit.call_args_list]
+        self.assertEqual(['APPEND', 'COMPACT'], kinds)
+
+    def test_single_message_with_both_increments_splits_into_two_snapshots(self, *_):
+        # A single message carrying both a data increment and a compact increment
+        # is split: new_files → APPEND, compact_before/after → COMPACT.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_make_file('append.parquet')]),
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old.parquet')],
+                compact_after=[_make_file('merged.parquet')],
+            ),
+        )
+
+        commit.commit([msg], commit_identifier=710)
+
+        self.assertEqual(2, commit._try_commit.call_count)
+        append_kwargs, compact_kwargs = [c.kwargs for c in commit._try_commit.call_args_list]
+        self.assertEqual('APPEND', append_kwargs['commit_kind'])
+        self.assertEqual('COMPACT', compact_kwargs['commit_kind'])
+        append_names = [e.file.file_name for e in append_kwargs['commit_entries_plan'](None)]
+        compact_names = [e.file.file_name for e in compact_kwargs['commit_entries_plan'](None)]
+        self.assertEqual(['append.parquet'], append_names)
+        self.assertEqual(['old.parquet', 'merged.parquet'], compact_names)
+
+    def test_data_only_batch_produces_single_append_snapshot(self, *_):
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_make_file('append.parquet')]),
+        )
+
+        commit.commit([msg], commit_identifier=720)
+
+        commit._try_commit.assert_called_once()
+        self.assertEqual('APPEND', commit._try_commit.call_args.kwargs['commit_kind'])
+
+    # ---- abort --------------------------------------------------------------
+
+    def test_abort_deletes_compact_after_and_changelog_but_not_compact_before(self, *_):
+        """A failed/cancelled compaction must clean every file it produced:
+        compact_after and compact changelog files, alongside the data-side
+        new_files/changelog. compact_before are pre-existing inputs and must be
+        left untouched."""
+        commit = self._create_commit()
+
+        def _with_path(name):
+            f = _make_file(name)
+            f.file_path = name
+            return f
+
+        before = _with_path('before.parquet')
+        after = _with_path('after.parquet')
+        compact_changelog = _with_path('compact-changelog.parquet')
+        new_file = _with_path('new.parquet')
+        data_changelog = _with_path('data-changelog.parquet')
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(
+                new_files=[new_file],
+                changelog_files=[data_changelog],
+            ),
+            compact_increment=CompactIncrement(
+                compact_before=[before],
+                compact_after=[after],
+                changelog_files=[compact_changelog],
+            ),
+        )
+
+        commit.abort([msg])
+
+        deleted = {c.args[0] for c in self.mock_table.file_io.delete_quietly.call_args_list}
+        self.assertEqual(
+            {'new.parquet', 'data-changelog.parquet', 'after.parquet', 'compact-changelog.parquet'},
+            deleted,
+        )
+        self.assertNotIn('before.parquet', deleted)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/file_store_commit_compact_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_compact_test.py
@@ -245,6 +245,52 @@ class TestFileStoreCommitCompact(unittest.TestCase):
         self.assertFalse(kwargs['detect_conflicts'])
         self.assertFalse(kwargs['allow_rollback'])
 
+    def test_compact_only_commit_does_not_anchor_row_id_check(self, *_):
+        # A compact message can carry check_from_snapshot (it round-trips through
+        # the serializer), but compaction skips row-id conflict detection, so it
+        # must not set the reusable ConflictDetection's row-id check anchor.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+        msg = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            compact_increment=CompactIncrement(
+                compact_before=[_make_file('old.parquet')],
+                compact_after=[_make_file('new.parquet')],
+            ),
+            check_from_snapshot=7,
+        )
+
+        commit.commit([msg], commit_identifier=300)
+
+        self.assertIsNone(commit.conflict_detection._row_id_check_from_snapshot)
+        self.assertFalse(commit.conflict_detection.has_row_id_check_from_snapshot())
+
+    def test_row_id_check_state_reset_between_commits(self, *_):
+        # StreamTableCommit reuses one FileStoreCommit (and its ConflictDetection)
+        # across commits. A data commit's row-id anchor must not leak into a later
+        # commit whose own messages carry no check_from_snapshot.
+        commit = self._create_commit()
+        commit._try_commit = Mock()
+
+        first = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_make_file('a.parquet')]),
+            check_from_snapshot=5,
+        )
+        commit.commit([first], commit_identifier=1)
+        self.assertEqual(5, commit.conflict_detection._row_id_check_from_snapshot)
+
+        second = CommitMessage(
+            partition=('p1',),
+            bucket=0,
+            data_increment=DataIncrement(new_files=[_make_file('b.parquet')]),
+            check_from_snapshot=-1,
+        )
+        commit.commit([second], commit_identifier=2)
+        self.assertIsNone(commit.conflict_detection._row_id_check_from_snapshot)
+
     def test_commit_skips_when_no_messages(self, *_):
         commit = self._create_commit()
         commit._try_commit = Mock()

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -21,10 +21,32 @@ from unittest.mock import MagicMock, Mock, patch
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.snapshot.snapshot_commit import PartitionStatistics
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.file_store_commit import FileStoreCommit
+
+
+def _make_data_file(name="data.parquet", *, file_source=0, first_row_id=None,
+                    row_count=10, min_sequence_number=5, max_sequence_number=10):
+    return DataFileMeta.create(
+        file_name=name,
+        file_size=4096,
+        row_count=row_count,
+        min_key=GenericRow([], []),
+        max_key=GenericRow([], []),
+        key_stats=SimpleStats.empty_stats(),
+        value_stats=SimpleStats.empty_stats(),
+        min_sequence_number=min_sequence_number,
+        max_sequence_number=max_sequence_number,
+        schema_id=0,
+        level=0,
+        extra_files=[],
+        file_source=file_source,
+        first_row_id=first_row_id,
+    )
 
 
 @patch('pypaimon.write.file_store_commit.ManifestFileManager')
@@ -88,7 +110,7 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message = CommitMessage(
             partition=('2024-01-15', 'us-east-1'),
             bucket=0,
-            new_files=[file_meta]
+            data_increment=DataIncrement(new_files=[file_meta])
         )
 
         # Test method
@@ -153,7 +175,7 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message = CommitMessage(
             partition=('2024-01-15', 'us-east-1'),
             bucket=0,
-            new_files=[file_meta_1, file_meta_2]
+            data_increment=DataIncrement(new_files=[file_meta_1, file_meta_2])
         )
 
         # Test method
@@ -225,13 +247,13 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message_1 = CommitMessage(
             partition=('2024-01-15', 'us-east-1'),
             bucket=0,
-            new_files=[file_meta_1]
+            data_increment=DataIncrement(new_files=[file_meta_1])
         )
 
         commit_message_2 = CommitMessage(
             partition=('2024-01-15', 'us-west-2'),
             bucket=0,
-            new_files=[file_meta_2]
+            data_increment=DataIncrement(new_files=[file_meta_2])
         )
 
         # Test method
@@ -294,7 +316,7 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message = CommitMessage(
             partition=(),  # Empty partition for unpartitioned table
             bucket=0,
-            new_files=[file_meta]
+            data_increment=DataIncrement(new_files=[file_meta])
         )
 
         # Test method
@@ -333,7 +355,7 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message = CommitMessage(
             partition=('2024-01-15', 'us-east-1'),
             bucket=0,
-            new_files=[file_meta]
+            data_increment=DataIncrement(new_files=[file_meta])
         )
 
         # Test method
@@ -375,7 +397,7 @@ class TestFileStoreCommit(unittest.TestCase):
         commit_message = CommitMessage(
             partition=('2024-01-15', 'us-east-1', 'extra-value'),  # 3 values but table has 2 keys
             bucket=0,
-            new_files=[file_meta]
+            data_increment=DataIncrement(new_files=[file_meta])
         )
 
         # Test method
@@ -447,6 +469,159 @@ class TestFileStoreCommit(unittest.TestCase):
             "index-manifest-existing",
             snapshot_commit.commit.call_args[0][0].index_manifest
         )
+
+    def test_compact_commit_inherits_index_manifest(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        # A COMPACT snapshot must inherit the previous index manifest just like
+        # APPEND does; the index manifest is cumulative table state, not a
+        # per-kind delta. Without this, forwarding index_deletes through the
+        # compact side of commit() would combine against an empty base and drop
+        # the whole index.
+        file_store_commit = self._create_file_store_commit()
+
+        self.mock_table.identifier = 'default.test_table'
+        self.mock_table.table_schema = Mock()
+        self.mock_table.table_schema.id = 7
+        self.mock_table.options.row_tracking_enabled.return_value = False
+
+        snapshot_commit = MagicMock()
+        snapshot_commit.__enter__.return_value = snapshot_commit
+        snapshot_commit.__exit__.return_value = False
+        snapshot_commit.commit.return_value = True
+        file_store_commit.snapshot_commit = snapshot_commit
+
+        file_store_commit._write_manifest_files = Mock(return_value=[Mock()])
+        file_store_commit._generate_partition_statistics = Mock(return_value=[])
+        file_store_commit.manifest_list_manager.read_all.return_value = []
+
+        latest_snapshot = Mock()
+        latest_snapshot.id = 3
+        latest_snapshot.total_record_count = 10
+        latest_snapshot.index_manifest = "index-manifest-existing"
+
+        commit_entry = Mock()
+        commit_entry.kind = 0
+        commit_entry.file = Mock()
+        commit_entry.file.row_count = 2
+
+        result = file_store_commit._try_commit_once(
+            retry_result=None,
+            commit_kind="COMPACT",
+            commit_entries=[commit_entry],
+            changelog_entries=[],
+            commit_identifier=12,
+            latest_snapshot=latest_snapshot
+        )
+
+        self.assertTrue(result.is_success())
+        self.assertEqual(
+            "index-manifest-existing",
+            snapshot_commit.commit.call_args[0][0].index_manifest
+        )
+
+    def _setup_row_tracking_commit(self):
+        """Shared scaffold for the row-tracking _try_commit_once tests."""
+        file_store_commit = self._create_file_store_commit()
+        self.mock_table.identifier = 'default.test_table'
+        self.mock_table.table_schema = Mock()
+        self.mock_table.table_schema.id = 7
+        self.mock_table.options.row_tracking_enabled.return_value = True
+
+        snapshot_commit = MagicMock()
+        snapshot_commit.__enter__.return_value = snapshot_commit
+        snapshot_commit.__exit__.return_value = False
+        snapshot_commit.commit.return_value = True
+        file_store_commit.snapshot_commit = snapshot_commit
+
+        file_store_commit._write_manifest_files = Mock(return_value=[Mock()])
+        file_store_commit._generate_partition_statistics = Mock(return_value=[])
+        file_store_commit.manifest_list_manager.read_all.return_value = []
+
+        latest_snapshot = Mock()
+        latest_snapshot.id = 3
+        latest_snapshot.total_record_count = 10
+        latest_snapshot.index_manifest = None
+        latest_snapshot.next_row_id = 50
+        return file_store_commit, snapshot_commit, latest_snapshot
+
+    def test_compact_commit_preserves_row_ids(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        # A COMPACT commit must not run row-tracking assignment: compact_after
+        # files keep their (possibly None) first_row_id and the snapshot keeps the
+        # previous next_row_id, otherwise row-id based updates/conflict checks can
+        # no longer locate the compacted rows. The compact_after file here has
+        # first_row_id=None and file_source=APPEND so the *old* (ungated) path
+        # would assign it a fresh id and advance next_row_id.
+        file_store_commit, snapshot_commit, latest_snapshot = self._setup_row_tracking_commit()
+        entry = ManifestEntry(
+            kind=0, partition=GenericRow([], []), bucket=0, total_buckets=1,
+            file=_make_data_file(first_row_id=None, row_count=10))
+
+        result = file_store_commit._try_commit_once(
+            retry_result=None,
+            commit_kind="COMPACT",
+            commit_entries=[entry],
+            changelog_entries=[],
+            commit_identifier=20,
+            latest_snapshot=latest_snapshot,
+        )
+
+        self.assertTrue(result.is_success())
+        # next_row_id carried over from latest, not advanced by the 10-row file.
+        self.assertEqual(50, snapshot_commit.commit.call_args[0][0].next_row_id)
+        # The entry that reached the manifest still has no first_row_id assigned.
+        written = file_store_commit._write_manifest_files.call_args[0][0]
+        self.assertIsNone(written[0].file.first_row_id)
+
+    def test_append_commit_still_assigns_row_ids(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        # Control for test_compact_commit_preserves_row_ids: the COMPACT gate must
+        # not disable row-tracking for the normal write path.
+        file_store_commit, snapshot_commit, latest_snapshot = self._setup_row_tracking_commit()
+        entry = ManifestEntry(
+            kind=0, partition=GenericRow([], []), bucket=0, total_buckets=1,
+            file=_make_data_file(first_row_id=None, row_count=10, min_sequence_number=0))
+
+        result = file_store_commit._try_commit_once(
+            retry_result=None,
+            commit_kind="APPEND",
+            commit_entries=[entry],
+            changelog_entries=[],
+            commit_identifier=21,
+            latest_snapshot=latest_snapshot,
+        )
+
+        self.assertTrue(result.is_success())
+        # APPEND assigns the fresh row id from next_row_id and advances it.
+        self.assertEqual(60, snapshot_commit.commit.call_args[0][0].next_row_id)
+        written = file_store_commit._write_manifest_files.call_args[0][0]
+        self.assertEqual(50, written[0].file.first_row_id)
+
+    def test_collect_changelog_entries_uses_message_total_buckets(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        # Changelog manifest entries must honor the plan's total_buckets (captured
+        # at write time) just like the delta entries, so a plan that survived a
+        # bucket rescale does not publish inconsistent bucket metadata in one
+        # commit.
+        file_store_commit = self._create_file_store_commit()
+        self.mock_table.total_buckets = 4
+        msg = CommitMessage(
+            partition=(),
+            bucket=0,
+            total_buckets=8,
+            data_increment=DataIncrement(
+                new_files=[_make_data_file("d.parquet")],
+                changelog_files=[_make_data_file("c.parquet")],
+            ),
+        )
+
+        changelog_entries = file_store_commit._collect_changelog_entries([msg])
+        delta_entries = file_store_commit._build_data_entries([msg])
+
+        self.assertEqual([8], [e.total_buckets for e in changelog_entries])
+        # Delta and changelog entries of the same commit agree on the bucket count.
+        self.assertEqual({8}, {e.total_buckets for e in delta_entries}
+                         | {e.total_buckets for e in changelog_entries})
 
     def test_null_partition_value(
             self, mock_manifest_list_manager, mock_manifest_file_manager):

--- a/paimon-python/pypaimon/tests/partition_predicate_test.py
+++ b/paimon-python/pypaimon/tests/partition_predicate_test.py
@@ -31,6 +31,7 @@ from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.row.offset_row import OffsetRow
 from pypaimon.write.commit.commit_scanner import CommitScanner
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.file_store_commit import FileStoreCommit
 
 PARTITION_FIELDS = [
@@ -182,7 +183,11 @@ class TestOverwritePartitionPredicate(unittest.TestCase):
 
     @staticmethod
     def _msg(partition):
-        return CommitMessage(partition=partition, bucket=0, new_files=[Mock(row_count=10)])
+        return CommitMessage(
+            partition=partition,
+            bucket=0,
+            data_increment=DataIncrement(new_files=[Mock(row_count=10)]),
+        )
 
     def _extract_partition_predicate(self, commit):
         entries_plan = commit._try_commit.call_args[1]['commit_entries_plan']

--- a/paimon-python/pypaimon/tests/table_commit_test.py
+++ b/paimon-python/pypaimon/tests/table_commit_test.py
@@ -22,6 +22,7 @@ from parameterized import parameterized
 
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.table_commit import BatchTableCommit, StreamTableCommit
 
 
@@ -51,7 +52,11 @@ class TestTableCommitEmptyOverwrite(unittest.TestCase):
         commit, mock_fsc = self._create_commit(BatchTableCommit, overwrite_partition={'f0': 1})
 
         messages = [
-            CommitMessage(partition=(1,), bucket=0, new_files=[Mock()] if has_files else [])
+            CommitMessage(
+                partition=(1,),
+                bucket=0,
+                data_increment=DataIncrement(new_files=[Mock()] if has_files else []),
+            )
             for has_files in msg_flags
         ]
         commit.commit(messages)
@@ -74,7 +79,11 @@ class TestTableCommitEmptyOverwrite(unittest.TestCase):
         commit, mock_fsc = self._create_commit(BatchTableCommit, overwrite_partition=None)
 
         messages = [
-            CommitMessage(partition=(), bucket=0, new_files=[Mock()] if has_files else [])
+            CommitMessage(
+                partition=(),
+                bucket=0,
+                data_increment=DataIncrement(new_files=[Mock()] if has_files else []),
+            )
             for has_files in msg_flags
         ]
         commit.commit(messages)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -194,6 +194,20 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             self._read_all(table)['age'].to_pylist(),
         )
 
+    def test_update_commit_message_carries_total_buckets(self):
+        """Row-id updates must stamp the planned bucket count onto their
+        CommitMessage like the other write paths, so a later commit does not
+        rewrite a stale plan with the table's current bucket count."""
+        table = self._create_seeded_table()
+        msgs = self._do_update(table, pa.Table.from_pydict({
+            '_ROW_ID': [0],
+            'age': [99],
+        }), ['age'])
+        self.assertTrue(msgs)
+        for m in msgs:
+            self.assertIsNotNone(m.total_buckets)
+            self.assertEqual(table.total_buckets, m.total_buckets)
+
     def test_update_by_predicate(self):
         table = self._create_seeded_table()
         wb = self._make_write_builder(table)

--- a/paimon-python/pypaimon/tests/write/changelog_producer_test.py
+++ b/paimon-python/pypaimon/tests/write/changelog_producer_test.py
@@ -30,6 +30,7 @@ from pypaimon import CatalogFactory, Schema
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.schema.data_types import DataField, AtomicType
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 
 
 class ChangelogProducerTest(unittest.TestCase):
@@ -70,10 +71,12 @@ class ChangelogProducerTest(unittest.TestCase):
         }, schema=self.pk_schema)
 
     def test_commit_message_with_changelog(self):
-        msg = CommitMessage(partition=('p1',), bucket=0, new_files=[], changelog_files=[])
+        msg = CommitMessage(partition=('p1',), bucket=0,
+                            data_increment=DataIncrement(new_files=[], changelog_files=[]))
         self.assertTrue(msg.is_empty())
 
-        msg2 = CommitMessage(partition=('p1',), bucket=0, new_files=['fake'])
+        msg2 = CommitMessage(partition=('p1',), bucket=0,
+                             data_increment=DataIncrement(new_files=['fake']))
         self.assertFalse(msg2.is_empty())
         self.assertEqual(msg2.changelog_files, [])
 

--- a/paimon-python/pypaimon/write/commit_message.py
+++ b/paimon-python/pypaimon/write/commit_message.py
@@ -16,9 +16,11 @@
 # under the License.
 
 from dataclasses import dataclass, field
-from typing import List, Tuple, Optional, TYPE_CHECKING
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.write.compact_increment import CompactIncrement
+from pypaimon.write.data_increment import DataIncrement
 
 if TYPE_CHECKING:
     from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
@@ -26,20 +28,66 @@ if TYPE_CHECKING:
 
 @dataclass
 class CommitMessage:
+    """File committable for sink.
+
+    Carries everything one (partition, bucket) writer or compactor contributes
+    to a snapshot, packaged as a (data_increment, compact_increment) pair so
+    the same message type can describe both pure writes and compaction results.
+
+    - partition / bucket: identify the (partition, bucket) the message
+      applies to.
+    - total_buckets: number of buckets the table had at write time, used by
+      the commit path to detect bucket-count changes.
+    - data_increment: ADD/DELETE/changelog/index deltas from a normal write.
+    - compact_increment: ADD/DELETE/changelog/index deltas from compaction.
+    - check_from_snapshot: row-tracking conflict-detection anchor; -1 means
+      "no check" (default). Read per-message by write/commit/conflict_detection.py.
+    - index_adds / index_deletes: index manifest entries added/removed by this
+      message (e.g. global index updates); committed alongside the data/compact
+      increments.
+    """
+
     partition: Tuple
     bucket: int
-    new_files: List[DataFileMeta]
+    total_buckets: Optional[int] = None
+    data_increment: DataIncrement = field(default_factory=DataIncrement)
+    compact_increment: CompactIncrement = field(default_factory=CompactIncrement)
     check_from_snapshot: Optional[int] = -1
-    deleted_files: List[DataFileMeta] = field(default_factory=list)
     index_adds: List['IndexManifestEntry'] = field(default_factory=list)
     index_deletes: List['IndexManifestEntry'] = field(default_factory=list)
-    changelog_files: List[DataFileMeta] = field(default_factory=list)
 
-    def is_empty(self):
+    # ---- Convenience accessors ---------------------------------------------
+    # Callers usually want the individual file lists rather than reaching
+    # through the increment.
+
+    @property
+    def new_files(self) -> List[DataFileMeta]:
+        return self.data_increment.new_files
+
+    @property
+    def deleted_files(self) -> List[DataFileMeta]:
+        return self.data_increment.deleted_files
+
+    @property
+    def changelog_files(self) -> List[DataFileMeta]:
+        return self.data_increment.changelog_files
+
+    @property
+    def compact_before(self) -> List[DataFileMeta]:
+        return self.compact_increment.compact_before
+
+    @property
+    def compact_after(self) -> List[DataFileMeta]:
+        return self.compact_increment.compact_after
+
+    @property
+    def compact_changelog_files(self) -> List[DataFileMeta]:
+        return self.compact_increment.changelog_files
+
+    def is_empty(self) -> bool:
         return (
-            not self.new_files
-            and not self.deleted_files
+            self.data_increment.is_empty()
+            and self.compact_increment.is_empty()
             and not self.index_adds
             and not self.index_deletes
-            and not self.changelog_files
         )

--- a/paimon-python/pypaimon/write/commit_message_serializer.py
+++ b/paimon-python/pypaimon/write/commit_message_serializer.py
@@ -1,0 +1,255 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import json
+from typing import Any, Dict, List
+
+from pypaimon.globalindex.global_index_meta import GlobalIndexMeta
+from pypaimon.index.deletion_vector_meta import DeletionVectorMeta
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.schema.data_file_meta import (DataFileMeta, _generic_row_from_dict,
+                                                     _generic_row_to_dict, decode_value,
+                                                     encode_value)
+from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.compact_increment import CompactIncrement
+from pypaimon.write.data_increment import DataIncrement
+
+
+class CommitMessageSerializer:
+    """JSON wire format for shipping CommitMessage between pypaimon processes
+    (e.g. Ray driver ↔ workers).
+
+    JSON on purpose: human-debuggable, tolerant of Python version drift, and
+    avoids pickle's compat/security pitfalls when shipping CompactTask outputs
+    from Ray workers back to the driver.
+
+    Every message round-trips (partition, bucket, total_buckets, data_increment,
+    compact_increment, check_from_snapshot, index_adds, index_deletes), with each
+    increment carrying its own new / deleted / changelog file lists plus index
+    file deltas. index_adds / index_deletes (the index manifest entries a
+    global-index update adds or removes) are round-tripped too, so a message
+    whose only content is index changes does not silently lose them when shipped
+    through this serializer.
+    """
+
+    # Wire format version; bump on incompatible payload changes.
+    VERSION = 1
+
+    @classmethod
+    def serialize(cls, message: CommitMessage) -> bytes:
+        return json.dumps(cls.to_dict(message), separators=(",", ":")).encode("utf-8")
+
+    @classmethod
+    def deserialize(cls, payload: bytes) -> CommitMessage:
+        return cls.from_dict(json.loads(payload.decode("utf-8")))
+
+    @classmethod
+    def to_dict(cls, message: CommitMessage) -> Dict[str, Any]:
+        partition = message.partition if message.partition is not None else ()
+        return {
+            "version": cls.VERSION,
+            "partition": [encode_value(v) for v in partition],
+            "bucket": message.bucket,
+            "total_buckets": message.total_buckets,
+            "data_increment": cls._data_increment_to_dict(message.data_increment),
+            "compact_increment": cls._compact_increment_to_dict(message.compact_increment),
+            "check_from_snapshot": message.check_from_snapshot,
+            "index_adds": [cls._index_manifest_entry_to_dict(e) for e in message.index_adds],
+            "index_deletes": [cls._index_manifest_entry_to_dict(e) for e in message.index_deletes],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CommitMessage:
+        version = data.get("version", cls.VERSION)
+        if version != cls.VERSION:
+            raise ValueError(
+                f"Unsupported CommitMessage payload version: {version} (expected {cls.VERSION})"
+            )
+        partition_values = data.get("partition") or []
+        return CommitMessage(
+            partition=tuple(decode_value(v) for v in partition_values),
+            bucket=data["bucket"],
+            total_buckets=data.get("total_buckets"),
+            data_increment=cls._data_increment_from_dict(data.get("data_increment")),
+            compact_increment=cls._compact_increment_from_dict(data.get("compact_increment")),
+            check_from_snapshot=data.get("check_from_snapshot", -1),
+            index_adds=[cls._index_manifest_entry_from_dict(e)
+                        for e in (data.get("index_adds") or [])],
+            index_deletes=[cls._index_manifest_entry_from_dict(e)
+                           for e in (data.get("index_deletes") or [])],
+        )
+
+    @classmethod
+    def serialize_list(cls, messages: List[CommitMessage]) -> List[bytes]:
+        return [cls.serialize(m) for m in messages]
+
+    @classmethod
+    def deserialize_list(cls, payloads: List[bytes]) -> List[CommitMessage]:
+        return [cls.deserialize(p) for p in payloads]
+
+    # ---- Increment helpers -------------------------------------------------
+
+    @classmethod
+    def _data_increment_to_dict(cls, inc: DataIncrement) -> Dict[str, Any]:
+        return {
+            "new_files": [f.to_dict() for f in inc.new_files],
+            "deleted_files": [f.to_dict() for f in inc.deleted_files],
+            "changelog_files": [f.to_dict() for f in inc.changelog_files],
+            "new_index_files": [_index_file_to_dict(i) for i in inc.new_index_files],
+            "deleted_index_files": [_index_file_to_dict(i) for i in inc.deleted_index_files],
+        }
+
+    @classmethod
+    def _data_increment_from_dict(cls, data) -> DataIncrement:
+        if not data:
+            return DataIncrement()
+        return DataIncrement(
+            new_files=[DataFileMeta.from_dict(f) for f in data.get("new_files") or []],
+            deleted_files=[DataFileMeta.from_dict(f) for f in data.get("deleted_files") or []],
+            changelog_files=[DataFileMeta.from_dict(f) for f in data.get("changelog_files") or []],
+            new_index_files=[_index_file_from_dict(i) for i in data.get("new_index_files") or []],
+            deleted_index_files=[_index_file_from_dict(i) for i in data.get("deleted_index_files") or []],
+        )
+
+    @classmethod
+    def _compact_increment_to_dict(cls, inc: CompactIncrement) -> Dict[str, Any]:
+        return {
+            "compact_before": [f.to_dict() for f in inc.compact_before],
+            "compact_after": [f.to_dict() for f in inc.compact_after],
+            "changelog_files": [f.to_dict() for f in inc.changelog_files],
+            "new_index_files": [_index_file_to_dict(i) for i in inc.new_index_files],
+            "deleted_index_files": [_index_file_to_dict(i) for i in inc.deleted_index_files],
+        }
+
+    @classmethod
+    def _compact_increment_from_dict(cls, data) -> CompactIncrement:
+        if not data:
+            return CompactIncrement()
+        return CompactIncrement(
+            compact_before=[DataFileMeta.from_dict(f) for f in data.get("compact_before") or []],
+            compact_after=[DataFileMeta.from_dict(f) for f in data.get("compact_after") or []],
+            changelog_files=[DataFileMeta.from_dict(f) for f in data.get("changelog_files") or []],
+            new_index_files=[_index_file_from_dict(i) for i in data.get("new_index_files") or []],
+            deleted_index_files=[_index_file_from_dict(i) for i in data.get("deleted_index_files") or []],
+        )
+
+    # ---- Index manifest entry helpers --------------------------------------
+
+    @classmethod
+    def _index_manifest_entry_to_dict(cls, entry: IndexManifestEntry) -> Dict[str, Any]:
+        return {
+            "kind": entry.kind,
+            "partition": _generic_row_to_dict(entry.partition),
+            "bucket": entry.bucket,
+            "index_file": _index_file_to_dict(entry.index_file),
+        }
+
+    @classmethod
+    def _index_manifest_entry_from_dict(cls, data: Dict[str, Any]) -> IndexManifestEntry:
+        return IndexManifestEntry(
+            kind=data["kind"],
+            partition=_generic_row_from_dict(data.get("partition")),
+            bucket=data["bucket"],
+            index_file=_index_file_from_dict(data["index_file"]),
+        )
+
+
+# IndexFileMeta carries the scalar identity fields plus two richer payloads:
+# dv_ranges (deletion-vector index) and global_index_meta (global index). All
+# are round-tripped so a message carrying global-index deletes (or, later,
+# deletion vectors) does not lose them when shipped through this serializer.
+def _index_file_to_dict(idx: IndexFileMeta) -> Dict[str, Any]:
+    return {
+        "index_type": idx.index_type,
+        "file_name": idx.file_name,
+        "file_size": idx.file_size,
+        "row_count": idx.row_count,
+        "external_path": idx.external_path,
+        "dv_ranges": _dv_ranges_to_list(idx.dv_ranges),
+        "global_index_meta": _global_index_meta_to_dict(idx.global_index_meta),
+    }
+
+
+def _index_file_from_dict(data: Dict[str, Any]) -> IndexFileMeta:
+    return IndexFileMeta(
+        index_type=data["index_type"],
+        file_name=data["file_name"],
+        file_size=data["file_size"],
+        row_count=data["row_count"],
+        external_path=data.get("external_path"),
+        dv_ranges=_dv_ranges_from_list(data.get("dv_ranges")),
+        global_index_meta=_global_index_meta_from_dict(data.get("global_index_meta")),
+    )
+
+
+def _dv_ranges_to_list(dv_ranges):
+    # In memory dv_ranges is keyed by data_file_name; the key is redundant with
+    # DeletionVectorMeta.data_file_name, so serialize as a flat list and rebuild
+    # the dict on the way back.
+    if not dv_ranges:
+        return None
+    return [
+        {
+            "data_file_name": dv.data_file_name,
+            "offset": dv.offset,
+            "length": dv.length,
+            "cardinality": dv.cardinality,
+        }
+        for dv in dv_ranges.values()
+    ]
+
+
+def _dv_ranges_from_list(data):
+    if not data:
+        return None
+    ranges = {}
+    for d in data:
+        dv = DeletionVectorMeta(
+            data_file_name=d["data_file_name"],
+            offset=d["offset"],
+            length=d["length"],
+            cardinality=d.get("cardinality"),
+        )
+        ranges[dv.data_file_name] = dv
+    return ranges
+
+
+def _global_index_meta_to_dict(meta):
+    if meta is None:
+        return None
+    return {
+        "row_range_start": meta.row_range_start,
+        "row_range_end": meta.row_range_end,
+        "index_field_id": meta.index_field_id,
+        "extra_field_ids": meta.extra_field_ids,
+        # index_meta is raw bytes; encode_value tags it for JSON round-trip.
+        "index_meta": encode_value(meta.index_meta),
+    }
+
+
+def _global_index_meta_from_dict(data):
+    if data is None:
+        return None
+    return GlobalIndexMeta(
+        row_range_start=data["row_range_start"],
+        row_range_end=data["row_range_end"],
+        index_field_id=data["index_field_id"],
+        extra_field_ids=data.get("extra_field_ids"),
+        index_meta=decode_value(data.get("index_meta")),
+    )

--- a/paimon-python/pypaimon/write/compact_increment.py
+++ b/paimon-python/pypaimon/write/compact_increment.py
@@ -1,0 +1,52 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from dataclasses import dataclass, field
+from typing import List
+
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+
+
+@dataclass
+class CompactIncrement:
+    """Files changed before and after compaction, with changelog produced during compaction.
+
+    - compact_before: input files consumed by compaction (DELETE entries).
+    - compact_after: rewritten output files (ADD entries).
+    - changelog_files: changelog files emitted while compacting (used by the
+      full-compaction changelog producer; empty in the basic dedup path).
+    - new_index_files / deleted_index_files: index file deltas attributable
+      to this compaction (deletion vectors / global index updates). Empty
+      lists by default.
+    """
+
+    compact_before: List[DataFileMeta] = field(default_factory=list)
+    compact_after: List[DataFileMeta] = field(default_factory=list)
+    changelog_files: List[DataFileMeta] = field(default_factory=list)
+    new_index_files: List[IndexFileMeta] = field(default_factory=list)
+    deleted_index_files: List[IndexFileMeta] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return (
+            not self.compact_before
+            and not self.compact_after
+            and not self.changelog_files
+            and not self.new_index_files
+            and not self.deleted_index_files
+        )

--- a/paimon-python/pypaimon/write/data_increment.py
+++ b/paimon-python/pypaimon/write/data_increment.py
@@ -1,0 +1,56 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from dataclasses import dataclass, field
+from typing import List
+
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+
+
+@dataclass
+class DataIncrement:
+    """Increment of data files, changelog files and index files produced by a write.
+
+    Carries everything one write attempt contributes to a snapshot, so a
+    CommitMessage can be constructed from a (DataIncrement, CompactIncrement)
+    pair.
+
+    - new_files: data files this write created (ADD entries).
+    - deleted_files: data files this write removed without compaction
+      (e.g. row-level delete in data-evolution tables); ADD/DELETE asymmetry
+      is preserved by giving each list its own slot.
+    - changelog_files: changelog data files associated with this write.
+    - new_index_files / deleted_index_files: index file deltas (deletion
+      vectors, global index, ...). Empty lists by default.
+    """
+
+    new_files: List[DataFileMeta] = field(default_factory=list)
+    deleted_files: List[DataFileMeta] = field(default_factory=list)
+    changelog_files: List[DataFileMeta] = field(default_factory=list)
+    new_index_files: List[IndexFileMeta] = field(default_factory=list)
+    deleted_index_files: List[IndexFileMeta] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return (
+            not self.new_files
+            and not self.deleted_files
+            and not self.changelog_files
+            and not self.new_index_files
+            and not self.deleted_index_files
+        )

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -168,11 +168,16 @@ class FileStoreCommit:
 
     def _commit_data(self, commit_messages: List[CommitMessage], commit_identifier: int,
                      index_adds: List, index_deletes: List) -> None:
-        # Extract the minimum check_from_snapshot from commit messages
+        # Only data-side messages (those contributing new/deleted files) anchor
+        # row-id conflict detection; compaction-only messages must not. Assign
+        # unconditionally so a prior commit's anchor cannot leak into this
+        # APPEND/OVERWRITE commit via the reusable ConflictDetection instance
+        # (StreamTableCommit reuses the same FileStoreCommit across commits).
         valid_snapshots = [msg.check_from_snapshot for msg in commit_messages
-                           if msg.check_from_snapshot != -1]
-        if valid_snapshots:
-            self.conflict_detection._row_id_check_from_snapshot = min(valid_snapshots)
+                           if msg.check_from_snapshot != -1
+                           and not msg.data_increment.is_empty()]
+        self.conflict_detection._row_id_check_from_snapshot = (
+            min(valid_snapshots) if valid_snapshots else None)
 
         commit_entries = self._build_data_entries(commit_messages)
         changelog_entries = self._collect_changelog_entries(commit_messages)

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -124,32 +124,61 @@ class FileStoreCommit:
         self.rollback = CommitRollback(table_rollback) if table_rollback is not None else None
 
     def commit(self, commit_messages: List[CommitMessage], commit_identifier: int):
-        """Commit the given commit messages in normal append mode."""
+        """Commit the given messages, splitting write and compaction results.
+
+        Each CommitMessage may carry a data_increment (normal write), a
+        compact_increment (compaction result), or both. Data increments feed an
+        APPEND (or OVERWRITE) snapshot; compact increments feed a separate
+        COMPACT snapshot, so a single commit() call produces up to two
+        snapshots, mirroring Java's FileStoreCommitImpl. Compaction never
+        assigns row-ids or runs conflict detection.
+        """
         if not commit_messages:
             return
 
-        # Extract the minimum check_from_snapshot from commit messages
-        valid_snapshots = [msg.check_from_snapshot for msg in commit_messages
-                           if msg.check_from_snapshot != -1]
-        if valid_snapshots:
-            self.conflict_detection._row_id_check_from_snapshot = min(valid_snapshots)
+        self._reject_unwired_slots(commit_messages)
 
         logger.info(
             "Ready to commit to table %s, number of commit messages: %d",
             self.table.identifier,
             len(commit_messages),
         )
-        commit_entries = self._collect_manifest_entries(commit_messages)
+
+        # index_adds / index_deletes ride with the snapshot their payload
+        # belongs to: messages carrying a compact increment go to the COMPACT
+        # snapshot, everything else (writes and pure index updates) goes to the
+        # APPEND snapshot. Attributing them to exactly one side keeps the same
+        # index manifest change from being committed twice.
+        data_index_adds, data_index_deletes = [], []
+        compact_index_adds, compact_index_deletes = [], []
+        for msg in commit_messages:
+            if msg.compact_increment.is_empty():
+                data_index_adds.extend(msg.index_adds)
+                data_index_deletes.extend(msg.index_deletes)
+            else:
+                compact_index_adds.extend(msg.index_adds)
+                compact_index_deletes.extend(msg.index_deletes)
+
+        # APPEND/OVERWRITE snapshot first, COMPACT second, mirroring Java's
+        # FileStoreCommitImpl.commit ordering.
+        self._commit_data(commit_messages, commit_identifier,
+                          data_index_adds, data_index_deletes)
+        self._commit_compact(commit_messages, commit_identifier,
+                             compact_index_adds, compact_index_deletes)
+
+    def _commit_data(self, commit_messages: List[CommitMessage], commit_identifier: int,
+                     index_adds: List, index_deletes: List) -> None:
+        # Extract the minimum check_from_snapshot from commit messages
+        valid_snapshots = [msg.check_from_snapshot for msg in commit_messages
+                           if msg.check_from_snapshot != -1]
+        if valid_snapshots:
+            self.conflict_detection._row_id_check_from_snapshot = min(valid_snapshots)
+
+        commit_entries = self._build_data_entries(commit_messages)
         changelog_entries = self._collect_changelog_entries(commit_messages)
 
         logger.info("Finished collecting changes, including: %d entries, %d changelog entries",
                     len(commit_entries), len(changelog_entries))
-
-        index_deletes = []
-        index_adds = []
-        for msg in commit_messages:
-            index_deletes.extend(msg.index_deletes)
-            index_adds.extend(msg.index_adds)
 
         if not index_deletes:
             from pypaimon.write.global_index_update_checker import (
@@ -186,6 +215,12 @@ class FileStoreCommit:
         if self.conflict_detection.has_global_index_additions(index_adds):
             detect_conflicts = True
 
+        # Nothing on the data side to commit (e.g. a compaction-only batch):
+        # skip so we do not emit an empty APPEND snapshot. Mirrors the
+        # short-circuit inside _try_commit.
+        if not commit_entries and not index_deletes and not index_adds:
+            return
+
         self._try_commit(commit_kind=commit_kind,
                          commit_identifier=commit_identifier,
                          commit_entries_plan=lambda snapshot: commit_entries,
@@ -194,6 +229,91 @@ class FileStoreCommit:
                          allow_rollback=allow_rollback,
                          index_deletes=index_deletes,
                          index_adds=index_adds)
+
+    def _commit_compact(self, commit_messages: List[CommitMessage], commit_identifier: int,
+                        index_adds: List, index_deletes: List) -> None:
+        # compact_before → DELETE entries, compact_after → ADD entries; snapshot
+        # kind = COMPACT. Skips row-id assignment and conflict detection (a
+        # compaction never produces new rows). Only ships the index changes
+        # attributed to this side; the new_files-driven global-index derivation
+        # lives on the data side. A message whose only content is index changes
+        # still needs to commit, so the empty-entries short-circuit accounts for
+        # them.
+        commit_entries = self._build_compact_entries(commit_messages)
+
+        if not commit_entries and not index_deletes and not index_adds:
+            return
+
+        logger.info("Finished collecting compact changes: %d entries", len(commit_entries))
+
+        self._try_commit(
+            commit_kind="COMPACT",
+            commit_identifier=commit_identifier,
+            commit_entries_plan=lambda snapshot: commit_entries,
+            detect_conflicts=False,
+            allow_rollback=False,
+            index_deletes=index_deletes,
+            index_adds=index_adds,
+        )
+
+    def _reject_unwired_slots(self, commit_messages: List[CommitMessage]) -> None:
+        # Reject increment slots the commit path does not yet wire up, loudly, so
+        # a future writer that starts filling them cannot silently lose data at
+        # commit time. data_increment.new_files / deleted_files / changelog_files
+        # are all wired (ADD / DELETE delta entries and the changelog manifest);
+        # the index-file slots are not yet handled.
+        for msg in commit_messages:
+            di = msg.data_increment
+            if di.new_index_files or di.deleted_index_files:
+                raise NotImplementedError(
+                    "FileStoreCommit does not yet handle DataIncrement.new_index_files / "
+                    "deleted_index_files; these slots "
+                    "will be wired in by the feature that first needs each one."
+                )
+            ci = msg.compact_increment
+            if (ci.changelog_files or ci.new_index_files or ci.deleted_index_files):
+                raise NotImplementedError(
+                    "FileStoreCommit does not yet handle CompactIncrement.changelog_files / "
+                    "new_index_files / deleted_index_files; these slots will be wired in by "
+                    "the feature that first needs each one."
+                )
+
+    def _entry(self, msg: CommitMessage, file: DataFileMeta, kind: int) -> ManifestEntry:
+        partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
+        # Prefer the message's total_buckets (captured when the plan was built)
+        # over the current table value, so a plan that survived a bucket rescale
+        # is not silently rewritten with the new count.
+        total_buckets = msg.total_buckets if msg.total_buckets is not None \
+            else self.table.total_buckets
+        return ManifestEntry(
+            kind=kind,
+            partition=partition,
+            bucket=msg.bucket,
+            total_buckets=total_buckets,
+            file=file,
+        )
+
+    def _build_data_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
+        # Data-side delta entries: new_files → ADD, deleted_files → DELETE.
+        # data_increment.changelog_files is written to the changelog manifest by
+        # _collect_changelog_entries, not here, so it produces no delta entry.
+        entries: List[ManifestEntry] = []
+        for msg in commit_messages:
+            for file in msg.new_files:
+                entries.append(self._entry(msg, file, kind=0))
+            for file in msg.deleted_files:
+                entries.append(self._entry(msg, file, kind=1))
+        return entries
+
+    def _build_compact_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
+        # Compact-side delta entries: compact_before → DELETE, compact_after → ADD.
+        entries: List[ManifestEntry] = []
+        for msg in commit_messages:
+            for file in msg.compact_before:
+                entries.append(self._entry(msg, file, kind=1))
+            for file in msg.compact_after:
+                entries.append(self._entry(msg, file, kind=0))
+        return entries
 
     def overwrite(self, overwrite_partition, commit_messages: List[CommitMessage], commit_identifier: int):
         """Commit the given commit messages in overwrite mode."""
@@ -429,9 +549,20 @@ class FileStoreCommit:
         row_tracking_enabled = self.table.options.row_tracking_enabled()
         next_row_id = None
         if row_tracking_enabled:
-            commit_entries = self._assign_snapshot_id(new_snapshot_id, commit_entries)
-            first_row_id_start = self._get_next_row_id_start(latest_snapshot)
-            commit_entries, next_row_id = self._assign_row_tracking_meta(first_row_id_start, commit_entries)
+            if commit_kind == "COMPACT":
+                # Compaction preserves the logical row ids of its input files: no
+                # snapshot-id sequence stamping, no fresh row-id assignment, and the
+                # snapshot keeps the previous next_row_id. Matches Java, where
+                # assignRowTracking leaves COMPACT files untouched and nextRowId is
+                # not advanced for a pure-compaction commit; otherwise a compact_after
+                # file would be re-stamped like a new append and row-id based
+                # updates/conflict checks could no longer locate the compacted rows.
+                next_row_id = self._get_next_row_id_start(latest_snapshot)
+            else:
+                commit_entries = self._assign_snapshot_id(new_snapshot_id, commit_entries)
+                first_row_id_start = self._get_next_row_id_start(latest_snapshot)
+                commit_entries, next_row_id = self._assign_row_tracking_meta(
+                    first_row_id_start, commit_entries)
 
         changelog_manifest_list_name = None
         changelog_manifest_list_size = None
@@ -477,6 +608,10 @@ class FileStoreCommit:
                     delta_record_count -= entry.file.row_count
 
             total_record_count += delta_record_count
+            # The index manifest is cumulative table state, not a per-kind delta,
+            # so every snapshot kind (APPEND / OVERWRITE / COMPACT) inherits the
+            # previous one; otherwise forwarding index changes through compaction
+            # would combine against an empty base and drop the whole index.
             index_manifest = latest_snapshot.index_manifest if latest_snapshot else None
             if index_deletes or index_adds:
                 from pypaimon.manifest.index_manifest_file import IndexManifestFile
@@ -646,17 +781,14 @@ class FileStoreCommit:
         time.sleep(total_wait_ms / 1000.0)
 
     def _collect_changelog_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
+        # changelog files become ADD entries in the changelog manifest. Reuse
+        # _entry() so they carry the same message-preferred total_buckets as the
+        # data entries in the same commit; otherwise a plan that survived a bucket
+        # rescale would publish data and changelog entries with mismatched counts.
         changelog_entries = []
         for msg in commit_messages:
-            partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
             for file in msg.changelog_files:
-                changelog_entries.append(ManifestEntry(
-                    kind=0,
-                    partition=partition,
-                    bucket=msg.bucket,
-                    total_buckets=self.table.total_buckets,
-                    file=file
-                ))
+                changelog_entries.append(self._entry(msg, file, kind=0))
         return changelog_entries
 
     def _collect_manifest_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
@@ -721,7 +853,13 @@ class FileStoreCommit:
     def abort(self, commit_messages: List[CommitMessage]):
         """Abort commit and delete files. Uses external_path if available to ensure proper scheme handling."""
         for message in commit_messages:
-            for file in list(message.new_files) + list(message.changelog_files):
+            # Delete every file this message produced: data-side new_files /
+            # changelog, and compaction outputs (compact_after + compact
+            # changelog). compact_before are pre-existing inputs consumed by the
+            # compaction and must be left untouched.
+            produced = (list(message.new_files) + list(message.changelog_files)
+                        + list(message.compact_after) + list(message.compact_changelog_files))
+            for file in produced:
                 try:
                     path_to_delete = file.external_path if file.external_path else file.file_path
                     if path_to_delete:

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.row_utils import row_values_to_arrow_table
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
@@ -261,8 +262,11 @@ class FileStoreWrite:
                 commit_message = CommitMessage(
                     partition=partition,
                     bucket=bucket,
-                    new_files=committed_files,
-                    changelog_files=changelog_files,
+                    total_buckets=self.table.total_buckets,
+                    data_increment=DataIncrement(
+                        new_files=committed_files,
+                        changelog_files=changelog_files,
+                    ),
                 )
                 commit_messages.append(commit_message)
         return commit_messages

--- a/paimon-python/pypaimon/write/global_index_update_checker.py
+++ b/paimon-python/pypaimon/write/global_index_update_checker.py
@@ -42,7 +42,7 @@ def build_index_delete_msgs(entries) -> list:
             )
         )
     return [
-        CommitMessage(partition=key, bucket=0, new_files=[], index_deletes=dels)
+        CommitMessage(partition=key, bucket=0, index_deletes=dels)
         for key, dels in by_partition.items()
     ]
 

--- a/paimon-python/pypaimon/write/table_delete.py
+++ b/paimon-python/pypaimon/write/table_delete.py
@@ -225,7 +225,6 @@ class TableDeleteByRowId:
         return CommitMessage(
             partition=partition,
             bucket=bucket,
-            new_files=[],
             check_from_snapshot=snapshot_id,
             index_adds=[new_entry],
             index_deletes=delete_entries,

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -41,6 +41,7 @@ from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.snapshot.time_travel_util import SCAN_KEYS, TimeTravelUtil
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.table_delete import TableDeleteByRowId
 from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 from pypaimon.write.table_upsert_by_key import TableUpsertByKey
@@ -408,7 +409,6 @@ class TableUpdate:
             messages[key] = CommitMessage(
                 partition=partition,
                 bucket=bucket,
-                new_files=[],
                 check_from_snapshot=snapshot_id,
             )
         return messages[key]
@@ -692,7 +692,13 @@ class ShardTableUpdator:
     def prepare_commit(self) -> List[CommitMessage]:
         commit_messages = []
         for (partition, files) in self.dict.items():
-            commit_messages.append(CommitMessage(partition, 0, files, self.snapshot_id))
+            commit_messages.append(CommitMessage(
+                partition=partition,
+                bucket=0,
+                total_buckets=self.table.total_buckets,
+                data_increment=DataIncrement(new_files=files),
+                check_from_snapshot=self.snapshot_id,
+            ))
         return commit_messages
 
     def update_by_arrow_batch(self, data: pa.RecordBatch):

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -32,6 +32,7 @@ from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.data_increment import DataIncrement
 from pypaimon.write.file_store_write import FileStoreWrite
 from pypaimon.write.row_utils import (
     require_columns,
@@ -571,7 +572,8 @@ class TableUpdateByRowId:
                     CommitMessage(
                         partition=partition_tuple,
                         bucket=0,
-                        new_files=new_files,
+                        total_buckets=self.table.total_buckets,
+                        data_increment=DataIncrement(new_files=new_files),
                         check_from_snapshot=self.snapshot_id,
                     )
                 )


### PR DESCRIPTION
## Purpose

Align `CommitMessage` with Java's `CommitMessageImpl` shape and add a JSON-safe wire format, so later compaction work has somewhere to plug `compact_before` / `compact_after` files and a serializer to ship them through Ray workers.

Foundation only — read / write / commit produce the same snapshots.

Split from #7771.

## Changes

- `DataIncrement` / `CompactIncrement` value objects; `CommitMessage` now holds `(partition, bucket, total_buckets, data_increment, compact_increment, check_from_snapshot)`. Convenience properties preserve `msg.new_files` / `msg.compact_before` ergonomics.
- `FileStoreCommit` emits ADD for `compact_after`, DELETE for `compact_before`, auto-picks `commit_kind=COMPACT` when only compact increments are present. New `commit_compact()` skips row-id assignment.
- `DataFileMeta.to_dict` / `from_dict` with tagged encoding for `bytes` / `Decimal` / `datetime` / `date` / `time` / `Timestamp`; `encode_value` / `decode_value` public for `CommitMessage.partition` round-trip.
- `CommitMessageSerializer` (VERSION=1) covers the full `DataIncrement` + `CompactIncrement` shape including `IndexFileMeta`.

## Tests

- `commit_message_serializer_test` — round-trip with non-JSON-native partition values + index files + version rejection.
- `file_store_commit_compact_test` — `compact_before` → DELETE, `compact_after` → ADD, auto-COMPACT kind.
- Existing `file_store_commit_test` / `partition_predicate_test` / `table_commit_test` adapted to the new `CommitMessage` signature.