### PR TITLE
[core] Log when scan uses global index

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -41,6 +41,9 @@ import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RowRangeIndex;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -56,6 +59,8 @@ import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequ
 
 /** Scan for data evolution table. */
 public class DataEvolutionBatchScan implements DataTableScan {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionBatchScan.class);
 
     private final FileStoreTable table;
     private final DataTableBatchScan batchScan;
@@ -274,7 +279,11 @@ public class DataEvolutionBatchScan implements DataTableScan {
         }
 
         try (GlobalIndexScanner scanner = optionalScanner.get()) {
-            return scanner.scan(filter);
+            Optional<GlobalIndexResult> result = scanner.scan(filter);
+            if (result.isPresent()) {
+                LOG.info("Scan table '{}' with global index.", table.name());
+            }
+            return result;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
### Purpose

Add an INFO log when data evolution scan evaluates filters through the global index and gets an index result.

### Changes

- Add a logger to `DataEvolutionBatchScan`.
- Log `Scan table '{}' with global index.` when global-index scan is actually used.

### Tests

- `mvn -pl paimon-core spotless:apply -DskipTests -DskipITs -Dscala-2.12`
- `mvn -pl paimon-core -DskipTests -DskipITs -Dscala-2.12 -Dcheckstyle.skip=false compile`