### PR TITLE
[common] Fix SubstringTransform null check for field refs

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/SubstringTransform.java
@@ -56,7 +56,8 @@ public class SubstringTransform implements Transform {
         if (source instanceof FieldRef) {
             FieldRef sourceFieldRef = (FieldRef) source;
             checkArgument(sourceFieldRef.type().is(CHARACTER_STRING));
-            sourceString = row.isNullAt(0) ? null : row.getString(sourceFieldRef.index());
+            int sourceIndex = sourceFieldRef.index();
+            sourceString = row.isNullAt(sourceIndex) ? null : row.getString(sourceIndex);
         } else {
             sourceString = (BinaryString) inputs.get(0);
         }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
@@ -108,8 +108,7 @@ class SubstringTransformTest {
         inputs.add(3);
         SubstringTransform transform = new SubstringTransform(inputs);
 
-        Object result =
-                transform.transform(GenericRow.of(null, BinaryString.fromString("hello")));
+        Object result = transform.transform(GenericRow.of(null, BinaryString.fromString("hello")));
 
         assertThat(result).isEqualTo(BinaryString.fromString("ell"));
     }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/SubstringTransformTest.java
@@ -99,4 +99,18 @@ class SubstringTransformTest {
                                 3));
         assertThat(result).isEqualTo(BinaryString.fromString("ell"));
     }
+
+    @Test
+    public void testSubstringRefInputUsesSourceFieldNullability() {
+        List<Object> inputs = new ArrayList<>();
+        inputs.add(new FieldRef(1, "f1", DataTypes.STRING()));
+        inputs.add(2);
+        inputs.add(3);
+        SubstringTransform transform = new SubstringTransform(inputs);
+
+        Object result =
+                transform.transform(GenericRow.of(null, BinaryString.fromString("hello")));
+
+        assertThat(result).isEqualTo(BinaryString.fromString("ell"));
+    }
 }


### PR DESCRIPTION
### Purpose

`SubstringTransform` checked source field nullability with column `0`, but read the value from `sourceFieldRef.index()`. When column `0` was null and the actual source field was non-null, substring masking incorrectly returned null.

This PR uses the source field index for both the null check and value access, and adds a regression test for that case.

### Tests

`mvn -pl paimon-common -am -Pfast-build -DfailIfNoTests=false -Dtest=SubstringTransformTest test`