### PR TITLE
[python][daft] Use external paths for native Parquet reads

### DIFF
--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from pypaimon.common.predicate import Predicate
+    from pypaimon.manifest.schema.data_file_meta import DataFileMeta
     from pypaimon.read.table_read import TableRead
     from pypaimon.read.split import Split
     from pypaimon.table.file_store_table import FileStoreTable
@@ -285,7 +286,7 @@ class PaimonDataSource(DataSource):
                     pv = pv_cache[pv_key]
 
                 for data_file in split.files:
-                    file_uri = self._build_file_uri(data_file.file_path)
+                    file_uri = self._build_file_uri(self._data_file_path(data_file))
                     yield DataSourceTask.parquet(
                         path=file_uri,
                         schema=self._schema,
@@ -329,6 +330,10 @@ class PaimonDataSource(DataSource):
         if self._warehouse_scheme:
             return f"{self._warehouse_scheme}://{file_path}"
         return f"file://{file_path}"
+
+    @staticmethod
+    def _data_file_path(data_file: DataFileMeta) -> str:
+        return data_file.external_path if data_file.external_path else data_file.file_path
 
     def _build_partition_values(self, split: Split) -> daft.recordbatch.RecordBatch | None:
         """Build a single-row RecordBatch encoding the partition values for a split."""

--- a/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_datasource_test.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 ################################################################################
 import unittest
+from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 
@@ -23,6 +25,12 @@ pypaimon = pytest.importorskip("pypaimon")
 daft = pytest.importorskip("daft")
 
 from pypaimon.daft.daft_datasource import PaimonDataSource
+
+
+@dataclass
+class _DataFile:
+    file_path: str
+    external_path: Optional[str] = None
 
 
 def _build_uri(warehouse_scheme: str, file_path: str) -> str:
@@ -60,6 +68,31 @@ class BuildFileUriTest(unittest.TestCase):
         self.assertEqual(
             _build_uri("", "/tmp/pytest-xxx/db.db/tbl/data.parquet"),
             "file:///tmp/pytest-xxx/db.db/tbl/data.parquet",
+        )
+
+
+class DataFilePathTest(unittest.TestCase):
+
+    def test_prefers_external_path(self):
+        data_file = _DataFile(
+            file_path="file:///warehouse/db.db/tbl/bucket-0/data.parquet",
+            external_path="s3://external-bucket/data/db.db/tbl/bucket-0/data.parquet",
+        )
+
+        self.assertEqual(
+            PaimonDataSource._data_file_path(data_file),
+            "s3://external-bucket/data/db.db/tbl/bucket-0/data.parquet",
+        )
+
+    def test_falls_back_to_file_path(self):
+        data_file = _DataFile(
+            file_path="file:///warehouse/db.db/tbl/bucket-0/data.parquet",
+            external_path=None,
+        )
+
+        self.assertEqual(
+            PaimonDataSource._data_file_path(data_file),
+            "file:///warehouse/db.db/tbl/bucket-0/data.parquet",
         )
 
 


### PR DESCRIPTION
### Purpose

Daft native Parquet reads always used `DataFileMeta.file_path` when creating Parquet tasks. This is incorrect for tables configured with `data-file.external-paths`, where the physical data file is stored in `DataFileMeta.external_path` while  `file_path` may point to the warehouse-derived table path.

### Tests

  - `pytest paimon-python/pypaimon/tests/daft/daft_datasource_test.py -q -rs`
  - `python -m pytest paimon-python/pypaimon/tests/daft/daft_datasource_test.py -q -rs`