### PR TITLE
[flink] Avoid executing empty BTree index build

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
@@ -195,9 +195,10 @@ public class BTreeIndexTopoBuilder {
             DataStream<Committable>[] rest =
                     allStreams.subList(1, allStreams.size()).toArray(new DataStream[0]);
             commit(table, allStreams.get(0).union(rest));
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     public static void buildIndexAndExecute(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilderTest.java
@@ -19,17 +19,45 @@
 package org.apache.paimon.flink.btree;
 
 import org.apache.paimon.flink.btree.BTreeIndexTopoBuilder.BTreeBuildTask;
+import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.Range;
 
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link BTreeIndexTopoBuilder}. */
 public class BTreeIndexTopoBuilderTest {
+
+    @Test
+    public void testBuildIndexReturnsFalseWhenNoBuildTask() throws Exception {
+        BTreeGlobalIndexBuilder indexBuilder = mock(BTreeGlobalIndexBuilder.class);
+        when(indexBuilder.withIndexField("id")).thenReturn(indexBuilder);
+        when(indexBuilder.scan()).thenReturn(Optional.empty());
+        StreamExecutionEnvironment env = mock(StreamExecutionEnvironment.class);
+
+        assertThat(
+                        BTreeIndexTopoBuilder.buildIndex(
+                                env,
+                                () -> indexBuilder,
+                                mock(FileStoreTable.class),
+                                Collections.singletonList("id"),
+                                null,
+                                new Options()))
+                .isFalse();
+        verifyNoInteractions(env);
+    }
 
     @Test
     public void testCalculateParallelismByTotalRowsInsteadOfRangeCount() {


### PR DESCRIPTION
### Purpose

Avoid executing the Flink job for BTree global index creation when no build topology is generated.

### Changes

- Return `true` from `BTreeIndexTopoBuilder.buildIndex` only after a commit topology is created.
- Return `false` when scans produce no build tasks.
- Add a unit test covering the no-build-task path.

### Root Cause

`buildIndex` previously returned `true` even when `allStreams` was empty, so `buildIndexAndExecute` could call `env.execute` for an empty BTree index build.

### Tests

- `mvn -pl paimon-flink/paimon-flink-common -am -Pfast-build -DfailIfNoTests=false -Dtest=BTreeIndexTopoBuilderTest test`
