### PR TITLE
[python] Add requests as dependency

### DIFF
--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -37,3 +37,4 @@ zstandard>=0.19,<1
 backports.zstd>=1.0.0,<1.4.0; python_version >= "3.9" and python_version < "3.14"
 cramjam>=1.3.0,<3; python_version>="3.7"
 pyyaml>=5.4,<7
+requests>=2.21.0,<3


### PR DESCRIPTION
### Purpose

Currently requests is required to using Paimon, otherwise it will raise error when importing `paimon` on current main branch:

```
>>> import pypaimon
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import pypaimon
  File "/home/asaka/paimon/paimon-python/pypaimon/__init__.py", line 26, in <module>
    from pypaimon.catalog.catalog_factory import CatalogFactory
  File "/home/asaka/paimon/paimon-python/pypaimon/catalog/catalog_factory.py", line 23, in <module>
    from pypaimon.catalog.filesystem_catalog import FileSystemCatalog
  File "/home/asaka/paimon/paimon-python/pypaimon/catalog/filesystem_catalog.py", line 45, in <module>
    from pypaimon.table.file_store_table import FileStoreTable
  File "/home/asaka/paimon/paimon-python/pypaimon/table/file_store_table.py", line 25, in <module>
    from pypaimon.read.read_builder import ReadBuilder
  File "/home/asaka/paimon/paimon-python/pypaimon/read/read_builder.py", line 20, in <module>
    from pypaimon.common.predicate import Predicate
  File "/home/asaka/paimon/paimon-python/pypaimon/common/predicate.py", line 29, in <module>
    from pypaimon.manifest.schema.simple_stats import SimpleStats
  File "/home/asaka/paimon/paimon-python/pypaimon/manifest/schema/simple_stats.py", line 22, in <module>
    from pypaimon.table.row.generic_row import GenericRow
  File "/home/asaka/paimon/paimon-python/pypaimon/table/row/generic_row.py", line 28, in <module>
    from pypaimon.table.row.blob import BlobData
  File "/home/asaka/paimon/paimon-python/pypaimon/table/row/blob.py", line 24, in <module>
    from pypaimon.common.uri_reader import UriReader, FileUriReader
  File "/home/asaka/paimon/paimon-python/pypaimon/common/uri_reader.py", line 23, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

With the latest release of `pypaimon` on PyPI, we can import `pypaimon`, but `import CatalogFactory from pypaimon` will raise the same error.

Adding `requests` to `requirements.txt` can resolve this error. `requests 2.21.0` was released in 2018, I think it's old enough to be used as the minimum version range.

### Tests
