### PR TITLE
[core] Add origin table option for blob view lookup

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -129,6 +129,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                         providerFactories,
                         schema(),
                         catalogEnvironment.catalogContext(),
+                        catalogEnvironment.identifier(),
                         () -> new AppendTableRead(providerFactories, schema()))
                 : new AppendTableRead(providerFactories, schema());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
@@ -50,15 +51,18 @@ import java.util.function.Supplier;
 public class DataEvolutionTableRead extends AppendTableRead {
 
     @Nullable private final CatalogContext catalogContext;
+    @Nullable private final Identifier originTable;
     @Nullable private final Supplier<InnerTableRead> readFactory;
 
     public DataEvolutionTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
             TableSchema schema,
             @Nullable CatalogContext catalogContext,
+            @Nullable Identifier originTable,
             @Nullable Supplier<InnerTableRead> readFactory) {
         super(providerFactories, schema);
         this.catalogContext = catalogContext;
+        this.originTable = originTable;
         this.readFactory = readFactory;
     }
 
@@ -129,7 +133,8 @@ public class DataEvolutionTableRead extends AppendTableRead {
         }
 
         BlobViewResolver resolver =
-                BlobViewLookup.createResolver(catalogContext, new ArrayList<>(viewStructs));
+                BlobViewLookup.createResolver(
+                        catalogContext, originTable, new ArrayList<>(viewStructs));
 
         RecordReader<InternalRow> reader = createDataReader(split, authResult);
         Set<Integer> blobViewFieldSet = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
@@ -29,12 +29,15 @@ import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobViewResolver;
 import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +58,8 @@ import java.util.concurrent.Future;
  */
 public class BlobViewLookup {
 
+    public static final String ORIGIN_VIEW_TABLE = "origin-view-table";
+
     private static final int PRELOAD_DESCRIPTOR_THREAD_NUM = 100;
     private static final long MIN_ROW_PER_TASK = 100L;
     private static final ExecutorService PRELOAD_DESCRIPTOR_EXECUTOR =
@@ -62,17 +67,22 @@ public class BlobViewLookup {
                     PRELOAD_DESCRIPTOR_THREAD_NUM, "blob-view-preload");
 
     public static BlobViewResolver createResolver(
-            CatalogContext catalogContext, List<BlobViewStruct> viewStructs) {
-        return createResolver(catalogContext, viewStructs, CatalogFactory::createCatalog);
+            CatalogContext catalogContext,
+            @Nullable Identifier originTable,
+            List<BlobViewStruct> viewStructs) {
+        return createResolver(
+                catalogContext, originTable, viewStructs, CatalogFactory::createCatalog);
     }
 
     @VisibleForTesting
     static BlobViewResolver createResolver(
             CatalogContext catalogContext,
+            @Nullable Identifier originTable,
             List<BlobViewStruct> viewStructs,
             CatalogLoader catalogLoader) {
+        CatalogContext lookupCatalogContext = withOriginViewTable(catalogContext, originTable);
         Map<BlobViewStruct, BlobDescriptor> cached =
-                preloadDescriptors(catalogContext, viewStructs, catalogLoader);
+                preloadDescriptors(lookupCatalogContext, viewStructs, catalogLoader);
         Map<Identifier, UriReader> cache = new HashMap<>();
         return blobView -> {
             BlobViewStruct viewStruct = blobView.viewStruct();
@@ -88,7 +98,7 @@ public class BlobViewLookup {
                     cache.computeIfAbsent(
                             viewStruct.identifier(),
                             identifier -> {
-                                try (Catalog catalog = catalogLoader.create(catalogContext)) {
+                                try (Catalog catalog = catalogLoader.create(lookupCatalogContext)) {
                                     return UriReader.fromFile(
                                             catalog.getTable(identifier).fileIO());
                                 } catch (Exception e) {
@@ -97,6 +107,22 @@ public class BlobViewLookup {
                             });
             blobView.resolve(uriReader, descriptor);
         };
+    }
+
+    @VisibleForTesting
+    static CatalogContext withOriginViewTable(
+            CatalogContext catalogContext, @Nullable Identifier originTable) {
+        if (originTable == null) {
+            return catalogContext;
+        }
+
+        Options options = new Options(catalogContext.options().toMap());
+        options.set(ORIGIN_VIEW_TABLE, originTable.getFullName());
+        return CatalogContext.create(
+                options,
+                catalogContext.hadoopConf(),
+                catalogContext.preferIO(),
+                catalogContext.fallbackIO());
     }
 
     private static Map<BlobViewStruct, BlobDescriptor> preloadDescriptors(

--- a/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link BlobViewLookup}. */
+class BlobViewLookupTest {
+
+    @Test
+    void testOriginViewTableOptionDoesNotMutateOriginalContext() {
+        Options options = new Options();
+        options.set(WAREHOUSE, "file:/tmp/warehouse");
+        CatalogContext context = CatalogContext.create(options);
+
+        CatalogContext lookupContext =
+                BlobViewLookup.withOriginViewTable(
+                        context, Identifier.create("default", "downstream"));
+
+        assertThat(lookupContext).isNotSameAs(context);
+        assertThat(lookupContext.options().get(BlobViewLookup.ORIGIN_VIEW_TABLE))
+                .isEqualTo("default.downstream");
+        assertThat(lookupContext.options().get(WAREHOUSE)).isEqualTo("file:/tmp/warehouse");
+        assertThat(context.options().get(BlobViewLookup.ORIGIN_VIEW_TABLE)).isNull();
+    }
+
+    @Test
+    void testOriginViewTableOptionSkippedWhenOriginTableIsUnknown() {
+        CatalogContext context = CatalogContext.create(new Options());
+
+        assertThat(BlobViewLookup.withOriginViewTable(context, null)).isSameAs(context);
+    }
+}


### PR DESCRIPTION
### What changed
- Pass the current table identifier from append-only data evolution reads into BlobViewLookup.
- Create a lookup-only CatalogContext carrying origin-view-table without mutating the original catalog context.
- Add unit coverage for the context option injection path.

### Why
BlobViewLookup may need to recreate a catalog while resolving referenced blob descriptors. Carrying the origin table in catalog options lets downstream catalog/auth integrations keep the original query table context.

### Validation
- mvn -pl paimon-core -Pfast-build -DskipTests compile
- mvn -pl paimon-core -Pfast-build -Dtest=BlobViewLookupTest test
- mvn -pl paimon-core -Pfast-build -Dtest=BlobTableTest#testBlobViewE2E test