### PR TITLE
[python] [daft] Fix double-scheme prefix

### DIFF
--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -49,11 +49,6 @@ PAIMON_FILE_FORMAT_PARQUET = "parquet"
 PAIMON_FILE_FORMAT_ORC = "orc"
 PAIMON_FILE_FORMAT_AVRO = "avro"
 
-_ABSOLUTE_URI_SCHEMES = (
-    "oss://", "s3://", "s3a://", "s3n://",
-    "hdfs://", "file://", "http://", "https://",
-)
-
 
 class _PaimonPKSplitTask(DataSourceTask):
     """DataSourceTask for PK-table splits that require LSM-tree merge.
@@ -300,7 +295,7 @@ class PaimonDataSource(DataSource):
 
     def _build_file_uri(self, file_path: str) -> str:
         """Reconstruct a full URI from a (potentially scheme-stripped) file_path."""
-        if file_path.startswith(_ABSOLUTE_URI_SCHEMES):
+        if urlparse(file_path).scheme:
             return file_path
         if self._warehouse_scheme:
             return f"{self._warehouse_scheme}://{file_path}"

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -49,11 +49,6 @@ PAIMON_FILE_FORMAT_PARQUET = "parquet"
 PAIMON_FILE_FORMAT_ORC = "orc"
 PAIMON_FILE_FORMAT_AVRO = "avro"
 
-# Schemes that, when already present in a file_path, indicate the path is
-# already an absolute URI and must not be re-prefixed. REST catalogs (DLF,
-# etc.) hand back paths like ``oss://bucket/...``; the previous unconditional
-# ``f"{scheme}://{file_path}"`` produced invalid double-scheme URIs such as
-# ``file://oss://...``.
 _ABSOLUTE_URI_SCHEMES = (
     "oss://", "s3://", "s3a://", "s3n://",
     "hdfs://", "file://", "http://", "https://",
@@ -304,12 +299,7 @@ class PaimonDataSource(DataSource):
                 yield _PaimonPKSplitTask(read_table, split, self._schema, self._blob_column_names)
 
     def _build_file_uri(self, file_path: str) -> str:
-        """Reconstruct a full URI from a (potentially scheme-stripped) file_path.
-
-        If ``file_path`` already carries a scheme (e.g. REST catalogs typically
-        return absolute ``oss://`` / ``s3://`` paths), return it unchanged.
-        Otherwise fall back to the warehouse scheme, or ``file://`` if none.
-        """
+        """Reconstruct a full URI from a (potentially scheme-stripped) file_path."""
         if file_path.startswith(_ABSOLUTE_URI_SCHEMES):
             return file_path
         if self._warehouse_scheme:

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -49,6 +49,16 @@ PAIMON_FILE_FORMAT_PARQUET = "parquet"
 PAIMON_FILE_FORMAT_ORC = "orc"
 PAIMON_FILE_FORMAT_AVRO = "avro"
 
+# Schemes that, when already present in a file_path, indicate the path is
+# already an absolute URI and must not be re-prefixed. REST catalogs (DLF,
+# etc.) hand back paths like ``oss://bucket/...``; the previous unconditional
+# ``f"{scheme}://{file_path}"`` produced invalid double-scheme URIs such as
+# ``file://oss://...``.
+_ABSOLUTE_URI_SCHEMES = (
+    "oss://", "s3://", "s3a://", "s3n://",
+    "hdfs://", "file://", "http://", "https://",
+)
+
 
 class _PaimonPKSplitTask(DataSourceTask):
     """DataSourceTask for PK-table splits that require LSM-tree merge.
@@ -294,7 +304,14 @@ class PaimonDataSource(DataSource):
                 yield _PaimonPKSplitTask(read_table, split, self._schema, self._blob_column_names)
 
     def _build_file_uri(self, file_path: str) -> str:
-        """Reconstruct a full URI from a (potentially scheme-stripped) file_path."""
+        """Reconstruct a full URI from a (potentially scheme-stripped) file_path.
+
+        If ``file_path`` already carries a scheme (e.g. REST catalogs typically
+        return absolute ``oss://`` / ``s3://`` paths), return it unchanged.
+        Otherwise fall back to the warehouse scheme, or ``file://`` if none.
+        """
+        if file_path.startswith(_ABSOLUTE_URI_SCHEMES):
+            return file_path
         if self._warehouse_scheme:
             return f"{self._warehouse_scheme}://{file_path}"
         return f"file://{file_path}"

--- a/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
@@ -17,6 +17,11 @@
 ################################################################################
 import unittest
 
+import pytest
+
+pypaimon = pytest.importorskip("pypaimon")
+daft = pytest.importorskip("daft")
+
 from pypaimon.daft.daft_datasource import PaimonDataSource
 
 

--- a/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
@@ -15,14 +15,12 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-"""Unit tests for PaimonDataSource helper methods."""
 import unittest
 
 from pypaimon.daft.daft_datasource import PaimonDataSource
 
 
 def _build_uri(warehouse_scheme: str, file_path: str) -> str:
-    """Invoke ``_build_file_uri`` on a stub with the given ``_warehouse_scheme``."""
     class _Stub:
         pass
     stub = _Stub()
@@ -31,15 +29,8 @@ def _build_uri(warehouse_scheme: str, file_path: str) -> str:
 
 
 class BuildFileUriTest(unittest.TestCase):
-    """Verify _build_file_uri does not double-prefix absolute paths.
-
-    REST catalogs (e.g. DLF) return absolute ``oss://`` / ``s3://`` paths in
-    DataFileMeta.file_path. The previous unconditional prefix produced
-    invalid URIs like ``file://oss://bucket/...``.
-    """
 
     def test_passes_through_when_path_already_has_scheme(self):
-        # (warehouse_scheme, file_path) -> expected (== file_path)
         cases = [
             ("",     "oss://bucket/db.db/tbl/data.parquet"),
             ("",     "s3://bucket/key.parquet"),
@@ -47,9 +38,7 @@ class BuildFileUriTest(unittest.TestCase):
             ("",     "s3n://bucket/key.parquet"),
             ("",     "hdfs://nameservice/path/data.parquet"),
             ("file", "file:///abs/path/data.parquet"),
-            # warehouse_scheme also set → file_path still wins (no double prefix)
             ("oss",  "oss://bucket/db.db/tbl/data.parquet"),
-            # Regression: real DLF + OSS shape, warehouse is a catalog name (no scheme)
             ("",     "oss://clg-paimon-fe4767/db.db/tbl/bucket-0/data-0.parquet"),
         ]
         for warehouse_scheme, file_path in cases:
@@ -63,7 +52,6 @@ class BuildFileUriTest(unittest.TestCase):
         )
 
     def test_defaults_to_file_scheme_when_both_unschemed(self):
-        # Local filesystem warehouse case (only scenario current tests cover).
         self.assertEqual(
             _build_uri("", "/tmp/pytest-xxx/db.db/tbl/data.parquet"),
             "file:///tmp/pytest-xxx/db.db/tbl/data.parquet",

--- a/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
@@ -1,0 +1,74 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+"""Unit tests for PaimonDataSource helper methods."""
+import unittest
+
+from pypaimon.daft.daft_datasource import PaimonDataSource
+
+
+def _build_uri(warehouse_scheme: str, file_path: str) -> str:
+    """Invoke ``_build_file_uri`` on a stub with the given ``_warehouse_scheme``."""
+    class _Stub:
+        pass
+    stub = _Stub()
+    stub._warehouse_scheme = warehouse_scheme
+    return PaimonDataSource._build_file_uri(stub, file_path)
+
+
+class BuildFileUriTest(unittest.TestCase):
+    """Verify _build_file_uri does not double-prefix absolute paths.
+
+    REST catalogs (e.g. DLF) return absolute ``oss://`` / ``s3://`` paths in
+    DataFileMeta.file_path. The previous unconditional prefix produced
+    invalid URIs like ``file://oss://bucket/...``.
+    """
+
+    def test_passes_through_when_path_already_has_scheme(self):
+        # (warehouse_scheme, file_path) -> expected (== file_path)
+        cases = [
+            ("",     "oss://bucket/db.db/tbl/data.parquet"),
+            ("",     "s3://bucket/key.parquet"),
+            ("",     "s3a://bucket/key.parquet"),
+            ("",     "s3n://bucket/key.parquet"),
+            ("",     "hdfs://nameservice/path/data.parquet"),
+            ("file", "file:///abs/path/data.parquet"),
+            # warehouse_scheme also set → file_path still wins (no double prefix)
+            ("oss",  "oss://bucket/db.db/tbl/data.parquet"),
+            # Regression: real DLF + OSS shape, warehouse is a catalog name (no scheme)
+            ("",     "oss://clg-paimon-fe4767/db.db/tbl/bucket-0/data-0.parquet"),
+        ]
+        for warehouse_scheme, file_path in cases:
+            with self.subTest(warehouse_scheme=warehouse_scheme, file_path=file_path):
+                self.assertEqual(_build_uri(warehouse_scheme, file_path), file_path)
+
+    def test_adds_warehouse_scheme_when_path_unschemed(self):
+        self.assertEqual(
+            _build_uri("oss", "bucket/db.db/tbl/data.parquet"),
+            "oss://bucket/db.db/tbl/data.parquet",
+        )
+
+    def test_defaults_to_file_scheme_when_both_unschemed(self):
+        # Local filesystem warehouse case (only scenario current tests cover).
+        self.assertEqual(
+            _build_uri("", "/tmp/pytest-xxx/db.db/tbl/data.parquet"),
+            "file:///tmp/pytest-xxx/db.db/tbl/data.parquet",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Purpose
When running a Daft read_paimon(...) against a Paimon table managed by Paimon REST catalog backed by OSS, the read crashes immediately:

  daft.exceptions.DaftCoreException: DaftError::External Unable to convert URL
    "file://oss://my_bucket/my_db.db/my_tablebucket-0/data-0d475e4b-c35b-4afa-a5d9-a467cc008462-0.parquet"
    to path

  Note the file://oss://... — double scheme. Daft's URL parser can't make sense of it. This PR fixes the above issue 

### Tests
`daft_datasource_test`