### PR TITLE
[python] [daft] Inject REST catalog OSS credentials into Daft IOConfig

### DIFF
--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -166,9 +166,6 @@ class PaimonDataSource(DataSource):
 
         self._file_format = table.options.file_format().lower()
         self._is_parquet = self._file_format == PAIMON_FILE_FORMAT_PARQUET
-        # REST catalogs (DLF) issue dynamic OSS tokens that Daft's static IOConfig can't refresh; fall back to pypaimon's reader which shares the catalog's token-aware file_io.
-        if self._is_parquet and catalog_options.get("metastore") == "rest":
-            self._is_parquet = False
 
         self._partition_field_arrow_types: dict[str, pa.DataType] = (
             {f.name: PyarrowFieldParser.from_paimon_type(f.type) for f in table.partition_keys_fields}

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -166,6 +166,9 @@ class PaimonDataSource(DataSource):
 
         self._file_format = table.options.file_format().lower()
         self._is_parquet = self._file_format == PAIMON_FILE_FORMAT_PARQUET
+        # REST catalogs (DLF) issue dynamic OSS tokens that Daft's static IOConfig can't refresh; fall back to pypaimon's reader which shares the catalog's token-aware file_io.
+        if self._is_parquet and catalog_options.get("metastore") == "rest":
+            self._is_parquet = False
 
         self._partition_field_arrow_types: dict[str, pa.DataType] = (
             {f.name: PyarrowFieldParser.from_paimon_type(f.type) for f in table.partition_keys_fields}

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -36,6 +36,23 @@ if TYPE_CHECKING:
     from pypaimon.table.file_store_table import FileStoreTable
 
 
+def _enrich_options_with_rest_token(
+    catalog_options: Dict[str, str], table: "FileStoreTable"
+) -> Dict[str, str]:
+    # REST catalogs (DLF) issue dynamic OSS STS tokens through table.file_io rather
+    # than catalog_options; fold them into the options dict so Daft's IOConfig gets
+    # the same credentials pypaimon would use for its own reads.
+    if catalog_options.get("metastore") != "rest":
+        return catalog_options
+    file_io = getattr(table, "file_io", None)
+    if file_io is None or not hasattr(file_io, "try_to_refresh_token"):
+        return catalog_options
+    file_io.try_to_refresh_token()
+    if file_io.token is None:
+        return catalog_options
+    return {**catalog_options, **file_io.token.token}
+
+
 def _read_table(
     table: FileStoreTable,
     catalog_options: Dict[str, str] | None = None,
@@ -68,7 +85,9 @@ def _read_table(
     if catalog_options is None:
         catalog_options = {}
 
-    io_config = io_config or _convert_paimon_catalog_options_to_io_config(catalog_options)
+    io_config = io_config or _convert_paimon_catalog_options_to_io_config(
+        _enrich_options_with_rest_token(catalog_options, table)
+    )
     io_config = io_config or context.get_context().daft_planning_config.default_io_config
 
     multithreaded_io = runners.get_or_create_runner().name != "ray"

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -74,11 +74,8 @@ def _read_table(
     multithreaded_io = runners.get_or_create_runner().name != "ray"
     storage_config = StorageConfig(multithreaded_io, io_config)
 
-    warehouse = catalog_options.get("warehouse", "")
-    scan_catalog_options = {"warehouse": warehouse} if warehouse else {}
-
     source = PaimonDataSource(
-        table, storage_config=storage_config, catalog_options=scan_catalog_options
+        table, storage_config=storage_config, catalog_options=catalog_options
     )
     return source.read()
 

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -39,9 +39,7 @@ if TYPE_CHECKING:
 def _enrich_options_with_rest_token(
     catalog_options: Dict[str, str], table: "FileStoreTable"
 ) -> Dict[str, str]:
-    # REST catalogs (DLF) issue dynamic OSS STS tokens through table.file_io rather
-    # than catalog_options; fold them into the options dict so Daft's IOConfig gets
-    # the same credentials pypaimon would use for its own reads.
+    # REST catalogs (DLF) deliver OSS STS tokens via table.file_io; fold them in so Daft's IOConfig matches pypaimon's.
     if catalog_options.get("metastore") != "rest":
         return catalog_options
     file_io = getattr(table, "file_io", None)

--- a/paimon-python/pypaimon/daft/daft_paimon.py
+++ b/paimon-python/pypaimon/daft/daft_paimon.py
@@ -29,6 +29,7 @@ Usage::
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, Optional
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     import daft
@@ -39,7 +40,8 @@ if TYPE_CHECKING:
 def _enrich_options_with_rest_token(
     catalog_options: Dict[str, str], table: "FileStoreTable"
 ) -> Dict[str, str]:
-    # REST catalogs (DLF) deliver OSS STS tokens via table.file_io; fold them in so Daft's IOConfig matches pypaimon's.
+    # REST catalogs (DLF) keep OSS STS tokens on table.file_io and the bucket on table.table_path,
+    # not in catalog_options; fold both in so Daft's IOConfig routes to OSS with valid credentials.
     if catalog_options.get("metastore") != "rest":
         return catalog_options
     file_io = getattr(table, "file_io", None)
@@ -48,7 +50,11 @@ def _enrich_options_with_rest_token(
     file_io.try_to_refresh_token()
     if file_io.token is None:
         return catalog_options
-    return {**catalog_options, **file_io.token.token}
+    enriched = {**catalog_options, **file_io.token.token}
+    parsed = urlparse(getattr(table, "table_path", "") or "")
+    if parsed.scheme and parsed.netloc:
+        enriched["warehouse"] = f"{parsed.scheme}://{parsed.netloc}"
+    return enriched
 
 
 def _read_table(

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -16,12 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-"""Tests for the daft + REST catalog code path.
-
-- Wrapper tests use MagicMock to isolate PaimonCatalog transformation logic.
-- Read-flow tests use the in-process RESTCatalogServer to exercise
-  _read_table + PaimonDataSource end-to-end against a real REST catalog.
-"""
+"""Tests for the daft + REST catalog code path."""
 
 from __future__ import annotations
 
@@ -239,23 +234,9 @@ def test_create_namespace_single_part():
     inner.create_database.assert_called_once_with("new_db", ignore_if_exists=False)
 
 
-# ---------------------------------------------------------------------------
-# Read-flow tests against an in-process REST catalog server
-# ---------------------------------------------------------------------------
-
-
 class DaftRestReadTest(RESTBaseTest):
-    """End-to-end tests for the daft → REST catalog read path.
-
-    Uses RESTBaseTest's in-process RESTCatalogServer; self.table is a
-    populated append-only table created in setUp.
-    """
 
     def test_read_table_forwards_full_catalog_options_to_datasource(self):
-        """Reproduces Bug A: _read_table trims catalog_options to just
-        {'warehouse': ...} before constructing PaimonDataSource, dropping
-        metastore/uri/token/dlf.* — fields the connector needs to detect
-        a REST catalog and reach DLF credentials."""
         from pypaimon.daft.daft_datasource import PaimonDataSource
         from pypaimon.daft.daft_paimon import _read_table
 
@@ -274,29 +255,11 @@ class DaftRestReadTest(RESTBaseTest):
             _read_table(self.table, catalog_options=self.options)
 
         received = captured["catalog_options"]
-        self.assertEqual(
-            received.get("metastore"), "rest",
-            f"metastore stripped before reaching PaimonDataSource; got {received}",
-        )
-        self.assertIn(
-            "uri", received,
-            f"uri stripped before reaching PaimonDataSource; got {received}",
-        )
-        self.assertIn(
-            "token", received,
-            f"token stripped before reaching PaimonDataSource; got {received}",
-        )
+        self.assertEqual(received.get("metastore"), "rest", received)
+        self.assertIn("uri", received, received)
+        self.assertIn("token", received, received)
 
     def test_rest_catalog_disables_native_parquet_reader(self):
-        """Reproduces Bug B: PaimonDataSource leaves _is_parquet=True for
-        REST catalogs, sending OSS reads through Daft's static IOConfig
-        which cannot refresh DLF dynamic STS tokens. Should fall back to
-        the pypaimon reader whose file_io does refresh tokens.
-
-        Default file format is ORC, which makes _is_parquet=False
-        trivially; explicitly create a parquet table to isolate the
-        REST-detection path.
-        """
         from daft import context
         from daft.daft import StorageConfig
 
@@ -327,9 +290,4 @@ class DaftRestReadTest(RESTBaseTest):
             catalog_options=self.options,
         )
 
-        self.assertFalse(
-            source._is_parquet,
-            "REST catalog should disable native parquet reader; "
-            "Daft's static IOConfig cannot refresh DLF dynamic OSS tokens, "
-            "but is_parquet=True ⇒ DataSourceTask.parquet is yielded.",
-        )
+        self.assertFalse(source._is_parquet)

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -289,3 +289,20 @@ class DaftRestReadTest(RESTBaseTest):
         for k, v in token_payload.items():
             self.assertEqual(captured["opts"].get(k), v, captured["opts"])
         fake_file_io.try_to_refresh_token.assert_called()
+
+    def test_enrich_is_noop_when_not_rest_metastore(self):
+        from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
+        opts = {"warehouse": "/tmp/x", "metastore": "filesystem"}
+        self.assertIs(_enrich_options_with_rest_token(opts, self.table), opts)
+
+    def test_enrich_is_noop_when_file_io_has_no_refresh(self):
+        from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
+        with patch.object(self.table, "file_io", MagicMock(spec=[])):
+            self.assertIs(_enrich_options_with_rest_token(self.options, self.table), self.options)
+
+    def test_enrich_is_noop_when_token_is_none(self):
+        from pypaimon.daft.daft_paimon import _enrich_options_with_rest_token
+        fake_file_io = MagicMock()
+        fake_file_io.token = None
+        with patch.object(self.table, "file_io", fake_file_io):
+            self.assertIs(_enrich_options_with_rest_token(self.options, self.table), self.options)

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -16,11 +16,16 @@
 # limitations under the License.
 ################################################################################
 
-"""Unit tests for PaimonCatalog REST catalog path (using mocks, no real server needed)."""
+"""Tests for the daft + REST catalog code path.
+
+- Wrapper tests use MagicMock to isolate PaimonCatalog transformation logic.
+- Read-flow tests use the in-process RESTCatalogServer to exercise
+  _read_table + PaimonDataSource end-to-end against a real REST catalog.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -34,6 +39,7 @@ from pypaimon.catalog.catalog_exception import (
 )
 
 from pypaimon.daft.daft_catalog import PaimonCatalog
+from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 
 # ---------------------------------------------------------------------------
 # Helpers: build a mock inner catalog that mimics RESTCatalog's interface
@@ -231,3 +237,99 @@ def test_create_namespace_single_part():
     cat.create_namespace("new_db")
 
     inner.create_database.assert_called_once_with("new_db", ignore_if_exists=False)
+
+
+# ---------------------------------------------------------------------------
+# Read-flow tests against an in-process REST catalog server
+# ---------------------------------------------------------------------------
+
+
+class DaftRestReadTest(RESTBaseTest):
+    """End-to-end tests for the daft → REST catalog read path.
+
+    Uses RESTBaseTest's in-process RESTCatalogServer; self.table is a
+    populated append-only table created in setUp.
+    """
+
+    def test_read_table_forwards_full_catalog_options_to_datasource(self):
+        """Reproduces Bug A: _read_table trims catalog_options to just
+        {'warehouse': ...} before constructing PaimonDataSource, dropping
+        metastore/uri/token/dlf.* — fields the connector needs to detect
+        a REST catalog and reach DLF credentials."""
+        from pypaimon.daft.daft_datasource import PaimonDataSource
+        from pypaimon.daft.daft_paimon import _read_table
+
+        captured = {}
+        original_init = PaimonDataSource.__init__
+
+        def spy_init(_self, table, storage_config, catalog_options):
+            captured["catalog_options"] = dict(catalog_options)
+            return original_init(
+                _self, table,
+                storage_config=storage_config,
+                catalog_options=catalog_options,
+            )
+
+        with patch.object(PaimonDataSource, "__init__", spy_init):
+            _read_table(self.table, catalog_options=self.options)
+
+        received = captured["catalog_options"]
+        self.assertEqual(
+            received.get("metastore"), "rest",
+            f"metastore stripped before reaching PaimonDataSource; got {received}",
+        )
+        self.assertIn(
+            "uri", received,
+            f"uri stripped before reaching PaimonDataSource; got {received}",
+        )
+        self.assertIn(
+            "token", received,
+            f"token stripped before reaching PaimonDataSource; got {received}",
+        )
+
+    def test_rest_catalog_disables_native_parquet_reader(self):
+        """Reproduces Bug B: PaimonDataSource leaves _is_parquet=True for
+        REST catalogs, sending OSS reads through Daft's static IOConfig
+        which cannot refresh DLF dynamic STS tokens. Should fall back to
+        the pypaimon reader whose file_io does refresh tokens.
+
+        Default file format is ORC, which makes _is_parquet=False
+        trivially; explicitly create a parquet table to isolate the
+        REST-detection path.
+        """
+        from daft import context
+        from daft.daft import StorageConfig
+
+        from pypaimon.daft.daft_datasource import PaimonDataSource
+        from pypaimon.daft.daft_io_config import (
+            _convert_paimon_catalog_options_to_io_config,
+        )
+
+        self.rest_catalog.create_table(
+            "default.daft_rest_parquet",
+            pypaimon.Schema.from_pyarrow_schema(
+                self.pa_schema, options={"file.format": "parquet"}
+            ),
+            False,
+        )
+        parquet_table = self.rest_catalog.get_table("default.daft_rest_parquet")
+        self.assertEqual(parquet_table.options.file_format(), "parquet")
+
+        io_config = (
+            _convert_paimon_catalog_options_to_io_config(self.options)
+            or context.get_context().daft_planning_config.default_io_config
+        )
+        storage_config = StorageConfig(True, io_config)
+
+        source = PaimonDataSource(
+            parquet_table,
+            storage_config=storage_config,
+            catalog_options=self.options,
+        )
+
+        self.assertFalse(
+            source._is_parquet,
+            "REST catalog should disable native parquet reader; "
+            "Daft's static IOConfig cannot refresh DLF dynamic OSS tokens, "
+            "but is_parquet=True ⇒ DataSourceTask.parquet is yielded.",
+        )

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -280,14 +280,17 @@ class DaftRestReadTest(RESTBaseTest):
             captured["opts"] = dict(opts)
             return original_builder(opts)
 
-        oss_options = {**self.options, "warehouse": "oss://bucket/wh"}
+        oss_options = {**self.options, "warehouse": "morax_test"}
+        oss_table_path = "oss://my-bucket/db.db/tbl-abc"
 
         with patch.object(self.table, "file_io", fake_file_io), \
+             patch.object(self.table, "table_path", oss_table_path), \
              patch.object(daft_io_config, "_convert_paimon_catalog_options_to_io_config", spy_builder):
             _read_table(self.table, catalog_options=oss_options)
 
         for k, v in token_payload.items():
             self.assertEqual(captured["opts"].get(k), v, captured["opts"])
+        self.assertEqual(captured["opts"].get("warehouse"), "oss://my-bucket", captured["opts"])
         fake_file_io.try_to_refresh_token.assert_called()
 
     def test_enrich_is_noop_when_not_rest_metastore(self):

--- a/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py
@@ -259,35 +259,33 @@ class DaftRestReadTest(RESTBaseTest):
         self.assertIn("uri", received, received)
         self.assertIn("token", received, received)
 
-    def test_rest_catalog_disables_native_parquet_reader(self):
-        from daft import context
-        from daft.daft import StorageConfig
+    def test_read_table_enriches_io_config_with_rest_token(self):
+        from pypaimon.daft import daft_io_config
+        from pypaimon.daft.daft_paimon import _read_table
 
-        from pypaimon.daft.daft_datasource import PaimonDataSource
-        from pypaimon.daft.daft_io_config import (
-            _convert_paimon_catalog_options_to_io_config,
-        )
+        token_payload = {
+            "fs.oss.accessKeyId": "ak-from-dlf",
+            "fs.oss.accessKeySecret": "sk-from-dlf",
+            "fs.oss.securityToken": "sts-from-dlf",
+        }
+        fake_token = MagicMock()
+        fake_token.token = token_payload
+        fake_file_io = MagicMock()
+        fake_file_io.token = fake_token
 
-        self.rest_catalog.create_table(
-            "default.daft_rest_parquet",
-            pypaimon.Schema.from_pyarrow_schema(
-                self.pa_schema, options={"file.format": "parquet"}
-            ),
-            False,
-        )
-        parquet_table = self.rest_catalog.get_table("default.daft_rest_parquet")
-        self.assertEqual(parquet_table.options.file_format(), "parquet")
+        captured = {}
+        original_builder = daft_io_config._convert_paimon_catalog_options_to_io_config
 
-        io_config = (
-            _convert_paimon_catalog_options_to_io_config(self.options)
-            or context.get_context().daft_planning_config.default_io_config
-        )
-        storage_config = StorageConfig(True, io_config)
+        def spy_builder(opts):
+            captured["opts"] = dict(opts)
+            return original_builder(opts)
 
-        source = PaimonDataSource(
-            parquet_table,
-            storage_config=storage_config,
-            catalog_options=self.options,
-        )
+        oss_options = {**self.options, "warehouse": "oss://bucket/wh"}
 
-        self.assertFalse(source._is_parquet)
+        with patch.object(self.table, "file_io", fake_file_io), \
+             patch.object(daft_io_config, "_convert_paimon_catalog_options_to_io_config", spy_builder):
+            _read_table(self.table, catalog_options=oss_options)
+
+        for k, v in token_payload.items():
+            self.assertEqual(captured["opts"].get(k), v, captured["opts"])
+        fake_file_io.try_to_refresh_token.assert_called()


### PR DESCRIPTION
### Purpose

  Daft reads against an Apache Paimon REST catalog (DLF) currently 401 on OSS: `_convert_paimon_catalog_options_to_io_config` builds Daft's `IOConfig` from static `fs.oss.*` keys, but DLF delivers per-table STS tokens through `table.file_io` rather than `catalog_options`.

  `_read_table` now folds `table.file_io.token.token` into the options before building `IOConfig`, so Daft's native parquet reader gets the same credentials pypaimon uses. It also stops trimming `catalog_options` to `{warehouse: ...}` so the enrichment can read the
  `metastore` field.

  ### Tests

  `daft_catalog_rest_test.py::DaftRestReadTest`:
  - `test_read_table_forwards_full_catalog_options_to_datasource`
  - `test_read_table_enriches_io_config_with_rest_token`
