### PR TITLE
[flink][spark] supports adding blob columns through `ALTER TABLE` statements

### DIFF
--- a/docs/docs/append-table/blob.mdx
+++ b/docs/docs/append-table/blob.mdx
@@ -106,7 +106,7 @@ This allows one table to mix raw-data BLOB fields, descriptor-only BLOB fields, 
       <td>No</td>
       <td style={{wordWrap: "break-word"}}>(none)</td>
       <td>String</td>
-      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code>, <code>blob-view-field</code>, or <code>blob-external-storage-field</code> are also treated as BLOB fields.</td>
+      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code>, <code>blob-view-field</code> are also treated as BLOB fields.</td>
     </tr>
     <tr>
       <td><h5>blob-as-descriptor</h5></td>
@@ -303,15 +303,7 @@ because existing fields cannot be newly configured as blob fields:
 
 ```sql
 ALTER TABLE image_table ADD image BYTES; -- or ADD COLUMN image BINARY in Spark SQL
-ALTER TABLE image_table SET ('blob-field' = 'image');
-```
-
-For descriptor BLOB columns, set `blob-descriptor-field` before adding the column. The following example uses Flink
-SQL; in Spark SQL, use `SET TBLPROPERTIES` and `ADD COLUMN image BINARY`.
-
-```sql
-ALTER TABLE image_table SET ('blob-descriptor-field' = 'image');
-ALTER TABLE image_table ADD image BYTES;
+ALTER TABLE image_table SET ('blob-field' = 'image'); -- error, existing column cannot be configured as blob
 ```
 
 When using the Paimon API, you can add a BLOB column directly because Paimon has a native `BLOB` type:

--- a/docs/docs/append-table/blob.mdx
+++ b/docs/docs/append-table/blob.mdx
@@ -106,7 +106,7 @@ This allows one table to mix raw-data BLOB fields, descriptor-only BLOB fields, 
       <td>No</td>
       <td style={{wordWrap: "break-word"}}>(none)</td>
       <td>String</td>
-      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code> or <code>blob-view-field</code> are also treated as BLOB fields.</td>
+      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code>, <code>blob-view-field</code>, or <code>blob-external-storage-field</code> are also treated as BLOB fields.</td>
     </tr>
     <tr>
       <td><h5>blob-as-descriptor</h5></td>
@@ -255,6 +255,73 @@ CREATE TABLE image_table (
 </TabItem>
 
 </Tabs>
+
+### Adding a Blob Column to an Existing Table
+
+Flink SQL and Spark SQL do not expose Paimon's `BLOB` type directly. To add a BLOB column with SQL, add a binary
+column (`BYTES` in Flink SQL, `BINARY` in Spark SQL) and configure the blob field option before adding the physical
+column. Currently, `ALTER TABLE` supports adding BLOB columns through `blob-field` or `blob-descriptor-field`.
+`blob-view-field` and `blob-external-storage-field` are immutable and should be configured when creating the table.
+
+{{< tabs "blob-add-column" >}}
+
+{{< tab "Flink SQL" >}}
+```sql
+CREATE TABLE image_table (
+    id INT,
+    name STRING
+) WITH (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+ALTER TABLE image_table SET ('blob-field' = 'image');
+ALTER TABLE image_table ADD image BYTES;
+```
+{{< /tab >}}
+
+{{< tab "Spark SQL" >}}
+```sql
+CREATE TABLE image_table (
+    id INT,
+    name STRING
+) TBLPROPERTIES (
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true'
+);
+
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-field' = 'image');
+ALTER TABLE image_table ADD COLUMN image BINARY;
+```
+{{< /tab >}}
+
+{{< /tabs >}}
+
+Do not add the binary column first and set `blob-field` later. For example, the following order creates a normal
+`BYTES` / `BINARY` column. The later option change will not convert the existing column to BLOB, and may be rejected
+because existing fields cannot be newly configured as blob fields:
+
+```sql
+ALTER TABLE image_table ADD image BYTES; -- or ADD COLUMN image BINARY in Spark SQL
+ALTER TABLE image_table SET ('blob-field' = 'image');
+```
+
+For descriptor BLOB columns, set `blob-descriptor-field` before adding the column. The following example uses Flink
+SQL; in Spark SQL, use `SET TBLPROPERTIES` and `ADD COLUMN image BINARY`.
+
+```sql
+ALTER TABLE image_table SET ('blob-descriptor-field' = 'image');
+ALTER TABLE image_table ADD image BYTES;
+```
+
+When using the Paimon API, you can add a BLOB column directly because Paimon has a native `BLOB` type:
+
+```java
+catalog.alterTable(
+        identifier,
+        Collections.singletonList(SchemaChange.addColumn("image", DataTypes.BLOB())),
+        false);
+```
 
 ### Inserting Blob Data
 

--- a/docs/docs/append-table/blob.mdx
+++ b/docs/docs/append-table/blob.mdx
@@ -263,9 +263,10 @@ column (`BYTES` in Flink SQL, `BINARY` in Spark SQL) and configure the blob fiel
 column. Currently, `ALTER TABLE` supports adding BLOB columns through `blob-field` or `blob-descriptor-field`.
 `blob-view-field` and `blob-external-storage-field` are immutable and should be configured when creating the table.
 
-{{< tabs "blob-add-column" >}}
+<Tabs groupId="blob-add-column">
 
-{{< tab "Flink SQL" >}}
+<TabItem value="flink-sql" label="Flink SQL">
+
 ```sql
 CREATE TABLE image_table (
     id INT,
@@ -278,9 +279,11 @@ CREATE TABLE image_table (
 ALTER TABLE image_table SET ('blob-field' = 'image');
 ALTER TABLE image_table ADD image BYTES;
 ```
-{{< /tab >}}
 
-{{< tab "Spark SQL" >}}
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
 ```sql
 CREATE TABLE image_table (
     id INT,
@@ -293,9 +296,10 @@ CREATE TABLE image_table (
 ALTER TABLE image_table SET TBLPROPERTIES ('blob-field' = 'image');
 ALTER TABLE image_table ADD COLUMN image BINARY;
 ```
-{{< /tab >}}
 
-{{< /tabs >}}
+</TabItem>
+
+</Tabs>
 
 Do not add the binary column first and set `blob-field` later. For example, the following order creates a normal
 `BYTES` / `BINARY` column. The later option change will not convert the existing column to BLOB, and may be rejected

--- a/docs/docs/append-table/blob.mdx
+++ b/docs/docs/append-table/blob.mdx
@@ -106,7 +106,7 @@ This allows one table to mix raw-data BLOB fields, descriptor-only BLOB fields, 
       <td>No</td>
       <td style={{wordWrap: "break-word"}}>(none)</td>
       <td>String</td>
-      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code>, <code>blob-view-field</code> are also treated as BLOB fields.</td>
+      <td>Specifies column names that should be stored as blob type. This is used when you want to treat a BYTES column as a BLOB. Fields listed in <code>blob-descriptor-field</code> or <code>blob-view-field</code> are also treated as BLOB fields.</td>
     </tr>
     <tr>
       <td><h5>blob-as-descriptor</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2299,7 +2299,6 @@ public class CoreOptions implements Serializable {
                                     + "Fields listed in blob-descriptor-field or blob-view-field "
                                     + "are also treated as BLOB fields.");
 
-    @Immutable
     public static final ConfigOption<String> BLOB_DESCRIPTOR_FIELD =
             key("blob-descriptor-field")
                     .stringType()

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1335,8 +1335,10 @@ public class SchemaManager implements Serializable {
                 throw new UnsupportedOperationException(
                         String.format(
                                 "Cannot configure existing field '%s' as a BLOB field. "
-                                        + "BLOB fields can only be added by adding new columns.",
-                                field));
+                                        + "BLOB fields can only be added as new columns. "
+                                        + "If you are using SQL to ADD a blob column, set '%s' "
+                                        + "before adding the binary column.",
+                                field, key));
             }
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -317,6 +317,8 @@ public class SchemaManager implements Serializable {
         for (SchemaChange change : changes) {
             if (change instanceof SetOption) {
                 SetOption setOption = (SetOption) change;
+                checkAlterBlobFieldOption(
+                        oldTableSchema, oldOptions, setOption.key(), setOption.value());
                 if (hasSnapshots.get()) {
                     checkAlterTableOption(
                             oldOptions,
@@ -327,6 +329,10 @@ public class SchemaManager implements Serializable {
                 newOptions.put(setOption.key(), setOption.value());
             } else if (change instanceof RemoveOption) {
                 RemoveOption removeOption = (RemoveOption) change;
+                if (isBlobFieldOption(removeOption.key())) {
+                    throw new UnsupportedOperationException(
+                            "Cannot remove blob field option: " + removeOption.key());
+                }
                 if (hasSnapshots.get()) {
                     checkResetTableOption(oldOptions, removeOption.key());
                 }
@@ -1281,6 +1287,78 @@ public class SchemaManager implements Serializable {
                     String.format(
                             "Cannot reset %s when %s enabled.", key, PK_CLUSTERING_OVERRIDE.key()));
         }
+    }
+
+    /**
+     * Check alter blob field option. Now we only allow adding non-existing new fields as BLOB
+     * fields, and removing existing BLOB fields is not allowed.
+     *
+     * @param oldTableSchema table schema
+     * @param oldOptions old table options
+     * @param key altering key
+     * @param value altering value
+     */
+    private static void checkAlterBlobFieldOption(
+            TableSchema oldTableSchema, Map<String, String> oldOptions, String key, String value) {
+        if (!isBlobFieldOption(key)) {
+            return;
+        }
+
+        Map<String, String> newOptions = new HashMap<>(oldOptions);
+        if (value == null) {
+            newOptions.remove(key);
+        } else {
+            newOptions.put(key, value);
+        }
+
+        Set<String> oldFields = getBlobFields(oldOptions, key);
+        Set<String> newFields = getBlobFields(newOptions, key);
+
+        // 1. do not allow removing existing blob fields
+        Set<String> removals = new HashSet<>(oldFields);
+        removals.removeAll(newFields);
+        for (String fieldName : oldTableSchema.fieldNames()) {
+            if (removals.contains(fieldName)) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Cannot remove an existing field '%s' from 'blob-field'.",
+                                fieldName));
+            }
+        }
+
+        // 2. do not allow adding existing fields as BLOB fields
+        Set<String> additions = new HashSet<>(newFields);
+        additions.removeAll(oldFields);
+        Set<String> existingFields = new HashSet<>(oldTableSchema.fieldNames());
+        for (String field : additions) {
+            if (existingFields.contains(field)) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Cannot configure existing field '%s' as a BLOB field. "
+                                        + "BLOB fields can only be added by adding new columns.",
+                                field));
+            }
+        }
+    }
+
+    private static boolean isBlobFieldOption(String key) {
+        return CoreOptions.BLOB_FIELD.key().equals(key)
+                || CoreOptions.BLOB_DESCRIPTOR_FIELD.key().equals(key)
+                || CoreOptions.BLOB_VIEW_FIELD.key().equals(key)
+                || CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key().equals(key);
+    }
+
+    private static Set<String> getBlobFields(Map<String, String> options, String key) {
+        if (CoreOptions.BLOB_FIELD.key().equals(key)) {
+            return new HashSet<>(CoreOptions.blobField(options));
+        } else if (CoreOptions.BLOB_DESCRIPTOR_FIELD.key().equals(key)) {
+            return new CoreOptions(options).blobDescriptorField();
+        } else if (CoreOptions.BLOB_VIEW_FIELD.key().equals(key)) {
+            return new CoreOptions(options).blobViewField();
+        } else if (CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key().equals(key)) {
+            return new CoreOptions(options).blobExternalStorageField();
+        }
+        throw new IllegalArgumentException("Unknown blob field option: " + key);
     }
 
     public static void checkAlterTablePath(String key) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -318,7 +318,7 @@ public class SchemaManager implements Serializable {
             if (change instanceof SetOption) {
                 SetOption setOption = (SetOption) change;
                 checkAlterBlobFieldOption(
-                        oldTableSchema, oldOptions, setOption.key(), setOption.value());
+                        newFields, newOptions, setOption.key(), setOption.value());
                 if (hasSnapshots.get()) {
                     checkAlterTableOption(
                             oldOptions,
@@ -329,7 +329,7 @@ public class SchemaManager implements Serializable {
                 newOptions.put(setOption.key(), setOption.value());
             } else if (change instanceof RemoveOption) {
                 RemoveOption removeOption = (RemoveOption) change;
-                if (isBlobFieldOption(removeOption.key())) {
+                if (isMutableBlobFieldOption(removeOption.key())) {
                     throw new UnsupportedOperationException(
                             "Cannot remove blob field option: " + removeOption.key());
                 }
@@ -1293,43 +1293,46 @@ public class SchemaManager implements Serializable {
      * Check alter blob field option. Now we only allow adding non-existing new fields as BLOB
      * fields, and removing existing BLOB fields is not allowed.
      *
-     * @param oldTableSchema table schema
-     * @param oldOptions old table options
+     * @param currentFields current table fields with previous changes applied
+     * @param currentOptions current table options with previous changes applied
      * @param key altering key
      * @param value altering value
      */
     private static void checkAlterBlobFieldOption(
-            TableSchema oldTableSchema, Map<String, String> oldOptions, String key, String value) {
-        if (!isBlobFieldOption(key)) {
+            List<DataField> currentFields,
+            Map<String, String> currentOptions,
+            String key,
+            String value) {
+        if (!isMutableBlobFieldOption(key)) {
             return;
         }
 
-        Map<String, String> newOptions = new HashMap<>(oldOptions);
+        Map<String, String> newOptions = new HashMap<>(currentOptions);
         if (value == null) {
             newOptions.remove(key);
         } else {
             newOptions.put(key, value);
         }
 
-        Set<String> oldFields = getBlobFields(oldOptions, key);
-        Set<String> newFields = getBlobFields(newOptions, key);
+        Set<String> oldFields = getMutableBlobFields(currentOptions, key);
+        Set<String> newFields = getMutableBlobFields(newOptions, key);
+        Set<String> existingFields =
+                currentFields.stream().map(DataField::name).collect(Collectors.toSet());
 
         // 1. do not allow removing existing blob fields
         Set<String> removals = new HashSet<>(oldFields);
         removals.removeAll(newFields);
-        for (String fieldName : oldTableSchema.fieldNames()) {
-            if (removals.contains(fieldName)) {
+        for (String fieldName : removals) {
+            if (existingFields.contains(fieldName)) {
                 throw new UnsupportedOperationException(
                         String.format(
-                                "Cannot remove an existing field '%s' from 'blob-field'.",
-                                fieldName));
+                                "Cannot remove an existing field '%s' from '%s'.", fieldName, key));
             }
         }
 
         // 2. do not allow adding existing fields as BLOB fields
         Set<String> additions = new HashSet<>(newFields);
         additions.removeAll(oldFields);
-        Set<String> existingFields = new HashSet<>(oldTableSchema.fieldNames());
         for (String field : additions) {
             if (existingFields.contains(field)) {
                 throw new UnsupportedOperationException(
@@ -1343,24 +1346,18 @@ public class SchemaManager implements Serializable {
         }
     }
 
-    private static boolean isBlobFieldOption(String key) {
+    private static boolean isMutableBlobFieldOption(String key) {
         return CoreOptions.BLOB_FIELD.key().equals(key)
-                || CoreOptions.BLOB_DESCRIPTOR_FIELD.key().equals(key)
-                || CoreOptions.BLOB_VIEW_FIELD.key().equals(key)
-                || CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key().equals(key);
+                || CoreOptions.BLOB_DESCRIPTOR_FIELD.key().equals(key);
     }
 
-    private static Set<String> getBlobFields(Map<String, String> options, String key) {
+    private static Set<String> getMutableBlobFields(Map<String, String> options, String key) {
         if (CoreOptions.BLOB_FIELD.key().equals(key)) {
             return new HashSet<>(CoreOptions.blobField(options));
         } else if (CoreOptions.BLOB_DESCRIPTOR_FIELD.key().equals(key)) {
             return new CoreOptions(options).blobDescriptorField();
-        } else if (CoreOptions.BLOB_VIEW_FIELD.key().equals(key)) {
-            return new CoreOptions(options).blobViewField();
-        } else if (CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key().equals(key)) {
-            return new CoreOptions(options).blobExternalStorageField();
         }
-        throw new IllegalArgumentException("Unknown blob field option: " + key);
+        throw new IllegalArgumentException("Unknown mutable blob field option: " + key);
     }
 
     public static void checkAlterTablePath(String key) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -166,6 +166,9 @@ public class SchemaValidation {
         FileFormat fileFormat =
                 FileFormat.fromIdentifier(options.formatType(), new Options(schema.options()));
         RowType tableRowType = new RowType(schema.fields());
+
+        // Validate blob-related fields
+        // Now we support configuring blob fields for future columns.
         validateBlobFields(tableRowType, options);
         Set<String> blobDescriptorFields = validateBlobDescriptorFields(tableRowType, options);
         Set<String> blobViewFields =
@@ -795,17 +798,14 @@ public class SchemaValidation {
     }
 
     private static void validateBlobFields(RowType rowType, CoreOptions options) {
-        Set<String> blobFieldNames =
-                rowType.getFields().stream()
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
-                        .map(DataField::name)
-                        .collect(Collectors.toCollection(HashSet::new));
+        Set<String> fieldNames = fieldNames(rowType);
+        Set<String> blobFieldNames = blobFieldNames(rowType);
         Set<String> configured =
                 CoreOptions.blobField(options.toMap()).stream()
                         .collect(Collectors.toCollection(HashSet::new));
         for (String field : configured) {
             checkArgument(
-                    blobFieldNames.contains(field),
+                    !fieldNames.contains(field) || blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema.",
                     field,
                     CoreOptions.BLOB_FIELD.key());
@@ -813,15 +813,12 @@ public class SchemaValidation {
     }
 
     private static Set<String> validateBlobDescriptorFields(RowType rowType, CoreOptions options) {
-        Set<String> blobFieldNames =
-                rowType.getFields().stream()
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
-                        .map(DataField::name)
-                        .collect(Collectors.toCollection(HashSet::new));
+        Set<String> fieldNames = fieldNames(rowType);
+        Set<String> blobFieldNames = blobFieldNames(rowType);
         Set<String> configured = options.blobDescriptorField();
         for (String field : configured) {
             checkArgument(
-                    blobFieldNames.contains(field),
+                    !fieldNames.contains(field) || blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema.",
                     field,
                     CoreOptions.BLOB_DESCRIPTOR_FIELD.key());
@@ -831,15 +828,12 @@ public class SchemaValidation {
 
     private static Set<String> validateBlobViewFields(
             RowType rowType, CoreOptions options, Set<String> blobDescriptorFields) {
-        Set<String> blobFieldNames =
-                rowType.getFields().stream()
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
-                        .map(DataField::name)
-                        .collect(Collectors.toCollection(HashSet::new));
+        Set<String> fieldNames = fieldNames(rowType);
+        Set<String> blobFieldNames = blobFieldNames(rowType);
         Set<String> configured = options.blobViewField();
         for (String field : configured) {
             checkArgument(
-                    blobFieldNames.contains(field),
+                    !fieldNames.contains(field) || blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema.",
                     field,
                     CoreOptions.BLOB_VIEW_FIELD.key());
@@ -855,15 +849,12 @@ public class SchemaValidation {
 
     private static void validateBlobExternalStorageFields(
             RowType rowType, CoreOptions options, Set<String> blobDescriptorFields) {
-        Set<String> blobFieldNames =
-                rowType.getFields().stream()
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
-                        .map(DataField::name)
-                        .collect(Collectors.toCollection(HashSet::new));
+        Set<String> fieldNames = fieldNames(rowType);
+        Set<String> blobFieldNames = blobFieldNames(rowType);
         Set<String> configured = options.blobExternalStorageField();
         for (String field : configured) {
             checkArgument(
-                    blobFieldNames.contains(field),
+                    !fieldNames.contains(field) || blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema.",
                     field,
                     CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key());
@@ -882,6 +873,19 @@ public class SchemaValidation {
                     CoreOptions.BLOB_EXTERNAL_STORAGE_PATH.key(),
                     CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key());
         }
+    }
+
+    private static Set<String> fieldNames(RowType rowType) {
+        return rowType.getFields().stream()
+                .map(DataField::name)
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    private static Set<String> blobFieldNames(RowType rowType) {
+        return rowType.getFields().stream()
+                .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
+                .map(DataField::name)
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     private static void validateIncrementalClustering(TableSchema schema, CoreOptions options) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -608,6 +608,93 @@ public class SchemaEvolutionTest {
         assertThat(newSchema.options()).contains(entries);
     }
 
+    @Test
+    public void testAlterAddBlobFieldOptionBeforeAddingColumn() throws Exception {
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.STRING()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        optionsForBlobTable(),
+                        "");
+        schemaManager.createTable(schema);
+
+        TableSchema schemaWithOption =
+                schemaManager.commitChanges(
+                        SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "picture"));
+        assertThat(schemaWithOption.fieldNames()).doesNotContain("picture");
+
+        TableSchema schemaWithBlobColumn =
+                schemaManager.commitChanges(SchemaChange.addColumn("picture", DataTypes.BLOB()));
+        assertThat(schemaWithBlobColumn.fields().get(2).type()).isEqualTo(DataTypes.BLOB());
+    }
+
+    @Test
+    public void testAlterBlobFieldOptionCannotConvertExistingColumn() throws Exception {
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.BYTES()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        optionsForBlobTable(),
+                        "");
+        schemaManager.createTable(schema);
+
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "f1")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Cannot configure existing field 'f1' as a BLOB field.");
+    }
+
+    @Test
+    public void testAlterBlobFieldOptionCanRemoveNonExistingField() throws Exception {
+        Map<String, String> options = optionsForBlobTable();
+        options.put(CoreOptions.BLOB_FIELD.key(), "picture");
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.STRING()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+        schemaManager.createTable(schema);
+
+        TableSchema newSchema =
+                schemaManager.commitChanges(
+                        SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "avatar"));
+        assertThat(CoreOptions.blobField(newSchema.options())).containsExactly("avatar");
+    }
+
+    @Test
+    public void testAlterBlobFieldOptionCannotRemoveExistingField() throws Exception {
+        Map<String, String> options = optionsForBlobTable();
+        options.put(CoreOptions.BLOB_FIELD.key(), "f1");
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.BLOB()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+        schemaManager.createTable(schema);
+
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Cannot remove an existing field 'f1' from 'blob-field'.");
+    }
+
+    private Map<String, String> optionsForBlobTable() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        return options;
+    }
+
     private List<String> readRecords(FileStoreTable table, Predicate filter) throws IOException {
         List<String> results = new ArrayList<>();
         forEachRemaining(

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -645,7 +645,8 @@ public class SchemaEvolutionTest {
                                 schemaManager.commitChanges(
                                         SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "f1")))
                 .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("Cannot configure existing field 'f1' as a BLOB field.");
+                .hasMessageContaining("Cannot configure existing field 'f1' as a BLOB field.")
+                .hasMessageContaining("set 'blob-field' before adding the binary column");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -689,6 +689,52 @@ public class SchemaEvolutionTest {
                 .hasMessageContaining("Cannot remove an existing field 'f1' from 'blob-field'.");
     }
 
+    @Test
+    public void testAlterBlobFieldOptionCannotRemoveFieldAddedInSameCommit() throws Exception {
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.STRING()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        optionsForBlobTable(),
+                        "");
+        schemaManager.createTable(schema);
+
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.setOption(
+                                                CoreOptions.BLOB_FIELD.key(), "picture"),
+                                        SchemaChange.addColumn("picture", DataTypes.BLOB()),
+                                        SchemaChange.setOption(CoreOptions.BLOB_FIELD.key(), "")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(
+                        "Cannot remove an existing field 'picture' from 'blob-field'.");
+    }
+
+    @Test
+    public void testAlterBlobFieldOptionCannotConfigureFieldAddedEarlierInSameCommit()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        RowType.of(DataTypes.INT(), DataTypes.STRING()).getFields(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        optionsForBlobTable(),
+                        "");
+        schemaManager.createTable(schema);
+
+        assertThatThrownBy(
+                        () ->
+                                schemaManager.commitChanges(
+                                        SchemaChange.addColumn("picture", DataTypes.BYTES()),
+                                        SchemaChange.setOption(
+                                                CoreOptions.BLOB_FIELD.key(), "picture")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Cannot configure existing field 'picture' as a BLOB field.")
+                .hasMessageContaining("set 'blob-field' before adding the binary column");
+    }
+
     private Map<String, String> optionsForBlobTable() {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -856,6 +856,9 @@ public class FlinkCatalog extends AbstractCatalog {
                                                     newTable.getOptions())
                                                     .stream())
                             .collect(Collectors.toList());
+            // Blob AddColumn conversion above uses new table options. Flink emits table option
+            // changes before physical column changes, so SchemaManager sees the BLOB option before
+            // adding the converted BLOB column.
             changes.addAll(schemaChanges);
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -47,6 +47,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
@@ -566,20 +567,23 @@ public class FlinkCatalog extends AbstractCatalog {
     private List<SchemaChange> toSchemaChange(
             TableChange change,
             Map<String, Integer> oldTableNonPhysicalColumnIndex,
-            @Nullable String primaryKeyConstraintName) {
+            @Nullable String primaryKeyConstraintName,
+            Set<String> blobTypeFields,
+            Map<String, String> options) {
         List<SchemaChange> schemaChanges = new ArrayList<>();
         if (change instanceof AddColumn) {
             if (((AddColumn) change).getColumn().isPhysical()) {
                 AddColumn add = (AddColumn) change;
                 String comment = add.getColumn().getComment().orElse(null);
                 SchemaChange.Move move = getMove(add.getPosition(), add.getColumn().getName());
-                schemaChanges.add(
-                        SchemaChange.addColumn(
+                DataType type =
+                        resolveDataType(
                                 add.getColumn().getName(),
-                                LogicalTypeConversion.toDataType(
-                                        add.getColumn().getDataType().getLogicalType()),
-                                comment,
-                                move));
+                                add.getColumn().getDataType().getLogicalType(),
+                                options,
+                                blobTypeFields);
+                schemaChanges.add(
+                        SchemaChange.addColumn(add.getColumn().getName(), type, comment, move));
             }
             return schemaChanges;
         } else if (change instanceof AddWatermark) {
@@ -847,7 +851,9 @@ public class FlinkCatalog extends AbstractCatalog {
                                             toSchemaChange(
                                                     tableChange,
                                                     oldTableNonPhysicalColumnIndex,
-                                                    primaryKeyConstraintName)
+                                                    primaryKeyConstraintName,
+                                                    blobTypeFields(newTable.getOptions()),
+                                                    newTable.getOptions())
                                                     .stream())
                             .collect(Collectors.toList());
             changes.addAll(schemaChanges);
@@ -1133,8 +1139,10 @@ public class FlinkCatalog extends AbstractCatalog {
 
     private static Set<String> blobTypeFields(Map<String, String> options) {
         Set<String> blobTypeFields = new HashSet<>(CoreOptions.blobField(options));
-        blobTypeFields.addAll(new CoreOptions(options).blobDescriptorField());
+        CoreOptions coreOptions = new CoreOptions(options);
+        blobTypeFields.addAll(coreOptions.blobDescriptorField());
         blobTypeFields.addAll(CoreOptions.blobViewField(options));
+        blobTypeFields.addAll(coreOptions.blobExternalStorageField());
         return blobTypeFields;
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -856,9 +856,7 @@ public class FlinkCatalog extends AbstractCatalog {
                                                     newTable.getOptions())
                                                     .stream())
                             .collect(Collectors.toList());
-            // Blob AddColumn conversion above uses new table options. Flink emits table option
-            // changes before physical column changes, so SchemaManager sees the BLOB option before
-            // adding the converted BLOB column.
+            // Blob AddColumn conversion above uses new table options.
             changes.addAll(schemaChanges);
         }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
@@ -108,6 +109,25 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
                         "[+I[null, aaa, 1.2, null, 3.4, null, null, null], +I[null, bbb, 4.5, null, 5.6, 5, null, null],"
                                 + " +I[null, ccc, 2.3, 6, 5.6, 5, null, null], +I[flink, fff, 45.34, 4, 2.45, 12, null, null],"
                                 + " +I[ggg, hhh, 23.43, 6, 2.34, 34, 23, true]]");
+    }
+
+    @Test
+    public void testAlterAddBlobColumn() throws Exception {
+        sql(
+                "CREATE TABLE T_BLOB (id INT, data STRING) WITH ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+        sql("INSERT INTO T_BLOB VALUES (1, 'old')");
+
+        sql("ALTER TABLE T_BLOB SET ('blob-field'='picture')");
+        sql("ALTER TABLE T_BLOB ADD picture BYTES");
+        sql("INSERT INTO T_BLOB VALUES (2, 'new', X'4869')");
+
+        assertThat(paimonTable("T_BLOB").rowType().getField("picture").type().is(DataTypeRoot.BLOB))
+                .isTrue();
+        List<Row> result = sql("SELECT * FROM T_BLOB ORDER BY id");
+        assertThat(result.get(0).getField(2)).isNull();
+        assertThat((byte[]) result.get(1).getField(2)).containsExactly((byte) 72, (byte) 105);
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -22,13 +22,21 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.DateTimeUtils;
 
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,6 +150,44 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         assertThat(
                         paimonTable("T_BLOB_DESCRIPTOR")
+                                .rowType()
+                                .getField("picture")
+                                .type()
+                                .is(DataTypeRoot.BLOB))
+                .isTrue();
+    }
+
+    @Test
+    public void testAlterAddBlobColumnWithCombinedTableChanges() throws Exception {
+        sql(
+                "CREATE TABLE T_BLOB_COMBINED (id INT, data STRING) WITH ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+
+        CatalogTable table = table("T_BLOB_COMBINED");
+        Map<String, String> newOptions = new HashMap<>(table.getOptions());
+        newOptions.put("blob-field", "picture");
+
+        CatalogTable newTable =
+                new ResolvedCatalogTable(
+                        table.copy(newOptions),
+                        ResolvedSchema.physical(
+                                new String[] {"id", "data", "picture"},
+                                new org.apache.flink.table.types.DataType[] {
+                                    DataTypes.INT(), DataTypes.STRING(), DataTypes.BYTES()
+                                }));
+
+        flinkCatalog()
+                .alterTable(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "T_BLOB_COMBINED"),
+                        newTable,
+                        Arrays.asList(
+                                TableChange.set("blob-field", "picture"),
+                                TableChange.add(Column.physical("picture", DataTypes.BYTES()))),
+                        false);
+
+        assertThat(
+                        paimonTable("T_BLOB_COMBINED")
                                 .rowType()
                                 .getField("picture")
                                 .type()

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SchemaChangeITCase.java
@@ -121,13 +121,32 @@ public class SchemaChangeITCase extends CatalogITCaseBase {
 
         sql("ALTER TABLE T_BLOB SET ('blob-field'='picture')");
         sql("ALTER TABLE T_BLOB ADD picture BYTES");
-        sql("INSERT INTO T_BLOB VALUES (2, 'new', X'4869')");
 
         assertThat(paimonTable("T_BLOB").rowType().getField("picture").type().is(DataTypeRoot.BLOB))
                 .isTrue();
+        sql("INSERT INTO T_BLOB VALUES (2, 'new', X'4869')");
         List<Row> result = sql("SELECT * FROM T_BLOB ORDER BY id");
         assertThat(result.get(0).getField(2)).isNull();
         assertThat((byte[]) result.get(1).getField(2)).containsExactly((byte) 72, (byte) 105);
+    }
+
+    @Test
+    public void testAlterAddBlobDescriptorColumn() throws Exception {
+        sql(
+                "CREATE TABLE T_BLOB_DESCRIPTOR (id INT, data STRING) WITH ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+
+        sql("ALTER TABLE T_BLOB_DESCRIPTOR SET ('blob-descriptor-field'='picture')");
+        sql("ALTER TABLE T_BLOB_DESCRIPTOR ADD picture BYTES");
+
+        assertThat(
+                        paimonTable("T_BLOB_DESCRIPTOR")
+                                .rowType()
+                                .getField("picture")
+                                .type()
+                                .is(DataTypeRoot.BLOB))
+                .isTrue();
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -38,6 +38,7 @@ import org.apache.paimon.spark.catalog.functions.PaimonFunctions;
 import org.apache.paimon.spark.catalog.functions.V1FunctionConverter;
 import org.apache.paimon.spark.utils.CatalogUtils;
 import org.apache.paimon.table.FormatTable;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.iceberg.IcebergTable;
 import org.apache.paimon.table.lance.LanceTable;
 import org.apache.paimon.table.object.ObjectTable;
@@ -85,6 +86,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -346,9 +348,15 @@ public class SparkCatalog extends SparkBaseCatalog
     @Override
     public org.apache.spark.sql.connector.catalog.Table alterTable(
             Identifier ident, TableChange... changes) throws NoSuchTableException {
-        List<SchemaChange> schemaChanges =
-                Arrays.stream(changes).map(this::toSchemaChange).collect(Collectors.toList());
         try {
+            Table table = catalog.getTable(toIdentifier(ident, catalogName));
+            // We have to get the new table options by merging current options with changes,
+            // in case that altering blob fields and adding blob columns come together
+            Map<String, String> newOptions = newTableOptions(table.options(), changes);
+            List<SchemaChange> schemaChanges = new ArrayList<>();
+            for (TableChange change : changes) {
+                schemaChanges.add(toSchemaChange(change, newOptions));
+            }
             catalog.alterTable(toIdentifier(ident, catalogName), schemaChanges, false);
             return loadTable(ident);
         } catch (Catalog.TableNotExistException e) {
@@ -471,7 +479,7 @@ public class SparkCatalog extends SparkBaseCatalog
         return new RollbackStagedTable(loadTable(ident), () -> {});
     }
 
-    private SchemaChange toSchemaChange(TableChange change) {
+    private SchemaChange toSchemaChange(TableChange change, Map<String, String> newOptions) {
         if (change instanceof TableChange.SetProperty) {
             TableChange.SetProperty set = (TableChange.SetProperty) change;
             validateAlterProperty(set.property());
@@ -494,7 +502,7 @@ public class SparkCatalog extends SparkBaseCatalog
             checkNoDefaultValue(add);
             return SchemaChange.addColumn(
                     add.fieldNames(),
-                    toPaimonType(add.dataType()).copy(add.isNullable()),
+                    resolveDataType(add, newOptions).copy(add.isNullable()),
                     add.comment(),
                     move);
         } else if (change instanceof TableChange.RenameColumn) {
@@ -524,6 +532,46 @@ public class SparkCatalog extends SparkBaseCatalog
             throw new UnsupportedOperationException(
                     "Change is not supported: " + change.getClass());
         }
+    }
+
+    private static Map<String, String> newTableOptions(
+            Map<String, String> currentOptions, TableChange[] changes) {
+        Map<String, String> options = new HashMap<>(currentOptions);
+        for (TableChange change : changes) {
+            if (change instanceof TableChange.SetProperty) {
+                TableChange.SetProperty set = (TableChange.SetProperty) change;
+                if (!set.property().equals(TableCatalog.PROP_COMMENT)) {
+                    options.put(set.property(), set.value());
+                }
+            } else if (change instanceof TableChange.RemoveProperty) {
+                TableChange.RemoveProperty remove = (TableChange.RemoveProperty) change;
+                if (!remove.property().equals(TableCatalog.PROP_COMMENT)) {
+                    options.remove(remove.property());
+                }
+            }
+        }
+        return options;
+    }
+
+    private static DataType resolveDataType(
+            TableChange.AddColumn add, Map<String, String> finalOptions) {
+        if (add.fieldNames().length == 1
+                && blobTypeFields(finalOptions).contains(add.fieldNames()[0])) {
+            checkArgument(
+                    add.dataType() instanceof org.apache.spark.sql.types.BinaryType,
+                    "The type of blob field must be binary");
+            return new BlobType().copy(add.isNullable());
+        }
+        return toPaimonType(add.dataType()).copy(add.isNullable());
+    }
+
+    private static Set<String> blobTypeFields(Map<String, String> options) {
+        Set<String> blobTypeFields = new HashSet<>(CoreOptions.blobField(options));
+        CoreOptions coreOptions = new CoreOptions(options);
+        blobTypeFields.addAll(coreOptions.blobDescriptorField());
+        blobTypeFields.addAll(coreOptions.blobViewField());
+        blobTypeFields.addAll(coreOptions.blobExternalStorageField());
+        return blobTypeFields;
     }
 
     private static SchemaChange.Move getMove(
@@ -560,9 +608,7 @@ public class SparkCatalog extends SparkBaseCatalog
     private Schema toInitialSchema(
             StructType schema, Transform[] partitions, Map<String, String> properties) {
         Map<String, String> normalizedProperties = new HashMap<>(properties);
-        List<String> blobFields = CoreOptions.blobField(properties);
-        Set<String> blobDescriptorFields = new CoreOptions(properties).blobDescriptorField();
-        List<String> blobViewFields = CoreOptions.blobViewField(properties);
+        Set<String> blobTypeFields = blobTypeFields(properties);
         String provider = properties.get(TableCatalog.PROP_PROVIDER);
         if (!usePaimon(provider)) {
             if (isFormatTable(provider)) {
@@ -596,9 +642,7 @@ public class SparkCatalog extends SparkBaseCatalog
         for (StructField field : schema.fields()) {
             String name = field.name();
             DataType type;
-            if (blobFields.contains(name)
-                    || blobDescriptorFields.contains(name)
-                    || blobViewFields.contains(name)) {
+            if (blobTypeFields.contains(name)) {
                 checkArgument(
                         field.dataType() instanceof org.apache.spark.sql.types.BinaryType,
                         "The type of blob field must be binary");

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -560,9 +560,9 @@ public class SparkCatalog extends SparkBaseCatalog
             checkArgument(
                     add.dataType() instanceof org.apache.spark.sql.types.BinaryType,
                     "The type of blob field must be binary");
-            return new BlobType().copy(add.isNullable());
+            return new BlobType();
         }
-        return toPaimonType(add.dataType()).copy(add.isNullable());
+        return toPaimonType(add.dataType());
     }
 
     private static Set<String> blobTypeFields(Map<String, String> options) {

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark;
 
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.StringUtils;
 
 import org.apache.spark.sql.AnalysisException;
@@ -93,6 +94,34 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
 
         assertThat(spark.table("testAddColumn").collectAsList().toString())
                 .isEqualTo("[[1,2,1,null], [5,6,3,null]]");
+    }
+
+    @Test
+    public void testAlterAddBlobColumn() {
+        spark.sql(
+                "CREATE TABLE testAlterAddBlobColumn (id INT, data STRING) "
+                        + "TBLPROPERTIES ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+        spark.sql("INSERT INTO testAlterAddBlobColumn VALUES (1, 'old')");
+
+        spark.sql(
+                "ALTER TABLE testAlterAddBlobColumn "
+                        + "SET TBLPROPERTIES ('blob-field'='picture')");
+        spark.sql("ALTER TABLE testAlterAddBlobColumn ADD COLUMN picture BINARY");
+        spark.sql("INSERT INTO testAlterAddBlobColumn VALUES (2, 'new', X'4869')");
+
+        assertThat(
+                        getTable("testAlterAddBlobColumn")
+                                .rowType()
+                                .getField("picture")
+                                .type()
+                                .is(DataTypeRoot.BLOB))
+                .isTrue();
+        List<Row> rows =
+                spark.sql("SELECT * FROM testAlterAddBlobColumn ORDER BY id").collectAsList();
+        assertThat(rows.get(0).get(2)).isNull();
+        assertThat((byte[]) rows.get(1).get(2)).containsExactly((byte) 72, (byte) 105);
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -125,6 +125,28 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
     }
 
     @Test
+    public void testAlterAddBlobDescriptorColumn() {
+        spark.sql(
+                "CREATE TABLE testAlterAddBlobDescriptorColumn (id INT, data STRING) "
+                        + "TBLPROPERTIES ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+
+        spark.sql(
+                "ALTER TABLE testAlterAddBlobDescriptorColumn "
+                        + "SET TBLPROPERTIES ('blob-descriptor-field'='picture')");
+        spark.sql("ALTER TABLE testAlterAddBlobDescriptorColumn ADD COLUMN picture BINARY");
+
+        assertThat(
+                        getTable("testAlterAddBlobDescriptorColumn")
+                                .rowType()
+                                .getField("picture")
+                                .type()
+                                .is(DataTypeRoot.BLOB))
+                .isTrue();
+    }
+
+    @Test
     public void testAddNotNullColumn() {
         createTable("testAddNotNullColumn");
 

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -24,6 +24,8 @@ import org.apache.paimon.utils.StringUtils;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableChange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -143,6 +145,29 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
                                 .getField("picture")
                                 .type()
                                 .is(DataTypeRoot.BLOB))
+                .isTrue();
+    }
+
+    @Test
+    public void testAlterAddBlobColumnWithCombinedTableChanges() throws Exception {
+        String tableName = "testAlterAddBlobColumnWithCombinedTableChanges";
+        spark.sql(
+                "CREATE TABLE "
+                        + tableName
+                        + " (id INT, data STRING) "
+                        + "TBLPROPERTIES ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true')");
+
+        ((SparkCatalog) spark.sessionState().catalogManager().currentCatalog())
+                .alterTable(
+                        Identifier.of(new String[] {"default"}, tableName),
+                        TableChange.setProperty("blob-field", "picture"),
+                        TableChange.addColumn(
+                                new String[] {"picture"},
+                                org.apache.spark.sql.types.DataTypes.BinaryType));
+
+        assertThat(getTable(tableName).rowType().getField("picture").type().is(DataTypeRoot.BLOB))
                 .isTrue();
     }
 


### PR DESCRIPTION
### Purpose
This is the part0 of https://github.com/apache/paimon/issues/7881
Currently, we can't add new blob columns through Flink/Spark sql. In this PR, I slightly changes the restriction of altering `blob-fields` configuration, as below:
1. `blob-field` and `blob-descriptor-field` are mutable now
1. Do not allow altering an existing fields to BLOB
2. Do not allow removing an existing fields from blob fields
3. Allow configuring a non-existing fields as blob -- this is for future blob fields

> Note that due to complexity, `blob-external-fields`, `blob-view-fields` are still immutable now

Then during altering tables, new bytes fields with blob-fields configured will be converted to blob fields, as below:
```sql
-- current setting is only 'blob-field'='video'
ALTER TABLE T_BLOB SET ('blob-field'='video,picture');
ALTER TABLE T_BLOB ADD picture BYTES
```

### Tests
See Unit Tests and ITCases