### PR TITLE
[flink] Fix scan parallelism propagating to downstream operators

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PaimonDataStreamScanProvider.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/PaimonDataStreamScanProvider.java
@@ -29,6 +29,9 @@ import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.data.RowData;
 
+import javax.annotation.Nullable;
+
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -41,16 +44,27 @@ public class PaimonDataStreamScanProvider implements DataStreamScanProvider, Lin
     private final Function<StreamExecutionEnvironment, DataStream<RowData>> producer;
     private final String name;
     private final Table table;
+    @Nullable private final Integer parallelism;
 
     public PaimonDataStreamScanProvider(
             boolean isBounded,
             Function<StreamExecutionEnvironment, DataStream<RowData>> producer,
             String name,
             Table table) {
+        this(isBounded, producer, name, table, null);
+    }
+
+    public PaimonDataStreamScanProvider(
+            boolean isBounded,
+            Function<StreamExecutionEnvironment, DataStream<RowData>> producer,
+            String name,
+            Table table,
+            @Nullable Integer parallelism) {
         this.isBounded = isBounded;
         this.producer = producer;
         this.name = name;
         this.table = table;
+        this.parallelism = parallelism;
     }
 
     @Override
@@ -62,6 +76,11 @@ public class PaimonDataStreamScanProvider implements DataStreamScanProvider, Lin
     @Override
     public boolean isBounded() {
         return isBounded;
+    }
+
+    @Override
+    public Optional<Integer> getParallelism() {
+        return Optional.ofNullable(parallelism);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/BaseDataTableSource.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.source;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.FlinkConnectorOptions.WatermarkEmitStrategy;
 import org.apache.paimon.flink.PaimonDataStreamScanProvider;
 import org.apache.paimon.flink.lookup.FileStoreLookupFunction;
@@ -206,7 +207,8 @@ public abstract class BaseDataTableSource extends FlinkTableSource
                                 .env(env)
                                 .build(),
                 tableIdentifier.asSummaryString(),
-                table);
+                table,
+                options.get(FlinkConnectorOptions.SCAN_PARALLELISM));
     }
 
     private ScanRuntimeProvider createPushedAggregateScan() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/SystemTableSource.java
@@ -132,7 +132,8 @@ public class SystemTableSource extends FlinkTableSource {
                     return dataStreamSource;
                 },
                 tableIdentifier.asSummaryString(),
-                table);
+                table,
+                options.get(FlinkConnectorOptions.SCAN_PARALLELISM));
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lineage/LineageUtilsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lineage/LineageUtilsTest.java
@@ -193,6 +193,24 @@ class LineageUtilsTest {
     }
 
     @Test
+    void testScanProviderGetParallelism() throws Exception {
+        FileStoreTable table =
+                createTable(new HashMap<>(), Collections.emptyList(), Arrays.asList("f0"));
+
+        PaimonDataStreamScanProvider noOverride =
+                new PaimonDataStreamScanProvider(true, env -> null, "paimon.db.src", table);
+        assertThat(noOverride.getParallelism()).isEmpty();
+
+        PaimonDataStreamScanProvider explicit =
+                new PaimonDataStreamScanProvider(true, env -> null, "paimon.db.src", table, 16);
+        assertThat(explicit.getParallelism()).contains(16);
+
+        PaimonDataStreamScanProvider nullValue =
+                new PaimonDataStreamScanProvider(true, env -> null, "paimon.db.src", table, null);
+        assertThat(nullValue.getParallelism()).isEmpty();
+    }
+
+    @Test
     void testSinkProviderImplementsLineageVertexProvider() throws Exception {
         FileStoreTable table =
                 createTable(new HashMap<>(), Collections.emptyList(), Arrays.asList("f0"));


### PR DESCRIPTION
### Purpose
 - PaimonDataStreamScanProvider did not override ParallelismProvider getParallelism.
 - As a result whole pipeline runs at the configured scan parallelism.
 - Update scan provider to override and provide getParallelism.
 - Closes user reported bug #7905
### Tests
 - UT