### PR TITLE
[core] Add access context for blob view fallback

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -3167,6 +3167,12 @@ components:
           type: array
           items:
             type: string
+        accessType:
+          type: string
+          description: Type of table access, omitted for direct table access.
+        fallbackFrom:
+          type: string
+          description: Source table for fallback access, omitted for direct table access.
     AuthTableQueryResponse:
       type: object
       properties:

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -809,7 +809,27 @@ public class RESTApi {
      */
     public AuthTableQueryResponse authTableQuery(
             Identifier identifier, @Nullable List<String> select) {
-        AuthTableQueryRequest request = new AuthTableQueryRequest(select);
+        return authTableQuery(identifier, select, null, null);
+    }
+
+    /**
+     * Auth table query with access context.
+     *
+     * @param identifier database name and table name.
+     * @param select select columns, null if select all
+     * @param accessType type of table access, null for direct table access
+     * @param fallbackFrom source table for fallback access, null for direct table access
+     * @return additional filter for row level access control and column masking rules
+     * @throws NoSuchResourceException Exception thrown on HTTP 404 means the table not exists
+     * @throws ForbiddenException Exception thrown on HTTP 403 means don't have the permission for
+     *     this table
+     */
+    public AuthTableQueryResponse authTableQuery(
+            Identifier identifier,
+            @Nullable List<String> select,
+            @Nullable String accessType,
+            @Nullable String fallbackFrom) {
+        AuthTableQueryRequest request = new AuthTableQueryRequest(select, accessType, fallbackFrom);
         return client.post(
                 resourcePaths.authTable(identifier.getDatabaseName(), identifier.getObjectName()),
                 request,

--- a/paimon-api/src/main/java/org/apache/paimon/rest/requests/AuthTableQueryRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/requests/AuthTableQueryRequest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.rest.RESTRequest;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
@@ -34,19 +35,53 @@ import java.util.List;
 public class AuthTableQueryRequest implements RESTRequest {
 
     private static final String FIELD_SELECT = "select";
+    private static final String FIELD_ACCESS_TYPE = "accessType";
+    private static final String FIELD_FALLBACK_FROM = "fallbackFrom";
 
     @JsonProperty(FIELD_SELECT)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     @Nullable
     private final List<String> select;
 
+    @JsonProperty(FIELD_ACCESS_TYPE)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    private final String accessType;
+
+    @JsonProperty(FIELD_FALLBACK_FROM)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    private final String fallbackFrom;
+
     @JsonCreator
-    public AuthTableQueryRequest(@JsonProperty(FIELD_SELECT) @Nullable List<String> select) {
+    public AuthTableQueryRequest(
+            @JsonProperty(FIELD_SELECT) @Nullable List<String> select,
+            @JsonProperty(FIELD_ACCESS_TYPE) @Nullable String accessType,
+            @JsonProperty(FIELD_FALLBACK_FROM) @Nullable String fallbackFrom) {
         this.select = select;
+        this.accessType = accessType;
+        this.fallbackFrom = fallbackFrom;
+    }
+
+    public AuthTableQueryRequest(@Nullable List<String> select) {
+        this(select, null, null);
     }
 
     @JsonGetter(FIELD_SELECT)
     @Nullable
     public List<String> select() {
         return select;
+    }
+
+    @JsonGetter(FIELD_ACCESS_TYPE)
+    @Nullable
+    public String accessType() {
+        return accessType;
+    }
+
+    @JsonGetter(FIELD_FALLBACK_FROM)
+    @Nullable
+    public String fallbackFrom() {
+        return fallbackFrom;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -592,6 +592,12 @@ public abstract class AbstractCatalog implements Catalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
+        return getTable(identifier, TableAccessContext.direct());
+    }
+
+    @Override
+    public Table getTable(Identifier identifier, TableAccessContext accessContext)
+            throws TableNotExistException {
         return CatalogUtils.loadTable(
                 this,
                 identifier,
@@ -601,7 +607,8 @@ public abstract class AbstractCatalog implements Catalog {
                 lockFactory().orElse(null),
                 lockContext().orElse(null),
                 context,
-                false);
+                false,
+                accessContext);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -158,6 +158,19 @@ public interface Catalog extends AutoCloseable {
     Table getTable(Identifier identifier) throws TableNotExistException;
 
     /**
+     * Return a {@link Table} identified by the given {@link Identifier} with access context.
+     *
+     * @param identifier Path of the table
+     * @param accessContext context describing why the table is accessed
+     * @return The requested table
+     * @throws TableNotExistException if the target does not exist
+     */
+    default Table getTable(Identifier identifier, TableAccessContext accessContext)
+            throws TableNotExistException {
+        return getTable(identifier);
+    }
+
+    /**
      * Return a {@link Table} identified by the given tableId.
      *
      * @param tableId Id of the table
@@ -1213,6 +1226,22 @@ public interface Catalog extends AutoCloseable {
      */
     TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException;
+
+    /**
+     * Auth table query select with access context and get the filter for row level access control
+     * and column masking rules.
+     *
+     * @param identifier path of the table to query
+     * @param select selected fields, null if select all
+     * @param accessContext context describing why the table is accessed
+     * @return additional filter for row level access control and column masking rules
+     * @throws TableNotExistException if the table does not exist
+     */
+    default TableQueryAuthResult authTableQuery(
+            Identifier identifier, @Nullable List<String> select, TableAccessContext accessContext)
+            throws TableNotExistException {
+        return authTableQuery(identifier, select);
+    }
 
     // ==================== Catalog Information ==========================
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -255,6 +255,31 @@ public class CatalogUtils {
             @Nullable CatalogContext catalogContext,
             boolean isRestCatalog)
             throws Catalog.TableNotExistException {
+        return loadTable(
+                catalog,
+                identifier,
+                internalFileIO,
+                externalFileIO,
+                metadataLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                isRestCatalog,
+                TableAccessContext.direct());
+    }
+
+    public static Table loadTable(
+            Catalog catalog,
+            Identifier identifier,
+            Function<Path, FileIO> internalFileIO,
+            Function<Path, FileIO> externalFileIO,
+            TableMetadata.Loader metadataLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            boolean isRestCatalog,
+            TableAccessContext tableAccessContext)
+            throws Catalog.TableNotExistException {
         if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
             return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
         }
@@ -299,7 +324,8 @@ public class CatalogUtils {
                         isRestCatalog ? null : lockContext,
                         catalogContext,
                         catalog.supportsVersionManagement(),
-                        catalog.supportsPartitionModification());
+                        catalog.supportsPartitionModification(),
+                        tableAccessContext);
         Path path = new Path(schema.options().get(PATH.key()));
         FileStoreTable table =
                 FileStoreTableFactory.create(dataFileIO.apply(path), path, schema, catalogEnv);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -376,6 +376,12 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public Table getTable(Identifier identifier, TableAccessContext accessContext)
+            throws TableNotExistException {
+        return wrapped.getTable(identifier, accessContext);
+    }
+
+    @Override
     public View getView(Identifier identifier) throws ViewNotExistException {
         return wrapped.getView(identifier);
     }
@@ -459,6 +465,13 @@ public abstract class DelegateCatalog implements Catalog {
     public TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException {
         return wrapped.authTableQuery(identifier, select);
+    }
+
+    @Override
+    public TableQueryAuthResult authTableQuery(
+            Identifier identifier, @Nullable List<String> select, TableAccessContext accessContext)
+            throws TableNotExistException {
+        return wrapped.authTableQuery(identifier, select, accessContext);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableAccessContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableAccessContext.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Context describing why a table is accessed. */
+public class TableAccessContext implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Type of table access. */
+    public enum AccessType {
+        DIRECT,
+        BLOB_VIEW_FALLBACK
+    }
+
+    private final AccessType accessType;
+    @Nullable private final Identifier fallbackFrom;
+
+    private TableAccessContext(AccessType accessType, @Nullable Identifier fallbackFrom) {
+        this.accessType = Objects.requireNonNull(accessType, "accessType");
+        this.fallbackFrom = fallbackFrom;
+    }
+
+    public static TableAccessContext direct() {
+        return new TableAccessContext(AccessType.DIRECT, null);
+    }
+
+    public static TableAccessContext blobViewFallback(Identifier fallbackFrom) {
+        return new TableAccessContext(
+                AccessType.BLOB_VIEW_FALLBACK,
+                Objects.requireNonNull(fallbackFrom, "fallbackFrom"));
+    }
+
+    public AccessType accessType() {
+        return accessType;
+    }
+
+    @Nullable
+    public Identifier fallbackFrom() {
+        return fallbackFrom;
+    }
+
+    public boolean isBlobViewFallback() {
+        return accessType == AccessType.BLOB_VIEW_FALLBACK;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.DelegateCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.catalog.TableAccessContext;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
@@ -149,7 +150,13 @@ public class PrivilegedCatalog extends DelegateCatalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
-        Table table = wrapped.getTable(identifier);
+        return getTable(identifier, TableAccessContext.direct());
+    }
+
+    @Override
+    public Table getTable(Identifier identifier, TableAccessContext accessContext)
+            throws TableNotExistException {
+        Table table = wrapped.getTable(identifier, accessContext);
         if (table instanceof FileStoreTable) {
             return PrivilegedFileStoreTable.wrap(
                     (FileStoreTable) table, privilegeManager.getPrivilegeChecker(), identifier);

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -29,6 +29,7 @@ import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.catalog.TableAccessContext;
 import org.apache.paimon.catalog.TableMetadata;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.consumer.ConsumerInfo;
@@ -307,6 +308,12 @@ public class RESTCatalog implements Catalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
+        return getTable(identifier, TableAccessContext.direct());
+    }
+
+    @Override
+    public Table getTable(Identifier identifier, TableAccessContext accessContext)
+            throws TableNotExistException {
         return CatalogUtils.loadTable(
                 this,
                 identifier,
@@ -316,7 +323,8 @@ public class RESTCatalog implements Catalog {
                 null,
                 null,
                 context,
-                true);
+                true,
+                accessContext);
     }
 
     @Override
@@ -614,9 +622,23 @@ public class RESTCatalog implements Catalog {
     @Override
     public TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException {
+        return authTableQuery(identifier, select, TableAccessContext.direct());
+    }
+
+    @Override
+    public TableQueryAuthResult authTableQuery(
+            Identifier identifier, @Nullable List<String> select, TableAccessContext accessContext)
+            throws TableNotExistException {
         checkNotSystemTable(identifier, "authTable");
         try {
-            AuthTableQueryResponse response = api.authTableQuery(identifier, select);
+            AuthTableQueryResponse response =
+                    api.authTableQuery(
+                            identifier,
+                            select,
+                            accessContext.accessType().name(),
+                            accessContext.fallbackFrom() == null
+                                    ? null
+                                    : accessContext.fallbackFrom().getFullName());
             return new TableQueryAuthResult(response.filter(), response.columnMasking());
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -128,6 +128,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                 ? new DataEvolutionTableRead(
                         providerFactories,
                         schema(),
+                        catalogEnvironment.identifier(),
                         catalogEnvironment.catalogContext(),
                         () -> new AppendTableRead(providerFactories, schema()))
                 : new AppendTableRead(providerFactories, schema());

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.paimon.catalog.CatalogSnapshotCommit;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.RenamingSnapshotCommit;
 import org.apache.paimon.catalog.SnapshotCommit;
+import org.apache.paimon.catalog.TableAccessContext;
 import org.apache.paimon.catalog.TableRollback;
 import org.apache.paimon.operation.Lock;
 import org.apache.paimon.table.source.TableQueryAuth;
@@ -54,6 +55,7 @@ public class CatalogEnvironment implements Serializable {
     @Nullable private final CatalogContext catalogContext;
     private final boolean supportsVersionManagement;
     private final boolean supportsPartitionModification;
+    @Nullable private final TableAccessContext tableAccessContext;
 
     public CatalogEnvironment(
             @Nullable Identifier identifier,
@@ -64,6 +66,28 @@ public class CatalogEnvironment implements Serializable {
             @Nullable CatalogContext catalogContext,
             boolean supportsVersionManagement,
             boolean supportsPartitionModification) {
+        this(
+                identifier,
+                uuid,
+                catalogLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                supportsVersionManagement,
+                supportsPartitionModification,
+                TableAccessContext.direct());
+    }
+
+    public CatalogEnvironment(
+            @Nullable Identifier identifier,
+            @Nullable String uuid,
+            @Nullable CatalogLoader catalogLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            boolean supportsVersionManagement,
+            boolean supportsPartitionModification,
+            TableAccessContext tableAccessContext) {
         this.identifier = identifier;
         this.uuid = uuid;
         this.catalogLoader = catalogLoader;
@@ -72,6 +96,7 @@ public class CatalogEnvironment implements Serializable {
         this.catalogContext = catalogContext;
         this.supportsVersionManagement = supportsVersionManagement;
         this.supportsPartitionModification = supportsPartitionModification;
+        this.tableAccessContext = tableAccessContext;
     }
 
     public static CatalogEnvironment empty() {
@@ -196,6 +221,10 @@ public class CatalogEnvironment implements Serializable {
         return catalogContext;
     }
 
+    public TableAccessContext tableAccessContext() {
+        return tableAccessContext == null ? TableAccessContext.direct() : tableAccessContext;
+    }
+
     public CatalogEnvironment copy(Identifier identifier) {
         return new CatalogEnvironment(
                 identifier,
@@ -205,7 +234,21 @@ public class CatalogEnvironment implements Serializable {
                 lockContext,
                 catalogContext,
                 supportsVersionManagement,
-                supportsPartitionModification);
+                supportsPartitionModification,
+                tableAccessContext());
+    }
+
+    public CatalogEnvironment copy(TableAccessContext tableAccessContext) {
+        return new CatalogEnvironment(
+                identifier,
+                uuid,
+                catalogLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                supportsVersionManagement,
+                supportsPartitionModification,
+                tableAccessContext);
     }
 
     public TableQueryAuth tableQueryAuth(CoreOptions options) {
@@ -214,7 +257,7 @@ public class CatalogEnvironment implements Serializable {
         }
         return select -> {
             try (Catalog catalog = catalogLoader.load()) {
-                return catalog.authTableQuery(identifier, select);
+                return catalog.authTableQuery(identifier, select, tableAccessContext());
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
@@ -49,15 +50,18 @@ import java.util.function.Supplier;
 /** A {@link TableRead} for data-evolution enabled append-only tables. */
 public class DataEvolutionTableRead extends AppendTableRead {
 
+    @Nullable private final Identifier identifier;
     @Nullable private final CatalogContext catalogContext;
     @Nullable private final Supplier<InnerTableRead> readFactory;
 
     public DataEvolutionTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
             TableSchema schema,
+            @Nullable Identifier identifier,
             @Nullable CatalogContext catalogContext,
             @Nullable Supplier<InnerTableRead> readFactory) {
         super(providerFactories, schema);
+        this.identifier = identifier;
         this.catalogContext = catalogContext;
         this.readFactory = readFactory;
     }
@@ -129,7 +133,8 @@ public class DataEvolutionTableRead extends AppendTableRead {
         }
 
         BlobViewResolver resolver =
-                BlobViewLookup.createResolver(catalogContext, new ArrayList<>(viewStructs));
+                BlobViewLookup.createResolver(
+                        catalogContext, identifier, new ArrayList<>(viewStructs));
 
         RecordReader<InternalRow> reader = createDataReader(split, authResult);
         Set<Integer> blobViewFieldSet = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableAccessContext;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobViewResolver;
@@ -35,6 +36,8 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,16 +66,26 @@ public class BlobViewLookup {
 
     public static BlobViewResolver createResolver(
             CatalogContext catalogContext, List<BlobViewStruct> viewStructs) {
-        return createResolver(catalogContext, viewStructs, CatalogFactory::createCatalog);
+        return createResolver(catalogContext, null, viewStructs);
+    }
+
+    public static BlobViewResolver createResolver(
+            CatalogContext catalogContext,
+            @Nullable Identifier fallbackFrom,
+            List<BlobViewStruct> viewStructs) {
+        return createResolver(
+                catalogContext, fallbackFrom, viewStructs, CatalogFactory::createCatalog);
     }
 
     @VisibleForTesting
     static BlobViewResolver createResolver(
             CatalogContext catalogContext,
+            @Nullable Identifier fallbackFrom,
             List<BlobViewStruct> viewStructs,
             CatalogLoader catalogLoader) {
+        TableAccessContext accessContext = accessContext(fallbackFrom);
         Map<BlobViewStruct, BlobDescriptor> cached =
-                preloadDescriptors(catalogContext, viewStructs, catalogLoader);
+                preloadDescriptors(catalogContext, viewStructs, accessContext, catalogLoader);
         Map<Identifier, UriReader> cache = new HashMap<>();
         return blobView -> {
             BlobViewStruct viewStruct = blobView.viewStruct();
@@ -90,7 +103,7 @@ public class BlobViewLookup {
                             identifier -> {
                                 try (Catalog catalog = catalogLoader.create(catalogContext)) {
                                     return UriReader.fromFile(
-                                            catalog.getTable(identifier).fileIO());
+                                            catalog.getTable(identifier, accessContext).fileIO());
                                 } catch (Exception e) {
                                     throw new RuntimeException(e);
                                 }
@@ -99,9 +112,16 @@ public class BlobViewLookup {
         };
     }
 
+    private static TableAccessContext accessContext(@Nullable Identifier fallbackFrom) {
+        return fallbackFrom == null
+                ? TableAccessContext.direct()
+                : TableAccessContext.blobViewFallback(fallbackFrom);
+    }
+
     private static Map<BlobViewStruct, BlobDescriptor> preloadDescriptors(
             CatalogContext catalogContext,
             List<BlobViewStruct> viewStructs,
+            TableAccessContext accessContext,
             CatalogLoader catalogLoader) {
         if (viewStructs.isEmpty()) {
             return Collections.emptyMap();
@@ -110,7 +130,11 @@ public class BlobViewLookup {
         Map<Identifier, TableReferences> grouped = groupReferencesByTable(viewStructs);
         try {
             return loadReferencedDescriptors(
-                    catalogContext, grouped.values(), PRELOAD_DESCRIPTOR_EXECUTOR, catalogLoader);
+                    catalogContext,
+                    grouped.values(),
+                    accessContext,
+                    PRELOAD_DESCRIPTOR_EXECUTOR,
+                    catalogLoader);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Failed to preload blob descriptors.", e);
@@ -151,12 +175,15 @@ public class BlobViewLookup {
     private static Map<BlobViewStruct, BlobDescriptor> loadReferencedDescriptors(
             CatalogContext catalogContext,
             Collection<TableReferences> grouped,
+            TableAccessContext accessContext,
             ExecutorService executor,
             CatalogLoader catalogLoader)
             throws Exception {
         List<TableReadPlan> plans = new ArrayList<>(grouped.size());
         for (TableReferences tableReferences : grouped) {
-            plans.add(createTableReadPlan(catalogContext, tableReferences, catalogLoader));
+            plans.add(
+                    createTableReadPlan(
+                            catalogContext, tableReferences, accessContext, catalogLoader));
         }
         long targetRowsPerTask = targetRowsPerTask(plans);
 
@@ -180,6 +207,7 @@ public class BlobViewLookup {
                                                 plan.fields,
                                                 plan.readType,
                                                 rangeChunk,
+                                                accessContext,
                                                 catalogLoader);
                                     } finally {
                                         Thread.currentThread()
@@ -206,11 +234,12 @@ public class BlobViewLookup {
     private static TableReadPlan createTableReadPlan(
             CatalogContext catalogContext,
             TableReferences tableReferences,
+            TableAccessContext accessContext,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             List<FieldRead> fields = new ArrayList<>(tableReferences.referencesByField.size());
-            Table table = catalog.getTable(tableReferences.identifier);
+            Table table = catalog.getTable(tableReferences.identifier, accessContext);
             for (Map.Entry<Integer, List<BlobViewStruct>> entry :
                     tableReferences.referencesByField.entrySet()) {
                 int fieldId = entry.getKey();
@@ -249,12 +278,13 @@ public class BlobViewLookup {
             List<FieldRead> fields,
             RowType readType,
             List<Range> rowRanges,
+            TableAccessContext accessContext,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             Map<BlobViewStruct, BlobDescriptor> resolved = new HashMap<>();
             Table table =
-                    catalog.getTable(identifier)
+                    catalog.getTable(identifier, accessContext)
                             .copy(
                                     Collections.singletonMap(
                                             CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true"));

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogAccessContextTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogAccessContextTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.ResolvingFileIO;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for table access context. */
+public class CatalogAccessContextTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testTableAccessContextPassedToQueryAuth() throws Exception {
+        Options catalogOptions = new Options();
+        catalogOptions.set(CatalogOptions.WAREHOUSE, tempDir.toUri().toString());
+        CatalogContext catalogContext = CatalogContext.create(catalogOptions);
+        FileIO fileIO = new ResolvingFileIO();
+        fileIO.configure(catalogContext);
+
+        TrackingCatalog catalog =
+                new TrackingCatalog(fileIO, new Path(tempDir.toUri().toString()), catalogContext);
+        Identifier tableIdentifier = Identifier.create("default", "T");
+        Identifier viewIdentifier = Identifier.create("default", "ViewT");
+        TableAccessContext accessContext = TableAccessContext.blobViewFallback(viewIdentifier);
+
+        catalog.createDatabase("default", true);
+        catalog.createTable(
+                tableIdentifier,
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .option(CoreOptions.QUERY_AUTH_ENABLED.key(), "true")
+                        .build(),
+                false);
+
+        Table table = catalog.getTable(tableIdentifier, accessContext);
+        table.newReadBuilder().newScan().plan();
+
+        assertThat(((FileStoreTable) table).catalogEnvironment().tableAccessContext())
+                .isSameAs(accessContext);
+        assertThat(catalog.latestAuthContext.get()).isSameAs(accessContext);
+        assertThat(catalog.latestAuthIdentifier.get()).isEqualTo(tableIdentifier);
+    }
+
+    private static class TrackingCatalog extends FileSystemCatalog {
+
+        private final AtomicReference<TableAccessContext> latestAuthContext =
+                new AtomicReference<>();
+        private final AtomicReference<Identifier> latestAuthIdentifier = new AtomicReference<>();
+
+        private TrackingCatalog(FileIO fileIO, Path warehouse, CatalogContext context) {
+            super(fileIO, warehouse, context);
+        }
+
+        @Override
+        public CatalogLoader catalogLoader() {
+            return () -> this;
+        }
+
+        @Override
+        public TableQueryAuthResult authTableQuery(
+                Identifier identifier,
+                @Nullable List<String> select,
+                TableAccessContext accessContext) {
+            latestAuthIdentifier.set(identifier);
+            latestAuthContext.set(accessContext);
+            return null;
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterFunctionRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
 import org.apache.paimon.rest.requests.AlterViewRequest;
+import org.apache.paimon.rest.requests.AuthTableQueryRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreateFunctionRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
@@ -308,5 +309,25 @@ public class RESTApiJsonTest {
                 RESTApi.fromJson(responseStr, AuthTableQueryResponse.class);
         assertEquals(response.filter(), parseData.filter());
         assertEquals(response.columnMasking(), parseData.columnMasking());
+    }
+
+    @Test
+    public void authTableQueryRequestParseTest() throws Exception {
+        AuthTableQueryRequest request =
+                new AuthTableQueryRequest(
+                        java.util.Arrays.asList("col1", "col2"),
+                        "BLOB_VIEW_FALLBACK",
+                        "db.blob_view");
+        String requestStr = RESTApi.toJson(request);
+        AuthTableQueryRequest parseData = RESTApi.fromJson(requestStr, AuthTableQueryRequest.class);
+        assertEquals(request.select(), parseData.select());
+        assertEquals(request.accessType(), parseData.accessType());
+        assertEquals(request.fallbackFrom(), parseData.fallbackFrom());
+
+        AuthTableQueryRequest oldRequest =
+                RESTApi.fromJson("{\"select\":[\"col1\"]}", AuthTableQueryRequest.class);
+        assertEquals(java.util.Collections.singletonList("col1"), oldRequest.select());
+        assertEquals(null, oldRequest.accessType());
+        assertEquals(null, oldRequest.fallbackFrom());
     }
 }


### PR DESCRIPTION
### Purpose

Blob view resolution may need to access an upstream blob table while users are querying a downstream blob-view table. Permission systems need to distinguish this fallback access from a direct upstream table query.

### Changes

- Add `TableAccessContext` to describe table access origins.
- Add context-aware `Catalog#getTable` and `Catalog#authTableQuery` default overloads.
- Carry table access context through `CatalogEnvironment` so scans can pass the same context to query auth.
- Pass `BLOB_VIEW_FALLBACK` context from `DataEvolutionTableRead` / `BlobViewLookup` when resolving upstream blob descriptors and URI readers.
- Add a focused test to verify access context reaches query auth.

### Tests

- `mvn -pl paimon-core -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=CatalogAccessContextTest test`
- `mvn -pl paimon-core -DskipITs -DskipTests -Dspotless.check.skip=true -Dcheckstyle.skip=true test-compile`
