### PR TITLE
[python] Remove tests in the build artifact

### DIFF
--- a/paimon-python/MANIFEST.in
+++ b/paimon-python/MANIFEST.in
@@ -20,3 +20,4 @@ include NOTICE
 include dev/requirements.txt
 include README.md
 recursive-include pypaimon *.py
+recursive-exclude pypaimon/tests *

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -115,7 +115,7 @@ def _build_dev_package():
 
 atexit.register(_build_dev_package)
 
-PACKAGES = find_packages(include=["pypaimon*"])
+PACKAGES = find_packages(include=["pypaimon*"], exclude=["pypaimon.tests*"])
 
 
 def read_requirements():


### PR DESCRIPTION
### Purpose
Currently, the `tests` folder is included in the generated package uploaded to PyPI server:

<img width="629" height="222" alt="{82B2247E-71C9-42C7-B588-706665221CDD}" src="https://github.com/user-attachments/assets/9cb18d5e-a1ad-459d-9cbd-ac1507b7d7d4" />

It contains more than 100 extra files and increases the package size by about 1.5 MB. These files are also installed on users' machines, but they are not needed. We should exclude the `tests` folder from the package.
