### PR TITLE
[python] Fix CachingFileIO bypassing delegate for several FileIO methods

### DIFF
--- a/paimon-python/pypaimon/filesystem/caching_file_io.py
+++ b/paimon-python/pypaimon/filesystem/caching_file_io.py
@@ -382,9 +382,30 @@ class CachingFileIO(FileIO):
     def is_dir(self, path: str) -> bool:
         return self._delegate.is_dir(path)
 
-    # FileIO base defines a no-op default, so __getattr__ never forwards this.
+    # FileIO base has raising / no-op defaults that block __getattr__ — forward explicitly.
     def to_filesystem_path(self, path: str) -> str:
         return self._delegate.to_filesystem_path(path)
+
+    def try_to_write_atomic(self, *args, **kwargs):
+        return self._delegate.try_to_write_atomic(*args, **kwargs)
+
+    def write_parquet(self, *args, **kwargs):
+        return self._delegate.write_parquet(*args, **kwargs)
+
+    def write_orc(self, *args, **kwargs):
+        return self._delegate.write_orc(*args, **kwargs)
+
+    def write_avro(self, *args, **kwargs):
+        return self._delegate.write_avro(*args, **kwargs)
+
+    def write_lance(self, *args, **kwargs):
+        return self._delegate.write_lance(*args, **kwargs)
+
+    def write_blob(self, *args, **kwargs):
+        return self._delegate.write_blob(*args, **kwargs)
+
+    def write_vortex(self, *args, **kwargs):
+        return self._delegate.write_vortex(*args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._delegate, name)

--- a/paimon-python/pypaimon/filesystem/caching_file_io.py
+++ b/paimon-python/pypaimon/filesystem/caching_file_io.py
@@ -382,6 +382,10 @@ class CachingFileIO(FileIO):
     def is_dir(self, path: str) -> bool:
         return self._delegate.is_dir(path)
 
+    # FileIO base defines a no-op default, so __getattr__ never forwards this.
+    def to_filesystem_path(self, path: str) -> str:
+        return self._delegate.to_filesystem_path(path)
+
     def __getattr__(self, name):
         return getattr(self._delegate, name)
 

--- a/paimon-python/pypaimon/tests/caching_file_io_test.py
+++ b/paimon-python/pypaimon/tests/caching_file_io_test.py
@@ -394,6 +394,21 @@ class CachingFileIOTest(unittest.TestCase):
         self.assertEqual("bucket/key", caching_io.to_filesystem_path("oss://bucket/key"))
         delegate.to_filesystem_path.assert_called_once_with("oss://bucket/key")
 
+    def test_write_parquet_when_enable_local_cache(self):
+        import pyarrow as pa
+        from pypaimon.filesystem.local_file_io import LocalFileIO
+
+        delegate = LocalFileIO()
+        cache = LocalDiskCacheManager(self.cache_dir, 2 ** 63 - 1, block_size=64)
+        caching_io = CachingFileIO(delegate, cache)
+
+        out_path = os.path.join(self.cache_dir, "data.parquet")
+        table = pa.table({"a": [1, 2, 3]})
+        caching_io.write_parquet(out_path, table)
+
+        self.assertTrue(os.path.exists(out_path))
+        self.assertEqual(table, pa.parquet.read_table(out_path))
+
 
 class ConfigOptionsTest(unittest.TestCase):
 

--- a/paimon-python/pypaimon/tests/caching_file_io_test.py
+++ b/paimon-python/pypaimon/tests/caching_file_io_test.py
@@ -385,6 +385,15 @@ class CachingFileIOTest(unittest.TestCase):
         caching_io.new_output_stream("/out")
         delegate.new_output_stream.assert_called_once_with("/out")
 
+    def test_to_filesystem_path_forwarded_to_delegate(self):
+        delegate = MagicMock()
+        delegate.to_filesystem_path.side_effect = lambda p: p.replace("oss://", "")
+        cache = LocalDiskCacheManager(self.cache_dir, 2 ** 63 - 1, block_size=64)
+        caching_io = CachingFileIO(delegate, cache)
+
+        self.assertEqual("bucket/key", caching_io.to_filesystem_path("oss://bucket/key"))
+        delegate.to_filesystem_path.assert_called_once_with("oss://bucket/key")
+
 
 class ConfigOptionsTest(unittest.TestCase):
 


### PR DESCRIPTION
  ### Purpose

  CachingFileIO does not forward several FileIO methods to the delegate,
  so the wrapper hits FileIO base's no-op / raising defaults instead.

  Observed failures:
  - PyArrow data reads fail with
    "Expected an S3 object path of the form 'bucket/key', got 'oss://...'"
    (to_filesystem_path returns the input unchanged)
  - Writes fail with
    "NotImplementedError: write_parquet must be implemented by FileIO subclasses"
    (write_parquet/orc/avro/lance/blob/vortex and try_to_write_atomic are not forwarded)

  ### Tests
  - test_to_filesystem_path_forwarded_to_delegate
  - test_write_parquet_when_enable_local_cache