### PR TITLE
[core] Avoid cross-file blob and vector compaction for data evolution

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -356,18 +356,35 @@ public class DataEvolutionCompactCoordinator {
                 Map<DataFileMeta, List<DataFileMeta>> dataFileToBlobFiles,
                 Map<DataFileMeta, List<DataFileMeta>> dataFileToVectorStoreFiles) {
             List<DataEvolutionCompactTask> tasks = new ArrayList<>();
+            boolean triggerNormalFile = false;
             if (dataFiles.size() >= compactMinFileNum) {
                 tasks.add(new DataEvolutionCompactTask(partition, dataFiles, false));
+                triggerNormalFile = true;
             }
 
             if (compactBlob) {
-                for (DataFileMeta dataFile : dataFiles) {
+                if (triggerNormalFile) {
+                    List<DataFileMeta> blobFiles = new ArrayList<>();
+                    for (DataFileMeta dataFile : dataFiles) {
+                        blobFiles.addAll(
+                                dataFileToBlobFiles.getOrDefault(
+                                        dataFile, Collections.emptyList()));
+                    }
                     for (List<DataFileMeta> blobFilesToCompact :
-                            blobFileGroupsToCompact(
-                                    dataFileToBlobFiles.getOrDefault(
-                                            dataFile, Collections.emptyList()))) {
+                            blobFileGroupsToCompact(blobFiles)) {
                         tasks.add(
                                 new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
+                    }
+                } else {
+                    for (DataFileMeta dataFile : dataFiles) {
+                        for (List<DataFileMeta> blobFilesToCompact :
+                                blobFileGroupsToCompact(
+                                        dataFileToBlobFiles.getOrDefault(
+                                                dataFile, Collections.emptyList()))) {
+                            tasks.add(
+                                    new DataEvolutionCompactTask(
+                                            partition, blobFilesToCompact, true));
+                        }
                     }
                 }
             }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -361,13 +361,14 @@ public class DataEvolutionCompactCoordinator {
             }
 
             if (compactBlob) {
-                List<DataFileMeta> blobFiles = new ArrayList<>();
                 for (DataFileMeta dataFile : dataFiles) {
-                    blobFiles.addAll(
-                            dataFileToBlobFiles.getOrDefault(dataFile, Collections.emptyList()));
-                }
-                for (List<DataFileMeta> blobFilesToCompact : blobFileGroupsToCompact(blobFiles)) {
-                    tasks.add(new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
+                    for (List<DataFileMeta> blobFilesToCompact :
+                            blobFileGroupsToCompact(
+                                    dataFileToBlobFiles.getOrDefault(
+                                            dataFile, Collections.emptyList()))) {
+                        tasks.add(
+                                new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
+                    }
                 }
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -356,10 +356,9 @@ public class DataEvolutionCompactCoordinator {
                 Map<DataFileMeta, List<DataFileMeta>> dataFileToBlobFiles,
                 Map<DataFileMeta, List<DataFileMeta>> dataFileToVectorStoreFiles) {
             List<DataEvolutionCompactTask> tasks = new ArrayList<>();
-            boolean triggerNormalFile = false;
-            if (dataFiles.size() >= compactMinFileNum) {
+            boolean triggerNormalFile = dataFiles.size() >= compactMinFileNum;
+            if (triggerNormalFile) {
                 tasks.add(new DataEvolutionCompactTask(partition, dataFiles, false));
-                triggerNormalFile = true;
             }
 
             if (compactBlob) {
@@ -390,14 +389,27 @@ public class DataEvolutionCompactCoordinator {
             }
 
             if (compactVector) {
-                List<DataFileMeta> vectorStoreFiles = new ArrayList<>();
-                for (DataFileMeta dataFile : dataFiles) {
-                    vectorStoreFiles.addAll(
-                            dataFileToVectorStoreFiles.getOrDefault(
-                                    dataFile, Collections.emptyList()));
-                }
-                if (vectorStoreFiles.size() >= compactMinFileNum) {
-                    tasks.add(new DataEvolutionCompactTask(partition, vectorStoreFiles, false));
+                if (triggerNormalFile) {
+                    List<DataFileMeta> vectorStoreFiles = new ArrayList<>();
+                    for (DataFileMeta dataFile : dataFiles) {
+                        vectorStoreFiles.addAll(
+                                dataFileToVectorStoreFiles.getOrDefault(
+                                        dataFile, Collections.emptyList()));
+                    }
+                    if (vectorStoreFiles.size() >= compactMinFileNum) {
+                        tasks.add(new DataEvolutionCompactTask(partition, vectorStoreFiles, false));
+                    }
+                } else {
+                    for (DataFileMeta dataFile : dataFiles) {
+                        List<DataFileMeta> vectorStoreFiles =
+                                dataFileToVectorStoreFiles.getOrDefault(
+                                        dataFile, Collections.emptyList());
+                        if (vectorStoreFiles.size() >= compactMinFileNum) {
+                            tasks.add(
+                                    new DataEvolutionCompactTask(
+                                            partition, vectorStoreFiles, false));
+                        }
+                    }
                 }
             }
             return tasks;

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -177,17 +177,31 @@ public class DataEvolutionCompactCoordinatorTest {
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
-        // Should have compaction tasks for both data files and blob files
-        assertThat(tasks.size()).isEqualTo(2);
+        // Should have compaction tasks for data files and blob files within each data-file range
+        assertThat(tasks.size()).isEqualTo(3);
 
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(0).file(), entries.get(3).file());
         assertThat(tasks.get(1).compactBefore())
-                .containsExactly(
-                        entries.get(1).file(),
-                        entries.get(2).file(),
-                        entries.get(4).file(),
-                        entries.get(5).file());
+                .containsExactly(entries.get(1).file(), entries.get(2).file());
+        assertThat(tasks.get(2).compactBefore())
+                .containsExactly(entries.get(4).file(), entries.get(5).file());
+    }
+
+    @Test
+    public void testCompactPlannerDoesNotCompactBlobFilesAcrossDataFiles() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeBlobEntry("file1.blob", 0L, 100L, 100, "pic"));
+        entries.add(makeEntry("file2.parquet", 100L, 100L, 100));
+        entries.add(makeBlobEntry("file2.blob", 100L, 100L, 100, "pic"));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                blobPlanner(1024, 1024, 100, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).isEmpty();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -205,6 +205,40 @@ public class DataEvolutionCompactCoordinatorTest {
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
         assertThat(tasks).isEmpty();
+
+        planner = blobPlanner(1024, 1024, 2, rowType(new DataField(1, "pic", DataTypes.BLOB())));
+        tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(entries.get(0).file(), entries.get(2).file());
+        assertThat(tasks.get(1).compactBefore())
+                .containsExactly(entries.get(1).file(), entries.get(3).file());
+    }
+
+    @Test
+    public void testCompactPlannerDoesNotCompactVectorStoreFilesAcrossDataFiles() {
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(makeEntry("file1.parquet", 0L, 100L, 100));
+        entries.add(makeVectorStoreEntry("file1.vector.json", 0L, 100L, 100));
+        entries.add(makeEntry("file2.parquet", 100L, 100L, 100));
+        entries.add(makeVectorStoreEntry("file2.vector.json", 100L, 100L, 100));
+
+        DataEvolutionCompactCoordinator.CompactPlanner planner =
+                vectorStorePlanner(1024, 1024, 100);
+
+        List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).isEmpty();
+
+        planner = vectorStorePlanner(1024, 1024, 2);
+        tasks = planner.compactPlan(entries);
+
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).compactBefore())
+                .containsExactly(entries.get(0).file(), entries.get(2).file());
+        assertThat(tasks.get(1).compactBefore())
+                .containsExactly(entries.get(1).file(), entries.get(3).file());
     }
 
     @Test
@@ -485,6 +519,23 @@ public class DataEvolutionCompactCoordinatorTest {
                         writeCol == null ? null : Collections.singletonList(writeCol)));
     }
 
+    private ManifestEntry makeVectorStoreEntry(
+            String fileName, long firstRowId, long rowCount, long fileSize) {
+        return ManifestEntry.create(
+                FileKind.ADD,
+                BinaryRow.EMPTY_ROW,
+                0,
+                0,
+                createDataFileMeta(
+                        fileName,
+                        firstRowId,
+                        rowCount,
+                        0,
+                        fileSize,
+                        0,
+                        Collections.singletonList("vec")));
+    }
+
     private DataFileMeta createDataFileMeta(
             String fileName, long firstRowId, long rowCount, long maxSeq, long fileSize) {
         return createDataFileMeta(fileName, firstRowId, rowCount, maxSeq, fileSize, 0, null);
@@ -552,6 +603,12 @@ public class DataEvolutionCompactCoordinatorTest {
                 compactMinFileNum,
                 schemaFetcher,
                 fieldIds(currentRowType));
+    }
+
+    private DataEvolutionCompactCoordinator.CompactPlanner vectorStorePlanner(
+            long targetFileSize, long openFileCost, long compactMinFileNum) {
+        return new DataEvolutionCompactCoordinator.CompactPlanner(
+                false, true, targetFileSize, openFileCost, compactMinFileNum);
     }
 
     private RowType rowType(DataField... fields) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -177,15 +177,18 @@ public class DataEvolutionCompactCoordinatorTest {
 
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
-        // Should have compaction tasks for data files and blob files within each data-file range
-        assertThat(tasks.size()).isEqualTo(3);
+        // Should have compaction tasks for data files and blob files within the data compaction
+        // range.
+        assertThat(tasks.size()).isEqualTo(2);
 
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(0).file(), entries.get(3).file());
         assertThat(tasks.get(1).compactBefore())
-                .containsExactly(entries.get(1).file(), entries.get(2).file());
-        assertThat(tasks.get(2).compactBefore())
-                .containsExactly(entries.get(4).file(), entries.get(5).file());
+                .containsExactly(
+                        entries.get(1).file(),
+                        entries.get(2).file(),
+                        entries.get(4).file(),
+                        entries.get(5).file());
     }
 
     @Test


### PR DESCRIPTION
### Purpose

This PR prevents standalone Data Evolution dedicated-file compaction from combining blob or vector-store files that belong to different regular data-file row-id ranges.

### Root Cause

The compact planner grouped dedicated files from a data compaction group before planning dedicated compact tasks. If blob or vector-store files were compacted across multiple regular data-file ranges without compacting those regular data files into the same row-id range, the compacted dedicated file could overlap several remaining data files.

Conflict detection groups files by overlapping row-id range and filters blob files from the error message, so the failure surfaced as multiple regular data files with different row-id ranges conflicting during COMPACT.

### Changes

- Keep cross-data-file blob/vector-store compaction only when the corresponding regular data files are compacted in the same task.
- Plan blob/vector-store compaction per containing data file when no regular data-file compaction is triggered.
- Update planner tests for both the no-compact and compact-together paths.

### Tests

- `JAVA_HOME=/opt/zulu8.68.0.21-ca-jdk8.0.362-macosx_aarch64 mvn -pl paimon-core spotless:apply`
- `JAVA_HOME=/opt/zulu8.68.0.21-ca-jdk8.0.362-macosx_aarch64 mvn -pl paimon-core -Dtest=DataEvolutionCompactCoordinatorTest test`
