### PR TITLE
[lumina] Support null vectors in Lumina index writer

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/ResultEntry.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/ResultEntry.java
@@ -24,7 +24,10 @@ import javax.annotation.Nullable;
 public class ResultEntry {
 
     private final String fileName;
+
+    /** Total logical rows processed by the writer, including null/skipped rows. */
     private final long rowCount;
+
     @Nullable private final byte[] meta;
 
     public ResultEntry(String fileName, long rowCount, @Nullable byte[] meta) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -634,6 +634,12 @@ public class GenericIndexTopoBuilder {
                 }
 
                 List<ResultEntry> resultEntries = indexWriter.finish();
+                if (!resultEntries.isEmpty() && resultEntries.get(0).rowCount() != rowsSeen) {
+                    LOG.warn(
+                            "rowCount mismatch: writer reported {} but caller saw {} rows",
+                            resultEntries.get(0).rowCount(),
+                            rowsSeen);
+                }
                 long elapsed = System.currentTimeMillis() - startTime;
                 LOG.info(
                         "Finished shard [{}, {}]: saw {} rows, "

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -600,7 +600,7 @@ public class GenericIndexTopoBuilder {
                             createIndexWriter(table, indexType, indexField, mergedOptions);
 
             try {
-                long rowsWritten = 0;
+                long rowsSeen = 0;
                 long lastRowId = Long.MIN_VALUE;
                 try (RecordReader<InternalRow> reader = tableRead.createReader(task.split);
                         CloseableIterator<InternalRow> iter = reader.toCloseableIterator()) {
@@ -627,16 +627,8 @@ public class GenericIndexTopoBuilder {
                         // Only write rows within this shard's range
                         if (currentRowId >= task.shardRange.from) {
                             Object fieldData = indexFieldGetter.getFieldOrNull(row);
-                            if (fieldData == null) {
-                                LOG.info(
-                                        "Null vector at rowId={}, stopping shard [{}, {}].",
-                                        currentRowId,
-                                        task.shardRange.from,
-                                        task.shardRange.to);
-                                break;
-                            }
                             indexWriter.write(fieldData);
-                            rowsWritten++;
+                            rowsSeen++;
                         }
                     }
                 }
@@ -644,17 +636,18 @@ public class GenericIndexTopoBuilder {
                 List<ResultEntry> resultEntries = indexWriter.finish();
                 long elapsed = System.currentTimeMillis() - startTime;
                 LOG.info(
-                        "Finished shard [{}, {}]: wrote {} rows, "
+                        "Finished shard [{}, {}]: saw {} rows, "
                                 + "produced {} result entries in {} ms.",
                         task.shardRange.from,
                         task.shardRange.to,
-                        rowsWritten,
+                        rowsSeen,
                         resultEntries.size(),
                         elapsed);
 
-                if (rowsWritten == 0) {
+                if (resultEntries.isEmpty()) {
                     LOG.warn(
-                            "Shard [{}, {}] produced 0 rows, skipping index flush.",
+                            "Shard [{}, {}] produced no index (all null or empty), "
+                                    + "skipping index flush.",
                             task.shardRange.from,
                             task.shardRange.to);
                     return;

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -359,7 +359,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             throw new IllegalArgumentException(
                     String.format(
                             "Vector element at rowId=%d, index=%d is %s",
-                            logicalRowId, elementIndex, Float.isNaN(value) ? "NaN" : "Infinity"));
+                            logicalRowId, elementIndex, Float.toString(value)));
         }
     }
 
@@ -473,12 +473,17 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         }
 
         private void ensureAvailable(int minBytes) throws IOException {
+            int zeroReadCount = 0;
             while (readBuf.remaining() < minBytes) {
                 readBuf.compact();
                 int bytesRead = channel.read(readBuf);
                 readBuf.flip();
                 if (bytesRead == -1) {
                     throw new IOException("Unexpected end of temp file");
+                }
+                if (bytesRead == 0 && ++zeroReadCount > 100) {
+                    throw new IOException(
+                            "Unable to read from temp file: repeated zero-byte reads");
                 }
             }
         }

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -88,10 +88,10 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
 
     private final int recordSizeInBytes;
     private final float[] vectorBuf;
-    private int count;
+    private long count;
     private boolean closed;
 
-    private int logicalRowId;
+    private long logicalRowId;
 
     public LuminaVectorGlobalIndexWriter(
             GlobalIndexFileWriter fileWriter,
@@ -401,18 +401,18 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         private final RandomAccessFile raf;
         private final FileChannel channel;
         private final int dim;
-        private final int totalCount;
+        private final long totalCount;
         private final int recordSizeInBytes;
-        private int cursor;
+        private long cursor;
         private final ByteBuffer readBuf;
         private final String phase;
         private int lastLoggedPercent;
 
-        FileBackedDataset(File file, int dim, int totalCount, String phase) throws IOException {
+        FileBackedDataset(File file, int dim, long totalCount, String phase) throws IOException {
             this(file, dim, totalCount, phase, IO_BUFFER_SIZE);
         }
 
-        FileBackedDataset(File file, int dim, int totalCount, String phase, int bufferSize)
+        FileBackedDataset(File file, int dim, long totalCount, String phase, int bufferSize)
                 throws IOException {
             this.raf = new RandomAccessFile(file, "r");
             this.channel = raf.getChannel();
@@ -442,9 +442,9 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             if (cursor >= totalCount) {
                 return 0;
             }
-            int remaining = totalCount - cursor;
+            long remaining = totalCount - cursor;
             int maxByVectorBuf = vectorBuf.length / dim;
-            int batchSize = Math.min(Math.min(maxByVectorBuf, idBuf.length), remaining);
+            int batchSize = (int) Math.min(Math.min(maxByVectorBuf, idBuf.length), remaining);
 
             try {
                 for (int i = 0; i < batchSize; i++) {
@@ -461,7 +461,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
 
             cursor += batchSize;
 
-            int percent = (int) ((long) cursor * 100 / totalCount);
+            int percent = (int) (cursor * 100 / totalCount);
             if (percent / 10 > lastLoggedPercent / 10) {
                 LOG.info(
                         "Lumina {} progress: {}/{} vectors ({}%)",

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -149,7 +149,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             return;
         }
 
-        // Validate and materialize into vectorBuf (single pass); float[] is zero-copy
+        // Validation must complete before any buffer/state mutation below
         float[] src = materializeAndValidate(fieldData);
 
         if (writeBuf.remaining() < recordSizeInBytes) {
@@ -481,9 +481,13 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                 if (bytesRead == -1) {
                     throw new IOException("Unexpected end of temp file");
                 }
-                if (bytesRead == 0 && ++zeroReadCount > 100) {
-                    throw new IOException(
-                            "Unable to read from temp file: repeated zero-byte reads");
+                if (bytesRead == 0) {
+                    if (++zeroReadCount > 100) {
+                        throw new IOException(
+                                "Unable to read from temp file: repeated zero-byte reads");
+                    }
+                } else {
+                    zeroReadCount = 0;
                 }
             }
         }

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -42,6 +42,7 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +89,11 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
 
     private int count;
     private boolean closed;
+
+    private long logicalRowId;
+    private long currentSegmentStart;
+    private long currentSegmentCount;
+    private final List<long[]> segments = new ArrayList<>();
 
     public LuminaVectorGlobalIndexWriter(
             GlobalIndexFileWriter fileWriter,
@@ -139,7 +145,13 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     @Override
     public void write(Object fieldData) {
         if (fieldData == null) {
-            throw new IllegalArgumentException("Field data must not be null");
+            flushSegmentMeta();
+            logicalRowId++;
+            return;
+        }
+
+        if (currentSegmentCount == 0) {
+            currentSegmentStart = logicalRowId;
         }
 
         int bytesNeeded = dim * Float.BYTES;
@@ -151,13 +163,16 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             float[] vector = (float[]) fieldData;
             checkDimension(vector.length);
             for (int i = 0; i < dim; i++) {
+                checkFinite(vector[i], i);
                 writeBuf.putFloat(vector[i]);
             }
         } else if (fieldData instanceof InternalVector) {
             InternalVector vector = (InternalVector) fieldData;
             checkDimension(vector.size());
             for (int i = 0; i < dim; i++) {
-                writeBuf.putFloat(vector.getFloat(i));
+                float v = vector.getFloat(i);
+                checkFinite(v, i);
+                writeBuf.putFloat(v);
             }
         } else if (fieldData instanceof InternalArray) {
             InternalArray array = (InternalArray) fieldData;
@@ -166,13 +181,24 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                 if (array.isNullAt(i)) {
                     throw new IllegalArgumentException("Vector element at index " + i + " is null");
                 }
-                writeBuf.putFloat(array.getFloat(i));
+                float v = array.getFloat(i);
+                checkFinite(v, i);
+                writeBuf.putFloat(v);
             }
         } else {
             throw new RuntimeException(
                     "Unsupported vector type: " + fieldData.getClass().getName());
         }
+        currentSegmentCount++;
+        logicalRowId++;
         count++;
+    }
+
+    private void flushSegmentMeta() {
+        if (currentSegmentCount > 0) {
+            segments.add(new long[] {currentSegmentStart, currentSegmentCount});
+            currentSegmentCount = 0;
+        }
     }
 
     private void flushWriteBuffer() {
@@ -190,6 +216,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     @Override
     public List<ResultEntry> finish() {
         try {
+            flushSegmentMeta();
             if (count == 0) {
                 return Collections.emptyList();
             }
@@ -230,7 +257,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             long phaseStart = System.currentTimeMillis();
             LOG.info("Lumina pretrain phase started");
             try (FileBackedDataset ds =
-                    new FileBackedDataset(tempVectorFile, dim, count, "pretrain")) {
+                    new FileBackedDataset(tempVectorFile, dim, count, segments, "pretrain")) {
                 index.pretrainFrom(ds);
             }
             LOG.info(
@@ -239,7 +266,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             phaseStart = System.currentTimeMillis();
             LOG.info("Lumina insert phase started");
             try (FileBackedDataset ds =
-                    new FileBackedDataset(tempVectorFile, dim, count, "insert")) {
+                    new FileBackedDataset(tempVectorFile, dim, count, segments, "insert")) {
                 index.insertFrom(ds);
             }
             LOG.info("Lumina insert phase done in {} ms", System.currentTimeMillis() - phaseStart);
@@ -258,7 +285,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                     System.currentTimeMillis() - buildStart);
 
             LuminaIndexMeta meta = new LuminaIndexMeta(options.toLuminaOptions());
-            return new ResultEntry(fileName, count, meta.serialize());
+            return new ResultEntry(fileName, logicalRowId, meta.serialize());
         }
     }
 
@@ -322,6 +349,15 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         }
     }
 
+    private void checkFinite(float value, int elementIndex) {
+        if (!Float.isFinite(value)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Vector element at rowId=%d, index=%d is %s",
+                            logicalRowId, elementIndex, Float.isNaN(value) ? "NaN" : "Infinity"));
+        }
+    }
+
     @Override
     public void close() {
         if (!closed) {
@@ -353,8 +389,12 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         private final ByteBuffer readBuf;
         private final String phase;
         private int lastLoggedPercent;
+        private final List<long[]> segments;
+        private int segIdx;
+        private long offsetInSeg;
 
-        FileBackedDataset(File file, int dim, int totalCount, String phase) throws IOException {
+        FileBackedDataset(File file, int dim, int totalCount, List<long[]> segments, String phase)
+                throws IOException {
             this.raf = new RandomAccessFile(file, "r");
             this.channel = raf.getChannel();
             this.dim = dim;
@@ -365,6 +405,9 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             this.readBuf.limit(0); // empty initially
             this.phase = phase;
             this.lastLoggedPercent = -1;
+            this.segments = segments;
+            this.segIdx = 0;
+            this.offsetInSeg = 0;
         }
 
         @Override
@@ -414,7 +457,17 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             }
 
             for (int i = 0; i < batchSize; i++) {
-                idBuf[i] = cursor + i;
+                if (segIdx >= segments.size()) {
+                    throw new IllegalStateException(
+                            "Segment index out of bounds: segments exhausted at vector "
+                                    + (cursor + i));
+                }
+                idBuf[i] = segments.get(segIdx)[0] + offsetInSeg;
+                offsetInSeg++;
+                if (offsetInSeg >= segments.get(segIdx)[1]) {
+                    segIdx++;
+                    offsetInSeg = 0;
+                }
             }
             cursor += batchSize;
 

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -87,6 +87,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     private ByteBuffer writeBuf;
 
     private final int recordSizeInBytes;
+    private final float[] vectorBuf;
     private int count;
     private boolean closed;
 
@@ -102,6 +103,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         this.count = 0;
         this.closed = false;
         this.recordSizeInBytes = checkedRecordSize(dim, IO_BUFFER_SIZE);
+        this.vectorBuf = new float[dim];
 
         validateFieldType(fieldType);
 
@@ -147,37 +149,42 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             return;
         }
 
-        // Validate before writing anything to avoid partial records in temp file
-        float[] validated = validateVector(fieldData);
+        // Validate and materialize into vectorBuf (single pass); float[] is zero-copy
+        float[] src = materializeAndValidate(fieldData);
 
         if (writeBuf.remaining() < recordSizeInBytes) {
             flushWriteBuffer();
         }
         writeBuf.putLong(logicalRowId);
         for (int i = 0; i < dim; i++) {
-            writeBuf.putFloat(validated[i]);
+            writeBuf.putFloat(src[i]);
         }
         logicalRowId++;
         count++;
     }
 
-    private float[] validateVector(Object fieldData) {
-        float[] result = new float[dim];
+    /**
+     * Validates the vector and returns a float[] ready to write. For float[] input, returns the
+     * input directly (zero-copy). For InternalVector/InternalArray, reads into the reusable
+     * vectorBuf field.
+     */
+    private float[] materializeAndValidate(Object fieldData) {
         if (fieldData instanceof float[]) {
             float[] vector = (float[]) fieldData;
             checkDimension(vector.length);
             for (int i = 0; i < dim; i++) {
                 checkFinite(vector[i], i);
-                result[i] = vector[i];
             }
+            return vector;
         } else if (fieldData instanceof InternalVector) {
             InternalVector vector = (InternalVector) fieldData;
             checkDimension(vector.size());
             for (int i = 0; i < dim; i++) {
                 float v = vector.getFloat(i);
                 checkFinite(v, i);
-                result[i] = v;
+                vectorBuf[i] = v;
             }
+            return vectorBuf;
         } else if (fieldData instanceof InternalArray) {
             InternalArray array = (InternalArray) fieldData;
             checkDimension(array.size());
@@ -187,13 +194,13 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                 }
                 float v = array.getFloat(i);
                 checkFinite(v, i);
-                result[i] = v;
+                vectorBuf[i] = v;
             }
+            return vectorBuf;
         } else {
             throw new RuntimeException(
                     "Unsupported vector type: " + fieldData.getClass().getName());
         }
-        return result;
     }
 
     private void flushWriteBuffer() {
@@ -402,13 +409,18 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         private int lastLoggedPercent;
 
         FileBackedDataset(File file, int dim, int totalCount, String phase) throws IOException {
+            this(file, dim, totalCount, phase, IO_BUFFER_SIZE);
+        }
+
+        FileBackedDataset(File file, int dim, int totalCount, String phase, int bufferSize)
+                throws IOException {
             this.raf = new RandomAccessFile(file, "r");
             this.channel = raf.getChannel();
             this.dim = dim;
             this.totalCount = totalCount;
-            this.recordSizeInBytes = checkedRecordSize(dim, IO_BUFFER_SIZE);
+            this.recordSizeInBytes = checkedRecordSize(dim, bufferSize);
             this.cursor = 0;
-            this.readBuf = ByteBuffer.allocateDirect(IO_BUFFER_SIZE);
+            this.readBuf = ByteBuffer.allocateDirect(bufferSize);
             this.readBuf.order(ByteOrder.nativeOrder());
             this.readBuf.limit(0); // empty initially
             this.phase = phase;

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -42,7 +42,6 @@ import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,19 +80,17 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     private final LuminaVectorIndexOptions options;
     private final int dim;
 
-    /** Temporary file storing vectors as raw native-order floats. */
+    /** Temporary file storing records as [rowId (long)][float * dim] in native byte order. */
     private File tempVectorFile;
 
     private FileChannel writeChannel;
     private ByteBuffer writeBuf;
 
+    private final int recordSizeInBytes;
     private int count;
     private boolean closed;
 
     private long logicalRowId;
-    private long currentSegmentStart;
-    private long currentSegmentCount;
-    private final List<long[]> segments = new ArrayList<>();
 
     public LuminaVectorGlobalIndexWriter(
             GlobalIndexFileWriter fileWriter,
@@ -104,6 +101,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         this.dim = options.dimension();
         this.count = 0;
         this.closed = false;
+        this.recordSizeInBytes = checkedRecordSize(dim, IO_BUFFER_SIZE);
 
         validateFieldType(fieldType);
 
@@ -145,26 +143,32 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     @Override
     public void write(Object fieldData) {
         if (fieldData == null) {
-            flushSegmentMeta();
             logicalRowId++;
             return;
         }
 
-        if (currentSegmentCount == 0) {
-            currentSegmentStart = logicalRowId;
-        }
+        // Validate before writing anything to avoid partial records in temp file
+        float[] validated = validateVector(fieldData);
 
-        int bytesNeeded = dim * Float.BYTES;
-        if (writeBuf.remaining() < bytesNeeded) {
+        if (writeBuf.remaining() < recordSizeInBytes) {
             flushWriteBuffer();
         }
+        writeBuf.putLong(logicalRowId);
+        for (int i = 0; i < dim; i++) {
+            writeBuf.putFloat(validated[i]);
+        }
+        logicalRowId++;
+        count++;
+    }
 
+    private float[] validateVector(Object fieldData) {
+        float[] result = new float[dim];
         if (fieldData instanceof float[]) {
             float[] vector = (float[]) fieldData;
             checkDimension(vector.length);
             for (int i = 0; i < dim; i++) {
                 checkFinite(vector[i], i);
-                writeBuf.putFloat(vector[i]);
+                result[i] = vector[i];
             }
         } else if (fieldData instanceof InternalVector) {
             InternalVector vector = (InternalVector) fieldData;
@@ -172,7 +176,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             for (int i = 0; i < dim; i++) {
                 float v = vector.getFloat(i);
                 checkFinite(v, i);
-                writeBuf.putFloat(v);
+                result[i] = v;
             }
         } else if (fieldData instanceof InternalArray) {
             InternalArray array = (InternalArray) fieldData;
@@ -183,22 +187,13 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                 }
                 float v = array.getFloat(i);
                 checkFinite(v, i);
-                writeBuf.putFloat(v);
+                result[i] = v;
             }
         } else {
             throw new RuntimeException(
                     "Unsupported vector type: " + fieldData.getClass().getName());
         }
-        currentSegmentCount++;
-        logicalRowId++;
-        count++;
-    }
-
-    private void flushSegmentMeta() {
-        if (currentSegmentCount > 0) {
-            segments.add(new long[] {currentSegmentStart, currentSegmentCount});
-            currentSegmentCount = 0;
-        }
+        return result;
     }
 
     private void flushWriteBuffer() {
@@ -216,8 +211,10 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     @Override
     public List<ResultEntry> finish() {
         try {
-            flushSegmentMeta();
             if (count == 0) {
+                writeChannel.close();
+                writeChannel = null;
+                writeBuf = null;
                 return Collections.emptyList();
             }
             // Flush remaining data and close the write channel
@@ -257,7 +254,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             long phaseStart = System.currentTimeMillis();
             LOG.info("Lumina pretrain phase started");
             try (FileBackedDataset ds =
-                    new FileBackedDataset(tempVectorFile, dim, count, segments, "pretrain")) {
+                    new FileBackedDataset(tempVectorFile, dim, count, "pretrain")) {
                 index.pretrainFrom(ds);
             }
             LOG.info(
@@ -266,7 +263,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             phaseStart = System.currentTimeMillis();
             LOG.info("Lumina insert phase started");
             try (FileBackedDataset ds =
-                    new FileBackedDataset(tempVectorFile, dim, count, segments, "insert")) {
+                    new FileBackedDataset(tempVectorFile, dim, count, "insert")) {
                 index.insertFrom(ds);
             }
             LOG.info("Lumina insert phase done in {} ms", System.currentTimeMillis() - phaseStart);
@@ -285,6 +282,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                     System.currentTimeMillis() - buildStart);
 
             LuminaIndexMeta meta = new LuminaIndexMeta(options.toLuminaOptions());
+            // rowCount = logical rows including nulls (not just indexed vectors)
             return new ResultEntry(fileName, logicalRowId, meta.serialize());
         }
     }
@@ -358,6 +356,18 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         }
     }
 
+    private static int checkedRecordSize(int dim, int bufferCapacity) {
+        long recordSize = Long.BYTES + (long) dim * Float.BYTES;
+        if (recordSize > bufferCapacity || recordSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException(
+                    "Vector record size "
+                            + recordSize
+                            + " exceeds buffer capacity "
+                            + bufferCapacity);
+        }
+        return (int) recordSize;
+    }
+
     @Override
     public void close() {
         if (!closed) {
@@ -385,29 +395,24 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         private final FileChannel channel;
         private final int dim;
         private final int totalCount;
+        private final int recordSizeInBytes;
         private int cursor;
         private final ByteBuffer readBuf;
         private final String phase;
         private int lastLoggedPercent;
-        private final List<long[]> segments;
-        private int segIdx;
-        private long offsetInSeg;
 
-        FileBackedDataset(File file, int dim, int totalCount, List<long[]> segments, String phase)
-                throws IOException {
+        FileBackedDataset(File file, int dim, int totalCount, String phase) throws IOException {
             this.raf = new RandomAccessFile(file, "r");
             this.channel = raf.getChannel();
             this.dim = dim;
             this.totalCount = totalCount;
+            this.recordSizeInBytes = checkedRecordSize(dim, IO_BUFFER_SIZE);
             this.cursor = 0;
             this.readBuf = ByteBuffer.allocateDirect(IO_BUFFER_SIZE);
             this.readBuf.order(ByteOrder.nativeOrder());
             this.readBuf.limit(0); // empty initially
             this.phase = phase;
             this.lastLoggedPercent = -1;
-            this.segments = segments;
-            this.segIdx = 0;
-            this.offsetInSeg = 0;
         }
 
         @Override
@@ -429,46 +434,19 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             int maxByVectorBuf = vectorBuf.length / dim;
             int batchSize = Math.min(Math.min(maxByVectorBuf, idBuf.length), remaining);
 
-            int floatsNeeded = batchSize * dim;
-            int destOffset = 0;
             try {
-                while (destOffset < floatsNeeded) {
-                    if (readBuf.remaining() < Float.BYTES) {
-                        // Compact any partial float bytes and refill
-                        readBuf.compact();
-                        int bytesRead = channel.read(readBuf);
-                        readBuf.flip();
-                        if (bytesRead == -1 && readBuf.remaining() < Float.BYTES) {
-                            throw new IOException(
-                                    "Unexpected end of temp file: read "
-                                            + destOffset
-                                            + " floats but need "
-                                            + floatsNeeded);
-                        }
+                for (int i = 0; i < batchSize; i++) {
+                    ensureAvailable(recordSizeInBytes);
+                    idBuf[i] = readBuf.getLong();
+                    int base = i * dim;
+                    for (int d = 0; d < dim; d++) {
+                        vectorBuf[base + d] = readBuf.getFloat();
                     }
-                    int availableFloats = readBuf.remaining() / Float.BYTES;
-                    int toRead = Math.min(availableFloats, floatsNeeded - destOffset);
-                    readBuf.asFloatBuffer().get(vectorBuf, destOffset, toRead);
-                    readBuf.position(readBuf.position() + toRead * Float.BYTES);
-                    destOffset += toRead;
                 }
             } catch (IOException e) {
                 throw new RuntimeException("Failed to read vectors from temp file", e);
             }
 
-            for (int i = 0; i < batchSize; i++) {
-                if (segIdx >= segments.size()) {
-                    throw new IllegalStateException(
-                            "Segment index out of bounds: segments exhausted at vector "
-                                    + (cursor + i));
-                }
-                idBuf[i] = segments.get(segIdx)[0] + offsetInSeg;
-                offsetInSeg++;
-                if (offsetInSeg >= segments.get(segIdx)[1]) {
-                    segIdx++;
-                    offsetInSeg = 0;
-                }
-            }
             cursor += batchSize;
 
             int percent = (int) ((long) cursor * 100 / totalCount);
@@ -480,6 +458,17 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             }
 
             return batchSize;
+        }
+
+        private void ensureAvailable(int minBytes) throws IOException {
+            while (readBuf.remaining() < minBytes) {
+                readBuf.compact();
+                int bytesRead = channel.read(readBuf);
+                readBuf.flip();
+                if (bytesRead == -1) {
+                    throw new IOException("Unexpected end of temp file");
+                }
+            }
         }
 
         @Override

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -91,7 +91,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     private int count;
     private boolean closed;
 
-    private long logicalRowId;
+    private int logicalRowId;
 
     public LuminaVectorGlobalIndexWriter(
             GlobalIndexFileWriter fileWriter,

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/FileBackedDatasetTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/FileBackedDatasetTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lumina.index;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link LuminaVectorGlobalIndexWriter.FileBackedDataset} temp file format. */
+public class FileBackedDatasetTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    public void testBasicReadback() throws IOException {
+        int dim = 3;
+        int numVectors = 4;
+        long[] rowIds = {0, 2, 5, 7};
+        float[][] vectors = {
+            {1.0f, 2.0f, 3.0f},
+            {4.0f, 5.0f, 6.0f},
+            {7.0f, 8.0f, 9.0f},
+            {10.0f, 11.0f, 12.0f}
+        };
+
+        File tempFile = writeTempFile(dim, rowIds, vectors);
+
+        try (LuminaVectorGlobalIndexWriter.FileBackedDataset ds =
+                new LuminaVectorGlobalIndexWriter.FileBackedDataset(
+                        tempFile, dim, numVectors, "test")) {
+            assertThat(ds.dim()).isEqualTo(dim);
+            assertThat(ds.totalSize()).isEqualTo(numVectors);
+
+            float[] vectorBuf = new float[dim * numVectors];
+            long[] idBuf = new long[numVectors];
+            long read = ds.getNextBatch(vectorBuf, idBuf);
+
+            assertThat(read).isEqualTo(numVectors);
+            assertThat(idBuf).containsExactly(0, 2, 5, 7);
+            assertThat(vectorBuf[0]).isEqualTo(1.0f);
+            assertThat(vectorBuf[3]).isEqualTo(4.0f);
+            assertThat(vectorBuf[9]).isEqualTo(10.0f);
+            assertThat(vectorBuf[11]).isEqualTo(12.0f);
+
+            assertThat(ds.getNextBatch(vectorBuf, idBuf)).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void testSmallBufferForcesBoundary() throws IOException {
+        int dim = 2;
+        int numVectors = 5;
+        long[] rowIds = {0, 1, 3, 6, 10};
+        float[][] vectors = {
+            {1.0f, 2.0f},
+            {3.0f, 4.0f},
+            {5.0f, 6.0f},
+            {7.0f, 8.0f},
+            {9.0f, 10.0f}
+        };
+
+        File tempFile = writeTempFile(dim, rowIds, vectors);
+
+        // Record size = 8 + 2*4 = 16 bytes. Use buffer of 20 bytes so records always cross
+        // boundary.
+        int smallBuffer = 20;
+        try (LuminaVectorGlobalIndexWriter.FileBackedDataset ds =
+                new LuminaVectorGlobalIndexWriter.FileBackedDataset(
+                        tempFile, dim, numVectors, "test", smallBuffer)) {
+            float[] vectorBuf = new float[dim * 2];
+            long[] idBuf = new long[2];
+
+            // Read in batches of 2
+            long read = ds.getNextBatch(vectorBuf, idBuf);
+            assertThat(read).isEqualTo(2);
+            assertThat(idBuf[0]).isEqualTo(0);
+            assertThat(idBuf[1]).isEqualTo(1);
+            assertThat(vectorBuf[0]).isEqualTo(1.0f);
+            assertThat(vectorBuf[2]).isEqualTo(3.0f);
+
+            read = ds.getNextBatch(vectorBuf, idBuf);
+            assertThat(read).isEqualTo(2);
+            assertThat(idBuf[0]).isEqualTo(3);
+            assertThat(idBuf[1]).isEqualTo(6);
+
+            read = ds.getNextBatch(vectorBuf, idBuf);
+            assertThat(read).isEqualTo(1);
+            assertThat(idBuf[0]).isEqualTo(10);
+            assertThat(vectorBuf[0]).isEqualTo(9.0f);
+            assertThat(vectorBuf[1]).isEqualTo(10.0f);
+
+            assertThat(ds.getNextBatch(vectorBuf, idBuf)).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void testSingleRecordPerBuffer() throws IOException {
+        int dim = 4;
+        int numVectors = 3;
+        long[] rowIds = {100, 200, 300};
+        float[][] vectors = {
+            {1.0f, 2.0f, 3.0f, 4.0f},
+            {5.0f, 6.0f, 7.0f, 8.0f},
+            {9.0f, 10.0f, 11.0f, 12.0f}
+        };
+
+        File tempFile = writeTempFile(dim, rowIds, vectors);
+
+        // Record size = 8 + 4*4 = 24. Buffer exactly fits one record.
+        int exactBuffer = 24;
+        try (LuminaVectorGlobalIndexWriter.FileBackedDataset ds =
+                new LuminaVectorGlobalIndexWriter.FileBackedDataset(
+                        tempFile, dim, numVectors, "test", exactBuffer)) {
+            float[] vectorBuf = new float[dim];
+            long[] idBuf = new long[1];
+
+            for (int i = 0; i < numVectors; i++) {
+                long read = ds.getNextBatch(vectorBuf, idBuf);
+                assertThat(read).isEqualTo(1);
+                assertThat(idBuf[0]).isEqualTo(rowIds[i]);
+                for (int d = 0; d < dim; d++) {
+                    assertThat(vectorBuf[d]).isEqualTo(vectors[i][d]);
+                }
+            }
+            assertThat(ds.getNextBatch(vectorBuf, idBuf)).isEqualTo(0);
+        }
+    }
+
+    private File writeTempFile(int dim, long[] rowIds, float[][] vectors) throws IOException {
+        File tempFile = new File(tempDir.toFile(), "test-vectors.bin");
+        try (RandomAccessFile raf = new RandomAccessFile(tempFile, "rw");
+                FileChannel channel = raf.getChannel()) {
+            int recordSize = Long.BYTES + dim * Float.BYTES;
+            ByteBuffer buf = ByteBuffer.allocate(recordSize);
+            buf.order(ByteOrder.nativeOrder());
+            for (int i = 0; i < rowIds.length; i++) {
+                buf.clear();
+                buf.putLong(rowIds[i]);
+                for (int d = 0; d < dim; d++) {
+                    buf.putFloat(vectors[i][d]);
+                }
+                buf.flip();
+                while (buf.hasRemaining()) {
+                    channel.write(buf);
+                }
+            }
+        }
+        return tempFile;
+    }
+}

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
@@ -718,6 +718,12 @@ public class LuminaVectorGlobalIndexTest {
                 .hasMessageContaining("rowId=1")
                 .hasMessageContaining("index=0")
                 .hasMessageContaining("Infinity");
+
+        assertThatThrownBy(() -> writer.write(new float[] {0.0f, Float.NEGATIVE_INFINITY}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowId=1")
+                .hasMessageContaining("index=1")
+                .hasMessageContaining("-Infinity");
     }
 
     private Options createDefaultOptions(int dimension) {

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
@@ -511,6 +511,215 @@ public class LuminaVectorGlobalIndexTest {
                 .hasMessageContaining("float vector");
     }
 
+    @Test
+    public void testNullVectorSkipWithCorrectIds() throws IOException {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        // [vec0, null, vec2, null, null, vec5]
+        float[][] vectors =
+                new float[][] {
+                    new float[] {1.0f, 0.0f},
+                    new float[] {0.1f, 0.95f},
+                    new float[] {0.0f, 1.0f}
+                };
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(vectors[0]); // row 0
+        writer.write(null); // row 1 - null
+        writer.write(vectors[1]); // row 2
+        writer.write(null); // row 3 - null
+        writer.write(null); // row 4 - null
+        writer.write(vectors[2]); // row 5
+
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).rowCount()).isEqualTo(6);
+
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+        GlobalIndexFileReader fileReader = createFileReader(indexPath);
+        try (LuminaVectorGlobalIndexReader reader =
+                new LuminaVectorGlobalIndexReader(fileReader, metas, vectorType, indexOptions)) {
+            // Search for vec0=(1,0), should find ID=0
+            VectorSearch vectorSearch = new VectorSearch(vectors[0], 3, fieldName);
+            LuminaScoredGlobalIndexResult result =
+                    (LuminaScoredGlobalIndexResult) reader.visitVectorSearch(vectorSearch).get();
+            assertThat(result.results().getLongCardinality()).isEqualTo(3);
+            // IDs should be {0, 2, 5} - shard-relative with null gaps
+            assertThat(result.results().contains(0L)).isTrue();
+            assertThat(result.results().contains(2L)).isTrue();
+            assertThat(result.results().contains(5L)).isTrue();
+            // IDs at null positions must NOT appear
+            assertThat(result.results().contains(1L)).isFalse();
+            assertThat(result.results().contains(3L)).isFalse();
+            assertThat(result.results().contains(4L)).isFalse();
+        }
+    }
+
+    @Test
+    public void testAllNullReturnsEmpty() {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(null);
+        writer.write(null);
+        writer.write(null);
+
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    public void testNullGapWithPreFilter() throws IOException {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        // [vec0, null, vec2, vec3, null, vec5]
+        float[][] vectors =
+                new float[][] {
+                    new float[] {1.0f, 0.0f},
+                    new float[] {0.95f, 0.1f},
+                    new float[] {0.9f, 0.2f},
+                    new float[] {0.0f, 1.0f}
+                };
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(vectors[0]); // row 0
+        writer.write(null); // row 1 - null
+        writer.write(vectors[1]); // row 2
+        writer.write(vectors[2]); // row 3
+        writer.write(null); // row 4 - null
+        writer.write(vectors[3]); // row 5
+
+        List<ResultEntry> results = writer.finish();
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+
+        GlobalIndexFileReader fileReader = createFileReader(indexPath);
+        try (LuminaVectorGlobalIndexReader reader =
+                new LuminaVectorGlobalIndexReader(fileReader, metas, vectorType, indexOptions)) {
+            // Pre-filter includes null gap IDs {1, 4} and valid ID {2}
+            RoaringNavigableMap64 filter = new RoaringNavigableMap64();
+            filter.add(1L); // null position - should not match
+            filter.add(2L); // valid vector
+            filter.add(4L); // null position - should not match
+            VectorSearch search =
+                    new VectorSearch(vectors[0], 3, fieldName).withIncludeRowIds(filter);
+            LuminaScoredGlobalIndexResult result =
+                    (LuminaScoredGlobalIndexResult) reader.visitVectorSearch(search).get();
+            // Only row 2 should be in results (rows 1 and 4 are null gaps)
+            assertThat(result.results().getLongCardinality()).isEqualTo(1);
+            assertThat(result.results().contains(2L)).isTrue();
+            assertThat(result.results().contains(1L)).isFalse();
+            assertThat(result.results().contains(4L)).isFalse();
+        }
+    }
+
+    @Test
+    public void testNullAtStart() throws IOException {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(null); // row 0 - null
+        writer.write(new float[] {1.0f, 0.0f}); // row 1
+
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).rowCount()).isEqualTo(2);
+
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+        GlobalIndexFileReader fileReader = createFileReader(indexPath);
+        try (LuminaVectorGlobalIndexReader reader =
+                new LuminaVectorGlobalIndexReader(fileReader, metas, vectorType, indexOptions)) {
+            VectorSearch search = new VectorSearch(new float[] {1.0f, 0.0f}, 1, fieldName);
+            LuminaScoredGlobalIndexResult result =
+                    (LuminaScoredGlobalIndexResult) reader.visitVectorSearch(search).get();
+            assertThat(result.results().contains(1L)).isTrue();
+            assertThat(result.results().contains(0L)).isFalse();
+        }
+    }
+
+    @Test
+    public void testNullAtEnd() throws IOException {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(new float[] {1.0f, 0.0f}); // row 0
+        writer.write(null); // row 1 - null
+
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).rowCount()).isEqualTo(2);
+
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+        GlobalIndexFileReader fileReader = createFileReader(indexPath);
+        try (LuminaVectorGlobalIndexReader reader =
+                new LuminaVectorGlobalIndexReader(fileReader, metas, vectorType, indexOptions)) {
+            VectorSearch search = new VectorSearch(new float[] {1.0f, 0.0f}, 1, fieldName);
+            LuminaScoredGlobalIndexResult result =
+                    (LuminaScoredGlobalIndexResult) reader.visitVectorSearch(search).get();
+            assertThat(result.results().contains(0L)).isTrue();
+            assertThat(result.results().contains(1L)).isFalse();
+        }
+    }
+
+    @Test
+    public void testNanInVectorRejected() {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        assertThatThrownBy(() -> writer.write(new float[] {1.0f, Float.NaN}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowId=0")
+                .hasMessageContaining("index=1")
+                .hasMessageContaining("NaN");
+    }
+
+    @Test
+    public void testInfinityInVectorRejected() {
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
+        LuminaVectorGlobalIndexWriter writer =
+                new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
+
+        writer.write(null); // row 0 - null, advances logicalRowId
+        assertThatThrownBy(() -> writer.write(new float[] {Float.POSITIVE_INFINITY, 0.0f}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowId=1")
+                .hasMessageContaining("index=0")
+                .hasMessageContaining("Infinity");
+    }
+
     private Options createDefaultOptions(int dimension) {
         Options options = new Options();
         options.setInteger(LuminaVectorIndexOptions.DIMENSION.key(), dimension);


### PR DESCRIPTION
Skip null vectors during index build instead of throwing or stopping the shard. Non-null vectors continue to be written with correct shard-relative IDs (containing gaps at null positions).

- Writer: write(null) advances logicalRowId without writing, tracks contiguous non-null segments for correct ID mapping in getNextBatch
- Writer: add NaN/Infinity validation for vector elements
- Flink caller: remove null break, use resultEntries.isEmpty() for commit skip, rename rowsWritten to rowsSeen
- Tests: null gap IDs, all-null shard, pre-filter with gap IDs, null at start/end boundaries, NaN/Infinity rejection

### Purpose

### Tests
