### PR TITLE
[core] Parallelize GlobalIndexEvaluator across multiple BTree fields

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -32,7 +32,6 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -209,18 +208,51 @@ public class GlobalIndexEvaluator
     }
 
     private List<List<Predicate>> groupByField(List<Predicate> children) {
-        Map<String, List<Predicate>> fieldGroups = new HashMap<>();
-        List<List<Predicate>> result = new ArrayList<>();
+        List<List<Predicate>> groups = new ArrayList<>();
+        List<java.util.Set<String>> groupFields = new ArrayList<>();
+
         for (Predicate child : children) {
-            if (child instanceof LeafPredicate) {
-                String fieldName = ((LeafPredicate) child).fieldName();
-                fieldGroups.computeIfAbsent(fieldName, k -> new ArrayList<>()).add(child);
-            } else {
-                result.add(Collections.singletonList(child));
+            java.util.Set<String> fields = collectFields(child);
+            int mergedIdx = -1;
+            for (int i = 0; i < groups.size(); i++) {
+                if (!java.util.Collections.disjoint(groupFields.get(i), fields)) {
+                    if (mergedIdx == -1) {
+                        groups.get(i).add(child);
+                        groupFields.get(i).addAll(fields);
+                        mergedIdx = i;
+                    } else {
+                        groups.get(mergedIdx).addAll(groups.get(i));
+                        groupFields.get(mergedIdx).addAll(groupFields.get(i));
+                        groups.remove(i);
+                        groupFields.remove(i);
+                        i--;
+                    }
+                }
+            }
+            if (mergedIdx == -1) {
+                List<Predicate> newGroup = new ArrayList<>();
+                newGroup.add(child);
+                groups.add(newGroup);
+                groupFields.add(fields);
             }
         }
-        result.addAll(fieldGroups.values());
-        return result;
+        return groups;
+    }
+
+    private java.util.Set<String> collectFields(Predicate predicate) {
+        java.util.Set<String> fields = new java.util.HashSet<>();
+        collectFieldsRecursive(predicate, fields);
+        return fields;
+    }
+
+    private void collectFieldsRecursive(Predicate predicate, java.util.Set<String> fields) {
+        if (predicate instanceof LeafPredicate) {
+            fields.add(((LeafPredicate) predicate).fieldName());
+        } else if (predicate instanceof CompoundPredicate) {
+            for (Predicate child : ((CompoundPredicate) predicate).children()) {
+                collectFieldsRecursive(child, fields);
+            }
+        }
     }
 
     private Optional<GlobalIndexResult> evaluateGroupWithoutParallel(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -32,16 +32,16 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
+
+import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 
 /** Predicate for filtering data using global indexes. */
 public class GlobalIndexEvaluator
@@ -50,12 +50,8 @@ public class GlobalIndexEvaluator
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
     private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache;
-    @Nullable private final ExecutorService executorService;
-
-    public GlobalIndexEvaluator(
-            RowType rowType, IntFunction<Collection<GlobalIndexReader>> readersFunction) {
-        this(rowType, readersFunction, null);
-    }
+    private final Map<Integer, Object> fieldLocks;
+    private final ExecutorService executorService;
 
     public GlobalIndexEvaluator(
             RowType rowType,
@@ -63,13 +59,27 @@ public class GlobalIndexEvaluator
             @Nullable ExecutorService executorService) {
         this.rowType = rowType;
         this.readersFunction = readersFunction;
-        this.executorService = executorService;
-        this.indexReadersCache =
-                executorService != null ? new ConcurrentHashMap<>() : new HashMap<>();
+        this.executorService =
+                executorService == null ? newDirectExecutorService() : executorService;
+        this.indexReadersCache = new ConcurrentHashMap<>();
+        this.fieldLocks = new ConcurrentHashMap<>();
     }
 
     public Optional<GlobalIndexResult> evaluate(@Nullable Predicate predicate) {
-        return predicate == null ? Optional.empty() : predicate.visit(this);
+        if (predicate == null) {
+            return Optional.empty();
+        }
+        try {
+            return visitAsync(predicate).get();
+        } catch (Exception e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            if (e.getCause() instanceof Error) {
+                throw (Error) e.getCause();
+            }
+            throw new RuntimeException(e.getCause() != null ? e.getCause() : e);
+        }
     }
 
     @Override
@@ -78,11 +88,12 @@ public class GlobalIndexEvaluator
         if (!fieldRefOptional.isPresent()) {
             return Optional.empty();
         }
-        Optional<GlobalIndexResult> compoundResult = Optional.empty();
         FieldRef fieldRef = fieldRefOptional.get();
         int fieldId = rowType.getField(fieldRef.name()).id();
         Collection<GlobalIndexReader> readers =
                 indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
+
+        Optional<GlobalIndexResult> compoundResult = Optional.empty();
         for (GlobalIndexReader fileIndexReader : readers) {
             Optional<GlobalIndexResult> childResult =
                     predicate.function().visit(fileIndexReader, fieldRef, predicate.literals());
@@ -91,11 +102,8 @@ public class GlobalIndexEvaluator
             }
 
             GlobalIndexResult result = childResult.get();
-
-            // AND Operation
             if (compoundResult.isPresent()) {
-                GlobalIndexResult r1 = compoundResult.get();
-                compoundResult = Optional.of(r1.and(result));
+                compoundResult = Optional.of(compoundResult.get().and(result));
             } else {
                 compoundResult = Optional.of(result);
             }
@@ -109,77 +117,51 @@ public class GlobalIndexEvaluator
 
     @Override
     public Optional<GlobalIndexResult> visit(CompoundPredicate predicate) {
-        if (executorService != null && predicate.children().size() > 1) {
-            return visitParallel(predicate);
-        }
-        return visitSequential(predicate);
+        throw new UnsupportedOperationException("Use visitAsync for compound predicates");
     }
 
-    private Optional<GlobalIndexResult> visitSequential(CompoundPredicate predicate) {
-        if (predicate.function() instanceof Or) {
-            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
-            for (Predicate predicate1 : predicate.children()) {
-                Optional<GlobalIndexResult> childResult = predicate1.visit(this);
+    private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(Predicate predicate) {
+        if (predicate instanceof LeafPredicate) {
+            return visitLeafAsync((LeafPredicate) predicate);
+        }
+        return visitCompoundAsync((CompoundPredicate) predicate);
+    }
 
-                if (!childResult.isPresent()) {
-                    return Optional.empty();
-                }
-                compoundResult = compoundResult.or(childResult.get());
-            }
-            return Optional.of(compoundResult);
-        } else {
-            Optional<GlobalIndexResult> compoundResult = Optional.empty();
-            for (Predicate predicate1 : predicate.children()) {
-                Optional<GlobalIndexResult> childResult = predicate1.visit(this);
-
-                // AND Operation
-                if (childResult.isPresent()) {
-                    if (compoundResult.isPresent()) {
-                        GlobalIndexResult r1 = compoundResult.get();
-                        GlobalIndexResult r2 = childResult.get();
-                        compoundResult = Optional.of(r1.and(r2));
-                    } else {
-                        compoundResult = childResult;
+    private CompletableFuture<Optional<GlobalIndexResult>> visitLeafAsync(LeafPredicate predicate) {
+        Optional<FieldRef> fieldRefOptional = predicate.fieldRefOptional();
+        if (!fieldRefOptional.isPresent()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        int fieldId = rowType.getField(fieldRefOptional.get().name()).id();
+        Object lock = fieldLocks.computeIfAbsent(fieldId, k -> new Object());
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    synchronized (lock) {
+                        return visit(predicate);
                     }
-                }
-
-                // if not remain, no need to test anymore
-                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
-                    return compoundResult;
-                }
-            }
-            return compoundResult;
-        }
+                },
+                executorService);
     }
 
-    private Optional<GlobalIndexResult> visitParallel(CompoundPredicate predicate) {
+    private CompletableFuture<Optional<GlobalIndexResult>> visitCompoundAsync(
+            CompoundPredicate predicate) {
         List<Predicate> children = flattenChildren(predicate);
-        List<List<Predicate>> groups = groupByField(children);
-        List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(groups.size());
-        for (List<Predicate> group : groups) {
-            futures.add(
-                    executorService.submit(() -> evaluateGroupWithoutParallel(group, predicate)));
-        }
+        List<CompletableFuture<Optional<GlobalIndexResult>>> childFutures =
+                children.stream().map(this::visitAsync).collect(Collectors.toList());
 
-        List<Optional<GlobalIndexResult>> results = new ArrayList<>(children.size());
-        for (Future<Optional<GlobalIndexResult>> future : futures) {
-            try {
-                results.add(future.get());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                }
-                if (cause instanceof Error) {
-                    throw (Error) cause;
-                }
-                throw new RuntimeException(cause);
-            }
-        }
+        return CompletableFuture.allOf(childFutures.toArray(new CompletableFuture[0]))
+                .thenApply(
+                        v -> {
+                            List<Optional<GlobalIndexResult>> results = new ArrayList<>();
+                            for (CompletableFuture<Optional<GlobalIndexResult>> f : childFutures) {
+                                results.add(f.join());
+                            }
+                            return combineResults(results, predicate);
+                        });
+    }
 
+    private Optional<GlobalIndexResult> combineResults(
+            List<Optional<GlobalIndexResult>> results, CompoundPredicate predicate) {
         if (predicate.function() instanceof Or) {
             GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
             for (Optional<GlobalIndexResult> childResult : results) {
@@ -192,125 +174,6 @@ public class GlobalIndexEvaluator
         } else {
             Optional<GlobalIndexResult> compoundResult = Optional.empty();
             for (Optional<GlobalIndexResult> childResult : results) {
-                if (childResult.isPresent()) {
-                    if (compoundResult.isPresent()) {
-                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
-                    } else {
-                        compoundResult = childResult;
-                    }
-                }
-                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
-                    return compoundResult;
-                }
-            }
-            return compoundResult;
-        }
-    }
-
-    private List<List<Predicate>> groupByField(List<Predicate> children) {
-        List<List<Predicate>> groups = new ArrayList<>();
-        List<java.util.Set<String>> groupFields = new ArrayList<>();
-
-        for (Predicate child : children) {
-            java.util.Set<String> fields = collectFields(child);
-            int mergedIdx = -1;
-            for (int i = 0; i < groups.size(); i++) {
-                if (!java.util.Collections.disjoint(groupFields.get(i), fields)) {
-                    if (mergedIdx == -1) {
-                        groups.get(i).add(child);
-                        groupFields.get(i).addAll(fields);
-                        mergedIdx = i;
-                    } else {
-                        groups.get(mergedIdx).addAll(groups.get(i));
-                        groupFields.get(mergedIdx).addAll(groupFields.get(i));
-                        groups.remove(i);
-                        groupFields.remove(i);
-                        i--;
-                    }
-                }
-            }
-            if (mergedIdx == -1) {
-                List<Predicate> newGroup = new ArrayList<>();
-                newGroup.add(child);
-                groups.add(newGroup);
-                groupFields.add(fields);
-            }
-        }
-        return groups;
-    }
-
-    private java.util.Set<String> collectFields(Predicate predicate) {
-        java.util.Set<String> fields = new java.util.HashSet<>();
-        collectFieldsRecursive(predicate, fields);
-        return fields;
-    }
-
-    private void collectFieldsRecursive(Predicate predicate, java.util.Set<String> fields) {
-        if (predicate instanceof LeafPredicate) {
-            Optional<FieldRef> ref = ((LeafPredicate) predicate).fieldRefOptional();
-            if (ref.isPresent()) {
-                fields.add(ref.get().name());
-            }
-        } else if (predicate instanceof CompoundPredicate) {
-            for (Predicate child : ((CompoundPredicate) predicate).children()) {
-                collectFieldsRecursive(child, fields);
-            }
-        }
-    }
-
-    private Optional<GlobalIndexResult> evaluateGroupWithoutParallel(
-            List<Predicate> group, CompoundPredicate parent) {
-        if (group.size() == 1) {
-            return evaluateWithoutParallel(group.get(0));
-        }
-        if (parent.function() instanceof Or) {
-            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
-            for (Predicate child : group) {
-                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
-                if (!childResult.isPresent()) {
-                    return Optional.empty();
-                }
-                compoundResult = compoundResult.or(childResult.get());
-            }
-            return Optional.of(compoundResult);
-        } else {
-            Optional<GlobalIndexResult> compoundResult = Optional.empty();
-            for (Predicate child : group) {
-                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
-                if (childResult.isPresent()) {
-                    if (compoundResult.isPresent()) {
-                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
-                    } else {
-                        compoundResult = childResult;
-                    }
-                }
-                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
-                    return compoundResult;
-                }
-            }
-            return compoundResult;
-        }
-    }
-
-    private Optional<GlobalIndexResult> evaluateWithoutParallel(Predicate predicate) {
-        if (predicate instanceof LeafPredicate) {
-            return visit((LeafPredicate) predicate);
-        }
-        CompoundPredicate compound = (CompoundPredicate) predicate;
-        if (compound.function() instanceof Or) {
-            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
-            for (Predicate child : compound.children()) {
-                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
-                if (!childResult.isPresent()) {
-                    return Optional.empty();
-                }
-                compoundResult = compoundResult.or(childResult.get());
-            }
-            return Optional.of(compoundResult);
-        } else {
-            Optional<GlobalIndexResult> compoundResult = Optional.empty();
-            for (Predicate child : compound.children()) {
-                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
                 if (childResult.isPresent()) {
                     if (compoundResult.isPresent()) {
                         compoundResult = Optional.of(compoundResult.get().and(childResult.get()));

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -156,7 +156,7 @@ public class GlobalIndexEvaluator
         List<Predicate> children = flattenChildren(predicate);
         List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(children.size());
         for (Predicate child : children) {
-            futures.add(executorService.submit(() -> evaluateChildSequentially(child)));
+            futures.add(executorService.submit(() -> evaluateWithoutParallel(child)));
         }
 
         List<Optional<GlobalIndexResult>> results = new ArrayList<>(children.size());
@@ -205,11 +205,38 @@ public class GlobalIndexEvaluator
         }
     }
 
-    private Optional<GlobalIndexResult> evaluateChildSequentially(Predicate child) {
-        if (child instanceof CompoundPredicate) {
-            return visitSequential((CompoundPredicate) child);
+    private Optional<GlobalIndexResult> evaluateWithoutParallel(Predicate predicate) {
+        if (predicate instanceof LeafPredicate) {
+            return visit((LeafPredicate) predicate);
         }
-        return child.visit(this);
+        CompoundPredicate compound = (CompoundPredicate) predicate;
+        if (compound.function() instanceof Or) {
+            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
+            for (Predicate child : compound.children()) {
+                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
+                if (!childResult.isPresent()) {
+                    return Optional.empty();
+                }
+                compoundResult = compoundResult.or(childResult.get());
+            }
+            return Optional.of(compoundResult);
+        } else {
+            Optional<GlobalIndexResult> compoundResult = Optional.empty();
+            for (Predicate child : compound.children()) {
+                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
+                if (childResult.isPresent()) {
+                    if (compoundResult.isPresent()) {
+                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
+                    } else {
+                        compoundResult = childResult;
+                    }
+                }
+                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
+                    return compoundResult;
+                }
+            }
+            return compoundResult;
+        }
     }
 
     private List<Predicate> flattenChildren(CompoundPredicate predicate) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -247,7 +247,10 @@ public class GlobalIndexEvaluator
 
     private void collectFieldsRecursive(Predicate predicate, java.util.Set<String> fields) {
         if (predicate instanceof LeafPredicate) {
-            fields.add(((LeafPredicate) predicate).fieldName());
+            Optional<FieldRef> ref = ((LeafPredicate) predicate).fieldRefOptional();
+            if (ref.isPresent()) {
+                fields.add(ref.get().name());
+            }
         } else if (predicate instanceof CompoundPredicate) {
             for (Predicate child : ((CompoundPredicate) predicate).children()) {
                 collectFieldsRecursive(child, fields);

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -153,7 +153,7 @@ public class GlobalIndexEvaluator
     }
 
     private Optional<GlobalIndexResult> visitParallel(CompoundPredicate predicate) {
-        List<Predicate> children = predicate.children();
+        List<Predicate> children = flattenChildren(predicate);
         List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(children.size());
         for (Predicate child : children) {
             futures.add(executorService.submit(() -> child.visit(this)));
@@ -203,6 +203,21 @@ public class GlobalIndexEvaluator
             }
             return compoundResult;
         }
+    }
+
+    private List<Predicate> flattenChildren(CompoundPredicate predicate) {
+        List<Predicate> result = new ArrayList<>();
+        for (Predicate child : predicate.children()) {
+            if (child instanceof CompoundPredicate) {
+                CompoundPredicate compound = (CompoundPredicate) child;
+                if (compound.function().getClass() == predicate.function().getClass()) {
+                    result.addAll(flattenChildren(compound));
+                    continue;
+                }
+            }
+            result.add(child);
+        }
+        return result;
     }
 
     public void close() {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -48,7 +48,6 @@ public class GlobalIndexEvaluator implements Closeable {
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
     private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache;
-    private final Map<GlobalIndexReader, Object> readerLocks;
     private final ExecutorService executorService;
 
     public GlobalIndexEvaluator(
@@ -60,7 +59,6 @@ public class GlobalIndexEvaluator implements Closeable {
         this.executorService =
                 executorService == null ? newDirectExecutorService() : executorService;
         this.indexReadersCache = new ConcurrentHashMap<>();
-        this.readerLocks = new ConcurrentHashMap<>();
     }
 
     public Optional<GlobalIndexResult> evaluate(@Nullable Predicate predicate) {
@@ -100,11 +98,10 @@ public class GlobalIndexEvaluator implements Closeable {
         List<CompletableFuture<Optional<GlobalIndexResult>>> readerFutures =
                 new ArrayList<>(readers.size());
         for (GlobalIndexReader reader : readers) {
-            Object lock = readerLocks.computeIfAbsent(reader, k -> new Object());
             readerFutures.add(
                     CompletableFuture.supplyAsync(
                             () -> {
-                                synchronized (lock) {
+                                synchronized (reader) {
                                     return predicate
                                             .function()
                                             .visit(reader, fieldRef, predicate.literals());
@@ -169,14 +166,11 @@ public class GlobalIndexEvaluator implements Closeable {
             Optional<GlobalIndexResult> compoundResult = Optional.empty();
             for (Optional<GlobalIndexResult> childResult : results) {
                 if (childResult.isPresent()) {
-                    compoundResult =
-                            compoundResult
-                                    .map(
-                                            globalIndexResult ->
-                                                    Optional.of(
-                                                            globalIndexResult.and(
-                                                                    childResult.get())))
-                                    .orElse(childResult);
+                    if (compoundResult.isPresent()) {
+                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
+                    } else {
+                        compoundResult = childResult;
+                    }
                 }
                 if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
                     return compoundResult;

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -102,9 +102,15 @@ public class GlobalIndexEvaluator implements Closeable {
                     CompletableFuture.supplyAsync(
                             () -> {
                                 synchronized (reader) {
-                                    return predicate
-                                            .function()
-                                            .visit(reader, fieldRef, predicate.literals());
+                                    Optional<GlobalIndexResult> result =
+                                            predicate
+                                                    .function()
+                                                    .visit(
+                                                            reader,
+                                                            fieldRef,
+                                                            predicate.literals());
+                                    result.ifPresent(GlobalIndexResult::results);
+                                    return result;
                                 }
                             },
                             executorService));

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -30,10 +30,16 @@ import org.apache.paimon.utils.IOUtils;
 import javax.annotation.Nullable;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
@@ -43,12 +49,23 @@ public class GlobalIndexEvaluator
 
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
-    private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache = new HashMap<>();
+    private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache;
+    @Nullable private final ExecutorService executorService;
 
     public GlobalIndexEvaluator(
             RowType rowType, IntFunction<Collection<GlobalIndexReader>> readersFunction) {
+        this(rowType, readersFunction, null);
+    }
+
+    public GlobalIndexEvaluator(
+            RowType rowType,
+            IntFunction<Collection<GlobalIndexReader>> readersFunction,
+            @Nullable ExecutorService executorService) {
         this.rowType = rowType;
         this.readersFunction = readersFunction;
+        this.executorService = executorService;
+        this.indexReadersCache =
+                executorService != null ? new ConcurrentHashMap<>() : new HashMap<>();
     }
 
     public Optional<GlobalIndexResult> evaluate(@Nullable Predicate predicate) {
@@ -92,6 +109,13 @@ public class GlobalIndexEvaluator
 
     @Override
     public Optional<GlobalIndexResult> visit(CompoundPredicate predicate) {
+        if (executorService != null && predicate.children().size() > 1) {
+            return visitParallel(predicate);
+        }
+        return visitSequential(predicate);
+    }
+
+    private Optional<GlobalIndexResult> visitSequential(CompoundPredicate predicate) {
         if (predicate.function() instanceof Or) {
             GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
             for (Predicate predicate1 : predicate.children()) {
@@ -120,6 +144,59 @@ public class GlobalIndexEvaluator
                 }
 
                 // if not remain, no need to test anymore
+                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
+                    return compoundResult;
+                }
+            }
+            return compoundResult;
+        }
+    }
+
+    private Optional<GlobalIndexResult> visitParallel(CompoundPredicate predicate) {
+        List<Predicate> children = predicate.children();
+        List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(children.size());
+        for (Predicate child : children) {
+            futures.add(executorService.submit(() -> child.visit(this)));
+        }
+
+        List<Optional<GlobalIndexResult>> results = new ArrayList<>(children.size());
+        for (Future<Optional<GlobalIndexResult>> future : futures) {
+            try {
+                results.add(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+                if (cause instanceof Error) {
+                    throw (Error) cause;
+                }
+                throw new RuntimeException(cause);
+            }
+        }
+
+        if (predicate.function() instanceof Or) {
+            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
+            for (Optional<GlobalIndexResult> childResult : results) {
+                if (!childResult.isPresent()) {
+                    return Optional.empty();
+                }
+                compoundResult = compoundResult.or(childResult.get());
+            }
+            return Optional.of(compoundResult);
+        } else {
+            Optional<GlobalIndexResult> compoundResult = Optional.empty();
+            for (Optional<GlobalIndexResult> childResult : results) {
+                if (childResult.isPresent()) {
+                    if (compoundResult.isPresent()) {
+                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
+                    } else {
+                        compoundResult = childResult;
+                    }
+                }
                 if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
                     return compoundResult;
                 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -23,7 +23,6 @@ import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
@@ -44,8 +43,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 
 /** Predicate for filtering data using global indexes. */
-public class GlobalIndexEvaluator
-        implements Closeable, PredicateVisitor<Optional<GlobalIndexResult>> {
+public class GlobalIndexEvaluator implements Closeable {
 
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
@@ -82,8 +80,7 @@ public class GlobalIndexEvaluator
         }
     }
 
-    @Override
-    public Optional<GlobalIndexResult> visit(LeafPredicate predicate) {
+    private Optional<GlobalIndexResult> visitLeaf(LeafPredicate predicate) {
         Optional<FieldRef> fieldRefOptional = predicate.fieldRefOptional();
         if (!fieldRefOptional.isPresent()) {
             return Optional.empty();
@@ -102,22 +99,16 @@ public class GlobalIndexEvaluator
             }
 
             GlobalIndexResult result = childResult.get();
-            if (compoundResult.isPresent()) {
-                compoundResult = Optional.of(compoundResult.get().and(result));
-            } else {
-                compoundResult = Optional.of(result);
-            }
+            compoundResult =
+                    compoundResult
+                            .map(globalIndexResult -> Optional.of(globalIndexResult.and(result)))
+                            .orElseGet(() -> Optional.of(result));
 
             if (compoundResult.get().results().isEmpty()) {
                 return compoundResult;
             }
         }
         return compoundResult;
-    }
-
-    @Override
-    public Optional<GlobalIndexResult> visit(CompoundPredicate predicate) {
-        throw new UnsupportedOperationException("Use visitAsync for compound predicates");
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(Predicate predicate) {
@@ -137,7 +128,7 @@ public class GlobalIndexEvaluator
         return CompletableFuture.supplyAsync(
                 () -> {
                     synchronized (lock) {
-                        return visit(predicate);
+                        return visitLeaf(predicate);
                     }
                 },
                 executorService);
@@ -175,11 +166,14 @@ public class GlobalIndexEvaluator
             Optional<GlobalIndexResult> compoundResult = Optional.empty();
             for (Optional<GlobalIndexResult> childResult : results) {
                 if (childResult.isPresent()) {
-                    if (compoundResult.isPresent()) {
-                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
-                    } else {
-                        compoundResult = childResult;
-                    }
+                    compoundResult =
+                            compoundResult
+                                    .map(
+                                            globalIndexResult ->
+                                                    Optional.of(
+                                                            globalIndexResult.and(
+                                                                    childResult.get())))
+                                    .orElse(childResult);
                 }
                 if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
                     return compoundResult;
@@ -204,6 +198,7 @@ public class GlobalIndexEvaluator
         return result;
     }
 
+    @Override
     public void close() {
         IOUtils.closeAllQuietly(
                 indexReadersCache.values().stream()

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -48,8 +48,6 @@ import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.
 /** Predicate for filtering data using global indexes. */
 public class GlobalIndexEvaluator implements Closeable {
 
-    private static final int MAX_PREDICATE_DEPTH = 1000;
-
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
     private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache;
@@ -71,7 +69,7 @@ public class GlobalIndexEvaluator implements Closeable {
             return Optional.empty();
         }
         try {
-            return visitAsync(predicate, 0).get();
+            return visitAsync(predicate).get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted during index evaluation", e);
@@ -86,16 +84,11 @@ public class GlobalIndexEvaluator implements Closeable {
         }
     }
 
-    private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(
-            Predicate predicate, int depth) {
-        if (depth > MAX_PREDICATE_DEPTH) {
-            throw new IllegalArgumentException(
-                    "Predicate tree exceeds maximum depth of " + MAX_PREDICATE_DEPTH);
-        }
+    private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(Predicate predicate) {
         if (predicate instanceof LeafPredicate) {
             return visitLeafAsync((LeafPredicate) predicate);
         }
-        return visitCompoundAsync((CompoundPredicate) predicate, depth);
+        return visitCompoundAsync((CompoundPredicate) predicate);
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitLeafAsync(LeafPredicate predicate) {
@@ -151,12 +144,10 @@ public class GlobalIndexEvaluator implements Closeable {
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitCompoundAsync(
-            CompoundPredicate predicate, int depth) {
+            CompoundPredicate predicate) {
         List<Predicate> children = flattenChildren(predicate);
         List<CompletableFuture<Optional<GlobalIndexResult>>> childFutures =
-                children.stream()
-                        .map(child -> visitAsync(child, depth + 1))
-                        .collect(Collectors.toList());
+                children.stream().map(this::visitAsync).collect(Collectors.toList());
 
         return CompletableFuture.allOf(childFutures.toArray(new CompletableFuture[0]))
                 .thenApply(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -48,7 +48,7 @@ public class GlobalIndexEvaluator implements Closeable {
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
     private final Map<Integer, Collection<GlobalIndexReader>> indexReadersCache;
-    private final Map<Integer, Object> fieldLocks;
+    private final Map<GlobalIndexReader, Object> readerLocks;
     private final ExecutorService executorService;
 
     public GlobalIndexEvaluator(
@@ -60,7 +60,7 @@ public class GlobalIndexEvaluator implements Closeable {
         this.executorService =
                 executorService == null ? newDirectExecutorService() : executorService;
         this.indexReadersCache = new ConcurrentHashMap<>();
-        this.fieldLocks = new ConcurrentHashMap<>();
+        this.readerLocks = new ConcurrentHashMap<>();
     }
 
     public Optional<GlobalIndexResult> evaluate(@Nullable Predicate predicate) {
@@ -80,37 +80,6 @@ public class GlobalIndexEvaluator implements Closeable {
         }
     }
 
-    private Optional<GlobalIndexResult> visitLeaf(LeafPredicate predicate) {
-        Optional<FieldRef> fieldRefOptional = predicate.fieldRefOptional();
-        if (!fieldRefOptional.isPresent()) {
-            return Optional.empty();
-        }
-        FieldRef fieldRef = fieldRefOptional.get();
-        int fieldId = rowType.getField(fieldRef.name()).id();
-        Collection<GlobalIndexReader> readers =
-                indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
-
-        Optional<GlobalIndexResult> compoundResult = Optional.empty();
-        for (GlobalIndexReader fileIndexReader : readers) {
-            Optional<GlobalIndexResult> childResult =
-                    predicate.function().visit(fileIndexReader, fieldRef, predicate.literals());
-            if (!childResult.isPresent()) {
-                continue;
-            }
-
-            GlobalIndexResult result = childResult.get();
-            compoundResult =
-                    compoundResult
-                            .map(globalIndexResult -> Optional.of(globalIndexResult.and(result)))
-                            .orElseGet(() -> Optional.of(result));
-
-            if (compoundResult.get().results().isEmpty()) {
-                return compoundResult;
-            }
-        }
-        return compoundResult;
-    }
-
     private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(Predicate predicate) {
         if (predicate instanceof LeafPredicate) {
             return visitLeafAsync((LeafPredicate) predicate);
@@ -123,15 +92,49 @@ public class GlobalIndexEvaluator implements Closeable {
         if (!fieldRefOptional.isPresent()) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        int fieldId = rowType.getField(fieldRefOptional.get().name()).id();
-        Object lock = fieldLocks.computeIfAbsent(fieldId, k -> new Object());
-        return CompletableFuture.supplyAsync(
-                () -> {
-                    synchronized (lock) {
-                        return visitLeaf(predicate);
-                    }
-                },
-                executorService);
+        FieldRef fieldRef = fieldRefOptional.get();
+        int fieldId = rowType.getField(fieldRef.name()).id();
+        Collection<GlobalIndexReader> readers =
+                indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
+
+        List<CompletableFuture<Optional<GlobalIndexResult>>> readerFutures =
+                new ArrayList<>(readers.size());
+        for (GlobalIndexReader reader : readers) {
+            Object lock = readerLocks.computeIfAbsent(reader, k -> new Object());
+            readerFutures.add(
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                synchronized (lock) {
+                                    return predicate
+                                            .function()
+                                            .visit(reader, fieldRef, predicate.literals());
+                                }
+                            },
+                            executorService));
+        }
+
+        return CompletableFuture.allOf(readerFutures.toArray(new CompletableFuture[0]))
+                .thenApply(
+                        v -> {
+                            Optional<GlobalIndexResult> compoundResult = Optional.empty();
+                            for (CompletableFuture<Optional<GlobalIndexResult>> f : readerFutures) {
+                                Optional<GlobalIndexResult> childResult = f.join();
+                                if (!childResult.isPresent()) {
+                                    continue;
+                                }
+                                if (compoundResult.isPresent()) {
+                                    compoundResult =
+                                            Optional.of(
+                                                    compoundResult.get().and(childResult.get()));
+                                } else {
+                                    compoundResult = childResult;
+                                }
+                                if (compoundResult.get().results().isEmpty()) {
+                                    return compoundResult;
+                                }
+                            }
+                            return compoundResult;
+                        });
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitCompoundAsync(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,9 +155,11 @@ public class GlobalIndexEvaluator
 
     private Optional<GlobalIndexResult> visitParallel(CompoundPredicate predicate) {
         List<Predicate> children = flattenChildren(predicate);
-        List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(children.size());
-        for (Predicate child : children) {
-            futures.add(executorService.submit(() -> evaluateWithoutParallel(child)));
+        List<List<Predicate>> groups = groupByField(children);
+        List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(groups.size());
+        for (List<Predicate> group : groups) {
+            futures.add(
+                    executorService.submit(() -> evaluateGroupWithoutParallel(group, predicate)));
         }
 
         List<Optional<GlobalIndexResult>> results = new ArrayList<>(children.size());
@@ -190,6 +193,55 @@ public class GlobalIndexEvaluator
         } else {
             Optional<GlobalIndexResult> compoundResult = Optional.empty();
             for (Optional<GlobalIndexResult> childResult : results) {
+                if (childResult.isPresent()) {
+                    if (compoundResult.isPresent()) {
+                        compoundResult = Optional.of(compoundResult.get().and(childResult.get()));
+                    } else {
+                        compoundResult = childResult;
+                    }
+                }
+                if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
+                    return compoundResult;
+                }
+            }
+            return compoundResult;
+        }
+    }
+
+    private List<List<Predicate>> groupByField(List<Predicate> children) {
+        Map<String, List<Predicate>> fieldGroups = new HashMap<>();
+        List<List<Predicate>> result = new ArrayList<>();
+        for (Predicate child : children) {
+            if (child instanceof LeafPredicate) {
+                String fieldName = ((LeafPredicate) child).fieldName();
+                fieldGroups.computeIfAbsent(fieldName, k -> new ArrayList<>()).add(child);
+            } else {
+                result.add(Collections.singletonList(child));
+            }
+        }
+        result.addAll(fieldGroups.values());
+        return result;
+    }
+
+    private Optional<GlobalIndexResult> evaluateGroupWithoutParallel(
+            List<Predicate> group, CompoundPredicate parent) {
+        if (group.size() == 1) {
+            return evaluateWithoutParallel(group.get(0));
+        }
+        if (parent.function() instanceof Or) {
+            GlobalIndexResult compoundResult = GlobalIndexResult.createEmpty();
+            for (Predicate child : group) {
+                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
+                if (!childResult.isPresent()) {
+                    return Optional.empty();
+                }
+                compoundResult = compoundResult.or(childResult.get());
+            }
+            return Optional.of(compoundResult);
+        } else {
+            Optional<GlobalIndexResult> compoundResult = Optional.empty();
+            for (Predicate child : group) {
+                Optional<GlobalIndexResult> childResult = evaluateWithoutParallel(child);
                 if (childResult.isPresent()) {
                     if (compoundResult.isPresent()) {
                         compoundResult = Optional.of(compoundResult.get().and(childResult.get()));

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -156,7 +156,7 @@ public class GlobalIndexEvaluator
         List<Predicate> children = flattenChildren(predicate);
         List<Future<Optional<GlobalIndexResult>>> futures = new ArrayList<>(children.size());
         for (Predicate child : children) {
-            futures.add(executorService.submit(() -> child.visit(this)));
+            futures.add(executorService.submit(() -> evaluateChildSequentially(child)));
         }
 
         List<Optional<GlobalIndexResult>> results = new ArrayList<>(children.size());
@@ -203,6 +203,13 @@ public class GlobalIndexEvaluator
             }
             return compoundResult;
         }
+    }
+
+    private Optional<GlobalIndexResult> evaluateChildSequentially(Predicate child) {
+        if (child instanceof CompoundPredicate) {
+            return visitSequential((CompoundPredicate) child);
+        }
+        return child.visit(this);
     }
 
     private List<Predicate> flattenChildren(CompoundPredicate predicate) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -185,7 +185,7 @@ public class GlobalIndexEvaluator implements Closeable {
         for (Predicate child : predicate.children()) {
             if (child instanceof CompoundPredicate) {
                 CompoundPredicate compound = (CompoundPredicate) child;
-                if (compound.function().getClass() == predicate.function().getClass()) {
+                if (compound.function().equals(predicate.function())) {
                     result.addAll(flattenChildren(compound));
                     continue;
                 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -29,13 +29,16 @@ import org.apache.paimon.utils.IOUtils;
 import javax.annotation.Nullable;
 
 import java.io.Closeable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
@@ -44,6 +47,8 @@ import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.
 
 /** Predicate for filtering data using global indexes. */
 public class GlobalIndexEvaluator implements Closeable {
+
+    private static final int MAX_PREDICATE_DEPTH = 1000;
 
     private final RowType rowType;
     private final IntFunction<Collection<GlobalIndexReader>> readersFunction;
@@ -66,23 +71,31 @@ public class GlobalIndexEvaluator implements Closeable {
             return Optional.empty();
         }
         try {
-            return visitAsync(predicate).get();
-        } catch (Exception e) {
+            return visitAsync(predicate, 0).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during index evaluation", e);
+        } catch (ExecutionException e) {
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();
             }
             if (e.getCause() instanceof Error) {
                 throw (Error) e.getCause();
             }
-            throw new RuntimeException(e.getCause() != null ? e.getCause() : e);
+            throw new RuntimeException(e.getCause());
         }
     }
 
-    private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(Predicate predicate) {
+    private CompletableFuture<Optional<GlobalIndexResult>> visitAsync(
+            Predicate predicate, int depth) {
+        if (depth > MAX_PREDICATE_DEPTH) {
+            throw new IllegalArgumentException(
+                    "Predicate tree exceeds maximum depth of " + MAX_PREDICATE_DEPTH);
+        }
         if (predicate instanceof LeafPredicate) {
             return visitLeafAsync((LeafPredicate) predicate);
         }
-        return visitCompoundAsync((CompoundPredicate) predicate);
+        return visitCompoundAsync((CompoundPredicate) predicate, depth);
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitLeafAsync(LeafPredicate predicate) {
@@ -105,10 +118,7 @@ public class GlobalIndexEvaluator implements Closeable {
                                     Optional<GlobalIndexResult> result =
                                             predicate
                                                     .function()
-                                                    .visit(
-                                                            reader,
-                                                            fieldRef,
-                                                            predicate.literals());
+                                                    .visit(reader, fieldRef, predicate.literals());
                                     result.ifPresent(GlobalIndexResult::results);
                                     return result;
                                 }
@@ -141,10 +151,12 @@ public class GlobalIndexEvaluator implements Closeable {
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> visitCompoundAsync(
-            CompoundPredicate predicate) {
+            CompoundPredicate predicate, int depth) {
         List<Predicate> children = flattenChildren(predicate);
         List<CompletableFuture<Optional<GlobalIndexResult>>> childFutures =
-                children.stream().map(this::visitAsync).collect(Collectors.toList());
+                children.stream()
+                        .map(child -> visitAsync(child, depth + 1))
+                        .collect(Collectors.toList());
 
         return CompletableFuture.allOf(childFutures.toArray(new CompletableFuture[0]))
                 .thenApply(
@@ -188,11 +200,16 @@ public class GlobalIndexEvaluator implements Closeable {
 
     private List<Predicate> flattenChildren(CompoundPredicate predicate) {
         List<Predicate> result = new ArrayList<>();
-        for (Predicate child : predicate.children()) {
+        Deque<Predicate> stack = new ArrayDeque<>(predicate.children());
+        while (!stack.isEmpty()) {
+            Predicate child = stack.pollFirst();
             if (child instanceof CompoundPredicate) {
                 CompoundPredicate compound = (CompoundPredicate) child;
                 if (compound.function().equals(predicate.function())) {
-                    result.addAll(flattenChildren(compound));
+                    List<Predicate> grandChildren = compound.children();
+                    for (int i = grandChildren.size() - 1; i >= 0; i--) {
+                        stack.addFirst(grandChildren.get(i));
+                    }
                     continue;
                 }
             }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -21,19 +21,11 @@ package org.apache.paimon.globalindex;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.VectorSearch;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static java.util.Collections.singletonList;
-import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecuteSequentialReturn;
 
 /**
  * A {@link GlobalIndexReader} that combines results from multiple readers by performing a union
@@ -42,16 +34,9 @@ import static org.apache.paimon.utils.ThreadPoolUtils.randomlyExecuteSequentialR
 public class UnionGlobalIndexReader implements GlobalIndexReader {
 
     private final List<GlobalIndexReader> readers;
-    private final @Nullable ExecutorService executor;
 
     public UnionGlobalIndexReader(List<GlobalIndexReader> readers) {
-        this(readers, null);
-    }
-
-    public UnionGlobalIndexReader(
-            List<GlobalIndexReader> readers, @Nullable ExecutorService executor) {
         this.readers = readers;
-        this.executor = executor;
     }
 
     @Override
@@ -163,18 +148,7 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
     }
 
     private <R> List<R> executeAllReaders(Function<GlobalIndexReader, R> function) {
-        if (executor == null) {
-            return readers.stream().map(function).collect(Collectors.toList());
-        }
-
-        Iterator<R> iterator =
-                randomlyExecuteSequentialReturn(
-                        executor, reader -> singletonList(function.apply(reader)), readers);
-        List<R> result = new ArrayList<>();
-        while (iterator.hasNext()) {
-            result.add(iterator.next());
-        }
-        return result;
+        return readers.stream().map(function).collect(Collectors.toList());
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -416,6 +416,48 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testSameFieldPredicatesNotAccessedConcurrently() {
+        executor = Executors.newFixedThreadPool(4);
+        RowType rowType = rowType();
+
+        AtomicInteger concurrency = new AtomicInteger(0);
+        AtomicInteger maxConcurrency = new AtomicInteger(0);
+
+        GlobalIndexReader concurrencyDetectingReader =
+                new StubGlobalIndexReader(resultOf(1, 2, 3, 4, 5)) {
+                    @Override
+                    public Optional<GlobalIndexResult> visitEqual(
+                            FieldRef fieldRef, Object literal) {
+                        int c = concurrency.incrementAndGet();
+                        maxConcurrency.updateAndGet(cur -> Math.max(cur, c));
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        concurrency.decrementAndGet();
+                        return super.visitEqual(fieldRef, literal);
+                    }
+                };
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> Collections.singletonList(concurrencyDetectingReader),
+                        executor);
+
+        // AND(a=1, a=2, a=3) — all same field, must not run concurrently
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(builder.equal(0, 1), builder.equal(0, 2), builder.equal(0, 3));
+
+        evaluator.evaluate(predicate);
+
+        assertThat(maxConcurrency.get()).isEqualTo(1);
+        evaluator.close();
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.globalindex;
 
+import org.apache.paimon.predicate.And;
+import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -504,6 +506,33 @@ class GlobalIndexEvaluatorTest {
         evaluator.evaluate(predicate);
 
         assertThat(maxConcurrencyA.get()).isEqualTo(1);
+        evaluator.close();
+    }
+
+    @Test
+    void testNonFieldLeafPredicateDoesNotThrow() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> Collections.singletonList(readerReturning(resultA)),
+                        executor);
+
+        // Manually build AND(alwaysTrue, a=1) to bypass PredicateBuilder simplification
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                new CompoundPredicate(
+                        And.INSTANCE,
+                        Arrays.asList(PredicateBuilder.alwaysTrue(), builder.equal(0, 42)));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L);
         evaluator.close();
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -333,6 +333,46 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testMixedNestedPredicateDoesNotDeadlockWithSmallPool() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3, 4, 5);
+        GlobalIndexResult resultB = resultOf(3, 4, 5, 6, 7);
+        GlobalIndexResult resultC = resultOf(1, 2, 3, 10, 11);
+        // Field c used for second OR child - distinct from field a/b
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+        fieldResults.put(2, resultC);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        // AND(OR(a, b), OR(a, c)) — mixed nesting, different compound types
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(
+                        PredicateBuilder.or(builder.equal(0, 1), builder.equal(1, 2)),
+                        PredicateBuilder.or(builder.equal(0, 3), builder.equal(2, 4)));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        // OR(a, b) = union({1..5}, {3..7}) = {1..7}
+        // OR(a, c) = union({1..5}, {1,2,3,10,11}) = {1,2,3,4,5,10,11}
+        // AND = intersection = {1,2,3,4,5}
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L, 4L, 5L);
+        evaluator.close();
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -83,7 +83,9 @@ class GlobalIndexEvaluatorTest {
         GlobalIndexResult expected = resultOf(1, 2, 3);
         GlobalIndexEvaluator evaluator =
                 new GlobalIndexEvaluator(
-                        rowType, fieldId -> Collections.singletonList(readerReturning(expected)));
+                        rowType,
+                        fieldId -> Collections.singletonList(readerReturning(expected)),
+                        null);
 
         PredicateBuilder builder = new PredicateBuilder(rowType);
         Predicate predicate = builder.equal(0, 42);
@@ -252,7 +254,8 @@ class GlobalIndexEvaluatorTest {
                             callCount.incrementAndGet();
                             return Collections.singletonList(
                                     readerReturning(resultOf(fieldId, fieldId + 10)));
-                        });
+                        },
+                        null);
 
         PredicateBuilder builder = new PredicateBuilder(rowType);
         Predicate predicate = PredicateBuilder.and(builder.equal(0, 1), builder.equal(1, 2));
@@ -540,7 +543,7 @@ class GlobalIndexEvaluatorTest {
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =
-                new GlobalIndexEvaluator(rowType, fieldId -> Collections.emptyList());
+                new GlobalIndexEvaluator(rowType, fieldId -> Collections.emptyList(), null);
 
         Optional<GlobalIndexResult> result = evaluator.evaluate(null);
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -578,6 +578,34 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testMultipleReadersPerFieldCombinedWithAnd() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult readerResult1 = resultOf(1, 2, 3, 4, 5);
+        GlobalIndexResult readerResult2 = resultOf(3, 4, 5, 6, 7);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Arrays.asList(
+                                        readerReturning(readerResult1),
+                                        readerReturning(readerResult2)),
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = builder.equal(0, 42);
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        // Multiple readers for same field are combined with AND (intersection)
+        assertBitmapContainsExactly(result.get().results(), 3L, 4L, 5L);
+        evaluator.close();
+    }
+
+    @Test
     void testNonFieldLeafPredicateDoesNotThrow() {
         executor = Executors.newFixedThreadPool(2);
         RowType rowType = rowType();

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -458,6 +458,56 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testMixedNestedSameFieldNotAccessedConcurrently() {
+        executor = Executors.newFixedThreadPool(4);
+        RowType rowType = rowType();
+
+        AtomicInteger concurrencyA = new AtomicInteger(0);
+        AtomicInteger maxConcurrencyA = new AtomicInteger(0);
+
+        GlobalIndexReader concurrencyDetectingReaderA =
+                new StubGlobalIndexReader(resultOf(1, 2, 3, 4, 5)) {
+                    @Override
+                    public Optional<GlobalIndexResult> visitEqual(
+                            FieldRef fieldRef, Object literal) {
+                        int c = concurrencyA.incrementAndGet();
+                        maxConcurrencyA.updateAndGet(cur -> Math.max(cur, c));
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        concurrencyA.decrementAndGet();
+                        return super.visitEqual(fieldRef, literal);
+                    }
+                };
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            if (fieldId == 0) {
+                                return Collections.singletonList(concurrencyDetectingReaderA);
+                            }
+                            return Collections.singletonList(
+                                    readerReturning(resultOf(1, 2, 3, 4, 5)));
+                        },
+                        executor);
+
+        // AND(OR(a=1, b=2), OR(a=3, c=4)) — field a appears in both OR subtrees
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(
+                        PredicateBuilder.or(builder.equal(0, 1), builder.equal(1, 2)),
+                        PredicateBuilder.or(builder.equal(0, 3), builder.equal(2, 4)));
+
+        evaluator.evaluate(predicate);
+
+        assertThat(maxConcurrencyA.get()).isEqualTo(1);
+        evaluator.close();
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -263,6 +263,76 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testNestedAndPredicateDoesNotDeadlockWithSmallPool() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3, 4, 5);
+        GlobalIndexResult resultB = resultOf(3, 4, 5, 6, 7);
+        GlobalIndexResult resultC = resultOf(4, 5, 8, 9);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+        fieldResults.put(2, resultC);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        // and(a, b, c) builds as and(and(a, b), c) — nested binary tree
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(builder.equal(0, 1), builder.equal(1, 2), builder.equal(2, 3));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        // intersection of {1..5}, {3..7}, {4,5,8,9} -> {4,5}
+        assertBitmapContainsExactly(result.get().results(), 4L, 5L);
+        evaluator.close();
+    }
+
+    @Test
+    void testNestedOrPredicateDoesNotDeadlockWithSmallPool() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2);
+        GlobalIndexResult resultB = resultOf(3, 4);
+        GlobalIndexResult resultC = resultOf(5, 6);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+        fieldResults.put(2, resultC);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        // or(a, b, c) builds as or(or(a, b), c) — nested binary tree
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.or(builder.equal(0, 1), builder.equal(1, 2), builder.equal(2, 3));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        // union of {1,2}, {3,4}, {5,6}
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L, 4L, 5L, 6L);
+        evaluator.close();
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -224,11 +224,17 @@ class GlobalIndexEvaluatorTest {
         GlobalIndexEvaluator evaluator =
                 new GlobalIndexEvaluator(
                         rowType,
-                        fieldId -> {
-                            threadNames.put(Thread.currentThread().getName(), true);
-                            return Collections.singletonList(
-                                    readerReturning(resultOf(fieldId, fieldId + 10)));
-                        },
+                        fieldId ->
+                                Collections.singletonList(
+                                        new StubGlobalIndexReader(resultOf(fieldId, fieldId + 10)) {
+                                            @Override
+                                            public Optional<GlobalIndexResult> visitEqual(
+                                                    FieldRef fieldRef, Object literal) {
+                                                threadNames.put(
+                                                        Thread.currentThread().getName(), true);
+                                                return super.visitEqual(fieldRef, literal);
+                                            }
+                                        }),
                         executor);
 
         PredicateBuilder builder = new PredicateBuilder(rowType);

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -519,6 +519,65 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testLazyResultNotMaterializedConcurrently() {
+        executor = Executors.newFixedThreadPool(4);
+        RowType rowType = rowType();
+
+        AtomicInteger concurrency = new AtomicInteger(0);
+        AtomicInteger maxConcurrency = new AtomicInteger(0);
+
+        GlobalIndexReader lazyReader =
+                new StubGlobalIndexReader(null) {
+                    @Override
+                    public Optional<GlobalIndexResult> visitEqual(
+                            FieldRef fieldRef, Object literal) {
+                        return Optional.of(
+                                GlobalIndexResult.create(
+                                        () -> {
+                                            int c = concurrency.incrementAndGet();
+                                            maxConcurrency.updateAndGet(cur -> Math.max(cur, c));
+                                            try {
+                                                Thread.sleep(50);
+                                            } catch (InterruptedException e) {
+                                                Thread.currentThread().interrupt();
+                                            }
+                                            concurrency.decrementAndGet();
+                                            RoaringNavigableMap64 bm = new RoaringNavigableMap64();
+                                            bm.add(1);
+                                            bm.add(2);
+                                            bm.add(3);
+                                            return bm;
+                                        }));
+                    }
+                };
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            if (fieldId == 0) {
+                                return Collections.singletonList(lazyReader);
+                            }
+                            return Collections.singletonList(
+                                    readerReturning(resultOf(1, 2, 3, 4, 5)));
+                        },
+                        executor);
+
+        // AND(OR(a=1, b=2), OR(a=3, c=4)) — field a in both OR subtrees
+        // lazy results for field a must not be materialized concurrently
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(
+                        PredicateBuilder.or(builder.equal(0, 1), builder.equal(1, 2)),
+                        PredicateBuilder.or(builder.equal(0, 3), builder.equal(2, 4)));
+
+        evaluator.evaluate(predicate);
+
+        assertThat(maxConcurrency.get()).isEqualTo(1);
+        evaluator.close();
+    }
+
+    @Test
     void testNonFieldLeafPredicateDoesNotThrow() {
         executor = Executors.newFixedThreadPool(2);
         RowType rowType = rowType();

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link GlobalIndexEvaluator}. */
+class GlobalIndexEvaluatorTest {
+
+    private ExecutorService executor;
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    private static RowType rowType() {
+        return new RowType(
+                Arrays.asList(
+                        new DataField(0, "a", DataTypes.INT()),
+                        new DataField(1, "b", DataTypes.INT()),
+                        new DataField(2, "c", DataTypes.INT())));
+    }
+
+    private static GlobalIndexResult resultOf(long... rowIds) {
+        return GlobalIndexResult.create(
+                () -> {
+                    RoaringNavigableMap64 bm = new RoaringNavigableMap64();
+                    for (long id : rowIds) {
+                        bm.add(id);
+                    }
+                    return bm;
+                });
+    }
+
+    private static GlobalIndexReader readerReturning(GlobalIndexResult result) {
+        return new StubGlobalIndexReader(result);
+    }
+
+    @Test
+    void testSingleFieldSequential() {
+        RowType rowType = rowType();
+        GlobalIndexResult expected = resultOf(1, 2, 3);
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType, fieldId -> Collections.singletonList(readerReturning(expected)));
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = builder.equal(0, 42);
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L);
+        evaluator.close();
+    }
+
+    @Test
+    void testAndParallelMultipleFields() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3, 4, 5);
+        GlobalIndexResult resultB = resultOf(3, 4, 5, 6, 7);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.and(builder.equal(0, 42), builder.equal(1, 99));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 3L, 4L, 5L);
+        evaluator.close();
+    }
+
+    @Test
+    void testOrParallelMultipleFields() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2);
+        GlobalIndexResult resultB = resultOf(3, 4);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.or(builder.equal(0, 42), builder.equal(1, 99));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L, 4L);
+        evaluator.close();
+    }
+
+    @Test
+    void testOrReturnsEmptyWhenChildUnsupported() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            if (fieldId == 0) {
+                                return Collections.singletonList(readerReturning(resultA));
+                            }
+                            return Collections.emptyList();
+                        },
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.or(builder.equal(0, 42), builder.equal(1, 99));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isEmpty();
+        evaluator.close();
+    }
+
+    @Test
+    void testAndWithEmptyResultShortCircuits() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3);
+        GlobalIndexResult resultB = resultOf(10, 11);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.and(builder.equal(0, 42), builder.equal(1, 99));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().results().isEmpty()).isTrue();
+        evaluator.close();
+    }
+
+    @Test
+    void testParallelUsesMultipleThreads() {
+        executor = Executors.newFixedThreadPool(3);
+        RowType rowType = rowType();
+
+        ConcurrentHashMap<String, Boolean> threadNames = new ConcurrentHashMap<>();
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            threadNames.put(Thread.currentThread().getName(), true);
+                            return Collections.singletonList(
+                                    readerReturning(resultOf(fieldId, fieldId + 10)));
+                        },
+                        executor);
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(builder.equal(0, 1), builder.equal(1, 2), builder.equal(2, 3));
+
+        evaluator.evaluate(predicate);
+
+        assertThat(threadNames.size()).isGreaterThan(1);
+        evaluator.close();
+    }
+
+    @Test
+    void testNullExecutorFallsBackToSequential() {
+        RowType rowType = rowType();
+
+        AtomicInteger callCount = new AtomicInteger();
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            callCount.incrementAndGet();
+                            return Collections.singletonList(
+                                    readerReturning(resultOf(fieldId, fieldId + 10)));
+                        });
+
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.and(builder.equal(0, 1), builder.equal(1, 2));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertThat(callCount.get()).isEqualTo(2);
+        evaluator.close();
+    }
+
+    @Test
+    void testNullPredicate() {
+        RowType rowType = rowType();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(rowType, fieldId -> Collections.emptyList());
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(null);
+
+        assertThat(result).isEmpty();
+        evaluator.close();
+    }
+
+    private static void assertBitmapContainsExactly(
+            RoaringNavigableMap64 bitmap, long... expected) {
+        assertThat(bitmap.getLongCardinality()).isEqualTo(expected.length);
+        for (long val : expected) {
+            assertThat(bitmap.contains(val)).isTrue();
+        }
+    }
+
+    private static class StubGlobalIndexReader implements GlobalIndexReader {
+
+        private final GlobalIndexResult result;
+
+        StubGlobalIndexReader(GlobalIndexResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitEqual(FieldRef fieldRef, Object literal) {
+            return Optional.ofNullable(result);
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitIsNotNull(FieldRef fieldRef) {
+            return Optional.ofNullable(result);
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitIsNull(FieldRef fieldRef) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitStartsWith(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitEndsWith(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitContains(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitLike(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitLessThan(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitNotEqual(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitLessOrEqual(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitGreaterThan(FieldRef fieldRef, Object literal) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitIn(FieldRef fieldRef, List<Object> literals) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<GlobalIndexResult> visitNotIn(FieldRef fieldRef, List<Object> literals) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -373,6 +373,49 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testDeepMixedNestedPredicateDoesNotDeadlockWithSmallPool() {
+        executor = Executors.newFixedThreadPool(2);
+        RowType rowType = rowType();
+
+        GlobalIndexResult resultA = resultOf(1, 2, 3, 4, 5);
+        GlobalIndexResult resultB = resultOf(2, 3, 4, 5, 6);
+        GlobalIndexResult resultC = resultOf(3, 4, 5, 6, 7);
+
+        ConcurrentHashMap<Integer, GlobalIndexResult> fieldResults = new ConcurrentHashMap<>();
+        fieldResults.put(0, resultA);
+        fieldResults.put(1, resultB);
+        fieldResults.put(2, resultC);
+
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(fieldResults.get(fieldId))),
+                        executor);
+
+        // AND(OR(AND(a, b), c), OR(AND(a, c), b)) — deep mixed nesting
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate =
+                PredicateBuilder.and(
+                        PredicateBuilder.or(
+                                PredicateBuilder.and(builder.equal(0, 1), builder.equal(1, 2)),
+                                builder.equal(2, 3)),
+                        PredicateBuilder.or(
+                                PredicateBuilder.and(builder.equal(0, 4), builder.equal(2, 5)),
+                                builder.equal(1, 6)));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        // OR(AND(a,b), c): AND(a,b)={2,3,4,5}, c={3..7} => union={2,3,4,5,6,7}
+        // OR(AND(a,c), b): AND(a,c)={3,4,5}, b={2..6} => union={2,3,4,5,6}
+        // top AND: intersection = {2,3,4,5,6}
+        assertBitmapContainsExactly(result.get().results(), 2L, 3L, 4L, 5L, 6L);
+        evaluator.close();
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -54,12 +54,14 @@ import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
 import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 import static org.apache.paimon.table.source.snapshot.TimeTravelUtil.tryTravelOrLatest;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
+import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 
 /** Scanner for shard-based global indexes. */
 public class GlobalIndexScanner implements Closeable {
 
     private final Options options;
     private final ExecutorService executor;
+    private final ExecutorService evaluatorExecutor;
     private final GlobalIndexEvaluator globalIndexEvaluator;
     private final IndexPathFactory indexPathFactory;
 
@@ -72,6 +74,10 @@ public class GlobalIndexScanner implements Closeable {
         this.options = options;
         this.executor =
                 ManifestReadThreadPool.getExecutorService(options.get(GLOBAL_INDEX_THREAD_NUM));
+        Integer threadNum = options.get(GLOBAL_INDEX_THREAD_NUM);
+        int parallelism =
+                threadNum != null ? threadNum : Runtime.getRuntime().availableProcessors();
+        this.evaluatorExecutor = createCachedThreadPool(parallelism, "GLOBAL-INDEX-EVALUATOR-POOL");
         this.indexPathFactory = indexPathFactory;
         GlobalIndexFileReader indexFileReader = meta -> fileIO.newInputStream(meta.filePath());
         Map<Integer, Map<String, Map<Range, List<IndexFileMeta>>>> indexMetas = new HashMap<>();
@@ -94,7 +100,8 @@ public class GlobalIndexScanner implements Closeable {
                                 indexFileReader,
                                 indexMetas.get(fieldId),
                                 rowType.getField(fieldId));
-        this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction);
+        this.globalIndexEvaluator =
+                new GlobalIndexEvaluator(rowType, readersFunction, evaluatorExecutor);
     }
 
     public static Optional<GlobalIndexScanner> create(
@@ -195,5 +202,6 @@ public class GlobalIndexScanner implements Closeable {
     @Override
     public void close() throws IOException {
         globalIndexEvaluator.close();
+        evaluatorExecutor.shutdownNow();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -32,7 +32,6 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
-import org.apache.paimon.utils.ManifestReadThreadPool;
 import org.apache.paimon.utils.Range;
 
 import java.io.Closeable;
@@ -61,7 +60,6 @@ public class GlobalIndexScanner implements Closeable {
 
     private final Options options;
     private final ExecutorService executor;
-    private final ExecutorService evaluatorExecutor;
     private final GlobalIndexEvaluator globalIndexEvaluator;
     private final IndexPathFactory indexPathFactory;
 
@@ -72,12 +70,10 @@ public class GlobalIndexScanner implements Closeable {
             IndexPathFactory indexPathFactory,
             Collection<IndexFileMeta> indexFiles) {
         this.options = options;
-        this.executor =
-                ManifestReadThreadPool.getExecutorService(options.get(GLOBAL_INDEX_THREAD_NUM));
         Integer threadNum = options.get(GLOBAL_INDEX_THREAD_NUM);
         int parallelism =
                 threadNum != null ? threadNum : Runtime.getRuntime().availableProcessors();
-        this.evaluatorExecutor = createCachedThreadPool(parallelism, "GLOBAL-INDEX-EVALUATOR-POOL");
+        this.executor = createCachedThreadPool(parallelism, "GLOBAL-INDEX-POOL");
         this.indexPathFactory = indexPathFactory;
         GlobalIndexFileReader indexFileReader = meta -> fileIO.newInputStream(meta.filePath());
         Map<Integer, Map<String, Map<Range, List<IndexFileMeta>>>> indexMetas = new HashMap<>();
@@ -100,8 +96,7 @@ public class GlobalIndexScanner implements Closeable {
                                 indexFileReader,
                                 indexMetas.get(fieldId),
                                 rowType.getField(fieldId));
-        this.globalIndexEvaluator =
-                new GlobalIndexEvaluator(rowType, readersFunction, evaluatorExecutor);
+        this.globalIndexEvaluator = new GlobalIndexEvaluator(rowType, readersFunction, executor);
     }
 
     public static Optional<GlobalIndexScanner> create(
@@ -183,7 +178,7 @@ public class GlobalIndexScanner implements Closeable {
                     unionReader.add(innerReader);
                 }
 
-                readers.add(new UnionGlobalIndexReader(unionReader, executor));
+                readers.add(new UnionGlobalIndexReader(unionReader));
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to create global index reader", e);
@@ -202,6 +197,6 @@ public class GlobalIndexScanner implements Closeable {
     @Override
     public void close() throws IOException {
         globalIndexEvaluator.close();
-        evaluatorExecutor.shutdownNow();
+        executor.shutdownNow();
     }
 }

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -18,8 +18,11 @@
 """Global index evaluator for filtering data using global indexes."""
 
 import threading
+from collections import deque
 from concurrent.futures import Executor, Future
 from typing import Callable, Collection, Dict, List, Optional
+
+_MAX_PREDICATE_DEPTH = 1000
 
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
@@ -69,9 +72,13 @@ class GlobalIndexEvaluator:
         future = self._visit_async(predicate)
         return future.result()
 
-    def _visit_async(self, predicate) -> Future:
+    def _visit_async(self, predicate, depth=0) -> Future:
+        if depth > _MAX_PREDICATE_DEPTH:
+            raise ValueError(
+                f"Predicate tree exceeds maximum depth of {_MAX_PREDICATE_DEPTH}"
+            )
         if isinstance(predicate, Predicate) and predicate.method in ('and', 'or'):
-            return self._visit_compound_async(predicate)
+            return self._visit_compound_async(predicate, depth)
         return self._visit_leaf_async(predicate)
 
     def _visit_leaf_async(self, predicate: Predicate) -> Future:
@@ -145,9 +152,9 @@ class GlobalIndexEvaluator:
                 return compound_result
         return compound_result
 
-    def _visit_compound_async(self, predicate: Predicate) -> Future:
+    def _visit_compound_async(self, predicate: Predicate, depth: int = 0) -> Future:
         children = self._flatten_children(predicate.method, predicate.literals)
-        child_futures = [self._visit_async(child) for child in children]
+        child_futures = [self._visit_async(child, depth + 1) for child in children]
 
         all_done = Future()
         if not child_futures:
@@ -198,9 +205,12 @@ class GlobalIndexEvaluator:
 
     def _flatten_children(self, method: str, children) -> list:
         result = []
-        for child in children:
+        stack = deque(children)
+        while stack:
+            child = stack.popleft()
             if isinstance(child, Predicate) and child.method == method:
-                result.extend(self._flatten_children(method, child.literals))
+                for grandchild in reversed(child.literals):
+                    stack.appendleft(grandchild)
             else:
                 result.append(child)
         return result

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -111,16 +111,32 @@ class GlobalIndexEvaluator:
                 result.append(child)
         return result
 
-    def _evaluate_child_sequentially(self, child):
-        if isinstance(child, Predicate) and child.method in ('and', 'or'):
-            if child.method == 'and':
-                return self._visit_and_sequential(child.literals)
-            else:
-                return self._visit_or_sequential(child.literals)
-        return self._visit_predicate(child)
+    def _evaluate_without_parallel(self, predicate):
+        if not isinstance(predicate, Predicate) or predicate.method not in ('and', 'or'):
+            return self._visit_predicate(predicate)
+        if predicate.method == 'and':
+            compound_result = None
+            for child in predicate.literals:
+                child_result = self._evaluate_without_parallel(child)
+                if child_result is not None:
+                    if compound_result is not None:
+                        compound_result = compound_result.and_(child_result)
+                    else:
+                        compound_result = child_result
+                if compound_result is not None and compound_result.is_empty():
+                    return compound_result
+            return compound_result
+        else:
+            compound_result = GlobalIndexResult.create_empty()
+            for child in predicate.literals:
+                child_result = self._evaluate_without_parallel(child)
+                if child_result is None:
+                    return None
+                compound_result = compound_result.or_(child_result)
+            return compound_result
 
     def _submit_children(self, children) -> List[Future]:
-        return [self._executor.submit(self._evaluate_child_sequentially, child) for child in children]
+        return [self._executor.submit(self._evaluate_without_parallel, child) for child in children]
 
     def _collect_results(self, futures: List[Future]) -> List[Optional[GlobalIndexResult]]:
         return [f.result() for f in futures]

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -57,6 +57,7 @@ class GlobalIndexEvaluator:
         self._readers_function = readers_function
         self._index_readers_cache: Dict[int, Collection[GlobalIndexReader]] = {}
         self._reader_locks: Dict[int, threading.Lock] = {}
+        self._locks_lock = threading.Lock()
         self._executor = executor if executor is not None else _DirectExecutor()
 
     def evaluate(
@@ -202,11 +203,12 @@ class GlobalIndexEvaluator:
         return result
 
     def _get_reader_lock(self, reader_id: int) -> threading.Lock:
-        lock = self._reader_locks.get(reader_id)
-        if lock is None:
-            lock = threading.Lock()
-            self._reader_locks[reader_id] = lock
-        return lock
+        with self._locks_lock:
+            lock = self._reader_locks.get(reader_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._reader_locks[reader_id] = lock
+            return lock
 
     def _visit_function(
         self,

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -56,8 +56,7 @@ class GlobalIndexEvaluator:
         self._field_by_name = {f.name: f for f in fields}
         self._readers_function = readers_function
         self._index_readers_cache: Dict[int, Collection[GlobalIndexReader]] = {}
-        self._field_locks: Dict[int, threading.Lock] = {}
-        self._meta_lock = threading.Lock()
+        self._reader_locks: Dict[int, threading.Lock] = {}
         self._executor = executor if executor is not None else _DirectExecutor()
 
     def evaluate(
@@ -82,21 +81,69 @@ class GlobalIndexEvaluator:
             return f
 
         field_id = field.id
-        lock = self._get_field_lock(field_id)
+        readers = self._index_readers_cache.get(field_id)
+        if readers is None:
+            readers = self._readers_function(field)
+            self._index_readers_cache[field_id] = readers
 
-        def task():
-            with lock:
-                return self._visit_leaf_predicate(predicate)
+        field_ref = FieldRef(predicate.index, predicate.field, str(field.type))
 
-        return self._executor.submit(task)
+        reader_futures = []
+        for reader in readers:
+            lock = self._get_reader_lock(id(reader))
+            reader_futures.append(
+                self._executor.submit(
+                    self._visit_reader, reader, predicate, field_ref, lock
+                )
+            )
+
+        all_done = Future()
+        if not reader_futures:
+            all_done.set_result(None)
+            return all_done
+
+        remaining = [len(reader_futures)]
+        count_lock = threading.Lock()
+
+        def on_done(_):
+            with count_lock:
+                remaining[0] -= 1
+                if remaining[0] == 0:
+                    try:
+                        all_done.set_result(
+                            self._combine_reader_results(reader_futures)
+                        )
+                    except Exception as e:
+                        all_done.set_exception(e)
+
+        for rf in reader_futures:
+            rf.add_done_callback(on_done)
+
+        return all_done
+
+    def _visit_reader(self, reader, predicate, field_ref, lock):
+        with lock:
+            return self._visit_function(reader, predicate, field_ref)
+
+    def _combine_reader_results(
+        self, reader_futures: List[Future]
+    ) -> Optional[GlobalIndexResult]:
+        compound_result: Optional[GlobalIndexResult] = None
+        for f in reader_futures:
+            child_result = f.result()
+            if child_result is None:
+                continue
+            if compound_result is not None:
+                compound_result = compound_result.and_(child_result)
+            else:
+                compound_result = child_result
+            if compound_result.is_empty():
+                return compound_result
+        return compound_result
 
     def _visit_compound_async(self, predicate: Predicate) -> Future:
         children = self._flatten_children(predicate.method, predicate.literals)
         child_futures = [self._visit_async(child) for child in children]
-
-        def combine():
-            results = [f.result() for f in child_futures]
-            return self._combine_results(results, predicate.method)
 
         all_done = Future()
         if not child_futures:
@@ -111,7 +158,10 @@ class GlobalIndexEvaluator:
                 remaining[0] -= 1
                 if remaining[0] == 0:
                     try:
-                        all_done.set_result(combine())
+                        results = [f.result() for f in child_futures]
+                        all_done.set_result(
+                            self._combine_results(results, predicate.method)
+                        )
                     except Exception as e:
                         all_done.set_exception(e)
 
@@ -151,46 +201,12 @@ class GlobalIndexEvaluator:
                 result.append(child)
         return result
 
-    def _get_field_lock(self, field_id: int) -> threading.Lock:
-        lock = self._field_locks.get(field_id)
-        if lock is not None:
-            return lock
-        with self._meta_lock:
-            lock = self._field_locks.get(field_id)
-            if lock is None:
-                lock = threading.Lock()
-                self._field_locks[field_id] = lock
-            return lock
-
-    def _visit_leaf_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
-        field = self._field_by_name.get(predicate.field)
-        if field is None:
-            return None
-
-        field_id = field.id
-        readers = self._index_readers_cache.get(field_id)
-        if readers is None:
-            readers = self._readers_function(field)
-            self._index_readers_cache[field_id] = readers
-
-        field_ref = FieldRef(predicate.index, predicate.field, str(field.type))
-
-        compound_result: Optional[GlobalIndexResult] = None
-
-        for reader in readers:
-            child_result = self._visit_function(reader, predicate, field_ref)
-            if child_result is None:
-                continue
-
-            if compound_result is not None:
-                compound_result = compound_result.and_(child_result)
-            else:
-                compound_result = child_result
-
-            if compound_result.is_empty():
-                return compound_result
-
-        return compound_result
+    def _get_reader_lock(self, reader_id: int) -> threading.Lock:
+        lock = self._reader_locks.get(reader_id)
+        if lock is None:
+            lock = threading.Lock()
+            self._reader_locks[reader_id] = lock
+        return lock
 
     def _visit_function(
         self,

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -17,6 +17,8 @@
 
 """Global index evaluator for filtering data using global indexes."""
 
+import threading
+from concurrent.futures import Executor, Future
 from typing import Callable, Collection, Dict, List, Optional
 
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
@@ -33,12 +35,15 @@ class GlobalIndexEvaluator:
     def __init__(
         self,
         fields: List[DataField],
-        readers_function: Callable[[DataField], Collection[GlobalIndexReader]]
+        readers_function: Callable[[DataField], Collection[GlobalIndexReader]],
+        executor: Optional[Executor] = None,
     ):
         self._fields = fields
         self._field_by_name = {f.name: f for f in fields}
         self._readers_function = readers_function
         self._index_readers_cache: Dict[int, Collection[GlobalIndexReader]] = {}
+        self._cache_lock = threading.Lock()
+        self._executor = executor
 
     def evaluate(
         self,
@@ -55,36 +60,80 @@ class GlobalIndexEvaluator:
     def _visit_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
         """Visit a predicate and return the index result."""
         if predicate.method == 'and':
-            compound_result: Optional[GlobalIndexResult] = None
-            for child in predicate.literals:
-                child_result = self._visit_predicate(child)
-                
-                if child_result is not None:
-                    if compound_result is not None:
-                        compound_result = compound_result.and_(child_result)
-                    else:
-                        compound_result = child_result
-                
-                if compound_result is not None and compound_result.is_empty():
-                    return compound_result
-            
-            return compound_result
-        
+            children = predicate.literals
+            if self._executor is not None and len(children) > 1:
+                return self._visit_and_parallel(children)
+            return self._visit_and_sequential(children)
+
         elif predicate.method == 'or':
-            compound_result = GlobalIndexResult.create_empty()
-            for child in predicate.literals:
-                child_result = self._visit_predicate(child)
-                
-                if child_result is None:
-                    return None
-                
-                compound_result = compound_result.or_(child_result)
-            
-            return compound_result
-        
+            children = predicate.literals
+            if self._executor is not None and len(children) > 1:
+                return self._visit_or_parallel(children)
+            return self._visit_or_sequential(children)
+
         else:
-            # Leaf predicate
             return self._visit_leaf_predicate(predicate)
+
+    def _visit_and_sequential(self, children) -> Optional[GlobalIndexResult]:
+        compound_result: Optional[GlobalIndexResult] = None
+        for child in children:
+            child_result = self._visit_predicate(child)
+
+            if child_result is not None:
+                if compound_result is not None:
+                    compound_result = compound_result.and_(child_result)
+                else:
+                    compound_result = child_result
+
+            if compound_result is not None and compound_result.is_empty():
+                return compound_result
+
+        return compound_result
+
+    def _visit_or_sequential(self, children) -> Optional[GlobalIndexResult]:
+        compound_result = GlobalIndexResult.create_empty()
+        for child in children:
+            child_result = self._visit_predicate(child)
+
+            if child_result is None:
+                return None
+
+            compound_result = compound_result.or_(child_result)
+
+        return compound_result
+
+    def _submit_children(self, children) -> List[Future]:
+        return [self._executor.submit(self._visit_predicate, child) for child in children]
+
+    def _collect_results(self, futures: List[Future]) -> List[Optional[GlobalIndexResult]]:
+        return [f.result() for f in futures]
+
+    def _visit_and_parallel(self, children) -> Optional[GlobalIndexResult]:
+        results = self._collect_results(self._submit_children(children))
+
+        compound_result: Optional[GlobalIndexResult] = None
+        for child_result in results:
+            if child_result is not None:
+                if compound_result is not None:
+                    compound_result = compound_result.and_(child_result)
+                else:
+                    compound_result = child_result
+
+            if compound_result is not None and compound_result.is_empty():
+                return compound_result
+
+        return compound_result
+
+    def _visit_or_parallel(self, children) -> Optional[GlobalIndexResult]:
+        results = self._collect_results(self._submit_children(children))
+
+        compound_result = GlobalIndexResult.create_empty()
+        for child_result in results:
+            if child_result is None:
+                return None
+            compound_result = compound_result.or_(child_result)
+
+        return compound_result
 
     def _visit_leaf_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
         """Visit a leaf predicate and return the index result."""
@@ -95,8 +144,11 @@ class GlobalIndexEvaluator:
         field_id = field.id
         readers = self._index_readers_cache.get(field_id)
         if readers is None:
-            readers = self._readers_function(field)
-            self._index_readers_cache[field_id] = readers
+            with self._cache_lock:
+                readers = self._index_readers_cache.get(field_id)
+                if readers is None:
+                    readers = self._readers_function(field)
+                    self._index_readers_cache[field_id] = readers
         
         field_ref = FieldRef(predicate.index, predicate.field, str(field.type))
         

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -111,8 +111,16 @@ class GlobalIndexEvaluator:
                 result.append(child)
         return result
 
+    def _evaluate_child_sequentially(self, child):
+        if isinstance(child, Predicate) and child.method in ('and', 'or'):
+            if child.method == 'and':
+                return self._visit_and_sequential(child.literals)
+            else:
+                return self._visit_or_sequential(child.literals)
+        return self._visit_predicate(child)
+
     def _submit_children(self, children) -> List[Future]:
-        return [self._executor.submit(self._visit_predicate, child) for child in children]
+        return [self._executor.submit(self._evaluate_child_sequentially, child) for child in children]
 
     def _collect_results(self, futures: List[Future]) -> List[Optional[GlobalIndexResult]]:
         return [f.result() for f in futures]

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -135,15 +135,54 @@ class GlobalIndexEvaluator:
                 compound_result = compound_result.or_(child_result)
             return compound_result
 
-    def _submit_children(self, children) -> List[Future]:
-        return [self._executor.submit(self._evaluate_without_parallel, child) for child in children]
+    def _group_by_field(self, children) -> list:
+        field_groups = {}
+        result = []
+        for child in children:
+            if isinstance(child, Predicate) and child.method not in ('and', 'or'):
+                field_name = child.field
+                if field_name not in field_groups:
+                    field_groups[field_name] = []
+                field_groups[field_name].append(child)
+            else:
+                result.append([child])
+        result.extend(field_groups.values())
+        return result
+
+    def _evaluate_group_without_parallel(self, group, method) -> Optional[GlobalIndexResult]:
+        if len(group) == 1:
+            return self._evaluate_without_parallel(group[0])
+        if method == 'or':
+            compound_result = GlobalIndexResult.create_empty()
+            for child in group:
+                child_result = self._evaluate_without_parallel(child)
+                if child_result is None:
+                    return None
+                compound_result = compound_result.or_(child_result)
+            return compound_result
+        else:
+            compound_result = None
+            for child in group:
+                child_result = self._evaluate_without_parallel(child)
+                if child_result is not None:
+                    if compound_result is not None:
+                        compound_result = compound_result.and_(child_result)
+                    else:
+                        compound_result = child_result
+                if compound_result is not None and compound_result.is_empty():
+                    return compound_result
+            return compound_result
+
+    def _submit_groups(self, groups, method) -> List[Future]:
+        return [self._executor.submit(self._evaluate_group_without_parallel, group, method) for group in groups]
 
     def _collect_results(self, futures: List[Future]) -> List[Optional[GlobalIndexResult]]:
         return [f.result() for f in futures]
 
     def _visit_and_parallel(self, children) -> Optional[GlobalIndexResult]:
         children = self._flatten_children('and', children)
-        results = self._collect_results(self._submit_children(children))
+        groups = self._group_by_field(children)
+        results = self._collect_results(self._submit_groups(groups, 'and'))
 
         compound_result: Optional[GlobalIndexResult] = None
         for child_result in results:
@@ -160,7 +199,8 @@ class GlobalIndexEvaluator:
 
     def _visit_or_parallel(self, children) -> Optional[GlobalIndexResult]:
         children = self._flatten_children('or', children)
-        results = self._collect_results(self._submit_children(children))
+        groups = self._group_by_field(children)
+        results = self._collect_results(self._submit_groups(groups, 'or'))
 
         compound_result = GlobalIndexResult.create_empty()
         for child_result in results:

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -22,8 +22,6 @@ from collections import deque
 from concurrent.futures import Executor, Future
 from typing import Callable, Collection, Dict, List, Optional
 
-_MAX_PREDICATE_DEPTH = 1000
-
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.common.predicate import Predicate
@@ -72,13 +70,9 @@ class GlobalIndexEvaluator:
         future = self._visit_async(predicate)
         return future.result()
 
-    def _visit_async(self, predicate, depth=0) -> Future:
-        if depth > _MAX_PREDICATE_DEPTH:
-            raise ValueError(
-                f"Predicate tree exceeds maximum depth of {_MAX_PREDICATE_DEPTH}"
-            )
+    def _visit_async(self, predicate) -> Future:
         if isinstance(predicate, Predicate) and predicate.method in ('and', 'or'):
-            return self._visit_compound_async(predicate, depth)
+            return self._visit_compound_async(predicate)
         return self._visit_leaf_async(predicate)
 
     def _visit_leaf_async(self, predicate: Predicate) -> Future:
@@ -152,9 +146,9 @@ class GlobalIndexEvaluator:
                 return compound_result
         return compound_result
 
-    def _visit_compound_async(self, predicate: Predicate, depth: int = 0) -> Future:
+    def _visit_compound_async(self, predicate: Predicate) -> Future:
         children = self._flatten_children(predicate.method, predicate.literals)
-        child_futures = [self._visit_async(child, depth + 1) for child in children]
+        child_futures = [self._visit_async(child) for child in children]
 
         all_done = Future()
         if not child_futures:

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -102,6 +102,15 @@ class GlobalIndexEvaluator:
 
         return compound_result
 
+    def _flatten_children(self, method: str, children) -> list:
+        result = []
+        for child in children:
+            if isinstance(child, Predicate) and child.method == method:
+                result.extend(self._flatten_children(method, child.literals))
+            else:
+                result.append(child)
+        return result
+
     def _submit_children(self, children) -> List[Future]:
         return [self._executor.submit(self._visit_predicate, child) for child in children]
 
@@ -109,6 +118,7 @@ class GlobalIndexEvaluator:
         return [f.result() for f in futures]
 
     def _visit_and_parallel(self, children) -> Optional[GlobalIndexResult]:
+        children = self._flatten_children('and', children)
         results = self._collect_results(self._submit_children(children))
 
         compound_result: Optional[GlobalIndexResult] = None
@@ -125,6 +135,7 @@ class GlobalIndexEvaluator:
         return compound_result
 
     def _visit_or_parallel(self, children) -> Optional[GlobalIndexResult]:
+        children = self._flatten_children('or', children)
         results = self._collect_results(self._submit_children(children))
 
         compound_result = GlobalIndexResult.create_empty()

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -124,7 +124,10 @@ class GlobalIndexEvaluator:
 
     def _visit_reader(self, reader, predicate, field_ref, lock):
         with lock:
-            return self._visit_function(reader, predicate, field_ref)
+            result = self._visit_function(reader, predicate, field_ref)
+            if result is not None:
+                result.results()
+            return result
 
     def _combine_reader_results(
         self, reader_futures: List[Future]

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -27,10 +27,24 @@ from pypaimon.common.predicate import Predicate
 from pypaimon.schema.data_types import DataField
 
 
+class _DirectExecutor(Executor):
+    """Executor that runs callables in the calling thread."""
+
+    def submit(self, fn, *args, **kwargs):
+        f = Future()
+        try:
+            result = fn(*args, **kwargs)
+            f.set_result(result)
+        except Exception as e:
+            f.set_exception(e)
+        return f
+
+    def shutdown(self, wait=True):
+        pass
+
+
 class GlobalIndexEvaluator:
-    """
-    Predicate evaluator for filtering data using global indexes.
-    """
+    """Predicate evaluator for filtering data using global indexes."""
 
     def __init__(
         self,
@@ -42,65 +56,91 @@ class GlobalIndexEvaluator:
         self._field_by_name = {f.name: f for f in fields}
         self._readers_function = readers_function
         self._index_readers_cache: Dict[int, Collection[GlobalIndexReader]] = {}
-        self._cache_lock = threading.Lock()
-        self._executor = executor
+        self._field_locks: Dict[int, threading.Lock] = {}
+        self._meta_lock = threading.Lock()
+        self._executor = executor if executor is not None else _DirectExecutor()
 
     def evaluate(
         self,
         predicate: Optional[Predicate]
     ) -> Optional[GlobalIndexResult]:
-        compound_result: Optional[GlobalIndexResult] = None
-        
-        # Evaluate predicate first
-        if predicate is not None:
-            compound_result = self._visit_predicate(predicate)
-        
-        return compound_result
+        if predicate is None:
+            return None
+        future = self._visit_async(predicate)
+        return future.result()
 
-    def _visit_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
-        """Visit a predicate and return the index result."""
-        if predicate.method == 'and':
-            children = predicate.literals
-            if self._executor is not None and len(children) > 1:
-                return self._visit_and_parallel(children)
-            return self._visit_and_sequential(children)
+    def _visit_async(self, predicate) -> Future:
+        if isinstance(predicate, Predicate) and predicate.method in ('and', 'or'):
+            return self._visit_compound_async(predicate)
+        return self._visit_leaf_async(predicate)
 
-        elif predicate.method == 'or':
-            children = predicate.literals
-            if self._executor is not None and len(children) > 1:
-                return self._visit_or_parallel(children)
-            return self._visit_or_sequential(children)
+    def _visit_leaf_async(self, predicate: Predicate) -> Future:
+        field = self._field_by_name.get(predicate.field)
+        if field is None:
+            f = Future()
+            f.set_result(None)
+            return f
 
+        field_id = field.id
+        lock = self._get_field_lock(field_id)
+
+        def task():
+            with lock:
+                return self._visit_leaf_predicate(predicate)
+
+        return self._executor.submit(task)
+
+    def _visit_compound_async(self, predicate: Predicate) -> Future:
+        children = self._flatten_children(predicate.method, predicate.literals)
+        child_futures = [self._visit_async(child) for child in children]
+
+        def combine():
+            results = [f.result() for f in child_futures]
+            return self._combine_results(results, predicate.method)
+
+        all_done = Future()
+        if not child_futures:
+            all_done.set_result(None)
+            return all_done
+
+        remaining = [len(child_futures)]
+        lock = threading.Lock()
+
+        def on_done(_):
+            with lock:
+                remaining[0] -= 1
+                if remaining[0] == 0:
+                    try:
+                        all_done.set_result(combine())
+                    except Exception as e:
+                        all_done.set_exception(e)
+
+        for cf in child_futures:
+            cf.add_done_callback(on_done)
+
+        return all_done
+
+    def _combine_results(
+        self, results: List[Optional[GlobalIndexResult]], method: str
+    ) -> Optional[GlobalIndexResult]:
+        if method == 'or':
+            compound_result = GlobalIndexResult.create_empty()
+            for child_result in results:
+                if child_result is None:
+                    return None
+                compound_result = compound_result.or_(child_result)
+            return compound_result
         else:
-            return self._visit_leaf_predicate(predicate)
-
-    def _visit_and_sequential(self, children) -> Optional[GlobalIndexResult]:
-        compound_result: Optional[GlobalIndexResult] = None
-        for child in children:
-            child_result = self._visit_predicate(child)
-
-            if child_result is not None:
-                if compound_result is not None:
-                    compound_result = compound_result.and_(child_result)
-                else:
-                    compound_result = child_result
-
-            if compound_result is not None and compound_result.is_empty():
-                return compound_result
-
-        return compound_result
-
-    def _visit_or_sequential(self, children) -> Optional[GlobalIndexResult]:
-        compound_result = GlobalIndexResult.create_empty()
-        for child in children:
-            child_result = self._visit_predicate(child)
-
-            if child_result is None:
-                return None
-
-            compound_result = compound_result.or_(child_result)
-
-        return compound_result
+            compound_result: Optional[GlobalIndexResult] = None
+            for child_result in results:
+                if child_result is not None:
+                    if compound_result is not None:
+                        compound_result = compound_result.and_(child_result)
+                    else:
+                        compound_result = child_result
+                if compound_result is not None and compound_result.is_empty():
+                    return compound_result
+            return compound_result
 
     def _flatten_children(self, method: str, children) -> list:
         result = []
@@ -111,160 +151,45 @@ class GlobalIndexEvaluator:
                 result.append(child)
         return result
 
-    def _evaluate_without_parallel(self, predicate):
-        if not isinstance(predicate, Predicate) or predicate.method not in ('and', 'or'):
-            return self._visit_predicate(predicate)
-        if predicate.method == 'and':
-            compound_result = None
-            for child in predicate.literals:
-                child_result = self._evaluate_without_parallel(child)
-                if child_result is not None:
-                    if compound_result is not None:
-                        compound_result = compound_result.and_(child_result)
-                    else:
-                        compound_result = child_result
-                if compound_result is not None and compound_result.is_empty():
-                    return compound_result
-            return compound_result
-        else:
-            compound_result = GlobalIndexResult.create_empty()
-            for child in predicate.literals:
-                child_result = self._evaluate_without_parallel(child)
-                if child_result is None:
-                    return None
-                compound_result = compound_result.or_(child_result)
-            return compound_result
-
-    def _collect_fields(self, predicate) -> set:
-        if not isinstance(predicate, Predicate):
-            return set()
-        if predicate.method in ('and', 'or'):
-            fields = set()
-            for child in predicate.literals:
-                fields.update(self._collect_fields(child))
-            return fields
-        return {predicate.field} if predicate.field else set()
-
-    def _group_by_field(self, children) -> list:
-        groups = []
-        group_fields = []
-
-        for child in children:
-            fields = self._collect_fields(child)
-            merged_idx = -1
-            i = 0
-            while i < len(groups):
-                if group_fields[i] & fields:
-                    if merged_idx == -1:
-                        groups[i].append(child)
-                        group_fields[i].update(fields)
-                        merged_idx = i
-                    else:
-                        groups[merged_idx].extend(groups[i])
-                        group_fields[merged_idx].update(group_fields[i])
-                        groups.pop(i)
-                        group_fields.pop(i)
-                        continue
-                i += 1
-            if merged_idx == -1:
-                groups.append([child])
-                group_fields.append(set(fields))
-
-        return groups
-
-    def _evaluate_group_without_parallel(self, group, method) -> Optional[GlobalIndexResult]:
-        if len(group) == 1:
-            return self._evaluate_without_parallel(group[0])
-        if method == 'or':
-            compound_result = GlobalIndexResult.create_empty()
-            for child in group:
-                child_result = self._evaluate_without_parallel(child)
-                if child_result is None:
-                    return None
-                compound_result = compound_result.or_(child_result)
-            return compound_result
-        else:
-            compound_result = None
-            for child in group:
-                child_result = self._evaluate_without_parallel(child)
-                if child_result is not None:
-                    if compound_result is not None:
-                        compound_result = compound_result.and_(child_result)
-                    else:
-                        compound_result = child_result
-                if compound_result is not None and compound_result.is_empty():
-                    return compound_result
-            return compound_result
-
-    def _submit_groups(self, groups, method) -> List[Future]:
-        return [self._executor.submit(self._evaluate_group_without_parallel, group, method) for group in groups]
-
-    def _collect_results(self, futures: List[Future]) -> List[Optional[GlobalIndexResult]]:
-        return [f.result() for f in futures]
-
-    def _visit_and_parallel(self, children) -> Optional[GlobalIndexResult]:
-        children = self._flatten_children('and', children)
-        groups = self._group_by_field(children)
-        results = self._collect_results(self._submit_groups(groups, 'and'))
-
-        compound_result: Optional[GlobalIndexResult] = None
-        for child_result in results:
-            if child_result is not None:
-                if compound_result is not None:
-                    compound_result = compound_result.and_(child_result)
-                else:
-                    compound_result = child_result
-
-            if compound_result is not None and compound_result.is_empty():
-                return compound_result
-
-        return compound_result
-
-    def _visit_or_parallel(self, children) -> Optional[GlobalIndexResult]:
-        children = self._flatten_children('or', children)
-        groups = self._group_by_field(children)
-        results = self._collect_results(self._submit_groups(groups, 'or'))
-
-        compound_result = GlobalIndexResult.create_empty()
-        for child_result in results:
-            if child_result is None:
-                return None
-            compound_result = compound_result.or_(child_result)
-
-        return compound_result
+    def _get_field_lock(self, field_id: int) -> threading.Lock:
+        lock = self._field_locks.get(field_id)
+        if lock is not None:
+            return lock
+        with self._meta_lock:
+            lock = self._field_locks.get(field_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._field_locks[field_id] = lock
+            return lock
 
     def _visit_leaf_predicate(self, predicate: Predicate) -> Optional[GlobalIndexResult]:
-        """Visit a leaf predicate and return the index result."""
         field = self._field_by_name.get(predicate.field)
         if field is None:
             return None
-        
+
         field_id = field.id
         readers = self._index_readers_cache.get(field_id)
         if readers is None:
-            with self._cache_lock:
-                readers = self._index_readers_cache.get(field_id)
-                if readers is None:
-                    readers = self._readers_function(field)
-                    self._index_readers_cache[field_id] = readers
-        
+            readers = self._readers_function(field)
+            self._index_readers_cache[field_id] = readers
+
         field_ref = FieldRef(predicate.index, predicate.field, str(field.type))
-        
+
         compound_result: Optional[GlobalIndexResult] = None
-        
+
         for reader in readers:
             child_result = self._visit_function(reader, predicate, field_ref)
             if child_result is None:
                 continue
-            
+
             if compound_result is not None:
-                compound_result = compound_result.or_(child_result)
+                compound_result = compound_result.and_(child_result)
             else:
                 compound_result = child_result
-            
+
             if compound_result.is_empty():
                 return compound_result
-        
+
         return compound_result
 
     def _visit_function(
@@ -273,10 +198,9 @@ class GlobalIndexEvaluator:
         predicate: Predicate,
         field_ref: FieldRef
     ) -> Optional[GlobalIndexResult]:
-        """Visit a predicate function with the given reader."""
         method = predicate.method
         literals = predicate.literals
-        
+
         if method == 'equal':
             return reader.visit_equal(field_ref, literals[0])
         elif method == 'notEqual':
@@ -311,7 +235,6 @@ class GlobalIndexEvaluator:
         return None
 
     def close(self) -> None:
-        """Close the evaluator and release resources."""
         for readers in self._index_readers_cache.values():
             for reader in readers:
                 try:

--- a/paimon-python/pypaimon/globalindex/global_index_evaluator.py
+++ b/paimon-python/pypaimon/globalindex/global_index_evaluator.py
@@ -135,19 +135,42 @@ class GlobalIndexEvaluator:
                 compound_result = compound_result.or_(child_result)
             return compound_result
 
+    def _collect_fields(self, predicate) -> set:
+        if not isinstance(predicate, Predicate):
+            return set()
+        if predicate.method in ('and', 'or'):
+            fields = set()
+            for child in predicate.literals:
+                fields.update(self._collect_fields(child))
+            return fields
+        return {predicate.field} if predicate.field else set()
+
     def _group_by_field(self, children) -> list:
-        field_groups = {}
-        result = []
+        groups = []
+        group_fields = []
+
         for child in children:
-            if isinstance(child, Predicate) and child.method not in ('and', 'or'):
-                field_name = child.field
-                if field_name not in field_groups:
-                    field_groups[field_name] = []
-                field_groups[field_name].append(child)
-            else:
-                result.append([child])
-        result.extend(field_groups.values())
-        return result
+            fields = self._collect_fields(child)
+            merged_idx = -1
+            i = 0
+            while i < len(groups):
+                if group_fields[i] & fields:
+                    if merged_idx == -1:
+                        groups[i].append(child)
+                        group_fields[i].update(fields)
+                        merged_idx = i
+                    else:
+                        groups[merged_idx].extend(groups[i])
+                        group_fields[merged_idx].update(group_fields[i])
+                        groups.pop(i)
+                        group_fields.pop(i)
+                        continue
+                i += 1
+            if merged_idx == -1:
+                groups.append([child])
+                group_fields.append(set(fields))
+
+        return groups
 
     def _evaluate_group_without_parallel(self, group, method) -> Optional[GlobalIndexResult]:
         if len(group) == 1:

--- a/paimon-python/pypaimon/globalindex/global_index_scanner.py
+++ b/paimon-python/pypaimon/globalindex/global_index_scanner.py
@@ -17,6 +17,8 @@
 
 """Scanner for shard-based global indexes."""
 
+import os
+from concurrent.futures import ThreadPoolExecutor
 from typing import Collection, Optional
 
 from pypaimon.globalindex.global_index_evaluator import GlobalIndexEvaluator
@@ -37,9 +39,15 @@ class GlobalIndexScanner:
         fields: list,
         file_io,
         index_path: str,
-        index_files: Collection['IndexFileMeta']
+        index_files: Collection['IndexFileMeta'],
+        thread_num: Optional[int] = None,
     ):
-        self._evaluator = self._create_evaluator(fields, file_io, index_path, index_files)
+        self._executor = ThreadPoolExecutor(
+            max_workers=thread_num or os.cpu_count() or 4
+        )
+        self._evaluator = self._create_evaluator(
+            fields, file_io, index_path, index_files
+        )
 
     def _create_evaluator(self, fields, file_io, index_path, index_files):
         index_metas = {}
@@ -71,7 +79,7 @@ class GlobalIndexScanner:
         def readers_function(field: DataField) -> Collection[GlobalIndexReader]:
             return _create_readers(file_io, index_path, index_metas.get(field.id), field)
 
-        return GlobalIndexEvaluator(fields, readers_function)
+        return GlobalIndexEvaluator(fields, readers_function, self._executor)
 
     @staticmethod
     def create(table, index_files=None, partition_filter=None, predicate=None) -> Optional['GlobalIndexScanner']:
@@ -90,7 +98,8 @@ class GlobalIndexScanner:
                 fields=table.fields,
                 file_io=table.file_io,
                 index_path=table.path_factory().global_index_path_factory().index_path(),
-                index_files=index_files
+                index_files=index_files,
+                thread_num=table.options.global_index_thread_num(),
             )
 
         # Scan index files from snapshot using partition_filter and predicate
@@ -121,7 +130,8 @@ class GlobalIndexScanner:
             fields=table.fields,
             file_io=table.file_io,
             index_path=table.path_factory().global_index_path_factory().index_path(),
-            index_files=scanned_index_files
+            index_files=scanned_index_files,
+            thread_num=table.options.global_index_thread_num(),
         )
 
     def scan(self, predicate: Optional[Predicate]) -> Optional[GlobalIndexResult]:
@@ -131,6 +141,7 @@ class GlobalIndexScanner:
     def close(self):
         """Close the scanner and release resources."""
         self._evaluator.close()
+        self._executor.shutdown(wait=False)
 
     def __enter__(self) -> 'GlobalIndexScanner':
         return self

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -527,6 +527,70 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_lazy_result_not_materialized_concurrently(self):
+        import threading
+        import time
+
+        fields = _make_fields()
+
+        concurrency = [0]
+        max_concurrency = [0]
+        lock = threading.Lock()
+
+        class LazyIOReader(GlobalIndexReader):
+            def visit_equal(self, field_ref, literal):
+                def supplier():
+                    with lock:
+                        concurrency[0] += 1
+                        max_concurrency[0] = max(max_concurrency[0], concurrency[0])
+                    time.sleep(0.05)
+                    with lock:
+                        concurrency[0] -= 1
+                    return GlobalIndexResult.from_range(Range(1, 3)).results()
+
+                return GlobalIndexResult.create(supplier)
+
+            def close(self):
+                pass
+
+        lazy_reader = LazyIOReader()
+
+        def readers_fn(field):
+            if field.id == 0:
+                return [lazy_reader]
+            return [StubGlobalIndexReader(GlobalIndexResult.from_range(Range(1, 5)))]
+
+        executor = ThreadPoolExecutor(max_workers=4)
+        evaluator = GlobalIndexEvaluator(fields, readers_fn, executor)
+
+        # AND(OR(a=1, b=2), OR(a=3, c=4)) — field a in both OR subtrees
+        # lazy results for field a must not be materialized concurrently
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[1]),
+                        Predicate(method='equal', index=1, field='b', literals=[2]),
+                    ],
+                ),
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[3]),
+                        Predicate(method='equal', index=2, field='c', literals=[4]),
+                    ],
+                ),
+            ],
+        )
+
+        evaluator.evaluate(predicate)
+
+        self.assertEqual(max_concurrency[0], 1)
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_non_field_leaf_predicate_does_not_throw(self):
         fields = _make_fields()
         result_a = GlobalIndexResult.from_range(Range(1, 3))

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -349,6 +349,67 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_deep_mixed_nested_does_not_deadlock_with_small_pool(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        result_b = GlobalIndexResult.from_range(Range(2, 6))
+        result_c = GlobalIndexResult.from_range(Range(3, 7))
+
+        field_results = {0: result_a, 1: result_b, 2: result_c}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        # AND(OR(AND(a, b), c), OR(AND(a, c), b)) — deep mixed nesting
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(
+                            method='and', index=None, field=None,
+                            literals=[
+                                Predicate(method='equal', index=0, field='a', literals=[1]),
+                                Predicate(method='equal', index=1, field='b', literals=[2]),
+                            ],
+                        ),
+                        Predicate(method='equal', index=2, field='c', literals=[3]),
+                    ],
+                ),
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(
+                            method='and', index=None, field=None,
+                            literals=[
+                                Predicate(method='equal', index=0, field='a', literals=[4]),
+                                Predicate(method='equal', index=2, field='c', literals=[5]),
+                            ],
+                        ),
+                        Predicate(method='equal', index=1, field='b', literals=[6]),
+                    ],
+                ),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # OR(AND(a,b), c): AND(a,b)=intersect([1,5],[2,6])=[2,5], c=[3,7] => union=[2,7]
+        # OR(AND(a,c), b): AND(a,c)=intersect([1,5],[3,7])=[3,5], b=[2,6] => union=[2,6]
+        # top AND: intersect([2,7],[2,6]) = [2,6]
+        self.assertEqual(bm.cardinality(), 5)
+        for v in [2, 3, 4, 5, 6]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -218,6 +218,88 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         self.assertEqual(call_count[0], 2)
         evaluator.close()
 
+    def test_nested_and_does_not_deadlock_with_small_pool(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        result_b = GlobalIndexResult.from_range(Range(3, 7))
+        result_c = GlobalIndexResult.from_range(Range(4, 5))
+
+        field_results = {0: result_a, 1: result_b, 2: result_c}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        # Nested binary tree: and(and(a, b), c)
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='and', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[1]),
+                        Predicate(method='equal', index=1, field='b', literals=[2]),
+                    ],
+                ),
+                Predicate(method='equal', index=2, field='c', literals=[3]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # intersection of [1,5], [3,7], [4,5] -> [4,5]
+        self.assertEqual(bm.cardinality(), 2)
+        for v in [4, 5]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
+    def test_nested_or_does_not_deadlock_with_small_pool(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 2))
+        result_b = GlobalIndexResult.from_range(Range(3, 4))
+        result_c = GlobalIndexResult.from_range(Range(5, 6))
+
+        field_results = {0: result_a, 1: result_b, 2: result_c}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        # Nested binary tree: or(or(a, b), c)
+        predicate = Predicate(
+            method='or', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[1]),
+                        Predicate(method='equal', index=1, field='b', literals=[2]),
+                    ],
+                ),
+                Predicate(method='equal', index=2, field='c', literals=[3]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # union of [1,2], [3,4], [5,6] -> {1,2,3,4,5,6}
+        self.assertEqual(bm.cardinality(), 6)
+        for v in [1, 2, 3, 4, 5, 6]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.globalindex.global_index_evaluator import GlobalIndexEvaluator
-from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
+from pypaimon.globalindex.global_index_reader import GlobalIndexReader
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.schema.data_types import DataField, AtomicType
 from pypaimon.utils.range import Range

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -410,6 +410,58 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_same_field_predicates_not_accessed_concurrently(self):
+        import threading
+        import time
+
+        fields = _make_fields()
+
+        concurrency = [0]
+        max_concurrency = [0]
+        lock = threading.Lock()
+
+        class ConcurrencyDetectingReader(GlobalIndexReader):
+            def __init__(self, result):
+                self._result = result
+
+            def visit_equal(self, field_ref, literal):
+                with lock:
+                    concurrency[0] += 1
+                    max_concurrency[0] = max(max_concurrency[0], concurrency[0])
+                time.sleep(0.05)
+                with lock:
+                    concurrency[0] -= 1
+                return self._result
+
+            def close(self):
+                pass
+
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        reader = ConcurrencyDetectingReader(result_a)
+
+        executor = ThreadPoolExecutor(max_workers=4)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [reader],
+            executor,
+        )
+
+        # AND(a=1, a=2, a=3) — all same field, must not run concurrently
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[1]),
+                Predicate(method='equal', index=0, field='a', literals=[2]),
+                Predicate(method='equal', index=0, field='a', literals=[3]),
+            ],
+        )
+
+        evaluator.evaluate(predicate)
+
+        self.assertEqual(max_concurrency[0], 1)
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -462,6 +462,71 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_mixed_nested_same_field_not_accessed_concurrently(self):
+        import threading
+        import time
+
+        fields = _make_fields()
+
+        concurrency_a = [0]
+        max_concurrency_a = [0]
+        lock = threading.Lock()
+
+        class ConcurrencyDetectingReader(GlobalIndexReader):
+            def __init__(self, result):
+                self._result = result
+
+            def visit_equal(self, field_ref, literal):
+                with lock:
+                    concurrency_a[0] += 1
+                    max_concurrency_a[0] = max(max_concurrency_a[0], concurrency_a[0])
+                time.sleep(0.05)
+                with lock:
+                    concurrency_a[0] -= 1
+                return self._result
+
+            def close(self):
+                pass
+
+        result_all = GlobalIndexResult.from_range(Range(1, 5))
+        detecting_reader = ConcurrencyDetectingReader(result_all)
+        normal_reader = StubGlobalIndexReader(result_all)
+
+        def readers_fn(field):
+            if field.id == 0:
+                return [detecting_reader]
+            return [normal_reader]
+
+        executor = ThreadPoolExecutor(max_workers=4)
+        evaluator = GlobalIndexEvaluator(fields, readers_fn, executor)
+
+        # AND(OR(a=1, b=2), OR(a=3, c=4)) — field a in both OR subtrees
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[1]),
+                        Predicate(method='equal', index=1, field='b', literals=[2]),
+                    ],
+                ),
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[3]),
+                        Predicate(method='equal', index=2, field='c', literals=[4]),
+                    ],
+                ),
+            ],
+        )
+
+        evaluator.evaluate(predicate)
+
+        self.assertEqual(max_concurrency_a[0], 1)
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -22,7 +22,7 @@ from pypaimon.common.predicate import Predicate
 from pypaimon.globalindex.global_index_evaluator import GlobalIndexEvaluator
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
-from pypaimon.schema.data_types import DataField, IntType
+from pypaimon.schema.data_types import DataField, AtomicType
 from pypaimon.utils.range import Range
 
 
@@ -41,9 +41,9 @@ class StubGlobalIndexReader(GlobalIndexReader):
 
 def _make_fields():
     return [
-        DataField(0, "a", IntType()),
-        DataField(1, "b", IntType()),
-        DataField(2, "c", IntType()),
+        DataField(0, "a", AtomicType("INT")),
+        DataField(1, "b", AtomicType("INT")),
+        DataField(2, "c", AtomicType("INT")),
     ]
 
 

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -527,6 +527,34 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_non_field_leaf_predicate_does_not_throw(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 3))
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(result_a)],
+            executor,
+        )
+
+        # AND(non-field leaf, a=1) — non-field leaf has field=None
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(method='alwaysTrue', index=None, field=None, literals=[]),
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        # alwaysTrue has no reader support, returns None — AND ignores it
+        self.assertIsNotNone(result)
+        self.assertEqual(result.results().cardinality(), 3)
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -591,6 +591,33 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_multiple_readers_per_field_combined_with_and(self):
+        fields = _make_fields()
+        reader_result1 = GlobalIndexResult.from_range(Range(1, 5))
+        reader_result2 = GlobalIndexResult.from_range(Range(3, 7))
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [
+                StubGlobalIndexReader(reader_result1),
+                StubGlobalIndexReader(reader_result2),
+            ],
+            executor,
+        )
+
+        predicate = Predicate(method='equal', index=0, field='a', literals=[42])
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # Multiple readers for same field are combined with AND (intersection)
+        self.assertEqual(bm.cardinality(), 3)
+        for v in [3, 4, 5]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_non_field_leaf_predicate_does_not_throw(self):
         fields = _make_fields()
         result_a = GlobalIndexResult.from_range(Range(1, 3))

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -1,0 +1,232 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+
+from pypaimon.common.predicate import Predicate
+from pypaimon.globalindex.global_index_evaluator import GlobalIndexEvaluator
+from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef
+from pypaimon.globalindex.global_index_result import GlobalIndexResult
+from pypaimon.schema.data_types import DataField, IntType
+from pypaimon.utils.range import Range
+
+
+class StubGlobalIndexReader(GlobalIndexReader):
+    """A test reader that returns a fixed result for equal predicates."""
+
+    def __init__(self, result):
+        self._result = result
+
+    def visit_equal(self, field_ref, literal):
+        return self._result
+
+    def close(self):
+        pass
+
+
+def _make_fields():
+    return [
+        DataField(0, "a", IntType()),
+        DataField(1, "b", IntType()),
+        DataField(2, "c", IntType()),
+    ]
+
+
+def _result_of(*row_ids):
+    return GlobalIndexResult.from_range(Range(min(row_ids), max(row_ids)))
+
+
+class GlobalIndexEvaluatorTest(unittest.TestCase):
+
+    def test_single_field_sequential(self):
+        fields = _make_fields()
+        expected = GlobalIndexResult.from_range(Range(1, 3))
+
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(expected)],
+        )
+
+        predicate = Predicate(method='equal', index=0, field='a', literals=[42])
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.results().cardinality(), 3)
+        evaluator.close()
+
+    def test_and_parallel_multiple_fields(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        result_b = GlobalIndexResult.from_range(Range(3, 7))
+
+        field_results = {0: result_a, 1: result_b}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+                Predicate(method='equal', index=1, field='b', literals=[99]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # intersection of [1,5] and [3,7] -> [3,5]
+        self.assertEqual(bm.cardinality(), 3)
+        for v in [3, 4, 5]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
+    def test_or_parallel_multiple_fields(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 2))
+        result_b = GlobalIndexResult.from_range(Range(10, 11))
+
+        field_results = {0: result_a, 1: result_b}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        predicate = Predicate(
+            method='or', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+                Predicate(method='equal', index=1, field='b', literals=[99]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # union of [1,2] and [10,11] -> {1,2,10,11}
+        self.assertEqual(bm.cardinality(), 4)
+        for v in [1, 2, 10, 11]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
+    def test_or_returns_none_when_child_unsupported(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 2))
+
+        def readers_fn(field):
+            if field.id == 0:
+                return [StubGlobalIndexReader(result_a)]
+            return []
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(fields, readers_fn, executor)
+
+        predicate = Predicate(
+            method='or', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+                Predicate(method='equal', index=1, field='b', literals=[99]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNone(result)
+        evaluator.close()
+        executor.shutdown(wait=False)
+
+    def test_and_with_disjoint_results(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 3))
+        result_b = GlobalIndexResult.from_range(Range(10, 12))
+
+        field_results = {0: result_a, 1: result_b}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+                Predicate(method='equal', index=1, field='b', literals=[99]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(result.is_empty())
+        evaluator.close()
+        executor.shutdown(wait=False)
+
+    def test_no_executor_falls_back_to_sequential(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        result_b = GlobalIndexResult.from_range(Range(3, 7))
+
+        field_results = {0: result_a, 1: result_b}
+        call_count = [0]
+
+        def readers_fn(field):
+            call_count[0] += 1
+            return [StubGlobalIndexReader(field_results[field.id])]
+
+        evaluator = GlobalIndexEvaluator(fields, readers_fn)
+
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(method='equal', index=0, field='a', literals=[42]),
+                Predicate(method='equal', index=1, field='b', literals=[99]),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(call_count[0], 2)
+        evaluator.close()
+
+    def test_null_predicate(self):
+        fields = _make_fields()
+        evaluator = GlobalIndexEvaluator(fields, lambda field: [])
+
+        result = evaluator.evaluate(None)
+
+        self.assertIsNone(result)
+        evaluator.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/global_index_evaluator_test.py
+++ b/paimon-python/pypaimon/tests/global_index_evaluator_test.py
@@ -300,6 +300,55 @@ class GlobalIndexEvaluatorTest(unittest.TestCase):
         evaluator.close()
         executor.shutdown(wait=False)
 
+    def test_mixed_nested_does_not_deadlock_with_small_pool(self):
+        fields = _make_fields()
+        result_a = GlobalIndexResult.from_range(Range(1, 5))
+        result_b = GlobalIndexResult.from_range(Range(3, 7))
+        result_c = GlobalIndexResult.from_range(Range(1, 3))
+
+        field_results = {0: result_a, 1: result_b, 2: result_c}
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        evaluator = GlobalIndexEvaluator(
+            fields,
+            lambda field: [StubGlobalIndexReader(field_results[field.id])],
+            executor,
+        )
+
+        # AND(OR(a, b), OR(a, c)) — mixed nesting
+        predicate = Predicate(
+            method='and', index=None, field=None,
+            literals=[
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[1]),
+                        Predicate(method='equal', index=1, field='b', literals=[2]),
+                    ],
+                ),
+                Predicate(
+                    method='or', index=None, field=None,
+                    literals=[
+                        Predicate(method='equal', index=0, field='a', literals=[3]),
+                        Predicate(method='equal', index=2, field='c', literals=[4]),
+                    ],
+                ),
+            ],
+        )
+
+        result = evaluator.evaluate(predicate)
+
+        self.assertIsNotNone(result)
+        bm = result.results()
+        # OR(a, b) = union([1,5], [3,7]) = [1,7]
+        # OR(a, c) = union([1,5], [1,3]) = [1,5]
+        # AND = intersection = [1,5]
+        self.assertEqual(bm.cardinality(), 5)
+        for v in [1, 2, 3, 4, 5]:
+            self.assertTrue(bm.contains(v))
+        evaluator.close()
+        executor.shutdown(wait=False)
+
     def test_null_predicate(self):
         fields = _make_fields()
         evaluator = GlobalIndexEvaluator(fields, lambda field: [])


### PR DESCRIPTION
When a compound predicate (AND/OR) involves multiple fields, each field's BTree index lookup is now submitted to a thread pool and executed in parallel. This reduces scan latency for multi-field global index queries.

Key changes:
- GlobalIndexEvaluator accepts an optional ExecutorService for parallel child predicate evaluation in visitParallel, with sequential fallback.
- GlobalIndexScanner creates an isolated evaluator thread pool to avoid deadlocks with the existing UnionGlobalIndexReader executor.
- Python side uses ThreadPoolExecutor with threading.Lock for thread-safe reader cache access.
- Added GlobalIndexEvaluatorTest for both Java and Python.
