### PR TITLE
[flink] Support blob compaction for data evolution tables

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -435,7 +435,7 @@
             <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
         </tr>
         <tr>
-            <td><h5>data-evolution.compaction.blob.enabled</h5></td>
+            <td><h5>blob-compaction.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to compact blob files when compacting a data evolution table.</td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -435,6 +435,12 @@
             <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
         </tr>
         <tr>
+            <td><h5>data-evolution.compaction.blob.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to compact blob files when compacting a data evolution table.</td>
+        </tr>
+        <tr>
             <td><h5>data-evolution.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2224,6 +2224,13 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_COMPACTION_BLOB_ENABLED =
+            key("data-evolution.compaction.blob.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to compact blob files when compacting a data evolution table.");
+
     public static final ConfigOption<Boolean> SNAPSHOT_IGNORE_EMPTY_COMMIT =
             key("snapshot.ignore-empty-commit")
                     .booleanType()
@@ -3688,6 +3695,10 @@ public class CoreOptions implements Serializable {
 
     public boolean dataEvolutionEnabled() {
         return options.get(DATA_EVOLUTION_ENABLED);
+    }
+
+    public boolean dataEvolutionCompactionBlobEnabled() {
+        return options.get(DATA_EVOLUTION_COMPACTION_BLOB_ENABLED);
     }
 
     public boolean prepareCommitWaitCompaction() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2224,8 +2224,8 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
-    public static final ConfigOption<Boolean> DATA_EVOLUTION_COMPACTION_BLOB_ENABLED =
-            key("data-evolution.compaction.blob.enabled")
+    public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
+            key("blob-compaction.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
@@ -3697,8 +3697,8 @@ public class CoreOptions implements Serializable {
         return options.get(DATA_EVOLUTION_ENABLED);
     }
 
-    public boolean dataEvolutionCompactionBlobEnabled() {
-        return options.get(DATA_EVOLUTION_COMPACTION_BLOB_ENABLED);
+    public boolean blobCompactionEnabled() {
+        return options.get(BLOB_COMPACTION_ENABLED);
     }
 
     public boolean prepareCommitWaitCompaction() {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -40,7 +40,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +47,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.LongFunction;
+import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
@@ -93,15 +93,12 @@ public class DataEvolutionCompactCoordinator {
                         openFileCost,
                         compactMinFileNum,
                         schemaId -> table.schemaManager().schema(schemaId).logicalRowType(),
-                        compactBlob ? currentBlobFieldIds(table.rowType(), options) : null);
-    }
-
-    private static Set<Integer> currentBlobFieldIds(RowType rowType, CoreOptions options) {
-        Set<Integer> fieldIds = new HashSet<>();
-        for (String fieldName : fieldNamesInBlobFile(rowType, options.blobInlineField())) {
-            fieldIds.add(rowType.getField(fieldName).id());
-        }
-        return fieldIds;
+                        compactBlob
+                                ? fieldNamesInBlobFile(table.rowType(), options.blobInlineField())
+                                        .stream()
+                                        .map(fieldName -> table.rowType().getField(fieldName).id())
+                                        .collect(Collectors.toSet())
+                                : null);
     }
 
     public List<DataEvolutionCompactTask> plan() {
@@ -221,9 +218,7 @@ public class DataEvolutionCompactCoordinator {
             this.compactMinFileNum = compactMinFileNum;
             Map<Long, RowType> schemaCache = new HashMap<>();
             this.schemaFetcher =
-                    schemaId ->
-                            schemaCache.computeIfAbsent(
-                                    schemaId, schemaFetcher::apply);
+                    schemaId -> schemaCache.computeIfAbsent(schemaId, schemaFetcher::apply);
             this.currentBlobFieldIds = currentBlobFieldIds;
         }
 
@@ -454,7 +449,8 @@ public class DataEvolutionCompactCoordinator {
             for (DataFileMeta file : continuousFiles) {
                 taskFiles.add(file);
                 fileSize += file.fileSize();
-                if (fileSize >= blobTargetFileSize && taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
+                if (fileSize >= blobTargetFileSize
+                        && taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
                     result.add(taskFiles);
                     taskFiles = new ArrayList<>();
                     fileSize = 0L;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -312,8 +312,9 @@ public class DataEvolutionCompactCoordinator {
                     blobFiles.addAll(
                             dataFileToBlobFiles.getOrDefault(dataFile, Collections.emptyList()));
                 }
-                if (blobFiles.size() >= compactMinFileNum) {
-                    tasks.add(new DataEvolutionCompactTask(partition, blobFiles, true));
+                List<DataFileMeta> blobFilesToCompact = blobFilesToCompact(blobFiles);
+                if (!blobFilesToCompact.isEmpty()) {
+                    tasks.add(new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
                 }
             }
 
@@ -329,6 +330,27 @@ public class DataEvolutionCompactCoordinator {
                 }
             }
             return tasks;
+        }
+
+        private List<DataFileMeta> blobFilesToCompact(List<DataFileMeta> blobFiles) {
+            if (blobFiles.size() < compactMinFileNum) {
+                return Collections.emptyList();
+            }
+
+            Map<List<String>, List<DataFileMeta>> writeColsToFiles = new LinkedHashMap<>();
+            for (DataFileMeta blobFile : blobFiles) {
+                writeColsToFiles
+                        .computeIfAbsent(blobFile.writeCols(), key -> new ArrayList<>())
+                        .add(blobFile);
+            }
+
+            List<DataFileMeta> result = new ArrayList<>();
+            for (List<DataFileMeta> files : writeColsToFiles.values()) {
+                if (files.size() >= compactMinFileNum) {
+                    result.addAll(files);
+                }
+            }
+            return result;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -222,7 +222,7 @@ public class DataEvolutionCompactCoordinator {
             this.schemaFetcher =
                     schemaId ->
                             schemaCache.computeIfAbsent(
-                                    schemaId, id -> schemaFetcher.apply(id));
+                                    schemaId, schemaFetcher::apply);
             this.currentBlobFieldIds = currentBlobFieldIds;
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.LongFunction;
 
+import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
 import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
@@ -87,6 +88,7 @@ public class DataEvolutionCompactCoordinator {
                         compactBlob,
                         compactVector,
                         targetFileSize,
+                        options.blobTargetFileSize(),
                         openFileCost,
                         compactMinFileNum,
                         schemaId -> table.schemaManager().schema(schemaId).logicalRowType(),
@@ -156,6 +158,7 @@ public class DataEvolutionCompactCoordinator {
         private final boolean compactBlob;
         private final boolean compactVector;
         private final long targetFileSize;
+        private final long blobTargetFileSize;
         private final long openFileCost;
         private final long compactMinFileNum;
         private final LongFunction<RowType> schemaFetcher;
@@ -170,6 +173,7 @@ public class DataEvolutionCompactCoordinator {
             this(
                     compactBlob,
                     compactVector,
+                    targetFileSize,
                     targetFileSize,
                     openFileCost,
                     compactMinFileNum,
@@ -191,6 +195,7 @@ public class DataEvolutionCompactCoordinator {
                     compactBlob,
                     compactVector,
                     targetFileSize,
+                    targetFileSize,
                     openFileCost,
                     compactMinFileNum,
                     schemaFetcher,
@@ -205,9 +210,30 @@ public class DataEvolutionCompactCoordinator {
                 long compactMinFileNum,
                 LongFunction<RowType> schemaFetcher,
                 @Nullable Set<Integer> currentBlobFieldIds) {
+            this(
+                    compactBlob,
+                    compactVector,
+                    targetFileSize,
+                    targetFileSize,
+                    openFileCost,
+                    compactMinFileNum,
+                    schemaFetcher,
+                    currentBlobFieldIds);
+        }
+
+        CompactPlanner(
+                boolean compactBlob,
+                boolean compactVector,
+                long targetFileSize,
+                long blobTargetFileSize,
+                long openFileCost,
+                long compactMinFileNum,
+                LongFunction<RowType> schemaFetcher,
+                @Nullable Set<Integer> currentBlobFieldIds) {
             this.compactBlob = compactBlob;
             this.compactVector = compactVector;
             this.targetFileSize = targetFileSize;
+            this.blobTargetFileSize = blobTargetFileSize;
             this.openFileCost = openFileCost;
             this.compactMinFileNum = compactMinFileNum;
             this.schemaFetcher = schemaFetcher;
@@ -403,11 +429,59 @@ public class DataEvolutionCompactCoordinator {
 
             List<List<DataFileMeta>> result = new ArrayList<>();
             for (List<DataFileMeta> files : fieldIdToFiles.values()) {
-                if (files.size() >= compactMinFileNum) {
-                    result.add(files);
-                }
+                result.addAll(fileGroupsToCompact(files));
             }
             return result;
+        }
+
+        private List<List<DataFileMeta>> fileGroupsToCompact(List<DataFileMeta> files) {
+            List<List<DataFileMeta>> result = new ArrayList<>();
+            List<DataFileMeta> sortedFiles = new ArrayList<>(files);
+            sortedFiles.sort(comparingLong(DataFileMeta::nonNullFirstRowId));
+
+            List<DataFileMeta> continuousFiles = new ArrayList<>();
+            long expectedFirstRowId = -1;
+            for (DataFileMeta file : sortedFiles) {
+                if (file.fileSize() >= blobTargetFileSize) {
+                    addFileGroupsToCompact(result, continuousFiles);
+                    continuousFiles.clear();
+                    expectedFirstRowId = -1;
+                    continue;
+                }
+
+                long firstRowId = file.nonNullFirstRowId();
+                if (!continuousFiles.isEmpty() && firstRowId != expectedFirstRowId) {
+                    addFileGroupsToCompact(result, continuousFiles);
+                    continuousFiles.clear();
+                }
+                continuousFiles.add(file);
+                expectedFirstRowId = firstRowId + file.rowCount();
+            }
+            addFileGroupsToCompact(result, continuousFiles);
+            return result;
+        }
+
+        private void addFileGroupsToCompact(
+                List<List<DataFileMeta>> result, List<DataFileMeta> continuousFiles) {
+            if (continuousFiles.size() < compactMinFileNum) {
+                return;
+            }
+
+            List<DataFileMeta> taskFiles = new ArrayList<>();
+            long fileSize = 0L;
+            for (DataFileMeta file : continuousFiles) {
+                taskFiles.add(file);
+                fileSize += file.fileSize();
+                if (fileSize >= blobTargetFileSize && taskFiles.size() >= compactMinFileNum) {
+                    result.add(taskFiles);
+                    taskFiles = new ArrayList<>();
+                    fileSize = 0L;
+                }
+            }
+
+            if (taskFiles.size() >= compactMinFileNum) {
+                result.add(taskFiles);
+            }
         }
 
         private int blobFieldId(DataFileMeta blobFile) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -60,6 +60,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class DataEvolutionCompactCoordinator {
 
     private static final int FILES_BATCH = 100_000;
+    private static final int BLOB_COMPACT_MIN_FILE_NUM = 2;
 
     private final CompactScanner scanner;
     private final CompactPlanner planner;
@@ -445,23 +446,22 @@ public class DataEvolutionCompactCoordinator {
 
         private void addFileGroupsToCompact(
                 List<List<DataFileMeta>> result, List<DataFileMeta> continuousFiles) {
-            if (continuousFiles.size() < compactMinFileNum) {
+            if (continuousFiles.size() < BLOB_COMPACT_MIN_FILE_NUM) {
                 return;
             }
-
             List<DataFileMeta> taskFiles = new ArrayList<>();
             long fileSize = 0L;
             for (DataFileMeta file : continuousFiles) {
                 taskFiles.add(file);
                 fileSize += file.fileSize();
-                if (fileSize >= blobTargetFileSize && taskFiles.size() >= compactMinFileNum) {
+                if (fileSize >= blobTargetFileSize && taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
                     result.add(taskFiles);
                     taskFiles = new ArrayList<>();
                     fileSize = 0L;
                 }
             }
 
-            if (taskFiles.size() >= compactMinFileNum) {
+            if (taskFiles.size() >= BLOB_COMPACT_MIN_FILE_NUM) {
                 result.add(taskFiles);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
@@ -52,7 +53,7 @@ import java.util.stream.Collectors;
 import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
-import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
+import static org.apache.paimon.types.DataTypeRoot.BLOB;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -79,6 +80,7 @@ public class DataEvolutionCompactCoordinator {
         long targetFileSize = options.targetFileSize(false);
         long openFileCost = options.splitOpenFileCost();
         long compactMinFileNum = options.compactionMinFileNum();
+        Set<String> blobInlineFields = options.blobInlineField();
 
         this.scanner =
                 new CompactScanner(
@@ -94,9 +96,13 @@ public class DataEvolutionCompactCoordinator {
                         compactMinFileNum,
                         schemaId -> table.schemaManager().schema(schemaId).logicalRowType(),
                         compactBlob
-                                ? fieldNamesInBlobFile(table.rowType(), options.blobInlineField())
-                                        .stream()
-                                        .map(fieldName -> table.rowType().getField(fieldName).id())
+                                ? table.rowType().getFields().stream()
+                                        .filter(
+                                                field ->
+                                                        field.type().is(BLOB)
+                                                                && !blobInlineFields.contains(
+                                                                        field.name()))
+                                        .map(DataField::id)
                                         .collect(Collectors.toSet())
                                 : null);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.paimon.append.dataevolution;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -168,6 +169,7 @@ public class DataEvolutionCompactCoordinator {
         private final LongFunction<RowType> schemaFetcher;
         @Nullable private final Set<Integer> currentBlobFieldIds;
 
+        @VisibleForTesting
         CompactPlanner(
                 boolean compactBlob,
                 boolean compactVector,
@@ -186,25 +188,6 @@ public class DataEvolutionCompactCoordinator {
                                 "Schema fetcher is required for blob compaction.");
                     },
                     null);
-        }
-
-        CompactPlanner(
-                boolean compactBlob,
-                boolean compactVector,
-                long targetFileSize,
-                long openFileCost,
-                long compactMinFileNum,
-                LongFunction<RowType> schemaFetcher,
-                @Nullable Set<Integer> currentBlobFieldIds) {
-            this(
-                    compactBlob,
-                    compactVector,
-                    targetFileSize,
-                    targetFileSize,
-                    openFileCost,
-                    compactMinFileNum,
-                    schemaFetcher,
-                    currentBlobFieldIds);
         }
 
         CompactPlanner(

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
 
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.TreeMap;
+import java.util.function.LongFunction;
 
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
@@ -83,7 +85,8 @@ public class DataEvolutionCompactCoordinator {
                         compactVector,
                         targetFileSize,
                         openFileCost,
-                        compactMinFileNum);
+                        compactMinFileNum,
+                        schemaId -> table.schemaManager().schema(schemaId).logicalRowType());
     }
 
     public List<DataEvolutionCompactTask> plan() {
@@ -143,6 +146,7 @@ public class DataEvolutionCompactCoordinator {
         private final long targetFileSize;
         private final long openFileCost;
         private final long compactMinFileNum;
+        private final LongFunction<RowType> schemaFetcher;
 
         CompactPlanner(
                 boolean compactBlob,
@@ -150,11 +154,31 @@ public class DataEvolutionCompactCoordinator {
                 long targetFileSize,
                 long openFileCost,
                 long compactMinFileNum) {
+            this(
+                    compactBlob,
+                    compactVector,
+                    targetFileSize,
+                    openFileCost,
+                    compactMinFileNum,
+                    schemaId -> {
+                        throw new IllegalStateException(
+                                "Schema fetcher is required for blob compaction.");
+                    });
+        }
+
+        CompactPlanner(
+                boolean compactBlob,
+                boolean compactVector,
+                long targetFileSize,
+                long openFileCost,
+                long compactMinFileNum,
+                LongFunction<RowType> schemaFetcher) {
             this.compactBlob = compactBlob;
             this.compactVector = compactVector;
             this.targetFileSize = targetFileSize;
             this.openFileCost = openFileCost;
             this.compactMinFileNum = compactMinFileNum;
+            this.schemaFetcher = schemaFetcher;
         }
 
         List<DataEvolutionCompactTask> compactPlan(List<ManifestEntry> input) {
@@ -337,20 +361,28 @@ public class DataEvolutionCompactCoordinator {
                 return Collections.emptyList();
             }
 
-            Map<List<String>, List<DataFileMeta>> writeColsToFiles = new LinkedHashMap<>();
+            Map<Integer, List<DataFileMeta>> fieldIdToFiles = new LinkedHashMap<>();
             for (DataFileMeta blobFile : blobFiles) {
-                writeColsToFiles
-                        .computeIfAbsent(blobFile.writeCols(), key -> new ArrayList<>())
+                fieldIdToFiles.computeIfAbsent(blobFieldId(blobFile), key -> new ArrayList<>())
                         .add(blobFile);
             }
 
             List<DataFileMeta> result = new ArrayList<>();
-            for (List<DataFileMeta> files : writeColsToFiles.values()) {
+            for (List<DataFileMeta> files : fieldIdToFiles.values()) {
                 if (files.size() >= compactMinFileNum) {
                     result.addAll(files);
                 }
             }
             return result;
+        }
+
+        private int blobFieldId(DataFileMeta blobFile) {
+            checkArgument(
+                    blobFile.writeCols() != null && blobFile.writeCols().size() == 1,
+                    "Blob file %s should contain exactly one write column.",
+                    blobFile);
+            RowType rowType = schemaFetcher.apply(blobFile.schemaId());
+            return rowType.getField(blobFile.writeCols().get(0)).id();
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -190,24 +190,6 @@ public class DataEvolutionCompactCoordinator {
                 long targetFileSize,
                 long openFileCost,
                 long compactMinFileNum,
-                LongFunction<RowType> schemaFetcher) {
-            this(
-                    compactBlob,
-                    compactVector,
-                    targetFileSize,
-                    targetFileSize,
-                    openFileCost,
-                    compactMinFileNum,
-                    schemaFetcher,
-                    null);
-        }
-
-        CompactPlanner(
-                boolean compactBlob,
-                boolean compactVector,
-                long targetFileSize,
-                long openFileCost,
-                long compactMinFileNum,
                 LongFunction<RowType> schemaFetcher,
                 @Nullable Set<Integer> currentBlobFieldIds) {
             this(
@@ -236,7 +218,11 @@ public class DataEvolutionCompactCoordinator {
             this.blobTargetFileSize = blobTargetFileSize;
             this.openFileCost = openFileCost;
             this.compactMinFileNum = compactMinFileNum;
-            this.schemaFetcher = schemaFetcher;
+            Map<Long, RowType> schemaCache = new HashMap<>();
+            this.schemaFetcher =
+                    schemaId ->
+                            schemaCache.computeIfAbsent(
+                                    schemaId, id -> schemaFetcher.apply(id));
             this.currentBlobFieldIds = currentBlobFieldIds;
         }
 
@@ -415,10 +401,6 @@ public class DataEvolutionCompactCoordinator {
         }
 
         private List<List<DataFileMeta>> blobFileGroupsToCompact(List<DataFileMeta> blobFiles) {
-            if (blobFiles.size() < compactMinFileNum) {
-                return Collections.emptyList();
-            }
-
             Map<Integer, List<DataFileMeta>> fieldIdToFiles = new LinkedHashMap<>();
             for (DataFileMeta blobFile : blobFiles) {
                 int fieldId = blobFieldId(blobFile);

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -40,15 +40,18 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.LongFunction;
 
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
+import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -86,7 +89,16 @@ public class DataEvolutionCompactCoordinator {
                         targetFileSize,
                         openFileCost,
                         compactMinFileNum,
-                        schemaId -> table.schemaManager().schema(schemaId).logicalRowType());
+                        schemaId -> table.schemaManager().schema(schemaId).logicalRowType(),
+                        compactBlob ? currentBlobFieldIds(table.rowType(), options) : null);
+    }
+
+    private static Set<Integer> currentBlobFieldIds(RowType rowType, CoreOptions options) {
+        Set<Integer> fieldIds = new HashSet<>();
+        for (String fieldName : fieldNamesInBlobFile(rowType, options.blobInlineField())) {
+            fieldIds.add(rowType.getField(fieldName).id());
+        }
+        return fieldIds;
     }
 
     public List<DataEvolutionCompactTask> plan() {
@@ -147,6 +159,7 @@ public class DataEvolutionCompactCoordinator {
         private final long openFileCost;
         private final long compactMinFileNum;
         private final LongFunction<RowType> schemaFetcher;
+        @Nullable private final Set<Integer> currentBlobFieldIds;
 
         CompactPlanner(
                 boolean compactBlob,
@@ -163,7 +176,8 @@ public class DataEvolutionCompactCoordinator {
                     schemaId -> {
                         throw new IllegalStateException(
                                 "Schema fetcher is required for blob compaction.");
-                    });
+                    },
+                    null);
         }
 
         CompactPlanner(
@@ -173,12 +187,31 @@ public class DataEvolutionCompactCoordinator {
                 long openFileCost,
                 long compactMinFileNum,
                 LongFunction<RowType> schemaFetcher) {
+            this(
+                    compactBlob,
+                    compactVector,
+                    targetFileSize,
+                    openFileCost,
+                    compactMinFileNum,
+                    schemaFetcher,
+                    null);
+        }
+
+        CompactPlanner(
+                boolean compactBlob,
+                boolean compactVector,
+                long targetFileSize,
+                long openFileCost,
+                long compactMinFileNum,
+                LongFunction<RowType> schemaFetcher,
+                @Nullable Set<Integer> currentBlobFieldIds) {
             this.compactBlob = compactBlob;
             this.compactVector = compactVector;
             this.targetFileSize = targetFileSize;
             this.openFileCost = openFileCost;
             this.compactMinFileNum = compactMinFileNum;
             this.schemaFetcher = schemaFetcher;
+            this.currentBlobFieldIds = currentBlobFieldIds;
         }
 
         List<DataEvolutionCompactTask> compactPlan(List<ManifestEntry> input) {
@@ -336,8 +369,7 @@ public class DataEvolutionCompactCoordinator {
                     blobFiles.addAll(
                             dataFileToBlobFiles.getOrDefault(dataFile, Collections.emptyList()));
                 }
-                List<DataFileMeta> blobFilesToCompact = blobFilesToCompact(blobFiles);
-                if (!blobFilesToCompact.isEmpty()) {
+                for (List<DataFileMeta> blobFilesToCompact : blobFileGroupsToCompact(blobFiles)) {
                     tasks.add(new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
                 }
             }
@@ -356,21 +388,23 @@ public class DataEvolutionCompactCoordinator {
             return tasks;
         }
 
-        private List<DataFileMeta> blobFilesToCompact(List<DataFileMeta> blobFiles) {
+        private List<List<DataFileMeta>> blobFileGroupsToCompact(List<DataFileMeta> blobFiles) {
             if (blobFiles.size() < compactMinFileNum) {
                 return Collections.emptyList();
             }
 
             Map<Integer, List<DataFileMeta>> fieldIdToFiles = new LinkedHashMap<>();
             for (DataFileMeta blobFile : blobFiles) {
-                fieldIdToFiles.computeIfAbsent(blobFieldId(blobFile), key -> new ArrayList<>())
-                        .add(blobFile);
+                int fieldId = blobFieldId(blobFile);
+                if (currentBlobFieldIds == null || currentBlobFieldIds.contains(fieldId)) {
+                    fieldIdToFiles.computeIfAbsent(fieldId, key -> new ArrayList<>()).add(blobFile);
+                }
             }
 
-            List<DataFileMeta> result = new ArrayList<>();
+            List<List<DataFileMeta>> result = new ArrayList<>();
             for (List<DataFileMeta> files : fieldIdToFiles.values()) {
                 if (files.size() >= compactMinFileNum) {
-                    result.addAll(files);
+                    result.add(files);
                 }
             }
             return result;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -183,6 +183,10 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         table = table.copy(DYNAMIC_WRITE_OPTIONS);
         CoreOptions options = table.coreOptions();
         RowType blobWriteType = blobWriteType(table, options);
+        if (blobWriteType.getFields().isEmpty()) {
+            return deleteOnlyCompactMessage();
+        }
+
         AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
         DataFilePathFactory pathFactory =
                 store.pathFactory().createDataFilePathFactory(partition, 0);
@@ -249,6 +253,18 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
 
+    private CommitMessage deleteOnlyCompactMessage() {
+        CompactIncrement compactIncrement =
+                new CompactIncrement(
+                        compactBefore,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+        return new CommitMessageImpl(
+                partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
+    }
+
     private RowType blobWriteType(FileStoreTable table, CoreOptions options) {
         Set<Integer> blobFieldIds = new HashSet<>();
         for (DataFileMeta file : compactBefore) {
@@ -265,7 +281,6 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                         .map(table.rowType()::getField)
                         .filter(field -> blobFieldIds.contains(field.id()))
                         .collect(Collectors.toList());
-        checkArgument(!fields.isEmpty(), "Cannot find blob fields for compaction task %s.", this);
         return new RowType(fields);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -21,16 +21,22 @@ package org.apache.paimon.append.dataevolution;
 import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.append.AppendCompactTask;
-import org.apache.paimon.append.MultipleBlobFileWriter;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fileindex.FileIndexOptions;
+import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.io.FileWriter;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.io.RowDataFileWriter;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.operation.AppendFileStoreWrite;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.statistics.NoneSimpleColStatsCollector;
+import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
@@ -48,13 +54,13 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
 import static org.apache.paimon.types.VectorType.fieldNamesInVectorFile;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
@@ -180,9 +186,16 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
     private CommitMessage doCompactBlobFiles(FileStoreTable table, String commitUser)
             throws Exception {
-        table = table.copy(DYNAMIC_WRITE_OPTIONS);
         CoreOptions options = table.coreOptions();
-        RowType blobWriteType = blobWriteType(table, options);
+        List<DataFileMeta> sortedCompactBefore = sortedByFirstRowId(compactBefore);
+        DataField blobField = blobField(table, options, sortedCompactBefore);
+        checkRowIdsContinuous(sortedCompactBefore, "Blob compact before files");
+        checkArgument(
+                sortedCompactBefore.size() > 1,
+                "Blob compaction task %s should contain at least two files to compact.",
+                this);
+
+        RowType blobWriteType = new RowType(Collections.singletonList(blobField));
 
         AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
         DataFilePathFactory pathFactory =
@@ -192,25 +205,14 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                 DataSplit.builder()
                         .withPartition(partition)
                         .withBucket(0)
-                        .withDataFiles(compactBefore)
+                        .withDataFiles(sortedCompactBefore)
                         .withBucketPath(pathFactory.parent().toString())
                         .rawConvertible(false)
                         .build();
         RecordReader<InternalRow> reader =
                 store.newDataEvolutionRead().withReadType(blobWriteType).createReader(dataSplit);
-        MultipleBlobFileWriter writer =
-                new MultipleBlobFileWriter(
-                        table.fileIO(),
-                        table.schema().id(),
-                        blobWriteType,
-                        pathFactory,
-                        () -> new LongCounter(0),
-                        FileSource.COMPACT,
-                        false,
-                        options.statsDenseStore(),
-                        options.blobTargetFileSize(),
-                        null,
-                        options.blobInlineField());
+        FileWriter<InternalRow, DataFileMeta> writer =
+                createBlobFileWriter(table, options, blobWriteType, blobField.name(), pathFactory);
 
         try {
             reader.forEachRemaining(
@@ -227,21 +229,21 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
             throw e;
         }
 
-        List<DataFileMeta> compactAfter = new ArrayList<>();
-        long firstRowId = compactBefore.get(0).nonNullFirstRowId();
-        long minSequenceId = minSequenceId();
-        long maxSequenceId = maxSequenceId();
-        for (DataFileMeta file : writer.result()) {
-            compactAfter.add(
-                    file.assignFirstRowId(firstRowId)
-                            .assignSequenceNumber(minSequenceId, maxSequenceId));
-        }
+        long firstRowId = sortedCompactBefore.get(0).nonNullFirstRowId();
+        long minSequenceId = minSequenceId(sortedCompactBefore);
+        long maxSequenceId = maxSequenceId(sortedCompactBefore);
+        DataFileMeta compactedFile =
+                writer.result()
+                        .assignFirstRowId(firstRowId)
+                        .assignSequenceNumber(minSequenceId, maxSequenceId);
+        compactAfter.add(compactedFile);
         checkArgument(
                 !compactAfter.isEmpty(), "Blob file compaction should produce at least one file.");
+        checkRowIdsContinuous(compactAfter, "Blob compact after files");
 
         CompactIncrement compactIncrement =
                 new CompactIncrement(
-                        compactBefore,
+                        sortedCompactBefore,
                         compactAfter,
                         Collections.emptyList(),
                         Collections.emptyList(),
@@ -250,28 +252,92 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
 
-    private RowType blobWriteType(FileStoreTable table, CoreOptions options) {
-        Set<Integer> blobFieldIds = new HashSet<>();
-        for (DataFileMeta file : compactBefore) {
+    private FileWriter<InternalRow, DataFileMeta> createBlobFileWriter(
+            FileStoreTable table,
+            CoreOptions options,
+            RowType blobWriteType,
+            String blobFieldName,
+            DataFilePathFactory pathFactory) {
+        BlobFileFormat blobFileFormat = new BlobFileFormat();
+        return new RowDataFileWriter(
+                table.fileIO(),
+                RollingFileWriter.createFileWriterContext(
+                        blobFileFormat,
+                        blobWriteType,
+                        new SimpleColStatsCollector.Factory[] {NoneSimpleColStatsCollector::new},
+                        "none"),
+                pathFactory.newBlobPath(),
+                blobWriteType,
+                table.schema().id(),
+                () -> new LongCounter(0),
+                new FileIndexOptions(),
+                FileSource.COMPACT,
+                false,
+                options.statsDenseStore(),
+                pathFactory.isExternalPath(),
+                Collections.singletonList(blobFieldName));
+    }
+
+    private List<DataFileMeta> sortedByFirstRowId(List<DataFileMeta> files) {
+        List<DataFileMeta> sorted = new ArrayList<>(files);
+        sorted.sort(comparingLong(DataFileMeta::nonNullFirstRowId));
+        return sorted;
+    }
+
+    private DataField blobField(
+            FileStoreTable table, CoreOptions options, List<DataFileMeta> files) {
+        Integer blobFieldId = null;
+        for (DataFileMeta file : files) {
             checkArgument(
                     file.writeCols() != null && file.writeCols().size() == 1,
                     "Blob file %s should contain exactly one write column.",
                     file);
             RowType fileRowType = table.schemaManager().schema(file.schemaId()).logicalRowType();
-            blobFieldIds.add(fileRowType.getField(file.writeCols().get(0)).id());
+            int currentFieldId = fileRowType.getField(file.writeCols().get(0)).id();
+            if (blobFieldId == null) {
+                blobFieldId = currentFieldId;
+            } else {
+                checkArgument(
+                        blobFieldId == currentFieldId,
+                        "Blob compact before files %s should contain the same field.",
+                        files);
+            }
         }
 
-        List<DataField> fields =
-                fieldNamesInBlobFile(table.rowType(), options.blobInlineField()).stream()
-                        .map(table.rowType()::getField)
-                        .filter(field -> blobFieldIds.contains(field.id()))
-                        .collect(Collectors.toList());
-        checkArgument(!fields.isEmpty(), "Cannot find blob fields for compaction task %s.", this);
-        return new RowType(fields);
+        checkArgument(blobFieldId != null, "Blob compaction task should not be empty.");
+        checkArgument(
+                table.rowType().containsField(blobFieldId),
+                "Cannot find blob field id %s in latest schema for compaction task %s.",
+                blobFieldId,
+                this);
+        DataField field = table.rowType().getField(blobFieldId);
+        Set<String> blobFieldNames =
+                fieldNamesInBlobFile(table.rowType(), options.blobInlineField());
+        checkArgument(
+                blobFieldNames.contains(field.name()),
+                "Field %s in latest schema is not a blob file field.",
+                field.name());
+        return field;
     }
 
-    private long minSequenceId() {
-        return compactBefore.stream()
+    private void checkRowIdsContinuous(List<DataFileMeta> files, String description) {
+        checkArgument(!files.isEmpty(), "%s should not be empty.", description);
+        long expectedFirstRowId = files.get(0).nonNullFirstRowId();
+        for (DataFileMeta file : files) {
+            long firstRowId = file.nonNullFirstRowId();
+            checkArgument(
+                    firstRowId == expectedFirstRowId,
+                    "%s should be continuous and sorted by row id, expected %s but got %s in file %s.",
+                    description,
+                    expectedFirstRowId,
+                    firstRowId,
+                    file);
+            expectedFirstRowId += file.rowCount();
+        }
+    }
+
+    private long minSequenceId(List<DataFileMeta> files) {
+        return files.stream()
                 .mapToLong(DataFileMeta::minSequenceNumber)
                 .min()
                 .orElseThrow(
@@ -280,8 +346,8 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                                         "Cannot get min sequence id from compact before files."));
     }
 
-    private long maxSequenceId() {
-        return compactBefore.stream()
+    private long maxSequenceId(List<DataFileMeta> files) {
+        return files.stream()
                 .mapToLong(DataFileMeta::maxSequenceNumber)
                 .max()
                 .orElseThrow(

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -72,6 +72,8 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionCompactTask.class);
 
     private static final Map<String, String> DYNAMIC_WRITE_OPTIONS = dynamicWriteOptions();
+    private static final Map<String, String> BLOB_COMPACT_READ_OPTIONS =
+            Collections.singletonMap(CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true");
 
     private static Map<String, String> dynamicWriteOptions() {
         Map<String, String> options = new HashMap<>();
@@ -197,7 +199,8 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
         RowType blobWriteType = new RowType(Collections.singletonList(blobField));
 
-        AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
+        FileStoreTable readTable = table.copy(BLOB_COMPACT_READ_OPTIONS);
+        AppendOnlyFileStore store = (AppendOnlyFileStore) readTable.store();
         DataFilePathFactory pathFactory =
                 store.pathFactory().createDataFilePathFactory(partition, 0);
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -21,26 +21,34 @@ package org.apache.paimon.append.dataevolution;
 import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.append.AppendCompactTask;
+import org.apache.paimon.append.MultipleBlobFileWriter;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.operation.AppendFileStoreWrite;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.RecordWriter;
 import org.apache.paimon.utils.SetUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,8 +65,14 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionCompactTask.class);
 
-    private static final Map<String, String> DYNAMIC_WRITE_OPTIONS =
-            Collections.singletonMap(CoreOptions.TARGET_FILE_SIZE.key(), "99999 G");
+    private static final Map<String, String> DYNAMIC_WRITE_OPTIONS = dynamicWriteOptions();
+
+    private static Map<String, String> dynamicWriteOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.TARGET_FILE_SIZE.key(), "99999 G");
+        options.put(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "99999 G");
+        return Collections.unmodifiableMap(options);
+    }
 
     private final boolean blobTask;
 
@@ -74,8 +88,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
     public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
         if (blobTask) {
-            // TODO: support blob file compaction
-            throw new UnsupportedOperationException("Blob task is not supported");
+            return doCompactBlobFiles(table, commitUser);
         }
         if (isVectorStoreFile(compactBefore.get(0).fileName())) {
             // TODO: support vector-store file compaction
@@ -163,6 +176,117 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                         Collections.emptyList());
         return new CommitMessageImpl(
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
+    }
+
+    private CommitMessage doCompactBlobFiles(FileStoreTable table, String commitUser)
+            throws Exception {
+        table = table.copy(DYNAMIC_WRITE_OPTIONS);
+        CoreOptions options = table.coreOptions();
+        RowType blobWriteType = blobWriteType(table, options);
+        AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
+        DataFilePathFactory pathFactory =
+                store.pathFactory().createDataFilePathFactory(partition, 0);
+
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withPartition(partition)
+                        .withBucket(0)
+                        .withDataFiles(compactBefore)
+                        .withBucketPath(pathFactory.parent().toString())
+                        .rawConvertible(false)
+                        .build();
+        RecordReader<InternalRow> reader =
+                store.newDataEvolutionRead().withReadType(blobWriteType).createReader(dataSplit);
+        MultipleBlobFileWriter writer =
+                new MultipleBlobFileWriter(
+                        table.fileIO(),
+                        table.schema().id(),
+                        blobWriteType,
+                        pathFactory,
+                        () -> new LongCounter(0),
+                        FileSource.COMPACT,
+                        false,
+                        options.statsDenseStore(),
+                        options.blobTargetFileSize(),
+                        null,
+                        options.blobInlineField());
+
+        try {
+            reader.forEachRemaining(
+                    row -> {
+                        try {
+                            writer.write(row);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+            writer.close();
+        } catch (Exception e) {
+            writer.abort();
+            throw e;
+        }
+
+        List<DataFileMeta> compactAfter = new ArrayList<>();
+        long firstRowId = compactBefore.get(0).nonNullFirstRowId();
+        long minSequenceId = minSequenceId();
+        long maxSequenceId = maxSequenceId();
+        for (DataFileMeta file : writer.result()) {
+            compactAfter.add(
+                    file.assignFirstRowId(firstRowId)
+                            .assignSequenceNumber(minSequenceId, maxSequenceId));
+        }
+        checkArgument(
+                !compactAfter.isEmpty(), "Blob file compaction should produce at least one file.");
+
+        CompactIncrement compactIncrement =
+                new CompactIncrement(
+                        compactBefore,
+                        compactAfter,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+        return new CommitMessageImpl(
+                partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
+    }
+
+    private RowType blobWriteType(FileStoreTable table, CoreOptions options) {
+        Set<Integer> blobFieldIds = new HashSet<>();
+        for (DataFileMeta file : compactBefore) {
+            checkArgument(
+                    file.writeCols() != null && file.writeCols().size() == 1,
+                    "Blob file %s should contain exactly one write column.",
+                    file);
+            RowType fileRowType = table.schemaManager().schema(file.schemaId()).logicalRowType();
+            blobFieldIds.add(fileRowType.getField(file.writeCols().get(0)).id());
+        }
+
+        List<DataField> fields =
+                fieldNamesInBlobFile(table.rowType(), options.blobInlineField()).stream()
+                        .map(table.rowType()::getField)
+                        .filter(field -> blobFieldIds.contains(field.id()))
+                        .collect(Collectors.toList());
+        checkArgument(!fields.isEmpty(), "Cannot find blob fields for compaction task %s.", this);
+        return new RowType(fields);
+    }
+
+    private long minSequenceId() {
+        return compactBefore.stream()
+                .mapToLong(DataFileMeta::minSequenceNumber)
+                .min()
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Cannot get min sequence id from compact before files."));
+    }
+
+    private long maxSequenceId() {
+        return compactBefore.stream()
+                .mapToLong(DataFileMeta::maxSequenceNumber)
+                .max()
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "Cannot get max sequence id from compact before files."));
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -296,8 +296,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
             RowType fileRowType =
                     schemaCache.computeIfAbsent(
                             file.schemaId(),
-                            schemaId ->
-                                    table.schemaManager().schema(schemaId).logicalRowType());
+                            schemaId -> table.schemaManager().schema(schemaId).logicalRowType());
             int currentFieldId = fileRowType.getField(file.writeCols().get(0)).id();
             if (blobFieldId == null) {
                 blobFieldId = currentFieldId;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -287,12 +287,17 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
     private DataField blobField(
             FileStoreTable table, CoreOptions options, List<DataFileMeta> files) {
         Integer blobFieldId = null;
+        Map<Long, RowType> schemaCache = new HashMap<>();
         for (DataFileMeta file : files) {
             checkArgument(
                     file.writeCols() != null && file.writeCols().size() == 1,
                     "Blob file %s should contain exactly one write column.",
                     file);
-            RowType fileRowType = table.schemaManager().schema(file.schemaId()).logicalRowType();
+            RowType fileRowType =
+                    schemaCache.computeIfAbsent(
+                            file.schemaId(),
+                            schemaId ->
+                                    table.schemaManager().schema(schemaId).logicalRowType());
             int currentFieldId = fileRowType.getField(file.writeCols().get(0)).id();
             if (blobFieldId == null) {
                 blobFieldId = currentFieldId;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -189,7 +189,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         CoreOptions options = table.coreOptions();
         List<DataFileMeta> sortedCompactBefore = sortedByFirstRowId(compactBefore);
         DataField blobField = blobField(table, options, sortedCompactBefore);
-        checkRowIdsContinuous(sortedCompactBefore, "Blob compact before files");
+        checkRowIdsContinuous(sortedCompactBefore);
         checkArgument(
                 sortedCompactBefore.size() > 1,
                 "Blob compaction task %s should contain at least two files to compact.",
@@ -237,9 +237,8 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                         .assignFirstRowId(firstRowId)
                         .assignSequenceNumber(minSequenceId, maxSequenceId);
         compactAfter.add(compactedFile);
-        checkArgument(
-                !compactAfter.isEmpty(), "Blob file compaction should produce at least one file.");
-        checkRowIdsContinuous(compactAfter, "Blob compact after files");
+        checkArgument(compactAfter.size() == 1, "Blob file compaction should produce one file.");
+        checkSameRowRange(sortedCompactBefore, compactAfter);
 
         CompactIncrement compactIncrement =
                 new CompactIncrement(
@@ -324,20 +323,46 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         return field;
     }
 
-    private void checkRowIdsContinuous(List<DataFileMeta> files, String description) {
-        checkArgument(!files.isEmpty(), "%s should not be empty.", description);
+    private void checkRowIdsContinuous(List<DataFileMeta> files) {
+        checkArgument(!files.isEmpty(), "%s should not be empty.", "Blob compact before files");
         long expectedFirstRowId = files.get(0).nonNullFirstRowId();
         for (DataFileMeta file : files) {
             long firstRowId = file.nonNullFirstRowId();
             checkArgument(
                     firstRowId == expectedFirstRowId,
                     "%s should be continuous and sorted by row id, expected %s but got %s in file %s.",
-                    description,
+                    "Blob compact before files",
                     expectedFirstRowId,
                     firstRowId,
                     file);
             expectedFirstRowId += file.rowCount();
         }
+    }
+
+    private void checkSameRowRange(
+            List<DataFileMeta> compactBefore, List<DataFileMeta> compactAfter) {
+        checkArgument(
+                !compactBefore.isEmpty(),
+                "%s compact before files should not be empty.",
+                "Blob compact files");
+        checkArgument(
+                !compactAfter.isEmpty(),
+                "%s compact after files should not be empty.",
+                "Blob compact files");
+        long beforeFirstRowId = compactBefore.get(0).nonNullFirstRowId();
+        long afterFirstRowId = compactAfter.get(0).nonNullFirstRowId();
+        long beforeRowCount = compactBefore.stream().mapToLong(DataFileMeta::rowCount).sum();
+        long afterRowCount = compactAfter.stream().mapToLong(DataFileMeta::rowCount).sum();
+        checkArgument(
+                beforeFirstRowId == afterFirstRowId && beforeRowCount == afterRowCount,
+                "%s compact after files should have the same row range as compact before files, "
+                        + "before first row id is %s with row count %s, "
+                        + "but after first row id is %s with row count %s.",
+                "Blob compact files",
+                beforeFirstRowId,
+                beforeRowCount,
+                afterFirstRowId,
+                afterRowCount);
     }
 
     private long minSequenceId(List<DataFileMeta> files) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -183,9 +183,6 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         table = table.copy(DYNAMIC_WRITE_OPTIONS);
         CoreOptions options = table.coreOptions();
         RowType blobWriteType = blobWriteType(table, options);
-        if (blobWriteType.getFields().isEmpty()) {
-            return deleteOnlyCompactMessage();
-        }
 
         AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
         DataFilePathFactory pathFactory =
@@ -253,18 +250,6 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
 
-    private CommitMessage deleteOnlyCompactMessage() {
-        CompactIncrement compactIncrement =
-                new CompactIncrement(
-                        compactBefore,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList());
-        return new CommitMessageImpl(
-                partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
-    }
-
     private RowType blobWriteType(FileStoreTable table, CoreOptions options) {
         Set<Integer> blobFieldIds = new HashSet<>();
         for (DataFileMeta file : compactBefore) {
@@ -281,6 +266,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                         .map(table.rowType()::getField)
                         .filter(field -> blobFieldIds.contains(field.id()))
                         .collect(Collectors.toList());
+        checkArgument(!fields.isEmpty(), "Cannot find blob fields for compaction task %s.", this);
         return new RowType(fields);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -211,7 +211,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 createReader(dataSplit, rowRanges, info.actualReadType), info);
     }
 
-    private DataEvolutionFileReader createUnionReader(
+    private RecordReader<InternalRow> createUnionReader(
             List<DataFileMeta> needMergeFiles,
             BinaryRow partition,
             DataFilePathFactory dataFilePathFactory,
@@ -232,6 +232,34 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
         long rowCount = fieldsFiles.get(0).rowCount();
         long firstRowId = fieldsFiles.get(0).files().get(0).nonNullFirstRowId();
+        if (fieldsFiles.size() == 1) {
+            FieldBunch bunch = fieldsFiles.get(0);
+            DataFileMeta firstFile = bunch.files().get(0);
+            String formatIdentifier = DataFilePathFactory.formatIdentifier(firstFile.fileName());
+            long schemaId = firstFile.schemaId();
+            TableSchema dataSchema = schemaFetcher.apply(schemaId).project(firstFile.writeCols());
+            List<String> readFieldNames =
+                    readRowType.getFields().stream()
+                            .map(DataField::name)
+                            .collect(Collectors.toList());
+            FormatReaderMapping formatReaderMapping =
+                    formatReaderMappings.computeIfAbsent(
+                            new FormatKey(schemaId, formatIdentifier, readFieldNames),
+                            key ->
+                                    formatBuilder.build(
+                                            formatIdentifier,
+                                            schema,
+                                            dataSchema,
+                                            readRowType.getFields(),
+                                            false));
+            return createFileReader(
+                    partition,
+                    bunch,
+                    dataFilePathFactory,
+                    formatReaderMapping,
+                    rowRanges,
+                    readRowType);
+        }
 
         if (rowRanges == null) {
             for (FieldBunch bunch : fieldsFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -440,7 +440,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             if (isBlobFile(file.fileName())) {
                 RowType rowType = fileToRowType.apply(file);
                 int fieldId = rowType.getField(file.writeCols().get(0)).id();
-                final long expectedRowCount = rowCount < 0 ? Long.MAX_VALUE : rowCount;
+                final long expectedRowCount = rowCount;
                 blobBunchMap
                         .computeIfAbsent(
                                 fieldId,
@@ -452,7 +452,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 VectorStoreBunchKey vectorStoreKey =
                         new VectorStoreBunchKey(
                                 file.schemaId(), fileFormat, file.writeCols(), rowType);
-                final long expectedRowCount = rowCount < 0 ? Long.MAX_VALUE : rowCount;
+                final long expectedRowCount = rowCount;
                 vectorStoreBunchMap
                         .computeIfAbsent(
                                 vectorStoreKey,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -232,34 +232,6 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
         long rowCount = fieldsFiles.get(0).rowCount();
         long firstRowId = fieldsFiles.get(0).files().get(0).nonNullFirstRowId();
-        if (fieldsFiles.size() == 1) {
-            FieldBunch bunch = fieldsFiles.get(0);
-            DataFileMeta firstFile = bunch.files().get(0);
-            String formatIdentifier = DataFilePathFactory.formatIdentifier(firstFile.fileName());
-            long schemaId = firstFile.schemaId();
-            TableSchema dataSchema = schemaFetcher.apply(schemaId).project(firstFile.writeCols());
-            List<String> readFieldNames =
-                    readRowType.getFields().stream()
-                            .map(DataField::name)
-                            .collect(Collectors.toList());
-            FormatReaderMapping formatReaderMapping =
-                    formatReaderMappings.computeIfAbsent(
-                            new FormatKey(schemaId, formatIdentifier, readFieldNames),
-                            key ->
-                                    formatBuilder.build(
-                                            formatIdentifier,
-                                            schema,
-                                            dataSchema,
-                                            readRowType.getFields(),
-                                            false));
-            return createFileReader(
-                    partition,
-                    bunch,
-                    dataFilePathFactory,
-                    formatReaderMapping,
-                    rowRanges,
-                    readRowType);
-        }
 
         if (rowRanges == null) {
             for (FieldBunch bunch : fieldsFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -440,7 +440,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             if (isBlobFile(file.fileName())) {
                 RowType rowType = fileToRowType.apply(file);
                 int fieldId = rowType.getField(file.writeCols().get(0)).id();
-                final long expectedRowCount = rowCount;
+                final long expectedRowCount = rowCount < 0 ? Long.MAX_VALUE : rowCount;
                 blobBunchMap
                         .computeIfAbsent(
                                 fieldId,
@@ -452,7 +452,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 VectorStoreBunchKey vectorStoreKey =
                         new VectorStoreBunchKey(
                                 file.schemaId(), fileFormat, file.writeCols(), rowType);
-                final long expectedRowCount = rowCount;
+                final long expectedRowCount = rowCount < 0 ? Long.MAX_VALUE : rowCount;
                 vectorStoreBunchMap
                         .computeIfAbsent(
                                 vectorStoreKey,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -211,7 +211,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
                 createReader(dataSplit, rowRanges, info.actualReadType), info);
     }
 
-    private RecordReader<InternalRow> createUnionReader(
+    private DataEvolutionFileReader createUnionReader(
             List<DataFileMeta> needMergeFiles,
             BinaryRow partition,
             DataFilePathFactory dataFilePathFactory,

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -92,12 +92,13 @@ public class MultipleBlobTableTest extends TableTestBase {
     public void testDataEvolutionBlobCompaction() throws Exception {
         createTableDefault();
 
-        commitDefault(writeDataDefault(1000, 1));
+        commitDefault(writeDataDefault(50, 20));
 
         FileStoreTable table = getTableDefault();
         List<DataFileMeta> before = currentDataFiles(table);
-        assertThat(before.stream().filter(file -> isBlobFile(file.fileName())).count())
-                .isEqualTo(20);
+        long beforeBlobFileCount =
+                before.stream().filter(file -> isBlobFile(file.fileName())).count();
+        assertThat(beforeBlobFileCount).isEqualTo(40);
 
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
@@ -111,7 +112,9 @@ public class MultipleBlobTableTest extends TableTestBase {
         commitDefault(compactMessages);
 
         List<DataFileMeta> after = currentDataFiles(table);
-        assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count()).isEqualTo(2);
+        long afterBlobFileCount =
+                after.stream().filter(file -> isBlobFile(file.fileName())).count();
+        assertThat(afterBlobFileCount).isLessThan(beforeBlobFileCount);
         coordinator = new DataEvolutionCompactCoordinator(table, true, false);
         assertThat(coordinator.plan().stream().anyMatch(DataEvolutionCompactTask::isBlobTask))
                 .isFalse();
@@ -170,7 +173,8 @@ public class MultipleBlobTableTest extends TableTestBase {
         schemaBuilder.column("f1", DataTypes.STRING());
         schemaBuilder.column("f2", DataTypes.BLOB());
         schemaBuilder.column("f3", DataTypes.BLOB());
-        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "25 MB");
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "25 MB");
         schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
         return schemaBuilder.build();

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -143,16 +143,11 @@ public class MultipleBlobTableTest extends TableTestBase {
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
-
-        List<CommitMessage> compactMessages = new ArrayList<>();
-        for (DataEvolutionCompactTask task : tasks) {
-            compactMessages.add(task.doCompact(table, commitUser));
-        }
-        commitDefault(compactMessages);
+        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isFalse();
 
         List<DataFileMeta> after = currentDataFiles(getTableDefault());
-        assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count()).isZero();
+        assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count())
+                .isEqualTo(20);
 
         AtomicInteger integer = new AtomicInteger(0);
         readDefault(

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.append;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.GenericRow;
@@ -29,15 +31,18 @@ import org.apache.paimon.operation.DataEvolutionSplitRead.FieldBunch;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.operation.DataEvolutionSplitRead.splitFieldBunches;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -79,6 +84,49 @@ public class MultipleBlobTableTest extends TableTestBase {
                 });
 
         assertThat(integer.get()).isEqualTo(1000);
+    }
+
+    @Test
+    public void testDataEvolutionBlobCompaction() throws Exception {
+        createTableDefault();
+
+        commitDefault(writeDataDefault(1000, 1));
+
+        FileStoreTable table = getTableDefault();
+        List<DataFileMeta> before = currentDataFiles(table);
+        assertThat(before.stream().filter(file -> isBlobFile(file.fileName())).count())
+                .isEqualTo(20);
+
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(table, true, false);
+        List<DataEvolutionCompactTask> tasks = coordinator.plan();
+        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+
+        List<CommitMessage> compactMessages = new ArrayList<>();
+        for (DataEvolutionCompactTask task : tasks) {
+            compactMessages.add(task.doCompact(table, commitUser));
+        }
+        commitDefault(compactMessages);
+
+        List<DataFileMeta> after = currentDataFiles(table);
+        assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count()).isEqualTo(2);
+
+        AtomicInteger integer = new AtomicInteger(0);
+        readDefault(
+                row -> {
+                    integer.incrementAndGet();
+                    if (integer.get() % 50 == 0) {
+                        assertThat(row.getBlob(2).toData()).isEqualTo(blobBytes1);
+                        assertThat(row.getBlob(3).toData()).isEqualTo(blobBytes2);
+                    }
+                });
+        assertThat(integer.get()).isEqualTo(1000);
+    }
+
+    private List<DataFileMeta> currentDataFiles(FileStoreTable table) {
+        return table.store().newScan().plan().files().stream()
+                .map(ManifestEntry::file)
+                .collect(Collectors.toList());
     }
 
     protected Schema schemaDefault() {

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -29,6 +29,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.operation.DataEvolutionSplitRead.FieldBunch;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -38,6 +39,7 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -110,6 +112,9 @@ public class MultipleBlobTableTest extends TableTestBase {
 
         List<DataFileMeta> after = currentDataFiles(table);
         assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count()).isEqualTo(2);
+        coordinator = new DataEvolutionCompactCoordinator(table, true, false);
+        assertThat(coordinator.plan().stream().anyMatch(DataEvolutionCompactTask::isBlobTask))
+                .isFalse();
 
         AtomicInteger integer = new AtomicInteger(0);
         readDefault(
@@ -119,6 +124,41 @@ public class MultipleBlobTableTest extends TableTestBase {
                         assertThat(row.getBlob(2).toData()).isEqualTo(blobBytes1);
                         assertThat(row.getBlob(3).toData()).isEqualTo(blobBytes2);
                     }
+                });
+        assertThat(integer.get()).isEqualTo(1000);
+    }
+
+    @Test
+    public void testDataEvolutionBlobCompactionAfterDropBlobColumns() throws Exception {
+        createTableDefault();
+
+        commitDefault(writeDataDefault(1000, 1));
+
+        catalog.alterTable(
+                identifier(),
+                Arrays.asList(SchemaChange.dropColumn("f2"), SchemaChange.dropColumn("f3")),
+                false);
+
+        FileStoreTable table = getTableDefault();
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(table, true, false);
+        List<DataEvolutionCompactTask> tasks = coordinator.plan();
+        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+
+        List<CommitMessage> compactMessages = new ArrayList<>();
+        for (DataEvolutionCompactTask task : tasks) {
+            compactMessages.add(task.doCompact(table, commitUser));
+        }
+        commitDefault(compactMessages);
+
+        List<DataFileMeta> after = currentDataFiles(getTableDefault());
+        assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count()).isZero();
+
+        AtomicInteger integer = new AtomicInteger(0);
+        readDefault(
+                row -> {
+                    integer.incrementAndGet();
+                    assertThat(row.getFieldCount()).isEqualTo(2);
                 });
         assertThat(integer.get()).isEqualTo(1000);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -183,6 +183,21 @@ public class DataEvolutionCompactCoordinatorTest {
     }
 
     @Test
+    public void testCompactPlannerSkipsSingleFilePerBlobField() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeBlobEntry("pic1.blob", 0L, 100L, 100, "pic1"));
+        entries.add(makeBlobEntry("pic2.blob", 0L, 100L, 100, "pic2"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                new DataEvolutionCompactCoordinator.CompactPlanner(true, false, 1024, 1024, 2);
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
     public void testPlanWithNullManifestRowId() {
         FileStoreTable table = mock(FileStoreTable.class);
         SnapshotReader snapshotReader = mock(SnapshotReader.class);
@@ -286,6 +301,11 @@ public class DataEvolutionCompactCoordinatorTest {
 
     private ManifestEntry makeBlobEntry(
             String fileName, long firstRowId, long rowCount, long fileSize) {
+        return makeBlobEntry(fileName, firstRowId, rowCount, fileSize, null);
+    }
+
+    private ManifestEntry makeBlobEntry(
+            String fileName, long firstRowId, long rowCount, long fileSize, String writeCol) {
         // Blob files have .blob extension
         String blobFileName = fileName.endsWith(".blob") ? fileName : fileName + ".blob";
         return ManifestEntry.create(
@@ -293,11 +313,27 @@ public class DataEvolutionCompactCoordinatorTest {
                 BinaryRow.EMPTY_ROW,
                 0,
                 0,
-                createDataFileMeta(blobFileName, firstRowId, rowCount, 0, fileSize));
+                createDataFileMeta(
+                        blobFileName,
+                        firstRowId,
+                        rowCount,
+                        0,
+                        fileSize,
+                        writeCol == null ? null : Collections.singletonList(writeCol)));
     }
 
     private DataFileMeta createDataFileMeta(
             String fileName, long firstRowId, long rowCount, long maxSeq, long fileSize) {
+        return createDataFileMeta(fileName, firstRowId, rowCount, maxSeq, fileSize, null);
+    }
+
+    private DataFileMeta createDataFileMeta(
+            String fileName,
+            long firstRowId,
+            long rowCount,
+            long maxSeq,
+            long fileSize,
+            List<String> writeCols) {
         return DataFileMeta.create(
                 fileName,
                 fileSize,
@@ -318,7 +354,7 @@ public class DataEvolutionCompactCoordinatorTest {
                 null,
                 null,
                 firstRowId,
-                null);
+                writeCols);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -165,11 +165,11 @@ public class DataEvolutionCompactCoordinatorTest {
         // Test blob file compaction when enabled
         List<ManifestEntry> entries = new ArrayList<>();
         entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
-        entries.add(makeBlobEntry("file1.blob", 0L, 100L, 100, "pic"));
-        entries.add(makeBlobEntry("file1b.blob", 0L, 100L, 100, "pic"));
+        entries.add(makeBlobEntry("file1.blob", 0L, 50L, 100, "pic"));
+        entries.add(makeBlobEntry("file1b.blob", 50L, 50L, 100, "pic"));
         entries.add(makeEntry("file2.parquet", 100L, 100L, 100));
-        entries.add(makeBlobEntry("file2.blob", 100L, 100L, 100, "pic"));
-        entries.add(makeBlobEntry("file2b.blob", 100L, 100L, 100, "pic"));
+        entries.add(makeBlobEntry("file2.blob", 100L, 50L, 100, "pic"));
+        entries.add(makeBlobEntry("file2b.blob", 150L, 50L, 100, "pic"));
 
         // Use small target to trigger compaction, with blob compaction enabled
         DataEvolutionCompactCoordinator.CompactPlanner planner =
@@ -242,11 +242,53 @@ public class DataEvolutionCompactCoordinatorTest {
     }
 
     @Test
+    public void testCompactPlannerSplitsBlobFilesByTargetSizeAndRowId() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 70L, 100));
+        entries.add(makeBlobEntry("a.blob", 0L, 10L, 400, "pic"));
+        entries.add(makeBlobEntry("b.blob", 10L, 10L, 400, "pic"));
+        entries.add(makeBlobEntry("c.blob", 20L, 10L, 1024, "pic"));
+        entries.add(makeBlobEntry("d.blob", 30L, 10L, 600, "pic"));
+        entries.add(makeBlobEntry("e.blob", 40L, 10L, 600, "pic"));
+        entries.add(makeBlobEntry("f.blob", 50L, 10L, 400, "pic"));
+        entries.add(makeBlobEntry("g.blob", 60L, 10L, 500, "pic"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks).allMatch(DataEvolutionCompactTask::isBlobTask);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(entries.get(1).file(), entries.get(2).file());
+        assertThat(tasks.get(1).compactBefore())
+                .containsExactly(entries.get(4).file(), entries.get(5).file());
+        assertThat(tasks.get(2).compactBefore())
+                .containsExactly(entries.get(6).file(), entries.get(7).file());
+    }
+
+    @Test
+    public void testCompactPlannerSkipsBlobGroupsWithTooFewSmallFiles() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 200L, 100));
+        entries.add(makeBlobEntry("large-pic.blob", 0L, 100L, 1024, "pic"));
+        entries.add(makeBlobEntry("small-pic.blob", 100L, 100L, 100, "pic"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
     public void testCompactPlannerGroupsBlobFilesByFieldId() {
         List<ManifestEntry> entries = new ArrayList<>();
-        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeEntry("file1.parquet", 0L, 200L, 100));
         entries.add(makeBlobEntry("old-pic.blob", 0L, 100L, 100, 0, "old_pic"));
-        entries.add(makeBlobEntry("new-pic.blob", 0L, 100L, 100, 1, "new_pic"));
+        entries.add(makeBlobEntry("new-pic.blob", 100L, 100L, 100, 1, "new_pic"));
 
         Map<Long, RowType> schemas = new HashMap<>();
         schemas.put(0L, rowType(new DataField(1, "old_pic", DataTypes.BLOB())));
@@ -438,8 +480,7 @@ public class DataEvolutionCompactCoordinatorTest {
             long maxSeq,
             long fileSize,
             List<String> writeCols) {
-        return createDataFileMeta(
-                fileName, firstRowId, rowCount, maxSeq, fileSize, 0, writeCols);
+        return createDataFileMeta(fileName, firstRowId, rowCount, maxSeq, fileSize, 0, writeCols);
     }
 
     private DataFileMeta createDataFileMeta(

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -48,8 +48,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.LongFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -210,6 +212,36 @@ public class DataEvolutionCompactCoordinatorTest {
     }
 
     @Test
+    public void testCompactPlannerCreatesOneBlobTaskPerField() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeBlobEntry("a1-1.blob", 0L, 50L, 100, "a1"));
+        entries.add(makeBlobEntry("a1-2.blob", 50L, 50L, 100, "a1"));
+        entries.add(makeBlobEntry("a2-1.blob", 0L, 30L, 100, "a2"));
+        entries.add(makeBlobEntry("a2-2.blob", 30L, 30L, 100, "a2"));
+        entries.add(makeBlobEntry("a2-3.blob", 60L, 40L, 100, "a2"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(
+                        1024,
+                        1024,
+                        2,
+                        rowType(
+                                new DataField(1, "a1", DataTypes.BLOB()),
+                                new DataField(2, "a2", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks).allMatch(DataEvolutionCompactTask::isBlobTask);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(entries.get(1).file(), entries.get(2).file());
+        assertThat(tasks.get(1).compactBefore())
+                .containsExactly(
+                        entries.get(3).file(), entries.get(4).file(), entries.get(5).file());
+    }
+
+    @Test
     public void testCompactPlannerGroupsBlobFilesByFieldId() {
         List<ManifestEntry> entries = new ArrayList<>();
         entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
@@ -220,7 +252,12 @@ public class DataEvolutionCompactCoordinatorTest {
         schemas.put(0L, rowType(new DataField(1, "old_pic", DataTypes.BLOB())));
         schemas.put(1L, rowType(new DataField(1, "new_pic", DataTypes.BLOB())));
         DataEvolutionCompactCoordinator.CompactPlanner planner =
-                blobPlanner(1024, 1024, 2, schemaId -> schemas.get(schemaId));
+                blobPlanner(
+                        1024,
+                        1024,
+                        2,
+                        schemaId -> schemas.get(schemaId),
+                        rowType(new DataField(1, "new_pic", DataTypes.BLOB())));
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
@@ -241,7 +278,12 @@ public class DataEvolutionCompactCoordinatorTest {
         schemas.put(0L, rowType(new DataField(1, "pic", DataTypes.BLOB())));
         schemas.put(1L, rowType(new DataField(2, "pic", DataTypes.BLOB())));
         DataEvolutionCompactCoordinator.CompactPlanner planner =
-                blobPlanner(1024, 1024, 2, schemaId -> schemas.get(schemaId));
+                blobPlanner(
+                        1024,
+                        1024,
+                        2,
+                        schemaId -> schemas.get(schemaId),
+                        rowType(new DataField(2, "pic", DataTypes.BLOB())));
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
@@ -433,20 +475,36 @@ public class DataEvolutionCompactCoordinatorTest {
 
     private DataEvolutionCompactCoordinator.CompactPlanner blobPlanner(
             long targetFileSize, long openFileCost, long compactMinFileNum, RowType rowType) {
-        return blobPlanner(targetFileSize, openFileCost, compactMinFileNum, schemaId -> rowType);
+        return blobPlanner(
+                targetFileSize, openFileCost, compactMinFileNum, schemaId -> rowType, rowType);
     }
 
     private DataEvolutionCompactCoordinator.CompactPlanner blobPlanner(
             long targetFileSize,
             long openFileCost,
             long compactMinFileNum,
-            LongFunction<RowType> schemaFetcher) {
+            LongFunction<RowType> schemaFetcher,
+            RowType currentRowType) {
         return new DataEvolutionCompactCoordinator.CompactPlanner(
-                true, false, targetFileSize, openFileCost, compactMinFileNum, schemaFetcher);
+                true,
+                false,
+                targetFileSize,
+                openFileCost,
+                compactMinFileNum,
+                schemaFetcher,
+                fieldIds(currentRowType));
     }
 
     private RowType rowType(DataField... fields) {
         return new RowType(Arrays.asList(fields));
+    }
+
+    private Set<Integer> fieldIds(RowType rowType) {
+        Set<Integer> fieldIds = new HashSet<>();
+        for (DataField field : rowType.getFields()) {
+            fieldIds.add(field.id());
+        }
+        return fieldIds;
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -36,6 +36,9 @@ import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.Test;
@@ -44,7 +47,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.LongFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -157,15 +163,15 @@ public class DataEvolutionCompactCoordinatorTest {
         // Test blob file compaction when enabled
         List<ManifestEntry> entries = new ArrayList<>();
         entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
-        entries.add(makeBlobEntry("file1.blob", 0L, 100L, 100));
-        entries.add(makeBlobEntry("file1b.blob", 0L, 100L, 100));
+        entries.add(makeBlobEntry("file1.blob", 0L, 100L, 100, "pic"));
+        entries.add(makeBlobEntry("file1b.blob", 0L, 100L, 100, "pic"));
         entries.add(makeEntry("file2.parquet", 100L, 100L, 100));
-        entries.add(makeBlobEntry("file2.blob", 100L, 100L, 100));
-        entries.add(makeBlobEntry("file2b.blob", 100L, 100L, 100));
+        entries.add(makeBlobEntry("file2.blob", 100L, 100L, 100, "pic"));
+        entries.add(makeBlobEntry("file2b.blob", 100L, 100L, 100, "pic"));
 
         // Use small target to trigger compaction, with blob compaction enabled
         DataEvolutionCompactCoordinator.CompactPlanner planner =
-                new DataEvolutionCompactCoordinator.CompactPlanner(true, false, 1024, 1024, 2);
+                blobPlanner(1024, 1024, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
@@ -190,7 +196,52 @@ public class DataEvolutionCompactCoordinatorTest {
         entries.add(makeBlobEntry("pic2.blob", 0L, 100L, 100, "pic2"));
 
         DataEvolutionCompactCoordinator.CompactPlanner planner =
-                new DataEvolutionCompactCoordinator.CompactPlanner(true, false, 1024, 1024, 2);
+                blobPlanner(
+                        1024,
+                        1024,
+                        2,
+                        rowType(
+                                new DataField(1, "pic1", DataTypes.BLOB()),
+                                new DataField(2, "pic2", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).isEmpty();
+    }
+
+    @Test
+    public void testCompactPlannerGroupsBlobFilesByFieldId() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeBlobEntry("old-pic.blob", 0L, 100L, 100, 0, "old_pic"));
+        entries.add(makeBlobEntry("new-pic.blob", 0L, 100L, 100, 1, "new_pic"));
+
+        Map<Long, RowType> schemas = new HashMap<>();
+        schemas.put(0L, rowType(new DataField(1, "old_pic", DataTypes.BLOB())));
+        schemas.put(1L, rowType(new DataField(1, "new_pic", DataTypes.BLOB())));
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1024, 2, schemaId -> schemas.get(schemaId));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).isBlobTask()).isTrue();
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(entries.get(1).file(), entries.get(2).file());
+    }
+
+    @Test
+    public void testCompactPlannerSeparatesBlobFilesByFieldIdWhenNameReused() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeBlobEntry("old-pic.blob", 0L, 100L, 100, 0, "pic"));
+        entries.add(makeBlobEntry("new-pic.blob", 0L, 100L, 100, 1, "pic"));
+
+        Map<Long, RowType> schemas = new HashMap<>();
+        schemas.put(0L, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+        schemas.put(1L, rowType(new DataField(2, "pic", DataTypes.BLOB())));
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1024, 2, schemaId -> schemas.get(schemaId));
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
@@ -306,6 +357,16 @@ public class DataEvolutionCompactCoordinatorTest {
 
     private ManifestEntry makeBlobEntry(
             String fileName, long firstRowId, long rowCount, long fileSize, String writeCol) {
+        return makeBlobEntry(fileName, firstRowId, rowCount, fileSize, 0, writeCol);
+    }
+
+    private ManifestEntry makeBlobEntry(
+            String fileName,
+            long firstRowId,
+            long rowCount,
+            long fileSize,
+            long schemaId,
+            String writeCol) {
         // Blob files have .blob extension
         String blobFileName = fileName.endsWith(".blob") ? fileName : fileName + ".blob";
         return ManifestEntry.create(
@@ -319,12 +380,13 @@ public class DataEvolutionCompactCoordinatorTest {
                         rowCount,
                         0,
                         fileSize,
+                        schemaId,
                         writeCol == null ? null : Collections.singletonList(writeCol)));
     }
 
     private DataFileMeta createDataFileMeta(
             String fileName, long firstRowId, long rowCount, long maxSeq, long fileSize) {
-        return createDataFileMeta(fileName, firstRowId, rowCount, maxSeq, fileSize, null);
+        return createDataFileMeta(fileName, firstRowId, rowCount, maxSeq, fileSize, 0, null);
     }
 
     private DataFileMeta createDataFileMeta(
@@ -333,6 +395,18 @@ public class DataEvolutionCompactCoordinatorTest {
             long rowCount,
             long maxSeq,
             long fileSize,
+            List<String> writeCols) {
+        return createDataFileMeta(
+                fileName, firstRowId, rowCount, maxSeq, fileSize, 0, writeCols);
+    }
+
+    private DataFileMeta createDataFileMeta(
+            String fileName,
+            long firstRowId,
+            long rowCount,
+            long maxSeq,
+            long fileSize,
+            long schemaId,
             List<String> writeCols) {
         return DataFileMeta.create(
                 fileName,
@@ -344,7 +418,7 @@ public class DataEvolutionCompactCoordinatorTest {
                 StatsTestUtils.newEmptySimpleStats(),
                 0,
                 maxSeq,
-                0,
+                schemaId,
                 0,
                 Collections.emptyList(),
                 Timestamp.fromEpochMillis(System.currentTimeMillis()),
@@ -355,6 +429,24 @@ public class DataEvolutionCompactCoordinatorTest {
                 null,
                 firstRowId,
                 writeCols);
+    }
+
+    private DataEvolutionCompactCoordinator.CompactPlanner blobPlanner(
+            long targetFileSize, long openFileCost, long compactMinFileNum, RowType rowType) {
+        return blobPlanner(targetFileSize, openFileCost, compactMinFileNum, schemaId -> rowType);
+    }
+
+    private DataEvolutionCompactCoordinator.CompactPlanner blobPlanner(
+            long targetFileSize,
+            long openFileCost,
+            long compactMinFileNum,
+            LongFunction<RowType> schemaFetcher) {
+        return new DataEvolutionCompactCoordinator.CompactPlanner(
+                true, false, targetFileSize, openFileCost, compactMinFileNum, schemaFetcher);
+    }
+
+    private RowType rowType(DataField... fields) {
+        return new RowType(Arrays.asList(fields));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -530,6 +530,7 @@ public class DataEvolutionCompactCoordinatorTest {
                 true,
                 false,
                 targetFileSize,
+                targetFileSize,
                 openFileCost,
                 compactMinFileNum,
                 schemaFetcher,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
@@ -81,10 +81,7 @@ public class DataEvolutionTableCompactSource
         public CompactSourceReader(FileStoreTable table, PartitionPredicate partitions) {
             compactionCoordinator =
                     new DataEvolutionCompactCoordinator(
-                            table,
-                            partitions,
-                            table.coreOptions().dataEvolutionCompactionBlobEnabled(),
-                            false);
+                            table, partitions, table.coreOptions().blobCompactionEnabled(), false);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
@@ -80,7 +80,7 @@ public class DataEvolutionTableCompactSource
 
         public CompactSourceReader(FileStoreTable table, PartitionPredicate partitions) {
             compactionCoordinator =
-                    new DataEvolutionCompactCoordinator(table, partitions, false, false);
+                    new DataEvolutionCompactCoordinator(table, partitions, true, false);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
@@ -80,7 +80,11 @@ public class DataEvolutionTableCompactSource
 
         public CompactSourceReader(FileStoreTable table, PartitionPredicate partitions) {
             compactionCoordinator =
-                    new DataEvolutionCompactCoordinator(table, partitions, true, false);
+                    new DataEvolutionCompactCoordinator(
+                            table,
+                            partitions,
+                            table.coreOptions().dataEvolutionCompactionBlobEnabled(),
+                            false);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -109,6 +109,84 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testBlobCompaction() throws Exception {
+        for (int i = 1; i <= 10; i++) {
+            batchSql("INSERT INTO blob_table VALUES (%s, 'paimon', X'48656C6C6F')", i);
+        }
+        batchSql("INSERT INTO blob_table VALUES (1, 'paimon', X'48656C6C6F')");
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `blob_table$files`"))
+                .containsExactly(Row.of(22L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+
+        tEnv.getConfig().set("table.dml-sync", "true");
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.blob_table')").await();
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `blob_table$files`")).containsExactly(Row.of(2L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(1L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(1L));
+        assertThat(batchSql("SELECT COUNT(*) FROM blob_table")).containsExactly(Row.of(11L));
+        assertThat(batchSql("SELECT picture FROM blob_table WHERE id = 1"))
+                .containsExactlyInAnyOrder(
+                        Row.of(new byte[] {72, 101, 108, 108, 111}),
+                        Row.of(new byte[] {72, 101, 108, 108, 111}));
+    }
+
+    @Test
+    public void testMultipleBlobCompaction() throws Exception {
+        for (int i = 1; i <= 10; i++) {
+            batchSql(
+                    "INSERT INTO multiple_blob_table VALUES (%s, 'paimon', X'48656C6C6F', X'5945')",
+                    i);
+        }
+        batchSql("INSERT INTO multiple_blob_table VALUES (1, 'paimon', X'48656C6C6F', X'5945')");
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `multiple_blob_table$files`"))
+                .containsExactly(Row.of(33L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `multiple_blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(22L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `multiple_blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+
+        tEnv.getConfig().set("table.dml-sync", "true");
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.multiple_blob_table')").await();
+
+        assertThat(batchSql("SELECT COUNT(*) FROM `multiple_blob_table$files`"))
+                .containsExactly(Row.of(3L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `multiple_blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(2L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `multiple_blob_table$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(1L));
+        assertThat(batchSql("SELECT COUNT(*) FROM multiple_blob_table"))
+                .containsExactly(Row.of(11L));
+        assertThat(batchSql("SELECT pic1, pic2 FROM multiple_blob_table WHERE id = 1"))
+                .containsExactlyInAnyOrder(
+                        Row.of(new byte[] {72, 101, 108, 108, 111}, new byte[] {89, 69}),
+                        Row.of(new byte[] {72, 101, 108, 108, 111}, new byte[] {89, 69}));
+    }
+
+    @Test
     public void testWriteBlobAsDescriptor() throws Exception {
         byte[] blobData = new byte[1024 * 1024];
         RANDOM.nextBytes(blobData);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -59,9 +59,9 @@ public class BlobTableITCase extends CatalogITCaseBase {
     protected List<String> ddl() {
         String externalStoragePath = warehouse.resolve("external-storage-blob-path").toString();
         return Arrays.asList(
-                "CREATE TABLE IF NOT EXISTS blob_table (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')",
+                "CREATE TABLE IF NOT EXISTS blob_table (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'data-evolution.compaction.blob.enabled'='true', 'blob-field'='picture')",
                 "CREATE TABLE IF NOT EXISTS blob_table_descriptor (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture', 'blob-as-descriptor'='true')",
-                "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pic1,pic2')",
+                "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'data-evolution.compaction.blob.enabled'='true', 'blob-field'='pic1,pic2')",
                 String.format(
                         "CREATE TABLE IF NOT EXISTS copy_blob_table (id INT, data STRING, picture BYTES)"
                                 + " WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true',"
@@ -184,6 +184,40 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 .containsExactlyInAnyOrder(
                         Row.of(new byte[] {72, 101, 108, 108, 111}, new byte[] {89, 69}),
                         Row.of(new byte[] {72, 101, 108, 108, 111}, new byte[] {89, 69}));
+    }
+
+    @Test
+    public void testBlobCompactionDisabledByDefault() throws Exception {
+        tEnv.executeSql(
+                "CREATE TABLE blob_compaction_disabled (id INT, data STRING, picture BYTES) "
+                        + "WITH ('row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true', "
+                        + "'blob-field'='picture')");
+
+        for (int i = 1; i <= 10; i++) {
+            batchSql(
+                    "INSERT INTO blob_compaction_disabled VALUES (%s, 'paimon', X'48656C6C6F')", i);
+        }
+        batchSql("INSERT INTO blob_compaction_disabled VALUES (1, 'paimon', X'48656C6C6F')");
+
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_compaction_disabled$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+
+        tEnv.getConfig().set("table.dml-sync", "true");
+        tEnv.executeSql("CALL sys.compact(`table` => 'default.blob_compaction_disabled')").await();
+
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_compaction_disabled$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(11L));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) FROM `blob_compaction_disabled$files` WHERE file_path NOT LIKE '%%.blob'"))
+                .containsExactly(Row.of(1L));
+        assertThat(batchSql("SELECT COUNT(*) FROM blob_compaction_disabled"))
+                .containsExactly(Row.of(11L));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -59,9 +59,9 @@ public class BlobTableITCase extends CatalogITCaseBase {
     protected List<String> ddl() {
         String externalStoragePath = warehouse.resolve("external-storage-blob-path").toString();
         return Arrays.asList(
-                "CREATE TABLE IF NOT EXISTS blob_table (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'data-evolution.compaction.blob.enabled'='true', 'blob-field'='picture')",
+                "CREATE TABLE IF NOT EXISTS blob_table (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='picture')",
                 "CREATE TABLE IF NOT EXISTS blob_table_descriptor (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture', 'blob-as-descriptor'='true')",
-                "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'data-evolution.compaction.blob.enabled'='true', 'blob-field'='pic1,pic2')",
+                "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pic1,pic2')",
                 String.format(
                         "CREATE TABLE IF NOT EXISTS copy_blob_table (id INT, data STRING, picture BYTES)"
                                 + " WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true',"


### PR DESCRIPTION
### Purpose
Enable Flink data-evolution compaction to plan and execute blob compaction tasks.

This implements `DataEvolutionCompactTask` support for `blobTask` by rewriting dedicated blob files with `MultipleBlobFileWriter`. It also enables the Flink data-evolution compact source to plan blob tasks.

The reader path now also supports blob-only merge groups, which is required when a data-evolution blob task contains multiple blob fields without the corresponding normal data file in the same split.

### Tests
- `mvn -pl paimon-core -DfailIfNoTests=false -Dtest=MultipleBlobTableTest#testDataEvolutionBlobCompaction test`
- `mvn -pl paimon-flink/paimon-flink-common -DfailIfNoTests=false -Dtest=BlobTableITCase#testBlobCompaction+testMultipleBlobCompaction test`
- `mvn -pl paimon-core -DfailIfNoTests=false -Dtest=MultipleBlobTableTest test`
- `mvn -pl paimon-flink/paimon-flink-common -DfailIfNoTests=false -Dtest=BlobTableITCase test`