### PR TITLE
[core] Track NaN counts in column statistics

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/SimpleColStats.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/SimpleColStats.java
@@ -29,6 +29,7 @@ import java.util.Objects;
  *   <li>min: the minimum value of the column
  *   <li>max: the maximum value of the column
  *   <li>nullCount: the number of nulls
+ *   <li>nanCount: the number of NaN values for FLOAT/DOUBLE columns, null if unknown
  * </ul>
  */
 public class SimpleColStats {
@@ -38,11 +39,21 @@ public class SimpleColStats {
     @Nullable private final Object min;
     @Nullable private final Object max;
     private final Long nullCount;
+    @Nullable private final Long nanCount;
 
     public SimpleColStats(@Nullable Object min, @Nullable Object max, @Nullable Long nullCount) {
+        this(min, max, nullCount, null);
+    }
+
+    public SimpleColStats(
+            @Nullable Object min,
+            @Nullable Object max,
+            @Nullable Long nullCount,
+            @Nullable Long nanCount) {
         this.min = min;
         this.max = max;
         this.nullCount = nullCount;
+        this.nanCount = nanCount;
     }
 
     @Nullable
@@ -60,6 +71,11 @@ public class SimpleColStats {
         return nullCount;
     }
 
+    @Nullable
+    public Long nanCount() {
+        return nanCount;
+    }
+
     public boolean isNone() {
         return min == null && max == null && nullCount == null;
     }
@@ -72,16 +88,17 @@ public class SimpleColStats {
         SimpleColStats that = (SimpleColStats) o;
         return Objects.equals(min, that.min)
                 && Objects.equals(max, that.max)
-                && Objects.equals(nullCount, that.nullCount);
+                && Objects.equals(nullCount, that.nullCount)
+                && Objects.equals(nanCount, that.nanCount);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(min, max, nullCount);
+        return Objects.hash(min, max, nullCount, nanCount);
     }
 
     @Override
     public String toString() {
-        return String.format("{%s, %s, %d}", min, max, nullCount);
+        return String.format("{%s, %s, %d, %s}", min, max, nullCount, nanCount);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/statistics/AbstractSimpleColStatsCollector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/statistics/AbstractSimpleColStatsCollector.java
@@ -29,8 +29,10 @@ public abstract class AbstractSimpleColStatsCollector implements SimpleColStatsC
 
     protected long nullCount;
 
+    protected long nanCount;
+
     @Override
     public SimpleColStats result() {
-        return new SimpleColStats(minValue, maxValue, nullCount);
+        return new SimpleColStats(minValue, maxValue, nullCount, nanCount);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/statistics/CountsSimpleColStatsCollector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/statistics/CountsSimpleColStatsCollector.java
@@ -28,11 +28,17 @@ public class CountsSimpleColStatsCollector extends AbstractSimpleColStatsCollect
     public void collect(Object field, Serializer<Object> serializer) {
         if (field == null) {
             nullCount++;
+            return;
+        }
+        if (field instanceof Double && Double.isNaN((Double) field)) {
+            nanCount++;
+        } else if (field instanceof Float && Float.isNaN((Float) field)) {
+            nanCount++;
         }
     }
 
     @Override
     public SimpleColStats convert(SimpleColStats source) {
-        return new SimpleColStats(null, null, source.nullCount());
+        return new SimpleColStats(null, null, source.nullCount(), source.nanCount());
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/statistics/FullSimpleColStatsCollector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/statistics/FullSimpleColStatsCollector.java
@@ -31,6 +31,15 @@ public class FullSimpleColStatsCollector extends AbstractSimpleColStatsCollector
             return;
         }
 
+        if (field instanceof Double && Double.isNaN((Double) field)) {
+            nanCount++;
+            return;
+        }
+        if (field instanceof Float && Float.isNaN((Float) field)) {
+            nanCount++;
+            return;
+        }
+
         // TODO use comparator for not comparable types and extract this logic to a util class
         if (!(field instanceof Comparable)) {
             return;

--- a/paimon-common/src/main/java/org/apache/paimon/statistics/TruncateSimpleColStatsCollector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/statistics/TruncateSimpleColStatsCollector.java
@@ -53,6 +53,15 @@ public class TruncateSimpleColStatsCollector extends AbstractSimpleColStatsColle
             return;
         }
 
+        if (field instanceof Double && Double.isNaN((Double) field)) {
+            nanCount++;
+            return;
+        }
+        if (field instanceof Float && Float.isNaN((Float) field)) {
+            nanCount++;
+            return;
+        }
+
         // fast fail since the result is not correct
         if (failed) {
             return;
@@ -86,17 +95,17 @@ public class TruncateSimpleColStatsCollector extends AbstractSimpleColStatsColle
         Object min = truncateMin(source.min());
         Object max = truncateMax(source.max());
         if (max == null) {
-            return new SimpleColStats(null, null, source.nullCount());
+            return new SimpleColStats(null, null, source.nullCount(), source.nanCount());
         }
-        return new SimpleColStats(min, max, source.nullCount());
+        return new SimpleColStats(min, max, source.nullCount(), source.nanCount());
     }
 
     @Override
     public SimpleColStats result() {
         if (failed) {
-            return new SimpleColStats(null, null, nullCount);
+            return new SimpleColStats(null, null, nullCount, nanCount);
         }
-        return new SimpleColStats(minValue, maxValue, nullCount);
+        return new SimpleColStats(minValue, maxValue, nullCount, nanCount);
     }
 
     /** @return a truncated value less or equal than the old value. */

--- a/paimon-common/src/test/java/org/apache/paimon/statistics/SimpleColStatsCollectorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/statistics/SimpleColStatsCollectorTest.java
@@ -25,6 +25,8 @@ import org.apache.paimon.data.serializer.InternalSerializers;
 import org.apache.paimon.data.serializer.Serializer;
 import org.apache.paimon.format.SimpleColStats;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
@@ -112,14 +114,14 @@ public class SimpleColStatsCollectorTest {
         check(
                 rows,
                 0,
-                new SimpleColStats(null, null, 0L),
-                new SimpleColStats(1, 4, 0L),
+                new SimpleColStats(null, null, 0L, 0L),
+                new SimpleColStats(1, 4, 0L, 0L),
                 new CountsSimpleColStatsCollector());
         check(
                 rows,
                 1,
-                new SimpleColStats(null, null, 1L),
-                new SimpleColStats(s1, s3, 1L),
+                new SimpleColStats(null, null, 1L, 0L),
+                new SimpleColStats(s1, s3, 1L, 0L),
                 new CountsSimpleColStatsCollector());
     }
 
@@ -130,14 +132,16 @@ public class SimpleColStatsCollectorTest {
         check(
                 rows,
                 0,
-                new SimpleColStats(1, 4, 0L),
-                new SimpleColStats(1, 4, 0L),
+                new SimpleColStats(1, 4, 0L, 0L),
+                new SimpleColStats(1, 4, 0L, 0L),
                 new FullSimpleColStatsCollector());
         check(
                 rows,
                 1,
-                new SimpleColStats(BinaryString.fromString(s1), BinaryString.fromString(s3), 1L),
-                new SimpleColStats(BinaryString.fromString(s1), BinaryString.fromString(s3), 1L),
+                new SimpleColStats(
+                        BinaryString.fromString(s1), BinaryString.fromString(s3), 1L, 0L),
+                new SimpleColStats(
+                        BinaryString.fromString(s1), BinaryString.fromString(s3), 1L, 0L),
                 new FullSimpleColStatsCollector());
     }
 
@@ -148,16 +152,108 @@ public class SimpleColStatsCollectorTest {
         check(
                 rows,
                 0,
-                new SimpleColStats(1, 4, 0L),
-                new SimpleColStats(1, 4, 0L),
+                new SimpleColStats(1, 4, 0L, 0L),
+                new SimpleColStats(1, 4, 0L, 0L),
                 new TruncateSimpleColStatsCollector(1));
         check(
                 rows,
                 1,
                 new SimpleColStats(
-                        BinaryString.fromString(s1_t), BinaryString.fromString(s3_t), 1L),
-                new SimpleColStats(BinaryString.fromString(s1), BinaryString.fromString(s3), 1L),
+                        BinaryString.fromString(s1_t), BinaryString.fromString(s3_t), 1L, 0L),
+                new SimpleColStats(
+                        BinaryString.fromString(s1), BinaryString.fromString(s3), 1L, 0L),
                 new TruncateSimpleColStatsCollector(2));
+    }
+
+    @Test
+    public void testFullCountsNaNAndExcludesFromBounds() {
+        RowType rowType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "d", new DoubleType()),
+                                new DataField(1, "f", new FloatType())));
+        Serializer<Object>[] floatSerializers = new Serializer[2];
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            floatSerializers[i] = InternalSerializers.create(rowType.getTypeAt(i));
+        }
+
+        FullSimpleColStatsCollector doubleCollector = new FullSimpleColStatsCollector();
+        doubleCollector.collect(1.0d, floatSerializers[0]);
+        doubleCollector.collect(Double.NaN, floatSerializers[0]);
+        doubleCollector.collect(5.0d, floatSerializers[0]);
+        doubleCollector.collect(Double.NaN, floatSerializers[0]);
+        doubleCollector.collect(null, floatSerializers[0]);
+        assertThat(doubleCollector.result()).isEqualTo(new SimpleColStats(1.0d, 5.0d, 1L, 2L));
+
+        FullSimpleColStatsCollector floatCollector = new FullSimpleColStatsCollector();
+        floatCollector.collect(2.0f, floatSerializers[1]);
+        floatCollector.collect(Float.NaN, floatSerializers[1]);
+        floatCollector.collect(7.0f, floatSerializers[1]);
+        assertThat(floatCollector.result()).isEqualTo(new SimpleColStats(2.0f, 7.0f, 0L, 1L));
+    }
+
+    @Test
+    public void testCountsNaN() {
+        Serializer<Object> doubleSerializer = InternalSerializers.create(new DoubleType());
+        CountsSimpleColStatsCollector collector = new CountsSimpleColStatsCollector();
+        collector.collect(1.0d, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(null, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        assertThat(collector.result()).isEqualTo(new SimpleColStats(null, null, 1L, 2L));
+    }
+
+    @Test
+    public void testFullAllNaN() {
+        Serializer<Object> doubleSerializer = InternalSerializers.create(new DoubleType());
+        FullSimpleColStatsCollector collector = new FullSimpleColStatsCollector();
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        assertThat(collector.result()).isEqualTo(new SimpleColStats(null, null, 0L, 3L));
+    }
+
+    @Test
+    public void testFullOnlyNaNAndNull() {
+        Serializer<Object> doubleSerializer = InternalSerializers.create(new DoubleType());
+        FullSimpleColStatsCollector collector = new FullSimpleColStatsCollector();
+        collector.collect(null, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(null, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(null, doubleSerializer);
+        assertThat(collector.result()).isEqualTo(new SimpleColStats(null, null, 3L, 2L));
+    }
+
+    @Test
+    public void testNoneIgnoresNaN() {
+        Serializer<Object> doubleSerializer = InternalSerializers.create(new DoubleType());
+        NoneSimpleColStatsCollector collector = new NoneSimpleColStatsCollector();
+        collector.collect(Double.NaN, doubleSerializer);
+        collector.collect(1.0d, doubleSerializer);
+        collector.collect(Double.NaN, doubleSerializer);
+        assertThat(collector.result()).isEqualTo(SimpleColStats.NONE);
+        assertThat(collector.result().nanCount()).isNull();
+    }
+
+    @Test
+    public void testConvertPreservesNanCount() {
+        SimpleColStats source = new SimpleColStats(1.0d, 5.0d, 2L, 7L);
+        assertThat(new FullSimpleColStatsCollector().convert(source).nanCount()).isEqualTo(7L);
+        assertThat(new CountsSimpleColStatsCollector().convert(source).nanCount()).isEqualTo(7L);
+        assertThat(new TruncateSimpleColStatsCollector(16).convert(source).nanCount())
+                .isEqualTo(7L);
+        assertThat(new NoneSimpleColStatsCollector().convert(source).nanCount()).isNull();
+    }
+
+    @Test
+    public void testSimpleColStatsEqualityIncludesNanCount() {
+        assertThat(new SimpleColStats(1.0d, 5.0d, 0L, 0L))
+                .isNotEqualTo(new SimpleColStats(1.0d, 5.0d, 0L, 1L));
+        assertThat(new SimpleColStats(1.0d, 5.0d, 0L, 0L))
+                .isNotEqualTo(new SimpleColStats(1.0d, 5.0d, 0L, null));
+        assertThat(new SimpleColStats(1.0d, 5.0d, 0L, 7L))
+                .isEqualTo(new SimpleColStats(1.0d, 5.0d, 0L, 7L));
     }
 
     @Test

--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/manifest/IcebergManifestFile.java
@@ -259,7 +259,8 @@ public class IcebergManifestFile extends ObjectsFile<IcebergManifestEntry> {
                 switch (type.getTypeRoot()) {
                     case FLOAT:
                     case DOUBLE:
-                        containsNan = isNaN(fieldStats.min()) || isNaN(fieldStats.max());
+                        Long nanCount = fieldStats.nanCount();
+                        containsNan = nanCount != null && nanCount > 0;
                         break;
                     default:
                         // contains_nan is only meaningful for FLOAT/DOUBLE per the Iceberg spec
@@ -286,16 +287,6 @@ public class IcebergManifestFile extends ObjectsFile<IcebergManifestEntry> {
                     existingRowsCount,
                     deletedRowsCount,
                     partitionSummaries);
-        }
-
-        private boolean isNaN(@Nullable Object value) {
-            if (value instanceof Float) {
-                return Float.isNaN((Float) value);
-            }
-            if (value instanceof Double) {
-                return Double.isNaN((Double) value);
-            }
-            return false;
         }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/stats/SimpleStatsCollectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/SimpleStatsCollectorTest.java
@@ -26,6 +26,8 @@ import org.apache.paimon.format.SimpleStatsCollector;
 import org.apache.paimon.statistics.FullSimpleColStatsCollector;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DoubleType;
+import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VarCharType;
@@ -59,24 +61,26 @@ public class SimpleStatsCollectorTest {
         assertThat(collector.extract())
                 .isEqualTo(
                         new SimpleColStats[] {
-                            new SimpleColStats(1, 1, 0L),
+                            new SimpleColStats(1, 1, 0L, 0L),
                             new SimpleColStats(
                                     BinaryString.fromString("Paimon"),
                                     BinaryString.fromString("Paimon"),
+                                    0L,
                                     0L),
-                            new SimpleColStats(null, null, 0L)
+                            new SimpleColStats(null, null, 0L, 0L)
                         });
 
         collector.collect(GenericRow.of(3, null, new GenericArray(new int[] {3, 30})));
         assertThat(collector.extract())
                 .isEqualTo(
                         new SimpleColStats[] {
-                            new SimpleColStats(1, 3, 0L),
+                            new SimpleColStats(1, 3, 0L, 0L),
                             new SimpleColStats(
                                     BinaryString.fromString("Paimon"),
                                     BinaryString.fromString("Paimon"),
-                                    1L),
-                            new SimpleColStats(null, null, 0L)
+                                    1L,
+                                    0L),
+                            new SimpleColStats(null, null, 0L, 0L)
                         });
 
         collector.collect(
@@ -87,24 +91,59 @@ public class SimpleStatsCollectorTest {
         assertThat(collector.extract())
                 .isEqualTo(
                         new SimpleColStats[] {
-                            new SimpleColStats(1, 3, 1L),
+                            new SimpleColStats(1, 3, 1L, 0L),
                             new SimpleColStats(
                                     BinaryString.fromString("Apache"),
                                     BinaryString.fromString("Paimon"),
-                                    1L),
-                            new SimpleColStats(null, null, 0L)
+                                    1L,
+                                    0L),
+                            new SimpleColStats(null, null, 0L, 0L)
                         });
 
         collector.collect(GenericRow.of(2, BinaryString.fromString("Batch"), null));
         assertThat(collector.extract())
                 .isEqualTo(
                         new SimpleColStats[] {
-                            new SimpleColStats(1, 3, 1L),
+                            new SimpleColStats(1, 3, 1L, 0L),
                             new SimpleColStats(
                                     BinaryString.fromString("Apache"),
                                     BinaryString.fromString("Paimon"),
-                                    1L),
-                            new SimpleColStats(null, null, 1L)
+                                    1L,
+                                    0L),
+                            new SimpleColStats(null, null, 1L, 0L)
+                        });
+    }
+
+    @Test
+    public void testCollectNaN() {
+        RowType rowType =
+                RowType.of(new DoubleType(), new FloatType(), new IntType(), new VarCharType(10));
+        SimpleStatsCollector collector =
+                new SimpleStatsCollector(
+                        rowType,
+                        IntStream.range(0, rowType.getFieldCount())
+                                .mapToObj(
+                                        i ->
+                                                (SimpleColStatsCollector.Factory)
+                                                        FullSimpleColStatsCollector::new)
+                                .toArray(SimpleColStatsCollector.Factory[]::new));
+
+        collector.collect(GenericRow.of(1.0d, 1.0f, 1, BinaryString.fromString("a")));
+        collector.collect(GenericRow.of(Double.NaN, 2.0f, 2, BinaryString.fromString("b")));
+        collector.collect(GenericRow.of(5.0d, Float.NaN, 3, null));
+        collector.collect(GenericRow.of(Double.NaN, Float.NaN, null, BinaryString.fromString("c")));
+
+        assertThat(collector.extract())
+                .isEqualTo(
+                        new SimpleColStats[] {
+                            new SimpleColStats(1.0d, 5.0d, 0L, 2L),
+                            new SimpleColStats(1.0f, 2.0f, 0L, 2L),
+                            new SimpleColStats(1, 3, 1L, 0L),
+                            new SimpleColStats(
+                                    BinaryString.fromString("a"),
+                                    BinaryString.fromString("c"),
+                                    1L,
+                                    0L)
                         });
     }
 }


### PR DESCRIPTION
### Purpose
 - Spark, Flink and Iceberg all support IsNaN as a first class predicate and use NaN counts in file/partition pruning.
 - Paimon's SimpleColStats only tracks min, max and null count today, there is no signal at the manifest layer to skip files.
 - Add a nanCount field to SimpleColStats and update the collectors to count the nans, and further be used for engine level predicate pushdown.

### Tests
 - UT