### PR TITLE
[globalindex] Support multi-column GlobalIndex framework

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/ConstantGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/ConstantGlobalIndexReader.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.predicate.FieldRef;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link GlobalIndexReader} that returns the same fixed result for every scalar predicate.
+ *
+ * <p>Used to pad an index that covers a shorter row range with an all-hit bitmap over the missing
+ * tail, so that AND-ing it with a longer-range index does not drop rows the shorter index simply
+ * has not indexed.
+ */
+public class ConstantGlobalIndexReader implements GlobalIndexReader {
+
+    private final CompletableFuture<Optional<GlobalIndexResult>> result;
+
+    public ConstantGlobalIndexReader(GlobalIndexResult result) {
+        this.result = CompletableFuture.completedFuture(Optional.of(result));
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitIsNotNull(FieldRef fieldRef) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitIsNull(FieldRef fieldRef) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitStartsWith(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitEndsWith(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitContains(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitLike(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitLessThan(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitGreaterOrEqual(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotEqual(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitLessOrEqual(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitEqual(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitGreaterThan(
+            FieldRef fieldRef, Object literal) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitIn(
+            FieldRef fieldRef, List<Object> literals) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotIn(
+            FieldRef fieldRef, List<Object> literals) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return result;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexMultiColumnWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexMultiColumnWriter.java
@@ -26,9 +26,13 @@ import javax.annotation.Nullable;
 public interface GlobalIndexMultiColumnWriter extends GlobalIndexWriter {
 
     /**
-     * Write a projected row containing all indexed columns for one record. The row layout matches
-     * the fields order passed to {@link GlobalIndexerFactory#create(java.util.List,
-     * org.apache.paimon.options.Options)}.
+     * Write one record's indexed columns at the given relative row id.
+     *
+     * @param rowId the record's row id relative to the current shard (0 to rowCnt - 1); a null row
+     *     still advances the row id without indexing a value
+     * @param row a projected row containing only the indexed columns, whose layout matches the
+     *     fields order passed to {@link GlobalIndexerFactory#create(java.util.List,
+     *     org.apache.paimon.options.Options)}
      */
-    void write(@Nullable InternalRow row);
+    void write(long rowId, @Nullable InternalRow row);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexMultiColumnWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexMultiColumnWriter.java
@@ -18,20 +18,17 @@
 
 package org.apache.paimon.globalindex;
 
-import org.apache.paimon.fileindex.FileIndexer;
-import org.apache.paimon.options.Options;
-import org.apache.paimon.types.DataField;
+import org.apache.paimon.data.InternalRow;
 
-import java.util.List;
+import javax.annotation.Nullable;
 
-/** File index factory to construct {@link FileIndexer}. */
-public interface GlobalIndexerFactory {
+/** Index writer for global index that accepts multiple column values per row. */
+public interface GlobalIndexMultiColumnWriter extends GlobalIndexWriter {
 
-    String identifier();
-
-    GlobalIndexer create(DataField dataField, Options options);
-
-    default GlobalIndexer create(List<DataField> fields, Options options) {
-        return create(fields.get(0), options);
-    }
+    /**
+     * Write a projected row containing all indexed columns for one record. The row layout matches
+     * the fields order passed to {@link GlobalIndexerFactory#create(java.util.List,
+     * org.apache.paimon.options.Options)}.
+     */
+    void write(@Nullable InternalRow row);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -41,4 +41,9 @@ public interface GlobalIndexer {
         GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
         return globalIndexerFactory.create(dataField, options);
     }
+
+    static GlobalIndexer create(String type, List<DataField> fields, Options options) {
+        GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
+        return globalIndexerFactory.create(fields, options);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -42,8 +42,9 @@ public interface GlobalIndexer {
         return globalIndexerFactory.create(dataField, options);
     }
 
-    static GlobalIndexer create(String type, List<DataField> fields, Options options) {
+    static GlobalIndexer create(
+            String type, DataField dataField, List<DataField> extraFields, Options options) {
         GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
-        return globalIndexerFactory.create(fields, options);
+        return globalIndexerFactory.create(dataField, extraFields, options);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexer.java
@@ -37,14 +37,14 @@ public interface GlobalIndexer {
             List<GlobalIndexIOMeta> files,
             ExecutorService executor);
 
-    static GlobalIndexer create(String type, DataField dataField, Options options) {
+    static GlobalIndexer create(String type, DataField indexField, Options options) {
         GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
-        return globalIndexerFactory.create(dataField, options);
+        return globalIndexerFactory.create(indexField, options);
     }
 
     static GlobalIndexer create(
-            String type, DataField dataField, List<DataField> extraFields, Options options) {
+            String type, DataField indexField, List<DataField> extraFields, Options options) {
         GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(type);
-        return globalIndexerFactory.create(dataField, extraFields, options);
+        return globalIndexerFactory.create(indexField, extraFields, options);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
@@ -29,7 +29,7 @@ public interface GlobalIndexerFactory {
 
     String identifier();
 
-    GlobalIndexer create(DataField dataField, Options options);
+    GlobalIndexer create(DataField indexField, Options options);
 
     /**
      * Whether this index type supports multi-column indexes. A factory that returns {@code true}
@@ -40,18 +40,18 @@ public interface GlobalIndexerFactory {
     }
 
     /**
-     * Creates an indexer over a primary column plus optional extra columns. {@code dataField} is
+     * Creates an indexer over a primary column plus optional extra columns. {@code indexField} is
      * the primary column; {@code extraFields} holds the remaining columns and is empty for a
      * single-column index.
      */
     default GlobalIndexer create(
-            DataField dataField, List<DataField> extraFields, Options options) {
+            DataField indexField, List<DataField> extraFields, Options options) {
         if (extraFields != null && !extraFields.isEmpty()) {
             throw new UnsupportedOperationException(
                     String.format(
                             "Index type '%s' does not support multi-column index, got extra columns: %s",
                             identifier(), extraFields));
         }
-        return create(dataField, options);
+        return create(indexField, options);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
@@ -32,6 +32,12 @@ public interface GlobalIndexerFactory {
     GlobalIndexer create(DataField dataField, Options options);
 
     default GlobalIndexer create(List<DataField> fields, Options options) {
+        if (fields.size() > 1) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Index type '%s' does not support multi-column index, got columns: %s",
+                            identifier(), fields));
+        }
         return create(fields.get(0), options);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
@@ -32,14 +32,6 @@ public interface GlobalIndexerFactory {
     GlobalIndexer create(DataField indexField, Options options);
 
     /**
-     * Whether this index type supports multi-column indexes. A factory that returns {@code true}
-     * must override {@link #create(DataField, List, Options)} to handle extra columns.
-     */
-    default boolean supportsMultiColumn() {
-        return false;
-    }
-
-    /**
      * Creates an indexer over a primary column plus optional extra columns. {@code indexField} is
      * the primary column; {@code extraFields} holds the remaining columns and is empty for a
      * single-column index.

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
@@ -31,6 +31,14 @@ public interface GlobalIndexerFactory {
 
     GlobalIndexer create(DataField dataField, Options options);
 
+    /**
+     * Whether this index type supports multi-column indexes. A factory that returns {@code true}
+     * must override {@link #create(List, Options)} to handle more than one column.
+     */
+    default boolean supportsMultiColumn() {
+        return false;
+    }
+
     default GlobalIndexer create(List<DataField> fields, Options options) {
         if (fields.size() > 1) {
             throw new UnsupportedOperationException(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexerFactory.java
@@ -33,19 +33,25 @@ public interface GlobalIndexerFactory {
 
     /**
      * Whether this index type supports multi-column indexes. A factory that returns {@code true}
-     * must override {@link #create(List, Options)} to handle more than one column.
+     * must override {@link #create(DataField, List, Options)} to handle extra columns.
      */
     default boolean supportsMultiColumn() {
         return false;
     }
 
-    default GlobalIndexer create(List<DataField> fields, Options options) {
-        if (fields.size() > 1) {
+    /**
+     * Creates an indexer over a primary column plus optional extra columns. {@code dataField} is
+     * the primary column; {@code extraFields} holds the remaining columns and is empty for a
+     * single-column index.
+     */
+    default GlobalIndexer create(
+            DataField dataField, List<DataField> extraFields, Options options) {
+        if (extraFields != null && !extraFields.isEmpty()) {
             throw new UnsupportedOperationException(
                     String.format(
-                            "Index type '%s' does not support multi-column index, got columns: %s",
-                            identifier(), fields));
+                            "Index type '%s' does not support multi-column index, got extra columns: %s",
+                            identifier(), extraFields));
         }
-        return create(fields.get(0), options);
+        return create(dataField, options);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -26,6 +26,7 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import org.junit.jupiter.api.AfterEach;
@@ -486,6 +487,57 @@ class GlobalIndexEvaluatorTest {
         assertThat(result).isPresent();
         // Multiple readers for same field are combined with AND (intersection)
         assertBitmapContainsExactly(result.get().results(), 3L, 4L, 5L);
+        evaluator.close();
+    }
+
+    @Test
+    void testShorterIndexPaddedToLongestRangeNotDroppedByAnd() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        // Field c (id 2) is an extra column of two multi-column indexes:
+        //  - a short index covering rows [0,4] that matches the predicate at {1,3}
+        //  - a long index covering rows [0,9] that matches the predicate at {1,3,7,8}
+        // The evaluator AND-s both readers for the leaf. Padding the short index over its
+        // unindexed tail (5..9) with an all-hit reader keeps the long index's tail matches.
+        GlobalIndexReader shortIndexPadded =
+                new UnionGlobalIndexReader(
+                        Arrays.asList(
+                                readerReturning(resultOf(1, 3)),
+                                new ConstantGlobalIndexReader(
+                                        GlobalIndexResult.fromRange(new Range(5, 9)))));
+        GlobalIndexReader longIndex = readerReturning(resultOf(1, 3, 7, 8));
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType, fieldId -> Arrays.asList(shortIndexPadded, longIndex));
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Optional<GlobalIndexResult> result = evaluator.evaluate(builder.equal(2, 42));
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 3L, 7L, 8L);
+        evaluator.close();
+    }
+
+    @Test
+    void testShorterIndexWithoutPaddingDropsTailUnderAnd() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        // Same setup as above but WITHOUT padding the short index: AND drops the tail matches
+        // {7,8}, which is exactly the bug the padding prevents.
+        GlobalIndexReader shortIndex = readerReturning(resultOf(1, 3));
+        GlobalIndexReader longIndex = readerReturning(resultOf(1, 3, 7, 8));
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(rowType, fieldId -> Arrays.asList(shortIndex, longIndex));
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Optional<GlobalIndexResult> result = evaluator.evaluate(builder.equal(2, 42));
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 3L);
         evaluator.close();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -29,6 +29,8 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Range;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,12 +47,54 @@ public class GlobalIndexBuilderUtils {
             String indexType,
             List<ResultEntry> entries)
             throws IOException {
+        return toIndexFileMetas(
+                fileIO, indexPathFactory, options, range, indexFieldId, null, indexType, entries);
+    }
+
+    public static List<IndexFileMeta> toIndexFileMetas(
+            FileIO fileIO,
+            IndexPathFactory indexPathFactory,
+            CoreOptions options,
+            Range range,
+            List<DataField> fields,
+            String indexType,
+            List<ResultEntry> entries)
+            throws IOException {
+        int indexFieldId = fields.get(0).id();
+        int[] extraFieldIds =
+                fields.size() > 1
+                        ? fields.subList(1, fields.size()).stream()
+                                .mapToInt(DataField::id)
+                                .toArray()
+                        : null;
+        return toIndexFileMetas(
+                fileIO,
+                indexPathFactory,
+                options,
+                range,
+                indexFieldId,
+                extraFieldIds,
+                indexType,
+                entries);
+    }
+
+    private static List<IndexFileMeta> toIndexFileMetas(
+            FileIO fileIO,
+            IndexPathFactory indexPathFactory,
+            CoreOptions options,
+            Range range,
+            int indexFieldId,
+            @Nullable int[] extraFieldIds,
+            String indexType,
+            List<ResultEntry> entries)
+            throws IOException {
         List<IndexFileMeta> results = new ArrayList<>();
         for (ResultEntry entry : entries) {
             String fileName = entry.fileName();
             long fileSize = fileIO.getFileSize(indexPathFactory.toPath(fileName));
             GlobalIndexMeta globalIndexMeta =
-                    new GlobalIndexMeta(range.from, range.to, indexFieldId, null, entry.meta());
+                    new GlobalIndexMeta(
+                            range.from, range.to, indexFieldId, extraFieldIds, entry.meta());
 
             Path externalPathDir = options.globalIndexExternalPath();
             String externalPathString = null;
@@ -75,6 +119,13 @@ public class GlobalIndexBuilderUtils {
             FileStoreTable table, String indexType, DataField indexField, Options options)
             throws IOException {
         GlobalIndexer globalIndexer = GlobalIndexer.create(indexType, indexField, options);
+        return globalIndexer.createWriter(createGlobalIndexFileReadWrite(table));
+    }
+
+    public static GlobalIndexWriter createIndexWriter(
+            FileStoreTable table, String indexType, List<DataField> fields, Options options)
+            throws IOException {
+        GlobalIndexer globalIndexer = GlobalIndexer.create(indexType, fields, options);
         return globalIndexer.createWriter(createGlobalIndexFileReadWrite(table));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -31,6 +31,9 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Range;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -41,6 +44,8 @@ import java.util.Map;
 
 /** Utils for global index build. */
 public class GlobalIndexBuilderUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalIndexBuilderUtils.class);
 
     public static final int MULTI_COLUMN_INDEX_FIELD_ID = -1;
 
@@ -148,6 +153,7 @@ public class GlobalIndexBuilderUtils {
             SchemaManager schemaManager, List<ManifestEntry> entries, List<String> indexColumns) {
         Map<Long, Boolean> schemaContainsColumns = new HashMap<>();
         long minRowId = Long.MAX_VALUE;
+        long minSchemaId = -1;
         for (ManifestEntry entry : entries) {
             long sid = entry.file().schemaId();
             boolean contains =
@@ -155,8 +161,26 @@ public class GlobalIndexBuilderUtils {
                             sid,
                             id -> schemaManager.schema(id).fieldNames().containsAll(indexColumns));
             if (!contains && entry.file().firstRowId() != null) {
-                minRowId = Math.min(minRowId, entry.file().nonNullFirstRowId());
+                long rowId = entry.file().nonNullFirstRowId();
+                if (rowId < minRowId) {
+                    minRowId = rowId;
+                    minSchemaId = sid;
+                }
             }
+        }
+        if (minRowId != Long.MAX_VALUE) {
+            List<String> schemaFields = schemaManager.schema(minSchemaId).fieldNames();
+            List<String> missingColumns = new ArrayList<>();
+            for (String col : indexColumns) {
+                if (!schemaFields.contains(col)) {
+                    missingColumns.add(col);
+                }
+            }
+            LOG.info(
+                    "Found non-indexable files: schemaId={} missing columns {}, boundaryRowId={}.",
+                    minSchemaId,
+                    missingColumns,
+                    minRowId);
         }
         return minRowId;
     }
@@ -174,6 +198,11 @@ public class GlobalIndexBuilderUtils {
                 result.add(entry);
             }
         }
+        LOG.info(
+                "Filtered {} files to {} indexable files (boundaryRowId={}).",
+                entries.size(),
+                result.size(),
+                boundaryRowId);
         return result;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -38,6 +38,8 @@ import java.util.List;
 /** Utils for global index build. */
 public class GlobalIndexBuilderUtils {
 
+    public static final int MULTI_COLUMN_INDEX_FIELD_ID = -1;
+
     public static List<IndexFileMeta> toIndexFileMetas(
             FileIO fileIO,
             IndexPathFactory indexPathFactory,
@@ -60,13 +62,15 @@ public class GlobalIndexBuilderUtils {
             String indexType,
             List<ResultEntry> entries)
             throws IOException {
-        int indexFieldId = fields.get(0).id();
-        int[] extraFieldIds =
-                fields.size() > 1
-                        ? fields.subList(1, fields.size()).stream()
-                                .mapToInt(DataField::id)
-                                .toArray()
-                        : null;
+        int indexFieldId;
+        int[] extraFieldIds;
+        if (fields.size() > 1) {
+            indexFieldId = MULTI_COLUMN_INDEX_FIELD_ID;
+            extraFieldIds = fields.stream().mapToInt(DataField::id).toArray();
+        } else {
+            indexFieldId = fields.get(0).id();
+            extraFieldIds = null;
+        }
         return toIndexFileMetas(
                 fileIO,
                 indexPathFactory,

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -142,12 +142,12 @@ public class GlobalIndexBuilderUtils {
     public static GlobalIndexWriter createIndexWriter(
             FileStoreTable table,
             String indexType,
-            DataField dataField,
+            DataField indexField,
             List<DataField> extraFields,
             Options options)
             throws IOException {
         GlobalIndexer globalIndexer =
-                GlobalIndexer.create(indexType, dataField, extraFields, options);
+                GlobalIndexer.create(indexType, indexField, extraFields, options);
         return globalIndexer.createWriter(createGlobalIndexFileReadWrite(table));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -140,9 +140,14 @@ public class GlobalIndexBuilderUtils {
     }
 
     public static GlobalIndexWriter createIndexWriter(
-            FileStoreTable table, String indexType, List<DataField> fields, Options options)
+            FileStoreTable table,
+            String indexType,
+            DataField dataField,
+            List<DataField> extraFields,
+            Options options)
             throws IOException {
-        GlobalIndexer globalIndexer = GlobalIndexer.create(indexType, fields, options);
+        GlobalIndexer globalIndexer =
+                GlobalIndexer.create(indexType, dataField, extraFields, options);
         return globalIndexer.createWriter(createGlobalIndexFileReadWrite(table));
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -47,8 +47,6 @@ public class GlobalIndexBuilderUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(GlobalIndexBuilderUtils.class);
 
-    public static final int MULTI_COLUMN_INDEX_FIELD_ID = -1;
-
     public static List<IndexFileMeta> toIndexFileMetas(
             FileIO fileIO,
             IndexPathFactory indexPathFactory,
@@ -62,6 +60,12 @@ public class GlobalIndexBuilderUtils {
                 fileIO, indexPathFactory, options, range, indexFieldId, null, indexType, entries);
     }
 
+    /**
+     * Builds the index file metas. The first column in {@code fields} is treated as the primary
+     * index column (e.g. the first column in {@code CREATE ... INDEX ON (a, b, c)}) and is stored
+     * as {@code indexFieldId}; the remaining columns go into {@code extraFieldIds}. Callers must
+     * pass {@code fields} in the intended column order.
+     */
     public static List<IndexFileMeta> toIndexFileMetas(
             FileIO fileIO,
             IndexPathFactory indexPathFactory,
@@ -71,15 +75,15 @@ public class GlobalIndexBuilderUtils {
             String indexType,
             List<ResultEntry> entries)
             throws IOException {
-        int indexFieldId;
-        int[] extraFieldIds;
-        if (fields.size() > 1) {
-            indexFieldId = MULTI_COLUMN_INDEX_FIELD_ID;
-            extraFieldIds = fields.stream().mapToInt(DataField::id).toArray();
-        } else {
-            indexFieldId = fields.get(0).id();
-            extraFieldIds = null;
-        }
+        // The first column is the primary index column and is stored as indexFieldId; the
+        // remaining columns (if any) go into extraFieldIds.
+        int indexFieldId = fields.get(0).id();
+        int[] extraFieldIds =
+                fields.size() > 1
+                        ? fields.subList(1, fields.size()).stream()
+                                .mapToInt(DataField::id)
+                                .toArray()
+                        : null;
         return toIndexFileMetas(
                 fileIO,
                 indexPathFactory,

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtils.java
@@ -24,7 +24,9 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Range;
@@ -33,7 +35,9 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** Utils for global index build. */
 public class GlobalIndexBuilderUtils {
@@ -131,6 +135,46 @@ public class GlobalIndexBuilderUtils {
             throws IOException {
         GlobalIndexer globalIndexer = GlobalIndexer.create(indexType, fields, options);
         return globalIndexer.createWriter(createGlobalIndexFileReadWrite(table));
+    }
+
+    /**
+     * Find the minimum firstRowId among files whose schema does not contain all index columns.
+     * Files at or beyond this rowId cannot be indexed because the column was added later via ALTER
+     * TABLE.
+     *
+     * @return the boundary rowId, or {@link Long#MAX_VALUE} if all files contain the columns
+     */
+    public static long findMinNonIndexableRowId(
+            SchemaManager schemaManager, List<ManifestEntry> entries, List<String> indexColumns) {
+        Map<Long, Boolean> schemaContainsColumns = new HashMap<>();
+        long minRowId = Long.MAX_VALUE;
+        for (ManifestEntry entry : entries) {
+            long sid = entry.file().schemaId();
+            boolean contains =
+                    schemaContainsColumns.computeIfAbsent(
+                            sid,
+                            id -> schemaManager.schema(id).fieldNames().containsAll(indexColumns));
+            if (!contains && entry.file().firstRowId() != null) {
+                minRowId = Math.min(minRowId, entry.file().nonNullFirstRowId());
+            }
+        }
+        return minRowId;
+    }
+
+    /** Keep only entries whose firstRowId is strictly less than the given boundary. */
+    public static List<ManifestEntry> filterEntriesBefore(
+            List<ManifestEntry> entries, long boundaryRowId) {
+        if (boundaryRowId == Long.MAX_VALUE) {
+            return entries;
+        }
+        List<ManifestEntry> result = new ArrayList<>();
+        for (ManifestEntry entry : entries) {
+            if (entry.file().firstRowId() != null
+                    && entry.file().nonNullFirstRowId() < boundaryRowId) {
+                result.add(entry);
+            }
+        }
+        return result;
     }
 
     private static GlobalIndexFileReadWrite createGlobalIndexFileReadWrite(FileStoreTable table) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -20,6 +20,7 @@ package org.apache.paimon.globalindex;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
@@ -37,6 +38,7 @@ import org.apache.paimon.utils.Range;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,26 +76,66 @@ public class GlobalIndexScanner implements Closeable {
                 GlobalIndexReadThreadPool.getExecutorService(options.get(GLOBAL_INDEX_THREAD_NUM));
         this.indexPathFactory = indexPathFactory;
         GlobalIndexFileReader indexFileReader = meta -> fileIO.newInputStream(meta.filePath());
+
+        // Single-column indexes: fieldId -> indexType -> range -> files
         Map<Integer, Map<String, Map<Range, List<IndexFileMeta>>>> indexMetas = new HashMap<>();
+        // Multi-column indexes: fieldIds -> indexType -> range -> files
+        Map<List<Integer>, Map<String, Map<Range, List<IndexFileMeta>>>> multiColumnMetas =
+                new HashMap<>();
+        // Reverse lookup: fieldId -> its multi-column group
+        Map<Integer, List<Integer>> fieldToGroup = new HashMap<>();
+
         for (IndexFileMeta indexFile : indexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
-            int fieldId = meta.indexFieldId();
             String indexType = indexFile.indexType();
-            indexMetas
-                    .computeIfAbsent(fieldId, k -> new HashMap<>())
-                    .computeIfAbsent(indexType, k -> new HashMap<>())
-                    .computeIfAbsent(
-                            new Range(meta.rowRangeStart(), meta.rowRangeEnd()),
-                            k -> new ArrayList<>())
-                    .add(indexFile);
+            Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
+
+            if (meta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
+                    && meta.extraFieldIds() != null) {
+                // Multi-column index: all participating fields share the same IndexFileMeta,
+                // so looking up from any fieldId returns identical index files.
+                List<Integer> fieldIds =
+                        Arrays.stream(meta.extraFieldIds())
+                                .boxed()
+                                .collect(Collectors.toList());
+                multiColumnMetas
+                        .computeIfAbsent(fieldIds, k -> new HashMap<>())
+                        .computeIfAbsent(indexType, k -> new HashMap<>())
+                        .computeIfAbsent(range, k -> new ArrayList<>())
+                        .add(indexFile);
+                for (int id : fieldIds) {
+                    fieldToGroup.put(id, fieldIds);
+                }
+            } else {
+                // Single-column index
+                int fieldId = meta.indexFieldId();
+                indexMetas
+                        .computeIfAbsent(fieldId, k -> new HashMap<>())
+                        .computeIfAbsent(indexType, k -> new HashMap<>())
+                        .computeIfAbsent(range, k -> new ArrayList<>())
+                        .add(indexFile);
+            }
         }
 
         IntFunction<Collection<GlobalIndexReader>> readersFunction =
-                fieldId ->
-                        createReaders(
+                fId -> {
+                    List<Integer> group = fieldToGroup.get(fId);
+                    if (group != null) {
+                        // Multi-column: resolve full field list
+                        List<DataField> fields =
+                                group.stream()
+                                        .map(rowType::getField)
+                                        .collect(Collectors.toList());
+                        return createReaders(
+                                indexFileReader, multiColumnMetas.get(group), fields);
+                    } else {
+                        // Single-column
+                        return createReaders(
                                 indexFileReader,
-                                indexMetas.get(fieldId),
-                                rowType.getField(fieldId));
+                                indexMetas.get(fId),
+                                Collections.singletonList(rowType.getField(fId)));
+                    }
+                };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }
 
@@ -127,7 +169,17 @@ public class GlobalIndexScanner implements Closeable {
                     if (globalIndex == null) {
                         return false;
                     }
-                    return filterFieldIds.contains(globalIndex.indexFieldId());
+                    if (filterFieldIds.contains(globalIndex.indexFieldId())) {
+                        return true;
+                    }
+                    if (globalIndex.extraFieldIds() != null) {
+                        for (int id : globalIndex.extraFieldIds()) {
+                            if (filterFieldIds.contains(id)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
                 };
 
         List<IndexFileMeta> indexFiles =
@@ -145,7 +197,7 @@ public class GlobalIndexScanner implements Closeable {
     private Collection<GlobalIndexReader> createReaders(
             GlobalIndexFileReader indexFileReadWrite,
             Map<String, Map<Range, List<IndexFileMeta>>> indexMetas,
-            DataField dataField) {
+            List<DataField> fields) {
         if (indexMetas == null) {
             return Collections.emptyList();
         }
@@ -155,7 +207,7 @@ public class GlobalIndexScanner implements Closeable {
             String indexType = entry.getKey();
             Map<Range, List<IndexFileMeta>> metas = entry.getValue();
             GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(indexType);
-            GlobalIndexer globalIndexer = globalIndexerFactory.create(dataField, options);
+            GlobalIndexer globalIndexer = globalIndexerFactory.create(fields, options);
 
             List<CompletableFuture<GlobalIndexReader>> futures = new ArrayList<>(metas.size());
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -53,8 +53,10 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
 import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Scanner for shard-based global indexes. */
@@ -98,6 +100,13 @@ public class GlobalIndexScanner implements Closeable {
                         Arrays.stream(meta.extraFieldIds())
                                 .boxed()
                                 .collect(Collectors.toList());
+                // Validate consistency: all files in the same group must have identical extraFieldIds
+                if (fieldToGroup.containsKey(fieldIds.get(0))) {
+                    List<Integer> existingGroup = fieldToGroup.get(fieldIds.get(0));
+                    checkArgument(
+                            existingGroup.equals(fieldIds),
+                            "Inconsistent extraFieldIds across index files.");
+                }
                 multiColumnMetas
                         .computeIfAbsent(fieldIds, k -> new HashMap<>())
                         .computeIfAbsent(indexType, k -> new HashMap<>())

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -108,11 +108,7 @@ public class GlobalIndexScanner implements Closeable {
                 fId -> {
                     IndexMetaFileGroup group = indexMetas.get(fId);
                     if (group != null) {
-                        List<DataField> fields =
-                                group.fieldIds.stream()
-                                        .map(rowType::getField)
-                                        .collect(Collectors.toList());
-                        return createReaders(indexFileReader, group.metas, fields);
+                        return createReaders(indexFileReader, group, rowType);
                     }
                     List<IndexMetaFileGroup> extraGroups = extraIndexMetas.get(fId);
                     if (extraGroups == null || extraGroups.isEmpty()) {
@@ -121,11 +117,7 @@ public class GlobalIndexScanner implements Closeable {
                     // Union readers from all groups that share this extra column
                     List<GlobalIndexReader> allReaders = new ArrayList<>();
                     for (IndexMetaFileGroup g : extraGroups) {
-                        List<DataField> fields =
-                                g.fieldIds.stream()
-                                        .map(rowType::getField)
-                                        .collect(Collectors.toList());
-                        allReaders.addAll(createReaders(indexFileReader, g.metas, fields));
+                        allReaders.addAll(createReaders(indexFileReader, g, rowType));
                     }
                     return allReaders;
                 };
@@ -148,6 +140,18 @@ public class GlobalIndexScanner implements Closeable {
             metas.computeIfAbsent(indexType, k -> new HashMap<>())
                     .computeIfAbsent(range, k -> new ArrayList<>())
                     .add(indexFile);
+        }
+
+        /** The primary index column. */
+        DataField indexField(RowType rowType) {
+            return rowType.getField(indexFieldId);
+        }
+
+        /** The extra columns beyond the primary one; empty for a single-column index. */
+        List<DataField> extraFields(RowType rowType) {
+            return fieldIds.subList(1, fieldIds.size()).stream()
+                    .map(rowType::getField)
+                    .collect(Collectors.toList());
         }
     }
 
@@ -209,21 +213,17 @@ public class GlobalIndexScanner implements Closeable {
     }
 
     private Collection<GlobalIndexReader> createReaders(
-            GlobalIndexFileReader indexFileReadWrite,
-            Map<String, Map<Range, List<IndexFileMeta>>> indexMetas,
-            List<DataField> fields) {
-        if (indexMetas == null) {
-            return Collections.emptyList();
-        }
+            GlobalIndexFileReader indexFileReadWrite, IndexMetaFileGroup group, RowType rowType) {
+        DataField indexField = group.indexField(rowType);
+        List<DataField> extraFields = group.extraFields(rowType);
 
         Set<GlobalIndexReader> readers = new HashSet<>();
-        for (Map.Entry<String, Map<Range, List<IndexFileMeta>>> entry : indexMetas.entrySet()) {
+        for (Map.Entry<String, Map<Range, List<IndexFileMeta>>> entry : group.metas.entrySet()) {
             String indexType = entry.getKey();
             Map<Range, List<IndexFileMeta>> metas = entry.getValue();
             GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(indexType);
             GlobalIndexer globalIndexer =
-                    globalIndexerFactory.create(
-                            fields.get(0), fields.subList(1, fields.size()), options);
+                    globalIndexerFactory.create(indexField, extraFields, options);
 
             List<CompletableFuture<GlobalIndexReader>> futures = new ArrayList<>(metas.size());
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -107,18 +107,27 @@ public class GlobalIndexScanner implements Closeable {
         IntFunction<Collection<GlobalIndexReader>> readersFunction =
                 fId -> {
                     IndexMetaFileGroup group = indexMetas.get(fId);
-                    if (group == null) {
-                        List<IndexMetaFileGroup> extraGroups = extraIndexMetas.get(fId);
-                        if (extraGroups == null || extraGroups.isEmpty()) {
-                            return Collections.emptyList();
-                        }
-                        group = extraGroups.get(0);
+                    if (group != null) {
+                        List<DataField> fields =
+                                group.fieldIds.stream()
+                                        .map(rowType::getField)
+                                        .collect(Collectors.toList());
+                        return createReaders(indexFileReader, group.metas, fields);
                     }
-                    List<DataField> fields =
-                            group.fieldIds.stream()
-                                    .map(rowType::getField)
-                                    .collect(Collectors.toList());
-                    return createReaders(indexFileReader, group.metas, fields);
+                    List<IndexMetaFileGroup> extraGroups = extraIndexMetas.get(fId);
+                    if (extraGroups == null || extraGroups.isEmpty()) {
+                        return Collections.emptyList();
+                    }
+                    // Union readers from all groups that share this extra column
+                    List<GlobalIndexReader> allReaders = new ArrayList<>();
+                    for (IndexMetaFileGroup g : extraGroups) {
+                        List<DataField> fields =
+                                g.fieldIds.stream()
+                                        .map(rowType::getField)
+                                        .collect(Collectors.toList());
+                        allReaders.addAll(createReaders(indexFileReader, g.metas, fields));
+                    }
+                    return allReaders;
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -114,12 +114,16 @@ public class GlobalIndexScanner implements Closeable {
                     if (extraGroups == null || extraGroups.isEmpty()) {
                         return Collections.emptyList();
                     }
-                    // Union readers from all groups that share this extra column
+                    // Union readers from all groups that share this extra column. Wrap them in a
+                    // single UnionGlobalIndexReader so the evaluator unions (OR) these alternative
+                    // indexes; returning them as separate readers would make visitLeafAsync AND
+                    // them together, which can yield an empty/partial bitmap when the indexes cover
+                    // different row ranges.
                     List<GlobalIndexReader> allReaders = new ArrayList<>();
                     for (IndexMetaFileGroup g : extraGroups) {
                         allReaders.addAll(createReaders(indexFileReader, g, rowType));
                     }
-                    return allReaders;
+                    return Collections.singletonList(new UnionGlobalIndexReader(allReaders));
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -221,7 +221,9 @@ public class GlobalIndexScanner implements Closeable {
             String indexType = entry.getKey();
             Map<Range, List<IndexFileMeta>> metas = entry.getValue();
             GlobalIndexerFactory globalIndexerFactory = GlobalIndexerFactoryUtils.load(indexType);
-            GlobalIndexer globalIndexer = globalIndexerFactory.create(fields, options);
+            GlobalIndexer globalIndexer =
+                    globalIndexerFactory.create(
+                            fields.get(0), fields.subList(1, fields.size()), options);
 
             List<CompletableFuture<GlobalIndexReader>> futures = new ArrayList<>(metas.size());
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -54,7 +54,6 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
 import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Scanner for shard-based global indexes. */
@@ -82,8 +81,9 @@ public class GlobalIndexScanner implements Closeable {
         // Multi-column indexes: fieldIds -> indexType -> range -> files
         Map<List<Integer>, Map<String, Map<Range, List<IndexFileMeta>>>> multiColumnMetas =
                 new HashMap<>();
-        // Reverse lookup: fieldId -> its multi-column group
-        Map<Integer, List<Integer>> fieldToGroup = new HashMap<>();
+        // Reverse lookup: fieldId -> all multi-column groups it participates in. A field can
+        // belong to several multi-column indexes (e.g. (a,b) and (a,c)) at the same time.
+        Map<Integer, List<List<Integer>>> fieldToGroups = new HashMap<>();
 
         for (IndexFileMeta indexFile : indexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
@@ -91,25 +91,22 @@ public class GlobalIndexScanner implements Closeable {
             Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
 
             if (meta.isMultiColumn() && meta.extraFieldIds() != null) {
-                // Multi-column index: all participating fields share the same IndexFileMeta,
-                // so looking up from any fieldId returns identical index files.
+                // Multi-column index: all participating fields share the same IndexFileMeta.
+                // Multiple index files belonging to the same group are aggregated under the same
+                // multiColumnMetas key, and each participating field records this group.
                 List<Integer> fieldIds =
                         Arrays.stream(meta.extraFieldIds()).boxed().collect(Collectors.toList());
-                // Validate consistency: all files in the same group must have identical
-                // extraFieldIds
-                if (fieldToGroup.containsKey(fieldIds.get(0))) {
-                    List<Integer> existingGroup = fieldToGroup.get(fieldIds.get(0));
-                    checkArgument(
-                            existingGroup.equals(fieldIds),
-                            "Inconsistent extraFieldIds across index files.");
-                }
                 multiColumnMetas
                         .computeIfAbsent(fieldIds, k -> new HashMap<>())
                         .computeIfAbsent(indexType, k -> new HashMap<>())
                         .computeIfAbsent(range, k -> new ArrayList<>())
                         .add(indexFile);
                 for (int id : fieldIds) {
-                    fieldToGroup.put(id, fieldIds);
+                    List<List<Integer>> groups =
+                            fieldToGroups.computeIfAbsent(id, k -> new ArrayList<>());
+                    if (!groups.contains(fieldIds)) {
+                        groups.add(fieldIds);
+                    }
                 }
             } else {
                 // Single-column index
@@ -124,19 +121,28 @@ public class GlobalIndexScanner implements Closeable {
 
         IntFunction<Collection<GlobalIndexReader>> readersFunction =
                 fId -> {
-                    List<Integer> group = fieldToGroup.get(fId);
-                    if (group != null) {
-                        // Multi-column: resolve full field list
+                    // A filter on a single field can be served by any index covering that field,
+                    // and every such index returns the same matching row ids. So pick ONE index
+                    // instead of running them all: prefer the single-column index (purpose-built
+                    // for this field and always able to serve the predicate); otherwise fall back
+                    // to one of the multi-column groups this field participates in.
+                    Map<String, Map<Range, List<IndexFileMeta>>> singleColumn = indexMetas.get(fId);
+                    if (singleColumn != null) {
+                        return createReaders(
+                                indexFileReader,
+                                singleColumn,
+                                Collections.singletonList(rowType.getField(fId)));
+                    }
+                    List<List<Integer>> groups = fieldToGroups.get(fId);
+                    if (groups != null && !groups.isEmpty()) {
+                        // No single-column index for this field: pick one of the multi-column
+                        // groups it belongs to to accelerate the single-column filter.
+                        List<Integer> group = groups.get(0);
                         List<DataField> fields =
                                 group.stream().map(rowType::getField).collect(Collectors.toList());
                         return createReaders(indexFileReader, multiColumnMetas.get(group), fields);
-                    } else {
-                        // Single-column
-                        return createReaders(
-                                indexFileReader,
-                                indexMetas.get(fId),
-                                Collections.singletonList(rowType.getField(fId)));
                     }
+                    return Collections.emptyList();
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -108,22 +108,21 @@ public class GlobalIndexScanner implements Closeable {
                 fId -> {
                     IndexMetaFileGroup group = indexMetas.get(fId);
                     if (group != null) {
-                        return createReaders(indexFileReader, group, rowType);
+                        return createReaders(indexFileReader, group, rowType, Long.MIN_VALUE);
                     }
                     List<IndexMetaFileGroup> extraGroups = extraIndexMetas.get(fId);
                     if (extraGroups == null || extraGroups.isEmpty()) {
                         return Collections.emptyList();
                     }
-                    // Union readers from all groups that share this extra column. Wrap them in a
-                    // single UnionGlobalIndexReader so the evaluator unions (OR) these alternative
-                    // indexes; returning them as separate readers would make visitLeafAsync AND
-                    // them together, which can yield an empty/partial bitmap when the indexes cover
-                    // different row ranges.
+                    long maxEnd = Long.MIN_VALUE;
+                    for (IndexMetaFileGroup g : extraGroups) {
+                        maxEnd = Math.max(maxEnd, g.coverageEnd());
+                    }
                     List<GlobalIndexReader> allReaders = new ArrayList<>();
                     for (IndexMetaFileGroup g : extraGroups) {
-                        allReaders.addAll(createReaders(indexFileReader, g, rowType));
+                        allReaders.addAll(createReaders(indexFileReader, g, rowType, maxEnd));
                     }
-                    return Collections.singletonList(new UnionGlobalIndexReader(allReaders));
+                    return allReaders;
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }
@@ -134,6 +133,7 @@ public class GlobalIndexScanner implements Closeable {
         private final int indexFieldId;
         private final List<Integer> fieldIds;
         private final Map<String, Map<Range, List<IndexFileMeta>>> metas = new HashMap<>();
+        private long coverageEnd = Long.MIN_VALUE;
 
         IndexMetaFileGroup(int indexFieldId, List<Integer> fieldIds) {
             this.indexFieldId = indexFieldId;
@@ -141,9 +141,15 @@ public class GlobalIndexScanner implements Closeable {
         }
 
         void addFile(String indexType, Range range, IndexFileMeta indexFile) {
+            coverageEnd = Math.max(coverageEnd, range.to);
             metas.computeIfAbsent(indexType, k -> new HashMap<>())
                     .computeIfAbsent(range, k -> new ArrayList<>())
                     .add(indexFile);
+        }
+
+        /** The largest indexed rowId across all files of this index (ranges start at 0). */
+        long coverageEnd() {
+            return coverageEnd;
         }
 
         /** The primary index column. */
@@ -217,7 +223,10 @@ public class GlobalIndexScanner implements Closeable {
     }
 
     private Collection<GlobalIndexReader> createReaders(
-            GlobalIndexFileReader indexFileReadWrite, IndexMetaFileGroup group, RowType rowType) {
+            GlobalIndexFileReader indexFileReadWrite,
+            IndexMetaFileGroup group,
+            RowType rowType,
+            long padToEnd) {
         DataField indexField = group.indexField(rowType);
         List<DataField> extraFields = group.extraFields(rowType);
 
@@ -229,9 +238,11 @@ public class GlobalIndexScanner implements Closeable {
             GlobalIndexer globalIndexer =
                     globalIndexerFactory.create(indexField, extraFields, options);
 
+            long typeEnd = Long.MIN_VALUE;
             List<CompletableFuture<GlobalIndexReader>> futures = new ArrayList<>(metas.size());
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {
                 Range range = rangeMetas.getKey();
+                typeEnd = Math.max(typeEnd, range.to);
                 List<IndexFileMeta> indexFileMetas = rangeMetas.getValue();
                 List<GlobalIndexIOMeta> globalMetas =
                         indexFileMetas.stream()
@@ -249,9 +260,16 @@ public class GlobalIndexScanner implements Closeable {
             }
 
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-            List<GlobalIndexReader> unionReader = new ArrayList<>(futures.size());
+            List<GlobalIndexReader> unionReader = new ArrayList<>(futures.size() + 1);
             for (CompletableFuture<GlobalIndexReader> future : futures) {
                 unionReader.add(future.join());
+            }
+            // Pad this index's missing tail with an all-hit reader so AND-ing it with a
+            // longer-range index does not drop rows it has not indexed (ranges start at 0).
+            if (padToEnd > typeEnd) {
+                unionReader.add(
+                        new ConstantGlobalIndexReader(
+                                GlobalIndexResult.fromRange(new Range(typeEnd + 1, padToEnd))));
             }
             readers.add(new UnionGlobalIndexReader(unionReader));
         }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -52,7 +52,6 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
-import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
 import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -91,8 +90,7 @@ public class GlobalIndexScanner implements Closeable {
             String indexType = indexFile.indexType();
             Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
 
-            if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID
-                    && meta.extraFieldIds() != null) {
+            if (meta.isMultiColumn() && meta.extraFieldIds() != null) {
                 // Multi-column index: all participating fields share the same IndexFileMeta,
                 // so looking up from any fieldId returns identical index files.
                 List<Integer> fieldIds =

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -75,44 +75,71 @@ public class GlobalIndexScanner implements Closeable {
                 GlobalIndexReadThreadPool.getExecutorService(options.get(GLOBAL_INDEX_THREAD_NUM));
         this.indexPathFactory = indexPathFactory;
         GlobalIndexFileReader indexFileReader = meta -> fileIO.newInputStream(meta.filePath());
-        Map<Integer, Map<String, Map<Range, List<IndexFileMeta>>>> indexMetas = new HashMap<>();
-        Map<Integer, List<Integer>> fieldIdToIndexFields = new HashMap<>();
+        Map<Integer, IndexMetaFileGroup> indexMetas = new HashMap<>();
+        Map<Integer, List<IndexMetaFileGroup>> extraIndexMetas = new HashMap<>();
         for (IndexFileMeta indexFile : indexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
             String indexType = indexFile.indexType();
             Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
-            int fieldId = meta.indexFieldId();
-            List<Integer> indexFields = meta.getIndexedFieldIds();
-            List<Integer> existing = fieldIdToIndexFields.get(fieldId);
-            if (existing == null) {
-                fieldIdToIndexFields.put(fieldId, indexFields);
+            int indexFieldId = meta.indexFieldId();
+            List<Integer> fieldIds = meta.getIndexedFieldIds();
+            IndexMetaFileGroup group = indexMetas.get(indexFieldId);
+            if (group == null) {
+                group = new IndexMetaFileGroup(indexFieldId, fieldIds);
+                indexMetas.put(indexFieldId, group);
+                if (meta.extraFieldIds() != null) {
+                    for (int extra : meta.extraFieldIds()) {
+                        extraIndexMetas.computeIfAbsent(extra, k -> new ArrayList<>()).add(group);
+                    }
+                }
             } else {
                 checkArgument(
-                        existing.equals(indexFields),
+                        group.fieldIds.equals(fieldIds),
                         "Primary field %s owns multiple indexes with different columns %s and %s; "
                                 + "a primary column can own at most one index.",
-                        fieldId,
-                        existing,
-                        indexFields);
+                        indexFieldId,
+                        group.fieldIds,
+                        fieldIds);
             }
-            indexMetas
-                    .computeIfAbsent(fieldId, k -> new HashMap<>())
-                    .computeIfAbsent(indexType, k -> new HashMap<>())
-                    .computeIfAbsent(range, k -> new ArrayList<>())
-                    .add(indexFile);
+            group.addFile(indexType, range, indexFile);
         }
 
         IntFunction<Collection<GlobalIndexReader>> readersFunction =
                 fId -> {
-                    List<Integer> group = fieldIdToIndexFields.get(fId);
+                    IndexMetaFileGroup group = indexMetas.get(fId);
                     if (group == null) {
-                        return Collections.emptyList();
+                        List<IndexMetaFileGroup> extraGroups = extraIndexMetas.get(fId);
+                        if (extraGroups == null || extraGroups.isEmpty()) {
+                            return Collections.emptyList();
+                        }
+                        group = extraGroups.get(0);
                     }
                     List<DataField> fields =
-                            group.stream().map(rowType::getField).collect(Collectors.toList());
-                    return createReaders(indexFileReader, indexMetas.get(fId), fields);
+                            group.fieldIds.stream()
+                                    .map(rowType::getField)
+                                    .collect(Collectors.toList());
+                    return createReaders(indexFileReader, group.metas, fields);
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
+    }
+
+    /** All index files of one global index (single- or multi-column), grouped for reading. */
+    private static class IndexMetaFileGroup {
+
+        private final int indexFieldId;
+        private final List<Integer> fieldIds;
+        private final Map<String, Map<Range, List<IndexFileMeta>>> metas = new HashMap<>();
+
+        IndexMetaFileGroup(int indexFieldId, List<Integer> fieldIds) {
+            this.indexFieldId = indexFieldId;
+            this.fieldIds = fieldIds;
+        }
+
+        void addFile(String indexType, Range range, IndexFileMeta indexFile) {
+            metas.computeIfAbsent(indexType, k -> new HashMap<>())
+                    .computeIfAbsent(range, k -> new ArrayList<>())
+                    .add(indexFile);
+        }
     }
 
     public static Optional<GlobalIndexScanner> create(
@@ -145,6 +172,8 @@ public class GlobalIndexScanner implements Closeable {
                     if (globalIndex == null) {
                         return false;
                     }
+                    // Collect indexes whose primary column is filtered, and also multi-column
+                    // indexes that have a filtered column as an extra (used as a fallback).
                     if (filterFieldIds.contains(globalIndex.indexFieldId())) {
                         return true;
                     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -37,7 +37,6 @@ import org.apache.paimon.utils.Range;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +53,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
 import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Scanner for shard-based global indexes. */
@@ -75,74 +75,42 @@ public class GlobalIndexScanner implements Closeable {
                 GlobalIndexReadThreadPool.getExecutorService(options.get(GLOBAL_INDEX_THREAD_NUM));
         this.indexPathFactory = indexPathFactory;
         GlobalIndexFileReader indexFileReader = meta -> fileIO.newInputStream(meta.filePath());
-
-        // Single-column indexes: fieldId -> indexType -> range -> files
         Map<Integer, Map<String, Map<Range, List<IndexFileMeta>>>> indexMetas = new HashMap<>();
-        // Multi-column indexes: fieldIds -> indexType -> range -> files
-        Map<List<Integer>, Map<String, Map<Range, List<IndexFileMeta>>>> multiColumnMetas =
-                new HashMap<>();
-        // Reverse lookup: fieldId -> all multi-column groups it participates in. A field can
-        // belong to several multi-column indexes (e.g. (a,b) and (a,c)) at the same time.
-        Map<Integer, List<List<Integer>>> fieldToGroups = new HashMap<>();
-
+        Map<Integer, List<Integer>> fieldIdToIndexFields = new HashMap<>();
         for (IndexFileMeta indexFile : indexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
             String indexType = indexFile.indexType();
             Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
-
-            if (meta.isMultiColumn() && meta.extraFieldIds() != null) {
-                // Multi-column index: all participating fields share the same IndexFileMeta.
-                // Multiple index files belonging to the same group are aggregated under the same
-                // multiColumnMetas key, and each participating field records this group.
-                List<Integer> fieldIds =
-                        Arrays.stream(meta.extraFieldIds()).boxed().collect(Collectors.toList());
-                multiColumnMetas
-                        .computeIfAbsent(fieldIds, k -> new HashMap<>())
-                        .computeIfAbsent(indexType, k -> new HashMap<>())
-                        .computeIfAbsent(range, k -> new ArrayList<>())
-                        .add(indexFile);
-                for (int id : fieldIds) {
-                    List<List<Integer>> groups =
-                            fieldToGroups.computeIfAbsent(id, k -> new ArrayList<>());
-                    if (!groups.contains(fieldIds)) {
-                        groups.add(fieldIds);
-                    }
-                }
+            int fieldId = meta.indexFieldId();
+            List<Integer> indexFields = meta.getIndexedFieldIds();
+            List<Integer> existing = fieldIdToIndexFields.get(fieldId);
+            if (existing == null) {
+                fieldIdToIndexFields.put(fieldId, indexFields);
             } else {
-                // Single-column index
-                int fieldId = meta.indexFieldId();
-                indexMetas
-                        .computeIfAbsent(fieldId, k -> new HashMap<>())
-                        .computeIfAbsent(indexType, k -> new HashMap<>())
-                        .computeIfAbsent(range, k -> new ArrayList<>())
-                        .add(indexFile);
+                checkArgument(
+                        existing.equals(indexFields),
+                        "Primary field %s owns multiple indexes with different columns %s and %s; "
+                                + "a primary column can own at most one index.",
+                        fieldId,
+                        existing,
+                        indexFields);
             }
+            indexMetas
+                    .computeIfAbsent(fieldId, k -> new HashMap<>())
+                    .computeIfAbsent(indexType, k -> new HashMap<>())
+                    .computeIfAbsent(range, k -> new ArrayList<>())
+                    .add(indexFile);
         }
 
         IntFunction<Collection<GlobalIndexReader>> readersFunction =
                 fId -> {
-                    // A filter on a single field can be served by any index covering that field,
-                    // and every such index returns the same matching row ids. So pick ONE index
-                    // instead of running them all: prefer the single-column index (purpose-built
-                    // for this field and always able to serve the predicate); otherwise fall back
-                    // to one of the multi-column groups this field participates in.
-                    Map<String, Map<Range, List<IndexFileMeta>>> singleColumn = indexMetas.get(fId);
-                    if (singleColumn != null) {
-                        return createReaders(
-                                indexFileReader,
-                                singleColumn,
-                                Collections.singletonList(rowType.getField(fId)));
+                    List<Integer> group = fieldIdToIndexFields.get(fId);
+                    if (group == null) {
+                        return Collections.emptyList();
                     }
-                    List<List<Integer>> groups = fieldToGroups.get(fId);
-                    if (groups != null && !groups.isEmpty()) {
-                        // No single-column index for this field: pick one of the multi-column
-                        // groups it belongs to to accelerate the single-column filter.
-                        List<Integer> group = groups.get(0);
-                        List<DataField> fields =
-                                group.stream().map(rowType::getField).collect(Collectors.toList());
-                        return createReaders(indexFileReader, multiColumnMetas.get(group), fields);
-                    }
-                    return Collections.emptyList();
+                    List<DataField> fields =
+                            group.stream().map(rowType::getField).collect(Collectors.toList());
+                    return createReaders(indexFileReader, indexMetas.get(fId), fields);
                 };
         this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -20,7 +20,6 @@ package org.apache.paimon.globalindex;
 
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
@@ -92,15 +91,14 @@ public class GlobalIndexScanner implements Closeable {
             String indexType = indexFile.indexType();
             Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
 
-            if (meta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
+            if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID
                     && meta.extraFieldIds() != null) {
                 // Multi-column index: all participating fields share the same IndexFileMeta,
                 // so looking up from any fieldId returns identical index files.
                 List<Integer> fieldIds =
-                        Arrays.stream(meta.extraFieldIds())
-                                .boxed()
-                                .collect(Collectors.toList());
-                // Validate consistency: all files in the same group must have identical extraFieldIds
+                        Arrays.stream(meta.extraFieldIds()).boxed().collect(Collectors.toList());
+                // Validate consistency: all files in the same group must have identical
+                // extraFieldIds
                 if (fieldToGroup.containsKey(fieldIds.get(0))) {
                     List<Integer> existingGroup = fieldToGroup.get(fieldIds.get(0));
                     checkArgument(
@@ -132,11 +130,8 @@ public class GlobalIndexScanner implements Closeable {
                     if (group != null) {
                         // Multi-column: resolve full field list
                         List<DataField> fields =
-                                group.stream()
-                                        .map(rowType::getField)
-                                        .collect(Collectors.toList());
-                        return createReaders(
-                                indexFileReader, multiColumnMetas.get(group), fields);
+                                group.stream().map(rowType::getField).collect(Collectors.toList());
+                        return createReaders(indexFileReader, multiColumnMetas.get(group), fields);
                     } else {
                         // Single-column
                         return createReaders(

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.index;
 
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -76,6 +77,10 @@ public class GlobalIndexMeta {
 
     public int indexFieldId() {
         return indexFieldId;
+    }
+
+    public boolean isMultiColumn() {
+        return indexFieldId == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -119,6 +119,22 @@ public class GlobalIndexMeta {
         return fields;
     }
 
+    /** The primary index column. */
+    public DataField getIndexField(RowType rowType) {
+        return rowType.getField(indexFieldId);
+    }
+
+    /** The extra columns beyond the primary one; empty for a single-column index. */
+    public List<DataField> getExtraFields(RowType rowType) {
+        List<DataField> fields = new ArrayList<>();
+        if (extraFieldIds != null) {
+            for (int id : extraFieldIds) {
+                fields.add(rowType.getField(id));
+            }
+        }
+        return fields;
+    }
+
     public List<String> getIndexedFieldNames(RowType rowType) {
         List<String> names = new ArrayList<>();
         for (int id : getIndexedFieldIds()) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -28,7 +28,9 @@ import org.apache.paimon.utils.Range;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /** Schema for global index. */
 public class GlobalIndexMeta {
@@ -91,5 +93,22 @@ public class GlobalIndexMeta {
     @Nullable
     public byte[] indexMeta() {
         return indexMeta;
+    }
+
+    public List<String> getIndexedFieldNames(RowType rowType) {
+        List<String> names = new ArrayList<>();
+        if (isMultiColumn()) {
+            for (int id : extraFieldIds) {
+                names.add(rowType.getField(id).name());
+            }
+        } else {
+            names.add(rowType.getField(indexFieldId).name());
+            if (extraFieldIds != null) {
+                for (int id : extraFieldIds) {
+                    names.add(rowType.getField(id).name());
+                }
+            }
+        }
+        return names;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.index;
 
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -81,8 +80,13 @@ public class GlobalIndexMeta {
         return indexFieldId;
     }
 
+    /**
+     * Whether this index covers more than one column. {@link #indexFieldId} is always the primary
+     * column; {@link #extraFieldIds} holds the remaining columns and is null/empty for a
+     * single-column index.
+     */
     public boolean isMultiColumn() {
-        return indexFieldId == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
+        return extraFieldIds != null && extraFieldIds.length > 0;
     }
 
     @Nullable
@@ -95,19 +99,30 @@ public class GlobalIndexMeta {
         return indexMeta;
     }
 
+    /** All indexed field ids in order: the primary {@link #indexFieldId} followed by the rest. */
+    public List<Integer> getIndexedFieldIds() {
+        List<Integer> ids = new ArrayList<>();
+        ids.add(indexFieldId);
+        if (extraFieldIds != null) {
+            for (int id : extraFieldIds) {
+                ids.add(id);
+            }
+        }
+        return ids;
+    }
+
+    public List<DataField> getIndexedFields(RowType rowType) {
+        List<DataField> fields = new ArrayList<>();
+        for (int id : getIndexedFieldIds()) {
+            fields.add(rowType.getField(id));
+        }
+        return fields;
+    }
+
     public List<String> getIndexedFieldNames(RowType rowType) {
         List<String> names = new ArrayList<>();
-        if (isMultiColumn()) {
-            for (int id : extraFieldIds) {
-                names.add(rowType.getField(id).name());
-            }
-        } else {
-            names.add(rowType.getField(indexFieldId).name());
-            if (extraFieldIds != null) {
-                for (int id : extraFieldIds) {
-                    names.add(rowType.getField(id).name());
-                }
-            }
+        for (int id : getIndexedFieldIds()) {
+            names.add(rowType.getField(id).name());
         }
         return names;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/GlobalIndexMeta.java
@@ -80,15 +80,6 @@ public class GlobalIndexMeta {
         return indexFieldId;
     }
 
-    /**
-     * Whether this index covers more than one column. {@link #indexFieldId} is always the primary
-     * column; {@link #extraFieldIds} holds the remaining columns and is null/empty for a
-     * single-column index.
-     */
-    public boolean isMultiColumn() {
-        return extraFieldIds != null && extraFieldIds.length > 0;
-    }
-
     @Nullable
     public int[] extraFieldIds() {
         return extraFieldIds;

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
@@ -28,6 +28,7 @@ import org.apache.paimon.utils.Range;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -239,15 +240,15 @@ public class IndexManifestFileHandler {
 
                 for (IndexManifestEntry added : addedIndexFiles) {
                     GlobalIndexMeta addedMeta = added.indexFile().globalIndexMeta();
-                    if (addedMeta == null) {
-                        continue;
-                    }
-                    if (retainedMeta.indexFieldId() != addedMeta.indexFieldId()
-                            || !Range.intersect(
-                                    retainedMeta.rowRangeStart(),
-                                    retainedMeta.rowRangeEnd(),
-                                    addedMeta.rowRangeStart(),
-                                    addedMeta.rowRangeEnd())) {
+                    if (addedMeta == null
+                            || retainedMeta.indexFieldId() != addedMeta.indexFieldId()
+                            || (Arrays.equals(
+                                            retainedMeta.extraFieldIds(), addedMeta.extraFieldIds())
+                                    && !Range.intersect(
+                                            retainedMeta.rowRangeStart(),
+                                            retainedMeta.rowRangeEnd(),
+                                            addedMeta.rowRangeStart(),
+                                            addedMeta.rowRangeEnd()))) {
                         continue;
                     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
@@ -28,6 +28,7 @@ import org.apache.paimon.utils.Range;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -239,14 +240,30 @@ public class IndexManifestFileHandler {
 
                 for (IndexManifestEntry added : addedIndexFiles) {
                     GlobalIndexMeta addedMeta = added.indexFile().globalIndexMeta();
-                    if (addedMeta == null
-                            || retainedMeta.indexFieldId() != addedMeta.indexFieldId()
-                            || !Range.intersect(
-                                    retainedMeta.rowRangeStart(),
-                                    retainedMeta.rowRangeEnd(),
-                                    addedMeta.rowRangeStart(),
-                                    addedMeta.rowRangeEnd())) {
+                    if (addedMeta == null) {
                         continue;
+                    }
+
+                    // Single-column: skip if different fieldId or no range overlap
+                    if (!retainedMeta.isMultiColumn()) {
+                        if (retainedMeta.indexFieldId() != addedMeta.indexFieldId()
+                                || !Range.intersect(
+                                        retainedMeta.rowRangeStart(),
+                                        retainedMeta.rowRangeEnd(),
+                                        addedMeta.rowRangeStart(),
+                                        addedMeta.rowRangeEnd())) {
+                            continue;
+                        }
+                    } else {
+                        // Multi-column: skip if different column group or no range overlap
+                        if (!Arrays.equals(retainedMeta.extraFieldIds(), addedMeta.extraFieldIds())
+                                || !Range.intersect(
+                                        retainedMeta.rowRangeStart(),
+                                        retainedMeta.rowRangeEnd(),
+                                        addedMeta.rowRangeStart(),
+                                        addedMeta.rowRangeEnd())) {
+                            continue;
+                        }
                     }
 
                     throw new IllegalStateException(

--- a/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/manifest/IndexManifestFileHandler.java
@@ -28,7 +28,6 @@ import org.apache.paimon.utils.Range;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -243,27 +242,13 @@ public class IndexManifestFileHandler {
                     if (addedMeta == null) {
                         continue;
                     }
-
-                    // Single-column: skip if different fieldId or no range overlap
-                    if (!retainedMeta.isMultiColumn()) {
-                        if (retainedMeta.indexFieldId() != addedMeta.indexFieldId()
-                                || !Range.intersect(
-                                        retainedMeta.rowRangeStart(),
-                                        retainedMeta.rowRangeEnd(),
-                                        addedMeta.rowRangeStart(),
-                                        addedMeta.rowRangeEnd())) {
-                            continue;
-                        }
-                    } else {
-                        // Multi-column: skip if different column group or no range overlap
-                        if (!Arrays.equals(retainedMeta.extraFieldIds(), addedMeta.extraFieldIds())
-                                || !Range.intersect(
-                                        retainedMeta.rowRangeStart(),
-                                        retainedMeta.rowRangeEnd(),
-                                        addedMeta.rowRangeStart(),
-                                        addedMeta.rowRangeEnd())) {
-                            continue;
-                        }
+                    if (retainedMeta.indexFieldId() != addedMeta.indexFieldId()
+                            || !Range.intersect(
+                                    retainedMeta.rowRangeStart(),
+                                    retainedMeta.rowRangeEnd(),
+                                    addedMeta.rowRangeStart(),
+                                    addedMeta.rowRangeEnd())) {
+                        continue;
                     }
 
                     throw new IllegalStateException(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
 import org.apache.paimon.globalindex.GlobalIndexReader;
@@ -34,6 +35,7 @@ import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
 import java.util.ArrayList;
@@ -78,10 +80,24 @@ public class FullTextReadImpl implements FullTextRead {
             return GlobalIndexResult.createEmpty();
         }
 
-        String indexType = splits.get(0).fullTextIndexFiles().get(0).indexType();
-        GlobalIndexer globalIndexer =
-                GlobalIndexerFactoryUtils.load(indexType)
-                        .create(textColumn, table.coreOptions().toConfiguration());
+        IndexFileMeta firstFile = splits.get(0).fullTextIndexFiles().get(0);
+        String indexType = firstFile.indexType();
+        GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
+        GlobalIndexer globalIndexer;
+        if (firstMeta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID) {
+            RowType rowType = table.rowType();
+            List<DataField> fields = new ArrayList<>();
+            for (int id : firstMeta.extraFieldIds()) {
+                fields.add(rowType.getField(id));
+            }
+            globalIndexer =
+                    GlobalIndexerFactoryUtils.load(indexType)
+                            .create(fields, table.coreOptions().toConfiguration());
+        } else {
+            globalIndexer =
+                    GlobalIndexerFactoryUtils.load(indexType)
+                            .create(textColumn, table.coreOptions().toConfiguration());
+        }
         IndexPathFactory indexPathFactory = table.store().pathFactory().globalIndexFileFactory();
 
         int parallelism = table.coreOptions().toConfiguration().get(GLOBAL_INDEX_THREAD_NUM);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -86,7 +86,10 @@ public class FullTextReadImpl implements FullTextRead {
             List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
-                            .create(fields, table.coreOptions().toConfiguration());
+                            .create(
+                                    fields.get(0),
+                                    fields.subList(1, fields.size()),
+                                    table.coreOptions().toConfiguration());
         } else {
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -82,7 +82,7 @@ public class FullTextReadImpl implements FullTextRead {
         String indexType = firstFile.indexType();
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
-        if (firstMeta.isMultiColumn()) {
+        if (firstMeta.extraFieldIds() != null) {
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
 import org.apache.paimon.globalindex.GlobalIndexReader;
@@ -84,7 +83,7 @@ public class FullTextReadImpl implements FullTextRead {
         String indexType = firstFile.indexType();
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
-        if (firstMeta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID) {
+        if (firstMeta.isMultiColumn()) {
             RowType rowType = table.rowType();
             List<DataField> fields = new ArrayList<>();
             for (int id : firstMeta.extraFieldIds()) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -34,7 +34,6 @@ import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
 import java.util.ArrayList;
@@ -84,11 +83,7 @@ public class FullTextReadImpl implements FullTextRead {
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
         if (firstMeta.isMultiColumn()) {
-            RowType rowType = table.rowType();
-            List<DataField> fields = new ArrayList<>();
-            for (int id : firstMeta.extraFieldIds()) {
-                fields.add(rowType.getField(id));
-            }
+            List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(fields, table.coreOptions().toConfiguration());

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -83,12 +83,11 @@ public class FullTextReadImpl implements FullTextRead {
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
         if (firstMeta.isMultiColumn()) {
-            List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(
-                                    fields.get(0),
-                                    fields.subList(1, fields.size()),
+                                    firstMeta.getIndexField(table.rowType()),
+                                    firstMeta.getExtraFields(table.rowType()),
                                     table.coreOptions().toConfiguration());
         } else {
             globalIndexer =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
@@ -61,17 +61,7 @@ public class FullTextScanImpl implements FullTextScan {
                     if (globalIndex == null) {
                         return false;
                     }
-                    if (textColumn.id() == globalIndex.indexFieldId()) {
-                        return true;
-                    }
-                    if (globalIndex.extraFieldIds() != null) {
-                        for (int id : globalIndex.extraFieldIds()) {
-                            if (textColumn.id() == id) {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
+                    return textColumn.id() == globalIndex.indexFieldId();
                 };
 
         List<IndexFileMeta> allIndexFiles =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
@@ -61,7 +61,17 @@ public class FullTextScanImpl implements FullTextScan {
                     if (globalIndex == null) {
                         return false;
                     }
-                    return textColumn.id() == globalIndex.indexFieldId();
+                    if (textColumn.id() == globalIndex.indexFieldId()) {
+                        return true;
+                    }
+                    if (globalIndex.extraFieldIds() != null) {
+                        for (int id : globalIndex.extraFieldIds()) {
+                            if (textColumn.id() == id) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
                 };
 
         List<IndexFileMeta> allIndexFiles =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -91,7 +91,7 @@ public class VectorReadImpl implements VectorRead, Serializable {
         String indexType = firstFile.indexType();
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
-        if (firstMeta.isMultiColumn()) {
+        if (firstMeta.extraFieldIds() != null) {
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
 import org.apache.paimon.globalindex.GlobalIndexReader;
@@ -36,6 +37,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.VectorSearch;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -87,10 +89,24 @@ public class VectorReadImpl implements VectorRead, Serializable {
 
         RoaringNavigableMap64 preFilter = preFilter(splits).orElse(null);
 
-        String indexType = splits.get(0).vectorIndexFiles().get(0).indexType();
-        GlobalIndexer globalIndexer =
-                GlobalIndexerFactoryUtils.load(indexType)
-                        .create(vectorColumn, table.coreOptions().toConfiguration());
+        IndexFileMeta firstFile = splits.get(0).vectorIndexFiles().get(0);
+        String indexType = firstFile.indexType();
+        GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
+        GlobalIndexer globalIndexer;
+        if (firstMeta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID) {
+            RowType rowType = table.rowType();
+            List<DataField> fields = new ArrayList<>();
+            for (int id : firstMeta.extraFieldIds()) {
+                fields.add(rowType.getField(id));
+            }
+            globalIndexer =
+                    GlobalIndexerFactoryUtils.load(indexType)
+                            .create(fields, table.coreOptions().toConfiguration());
+        } else {
+            globalIndexer =
+                    GlobalIndexerFactoryUtils.load(indexType)
+                            .create(vectorColumn, table.coreOptions().toConfiguration());
+        }
         IndexPathFactory indexPathFactory = table.store().pathFactory().globalIndexFileFactory();
 
         int parallelism = table.coreOptions().toConfiguration().get(GLOBAL_INDEX_THREAD_NUM);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -92,12 +92,11 @@ public class VectorReadImpl implements VectorRead, Serializable {
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
         if (firstMeta.isMultiColumn()) {
-            List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(
-                                    fields.get(0),
-                                    fields.subList(1, fields.size()),
+                                    firstMeta.getIndexField(table.rowType()),
+                                    firstMeta.getExtraFields(table.rowType()),
                                     table.coreOptions().toConfiguration());
         } else {
             globalIndexer =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -36,7 +36,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.VectorSearch;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -93,11 +92,7 @@ public class VectorReadImpl implements VectorRead, Serializable {
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
         if (firstMeta.isMultiColumn()) {
-            RowType rowType = table.rowType();
-            List<DataField> fields = new ArrayList<>();
-            for (int id : firstMeta.extraFieldIds()) {
-                fields.add(rowType.getField(id));
-            }
+            List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
                             .create(fields, table.coreOptions().toConfiguration());

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -95,7 +95,10 @@ public class VectorReadImpl implements VectorRead, Serializable {
             List<DataField> fields = firstMeta.getIndexedFields(table.rowType());
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)
-                            .create(fields, table.coreOptions().toConfiguration());
+                            .create(
+                                    fields.get(0),
+                                    fields.subList(1, fields.size()),
+                                    table.coreOptions().toConfiguration());
         } else {
             globalIndexer =
                     GlobalIndexerFactoryUtils.load(indexType)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorReadImpl.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
 import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
 import org.apache.paimon.globalindex.GlobalIndexReader;
@@ -93,7 +92,7 @@ public class VectorReadImpl implements VectorRead, Serializable {
         String indexType = firstFile.indexType();
         GlobalIndexMeta firstMeta = checkNotNull(firstFile.globalIndexMeta());
         GlobalIndexer globalIndexer;
-        if (firstMeta.indexFieldId() == GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID) {
+        if (firstMeta.isMultiColumn()) {
             RowType rowType = table.rowType();
             List<DataField> fields = new ArrayList<>();
             for (int id : firstMeta.extraFieldIds()) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
@@ -82,17 +82,7 @@ public class VectorScanImpl implements VectorScan {
                         return false;
                     }
                     int fieldId = globalIndex.indexFieldId();
-                    if (vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId)) {
-                        return true;
-                    }
-                    if (globalIndex.extraFieldIds() != null) {
-                        for (int id : globalIndex.extraFieldIds()) {
-                            if (vectorColumn.id() == id || filterFieldIds.contains(id)) {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
+                    return vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId);
                 };
 
         List<IndexFileMeta> allIndexFiles =
@@ -104,7 +94,7 @@ public class VectorScanImpl implements VectorScan {
         Map<Range, List<IndexFileMeta>> vectorByRange = new HashMap<>();
         for (IndexFileMeta indexFile : allIndexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
-            if (containsField(meta, vectorColumn.id())) {
+            if (isPrimaryColumn(meta, vectorColumn.id())) {
                 Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
                 vectorByRange.computeIfAbsent(range, k -> new ArrayList<>()).add(indexFile);
             }
@@ -121,7 +111,7 @@ public class VectorScanImpl implements VectorScan {
                                     f -> {
                                         GlobalIndexMeta globalIndex =
                                                 checkNotNull(f.globalIndexMeta());
-                                        if (containsField(globalIndex, vectorColumn.id())) {
+                                        if (isPrimaryColumn(globalIndex, vectorColumn.id())) {
                                             return false;
                                         }
                                         return range.hasIntersection(globalIndex.rowRange());
@@ -133,17 +123,7 @@ public class VectorScanImpl implements VectorScan {
         return () -> splits;
     }
 
-    private static boolean containsField(GlobalIndexMeta meta, int fieldId) {
-        if (meta.indexFieldId() == fieldId) {
-            return true;
-        }
-        if (meta.extraFieldIds() != null) {
-            for (int id : meta.extraFieldIds()) {
-                if (id == fieldId) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    private static boolean isPrimaryColumn(GlobalIndexMeta meta, int fieldId) {
+        return meta.indexFieldId() == fieldId;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
@@ -82,7 +82,17 @@ public class VectorScanImpl implements VectorScan {
                         return false;
                     }
                     int fieldId = globalIndex.indexFieldId();
-                    return vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId);
+                    if (vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId)) {
+                        return true;
+                    }
+                    if (globalIndex.extraFieldIds() != null) {
+                        for (int id : globalIndex.extraFieldIds()) {
+                            if (vectorColumn.id() == id || filterFieldIds.contains(id)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
                 };
 
         List<IndexFileMeta> allIndexFiles =
@@ -94,7 +104,7 @@ public class VectorScanImpl implements VectorScan {
         Map<Range, List<IndexFileMeta>> vectorByRange = new HashMap<>();
         for (IndexFileMeta indexFile : allIndexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
-            if (meta.indexFieldId() == vectorColumn.id()) {
+            if (containsField(meta, vectorColumn.id())) {
                 Range range = new Range(meta.rowRangeStart(), meta.rowRangeEnd());
                 vectorByRange.computeIfAbsent(range, k -> new ArrayList<>()).add(indexFile);
             }
@@ -111,7 +121,7 @@ public class VectorScanImpl implements VectorScan {
                                     f -> {
                                         GlobalIndexMeta globalIndex =
                                                 checkNotNull(f.globalIndexMeta());
-                                        if (globalIndex.indexFieldId() == vectorColumn.id()) {
+                                        if (containsField(globalIndex, vectorColumn.id())) {
                                             return false;
                                         }
                                         return range.hasIntersection(globalIndex.rowRange());
@@ -121,5 +131,19 @@ public class VectorScanImpl implements VectorScan {
         }
 
         return () -> splits;
+    }
+
+    private static boolean containsField(GlobalIndexMeta meta, int fieldId) {
+        if (meta.indexFieldId() == fieldId) {
+            return true;
+        }
+        if (meta.extraFieldIds() != null) {
+            for (int id : meta.extraFieldIds()) {
+                if (id == fieldId) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
@@ -82,7 +82,18 @@ public class VectorScanImpl implements VectorScan {
                         return false;
                     }
                     int fieldId = globalIndex.indexFieldId();
-                    return vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId);
+                    if (vectorColumn.id() == fieldId || filterFieldIds.contains(fieldId)) {
+                        return true;
+                    }
+                    int[] extras = globalIndex.extraFieldIds();
+                    if (extras != null) {
+                        for (int extra : extras) {
+                            if (filterFieldIds.contains(extra)) {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
                 };
 
         List<IndexFileMeta> allIndexFiles =

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
@@ -234,9 +234,20 @@ public class TableIndexesTable implements ReadonlyTable {
             GlobalIndexMeta globalMeta = indexManifestEntry.indexFile().globalIndexMeta();
             String indexFieldName = null;
             if (globalMeta != null) {
-                try {
-                    indexFieldName = logicalRowType.getField(globalMeta.indexFieldId()).name();
-                } catch (RuntimeException ignored) {
+                if (globalMeta.isMultiColumn() && globalMeta.extraFieldIds() != null) {
+                    StringBuilder sb = new StringBuilder();
+                    for (int i = 0; i < globalMeta.extraFieldIds().length; i++) {
+                        if (i > 0) {
+                            sb.append(",");
+                        }
+                        sb.append(logicalRowType.getField(globalMeta.extraFieldIds()[i]).name());
+                    }
+                    indexFieldName = sb.toString();
+                } else {
+                    try {
+                        indexFieldName = logicalRowType.getField(globalMeta.indexFieldId()).name();
+                    } catch (RuntimeException ignored) {
+                    }
                 }
             }
             return GenericRow.of(

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/TableIndexesTable.java
@@ -234,20 +234,17 @@ public class TableIndexesTable implements ReadonlyTable {
             GlobalIndexMeta globalMeta = indexManifestEntry.indexFile().globalIndexMeta();
             String indexFieldName = null;
             if (globalMeta != null) {
-                if (globalMeta.isMultiColumn() && globalMeta.extraFieldIds() != null) {
-                    StringBuilder sb = new StringBuilder();
-                    for (int i = 0; i < globalMeta.extraFieldIds().length; i++) {
-                        if (i > 0) {
-                            sb.append(",");
-                        }
-                        sb.append(logicalRowType.getField(globalMeta.extraFieldIds()[i]).name());
-                    }
-                    indexFieldName = sb.toString();
-                } else {
-                    try {
-                        indexFieldName = logicalRowType.getField(globalMeta.indexFieldId()).name();
-                    } catch (RuntimeException ignored) {
-                    }
+                try {
+                    indexFieldName =
+                            String.join(",", globalMeta.getIndexedFieldNames(logicalRowType));
+                } catch (RuntimeException e) {
+                    // Indexed columns may no longer exist in the current schema (e.g. dropped via
+                    // ALTER TABLE); leave the name empty instead of failing the listing.
+                    LOG.debug(
+                            "Failed to resolve indexed field names for index file {} (primary field {}).",
+                            indexManifestEntry.indexFile().fileName(),
+                            globalMeta.indexFieldId(),
+                            e);
                 }
             }
             return GenericRow.of(

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
@@ -77,7 +77,7 @@ class GlobalIndexBuilderUtilsTest {
         coreOptions = new CoreOptions(new Options().toMap());
     }
 
-    // Test: 2 columns (title + vec), indexFieldId=-1, all field ids stored in extraFieldIds
+    // Test: 2 columns (title + vec), primary column title is indexFieldId, rest in extraFieldIds
     @Test
     void testToIndexFileMetasMultiColumn() throws IOException {
         DataField titleField = new DataField(1, "title", new VarCharType(Integer.MAX_VALUE));
@@ -92,8 +92,8 @@ class GlobalIndexBuilderUtilsTest {
                         fileIO, indexPathFactory, coreOptions, range, fields, "test-type", entries);
 
         assertThat(metas).hasSize(1);
-        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(-1);
-        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {1, 2});
+        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(1);
+        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {2});
         assertThat(metas.get(0).globalIndexMeta().rowRangeStart()).isEqualTo(0);
         assertThat(metas.get(0).globalIndexMeta().rowRangeEnd()).isEqualTo(99);
     }
@@ -117,7 +117,8 @@ class GlobalIndexBuilderUtilsTest {
         assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isNull();
     }
 
-    // Test: 3 columns (title + vec + id), indexFieldId=-1, all field ids in extraFieldIds
+    // Test: 3 columns (title + vec + id), primary column title is indexFieldId, rest in
+    // extraFieldIds
     @Test
     void testToIndexFileMetasThreeColumns() throws IOException {
         DataField titleField = new DataField(1, "title", new VarCharType(Integer.MAX_VALUE));
@@ -133,8 +134,8 @@ class GlobalIndexBuilderUtilsTest {
                         fileIO, indexPathFactory, coreOptions, range, fields, "test-type", entries);
 
         assertThat(metas).hasSize(1);
-        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(-1);
-        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {1, 2, 3});
+        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(1);
+        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {2, 3});
     }
 
     private List<ResultEntry> createDummyResultEntries() throws IOException {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexBuilderUtilsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.FloatType;
+import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.Range;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link GlobalIndexBuilderUtils}. */
+class GlobalIndexBuilderUtilsTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private FileIO fileIO;
+    private IndexPathFactory indexPathFactory;
+    private CoreOptions coreOptions;
+
+    @BeforeEach
+    void setUp() {
+        fileIO = new LocalFileIO();
+        Path dir = new Path(tempDir.toString());
+        indexPathFactory =
+                new IndexPathFactory() {
+                    @Override
+                    public Path toPath(String fileName) {
+                        return new Path(dir, fileName);
+                    }
+
+                    @Override
+                    public Path newPath() {
+                        return new Path(dir, UUID.randomUUID().toString());
+                    }
+
+                    @Override
+                    public boolean isExternalPath() {
+                        return false;
+                    }
+                };
+        coreOptions = new CoreOptions(new Options().toMap());
+    }
+
+    // Test: 2 columns (title + vec), indexFieldId=-1, all field ids stored in extraFieldIds
+    @Test
+    void testToIndexFileMetasMultiColumn() throws IOException {
+        DataField titleField = new DataField(1, "title", new VarCharType(Integer.MAX_VALUE));
+        DataField vecField = new DataField(2, "vec", new ArrayType(new FloatType()));
+        List<DataField> fields = Arrays.asList(titleField, vecField);
+
+        List<ResultEntry> entries = createDummyResultEntries();
+        Range range = new Range(0, 99);
+
+        List<IndexFileMeta> metas =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        fileIO, indexPathFactory, coreOptions, range, fields, "test-type", entries);
+
+        assertThat(metas).hasSize(1);
+        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(-1);
+        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {1, 2});
+        assertThat(metas.get(0).globalIndexMeta().rowRangeStart()).isEqualTo(0);
+        assertThat(metas.get(0).globalIndexMeta().rowRangeEnd()).isEqualTo(99);
+    }
+
+    // Test: single column, extraFieldIds should be null (backward compatible with single-column
+    // path)
+    @Test
+    void testToIndexFileMetasSingleColumn() throws IOException {
+        DataField titleField = new DataField(1, "title", new VarCharType(Integer.MAX_VALUE));
+        List<DataField> fields = Collections.singletonList(titleField);
+
+        List<ResultEntry> entries = createDummyResultEntries();
+        Range range = new Range(0, 49);
+
+        List<IndexFileMeta> metas =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        fileIO, indexPathFactory, coreOptions, range, fields, "test-type", entries);
+
+        assertThat(metas).hasSize(1);
+        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(1);
+        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isNull();
+    }
+
+    // Test: 3 columns (title + vec + id), indexFieldId=-1, all field ids in extraFieldIds
+    @Test
+    void testToIndexFileMetasThreeColumns() throws IOException {
+        DataField titleField = new DataField(1, "title", new VarCharType(Integer.MAX_VALUE));
+        DataField vecField = new DataField(2, "vec", new ArrayType(new FloatType()));
+        DataField idField = new DataField(3, "id", new IntType());
+        List<DataField> fields = Arrays.asList(titleField, vecField, idField);
+
+        List<ResultEntry> entries = createDummyResultEntries();
+        Range range = new Range(0, 199);
+
+        List<IndexFileMeta> metas =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        fileIO, indexPathFactory, coreOptions, range, fields, "test-type", entries);
+
+        assertThat(metas).hasSize(1);
+        assertThat(metas.get(0).globalIndexMeta().indexFieldId()).isEqualTo(-1);
+        assertThat(metas.get(0).globalIndexMeta().extraFieldIds()).isEqualTo(new int[] {1, 2, 3});
+    }
+
+    private List<ResultEntry> createDummyResultEntries() throws IOException {
+        String fileName = "test-index-" + UUID.randomUUID();
+        Path filePath = indexPathFactory.toPath(fileName);
+        fileIO.newOutputStream(filePath, false).close();
+        return Collections.singletonList(new ResultEntry(fileName, 100, null));
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
@@ -48,8 +48,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
-
 /**
  * The checker for merge into update result. It will check each committable to see if some
  * global-indexed columns are updated. It will take some actions according to {@link
@@ -168,7 +166,7 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
 
     private static Collection<String> getIndexedFieldNames(GlobalIndexMeta meta, RowType rowType) {
         int fieldId = meta.indexFieldId();
-        if (fieldId == MULTI_COLUMN_INDEX_FIELD_ID) {
+        if (meta.isMultiColumn()) {
             List<String> names = new ArrayList<>();
             for (int id : meta.extraFieldIds()) {
                 names.add(rowType.getField(id).name());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
@@ -39,8 +39,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -102,8 +100,8 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                                     GlobalIndexMeta globalIndexMeta =
                                             entry.indexFile().globalIndexMeta();
                                     if (globalIndexMeta != null) {
-                                        Collection<String> indexedNames =
-                                                getIndexedFieldNames(globalIndexMeta, rowType);
+                                        List<String> indexedNames =
+                                                globalIndexMeta.getIndexedFieldNames(rowType);
                                         boolean overlaps =
                                                 indexedNames.stream()
                                                         .anyMatch(updatedColumns::contains);
@@ -121,7 +119,7 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                     Set<String> conflictedColumns =
                             affectedEntries.stream()
                                     .map(file -> file.indexFile().globalIndexMeta())
-                                    .flatMap(meta -> getIndexedFieldNames(meta, rowType).stream())
+                                    .flatMap(meta -> meta.getIndexedFieldNames(rowType).stream())
                                     .collect(Collectors.toSet());
 
                     throw new RuntimeException(
@@ -162,24 +160,5 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                     throw new UnsupportedOperationException("Unsupported option: " + updateAction);
             }
         }
-    }
-
-    private static Collection<String> getIndexedFieldNames(GlobalIndexMeta meta, RowType rowType) {
-        int fieldId = meta.indexFieldId();
-        if (meta.isMultiColumn()) {
-            List<String> names = new ArrayList<>();
-            for (int id : meta.extraFieldIds()) {
-                names.add(rowType.getField(id).name());
-            }
-            return names;
-        }
-        List<String> names = new ArrayList<>();
-        names.add(rowType.getField(fieldId).name());
-        if (meta.extraFieldIds() != null) {
-            for (int id : meta.extraFieldIds()) {
-                names.add(rowType.getField(id).name());
-            }
-        }
-        return names;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/MergeIntoUpdateChecker.java
@@ -39,12 +39,16 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID;
 
 /**
  * The checker for merge into update result. It will check each committable to see if some
@@ -100,10 +104,12 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                                     GlobalIndexMeta globalIndexMeta =
                                             entry.indexFile().globalIndexMeta();
                                     if (globalIndexMeta != null) {
-                                        String fieldName =
-                                                rowType.getField(globalIndexMeta.indexFieldId())
-                                                        .name();
-                                        return updatedColumns.contains(fieldName)
+                                        Collection<String> indexedNames =
+                                                getIndexedFieldNames(globalIndexMeta, rowType);
+                                        boolean overlaps =
+                                                indexedNames.stream()
+                                                        .anyMatch(updatedColumns::contains);
+                                        return overlaps
                                                 && affectedPartitions.contains(entry.partition());
                                     }
                                     return false;
@@ -116,8 +122,8 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                 case THROW_ERROR:
                     Set<String> conflictedColumns =
                             affectedEntries.stream()
-                                    .map(file -> file.indexFile().globalIndexMeta().indexFieldId())
-                                    .map(id -> rowType.getField(id).name())
+                                    .map(file -> file.indexFile().globalIndexMeta())
+                                    .flatMap(meta -> getIndexedFieldNames(meta, rowType).stream())
                                     .collect(Collectors.toSet());
 
                     throw new RuntimeException(
@@ -158,5 +164,24 @@ public class MergeIntoUpdateChecker extends BoundedOneInputOperator<Committable,
                     throw new UnsupportedOperationException("Unsupported option: " + updateAction);
             }
         }
+    }
+
+    private static Collection<String> getIndexedFieldNames(GlobalIndexMeta meta, RowType rowType) {
+        int fieldId = meta.indexFieldId();
+        if (fieldId == MULTI_COLUMN_INDEX_FIELD_ID) {
+            List<String> names = new ArrayList<>();
+            for (int id : meta.extraFieldIds()) {
+                names.add(rowType.getField(id).name());
+            }
+            return names;
+        }
+        List<String> names = new ArrayList<>();
+        names.add(rowType.getField(fieldId).name());
+        if (meta.extraFieldIds() != null) {
+            for (int id : meta.extraFieldIds()) {
+                names.add(rowType.getField(id).name());
+            }
+        }
+        return names;
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -51,6 +51,7 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
+import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -573,6 +574,7 @@ public class GenericIndexTopoBuilder {
         private transient InternalRow.FieldGetter[] indexFieldGetters;
         private transient int rowIdFieldIndex;
         private transient boolean multiColumn;
+        private transient ProjectedRow writerProjection;
 
         BuildIndexOperator(
                 ReadBuilder readBuilder,
@@ -602,6 +604,13 @@ public class GenericIndexTopoBuilder {
             }
             this.rowIdFieldIndex = projectedRowType.getFieldIndex(SpecialFields.ROW_ID.name());
             this.multiColumn = indexFields.size() > 1;
+            if (multiColumn) {
+                int[] projection = new int[indexFields.size()];
+                for (int i = 0; i < indexFields.size(); i++) {
+                    projection[i] = projectedRowType.getFieldIndex(indexFields.get(i).name());
+                }
+                this.writerProjection = ProjectedRow.from(projection);
+            }
         }
 
         @Override
@@ -664,7 +673,8 @@ public class GenericIndexTopoBuilder {
                                             task.shardRange.to);
                                     break;
                                 }
-                                ((GlobalIndexMultiColumnWriter) indexWriter).write(row);
+                                ((GlobalIndexMultiColumnWriter) indexWriter)
+                                        .write(writerProjection.replaceRow(row));
                             } else {
                                 Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
                                 if (fieldData == null) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -29,7 +29,9 @@ import org.apache.paimon.flink.sink.StoreCommitter;
 import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
+import org.apache.paimon.globalindex.GlobalIndexMultiColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
@@ -103,7 +105,7 @@ public class GenericIndexTopoBuilder {
         buildIndexAndExecute(
                 env,
                 table,
-                indexColumn,
+                Collections.singletonList(indexColumn),
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -119,12 +121,31 @@ public class GenericIndexTopoBuilder {
             Options userOptions,
             long maxIndexedRowId)
             throws Exception {
+        buildIndexAndExecute(
+                env,
+                table,
+                Collections.singletonList(indexColumn),
+                indexType,
+                partitionPredicate,
+                userOptions,
+                maxIndexedRowId);
+    }
+
+    public static void buildIndexAndExecute(
+            StreamExecutionEnvironment env,
+            FileStoreTable table,
+            List<String> indexColumns,
+            String indexType,
+            PartitionPredicate partitionPredicate,
+            Options userOptions,
+            long maxIndexedRowId)
+            throws Exception {
         boolean hasIndexToBuild =
                 buildIndex(
                         env,
                         () -> new GenericGlobalIndexBuilder(table),
                         table,
-                        indexColumn,
+                        indexColumns,
                         indexType,
                         partitionPredicate,
                         userOptions,
@@ -149,11 +170,32 @@ public class GenericIndexTopoBuilder {
                 env,
                 indexBuilderSupplier,
                 table,
-                indexColumn,
+                Collections.singletonList(indexColumn),
                 indexType,
                 partitionPredicate,
                 userOptions,
                 NO_MAX_INDEXED_ROW_ID);
+    }
+
+    public static boolean buildIndex(
+            StreamExecutionEnvironment env,
+            Supplier<GenericGlobalIndexBuilder> indexBuilderSupplier,
+            FileStoreTable table,
+            String indexColumn,
+            String indexType,
+            PartitionPredicate partitionPredicate,
+            Options userOptions,
+            long maxIndexedRowId)
+            throws Exception {
+        return buildIndex(
+                env,
+                indexBuilderSupplier,
+                table,
+                Collections.singletonList(indexColumn),
+                indexType,
+                partitionPredicate,
+                userOptions,
+                maxIndexedRowId);
     }
 
     /**
@@ -166,7 +208,7 @@ public class GenericIndexTopoBuilder {
             StreamExecutionEnvironment env,
             Supplier<GenericGlobalIndexBuilder> indexBuilderSupplier,
             FileStoreTable table,
-            String indexColumn,
+            List<String> indexColumns,
             String indexType,
             PartitionPredicate partitionPredicate,
             Options userOptions,
@@ -183,7 +225,7 @@ public class GenericIndexTopoBuilder {
         return buildTopology(
                 env,
                 table,
-                indexColumn,
+                indexColumns,
                 indexType,
                 userOptions,
                 entries,
@@ -203,7 +245,7 @@ public class GenericIndexTopoBuilder {
     private static boolean buildTopology(
             StreamExecutionEnvironment env,
             FileStoreTable table,
-            String indexColumn,
+            List<String> indexColumns,
             String indexType,
             Options userOptions,
             List<ManifestEntry> entries,
@@ -212,24 +254,24 @@ public class GenericIndexTopoBuilder {
             throws Exception {
         long totalRowCount = entries.stream().mapToLong(e -> e.file().rowCount()).sum();
         LOG.info(
-                "Scanned {} files ({} rows) across {} partitions for {} index on column '{}'"
+                "Scanned {} files ({} rows) across {} partitions for {} index on columns '{}'"
                         + (maxIndexedRowId >= 0 ? ", maxIndexedRowId={}." : "."),
                 entries.size(),
                 totalRowCount,
                 entries.stream().map(ManifestEntry::partition).distinct().count(),
                 indexType,
-                indexColumn,
+                indexColumns,
                 maxIndexedRowId);
 
         long minNonIndexableRowId =
-                findMinNonIndexableRowId(table.schemaManager(), entries, indexColumn);
+                findMinNonIndexableRowId(table.schemaManager(), entries, indexColumns);
         entries = filterEntriesBefore(entries, minNonIndexableRowId);
 
         RowType rowType = table.rowType();
-        DataField indexField = rowType.getField(indexColumn);
-        // Project indexColumn + _ROW_ID so we can read the actual row ID from data
-        List<String> readColumns = new ArrayList<>();
-        readColumns.add(indexColumn);
+        List<DataField> indexFields =
+                indexColumns.stream().map(rowType::getField).collect(Collectors.toList());
+        // Project indexColumns + _ROW_ID so we can read the actual row ID from data
+        List<String> readColumns = new ArrayList<>(indexColumns);
         readColumns.add(SpecialFields.ROW_ID.name());
         RowType projectedRowType = SpecialFields.rowTypeWithRowId(rowType).project(readColumns);
 
@@ -277,7 +319,7 @@ public class GenericIndexTopoBuilder {
                                         readBuilder,
                                         table,
                                         indexType,
-                                        indexField,
+                                        indexFields,
                                         projectedRowType,
                                         mergedOptions))
                         .setParallelism(parallelism);
@@ -299,20 +341,22 @@ public class GenericIndexTopoBuilder {
     }
 
     /**
-     * Find the minimum firstRowId among files whose schema does not contain the index column. Files
-     * at or beyond this rowId cannot be indexed because the column was added later via ALTER TABLE.
+     * Find the minimum firstRowId among files whose schema does not contain all index columns.
+     * Files at or beyond this rowId cannot be indexed because the column was added later via ALTER
+     * TABLE.
      *
-     * @return the boundary rowId, or {@link Long#MAX_VALUE} if all files contain the column
+     * @return the boundary rowId, or {@link Long#MAX_VALUE} if all files contain the columns
      */
     static long findMinNonIndexableRowId(
-            SchemaManager schemaManager, List<ManifestEntry> entries, String indexColumn) {
-        Map<Long, Boolean> schemaContainsColumn = new HashMap<>();
+            SchemaManager schemaManager, List<ManifestEntry> entries, List<String> indexColumns) {
+        Map<Long, Boolean> schemaContainsColumns = new HashMap<>();
         long minRowId = Long.MAX_VALUE;
         for (ManifestEntry entry : entries) {
             long sid = entry.file().schemaId();
             boolean contains =
-                    schemaContainsColumn.computeIfAbsent(
-                            sid, id -> schemaManager.schema(id).fieldNames().contains(indexColumn));
+                    schemaContainsColumns.computeIfAbsent(
+                            sid,
+                            id -> schemaManager.schema(id).fieldNames().containsAll(indexColumns));
             if (!contains && entry.file().firstRowId() != null) {
                 minRowId = Math.min(minRowId, entry.file().nonNullFirstRowId());
             }
@@ -548,25 +592,26 @@ public class GenericIndexTopoBuilder {
         private final ReadBuilder readBuilder;
         private final FileStoreTable table;
         private final String indexType;
-        private final DataField indexField;
+        private final List<DataField> indexFields;
         private final RowType projectedRowType;
         private final Options mergedOptions;
 
         private transient TableRead tableRead;
-        private transient InternalRow.FieldGetter indexFieldGetter;
+        private transient InternalRow.FieldGetter[] indexFieldGetters;
         private transient int rowIdFieldIndex;
+        private transient boolean multiColumn;
 
         BuildIndexOperator(
                 ReadBuilder readBuilder,
                 FileStoreTable table,
                 String indexType,
-                DataField indexField,
+                List<DataField> indexFields,
                 RowType projectedRowType,
                 Options mergedOptions) {
             this.readBuilder = readBuilder;
             this.table = table;
             this.indexType = indexType;
-            this.indexField = indexField;
+            this.indexFields = indexFields;
             this.projectedRowType = projectedRowType;
             this.mergedOptions = mergedOptions;
         }
@@ -575,10 +620,15 @@ public class GenericIndexTopoBuilder {
         public void open() throws Exception {
             super.open();
             this.tableRead = readBuilder.newRead();
-            this.indexFieldGetter =
-                    InternalRow.createFieldGetter(
-                            indexField.type(), projectedRowType.getFieldIndex(indexField.name()));
+            this.indexFieldGetters = new InternalRow.FieldGetter[indexFields.size()];
+            for (int i = 0; i < indexFields.size(); i++) {
+                DataField field = indexFields.get(i);
+                indexFieldGetters[i] =
+                        InternalRow.createFieldGetter(
+                                field.type(), projectedRowType.getFieldIndex(field.name()));
+            }
             this.rowIdFieldIndex = projectedRowType.getFieldIndex(SpecialFields.ROW_ID.name());
+            this.multiColumn = indexFields.size() > 1;
         }
 
         @Override
@@ -595,9 +645,8 @@ public class GenericIndexTopoBuilder {
                     task.split.dataFiles().size());
             long startTime = System.currentTimeMillis();
 
-            GlobalIndexSingletonWriter indexWriter =
-                    (GlobalIndexSingletonWriter)
-                            createIndexWriter(table, indexType, indexField, mergedOptions);
+            GlobalIndexWriter indexWriter =
+                    createIndexWriter(table, indexType, indexFields, mergedOptions);
 
             try {
                 long rowsSeen = 0;
@@ -626,8 +675,20 @@ public class GenericIndexTopoBuilder {
                         }
                         // Only write rows within this shard's range
                         if (currentRowId >= task.shardRange.from) {
-                            Object fieldData = indexFieldGetter.getFieldOrNull(row);
-                            indexWriter.write(fieldData);
+                            if (multiColumn) {
+                                ((GlobalIndexMultiColumnWriter) indexWriter).write(row);
+                            } else {
+                                Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
+                                if (fieldData == null) {
+                                    LOG.info(
+                                            "Null value at rowId={}, stopping shard [{}, {}].",
+                                            currentRowId,
+                                            task.shardRange.from,
+                                            task.shardRange.to);
+                                    break;
+                                }
+                                ((GlobalIndexSingletonWriter) indexWriter).write(fieldData);
+                            }
                             rowsSeen++;
                         }
                     }
@@ -664,7 +725,7 @@ public class GenericIndexTopoBuilder {
                                 table,
                                 partition,
                                 task.shardRange,
-                                indexField,
+                                indexFields,
                                 indexType,
                                 resultEntries);
                 output.collect(
@@ -688,7 +749,7 @@ public class GenericIndexTopoBuilder {
             FileStoreTable table,
             BinaryRow partition,
             Range rowRange,
-            DataField indexField,
+            List<DataField> indexFields,
             String indexType,
             List<ResultEntry> resultEntries)
             throws IOException {
@@ -698,14 +759,14 @@ public class GenericIndexTopoBuilder {
                         table.store().pathFactory().globalIndexFileFactory(),
                         table.coreOptions(),
                         rowRange,
-                        indexField.id(),
+                        indexFields,
                         indexType,
                         resultEntries);
         return new CommitMessageImpl(
                 partition, 0, null, indexIncrement(indexFileMetas), emptyIncrement());
     }
 
-    private static void closeWriterQuietly(GlobalIndexSingletonWriter writer) {
+    private static void closeWriterQuietly(GlobalIndexWriter writer) {
         if (writer instanceof Closeable) {
             try {
                 ((Closeable) writer).close();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -658,33 +658,16 @@ public class GenericIndexTopoBuilder {
                         // Only write rows within this shard's range
                         if (currentRowId >= task.shardRange.from) {
                             if (multiColumn) {
-                                boolean hasNull = false;
-                                for (InternalRow.FieldGetter getter : indexFieldGetters) {
-                                    if (getter.getFieldOrNull(row) == null) {
-                                        hasNull = true;
-                                        break;
-                                    }
-                                }
-                                if (hasNull) {
-                                    LOG.info(
-                                            "Null value in indexed columns at rowId={}, stopping shard [{}, {}].",
-                                            currentRowId,
-                                            task.shardRange.from,
-                                            task.shardRange.to);
-                                    break;
-                                }
+                                // Pass the row through, including null fields; each index type
+                                // decides how to handle nulls. A null field advances the logical
+                                // row id without indexing a value, so it must not end the shard:
+                                // later non-null rows still need to be indexed and row-id alignment
+                                // must be preserved.
                                 ((GlobalIndexMultiColumnWriter) indexWriter)
                                         .write(writerProjection.replaceRow(row));
                             } else {
+                                // A null value advances the logical row id without indexing.
                                 Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
-                                if (fieldData == null) {
-                                    LOG.info(
-                                            "Null value at rowId={}, stopping shard [{}, {}].",
-                                            currentRowId,
-                                            task.shardRange.from,
-                                            task.shardRange.to);
-                                    break;
-                                }
                                 ((GlobalIndexSingletonWriter) indexWriter).write(fieldData);
                             }
                             rowsSeen++;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -694,6 +694,21 @@ public class GenericIndexTopoBuilder {
                         // Only write rows within this shard's range
                         if (currentRowId >= task.shardRange.from) {
                             if (multiColumn) {
+                                boolean hasNull = false;
+                                for (InternalRow.FieldGetter getter : indexFieldGetters) {
+                                    if (getter.getFieldOrNull(row) == null) {
+                                        hasNull = true;
+                                        break;
+                                    }
+                                }
+                                if (hasNull) {
+                                    LOG.info(
+                                            "Null value in indexed columns at rowId={}, stopping shard [{}, {}].",
+                                            currentRowId,
+                                            task.shardRange.from,
+                                            task.shardRange.to);
+                                    break;
+                                }
                                 ((GlobalIndexMultiColumnWriter) indexWriter).write(row);
                             } else {
                                 Object fieldData = indexFieldGetters[0].getFieldOrNull(row);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -106,7 +106,8 @@ public class GenericIndexTopoBuilder {
         buildIndexAndExecute(
                 env,
                 table,
-                Collections.singletonList(indexColumn),
+                indexColumn,
+                Collections.emptyList(),
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -125,7 +126,8 @@ public class GenericIndexTopoBuilder {
         buildIndexAndExecute(
                 env,
                 table,
-                Collections.singletonList(indexColumn),
+                indexColumn,
+                Collections.emptyList(),
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -135,7 +137,8 @@ public class GenericIndexTopoBuilder {
     public static void buildIndexAndExecute(
             StreamExecutionEnvironment env,
             FileStoreTable table,
-            List<String> indexColumns,
+            String indexColumn,
+            List<String> extraColumns,
             String indexType,
             PartitionPredicate partitionPredicate,
             Options userOptions)
@@ -143,7 +146,8 @@ public class GenericIndexTopoBuilder {
         buildIndexAndExecute(
                 env,
                 table,
-                indexColumns,
+                indexColumn,
+                extraColumns,
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -153,7 +157,8 @@ public class GenericIndexTopoBuilder {
     public static void buildIndexAndExecute(
             StreamExecutionEnvironment env,
             FileStoreTable table,
-            List<String> indexColumns,
+            String indexColumn,
+            List<String> extraColumns,
             String indexType,
             PartitionPredicate partitionPredicate,
             Options userOptions,
@@ -164,7 +169,8 @@ public class GenericIndexTopoBuilder {
                         env,
                         () -> new GenericGlobalIndexBuilder(table),
                         table,
-                        indexColumns,
+                        indexColumn,
+                        extraColumns,
                         indexType,
                         partitionPredicate,
                         userOptions,
@@ -189,7 +195,8 @@ public class GenericIndexTopoBuilder {
                 env,
                 indexBuilderSupplier,
                 table,
-                Collections.singletonList(indexColumn),
+                indexColumn,
+                Collections.emptyList(),
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -210,7 +217,8 @@ public class GenericIndexTopoBuilder {
                 env,
                 indexBuilderSupplier,
                 table,
-                Collections.singletonList(indexColumn),
+                indexColumn,
+                Collections.emptyList(),
                 indexType,
                 partitionPredicate,
                 userOptions,
@@ -227,7 +235,8 @@ public class GenericIndexTopoBuilder {
             StreamExecutionEnvironment env,
             Supplier<GenericGlobalIndexBuilder> indexBuilderSupplier,
             FileStoreTable table,
-            List<String> indexColumns,
+            String indexColumn,
+            List<String> extraColumns,
             String indexType,
             PartitionPredicate partitionPredicate,
             Options userOptions,
@@ -244,7 +253,8 @@ public class GenericIndexTopoBuilder {
         return buildTopology(
                 env,
                 table,
-                indexColumns,
+                indexColumn,
+                extraColumns,
                 indexType,
                 userOptions,
                 entries,
@@ -264,13 +274,19 @@ public class GenericIndexTopoBuilder {
     private static boolean buildTopology(
             StreamExecutionEnvironment env,
             FileStoreTable table,
-            List<String> indexColumns,
+            String indexColumn,
+            List<String> extraColumns,
             String indexType,
             Options userOptions,
             List<ManifestEntry> entries,
             List<IndexManifestEntry> deletedIndexEntries,
             long maxIndexedRowId)
             throws Exception {
+        // The primary column followed by the extra columns, in index order.
+        List<String> indexColumns = new ArrayList<>(1 + extraColumns.size());
+        indexColumns.add(indexColumn);
+        indexColumns.addAll(extraColumns);
+
         long totalRowCount = entries.stream().mapToLong(e -> e.file().rowCount()).sum();
         LOG.info(
                 "Scanned {} files ({} rows) across {} partitions for {} index on columns '{}'"
@@ -287,8 +303,9 @@ public class GenericIndexTopoBuilder {
         entries = filterEntriesBefore(entries, minNonIndexableRowId);
 
         RowType rowType = table.rowType();
-        List<DataField> indexFields =
-                indexColumns.stream().map(rowType::getField).collect(Collectors.toList());
+        DataField indexField = rowType.getField(indexColumn);
+        List<DataField> extraFields =
+                extraColumns.stream().map(rowType::getField).collect(Collectors.toList());
         // Project indexColumns + _ROW_ID so we can read the actual row ID from data
         List<String> readColumns = new ArrayList<>(indexColumns);
         readColumns.add(SpecialFields.ROW_ID.name());
@@ -338,7 +355,8 @@ public class GenericIndexTopoBuilder {
                                         readBuilder,
                                         table,
                                         indexType,
-                                        indexFields,
+                                        indexField,
+                                        extraFields,
                                         projectedRowType,
                                         mergedOptions))
                         .setParallelism(parallelism);
@@ -566,11 +584,13 @@ public class GenericIndexTopoBuilder {
         private final ReadBuilder readBuilder;
         private final FileStoreTable table;
         private final String indexType;
-        private final List<DataField> indexFields;
+        private final DataField indexField;
+        private final List<DataField> extraFields;
         private final RowType projectedRowType;
         private final Options mergedOptions;
 
         private transient TableRead tableRead;
+        private transient List<DataField> indexedFields;
         private transient InternalRow.FieldGetter[] indexFieldGetters;
         private transient int rowIdFieldIndex;
         private transient boolean multiColumn;
@@ -580,13 +600,15 @@ public class GenericIndexTopoBuilder {
                 ReadBuilder readBuilder,
                 FileStoreTable table,
                 String indexType,
-                List<DataField> indexFields,
+                DataField indexField,
+                List<DataField> extraFields,
                 RowType projectedRowType,
                 Options mergedOptions) {
             this.readBuilder = readBuilder;
             this.table = table;
             this.indexType = indexType;
-            this.indexFields = indexFields;
+            this.indexField = indexField;
+            this.extraFields = extraFields;
             this.projectedRowType = projectedRowType;
             this.mergedOptions = mergedOptions;
         }
@@ -595,19 +617,24 @@ public class GenericIndexTopoBuilder {
         public void open() throws Exception {
             super.open();
             this.tableRead = readBuilder.newRead();
-            this.indexFieldGetters = new InternalRow.FieldGetter[indexFields.size()];
-            for (int i = 0; i < indexFields.size(); i++) {
-                DataField field = indexFields.get(i);
+            // The primary column followed by the extra columns, in index order. Field getters and
+            // the writer projection both need the full ordered list.
+            this.indexedFields = new ArrayList<>(1 + extraFields.size());
+            indexedFields.add(indexField);
+            indexedFields.addAll(extraFields);
+            this.indexFieldGetters = new InternalRow.FieldGetter[indexedFields.size()];
+            for (int i = 0; i < indexedFields.size(); i++) {
+                DataField field = indexedFields.get(i);
                 indexFieldGetters[i] =
                         InternalRow.createFieldGetter(
                                 field.type(), projectedRowType.getFieldIndex(field.name()));
             }
             this.rowIdFieldIndex = projectedRowType.getFieldIndex(SpecialFields.ROW_ID.name());
-            this.multiColumn = indexFields.size() > 1;
+            this.multiColumn = !extraFields.isEmpty();
             if (multiColumn) {
-                int[] projection = new int[indexFields.size()];
-                for (int i = 0; i < indexFields.size(); i++) {
-                    projection[i] = projectedRowType.getFieldIndex(indexFields.get(i).name());
+                int[] projection = new int[indexedFields.size()];
+                for (int i = 0; i < indexedFields.size(); i++) {
+                    projection[i] = projectedRowType.getFieldIndex(indexedFields.get(i).name());
                 }
                 this.writerProjection = ProjectedRow.from(projection);
             }
@@ -628,12 +655,7 @@ public class GenericIndexTopoBuilder {
             long startTime = System.currentTimeMillis();
 
             GlobalIndexWriter indexWriter =
-                    createIndexWriter(
-                            table,
-                            indexType,
-                            indexFields.get(0),
-                            indexFields.subList(1, indexFields.size()),
-                            mergedOptions);
+                    createIndexWriter(table, indexType, indexField, extraFields, mergedOptions);
 
             try {
                 long rowsSeen = 0;
@@ -706,7 +728,7 @@ public class GenericIndexTopoBuilder {
                                 table,
                                 partition,
                                 task.shardRange,
-                                indexFields,
+                                indexedFields,
                                 indexType,
                                 resultEntries);
                 output.collect(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -658,15 +658,10 @@ public class GenericIndexTopoBuilder {
                         // Only write rows within this shard's range
                         if (currentRowId >= task.shardRange.from) {
                             if (multiColumn) {
-                                // Pass the row through, including null fields; each index type
-                                // decides how to handle nulls. A null field advances the logical
-                                // row id without indexing a value, so it must not end the shard:
-                                // later non-null rows still need to be indexed and row-id alignment
-                                // must be preserved.
+                                long rowId = currentRowId - task.shardRange.from;
                                 ((GlobalIndexMultiColumnWriter) indexWriter)
-                                        .write(writerProjection.replaceRow(row));
+                                        .write(rowId, writerProjection.replaceRow(row));
                             } else {
-                                // A null value advances the logical row id without indexing.
                                 Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
                                 ((GlobalIndexSingletonWriter) indexWriter).write(fieldData);
                             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -628,7 +628,12 @@ public class GenericIndexTopoBuilder {
             long startTime = System.currentTimeMillis();
 
             GlobalIndexWriter indexWriter =
-                    createIndexWriter(table, indexType, indexFields, mergedOptions);
+                    createIndexWriter(
+                            table,
+                            indexType,
+                            indexFields.get(0),
+                            indexFields.subList(1, indexFields.size()),
+                            mergedOptions);
 
             try {
                 long rowsSeen = 0;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -40,7 +40,6 @@ import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -67,7 +66,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +74,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.createIndexWriter;
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.filterEntriesBefore;
+import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.findMinNonIndexableRowId;
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.toIndexFileMetas;
 import static org.apache.paimon.io.CompactIncrement.emptyIncrement;
 import static org.apache.paimon.io.DataIncrement.deleteIndexIncrement;
@@ -356,51 +356,6 @@ public class GenericIndexTopoBuilder {
 
         commit(table, indexType, built);
         return true;
-    }
-
-    /**
-     * Find the minimum firstRowId among files whose schema does not contain all index columns.
-     * Files at or beyond this rowId cannot be indexed because the column was added later via ALTER
-     * TABLE.
-     *
-     * @return the boundary rowId, or {@link Long#MAX_VALUE} if all files contain the columns
-     */
-    static long findMinNonIndexableRowId(
-            SchemaManager schemaManager, List<ManifestEntry> entries, List<String> indexColumns) {
-        Map<Long, Boolean> schemaContainsColumns = new HashMap<>();
-        long minRowId = Long.MAX_VALUE;
-        for (ManifestEntry entry : entries) {
-            long sid = entry.file().schemaId();
-            boolean contains =
-                    schemaContainsColumns.computeIfAbsent(
-                            sid,
-                            id -> schemaManager.schema(id).fieldNames().containsAll(indexColumns));
-            if (!contains && entry.file().firstRowId() != null) {
-                minRowId = Math.min(minRowId, entry.file().nonNullFirstRowId());
-            }
-        }
-        return minRowId;
-    }
-
-    /** Keep only entries whose firstRowId is strictly less than the given boundary. */
-    static List<ManifestEntry> filterEntriesBefore(
-            List<ManifestEntry> entries, long boundaryRowId) {
-        if (boundaryRowId == Long.MAX_VALUE) {
-            return entries;
-        }
-        List<ManifestEntry> result = new ArrayList<>();
-        for (ManifestEntry entry : entries) {
-            if (entry.file().firstRowId() != null
-                    && entry.file().nonNullFirstRowId() < boundaryRowId) {
-                result.add(entry);
-            }
-        }
-        LOG.info(
-                "Filtered {} files at or beyond rowId {}, {} files remain.",
-                entries.size() - result.size(),
-                boundaryRowId,
-                result.size());
-        return result;
     }
 
     /**

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -137,6 +137,24 @@ public class GenericIndexTopoBuilder {
             List<String> indexColumns,
             String indexType,
             PartitionPredicate partitionPredicate,
+            Options userOptions)
+            throws Exception {
+        buildIndexAndExecute(
+                env,
+                table,
+                indexColumns,
+                indexType,
+                partitionPredicate,
+                userOptions,
+                NO_MAX_INDEXED_ROW_ID);
+    }
+
+    public static void buildIndexAndExecute(
+            StreamExecutionEnvironment env,
+            FileStoreTable table,
+            List<String> indexColumns,
+            String indexType,
+            PartitionPredicate partitionPredicate,
             Options userOptions,
             long maxIndexedRowId)
             throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -139,7 +139,8 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 GenericIndexTopoBuilder.buildIndexAndExecute(
                         procedureContext.getExecutionEnvironment(),
                         table,
-                        indexColumns,
+                        indexColumns.get(0),
+                        indexColumns.subList(1, indexColumns.size()),
                         indexType,
                         partitionPredicate,
                         userOptions);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.flink.btree.BTreeIndexTopoBuilder;
 import org.apache.paimon.flink.globalindex.GenericIndexTopoBuilder;
+import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
@@ -114,10 +115,13 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
 
         // Build global index based on index type
         indexType = indexType.toLowerCase().trim();
-        if ("btree".equals(indexType)) {
+        if (indexColumns.size() > 1) {
+            // Whether multi-column is supported is decided by each index type's factory; fail fast
+            // up front instead of failing later in the build job.
             checkArgument(
-                    indexColumns.size() == 1,
-                    "BTree index only supports single column, got: %s",
+                    GlobalIndexerFactoryUtils.load(indexType).supportsMultiColumn(),
+                    "Index type '%s' does not support multi-column index, got columns: %s",
+                    indexType,
                     indexColumns);
         }
         try {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -20,11 +20,12 @@ package org.apache.paimon.flink.procedure;
 
 import org.apache.paimon.flink.btree.BTreeIndexTopoBuilder;
 import org.apache.paimon.flink.globalindex.GenericIndexTopoBuilder;
-import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ParameterUtils;
 
@@ -116,13 +117,21 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
         // Build global index based on index type
         indexType = indexType.toLowerCase().trim();
         if (indexColumns.size() > 1) {
-            // Whether multi-column is supported is decided by each index type's factory; fail fast
-            // up front instead of failing later in the build job.
-            checkArgument(
-                    GlobalIndexerFactoryUtils.load(indexType).supportsMultiColumn(),
-                    "Index type '%s' does not support multi-column index, got columns: %s",
-                    indexType,
-                    indexColumns);
+            // Fail fast before submitting the job: index types that do not support multi-column
+            // throw from GlobalIndexerFactory#create, which happens before any indexer side effect.
+            DataField indexField = rowType.getField(indexColumns.get(0));
+            List<DataField> extraFields =
+                    indexColumns.subList(1, indexColumns.size()).stream()
+                            .map(rowType::getField)
+                            .collect(Collectors.toList());
+            try {
+                GlobalIndexer.create(indexType, indexField, extraFields, userOptions);
+            } catch (UnsupportedOperationException e) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Index type '%s' does not support multi-column index, got columns: %s",
+                                indexType, indexColumns));
+            }
         }
         try {
             if ("btree".equals(indexType)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -98,11 +98,6 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 indexColumns.size() == new HashSet<>(indexColumns).size(),
                 "Duplicate index columns are not allowed: %s",
                 indexColumns);
-        // No hard cap on the number of index columns: unlike row-store B-tree indexes
-        // (e.g. MySQL 16, PostgreSQL 32) whose limit comes from composing columns into a
-        // single key, the global index is built on per-type index frameworks. Whether
-        // multiple columns are supported, and any practical limit, is decided by each
-        // index type (single-column types reject multi-column via UnsupportedOperationException).
         for (String col : indexColumns) {
             checkArgument(
                     rowType.containsField(col),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -108,6 +108,12 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
 
         // Build global index based on index type
         indexType = indexType.toLowerCase().trim();
+        if ("btree".equals(indexType)) {
+            checkArgument(
+                    indexColumns.size() == 1,
+                    "BTree index only supports single column, got: %s",
+                    indexColumns);
+        }
         try {
             if ("btree".equals(indexType)) {
                 BTreeIndexTopoBuilder.buildIndexAndExecute(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -32,8 +32,10 @@ import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.ParameterUtils.getPartitions;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -85,11 +87,18 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 tableId);
 
         RowType rowType = table.rowType();
-        checkArgument(
-                rowType.containsField(indexColumn),
-                "Column '%s' does not exist in table '%s'.",
-                indexColumn,
-                tableId);
+        List<String> indexColumns =
+                Arrays.stream(indexColumn.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+        for (String col : indexColumns) {
+            checkArgument(
+                    rowType.containsField(col),
+                    "Column '%s' does not exist in table '%s'.",
+                    col,
+                    tableId);
+        }
 
         // Parse partition predicate
         PartitionPredicate partitionPredicate = parsePartitionPredicate(table, partitions);
@@ -104,7 +113,7 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 BTreeIndexTopoBuilder.buildIndexAndExecute(
                         procedureContext.getExecutionEnvironment(),
                         table,
-                        indexColumn,
+                        indexColumns.get(0),
                         partitionPredicate,
                         userOptions);
                 return new String[] {
@@ -114,7 +123,7 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                 GenericIndexTopoBuilder.buildIndexAndExecute(
                         procedureContext.getExecutionEnvironment(),
                         table,
-                        indexColumn,
+                        indexColumns,
                         indexType,
                         partitionPredicate,
                         userOptions);
@@ -122,8 +131,8 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
         } catch (Exception e) {
             throw new RuntimeException(
                     String.format(
-                            "Failed to create %s index for column '%s' on table '%s'.",
-                            indexType, indexColumn, table.name()),
+                            "Failed to create %s index for columns '%s' on table '%s'.",
+                            indexType, indexColumns, table.name()),
                     e);
         }
         return new String[] {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -92,6 +92,7 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                         .map(String::trim)
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.toList());
+        checkArgument(!indexColumns.isEmpty(), "At least one column required.");
         for (String col : indexColumns) {
             checkArgument(
                     rowType.containsField(col),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/CreateGlobalIndexProcedure.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.annotation.ProcedureHint;
 import org.apache.flink.table.procedure.ProcedureContext;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -93,6 +94,15 @@ public class CreateGlobalIndexProcedure extends ProcedureBase {
                         .filter(s -> !s.isEmpty())
                         .collect(Collectors.toList());
         checkArgument(!indexColumns.isEmpty(), "At least one column required.");
+        checkArgument(
+                indexColumns.size() == new HashSet<>(indexColumns).size(),
+                "Duplicate index columns are not allowed: %s",
+                indexColumns);
+        // No hard cap on the number of index columns: unlike row-store B-tree indexes
+        // (e.g. MySQL 16, PostgreSQL 32) whose limit comes from composing columns into a
+        // single key, the global index is built on per-type index frameworks. Whether
+        // multiple columns are supported, and any practical limit, is decided by each
+        // index type (single-column types reject multi-column via UnsupportedOperationException).
         for (String col : indexColumns) {
             checkArgument(
                     rowType.containsField(col),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
@@ -102,6 +102,7 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                 indexColumns.stream()
                         .map(col -> rowType.getField(col).id())
                         .collect(Collectors.toList());
+        final String columnsDesc = String.join(",", indexColumns);
 
         // Parse partition predicate
         PartitionPredicate partitionPredicate = parsePartitionPredicate(table, partitions);
@@ -138,12 +139,12 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                 "Found {} {} global index files to delete for columns '{}' on table '{}'",
                 waitToDelete.size(),
                 indexTypeLower,
-                indexColumns,
+                columnsDesc,
                 table.name());
 
         if (waitToDelete.isEmpty()) {
             return new String[] {
-                "No " + indexTypeLower + " global index found for columns '" + indexColumns + "'"
+                "No " + indexTypeLower + " global index found for columns '" + columnsDesc + "'"
             };
         }
 
@@ -181,7 +182,7 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                 "Successfully dropped {} {} global index files for columns '{}' on table '{}'",
                 waitToDelete.size(),
                 indexTypeLower,
-                indexColumns,
+                columnsDesc,
                 table.name());
 
         return new String[] {
@@ -190,7 +191,7 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                     + " "
                     + indexTypeLower
                     + " global index files for columns '"
-                    + indexColumns
+                    + columnsDesc
                     + "' on table '"
                     + table.name()
                     + "'"

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedure.java
@@ -42,6 +42,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -82,22 +83,31 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
 
         FileStoreTable table = (FileStoreTable) table(tableId);
 
-        // Validate column exists
+        // Parse comma-separated columns (consistent with create procedure)
         RowType rowType = table.rowType();
-        checkArgument(
-                rowType.containsField(indexColumn),
-                "Column '%s' does not exist in table '%s'.",
-                indexColumn,
-                tableId);
+        List<String> indexColumns =
+                Arrays.stream(indexColumn.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+        checkArgument(!indexColumns.isEmpty(), "At least one column required.");
+        for (String col : indexColumns) {
+            checkArgument(
+                    rowType.containsField(col),
+                    "Column '%s' does not exist in table '%s'.",
+                    col,
+                    tableId);
+        }
+        final List<Integer> indexFieldIds =
+                indexColumns.stream()
+                        .map(col -> rowType.getField(col).id())
+                        .collect(Collectors.toList());
 
         // Parse partition predicate
         PartitionPredicate partitionPredicate = parsePartitionPredicate(table, partitions);
 
         // Normalize index type
         final String indexTypeLower = indexType.toLowerCase().trim();
-
-        // Get column field ID for final reference in lambda
-        final int columnId = rowType.getField(indexColumn).id();
 
         // Get latest snapshot
         Snapshot snapshot =
@@ -108,12 +118,15 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                                                 String.format(
                                                         "Table '%s' has no snapshot.", tableId)));
 
-        // Create filter for index entries to delete
+        // Create filter for index entries to delete — match by primary column + full column set
         Filter<IndexManifestEntry> filter =
                 entry ->
                         entry.indexFile().indexType().equals(indexTypeLower)
                                 && entry.indexFile().globalIndexMeta() != null
-                                && entry.indexFile().globalIndexMeta().indexFieldId() == columnId
+                                && entry.indexFile()
+                                        .globalIndexMeta()
+                                        .getIndexedFieldIds()
+                                        .equals(indexFieldIds)
                                 && (partitionPredicate == null
                                         || partitionPredicate.test(entry.partition()));
 
@@ -122,15 +135,15 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                 table.store().newIndexFileHandler().scan(snapshot, filter);
 
         LOG.info(
-                "Found {} {} global index files to delete for column '{}' on table '{}'",
+                "Found {} {} global index files to delete for columns '{}' on table '{}'",
                 waitToDelete.size(),
                 indexTypeLower,
-                indexColumn,
+                indexColumns,
                 table.name());
 
         if (waitToDelete.isEmpty()) {
             return new String[] {
-                "No " + indexTypeLower + " global index found for column '" + indexColumn + "'"
+                "No " + indexTypeLower + " global index found for columns '" + indexColumns + "'"
             };
         }
 
@@ -165,10 +178,10 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
         }
 
         LOG.info(
-                "Successfully dropped {} {} global index files for column '{}' on table '{}'",
+                "Successfully dropped {} {} global index files for columns '{}' on table '{}'",
                 waitToDelete.size(),
                 indexTypeLower,
-                indexColumn,
+                indexColumns,
                 table.name());
 
         return new String[] {
@@ -176,8 +189,8 @@ public class DropGlobalIndexProcedure extends ProcedureBase {
                     + waitToDelete.size()
                     + " "
                     + indexTypeLower
-                    + " global index files for column '"
-                    + indexColumn
+                    + " global index files for columns '"
+                    + indexColumns
                     + "' on table '"
                     + table.name()
                     + "'"

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
@@ -475,7 +475,7 @@ class GenericIndexTopoBuilderTest {
                 GenericIndexTopoBuilder.filterEntriesBefore(
                         entries,
                         GenericIndexTopoBuilder.findMinNonIndexableRowId(
-                                schemaManager, entries, "vec"));
+                                schemaManager, entries, Collections.singletonList("vec")));
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).file().nonNullFirstRowId()).isEqualTo(0L);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.io.PojoDataFileMeta;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -472,9 +473,9 @@ class GenericIndexTopoBuilderTest {
         entries.add(createEntryWithSchemaId(BinaryRow.EMPTY_ROW, 200L, 100, 0L));
 
         List<ManifestEntry> result =
-                GenericIndexTopoBuilder.filterEntriesBefore(
+                GlobalIndexBuilderUtils.filterEntriesBefore(
                         entries,
-                        GenericIndexTopoBuilder.findMinNonIndexableRowId(
+                        GlobalIndexBuilderUtils.findMinNonIndexableRowId(
                                 schemaManager, entries, Collections.singletonList("vec")));
 
         assertThat(result).hasSize(2);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/DropGlobalIndexProcedureITCase.java
@@ -299,6 +299,6 @@ public class DropGlobalIndexProcedureITCase extends CatalogITCaseBase {
         assertThat(dropResult.get(0).getField(0))
                 .isInstanceOf(String.class)
                 .asString()
-                .contains("No btree global index found for column 'name'");
+                .contains("No btree global index found for columns 'name'");
     }
 }

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -21,7 +21,6 @@ package org.apache.paimon.spark.commands
 import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
 import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
@@ -588,27 +587,13 @@ case class MergeIntoPaimonDataEvolutionTable(
       return updateCommit
     }
 
-    def getIndexedFieldNames(
-        meta: GlobalIndexMeta,
-        rt: org.apache.paimon.types.RowType): Seq[String] = {
-      if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID) {
-        meta.extraFieldIds().map(id => rt.getField(id).name()).toSeq
-      } else {
-        val names = ArrayBuffer(rt.getField(meta.indexFieldId()).name())
-        if (meta.extraFieldIds() != null) {
-          meta.extraFieldIds().foreach(id => names += rt.getField(id).name())
-        }
-        names.toSeq
-      }
-    }
-
     val filter: org.apache.paimon.utils.Filter[IndexManifestEntry] =
       (entry: IndexManifestEntry) => {
         val globalIndexMeta = entry.indexFile().globalIndexMeta()
         if (globalIndexMeta == null) {
           false
         } else {
-          val indexedNames = getIndexedFieldNames(globalIndexMeta, rowType)
+          val indexedNames = globalIndexMeta.getIndexedFieldNames(rowType).asScala
           affectedParts.contains(entry.partition()) && updateColumns.exists(
             col => indexedNames.contains(col.name))
         }
@@ -627,7 +612,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         case GlobalIndexColumnUpdateAction.THROW_ERROR =>
           val updatedColNames = updateColumns.map(_.name)
           val conflicted = affectedIndexEntries
-            .flatMap(e => getIndexedFieldNames(e.indexFile().globalIndexMeta(), rowType))
+            .flatMap(e => e.indexFile().globalIndexMeta().getIndexedFieldNames(rowType).asScala)
             .toSet
           throw new RuntimeException(
             s"""MergeInto: update columns contain globally indexed columns, not supported now.

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -21,6 +21,8 @@ package org.apache.paimon.spark.commands
 import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
+import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
 import org.apache.paimon.spark.SparkTable
@@ -586,15 +588,29 @@ case class MergeIntoPaimonDataEvolutionTable(
       return updateCommit
     }
 
+    def getIndexedFieldNames(
+        meta: GlobalIndexMeta,
+        rt: org.apache.paimon.types.RowType): Seq[String] = {
+      if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID) {
+        meta.extraFieldIds().map(id => rt.getField(id).name()).toSeq
+      } else {
+        val names = ArrayBuffer(rt.getField(meta.indexFieldId()).name())
+        if (meta.extraFieldIds() != null) {
+          meta.extraFieldIds().foreach(id => names += rt.getField(id).name())
+        }
+        names.toSeq
+      }
+    }
+
     val filter: org.apache.paimon.utils.Filter[IndexManifestEntry] =
       (entry: IndexManifestEntry) => {
         val globalIndexMeta = entry.indexFile().globalIndexMeta()
         if (globalIndexMeta == null) {
           false
         } else {
-          val fieldName = rowType.getField(globalIndexMeta.indexFieldId()).name()
+          val indexedNames = getIndexedFieldNames(globalIndexMeta, rowType)
           affectedParts.contains(entry.partition()) && updateColumns.exists(
-            _.name.equals(fieldName))
+            col => indexedNames.contains(col.name))
         }
       }
 
@@ -611,8 +627,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         case GlobalIndexColumnUpdateAction.THROW_ERROR =>
           val updatedColNames = updateColumns.map(_.name)
           val conflicted = affectedIndexEntries
-            .map(_.indexFile().globalIndexMeta().indexFieldId())
-            .map(id => rowType.getField(id).name())
+            .flatMap(e => getIndexedFieldNames(e.indexFile().globalIndexMeta(), rowType))
             .toSet
           throw new RuntimeException(
             s"""MergeInto: update columns contain globally indexed columns, not supported now.

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -94,7 +94,11 @@ public class DefaultGlobalIndexBuilder implements Serializable {
         this.partition = partition;
         this.readType = readType;
         this.indexField = indexField;
-        this.extraFields = extraFields;
+        // Copy into a serializable ArrayList: callers may pass a List#subList view (e.g.
+        // indexFields.subList(1, ...)), which is not Serializable, and this builder is serialized
+        // and shipped to Spark executors. A null value means no extra columns.
+        this.extraFields =
+                extraFields == null ? Collections.emptyList() : new ArrayList<>(extraFields);
         this.indexType = indexType;
         this.rowRange = rowRange;
         this.options = options;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -38,9 +38,6 @@ import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
@@ -52,7 +49,6 @@ import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.toIndexFileM
 /** Default global index builder. */
 public class DefaultGlobalIndexBuilder implements Serializable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultGlobalIndexBuilder.class);
     private static final long serialVersionUID = 1L;
 
     private final FileStoreTable table;
@@ -133,31 +129,17 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                 GlobalIndexMultiColumnWriter multiWriter =
                         (GlobalIndexMultiColumnWriter) indexWriter;
                 int[] projection = new int[indexFields.size()];
-                InternalRow.FieldGetter[] getters = new InternalRow.FieldGetter[indexFields.size()];
                 for (int i = 0; i < indexFields.size(); i++) {
                     DataField field = indexFields.get(i);
                     projection[i] = readType.getFieldIndex(field.name());
-                    getters[i] =
-                            InternalRow.createFieldGetter(
-                                    field.type(), readType.getFieldIndex(field.name()));
                 }
                 ProjectedRow projectedRow = ProjectedRow.from(projection);
                 while (rows.hasNext()) {
                     InternalRow row = rows.next();
-                    boolean hasNull = false;
-                    for (InternalRow.FieldGetter getter : getters) {
-                        if (getter.getFieldOrNull(row) == null) {
-                            hasNull = true;
-                            break;
-                        }
-                    }
-                    if (hasNull) {
-                        LOG.info(
-                                "Null value in indexed columns, stopping shard [{}, {}].",
-                                rowRange.from,
-                                rowRange.to);
-                        break;
-                    }
+                    // Pass the row through, including null fields; each index type decides how to
+                    // handle nulls. A null field advances the logical row id without indexing a
+                    // value, so it must not end the shard: later non-null rows still need to be
+                    // indexed and row-id alignment must be preserved.
                     multiWriter.write(projectedRow.replaceRow(row));
                     rowCounter.add(1);
                 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -29,6 +29,7 @@ import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.types.DataField;
@@ -134,13 +135,14 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                     projection[i] = readType.getFieldIndex(field.name());
                 }
                 ProjectedRow projectedRow = ProjectedRow.from(projection);
+                int rowIdIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
                 while (rows.hasNext()) {
                     InternalRow row = rows.next();
-                    // Pass the row through, including null fields; each index type decides how to
-                    // handle nulls. A null field advances the logical row id without indexing a
-                    // value, so it must not end the shard: later non-null rows still need to be
-                    // indexed and row-id alignment must be preserved.
-                    multiWriter.write(projectedRow.replaceRow(row));
+                    long absRowId = row.getLong(rowIdIndex);
+                    if (absRowId < rowRange.from || absRowId > rowRange.to) {
+                        continue;
+                    }
+                    multiWriter.write(absRowId - rowRange.from, projectedRow.replaceRow(row));
                     rowCounter.add(1);
                 }
             } else {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -38,6 +38,9 @@ import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
@@ -49,6 +52,7 @@ import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.toIndexFileM
 /** Default global index builder. */
 public class DefaultGlobalIndexBuilder implements Serializable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultGlobalIndexBuilder.class);
     private static final long serialVersionUID = 1L;
 
     private final FileStoreTable table;
@@ -129,15 +133,34 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                 GlobalIndexMultiColumnWriter multiWriter =
                         (GlobalIndexMultiColumnWriter) indexWriter;
                 int[] projection = new int[indexFields.size()];
+                InternalRow.FieldGetter[] getters = new InternalRow.FieldGetter[indexFields.size()];
                 for (int i = 0; i < indexFields.size(); i++) {
-                    projection[i] = readType.getFieldIndex(indexFields.get(i).name());
+                    DataField field = indexFields.get(i);
+                    projection[i] = readType.getFieldIndex(field.name());
+                    getters[i] =
+                            InternalRow.createFieldGetter(
+                                    field.type(), readType.getFieldIndex(field.name()));
                 }
                 ProjectedRow projectedRow = ProjectedRow.from(projection);
-                rows.forEachRemaining(
-                        row -> {
-                            multiWriter.write(projectedRow.replaceRow(row));
-                            rowCounter.add(1);
-                        });
+                while (rows.hasNext()) {
+                    InternalRow row = rows.next();
+                    boolean hasNull = false;
+                    for (InternalRow.FieldGetter getter : getters) {
+                        if (getter.getFieldOrNull(row) == null) {
+                            hasNull = true;
+                            break;
+                        }
+                    }
+                    if (hasNull) {
+                        LOG.info(
+                                "Null value in indexed columns, stopping shard [{}, {}].",
+                                rowRange.from,
+                                rowRange.to);
+                        break;
+                    }
+                    multiWriter.write(projectedRow.replaceRow(row));
+                    rowCounter.add(1);
+                }
             } else {
                 DataField indexField = indexFields.get(0);
                 GlobalIndexSingletonWriter singleWriter = (GlobalIndexSingletonWriter) indexWriter;

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -35,6 +35,7 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.CloseableIterator;
 import org.apache.paimon.utils.LongCounter;
+import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.Range;
 
 import java.io.IOException;
@@ -127,9 +128,14 @@ public class DefaultGlobalIndexBuilder implements Serializable {
             if (multiColumn) {
                 GlobalIndexMultiColumnWriter multiWriter =
                         (GlobalIndexMultiColumnWriter) indexWriter;
+                int[] projection = new int[indexFields.size()];
+                for (int i = 0; i < indexFields.size(); i++) {
+                    projection[i] = readType.getFieldIndex(indexFields.get(i).name());
+                }
+                ProjectedRow projectedRow = ProjectedRow.from(projection);
                 rows.forEachRemaining(
                         row -> {
-                            multiWriter.write(row);
+                            multiWriter.write(projectedRow.replaceRow(row));
                             rowCounter.add(1);
                         });
             } else {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -122,7 +122,13 @@ public class DefaultGlobalIndexBuilder implements Serializable {
 
     private List<ResultEntry> writePaimonRows(
             CloseableIterator<InternalRow> rows, LongCounter rowCounter) throws IOException {
-        GlobalIndexWriter indexWriter = createIndexWriter(table, indexType, indexFields, options);
+        GlobalIndexWriter indexWriter =
+                createIndexWriter(
+                        table,
+                        indexType,
+                        indexFields.get(0),
+                        indexFields.subList(1, indexFields.size()),
+                        options);
         boolean multiColumn = indexFields.size() > 1;
 
         try {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -41,6 +41,7 @@ import org.apache.paimon.utils.Range;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,7 +56,8 @@ public class DefaultGlobalIndexBuilder implements Serializable {
     private final FileStoreTable table;
     private final BinaryRow partition;
     private final RowType readType;
-    private final List<DataField> indexFields;
+    private final DataField indexField;
+    private final List<DataField> extraFields;
     private final String indexType;
     private final Range rowRange;
     private final Options options;
@@ -72,7 +74,8 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                 table,
                 partition,
                 readType,
-                Collections.singletonList(indexField),
+                indexField,
+                Collections.emptyList(),
                 indexType,
                 rowRange,
                 options);
@@ -82,17 +85,27 @@ public class DefaultGlobalIndexBuilder implements Serializable {
             FileStoreTable table,
             BinaryRow partition,
             RowType readType,
-            List<DataField> indexFields,
+            DataField indexField,
+            List<DataField> extraFields,
             String indexType,
             Range rowRange,
             Options options) {
         this.table = table;
         this.partition = partition;
         this.readType = readType;
-        this.indexFields = indexFields;
+        this.indexField = indexField;
+        this.extraFields = extraFields;
         this.indexType = indexType;
         this.rowRange = rowRange;
         this.options = options;
+    }
+
+    /** The primary index column followed by the extra columns, in index order. */
+    private List<DataField> indexedFields() {
+        List<DataField> fields = new ArrayList<>(1 + extraFields.size());
+        fields.add(indexField);
+        fields.addAll(extraFields);
+        return fields;
     }
 
     public FileStoreTable table() {
@@ -112,7 +125,7 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                         table.store().pathFactory().globalIndexFileFactory(),
                         table.coreOptions(),
                         rowRange,
-                        indexFields,
+                        indexedFields(),
                         indexType,
                         resultEntries);
         DataIncrement dataIncrement = DataIncrement.indexIncrement(indexFileMetas);
@@ -123,21 +136,17 @@ public class DefaultGlobalIndexBuilder implements Serializable {
     private List<ResultEntry> writePaimonRows(
             CloseableIterator<InternalRow> rows, LongCounter rowCounter) throws IOException {
         GlobalIndexWriter indexWriter =
-                createIndexWriter(
-                        table,
-                        indexType,
-                        indexFields.get(0),
-                        indexFields.subList(1, indexFields.size()),
-                        options);
-        boolean multiColumn = indexFields.size() > 1;
+                createIndexWriter(table, indexType, indexField, extraFields, options);
+        boolean multiColumn = !extraFields.isEmpty();
 
         try {
             if (multiColumn) {
                 GlobalIndexMultiColumnWriter multiWriter =
                         (GlobalIndexMultiColumnWriter) indexWriter;
-                int[] projection = new int[indexFields.size()];
-                for (int i = 0; i < indexFields.size(); i++) {
-                    DataField field = indexFields.get(i);
+                List<DataField> indexedFields = indexedFields();
+                int[] projection = new int[indexedFields.size()];
+                for (int i = 0; i < indexedFields.size(); i++) {
+                    DataField field = indexedFields.get(i);
                     projection[i] = readType.getFieldIndex(field.name());
                 }
                 ProjectedRow projectedRow = ProjectedRow.from(projection);
@@ -152,7 +161,6 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                     rowCounter.add(1);
                 }
             } else {
-                DataField indexField = indexFields.get(0);
                 GlobalIndexSingletonWriter singleWriter = (GlobalIndexSingletonWriter) indexWriter;
                 InternalRow.FieldGetter getter =
                         InternalRow.createFieldGetter(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -20,7 +20,9 @@ package org.apache.paimon.spark.globalindex;
 
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.globalindex.GlobalIndexMultiColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
@@ -37,6 +39,7 @@ import org.apache.paimon.utils.Range;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.paimon.globalindex.GlobalIndexBuilderUtils.createIndexWriter;
@@ -50,7 +53,7 @@ public class DefaultGlobalIndexBuilder implements Serializable {
     private final FileStoreTable table;
     private final BinaryRow partition;
     private final RowType readType;
-    private final DataField indexField;
+    private final List<DataField> indexFields;
     private final String indexType;
     private final Range rowRange;
     private final Options options;
@@ -63,10 +66,28 @@ public class DefaultGlobalIndexBuilder implements Serializable {
             String indexType,
             Range rowRange,
             Options options) {
+        this(
+                table,
+                partition,
+                readType,
+                Collections.singletonList(indexField),
+                indexType,
+                rowRange,
+                options);
+    }
+
+    public DefaultGlobalIndexBuilder(
+            FileStoreTable table,
+            BinaryRow partition,
+            RowType readType,
+            List<DataField> indexFields,
+            String indexType,
+            Range rowRange,
+            Options options) {
         this.table = table;
         this.partition = partition;
         this.readType = readType;
-        this.indexField = indexField;
+        this.indexFields = indexFields;
         this.indexType = indexType;
         this.rowRange = rowRange;
         this.options = options;
@@ -89,7 +110,7 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                         table.store().pathFactory().globalIndexFileFactory(),
                         table.coreOptions(),
                         rowRange,
-                        indexField.id(),
+                        indexFields,
                         indexType,
                         resultEntries);
         DataIncrement dataIncrement = DataIncrement.indexIncrement(indexFileMetas);
@@ -99,27 +120,38 @@ public class DefaultGlobalIndexBuilder implements Serializable {
 
     private List<ResultEntry> writePaimonRows(
             CloseableIterator<InternalRow> rows, LongCounter rowCounter) throws IOException {
-        GlobalIndexSingletonWriter indexWriter =
-                (GlobalIndexSingletonWriter)
-                        createIndexWriter(table, indexType, indexField, options);
+        GlobalIndexWriter indexWriter = createIndexWriter(table, indexType, indexFields, options);
+        boolean multiColumn = indexFields.size() > 1;
 
         try {
-            InternalRow.FieldGetter getter =
-                    InternalRow.createFieldGetter(
-                            indexField.type(), readType.getFieldIndex(indexField.name()));
-            rows.forEachRemaining(
-                    row -> {
-                        Object indexO = getter.getFieldOrNull(row);
-                        indexWriter.write(indexO);
-                        rowCounter.add(1);
-                    });
+            if (multiColumn) {
+                GlobalIndexMultiColumnWriter multiWriter =
+                        (GlobalIndexMultiColumnWriter) indexWriter;
+                rows.forEachRemaining(
+                        row -> {
+                            multiWriter.write(row);
+                            rowCounter.add(1);
+                        });
+            } else {
+                DataField indexField = indexFields.get(0);
+                GlobalIndexSingletonWriter singleWriter = (GlobalIndexSingletonWriter) indexWriter;
+                InternalRow.FieldGetter getter =
+                        InternalRow.createFieldGetter(
+                                indexField.type(), readType.getFieldIndex(indexField.name()));
+                rows.forEachRemaining(
+                        row -> {
+                            Object indexO = getter.getFieldOrNull(row);
+                            singleWriter.write(indexO);
+                            rowCounter.add(1);
+                        });
+            }
             return indexWriter.finish();
         } finally {
             closeWriterQuietly(indexWriter);
         }
     }
 
-    private static void closeWriterQuietly(GlobalIndexSingletonWriter writer) {
+    private static void closeWriterQuietly(GlobalIndexWriter writer) {
         if (writer instanceof java.io.Closeable) {
             try {
                 ((java.io.Closeable) writer).close();

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -77,6 +77,28 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             DataField indexField,
             Options options)
             throws IOException {
+        return buildIndex(
+                spark,
+                relation,
+                partitionPredicate,
+                table,
+                indexType,
+                readType,
+                Collections.singletonList(indexField),
+                options);
+    }
+
+    @Override
+    public List<CommitMessage> buildIndex(
+            SparkSession spark,
+            DataSourceV2Relation relation,
+            PartitionPredicate partitionPredicate,
+            FileStoreTable table,
+            String indexType,
+            RowType readType,
+            List<DataField> indexFields,
+            Options options)
+            throws IOException {
         Options tableOptions = table.coreOptions().toConfiguration();
         long rowsPerShard =
                 tableOptions
@@ -106,7 +128,7 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                                 table,
                                 partition,
                                 readType,
-                                indexField,
+                                indexFields,
                                 indexType,
                                 indexedSplit.rowRanges().get(0),
                                 options);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -21,12 +21,14 @@ package org.apache.paimon.spark.globalindex;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageSerializer;
@@ -110,6 +112,13 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
 
         List<ManifestEntry> entries =
                 table.store().newScan().withPartitionFilter(partitionPredicate).plan().files();
+        List<String> indexColumns =
+                indexFields.stream().map(DataField::name).collect(Collectors.toList());
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        long boundaryRowId =
+                GlobalIndexBuilderUtils.findMinNonIndexableRowId(
+                        schemaManager, entries, indexColumns);
+        entries = GlobalIndexBuilderUtils.filterEntriesBefore(entries, boundaryRowId);
         // generate splits for each partition && shard
         Map<BinaryRow, List<IndexedSplit>> splits = split(table, entries, rowsPerShard);
 

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -86,7 +86,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                 table,
                 indexType,
                 readType,
-                Collections.singletonList(indexField),
+                indexField,
+                Collections.emptyList(),
                 options);
     }
 
@@ -98,7 +99,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             FileStoreTable table,
             String indexType,
             RowType readType,
-            List<DataField> indexFields,
+            DataField indexField,
+            List<DataField> extraFields,
             Options options)
             throws IOException {
         Options tableOptions = table.coreOptions().toConfiguration();
@@ -112,6 +114,9 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
 
         List<ManifestEntry> entries =
                 table.store().newScan().withPartitionFilter(partitionPredicate).plan().files();
+        List<DataField> indexFields = new ArrayList<>();
+        indexFields.add(indexField);
+        indexFields.addAll(extraFields);
         List<String> indexColumns =
                 indexFields.stream().map(DataField::name).collect(Collectors.toList());
         SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
@@ -137,7 +142,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                                 table,
                                 partition,
                                 readType,
-                                indexFields,
+                                indexField,
+                                extraFields,
                                 indexType,
                                 indexedSplit.rowRanges().get(0),
                                 options);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
@@ -57,6 +57,12 @@ public interface GlobalIndexTopologyBuilder {
             List<DataField> indexFields,
             Options options)
             throws IOException {
+        if (indexFields.size() > 1) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Topology builder '%s' does not support multi-column index, got columns: %s",
+                            identifier(), indexFields));
+        }
         return buildIndex(
                 spark,
                 relation,

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
@@ -46,4 +46,25 @@ public interface GlobalIndexTopologyBuilder {
             DataField indexField,
             Options options)
             throws IOException;
+
+    default List<CommitMessage> buildIndex(
+            SparkSession spark,
+            DataSourceV2Relation relation,
+            PartitionPredicate partitionPredicate,
+            FileStoreTable table,
+            String indexType,
+            RowType readType,
+            List<DataField> indexFields,
+            Options options)
+            throws IOException {
+        return buildIndex(
+                spark,
+                relation,
+                partitionPredicate,
+                table,
+                indexType,
+                readType,
+                indexFields.get(0),
+                options);
+    }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/GlobalIndexTopologyBuilder.java
@@ -54,14 +54,15 @@ public interface GlobalIndexTopologyBuilder {
             FileStoreTable table,
             String indexType,
             RowType readType,
-            List<DataField> indexFields,
+            DataField indexField,
+            List<DataField> extraFields,
             Options options)
             throws IOException {
-        if (indexFields.size() > 1) {
+        if (extraFields != null && !extraFields.isEmpty()) {
             throw new UnsupportedOperationException(
                     String.format(
-                            "Topology builder '%s' does not support multi-column index, got columns: %s",
-                            identifier(), indexFields));
+                            "Topology builder '%s' does not support multi-column index, got extra columns: %s",
+                            identifier(), extraFields));
         }
         return buildIndex(
                 spark,
@@ -70,7 +71,7 @@ public interface GlobalIndexTopologyBuilder {
                 table,
                 indexType,
                 readType,
-                indexFields.get(0),
+                indexField,
                 options);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -138,6 +138,7 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         .map(String::trim)
                                         .filter(s -> !s.isEmpty())
                                         .collect(Collectors.toList());
+                        checkArgument(!indexColumns.isEmpty(), "At least one column required.");
                         for (String col : indexColumns) {
                             checkArgument(
                                     rowType.containsField(col),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -122,6 +122,11 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
         return modifySparkTable(
                 tableIdent,
                 sparkTable -> {
+                    List<String> indexColumns =
+                            Arrays.stream(column.split(","))
+                                    .map(String::trim)
+                                    .filter(s -> !s.isEmpty())
+                                    .collect(Collectors.toList());
                     try {
                         org.apache.paimon.table.Table t = sparkTable.getTable();
                         checkArgument(
@@ -134,11 +139,6 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                 tableIdent);
 
                         RowType rowType = table.rowType();
-                        List<String> indexColumns =
-                                Arrays.stream(column.split(","))
-                                        .map(String::trim)
-                                        .filter(s -> !s.isEmpty())
-                                        .collect(Collectors.toList());
                         checkArgument(!indexColumns.isEmpty(), "At least one column required.");
                         checkArgument(
                                 indexColumns.size() == new HashSet<>(indexColumns).size(),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.procedure;
 
+import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.spark.globalindex.GlobalIndexTopologyBuilder;
@@ -157,12 +158,6 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                     col,
                                     tableIdent);
                         }
-                        if ("btree".equalsIgnoreCase(indexType)) {
-                            checkArgument(
-                                    indexColumns.size() == 1,
-                                    "BTree index only supports single column, got: %s",
-                                    indexColumns);
-                        }
                         DataSourceV2Relation relation = createRelation(tableIdent, sparkTable);
                         PartitionPredicate partitionPredicate =
                                 SparkProcedureUtils.convertToPartitionPredicate(
@@ -179,6 +174,17 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         RowType readRowType = SpecialFields.rowTypeWithRowId(projectedRowType);
 
                         Options userOptions = createUserOptions(table, optionString);
+
+                        if (indexColumns.size() > 1) {
+                            // Whether multi-column is supported is decided by each index type's
+                            // factory; fail fast up front instead of failing later in the build
+                            // job.
+                            checkArgument(
+                                    GlobalIndexerFactoryUtils.load(indexType).supportsMultiColumn(),
+                                    "Index type '%s' does not support multi-column index, got columns: %s",
+                                    indexType,
+                                    indexColumns);
+                        }
 
                         GlobalIndexTopologyBuilder topoBuilder =
                                 GlobalIndexTopologyBuilderUtils.createTopoBuilder(indexType);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -208,7 +208,7 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         throw new RuntimeException(
                                 String.format(
                                         "Failed to create %s index for columns '%s' on table '%s'.",
-                                        indexType, column, tableIdent),
+                                        indexType, indexColumns, tableIdent),
                                 e);
                     }
                 });

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -145,6 +145,12 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                     col,
                                     tableIdent);
                         }
+                        if ("btree".equalsIgnoreCase(indexType)) {
+                            checkArgument(
+                                    indexColumns.size() == 1,
+                                    "BTree index only supports single column, got: %s",
+                                    indexColumns);
+                        }
                         DataSourceV2Relation relation = createRelation(tableIdent, sparkTable);
                         PartitionPredicate partitionPredicate =
                                 SparkProcedureUtils.convertToPartitionPredicate(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -43,12 +43,13 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.spark.sql.types.DataTypes.StringType;
@@ -132,11 +133,18 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                 tableIdent);
 
                         RowType rowType = table.rowType();
-                        checkArgument(
-                                rowType.containsField(column),
-                                "Column '%s' does not exist in table '%s'.",
-                                column,
-                                tableIdent);
+                        List<String> indexColumns =
+                                Arrays.stream(column.split(","))
+                                        .map(String::trim)
+                                        .filter(s -> !s.isEmpty())
+                                        .collect(Collectors.toList());
+                        for (String col : indexColumns) {
+                            checkArgument(
+                                    rowType.containsField(col),
+                                    "Column '%s' does not exist in table '%s'.",
+                                    col,
+                                    tableIdent);
+                        }
                         DataSourceV2Relation relation = createRelation(tableIdent, sparkTable);
                         PartitionPredicate partitionPredicate =
                                 SparkProcedureUtils.convertToPartitionPredicate(
@@ -145,9 +153,11 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         spark(),
                                         relation);
 
-                        DataField indexField = rowType.getField(column);
-                        RowType projectedRowType =
-                                rowType.project(Collections.singletonList(column));
+                        List<DataField> indexFields =
+                                indexColumns.stream()
+                                        .map(rowType::getField)
+                                        .collect(Collectors.toList());
+                        RowType projectedRowType = rowType.project(indexColumns);
                         RowType readRowType = SpecialFields.rowTypeWithRowId(projectedRowType);
 
                         Options userOptions = createUserOptions(table, optionString);
@@ -163,7 +173,7 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         table,
                                         indexType,
                                         readRowType,
-                                        indexField,
+                                        indexFields,
                                         userOptions);
 
                         try (TableCommitImpl commit =
@@ -179,7 +189,7 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                     } catch (Exception e) {
                         throw new RuntimeException(
                                 String.format(
-                                        "Failed to create %s index for column '%s' on table '%s'.",
+                                        "Failed to create %s index for columns '%s' on table '%s'.",
                                         indexType, column, tableIdent),
                                 e);
                     }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -139,6 +140,16 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         .filter(s -> !s.isEmpty())
                                         .collect(Collectors.toList());
                         checkArgument(!indexColumns.isEmpty(), "At least one column required.");
+                        checkArgument(
+                                indexColumns.size() == new HashSet<>(indexColumns).size(),
+                                "Duplicate index columns are not allowed: %s",
+                                indexColumns);
+                        // No hard cap on the number of index columns: unlike row-store B-tree
+                        // indexes (e.g. MySQL 16, PostgreSQL 32) whose limit comes from composing
+                        // columns into a single key, the global index is built on per-type index
+                        // frameworks. Whether multiple columns are supported, and any practical
+                        // limit, is decided by each index type (single-column types reject
+                        // multi-column via UnsupportedOperationException).
                         for (String col : indexColumns) {
                             checkArgument(
                                     rowType.containsField(col),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -197,7 +197,8 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                                         table,
                                         indexType,
                                         readRowType,
-                                        indexFields,
+                                        indexFields.get(0),
+                                        indexFields.subList(1, indexFields.size()),
                                         userOptions);
 
                         try (TableCommitImpl commit =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedure.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.procedure;
 
-import org.apache.paimon.globalindex.GlobalIndexerFactoryUtils;
+import org.apache.paimon.globalindex.GlobalIndexer;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.spark.globalindex.GlobalIndexTopologyBuilder;
@@ -176,14 +176,21 @@ public class CreateGlobalIndexProcedure extends BaseProcedure {
                         Options userOptions = createUserOptions(table, optionString);
 
                         if (indexColumns.size() > 1) {
-                            // Whether multi-column is supported is decided by each index type's
-                            // factory; fail fast up front instead of failing later in the build
-                            // job.
-                            checkArgument(
-                                    GlobalIndexerFactoryUtils.load(indexType).supportsMultiColumn(),
-                                    "Index type '%s' does not support multi-column index, got columns: %s",
-                                    indexType,
-                                    indexColumns);
+                            // Fail fast before submitting the job: index types that do not support
+                            // multi-column throw from GlobalIndexerFactory#create, which happens
+                            // before any indexer side effect.
+                            try {
+                                GlobalIndexer.create(
+                                        indexType,
+                                        indexFields.get(0),
+                                        indexFields.subList(1, indexFields.size()),
+                                        userOptions);
+                            } catch (UnsupportedOperationException e) {
+                                throw new IllegalArgumentException(
+                                        String.format(
+                                                "Index type '%s' does not support multi-column index, got columns: %s",
+                                                indexType, indexColumns));
+                            }
                         }
 
                         GlobalIndexTopologyBuilder topoBuilder =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -107,6 +108,13 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
 
         LOG.info("Starting to drop index for table " + tableIdent + " WHERE: " + finalWhere);
 
+        List<String> indexColumns =
+                Arrays.stream(column.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+        checkArgument(!indexColumns.isEmpty(), "At least one column required.");
+
         return modifyPaimonTable(
                 tableIdent,
                 t -> {
@@ -117,11 +125,17 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
                         FileStoreTable table = (FileStoreTable) t;
 
                         RowType rowType = table.rowType();
-                        checkArgument(
-                                rowType.containsField(column),
-                                "Column '%s' does not exist in table '%s'.",
-                                column,
-                                tableIdent);
+                        for (String col : indexColumns) {
+                            checkArgument(
+                                    rowType.containsField(col),
+                                    "Column '%s' does not exist in table '%s'.",
+                                    col,
+                                    tableIdent);
+                        }
+                        List<Integer> indexFieldIds =
+                                indexColumns.stream()
+                                        .map(col -> rowType.getField(col).id())
+                                        .collect(Collectors.toList());
                         DataSourceV2Relation relation = createRelation(tableIdent);
                         PartitionPredicate partitionPredicate =
                                 SparkProcedureUtils.convertToPartitionPredicate(
@@ -144,9 +158,9 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
                                         entry.indexFile().indexType().equals(indexType)
                                                 && entry.indexFile().globalIndexMeta() != null
                                                 && entry.indexFile()
-                                                                .globalIndexMeta()
-                                                                .indexFieldId()
-                                                        == rowType.getField(column).id()
+                                                        .globalIndexMeta()
+                                                        .getIndexedFieldIds()
+                                                        .equals(indexFieldIds)
                                                 && (partitionPredicate == null
                                                         || partitionPredicate.test(
                                                                 entry.partition()));
@@ -192,8 +206,8 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
                     } catch (Exception e) {
                         throw new RuntimeException(
                                 String.format(
-                                        "Failed to drop %s index for column '%s' on table '%s'.",
-                                        indexType, column, tableIdent),
+                                        "Failed to drop %s index for columns '%s' on table '%s'.",
+                                        indexType, indexColumns, tableIdent),
                                 e);
                     }
                 });

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/DropGlobalIndexProcedure.java
@@ -207,7 +207,7 @@ public class DropGlobalIndexProcedure extends BaseProcedure {
                         throw new RuntimeException(
                                 String.format(
                                         "Failed to drop %s index for columns '%s' on table '%s'.",
-                                        indexType, indexColumns, tableIdent),
+                                        indexType, String.join(",", indexColumns), tableIdent),
                                 e);
                     }
                 });

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -21,6 +21,8 @@ package org.apache.paimon.spark.commands
 import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
+import org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
+import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
 import org.apache.paimon.spark.SparkTable
@@ -594,9 +596,9 @@ case class MergeIntoPaimonDataEvolutionTable(
         if (globalIndexMeta == null) {
           false
         } else {
-          val fieldName = rowType.getField(globalIndexMeta.indexFieldId()).name()
+          val indexedNames = getIndexedFieldNames(globalIndexMeta, rowType)
           affectedParts.contains(entry.partition()) && updateColumns.exists(
-            _.name.equals(fieldName))
+            col => indexedNames.contains(col.name))
         }
       }
 
@@ -613,8 +615,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         case GlobalIndexColumnUpdateAction.THROW_ERROR =>
           val updatedColNames = updateColumns.map(_.name)
           val conflicted = affectedIndexEntries
-            .map(_.indexFile().globalIndexMeta().indexFieldId())
-            .map(id => rowType.getField(id).name())
+            .flatMap(e => getIndexedFieldNames(e.indexFile().globalIndexMeta(), rowType))
             .toSet
           throw new RuntimeException(
             s"""MergeInto: update columns contain globally indexed columns, not supported now.
@@ -635,6 +636,20 @@ case class MergeIntoPaimonDataEvolutionTable(
           }
           updateCommit ++ deleteCommitMessages
       }
+    }
+  }
+
+  private def getIndexedFieldNames(
+      meta: GlobalIndexMeta,
+      rowType: org.apache.paimon.types.RowType): Seq[String] = {
+    if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID) {
+      meta.extraFieldIds().map(id => rowType.getField(id).name()).toSeq
+    } else {
+      val names = ArrayBuffer(rowType.getField(meta.indexFieldId()).name())
+      if (meta.extraFieldIds() != null) {
+        meta.extraFieldIds().foreach(id => names += rowType.getField(id).name())
+      }
+      names.toSeq
     }
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -21,7 +21,6 @@ package org.apache.paimon.spark.commands
 import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
-import org.apache.paimon.globalindex.GlobalIndexBuilderUtils.MULTI_COLUMN_INDEX_FIELD_ID
 import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
@@ -596,7 +595,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         if (globalIndexMeta == null) {
           false
         } else {
-          val indexedNames = getIndexedFieldNames(globalIndexMeta, rowType)
+          val indexedNames = globalIndexMeta.getIndexedFieldNames(rowType).asScala
           affectedParts.contains(entry.partition()) && updateColumns.exists(
             col => indexedNames.contains(col.name))
         }
@@ -615,7 +614,7 @@ case class MergeIntoPaimonDataEvolutionTable(
         case GlobalIndexColumnUpdateAction.THROW_ERROR =>
           val updatedColNames = updateColumns.map(_.name)
           val conflicted = affectedIndexEntries
-            .flatMap(e => getIndexedFieldNames(e.indexFile().globalIndexMeta(), rowType))
+            .flatMap(e => e.indexFile().globalIndexMeta().getIndexedFieldNames(rowType).asScala)
             .toSet
           throw new RuntimeException(
             s"""MergeInto: update columns contain globally indexed columns, not supported now.
@@ -636,20 +635,6 @@ case class MergeIntoPaimonDataEvolutionTable(
           }
           updateCommit ++ deleteCommitMessages
       }
-    }
-  }
-
-  private def getIndexedFieldNames(
-      meta: GlobalIndexMeta,
-      rowType: org.apache.paimon.types.RowType): Seq[String] = {
-    if (meta.indexFieldId() == MULTI_COLUMN_INDEX_FIELD_ID) {
-      meta.extraFieldIds().map(id => rowType.getField(id).name()).toSeq
-    } else {
-      val names = ArrayBuffer(rowType.getField(meta.indexFieldId()).name())
-      if (meta.extraFieldIds() != null) {
-        meta.extraFieldIds().foreach(id => names += rowType.getField(id).name())
-      }
-      names.toSeq
     }
   }
 


### PR DESCRIPTION
 Extend the GlobalIndex SPI, build path, and query path to support one index builder handling multiple columns (e.g. Lucene indexing title + content + tags together). Key changes:
  
  - GlobalIndexerFactory/GlobalIndexer: add List<DataField> create overloads
  - GlobalIndexMultiColumnWriter: new interface for multi-column writes
  - GlobalIndexBuilderUtils: toIndexFileMetas/createIndexWriter accept List<DataField>
  - GlobalIndexScanner: route extraFieldIds to same reader group
  - VectorScanImpl/FullTextScanImpl: match against extraFieldIds
  - GenericIndexTopoBuilder (Flink): multi-column projection and writer dispatch
  - DefaultGlobalIndexBuilder/TopoBuilder (Spark): multi-column support
  - All single-column APIs preserved for backward compatibility

  Purpose

  Some index engines (e.g. Lucene) can build a single index over multiple columns — full-text on title and vector on embedding in the same index file. Previously the GlobalIndex SPI only supported one column
  per indexer: GlobalIndexerFactory.create(DataField, Options) and GlobalIndexSingletonWriter.write(Object). This meant multi-column engines had to create separate index files per column, losing co-located
  search benefits and doubling I/O.
  
  This PR adds a multi-column path through the entire stack:

  1. SPI layer (paimon-common): GlobalIndexerFactory.create(List<DataField>, Options) default method (falls back to single-column for existing implementations). New GlobalIndexMultiColumnWriter interface
  accepts InternalRow with all indexed columns projected in field order.
  2. Core index metadata (paimon-core): GlobalIndexBuilderUtils.toIndexFileMetas populates GlobalIndexMeta.extraFieldIds from the field list beyond the first. GlobalIndexScanner.createReaders resolves the full
   field list from metadata and passes it to the factory. Extra field IDs are registered in the indexMetas map so queries against any column in the group find the same reader.
  3. Query path (paimon-core): VectorScanImpl and FullTextScanImpl check extraFieldIds when matching index files to query columns, so a vector query on embedding finds an index whose primary field is title but
   includes embedding as an extra field.
  4. Flink build (paimon-flink): GenericIndexTopoBuilder accepts List<String> indexColumns, projects all columns + _ROW_ID, and dispatches to GlobalIndexMultiColumnWriter.write(InternalRow) when multi-column.
  findMinNonIndexableRowId checks containsAll(indexColumns) for schema evolution safety.
  5. Spark build (paimon-spark): DefaultGlobalIndexBuilder and DefaultGlobalIndexTopoBuilder gain List<DataField> overloads, with single-column constructors delegating to the multi-column path.

  All existing single-column callers are unchanged — new APIs have default implementations that delegate to the original single-column methods.

  Tests
  
  - GenericIndexTopoBuilderTest: Updated findMinNonIndexableRowId call to use List<String> signature.
  - paimon-lucene module (on feature-globalindex-support-multi-test branch): A full Lucene 9.12.0 implementation exercising the multi-column framework end-to-end:
    - LuceneGlobalIndexTest — single-column vector write/search, top-K score ordering (2 tests)
    - LuceneFullTextIndexTest — single-column full-text write/search, score verification, no-results case (3 tests)
    - LuceneMultiColumnIndexTest — multi-column (text + vector) via GlobalIndexerFactory.create(List<DataField>, Options) → GlobalIndexMultiColumnWriter.write(InternalRow), verifies both full-text and vector
  queries on same index file; also tests SPI discovery path via GlobalIndexer.create("lucene", ...) (2 tests)
    - LuceneGlobalIndexScanTest — end-to-end Paimon table tests: creates FileStoreTable, writes data, builds Lucene index, commits via DataIncrement.indexIncrement, queries via
  VectorSearchBuilder/FullTextSearchBuilder → ReadBuilder.newScan().withGlobalIndexResult(), reads back rows and asserts correctness (3 tests)