### PR TITLE
[flink] Support blob compaction for data evolution tables

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -108,6 +108,44 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testBlobCompaction() throws Exception {
+        for (int i = 1; i <= 10; i++) {
+            batchSql("INSERT INTO blob_table VALUES (%s, 'paimon', X'48656C6C6F')", i);
+        }
+        batchSql("INSERT INTO blob_table VALUES (1, 'paimon', X'48656C6C6F')");
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `blob_table$files`"))
+                .containsExactly(Row.of(22L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+
+        tEnv.getConfig().set("table.dml-sync", "true");
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.blob_table')").await();
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `blob_table$files`"))
+                .containsExactly(Row.of(12L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(1L));
+        assertThat(batchSql("SELECT COUNT(*) FROM blob_table")).containsExactly(Row.of(11L));
+        assertThat(batchSql("SELECT picture FROM blob_table WHERE id = 1"))
+                .containsExactlyInAnyOrder(
+                        Row.of(new byte[] {72, 101, 108, 108, 111}),
+                        Row.of(new byte[] {72, 101, 108, 108, 111}));
+    }
+
+    @Test
     public void testWriteBlobAsDescriptor() throws Exception {
         byte[] blobData = new byte[1024 * 1024];
         RANDOM.nextBytes(blobData);


### PR DESCRIPTION
### Purpose
Enable Flink data-evolution compaction to plan and execute blob compaction tasks.

This implements `DataEvolutionCompactTask` support for `blobTask` by rewriting dedicated blob files with `MultipleBlobFileWriter`. It also enables the Flink data-evolution compact source to plan blob tasks.

The reader path now also supports blob-only merge groups, which is required when a data-evolution blob task contains multiple blob fields without the corresponding normal data file in the same split.

### Tests
- `mvn -pl paimon-core -DfailIfNoTests=false -Dtest=MultipleBlobTableTest#testDataEvolutionBlobCompaction test`
- `mvn -pl paimon-flink/paimon-flink-common -DfailIfNoTests=false -Dtest=BlobTableITCase#testBlobCompaction+testMultipleBlobCompaction test`
- `mvn -pl paimon-core -DfailIfNoTests=false -Dtest=MultipleBlobTableTest test`
- `mvn -pl paimon-flink/paimon-flink-common -DfailIfNoTests=false -Dtest=BlobTableITCase test`