### PR TITLE
[vortex] Support file rolling and align vectorTargetFileSize default with targetFileSize

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2494,7 +2494,7 @@ public class CoreOptions implements Serializable {
                             Description.builder()
                                     .text(
                                             "Target size of a vector-store file."
-                                                    + " Default is 10 * TARGET_FILE_SIZE.")
+                                                    + " Default is the same as TARGET_FILE_SIZE.")
                                     .build());
 
     @Immutable
@@ -3930,10 +3930,9 @@ public class CoreOptions implements Serializable {
     }
 
     public long vectorTargetFileSize() {
-        // Since vectors are large, it would be better to set a larger target size for vectors.
         return options.getOptional(VECTOR_TARGET_FILE_SIZE)
                 .map(MemorySize::getBytes)
-                .orElse(10 * targetFileSize(false));
+                .orElse(targetFileSize(false));
     }
 
     /** Specifies the merge engine for table with primary key. */

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -233,6 +233,13 @@ class CoreOptions:
         .default_value(MemorySize.of_mebi_bytes(256))
         .with_description("The target file size for blob files.")
     )
+
+    VECTOR_TARGET_FILE_SIZE: ConfigOption[MemorySize] = (
+        ConfigOptions.key("vector.target-file-size")
+        .memory_type()
+        .no_default_value()
+        .with_description("Target size of a vector-store file. Default is the same as TARGET_FILE_SIZE.")
+    )
     DATA_FILE_PREFIX: ConfigOption[str] = (
         ConfigOptions.key("data-file.prefix")
         .string_type()
@@ -649,6 +656,12 @@ class CoreOptions:
             return self.options.get(CoreOptions.BLOB_TARGET_FILE_SIZE, None).get_bytes()
         elif default is not None:
             return MemorySize.parse(default).get_bytes()
+        else:
+            return self.target_file_size(has_primary_key=False)
+
+    def vector_target_file_size(self):
+        if self.options.contains(CoreOptions.VECTOR_TARGET_FILE_SIZE):
+            return self.options.get(CoreOptions.VECTOR_TARGET_FILE_SIZE, None).get_bytes()
         else:
             return self.target_file_size(has_primary_key=False)
 

--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexRecordsWriter.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexRecordsWriter.java
@@ -36,26 +36,18 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
-/**
- * Vortex records writer.
- *
- * <p>Hands record batches to the native Vortex writer via the synchronous {@code
- * writeBatch(byte[])} path: each batch is serialized to an Arrow IPC byte array and copied into
- * native memory by the JNI call. Once {@code writeBatch} returns, the byte array (and the source
- * Arrow buffers) are no longer referenced by the native side, so the underlying {@link
- * ArrowFormatWriter} can be reset and reused immediately. This trades the FFI zero-copy throughput
- * for bounded memory and simpler lifetime management — without it, native asynchronously borrows
- * the Arrow buffers and they must be kept alive until file close, which grows unboundedly with
- * batch count.
- */
+/** Vortex records writer. */
 public class VortexRecordsWriter implements BundleFormatWriter {
 
     private static final Logger LOG = LoggerFactory.getLogger(VortexRecordsWriter.class);
+
+    private static final double COMPRESSION_RATIO = 0.25;
 
     private final ArrowFormatWriter arrowFormatWriter;
     private final VortexWriter nativeWriter;
     private final String path;
     private long jniCost = 0;
+    private long ipcBytes = 0;
 
     public VortexRecordsWriter(
             RowType rowType,
@@ -94,9 +86,7 @@ public class VortexRecordsWriter implements BundleFormatWriter {
 
     @Override
     public boolean reachTargetSize(boolean suggestedCheck, long targetSize) {
-        // Vortex applies its own compression/encoding, so in-memory Arrow size is much larger
-        // than the actual file size on disk. Always return false to avoid rolling into small files.
-        return false;
+        return suggestedCheck && (long) (ipcBytes * COMPRESSION_RATIO) >= targetSize;
     }
 
     @Override
@@ -143,6 +133,7 @@ public class VortexRecordsWriter implements BundleFormatWriter {
 
     private void writeVsr(VectorSchemaRoot vsr) throws IOException {
         byte[] bytes = ArrowUtils.serializeToIpc(vsr);
+        ipcBytes += bytes.length;
         long t1 = System.currentTimeMillis();
         nativeWriter.writeBatch(bytes);
         jniCost += (System.currentTimeMillis() - t1);

--- a/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexReaderWriterTest.java
+++ b/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexReaderWriterTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -474,6 +475,45 @@ public class VortexReaderWriterTest {
                 batch.releaseBatch();
             }
             assertEquals(3, idx, "Should have read exactly 3 rows");
+        }
+    }
+
+    @Test
+    public void testReachTargetSize(@TempDir java.nio.file.Path tempDir) throws Exception {
+        RowType rowType = RowType.of(DataTypes.INT(), DataTypes.STRING());
+        Options options = new Options();
+        // Use small batch size to trigger flush frequently
+        VortexFileFormat format =
+                new VortexFileFormatFactory()
+                        .create(new FileFormatFactory.FormatContext(options, 2, 1));
+
+        FileIO fileIO = new LocalFileIO();
+        Path testFile =
+                new Path(new Path(tempDir.toUri()), "test_target_size_" + UUID.randomUUID());
+
+        FormatWriter writer =
+                ((SupportsDirectWrite) format.createWriterFactory(rowType))
+                        .create(fileIO, testFile, "");
+        try {
+            // Before any write, should not reach target size
+            assertFalse(writer.reachTargetSize(true, 1));
+
+            // Write rows to fill the batch (batchSize=2), triggering a flush
+            writer.addElement(GenericRow.of(1, BinaryString.fromString("hello")));
+            writer.addElement(GenericRow.of(2, BinaryString.fromString("world")));
+            // batch is full, next addElement triggers flush
+            writer.addElement(GenericRow.of(3, BinaryString.fromString("vortex")));
+
+            // After flush, ipcBytes > 0. With a very small target, should reach target size
+            assertTrue(writer.reachTargetSize(true, 1));
+
+            // suggestedCheck=false should always return false
+            assertFalse(writer.reachTargetSize(false, 1));
+
+            // With a very large target, should not reach target size
+            assertFalse(writer.reachTargetSize(true, Long.MAX_VALUE));
+        } finally {
+            writer.close();
         }
     }
 


### PR DESCRIPTION
- Implement reachTargetSize in VortexRecordsWriter using IPC bytes accumulation with a compression ratio estimate (0.25) to support file rolling
- Change vectorTargetFileSize default from 10x to 1x targetFileSize
- Add VECTOR_TARGET_FILE_SIZE config and accessor in Python CoreOptions
- Add testReachTargetSize unit test