### PR TITLE
Add the parameter: metastore.drop-partition-ignore-nonexistent to ignore exceptions when a Hive partition does not exist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ Cargo.lock
 *libvortex_jni*
 ### Tantivy lib ###
 *libtantivy_jni*
+
+.cursor-svg-check/

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -1673,6 +1673,20 @@ public class CoreOptions implements Serializable {
                                     + "you need to create this table as a partitioned table in Hive metastore.\n"
                                     + "This config option does not affect the default filesystem metastore.");
 
+    public static final ConfigOption<Boolean> METASTORE_DROP_PARTITION_IGNORE_NONEXISTENT =
+            key("metastore.drop-partition-ignore-nonexistent")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to ignore HMS drop-partition failures when the partition "
+                                    + "is confirmed not to exist in Hive Metastore. "
+                                    + "Useful when HMS has been manually cleaned up or returns "
+                                    + "non-standard exceptions (e.g., MetaException caused by "
+                                    + "NullPointerException in some HMS versions) instead of "
+                                    + "NoSuchObjectException for missing partitions. "
+                                    + "When enabled, Paimon will verify the partition's existence "
+                                    + "before deciding to ignore the error.");
+
     public static final ConfigOption<String> METASTORE_TAG_TO_PARTITION =
             key("metastore.tag-to-partition")
                     .stringType()
@@ -3424,6 +3438,10 @@ public class CoreOptions implements Serializable {
 
     public boolean partitionedTableInMetastore() {
         return options.get(METASTORE_PARTITIONED_TABLE);
+    }
+
+    public boolean metastoreDropPartitionIgnoreNonexistent() {
+        return options.get(METASTORE_DROP_PARTITION_IGNORE_NONEXISTENT);
     }
 
     @Nullable

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionEventType;
@@ -443,6 +444,7 @@ public class HiveCatalog extends AbstractCatalog {
         TableSchema schema = this.loadTableSchema(identifier);
         CoreOptions options = CoreOptions.fromMap(schema.options());
         boolean tagToPart = options.tagToPartitionField() != null;
+        boolean ignorePartitionNonexistent = options.metastoreDropPartitionIgnoreNonexistent();
         if (metastorePartitioned(schema)) {
             List<Map<String, String>> metaPartitions =
                     tagToPart
@@ -461,6 +463,20 @@ public class HiveCatalog extends AbstractCatalog {
                                                     false));
                 } catch (NoSuchObjectException e) {
                     // do nothing if the partition not exists
+                } catch (MetaException e) {
+                    if (ignorePartitionNonexistent
+                            && !partitionExistsInHms(identifier, partitionValues)) {
+                        LOG.warn(
+                                "Drop partition {} of table {} returned MetaException, but "
+                                        + "the partition is confirmed not to exist in HMS. "
+                                        + "Ignoring the error and continuing with Paimon-side drop. "
+                                        + "Original exception: {}",
+                                part,
+                                identifier,
+                                e.getMessage());
+                    } else {
+                        throw new RuntimeException(e);
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -468,6 +484,31 @@ public class HiveCatalog extends AbstractCatalog {
         }
         if (!tagToPart) {
             super.dropPartitions(identifier, partitions);
+        }
+    }
+
+    private boolean partitionExistsInHms(Identifier identifier, List<String> partitionValues) {
+        try {
+            clients.run(
+                    client ->
+                            client.getPartition(
+                                    identifier.getDatabaseName(),
+                                    identifier.getTableName(),
+                                    partitionValues));
+            return true;
+        } catch (NoSuchObjectException e) {
+            return false;
+        } catch (Exception e) {
+            // In case of HMS connection or other unknown errors, conservatively assume the
+            // partition may exist and redirect the original exception upwards to avoid accidental
+            // deletion.
+            LOG.warn(
+                    "Failed to verify partition existence in HMS for table {}, "
+                            + "partition values {}: {}",
+                    identifier,
+                    partitionValues,
+                    e.getMessage());
+            return true;
         }
     }
 


### PR DESCRIPTION
Fixed a bug that caused the Partition Expire operation to fail due to a non-existent Hive partition.
