### PR TITLE
[hotfix] pin vortex version = 0.70.0 to avoid test failure

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -135,7 +135,7 @@ jobs:
             python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.48.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6'
             python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
             if python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"; then
-              python -m pip install vortex-data
+              python -m pip install vortex-data==0.70.0
             fi
           fi
           df -h

--- a/paimon-python/dev/requirements-dev.txt
+++ b/paimon-python/dev/requirements-dev.txt
@@ -25,5 +25,7 @@ pytest~=7.0
 ray>=2.10.0
 requests
 parameterized
+# Vortex 0.71.0 regresses native predicate pushdown on single-row files.
+vortex-data==0.70.0; python_version >= "3.11"
 # Lumina vector search (optional, for lumina index tests)
 lumina-data>=0.1.0

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -168,6 +168,9 @@ setup(
             'pylance>=0.20,<1; python_version>="3.9"',
             'pylance>=0.10,<1; python_version>="3.8" and python_version<"3.9"'
         ],
+        'vortex': [
+            'vortex-data==0.70.0; python_version>="3.11"',
+        ],
         'lumina': [
             'lumina-data>=0.1.0'
         ],


### PR DESCRIPTION
### Purpose
So many PRs are blocked by the same test failure:

```text
pyarrow.lib.ArrowInvalid: External error: Reduced array dtype mismatch from vortex.between to vortex.constant
```

It seems that in vortex, the PR https://github.com/vortex-data/vortex/pull/7948/changes change the optimize logic.
When trying to reduce the between predicate to constant, the returned type losses its nullability.

I tested that 0.70.0 is fine. I'll try to fix this issue in Vortex, and temporarily, pin the vortex version to 0.70.0.

### Tests
