### PR TITLE
[core] fix RenamingSnapshotCommitTest compile error from #6778

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/catalog/RenamingSnapshotCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/RenamingSnapshotCommitTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -116,7 +114,6 @@ public class RenamingSnapshotCommitTest {
         long commitIdentifier = id;
         Snapshot.CommitKind commitKind = Snapshot.CommitKind.APPEND;
         long timeMillis = System.currentTimeMillis();
-        Map<Integer, Long> logOffsets = new HashMap<>();
         Long totalRecordCount = 100L;
         Long deltaRecordCount = 100L;
 
@@ -134,7 +131,6 @@ public class RenamingSnapshotCommitTest {
                 commitIdentifier,
                 commitKind,
                 timeMillis,
-                logOffsets,
                 totalRecordCount,
                 deltaRecordCount,
                 null,


### PR DESCRIPTION
## Problem

After #6778 landed, `paimon-core` no longer compiles on master:

```
paimon-core/src/test/java/org/apache/paimon/catalog/RenamingSnapshotCommitTest.java:[124,17]
  incompatible types: possible lossy conversion from long to int
```

`createSnapshot()` builds the `Snapshot` via:

```java
Map<Integer, Long> logOffsets = new HashMap<>();
...
return new Snapshot(
        id, schemaId, baseManifestList, baseManifestListSize, ...,
        timeMillis,
        logOffsets,          // ← stray 14th arg
        totalRecordCount, deltaRecordCount,
        null, null, null, null, null);
```

`Snapshot` (`paimon-api/src/main/java/org/apache/paimon/Snapshot.java`) has two public constructors — 20 args and 22 args — and neither contains a `logOffsets` parameter. With the extra arg the call is 21-wide; javac picks the closest 22-arg overload and the type system then reports a misleading \"long → int\" mismatch on the first arg.

Every PR opened against master right now hits this.

## Fix

Drop the stray `logOffsets` declaration and the corresponding constructor argument (plus the two now-unused `java.util.Map` / `java.util.HashMap` imports). The remaining 20 args line up positionally with the 20-arg `Snapshot` ctor.

This assumes `logOffsets` was an accidental leftover — `Snapshot` itself is not intended to carry a per-bucket log-offset map. If the intent of #6778 was actually to extend `Snapshot` with a `logOffsets` field, that's a larger change that should land in `Snapshot.java` (with serialization, equals/hashCode, etc.); flag this PR and we can switch direction.

## Verification

CI on this branch is the source of truth — local Maven was not run. The change is mechanical (remove a never-referenced local + the matching arg + two imports) and the arg counts are spelled out above.