### PR TITLE
[common] Serialize BlobDescriptor with current version

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobDescriptor.java
@@ -117,7 +117,7 @@ public class BlobDescriptor implements Serializable {
         ByteBuffer buffer = ByteBuffer.allocate(totalSize);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
 
-        buffer.put(version);
+        buffer.put(CURRENT_VERSION);
         buffer.putLong(MAGIC);
         buffer.putInt(uriLength);
         buffer.put(uriBytes);

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobDescriptorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobDescriptorTest.java
@@ -114,6 +114,24 @@ public class BlobDescriptorTest {
         assertThat(blobDescriptor.length()).isEqualTo(200L);
     }
 
+    @Test
+    public void testSerializeUsesCurrentVersion() throws Exception {
+        byte[] serializedV1 =
+                IOUtils.readFully(
+                        BlobDescriptorTest.class
+                                .getClassLoader()
+                                .getResourceAsStream("compatible/blob_descriptor_v1"),
+                        true);
+
+        BlobDescriptor blobDescriptor = BlobDescriptor.deserialize(serializedV1);
+        byte[] serialized = blobDescriptor.serialize();
+
+        assertThat(serialized[0]).isEqualTo((byte) 2);
+        assertThat(BlobDescriptor.isBlobDescriptor(serialized)).isTrue();
+        assertThat(BlobDescriptor.deserialize(serialized))
+                .isEqualTo(new BlobDescriptor("/test/path", 100L, 200L));
+    }
+
     private BlobDescriptor createDescriptorWithVersion(
             byte version, String uri, long offset, long length) throws Exception {
         Constructor<BlobDescriptor> constructor =


### PR DESCRIPTION
### Purpose

`BlobDescriptor.serialize()` should always write the current descriptor format version. Otherwise, a descriptor deserialized from an older version may be serialized with the old version byte while still using the current layout with the magic header, making the bytes inconsistent.

### Changes

- Write `CURRENT_VERSION` in `BlobDescriptor.serialize()`.
- Add a regression test for deserializing a v1 blob descriptor and serializing it back with the current version.

### Tests

- `mvn -U -pl paimon-common -am -Dtest=BlobDescriptorTest -DfailIfNoTests=false test`
