### PR TITLE
[core] Avoid deleting directories in orphan files cleanup

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -258,7 +258,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             }
 
             return files.stream()
-                    .filter(status -> !isDataStructureDirectory(status))
+                    .filter(status -> !status.isDir())
                     .filter(this::oldEnough)
                     .map(status -> Pair.of(status.getPath(), status.getLen()))
                     .collect(Collectors.toList());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -258,6 +258,7 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
             }
 
             return files.stream()
+                    .filter(status -> !isDataStructureDirectory(status))
                     .filter(this::oldEnough)
                     .map(status -> Pair.of(status.getPath(), status.getLen()))
                     .collect(Collectors.toList());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -398,10 +398,9 @@ public abstract class OrphanFilesClean implements Serializable {
 
         for (FileStatus status : statuses) {
             Path path = status.getPath();
-            if (filter.test(path)) {
+            if (status.isDir() && filter.test(path)) {
                 filtered.add(path);
             }
-            // ignore unknown dirs
         }
 
         return filtered;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -181,6 +181,7 @@ public abstract class OrphanFilesClean implements Serializable {
             Path directory, Predicate<FileStatus> fileStatusFilter, Predicate<Path> fileFilter) {
         List<FileStatus> statuses = tryBestListingDirs(directory);
         return statuses.stream()
+                .filter(status -> !status.isDir())
                 .filter(fileStatusFilter)
                 .filter(status -> fileFilter.test(status.getPath()))
                 .map(status -> Pair.of(status.getPath(), status.getLen()))

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -220,11 +220,15 @@ public abstract class OrphanFilesClean implements Serializable {
         if (!dryRun) {
             try {
                 if (fileIO.isDir(path)) {
-                    fileIO.deleteDirectoryQuietly(path);
-                } else {
-                    fileIO.deleteQuietly(path);
+                    LOG.error(
+                            "Refusing to delete directory {} in orphan file cleanup. "
+                                    + "This indicates a bug in candidate collection.",
+                            path);
+                    return;
                 }
-            } catch (IOException ignored) {
+                fileIO.deleteQuietly(path);
+            } catch (IOException e) {
+                LOG.warn("Failed to check whether {} is directory, skip deleting it.", path, e);
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -220,14 +220,6 @@ public abstract class OrphanFilesClean implements Serializable {
         if (!dryRun) {
             try {
                 if (fileIO.isDir(path)) {
-                    String name = path.getName();
-                    if (name.startsWith(BUCKET_PATH_PREFIX) || name.contains("=")) {
-                        LOG.warn(
-                                "Skipping deletion of data structure directory that was mistakenly "
-                                        + "identified as orphan: {}",
-                                path);
-                        return;
-                    }
                     fileIO.deleteDirectoryQuietly(path);
                 } else {
                     fileIO.deleteQuietly(path);
@@ -461,19 +453,6 @@ public abstract class OrphanFilesClean implements Serializable {
 
     protected boolean oldEnough(FileStatus status) {
         return status.getModificationTime() < olderThanMillis;
-    }
-
-    /**
-     * Returns true if the given status represents a structural data directory (bucket or partition)
-     * that should never be treated as an orphan file candidate. Other directories (e.g. unknown
-     * temp dirs) are still eligible for orphan cleanup.
-     */
-    protected static boolean isDataStructureDirectory(FileStatus status) {
-        if (!status.isDir()) {
-            return false;
-        }
-        String name = status.getPath().getName();
-        return name.startsWith(BUCKET_PATH_PREFIX) || name.contains("=");
     }
 
     public static long olderThanMillis(@Nullable String olderThan) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -401,6 +401,7 @@ public abstract class OrphanFilesClean implements Serializable {
             if (status.isDir() && filter.test(path)) {
                 filtered.add(path);
             }
+            // ignore unknown dirs
         }
 
         return filtered;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -220,6 +220,14 @@ public abstract class OrphanFilesClean implements Serializable {
         if (!dryRun) {
             try {
                 if (fileIO.isDir(path)) {
+                    String name = path.getName();
+                    if (name.startsWith(BUCKET_PATH_PREFIX) || name.contains("=")) {
+                        LOG.warn(
+                                "Skipping deletion of data structure directory that was mistakenly "
+                                        + "identified as orphan: {}",
+                                path);
+                        return;
+                    }
                     fileIO.deleteDirectoryQuietly(path);
                 } else {
                     fileIO.deleteQuietly(path);
@@ -453,6 +461,19 @@ public abstract class OrphanFilesClean implements Serializable {
 
     protected boolean oldEnough(FileStatus status) {
         return status.getModificationTime() < olderThanMillis;
+    }
+
+    /**
+     * Returns true if the given status represents a structural data directory (bucket or partition)
+     * that should never be treated as an orphan file candidate. Other directories (e.g. unknown
+     * temp dirs) are still eligible for orphan cleanup.
+     */
+    protected static boolean isDataStructureDirectory(FileStatus status) {
+        if (!status.isDir()) {
+            return false;
+        }
+        String name = status.getPath().getName();
+        return name.startsWith(BUCKET_PATH_PREFIX) || name.contains("=");
     }
 
     public static long olderThanMillis(@Nullable String olderThan) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -224,9 +224,9 @@ public abstract class OrphanFilesClean implements Serializable {
                             "Refusing to delete directory {} in orphan file cleanup. "
                                     + "This indicates a bug in candidate collection.",
                             path);
-                    return;
+                } else {
+                    fileIO.deleteQuietly(path);
                 }
-                fileIO.deleteQuietly(path);
             } catch (IOException e) {
                 LOG.warn("Failed to check whether {} is directory, skip deleting it.", path, e);
             }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -634,8 +634,7 @@ public class LocalOrphanFilesCleanTest {
 
         Path partitionPath = new Path(tablePath, "part1=0/part2=a");
         Path bucketPath =
-                listSubDirs(partitionPath, p -> p.getName().startsWith(BUCKET_PATH_PREFIX))
-                        .get(0);
+                listSubDirs(partitionPath, p -> p.getName().startsWith(BUCKET_PATH_PREFIX)).get(0);
         assertThat(fileIO.listStatus(bucketPath)).isNotEmpty();
 
         Path subdirInBucket = new Path(bucketPath, "orphan-subdir");

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -628,6 +628,34 @@ public class LocalOrphanFilesCleanTest {
                 .isTrue();
     }
 
+    @Test
+    void testDirectoriesNotTreatedAsOrphanCandidates() throws Exception {
+        commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
+
+        Path partitionPath = new Path(tablePath, "part1=0/part2=a");
+        Path bucketPath = new Path(partitionPath, "bucket-0");
+        assertThat(fileIO.exists(bucketPath)).isTrue();
+        assertThat(fileIO.listStatus(bucketPath)).isNotEmpty();
+
+        Path subdirInBucket = new Path(bucketPath, "orphan-subdir");
+        fileIO.mkdirs(subdirInBucket);
+        fileIO.tryToWriteAtomic(new Path(subdirInBucket, "stale-file.tmp"), "data");
+
+        long oldTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2);
+        Files.setLastModifiedTime(
+                tempDir.resolve("part1=0/part2=a/bucket-0/orphan-subdir"),
+                FileTime.fromMillis(oldTime));
+
+        LocalOrphanFilesClean orphanFilesClean =
+                new LocalOrphanFilesClean(table, System.currentTimeMillis());
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFilesPath())
+                .noneMatch(p -> p.toString().contains("orphan-subdir"));
+        assertThat(fileIO.exists(bucketPath)).isTrue();
+        assertThat(fileIO.listStatus(bucketPath).length).isGreaterThanOrEqualTo(1);
+    }
+
     private void writeData(
             SnapshotManager snapshotManager,
             List<List<TestPojo>> committedData,
@@ -824,11 +852,7 @@ public class LocalOrphanFilesCleanTest {
             String fileName =
                     fileNamePrefix.get(RANDOM.nextInt(fileNamePrefix.size())) + UUID.randomUUID();
             Path file = new Path(dir, fileName);
-            if (RANDOM.nextBoolean()) {
-                fileIO.tryToWriteAtomic(file, "");
-            } else {
-                fileIO.mkdirs(file);
-            }
+            fileIO.tryToWriteAtomic(file, "");
             manuallyAddedFiles.add(file);
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -633,17 +633,19 @@ public class LocalOrphanFilesCleanTest {
         commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
 
         Path partitionPath = new Path(tablePath, "part1=0/part2=a");
-        Path bucketPath = new Path(partitionPath, "bucket-0");
-        assertThat(fileIO.exists(bucketPath)).isTrue();
+        Path bucketPath =
+                listSubDirs(partitionPath, p -> p.getName().startsWith(BUCKET_PATH_PREFIX))
+                        .get(0);
         assertThat(fileIO.listStatus(bucketPath)).isNotEmpty();
 
         Path subdirInBucket = new Path(bucketPath, "orphan-subdir");
         fileIO.mkdirs(subdirInBucket);
         fileIO.tryToWriteAtomic(new Path(subdirInBucket, "stale-file.tmp"), "data");
 
+        String bucketName = bucketPath.getName();
         long oldTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2);
         Files.setLastModifiedTime(
-                tempDir.resolve("part1=0/part2=a/bucket-0/orphan-subdir"),
+                tempDir.resolve("part1=0/part2=a/" + bucketName + "/orphan-subdir"),
                 FileTime.fromMillis(oldTime));
 
         LocalOrphanFilesClean orphanFilesClean =

--- a/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/LocalOrphanFilesCleanTest.java
@@ -656,6 +656,29 @@ public class LocalOrphanFilesCleanTest {
         assertThat(fileIO.listStatus(bucketPath).length).isGreaterThanOrEqualTo(1);
     }
 
+    @Test
+    void testDirectoryInSnapshotDirNotTreatedAsCandidate() throws Exception {
+        commit(Collections.singletonList(new TestPojo(1, 0, "a", "v1")));
+
+        Path snapshotDir = new Path(tablePath, "snapshot");
+        assertThat(fileIO.exists(snapshotDir)).isTrue();
+
+        Path unknownDir = new Path(snapshotDir, "UNKNOWN-stale-dir");
+        fileIO.mkdirs(unknownDir);
+
+        long oldTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2);
+        Files.setLastModifiedTime(
+                tempDir.resolve("snapshot/UNKNOWN-stale-dir"), FileTime.fromMillis(oldTime));
+
+        LocalOrphanFilesClean orphanFilesClean =
+                new LocalOrphanFilesClean(table, System.currentTimeMillis());
+        CleanOrphanFilesResult result = orphanFilesClean.clean();
+
+        assertThat(result.getDeletedFilesPath())
+                .noneMatch(p -> p.toString().contains("UNKNOWN-stale-dir"));
+        assertThat(fileIO.exists(unknownDir)).isTrue();
+    }
+
     private void writeData(
             SnapshotManager snapshotManager,
             List<List<TestPojo>> committedData,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -282,8 +282,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                         Path dirPath = new Path(dir);
                                         List<FileStatus> files = tryBestListingDirs(dirPath);
                                         for (FileStatus file : files) {
-                                            if (!isDataStructureDirectory(file)
-                                                    && oldEnough(file)) {
+                                            if (!file.isDir() && oldEnough(file)) {
                                                 out.collect(
                                                         Tuple2.of(
                                                                 file.getPath().toString(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -327,6 +327,9 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                 while (!dryRun && !emptyDirs.isEmpty()) {
                                     Set<Path> newEmptyDir = new HashSet<>();
                                     for (Path emptyDir : emptyDirs) {
+                                        if (table.location().equals(emptyDir)) {
+                                            continue;
+                                        }
                                         try {
                                             if (fileIO.delete(emptyDir, false)) {
                                                 LOG.info("Clean empty dir: {}", emptyDir);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -282,7 +282,8 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                         Path dirPath = new Path(dir);
                                         List<FileStatus> files = tryBestListingDirs(dirPath);
                                         for (FileStatus file : files) {
-                                            if (oldEnough(file)) {
+                                            if (!isDataStructureDirectory(file)
+                                                    && oldEnough(file)) {
                                                 out.collect(
                                                         Tuple2.of(
                                                                 file.getPath().toString(),
@@ -324,7 +325,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                             @Override
                             public void endInput() throws IOException {
                                 // delete empty dir
-                                while (!emptyDirs.isEmpty()) {
+                                while (!dryRun && !emptyDirs.isEmpty()) {
                                     Set<Path> newEmptyDir = new HashSet<>();
                                     for (Path emptyDir : emptyDirs) {
                                         try {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -125,7 +125,9 @@ case class SparkOrphanFilesClean(
       .parallelize(fileDirs, maxFileDirsParallelism)
       .flatMap {
         dir =>
-          tryBestListingDirs(new Path(dir)).asScala.filter(oldEnough).map {
+          tryBestListingDirs(new Path(dir)).asScala
+            .filter(file => !isDataStructureDirectory(file))
+            .filter(oldEnough).map {
             file =>
               val path = file.getPath
               (path.getName, path.toString, file.getLen, path.getParent.toString)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -126,7 +126,7 @@ case class SparkOrphanFilesClean(
       .flatMap {
         dir =>
           tryBestListingDirs(new Path(dir)).asScala
-            .filter(file => !isDataStructureDirectory(file))
+            .filter(file => !file.isDir())
             .filter(oldEnough).map {
             file =>
               val path = file.getPath

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -127,11 +127,12 @@ case class SparkOrphanFilesClean(
         dir =>
           tryBestListingDirs(new Path(dir)).asScala
             .filter(file => !file.isDir())
-            .filter(oldEnough).map {
-            file =>
-              val path = file.getPath
-              (path.getName, path.toString, file.getLen, path.getParent.toString)
-          }
+            .filter(oldEnough)
+            .map {
+              file =>
+                val path = file.getPath
+                (path.getName, path.toString, file.getLen, path.getParent.toString)
+            }
       }
       .toDF("name", "path", "len", "dataDir")
       .repartition(parallelism)


### PR DESCRIPTION
### Purpose
This PR fixes a potential data loss risk in orphan files cleanup.

  The issue was introduced by #7295, which added support for cleaning empty partition directories without
  bucket subdirectories. In that change, `listFileDirs` may add a partition directory to the directories to
  be scanned when its child listing is empty.

  This is safe when the partition is truly empty. However, if a transient `listStatus` failure returns an
  empty result, a partition directory that still contains data may be treated as empty and later scanned
  again. **When the later listing succeeds**, bucket or partition directories could be collected as orphan file
  candidates.

  Before this fix, `cleanFile` recursively deleted directory candidates via `deleteDirectoryQuietly`, so a
  directory incorrectly collected as an orphan candidate could delete still-referenced data files under
  that directory.

### Changes
This PR adds multiple safeguards:

  1. Filter directories from all orphan file candidate collection paths, including Local, Flink, Spark, and
  snapshot/changelog special cleanup.
  2. Make `cleanFile` refuse directories by removing recursive directory deletion from orphan file cleanup.
  3. Harden Flink empty directory cleanup: respect `dryRun`, stop at the table location, and keep deletion
  non-recursive via `delete(path, false)`.
### Tests
  - `testDirectoriesNotTreatedAsOrphanCandidates`
  - `testDirectoryInSnapshotDirNotTreatedAsCandidate`