### PR TITLE
[format] Pass through parquet statistics and page-size-check config in RowDataParquetBuilder

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -96,7 +96,23 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
                         .withBloomFilterEnabled(
                                 conf.getBoolean(
                                         ParquetOutputFormat.BLOOM_FILTER_ENABLED,
-                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED));
+                                        ParquetProperties.DEFAULT_BLOOM_FILTER_ENABLED))
+                        .withMinRowCountForPageSizeCheck(
+                                conf.getInt(
+                                        ParquetOutputFormat.MIN_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
+                                        ParquetProperties.DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK))
+                        .withMaxRowCountForPageSizeCheck(
+                                conf.getInt(
+                                        ParquetOutputFormat.MAX_ROW_COUNT_FOR_PAGE_SIZE_CHECK,
+                                        ParquetProperties.DEFAULT_MAXIMUM_RECORD_COUNT_FOR_CHECK))
+                        .withStatisticsTruncateLength(
+                                conf.getInt(
+                                        ParquetOutputFormat.STATISTICS_TRUNCATE_LENGTH,
+                                        ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH))
+                        .withColumnIndexTruncateLength(
+                                conf.getInt(
+                                        ParquetOutputFormat.COLUMN_INDEX_TRUNCATE_LENGTH,
+                                        ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH));
         new ColumnConfigParser()
                 .withColumnConfig(
                         ParquetOutputFormat.ENABLE_DICTIONARY,


### PR DESCRIPTION
  ### Purpose

  Linked issue: #7620

  Pass through parquet statistics and page-size-check configuration in  `RowDataParquetBuilder`.

  Currently `RowDataParquetBuilder` does not forward the following Parquet config keys to  the writer:
  - `parquet.statistics.truncate.length`
  - `parquet.columnindex.truncate.length`
  - `parquet.page.size.row.check.min`
  - `parquet.page.size.row.check.max`

  Without these, users cannot tune Parquet page-size checking behavior or control the  truncation length of statistics and column indexes. This is especially relevant for  tables with large records, where the default page-size check thresholds can lead to  oversized pages.

  Split out from #7621 per reviewer feedback, as this is an independent enhancement.

  #### Changes

  - **`RowDataParquetBuilder`**: add `.withMinRowCountForPageSizeCheck()`,
  `.withMaxRowCountForPageSizeCheck()`, `.withStatisticsTruncateLength()`,  `.withColumnIndexTruncateLength()` to the builder chain, reading from the existing  Hadoop `Configuration` with Parquet's default values as fallback.

  ### Tests

  Existing Parquet write tests cover the default config path. The new keys follow the same  pattern as other builder options (e.g. `withDictionaryPageSize`, `withPageSize`) and  use Parquet's built-in defaults when not set.

  ### API and Format

  N/A — no public API or format changes. Users can now set these keys via table properties, using the same mechanism as other Parquet config keys.

  ### Documentation

  N/A