### PR TITLE
[core] Fix chain table sequence field validation

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -924,7 +924,8 @@ public class SchemaValidation {
             Preconditions.checkArgument(
                     options.bucket() > 0, "Bucket number must be greater than 0 for chain table.");
             Preconditions.checkArgument(
-                    options.sequenceField() != null, "Sequence field is required for chain table.");
+                    !options.sequenceField().isEmpty(),
+                    "Sequence field is required for chain table.");
             Preconditions.checkArgument(
                     changelogProducer == ChangelogProducer.NONE
                             || changelogProducer == ChangelogProducer.INPUT,

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -233,6 +233,29 @@ class SchemaValidationTest {
     }
 
     @Test
+    public void testChainTableRequiresSequenceField() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.CHAIN_TABLE_ENABLED.key(), "true");
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), "$f0");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd");
+
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.STRING()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "f2", DataTypes.BIGINT()),
+                        new DataField(3, "f3", DataTypes.STRING()));
+        List<String> partitionKeys = singletonList("f0");
+        List<String> primaryKeys = Arrays.asList("f0", "f1");
+        TableSchema schema =
+                new TableSchema(1, fields, 10, partitionKeys, primaryKeys, options, "");
+
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessage("Sequence field is required for chain table.");
+    }
+
+    @Test
     public void testVectorStoreUnknownColumn() {
         Map<String, String> options = new HashMap<>();
         options.put(BUCKET.key(), String.valueOf(-1));


### PR DESCRIPTION
### Purpose

`CoreOptions.sequenceField()` returns an empty list when `sequence.field` is not configured, but chain table validation only checked it against `null`.

This allowed tables with `'chain-table.enabled' = 'true'` to pass schema validation without `sequence.field`, while chain table requires sequence semantics.

### Tests

- `mvn -pl paimon-core -Pfast-build -Dtest=SchemaValidationTest test`
