### PR TITLE
[python] Implement snapshot expiration for pypaimon

### DIFF
--- a/paimon-python/pypaimon/changelog/changelog_manager.py
+++ b/paimon-python/pypaimon/changelog/changelog_manager.py
@@ -349,3 +349,7 @@ class ChangelogManager:
             pass
         except Exception as e:
             logger.warning(f"Failed to delete earliest hint {earliest_file}: {e}")
+
+    def delete_changelog(self, changelog_id: int) -> None:
+        path = self.long_lived_changelog_path(changelog_id)
+        self.file_io.delete_quietly(path)

--- a/paimon-python/pypaimon/cli/cli_table.py
+++ b/paimon-python/pypaimon/cli/cli_table.py
@@ -879,6 +879,56 @@ def cmd_table_drop_partition(args):
         sys.exit(1)
 
 
+def cmd_table_expire_snapshots(args):
+    """Execute the 'table expire-snapshots' command."""
+    from pypaimon.cli.cli import load_catalog_config, create_catalog
+    from pypaimon.table.file_store_table import FileStoreTable
+    from pypaimon.options.expire_config import ExpireConfig
+
+    config = load_catalog_config(args.config)
+    catalog = create_catalog(config)
+    table_identifier = args.table
+
+    try:
+        table = catalog.get_table(table_identifier)
+    except Exception as e:
+        print(f"Error: Failed to get table '{table_identifier}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(table, FileStoreTable):
+        print(f"Error: Table '{table_identifier}' is not a FileStoreTable.", file=sys.stderr)
+        sys.exit(1)
+
+    expire_config = ExpireConfig(
+        snapshot_retain_max=getattr(args, 'retain_max', None) or sys.maxsize,
+        snapshot_retain_min=getattr(args, 'retain_min', None) or 1,
+        snapshot_time_retain_millis=_parse_duration_millis(
+            getattr(args, 'time_retain', None)),
+        snapshot_max_deletes=getattr(args, 'max_deletes', None) or sys.maxsize,
+    )
+
+    expired = table.new_expire_snapshots().config(expire_config).expire()
+    print(JSON.to_json({"expired_snapshot_count": expired}, indent=2))
+
+
+def _parse_duration_millis(duration_str):
+    if not duration_str:
+        return sys.maxsize
+    unit = duration_str[-1].lower()
+    multipliers = {'d': 86400000, 'h': 3600000, 'm': 60000, 's': 1000}
+    if unit not in multipliers:
+        print(f"Error: Unknown duration unit '{unit}'. Use d/h/m/s (e.g. 7d, 24h).",
+              file=sys.stderr)
+        sys.exit(1)
+    try:
+        value = int(duration_str[:-1])
+    except ValueError:
+        print(f"Error: Invalid duration value '{duration_str}'. Use format like 7d, 24h.",
+              file=sys.stderr)
+        sys.exit(1)
+    return value * multipliers[unit]
+
+
 def add_table_subcommands(table_parser):
     """
     Add table subcommands to the parser.
@@ -1170,3 +1220,22 @@ def add_table_subcommands(table_parser):
     update_comment_parser = alter_subparsers.add_parser('update-comment', help='Update table comment')
     update_comment_parser.add_argument('--comment', '-c', required=True, help='New table comment')
     update_comment_parser.set_defaults(func=cmd_table_alter)
+
+    # table expire-snapshots command
+    expire_parser = table_subparsers.add_parser(
+        'expire-snapshots', help='Expire old snapshots and clean up files'
+    )
+    expire_parser.add_argument('table', help='Table identifier in format: database.table')
+    expire_parser.add_argument(
+        '--retain-max', type=int, default=None,
+        help='Maximum number of snapshots to retain')
+    expire_parser.add_argument(
+        '--retain-min', type=int, default=None,
+        help='Minimum number of snapshots to retain')
+    expire_parser.add_argument(
+        '--time-retain', type=str, default=None,
+        help='Minimum time to retain snapshots (e.g. 7d, 24h)')
+    expire_parser.add_argument(
+        '--max-deletes', type=int, default=None,
+        help='Maximum number of snapshots to delete per run')
+    expire_parser.set_defaults(func=cmd_table_expire_snapshots)

--- a/paimon-python/pypaimon/manifest/schema/data_file_meta.py
+++ b/paimon-python/pypaimon/manifest/schema/data_file_meta.py
@@ -30,6 +30,9 @@ from pypaimon.utils.file_store_path_factory import _is_null_or_whitespace_only
 
 @dataclass
 class DataFileMeta:
+    FILE_SOURCE_APPEND = 0
+    FILE_SOURCE_COMPACT = 1
+
     file_name: str
     file_size: int
     row_count: int

--- a/paimon-python/pypaimon/manifest/schema/file_entry.py
+++ b/paimon-python/pypaimon/manifest/schema/file_entry.py
@@ -26,6 +26,9 @@ class FileEntry:
     The same Identifier indicates that the FileEntry refers to the same data file.
     """
 
+    KIND_ADD = 0
+    KIND_DELETE = 1
+
     class Identifier:
         """Unique identifier for a file entry.
 
@@ -109,13 +112,13 @@ class FileEntry:
 
         for entry in entries:
             entry_identifier = entry.identifier()
-            if entry.kind == 0:  # ADD
+            if entry.kind == FileEntry.KIND_ADD:
                 if entry_identifier in entry_map:
                     raise RuntimeError(
                         "Trying to add file {} which is already added.".format(
                             entry.file.file_name))
                 entry_map[entry_identifier] = entry
-            elif entry.kind == 1:  # DELETE
+            elif entry.kind == FileEntry.KIND_DELETE:
                 if entry_identifier in entry_map:
                     del entry_map[entry_identifier]
                 else:

--- a/paimon-python/pypaimon/operation/__init__.py
+++ b/paimon-python/pypaimon/operation/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/paimon-python/pypaimon/operation/expire_snapshots.py
+++ b/paimon-python/pypaimon/operation/expire_snapshots.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import time
+from typing import List, Optional
+
+from pypaimon.options.expire_config import ExpireConfig
+from pypaimon.snapshot.snapshot import Snapshot
+
+logger = logging.getLogger(__name__)
+
+
+class ExpireSnapshots:
+
+    def __init__(self, snapshot_manager, changelog_manager, consumer_manager,
+                 snapshot_deletion, tag_manager):
+        self.snapshot_manager = snapshot_manager
+        self.changelog_manager = changelog_manager
+        self.consumer_manager = consumer_manager
+        self.snapshot_deletion = snapshot_deletion
+        self.tag_manager = tag_manager
+        self._config: Optional[ExpireConfig] = None
+
+    def config(self, expire_config: ExpireConfig) -> 'ExpireSnapshots':
+        self._config = expire_config
+        return self
+
+    def expire(self) -> int:
+        if self._config is None:
+            self._config = ExpireConfig()
+        self._config.validate()
+
+        changelog_decoupled = self._config.is_changelog_decoupled()
+        retain_max = self._config.snapshot_retain_max
+        retain_min = self._config.snapshot_retain_min
+        max_deletes = self._config.snapshot_max_deletes
+        older_than_millis = int(time.time() * 1000) - self._config.snapshot_time_retain_millis
+
+        latest_id = self.snapshot_manager.latest_snapshot_id()
+        earliest_id = self.snapshot_manager.earliest_snapshot_id()
+        if latest_id is None or earliest_id is None:
+            return 0
+
+        begin = max(latest_id - retain_max + 1, earliest_id)
+        max_exclusive = latest_id - retain_min + 1
+
+        consumer_min = self.consumer_manager.min_next_snapshot()
+        if consumer_min is not None:
+            max_exclusive = min(max_exclusive, consumer_min)
+        max_exclusive = min(max_exclusive, earliest_id + max_deletes)
+
+        for sid in range(begin, max_exclusive):
+            try:
+                next_snapshot = self.snapshot_manager.get_snapshot_by_id(sid + 1)
+                if next_snapshot is not None and next_snapshot.time_millis >= older_than_millis:
+                    return self._expire_until(earliest_id, sid, changelog_decoupled)
+            except FileNotFoundError:
+                pass
+
+        return self._expire_until(earliest_id, max_exclusive, changelog_decoupled)
+
+    def _expire_until(self, earliest_id: int, end_exclusive_id: int,
+                      changelog_decoupled: bool) -> int:
+        if end_exclusive_id <= earliest_id:
+            self.snapshot_manager.commit_earliest_hint(earliest_id)
+            return 0
+
+        snapshots_batch = self.snapshot_manager.get_snapshots_batch(
+            list(range(earliest_id, end_exclusive_id + 1))
+        )
+        all_snapshots = [snapshots_batch[sid] for sid in range(earliest_id, end_exclusive_id + 1)
+                         if snapshots_batch.get(sid) is not None]
+        expiring_snapshots = [s for s in all_snapshots if s.id < end_exclusive_id]
+        if not expiring_snapshots:
+            self.snapshot_manager.commit_earliest_hint(end_exclusive_id)
+            return 0
+
+        end_snapshot = snapshots_batch.get(end_exclusive_id)
+        if end_snapshot is None:
+            self.snapshot_manager.commit_earliest_hint(earliest_id)
+            return 0
+
+        tagged_snapshots = self.tag_manager.tagged_snapshots()
+
+        self._clean_data_files(all_snapshots, earliest_id, tagged_snapshots,
+                               changelog_decoupled)
+
+        if not changelog_decoupled:
+            self._clean_changelog_data(expiring_snapshots)
+
+        self.snapshot_deletion.clean_empty_directories()
+
+        self._clean_metadata(expiring_snapshots, tagged_snapshots, earliest_id,
+                             end_exclusive_id, end_snapshot, changelog_decoupled)
+
+        return self._delete_snapshots(expiring_snapshots, end_exclusive_id,
+                                      changelog_decoupled)
+
+    def _clean_data_files(self, all_snapshots: List[Snapshot], earliest_id: int,
+                          tagged_snapshots: list, changelog_decoupled: bool) -> None:
+        for snapshot in all_snapshots:
+            if snapshot.id == earliest_id:
+                continue
+            try:
+                skipper = self.snapshot_deletion.create_data_file_skipper_for_tags(
+                    tagged_snapshots, snapshot.id)
+                self.snapshot_deletion.clean_unused_data_files(
+                    snapshot, skipper, changelog_decoupled)
+            except IOError:
+                logger.warning("Failed to clean data files for snapshot %d",
+                               snapshot.id, exc_info=True)
+
+    def _clean_changelog_data(self, expiring_snapshots: List[Snapshot]) -> None:
+        for snapshot in expiring_snapshots:
+            if snapshot.changelog_manifest_list:
+                self.snapshot_deletion.delete_added_data_files(
+                    snapshot.changelog_manifest_list)
+
+    def _clean_metadata(self, expiring_snapshots: List[Snapshot], tagged_snapshots: list,
+                        earliest_id: int, end_exclusive_id: int,
+                        end_snapshot: Snapshot, changelog_decoupled: bool) -> None:
+        skipping_tags = [t for t in tagged_snapshots if earliest_id <= t.id < end_exclusive_id]
+        skipping_snapshots = list(skipping_tags) + [end_snapshot]
+        skipping_set = self.snapshot_deletion.manifest_skipping_set(skipping_snapshots)
+        for snapshot in expiring_snapshots:
+            self.snapshot_deletion.clean_unused_manifests(
+                snapshot, skipping_set, changelog_decoupled)
+
+    def _delete_snapshots(self, expiring_snapshots: List[Snapshot],
+                          end_exclusive_id: int, changelog_decoupled: bool) -> int:
+        new_earliest_id = end_exclusive_id
+        for snapshot in expiring_snapshots:
+            if changelog_decoupled:
+                if not self._commit_changelog(snapshot):
+                    logger.warning(
+                        "Stopping expiration at snapshot %d: "
+                        "failed to commit changelog in decoupled mode", snapshot.id)
+                    new_earliest_id = snapshot.id
+                    break
+            self.snapshot_manager.delete_snapshot(snapshot.id)
+
+        self.snapshot_manager.commit_earliest_hint(new_earliest_id)
+
+        if new_earliest_id == end_exclusive_id:
+            return len(expiring_snapshots)
+        return sum(1 for s in expiring_snapshots if s.id < new_earliest_id)
+
+    def _commit_changelog(self, snapshot: Snapshot) -> bool:
+        """Convert an expiring snapshot to a long-lived changelog before deletion."""
+        try:
+            from pypaimon.changelog.changelog import Changelog
+            changelog = Changelog.from_snapshot(snapshot)
+            self.changelog_manager.commit_changelog(changelog, snapshot.id)
+            self.changelog_manager.commit_long_lived_changelog_latest_hint(snapshot.id)
+            return True
+        except Exception:
+            logger.error("Failed to commit changelog for snapshot %d",
+                         snapshot.id, exc_info=True)
+            return False

--- a/paimon-python/pypaimon/operation/snapshot_deletion.py
+++ b/paimon-python/pypaimon/operation/snapshot_deletion.py
@@ -1,0 +1,262 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.file_entry import FileEntry
+from pypaimon.snapshot.snapshot import Snapshot
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotDeletion:
+    """Deletes data files and manifests associated with expired snapshots."""
+
+    def __init__(self, table):
+        from pypaimon.table.file_store_table import FileStoreTable
+        self.table: FileStoreTable = table
+        self.file_io = table.file_io
+        self.path_factory = table.path_factory()
+        self.manifest_list_manager = table.manifest_list_manager()
+        self.manifest_file_manager = table.manifest_file_manager()
+        self.deletion_buckets: Dict[tuple, Set[int]] = {}
+        self._cached_tag_id: Optional[int] = None
+        self._cached_tag_data_files: Optional[Dict[tuple, Dict[int, Set[str]]]] = None
+
+    def clean_unused_data_files(self, snapshot: Snapshot, skipper: Callable = lambda entry: False,
+                                changelog_decoupled: bool = False) -> None:
+        if not snapshot.delta_manifest_list:
+            return
+        manifest_metas = self._try_read_manifest_list(snapshot.delta_manifest_list)
+        if not manifest_metas:
+            return
+        data_file_to_delete: Dict[str, Tuple] = {}
+        for meta in manifest_metas:
+            try:
+                entries = self.manifest_file_manager.read(meta.file_name, drop_stats=True)
+            except IOError:
+                logger.warning("Failed to read manifest %s, skipping",
+                               meta.file_name, exc_info=True)
+                return
+            self._get_data_file_to_delete(data_file_to_delete, entries)
+
+        if changelog_decoupled:
+            self._do_clean_unused_data_files(
+                data_file_to_delete,
+                self._decoupled_changelog_skipper(skipper))
+        else:
+            self._do_clean_unused_data_files(data_file_to_delete, skipper)
+
+    def delete_added_data_files(self, manifest_list_name: str) -> None:
+        """Delete all ADD-kind data files from a manifest list (for changelog cleanup)."""
+        metas = self._try_read_manifest_list(manifest_list_name)
+        for meta in metas:
+            try:
+                entries = self.manifest_file_manager.read(meta.file_name, drop_stats=True)
+                for entry in entries:
+                    if entry.kind == FileEntry.KIND_ADD:
+                        bucket_path = self.path_factory.bucket_path(entry.partition, entry.bucket)
+                        self.file_io.delete_quietly(f"{bucket_path}/{entry.file.file_name}")
+            except IOError:
+                logger.debug("Failed to read manifest %s for changelog cleanup",
+                             meta.file_name, exc_info=True)
+
+    def clean_unused_manifests(self, snapshot: Snapshot, skipping_set: Set[str],
+                               changelog_decoupled: bool = False) -> None:
+        paths_to_delete = []
+        manifest_path = self.path_factory.manifest_path()
+
+        if not changelog_decoupled:
+            for ml_name in [snapshot.base_manifest_list, snapshot.delta_manifest_list,
+                            snapshot.changelog_manifest_list]:
+                if not ml_name:
+                    continue
+                metas = self._try_read_manifest_list(ml_name)
+                for meta in metas:
+                    if meta.file_name not in skipping_set:
+                        paths_to_delete.append(f"{manifest_path}/{meta.file_name}")
+                        skipping_set.add(meta.file_name)
+                if ml_name not in skipping_set:
+                    paths_to_delete.append(f"{manifest_path}/{ml_name}")
+                    skipping_set.add(ml_name)
+
+        if snapshot.index_manifest and snapshot.index_manifest not in skipping_set:
+            paths_to_delete.append(f"{manifest_path}/{snapshot.index_manifest}")
+            skipping_set.add(snapshot.index_manifest)
+        if snapshot.statistics and snapshot.statistics not in skipping_set:
+            stats_path = self.path_factory.statistics_path()
+            paths_to_delete.append(f"{stats_path}/{snapshot.statistics}")
+            skipping_set.add(snapshot.statistics)
+        self._delete_files_parallel(paths_to_delete)
+
+    def manifest_skipping_set(self, skipping_snapshots: List[Snapshot]) -> Set[str]:
+        result: Set[str] = set()
+        for snapshot in skipping_snapshots:
+            for ml_name in [snapshot.base_manifest_list, snapshot.delta_manifest_list,
+                            snapshot.changelog_manifest_list]:
+                if ml_name:
+                    result.add(ml_name)
+                    for meta in self._try_read_manifest_list(ml_name):
+                        result.add(meta.file_name)
+            if snapshot.index_manifest:
+                result.add(snapshot.index_manifest)
+                try:
+                    for ie in self.table.index_manifest_file().read(snapshot.index_manifest):
+                        result.add(ie.index_file.file_name)
+                except IOError:
+                    logger.debug("Failed to read index manifest %s",
+                                 snapshot.index_manifest, exc_info=True)
+            if snapshot.statistics:
+                result.add(snapshot.statistics)
+        return result
+
+    def create_data_file_skipper_for_tags(self, tagged_snapshots: list,
+                                          expiring_snapshot_id: int) -> Callable:
+        prev_tag = self._find_previous_tag(tagged_snapshots, expiring_snapshot_id)
+        if prev_tag is None:
+            return lambda entry: False
+        if self._cached_tag_id != prev_tag.id:
+            self._cached_tag_id = prev_tag.id
+            self._cached_tag_data_files = self._collect_tag_data_files(prev_tag)
+        return lambda entry: self._contains_data_file(self._cached_tag_data_files, entry)
+
+    def clean_empty_directories(self) -> None:
+        if not self.deletion_buckets:
+            return
+        parent_dirs_to_check = set()
+        for partition, buckets in self.deletion_buckets.items():
+            for bucket in buckets:
+                bucket_path = self.path_factory.bucket_path(partition, bucket)
+                if self._try_delete_empty_directory(bucket_path):
+                    parent_dirs_to_check.add(bucket_path.rsplit('/', 1)[0])
+        for _ in range(len(self.table.partition_keys)):
+            next_parents = set()
+            for dir_path in parent_dirs_to_check:
+                if self._try_delete_empty_directory(dir_path):
+                    next_parents.add(dir_path.rsplit('/', 1)[0])
+            parent_dirs_to_check = next_parents
+        self.deletion_buckets.clear()
+
+    # --- private helpers ---
+
+    @staticmethod
+    def _decoupled_changelog_skipper(base_skipper: Callable) -> Callable:
+        """In decoupled mode, also skip APPEND-source files (or files with unknown source
+        from old table versions). These are retained for ExpireChangelogImpl."""
+        def _should_skip(entry) -> bool:
+            if base_skipper(entry):
+                return True
+            file_source = getattr(entry.file, 'file_source', None)
+            return file_source is None or file_source == DataFileMeta.FILE_SOURCE_APPEND
+        return _should_skip
+
+    def _get_data_file_to_delete(self, data_file_to_delete: Dict[str, Tuple],
+                                 entries: list) -> None:
+        for entry in entries:
+            file_name = entry.file.file_name
+            if entry.kind == FileEntry.KIND_DELETE:
+                extra = (entry.file.extra_files
+                         if hasattr(entry.file, 'extra_files') and entry.file.extra_files
+                         else [])
+                data_file_to_delete[file_name] = (entry, extra)
+            elif entry.kind == FileEntry.KIND_ADD:
+                data_file_to_delete.pop(file_name, None)
+
+    def _do_clean_unused_data_files(self, data_file_to_delete: Dict[str, Tuple],
+                                    skipper: Callable) -> None:
+        paths_to_delete = []
+        for file_name, (entry, extra_files) in data_file_to_delete.items():
+            if skipper(entry):
+                continue
+            bucket_path = self.path_factory.bucket_path(entry.partition, entry.bucket)
+            paths_to_delete.append(f"{bucket_path}/{file_name}")
+            for extra in extra_files:
+                paths_to_delete.append(f"{bucket_path}/{extra}")
+            self._record_deletion_bucket(entry.partition, entry.bucket)
+        self._delete_files_parallel(paths_to_delete)
+
+    def _record_deletion_bucket(self, partition: tuple, bucket: int) -> None:
+        self.deletion_buckets.setdefault(partition, set()).add(bucket)
+
+    def _find_previous_tag(self, tagged_snapshots: list, snapshot_id: int):
+        result = None
+        for tag in tagged_snapshots:
+            if tag.id < snapshot_id:
+                result = tag
+            else:
+                break
+        return result
+
+    def _collect_tag_data_files(self, tag_snapshot: Snapshot) -> Dict[tuple, Dict[int, Set[str]]]:
+        result: Dict[tuple, Dict[int, Set[str]]] = {}
+        all_metas = []
+        for ml_name in [tag_snapshot.base_manifest_list, tag_snapshot.delta_manifest_list]:
+            if ml_name:
+                all_metas.extend(self._try_read_manifest_list(ml_name))
+        all_entries = []
+        for meta in all_metas:
+            try:
+                all_entries.extend(self.manifest_file_manager.read(meta.file_name, drop_stats=True))
+            except IOError:
+                logger.debug("Failed to read manifest %s for tag data files",
+                             meta.file_name, exc_info=True)
+        for entry in FileEntry.merge_entries(all_entries):
+            (result
+             .setdefault(entry.partition, {})
+             .setdefault(entry.bucket, set())
+             .add(entry.file.file_name))
+        return result
+
+    def _contains_data_file(self, tag_data_files, entry) -> bool:
+        if tag_data_files is None:
+            return False
+        bucket_map = tag_data_files.get(entry.partition)
+        if bucket_map is None:
+            return False
+        file_set = bucket_map.get(entry.bucket)
+        return file_set is not None and entry.file.file_name in file_set
+
+    def _try_delete_empty_directory(self, path: str) -> bool:
+        try:
+            if not self.file_io.list_status(path):
+                self.file_io.delete(path, recursive=False)
+                return True
+        except OSError:
+            logger.debug("Failed to delete empty directory %s", path, exc_info=True)
+        return False
+
+    def _try_read_manifest_list(self, manifest_list_name: str) -> list:
+        try:
+            return self.manifest_list_manager.read(manifest_list_name)
+        except IOError:
+            logger.debug("Failed to read manifest list %s", manifest_list_name, exc_info=True)
+            return []
+
+    def _delete_files_parallel(self, paths: List[str]) -> None:
+        if not paths:
+            return
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(self.file_io.delete_quietly, p) for p in paths]
+            for f in as_completed(futures):
+                try:
+                    f.result()
+                except OSError:
+                    logger.debug("Failed to delete file during parallel cleanup",
+                                 exc_info=True)

--- a/paimon-python/pypaimon/options/__init__.py
+++ b/paimon-python/pypaimon/options/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/paimon-python/pypaimon/options/expire_config.py
+++ b/paimon-python/pypaimon/options/expire_config.py
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ExpireConfig:
+    snapshot_retain_max: int = sys.maxsize
+    snapshot_retain_min: int = 1
+    snapshot_time_retain_millis: int = sys.maxsize
+    snapshot_max_deletes: int = sys.maxsize
+    changelog_retain_max: Optional[int] = None
+    changelog_retain_min: Optional[int] = None
+    changelog_time_retain_millis: Optional[int] = None
+    changelog_max_deletes: Optional[int] = None
+    changelog_decoupled: Optional[bool] = None
+
+    def effective_changelog_retain_max(self) -> int:
+        return self.changelog_retain_max if self.changelog_retain_max is not None else self.snapshot_retain_max
+
+    def effective_changelog_retain_min(self) -> int:
+        return self.changelog_retain_min if self.changelog_retain_min is not None else self.snapshot_retain_min
+
+    def effective_changelog_time_retain_millis(self) -> int:
+        if self.changelog_time_retain_millis is not None:
+            return self.changelog_time_retain_millis
+        return self.snapshot_time_retain_millis
+
+    def effective_changelog_max_deletes(self) -> int:
+        return self.changelog_max_deletes if self.changelog_max_deletes is not None else self.snapshot_max_deletes
+
+    def is_changelog_decoupled(self) -> bool:
+        if self.changelog_decoupled is not None:
+            return self.changelog_decoupled
+        return (
+            self.effective_changelog_retain_max() > self.snapshot_retain_max
+            or self.effective_changelog_retain_min() > self.snapshot_retain_min
+            or self.effective_changelog_time_retain_millis() > self.snapshot_time_retain_millis
+        )
+
+    def validate(self):
+        if self.snapshot_retain_max < self.snapshot_retain_min:
+            raise ValueError(
+                f"snapshot_retain_max ({self.snapshot_retain_max}) must be >= "
+                f"snapshot_retain_min ({self.snapshot_retain_min})"
+            )

--- a/paimon-python/pypaimon/snapshot/snapshot_manager.py
+++ b/paimon-python/pypaimon/snapshot/snapshot_manager.py
@@ -388,3 +388,44 @@ class SnapshotManager:
         # All fetched snapshots were skipped, but more may exist
         # Return next_id pointing past the batch
         return (None, start_id + lookahead_size, skipped_count)
+
+    def safely_get_all_snapshots(self) -> List[Snapshot]:
+        """List all snapshots, skipping those that fail to read."""
+        import re
+        snapshot_pattern = re.compile(r'^snapshot-(\d+)$')
+        try:
+            statuses = self.file_io.list_status(self.snapshot_dir)
+        except Exception:
+            return []
+        ids = []
+        for status in statuses:
+            name = status.path.rstrip('/').split('/')[-1]
+            match = snapshot_pattern.match(name)
+            if match:
+                ids.append(int(match.group(1)))
+        ids.sort()
+        snapshots = []
+        for sid in ids:
+            try:
+                snapshot = self.get_snapshot_by_id(sid)
+                if snapshot is not None:
+                    snapshots.append(snapshot)
+            except Exception:
+                logger.debug("Skipping unreadable snapshot-%d", sid)
+        return snapshots
+
+    def earliest_snapshot_id(self) -> Optional[int]:
+        snapshot = self.try_get_earliest_snapshot()
+        return snapshot.id if snapshot else None
+
+    def latest_snapshot_id(self) -> Optional[int]:
+        snapshot = self.get_latest_snapshot()
+        return snapshot.id if snapshot else None
+
+    def delete_snapshot(self, snapshot_id: int) -> None:
+        path = self.get_snapshot_path(snapshot_id)
+        self.file_io.delete_quietly(path)
+
+    def commit_earliest_hint(self, snapshot_id: int) -> None:
+        earliest_path = f"{self.snapshot_dir}/EARLIEST"
+        self.file_io.overwrite_file_utf8(earliest_path, str(snapshot_id))

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -136,6 +136,21 @@ class FileStoreTable(Table):
         from pypaimon.changelog.changelog_manager import ChangelogManager
         return ChangelogManager(self.file_io, self.table_path, self.current_branch())
 
+    def manifest_list_manager(self):
+        """Get the manifest list manager for this table."""
+        from pypaimon.manifest.manifest_list_manager import ManifestListManager
+        return ManifestListManager(self)
+
+    def manifest_file_manager(self):
+        """Get the manifest file manager for this table."""
+        from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+        return ManifestFileManager(self)
+
+    def index_manifest_file(self):
+        """Get the index manifest file handler for this table."""
+        from pypaimon.manifest.index_manifest_file import IndexManifestFile
+        return IndexManifestFile(self)
+
     def rename_branch(self, from_branch: str, to_branch: str) -> None:
         """
         Rename a branch.
@@ -405,6 +420,17 @@ class FileStoreTable(Table):
 
     def new_stream_read_builder(self) -> 'StreamReadBuilder':
         return StreamReadBuilder(self)
+
+    def new_expire_snapshots(self):
+        from pypaimon.operation.expire_snapshots import ExpireSnapshots
+        from pypaimon.operation.snapshot_deletion import SnapshotDeletion
+        return ExpireSnapshots(
+            self.snapshot_manager(),
+            self.changelog_manager(),
+            self.consumer_manager(),
+            SnapshotDeletion(self),
+            self.tag_manager(),
+        )
 
     def new_batch_write_builder(self) -> BatchWriteBuilder:
         return BatchWriteBuilder(self)

--- a/paimon-python/pypaimon/tag/tag_manager.py
+++ b/paimon-python/pypaimon/tag/tag_manager.py
@@ -250,3 +250,17 @@ class TagManager:
         self.file_io.rename(old_path, new_path)
 
         logger.info(f"Tag renamed from '{old_name}' to '{new_name}'.")
+
+    def tagged_snapshots(self) -> list:
+        """Return all tags sorted by snapshot_id. Skips unreadable tags."""
+        tag_names = self.list_tags()
+        tags = []
+        for name in tag_names:
+            try:
+                tag = self.get(name)
+                if tag is not None:
+                    tags.append(tag)
+            except Exception:
+                logger.debug("Skipping unreadable tag: %s", name)
+        tags.sort(key=lambda t: t.id)
+        return tags

--- a/paimon-python/pypaimon/tests/changelog_manager_infra_test.py
+++ b/paimon-python/pypaimon/tests/changelog_manager_infra_test.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock
+
+
+class ChangelogManagerInfraTest(unittest.TestCase):
+    def _build_manager(self, file_io, table_path="/tmp/test_table"):
+        from pypaimon.changelog.changelog_manager import ChangelogManager
+        return ChangelogManager(file_io, table_path)
+
+    def test_delete_changelog(self):
+        file_io = Mock()
+        manager = self._build_manager(file_io)
+        manager.delete_changelog(5)
+        file_io.delete_quietly.assert_called_once_with("/tmp/test_table/changelog/changelog-5")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/operation/__init__.py
+++ b/paimon-python/pypaimon/tests/operation/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/paimon-python/pypaimon/tests/operation/expire_config_test.py
+++ b/paimon-python/pypaimon/tests/operation/expire_config_test.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+import unittest
+
+
+class ExpireConfigTest(unittest.TestCase):
+
+    def test_defaults(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig()
+        self.assertEqual(config.snapshot_retain_max, sys.maxsize)
+        self.assertEqual(config.snapshot_retain_min, 1)
+        self.assertEqual(config.snapshot_time_retain_millis, sys.maxsize)
+        self.assertEqual(config.snapshot_max_deletes, sys.maxsize)
+
+    def test_changelog_fallback_to_snapshot(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=10, snapshot_retain_min=2)
+        self.assertEqual(config.effective_changelog_retain_max(), 10)
+        self.assertEqual(config.effective_changelog_retain_min(), 2)
+
+    def test_changelog_override(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=10, changelog_retain_max=20)
+        self.assertEqual(config.effective_changelog_retain_max(), 20)
+
+    def test_changelog_decoupled_auto_derived(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=10, changelog_retain_max=20)
+        self.assertTrue(config.is_changelog_decoupled())
+
+    def test_changelog_not_decoupled_when_equal(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=10)
+        self.assertFalse(config.is_changelog_decoupled())
+
+    def test_retain_max_must_gte_retain_min(self):
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=1, snapshot_retain_min=5)
+        with self.assertRaises(ValueError):
+            config.validate()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/operation/expire_snapshots_test.py
+++ b/paimon-python/pypaimon/tests/operation/expire_snapshots_test.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+
+
+class ExpireSnapshotsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.warehouse = os.path.join(self.tempdir, "warehouse")
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("default", True)
+        self.pa_schema = pa.schema([
+            ("id", pa.int32()),
+            ("name", pa.string()),
+            ("dt", pa.string()),
+        ])
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def _create_table(self, name, **opts):
+        options = {"bucket": "-1"}
+        options.update(opts)
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema, partition_keys=["dt"], options=options,
+        )
+        self.catalog.create_table(f"default.{name}", schema, False)
+        return self.catalog.get_table(f"default.{name}")
+
+    def _write(self, table, ids, names, dts):
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        data = pa.Table.from_pydict(
+            {"id": ids, "name": names, "dt": dts}, schema=self.pa_schema,
+        )
+        tw.write_arrow(data)
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+    def _read_ids(self, table):
+        rb = table.new_read_builder()
+        result = rb.new_read().to_arrow(rb.new_scan().plan().splits())
+        return sorted(result.column("id").to_pylist())
+
+    def test_expire_with_retain_max(self):
+        table = self._create_table("expire_max")
+        for i in range(5):
+            self._write(table, [i], [f"n{i}"], ["p1"])
+
+        sm = table.snapshot_manager()
+        self.assertEqual(sm.latest_snapshot_id(), 5)
+        self.assertEqual(sm.earliest_snapshot_id(), 1)
+
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=2, snapshot_retain_min=1)
+        expired = table.new_expire_snapshots().config(config).expire()
+
+        self.assertGreater(expired, 0)
+        self.assertGreaterEqual(sm.earliest_snapshot_id(), 4)
+        self.assertEqual(self._read_ids(table), [0, 1, 2, 3, 4])
+
+    def test_expire_with_retain_min(self):
+        table = self._create_table("expire_min")
+        for i in range(3):
+            self._write(table, [i], [f"n{i}"], ["p1"])
+
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=3, snapshot_retain_min=2)
+        table.new_expire_snapshots().config(config).expire()
+
+        sm = table.snapshot_manager()
+        remaining = sm.latest_snapshot_id() - sm.earliest_snapshot_id() + 1
+        self.assertGreaterEqual(remaining, 2)
+
+    def test_expire_protects_tagged_snapshot_files(self):
+        table = self._create_table("expire_tag")
+        self._write(table, [1], ["a"], ["p1"])
+        table.create_tag("v1", snapshot_id=1)
+        self._write(table, [2], ["b"], ["p1"])
+        self._write(table, [3], ["c"], ["p1"])
+
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=1, snapshot_retain_min=1)
+        table.new_expire_snapshots().config(config).expire()
+
+        self.assertEqual(self._read_ids(table), [1, 2, 3])
+
+    def test_expire_protects_consumer(self):
+        table = self._create_table("expire_consumer")
+        for i in range(5):
+            self._write(table, [i], [f"n{i}"], ["p1"])
+
+        from pypaimon.consumer.consumer import Consumer
+        cm = table.consumer_manager()
+        cm.reset_consumer("test-consumer", Consumer(next_snapshot=3))
+
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=1, snapshot_retain_min=1)
+        table.new_expire_snapshots().config(config).expire()
+
+        sm = table.snapshot_manager()
+        self.assertLessEqual(sm.earliest_snapshot_id(), 3)
+
+    def test_expire_no_snapshots(self):
+        table = self._create_table("expire_empty")
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=1)
+        expired = table.new_expire_snapshots().config(config).expire()
+        self.assertEqual(expired, 0)
+
+    def test_expire_max_deletes(self):
+        table = self._create_table("expire_limit")
+        for i in range(10):
+            self._write(table, [i], [f"n{i}"], ["p1"])
+
+        from pypaimon.options.expire_config import ExpireConfig
+        config = ExpireConfig(snapshot_retain_max=1, snapshot_retain_min=1, snapshot_max_deletes=3)
+        expired = table.new_expire_snapshots().config(config).expire()
+
+        self.assertLessEqual(expired, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/operation/snapshot_deletion_test.py
+++ b/paimon-python/pypaimon/tests/operation/snapshot_deletion_test.py
@@ -1,0 +1,89 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+
+
+class SnapshotDeletionIntegrationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.warehouse = os.path.join(self.tempdir, "warehouse")
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("default", True)
+        self.pa_schema = pa.schema([
+            ("id", pa.int32()),
+            ("name", pa.string()),
+            ("dt", pa.string()),
+        ])
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def _write_data(self, table, ids, names, dts):
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data = pa.Table.from_pydict(
+            {"id": ids, "name": names, "dt": dts},
+            schema=self.pa_schema,
+        )
+        table_write.write_arrow(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+    def test_clean_unused_data_files_basic(self):
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema, partition_keys=["dt"], options={"bucket": "-1"},
+        )
+        self.catalog.create_table("default.del_test", schema, False)
+        table = self.catalog.get_table("default.del_test")
+        self._write_data(table, [1], ["a"], ["p1"])
+        self._write_data(table, [2], ["b"], ["p1"])
+
+        from pypaimon.operation.snapshot_deletion import SnapshotDeletion
+        deletion = SnapshotDeletion(table)
+        snapshot1 = table.snapshot_manager().get_snapshot_by_id(1)
+        deletion.clean_unused_data_files(snapshot1, skipper=lambda entry: False)
+        deletion.clean_empty_directories()
+
+    def test_clean_unused_manifests(self):
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema, partition_keys=["dt"], options={"bucket": "-1"},
+        )
+        self.catalog.create_table("default.manifest_test", schema, False)
+        table = self.catalog.get_table("default.manifest_test")
+        self._write_data(table, [1], ["a"], ["p1"])
+        self._write_data(table, [2], ["b"], ["p1"])
+
+        from pypaimon.operation.snapshot_deletion import SnapshotDeletion
+        deletion = SnapshotDeletion(table)
+        snapshot2 = table.snapshot_manager().get_snapshot_by_id(2)
+        skipping_set = deletion.manifest_skipping_set([snapshot2])
+        snapshot1 = table.snapshot_manager().get_snapshot_by_id(1)
+        deletion.clean_unused_manifests(snapshot1, skipping_set)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/snapshot_manager_test.py
+++ b/paimon-python/pypaimon/tests/snapshot_manager_test.py
@@ -112,5 +112,76 @@ class SnapshotManagerTest(unittest.TestCase):
         self.assertEqual(skipped_count, 3)
 
 
+class SnapshotManagerInfraTest(unittest.TestCase):
+    """Tests for SnapshotManager infrastructure methods needed by expire/orphan-clean."""
+
+    def test_safely_get_all_snapshots_skips_unreadable(self):
+        file_io = Mock()
+        file_io.list_status.return_value = [
+            Mock(path="/tmp/test/snapshot/snapshot-1"),
+            Mock(path="/tmp/test/snapshot/snapshot-2"),
+            Mock(path="/tmp/test/snapshot/snapshot-bad"),
+            Mock(path="/tmp/test/snapshot/LATEST"),
+        ]
+        snapshots = {1: _create_mock_snapshot(1), 2: _create_mock_snapshot(2)}
+        manager = _build_manager(file_io)
+        manager.get_snapshot_by_id = lambda sid: snapshots.get(sid)
+        result = manager.safely_get_all_snapshots()
+        self.assertEqual(len(result), 2)
+        self.assertEqual([s.id for s in result], [1, 2])
+
+    def test_safely_get_all_snapshots_tolerates_read_failure(self):
+        file_io = Mock()
+        file_io.list_status.return_value = [
+            Mock(path="/tmp/test/snapshot/snapshot-1"),
+            Mock(path="/tmp/test/snapshot/snapshot-2"),
+        ]
+        manager = _build_manager(file_io)
+
+        def get_snapshot_by_id(sid):
+            if sid == 2:
+                raise FileNotFoundError("deleted concurrently")
+            return _create_mock_snapshot(sid)
+        manager.get_snapshot_by_id = get_snapshot_by_id
+        result = manager.safely_get_all_snapshots()
+        self.assertEqual(len(result), 1)
+
+    def test_earliest_snapshot_id(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.try_get_earliest_snapshot = lambda: _create_mock_snapshot(5)
+        self.assertEqual(manager.earliest_snapshot_id(), 5)
+
+    def test_earliest_snapshot_id_none(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.try_get_earliest_snapshot = lambda: None
+        self.assertIsNone(manager.earliest_snapshot_id())
+
+    def test_latest_snapshot_id(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.get_latest_snapshot = lambda: _create_mock_snapshot(10)
+        self.assertEqual(manager.latest_snapshot_id(), 10)
+
+    def test_latest_snapshot_id_none(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.get_latest_snapshot = lambda: None
+        self.assertIsNone(manager.latest_snapshot_id())
+
+    def test_delete_snapshot(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.delete_snapshot(5)
+        file_io.delete_quietly.assert_called_once_with("/tmp/test_table/snapshot/snapshot-5")
+
+    def test_commit_earliest_hint(self):
+        file_io = Mock()
+        manager = _build_manager(file_io)
+        manager.commit_earliest_hint(3)
+        file_io.overwrite_file_utf8.assert_called_once_with("/tmp/test_table/snapshot/EARLIEST", "3")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/tag_manager_infra_test.py
+++ b/paimon-python/pypaimon/tests/tag_manager_infra_test.py
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock
+from pypaimon.tag.tag import Tag
+
+
+class TagManagerInfraTest(unittest.TestCase):
+    def _build_manager(self, file_io, table_path="/tmp/test_table"):
+        from pypaimon.tag.tag_manager import TagManager
+        return TagManager(file_io, table_path)
+
+    def test_tagged_snapshots_returns_sorted(self):
+        file_io = Mock()
+        manager = self._build_manager(file_io)
+        tag_a, tag_b, tag_c = Mock(spec=Tag), Mock(spec=Tag), Mock(spec=Tag)
+        tag_a.id, tag_b.id, tag_c.id = 5, 2, 8
+        manager.list_tags = Mock(return_value=["tag_a", "tag_c", "tag_b"])
+        manager.get = Mock(side_effect=lambda name: {"tag_a": tag_a, "tag_b": tag_b, "tag_c": tag_c}[name])
+        result = manager.tagged_snapshots()
+        self.assertEqual([t.id for t in result], [2, 5, 8])
+
+    def test_tagged_snapshots_skips_unreadable(self):
+        file_io = Mock()
+        manager = self._build_manager(file_io)
+        tag_a = Mock(spec=Tag)
+        tag_a.id = 1
+        manager.list_tags = Mock(return_value=["tag_a", "tag_broken"])
+        manager.get = Mock(side_effect=lambda name: tag_a if name == "tag_a" else None)
+        result = manager.tagged_snapshots()
+        self.assertEqual(len(result), 1)
+
+    def test_tagged_snapshots_empty(self):
+        file_io = Mock()
+        manager = self._build_manager(file_io)
+        manager.list_tags = Mock(return_value=[])
+        self.assertEqual(manager.tagged_snapshots(), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `ExpireSnapshots` API and `expire-snapshots` CLI command, mirroring Java's `ExpireSnapshotsImpl`
- Support `retain_max`, `retain_min`, `time_retain`, `max_deletes` configuration
- Protect tagged snapshot files, consumer-referenced snapshots, and changelog-decoupled mode

## Tests

- Unit tests for `ExpireConfig`, `SnapshotManager`, `TagManager`, `ChangelogManager` infrastructure methods
- Integration tests for `SnapshotDeletion` and `ExpireSnapshots` (tag protection, consumer protection, max_deletes)