### PR TITLE
[Flink] Fix ReadOperator to stop reading after LIMIT on dedicated split path.

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.NestedProjectedRowData;
+import org.apache.paimon.flink.source.RecordLimiter;
 import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
@@ -68,6 +69,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
     private transient long emitEventTimeLag = FileStoreSourceReaderMetrics.UNDEFINED;
     private transient long idleStartTime = FileStoreSourceReaderMetrics.ACTIVE;
     private transient Counter numRecordsIn;
+    @Nullable private transient RecordLimiter recordLimiter;
     @Nullable private final Long limit;
 
     public ReadOperator(
@@ -98,6 +100,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
                                 .getIOManager()
                                 .getSpillingDirectoriesPaths());
         this.read = readSupplier.get().withIOManager(ioManager);
+        this.recordLimiter = RecordLimiter.create(limit);
         this.reuseRow = new FlinkRowData(null);
         this.reuseRecord = new StreamRecord<>(null);
         this.idlingStarted();
@@ -122,7 +125,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
         boolean firstRecord = true;
         try (CloseableIterator<InternalRow> iterator =
                 read.createReader(split).toCloseableIterator()) {
-            while (iterator.hasNext()) {
+            while (!reachLimit() && iterator.hasNext()) {
                 emitEventTimeLag = System.currentTimeMillis() - eventTime;
 
                 // each Split is already counted as one input record,
@@ -133,10 +136,6 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
                     numRecordsIn.inc();
                 }
 
-                if (reachLimit()) {
-                    return;
-                }
-
                 reuseRow.replace(iterator.next());
                 if (nestedProjectedRowData == null) {
                     reuseRecord.replace(reuseRow);
@@ -145,6 +144,10 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
                     reuseRecord.replace(nestedProjectedRowData);
                 }
                 output.collect(reuseRecord);
+
+                if (recordLimiter != null) {
+                    recordLimiter.increment();
+                }
             }
         }
         // start idle when data sending is completed
@@ -160,7 +163,7 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
     }
 
     private boolean reachLimit() {
-        if (limit != null && numRecordsIn.getCount() > limit) {
+        if (recordLimiter != null && recordLimiter.reachLimit()) {
             LOG.info("Reader {} reach the limit record {}.", this, limit);
             return true;
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/DedicatedSplitReadLimitTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/DedicatedSplitReadLimitTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.operator;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.metrics.MetricRegistry;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.types.DataTypes;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests {@link ReadOperator} limit on the dedicated split read path. */
+public class DedicatedSplitReadLimitTest {
+
+    private static final int LIMIT = 10;
+
+    @TempDir Path tempDir;
+
+    private Table table;
+
+    @BeforeEach
+    public void before()
+            throws Catalog.TableAlreadyExistException, Catalog.DatabaseNotExistException,
+                    Catalog.TableNotExistException, Catalog.DatabaseAlreadyExistException {
+        Catalog catalog =
+                CatalogFactory.createCatalog(
+                        CatalogContext.create(new org.apache.paimon.fs.Path(tempDir.toUri())));
+        Schema schema =
+                Schema.newBuilder()
+                        .column("a", DataTypes.INT())
+                        .column("b", DataTypes.INT())
+                        .column("c", DataTypes.INT())
+                        .primaryKey("a")
+                        .option("bucket", "1")
+                        .build();
+        Identifier identifier = Identifier.create("default", "t");
+        catalog.createDatabase("default", false);
+        catalog.createTable(identifier, schema, false);
+        this.table = catalog.getTable(identifier);
+    }
+
+    @Test
+    public void testReadOperatorStopsAfterLimit() throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        for (int i = 0; i < 100; i++) {
+            write.write(GenericRow.of(i, i, i));
+        }
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        ReadBatchCountingRead countingRead =
+                new ReadBatchCountingRead(table.newReadBuilder().newRead());
+        ReadOperator readOperator = new ReadOperator(() -> countingRead, null, (long) LIMIT);
+
+        OneInputStreamOperatorTestHarness<Split, RowData> harness =
+                new OneInputStreamOperatorTestHarness<>(readOperator);
+        harness.setup(
+                InternalSerializers.create(
+                        RowType.of(new IntType(), new IntType(), new IntType())));
+        harness.open();
+        for (Split split : table.newReadBuilder().newScan().plan().splits()) {
+            harness.processElement(new StreamRecord<>(split));
+        }
+
+        assertThat(harness.getOutput()).hasSize(LIMIT);
+        assertThat(countingRead.readBatchInvocations()).isEqualTo(1);
+    }
+
+    private static class ReadBatchCountingRead implements TableRead {
+
+        private final TableRead delegate;
+        private final AtomicInteger readBatchInvocations = new AtomicInteger();
+
+        private ReadBatchCountingRead(TableRead delegate) {
+            this.delegate = delegate;
+        }
+
+        int readBatchInvocations() {
+            return readBatchInvocations.get();
+        }
+
+        @Override
+        public TableRead withMetricRegistry(MetricRegistry registry) {
+            delegate.withMetricRegistry(registry);
+            return this;
+        }
+
+        @Override
+        public TableRead executeFilter() {
+            delegate.executeFilter();
+            return this;
+        }
+
+        @Override
+        public TableRead withIOManager(IOManager ioManager) {
+            delegate.withIOManager(ioManager);
+            return this;
+        }
+
+        @Override
+        public RecordReader<InternalRow> createReader(Split split) throws IOException {
+            RecordReader<InternalRow> reader = delegate.createReader(split);
+            return new RecordReader<InternalRow>() {
+                @Override
+                public RecordIterator<InternalRow> readBatch() throws IOException {
+                    readBatchInvocations.incrementAndGet();
+                    return reader.readBatch();
+                }
+
+                @Override
+                public void close() throws IOException {
+                    reader.close();
+                }
+            };
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -238,15 +238,11 @@ public class OperatorSourceTest {
         }
         ArrayList<Object> values = new ArrayList<>(harness.getOutput());
 
-        // In ReadOperator each Split is already counted as one input record. But in this case it
-        // will not happen.
-        // So in this case the result values's size if 3 even if the limit is 2.
-        // The IT case see BatchFileStoreITCase#testBatchReadSourceWithSnapshot.
+        // ReadOperator limit is enforced on emitted records.
         assertThat(values)
                 .containsExactlyInAnyOrder(
                         new StreamRecord<>(GenericRowData.of(1, 1, 1)),
-                        new StreamRecord<>(GenericRowData.of(2, 2, 2)),
-                        new StreamRecord<>(GenericRowData.of(3, 3, 3)));
+                        new StreamRecord<>(GenericRowData.of(2, 2, 2)));
     }
 
     @Test


### PR DESCRIPTION
## Problem

With `scan.dedicated-split-generation=true`, `LIMIT N` returns correct results but scans the entire ORC file. Flink UI shows the Limit stage ~19s for 10 records.

```sql
/*+ config(job_name=hl_0527, cluster=hongli-duibi-0528) */ 
select
  *
from
  `PAIMON-MAINSE-DUMP-EA-20250514`.`PAIMON-MAINSE-DUMP-EA-20250514_MAINSE_DUMP`.`APP10000004119_MAINSE_PAIMON_D20260526194436`
  /*+ `OPTIONS`('scan.dedicated-split-generation'='true', 'parallelism' = '1') */
limit
  10;
```

A related core-layer fix is in https://github.com/apache/paimon/pull/7994: `ApplyBitmapIndexRecordReader` does not signal reader exhaustion after the bitmap selection is consumed, so `RecordReaderIterator` keeps calling `readBatch()` until EOF. That PR fixes the root cause for all `toCloseableIterator()` / `forEachRemaining()` callers. **This PR (#7991) fixes the same symptom on the Flink dedicated split path** by stopping `ReadOperator` from calling `hasNext()` after the limit is reached.

## Root Cause --- Short Summary

When `scan.dedicated-split-generation=true`, `ReadOperator.processElement()` uses `while (iterator.hasNext())` with `reachLimit()` checked **inside** the loop body. That does **not** stop the extra `hasNext()` after N rows, because **`hasNext()` is evaluated in the `while` condition before the body runs** — including `reachLimit()`. Even after 10 rows are emitted, the loop enters a new iteration and calls `hasNext()` first, which triggers `RecordReaderIterator.advanceIfNeeded()` and repeatedly calls `RecordReader.readBatch()` until EOF.

The old `reachLimit()` also could not reliably stop at N: it used `numRecordsIn > limit` (not `>=`), and skipped `numRecordsIn.inc()` on the first row — so after emitting 10 rows, `numRecordsIn` was still 9 and `reachLimit()` returned false anyway.

Although `ApplyBitmapIndexRecordReader` (from `ReadBuilder.withLimit(N)`) stops yielding rows after N, the iterator layer keeps calling `readBatch()`. The FLIP-27 path avoids this via `RecordLimiter` in `FileStoreSourceSplitReader.fetch()`. This PR applies the same pattern in `ReadOperator`.

## Root Cause --- Detailed explanation

### 1. Read path when `dedicated-split-generation=true`

Flink SQL `LIMIT N` is pushed down to Paimon in two places:

- **`ReadBuilder.withLimit(N)`** — may wrap the storage reader (e.g. `FileIndexEvaluator` → `ApplyBitmapIndexRecordReader`). Because `file-index.read.enabled` defaults to `true`, a query with only `LIMIT N` (no filter) is pushed down as a bitmap selection, and the ORC reader is wrapped by `ApplyBitmapIndexRecordReader`.
- **`ReadOperator(limit=N)`** — reads splits on the dedicated path (`MonitorSource` → shuffle → `ReadOperator`).

When the wrapper returns `null` after row N, `RecordReaderIterator` treats it as batch exhaustion and keeps calling `readBatch()` until EOF.

The slow case is in **`ReadOperator.processElement()`**, which reads via:

```text
TableRead.createReader(split).toCloseableIterator()  →  RecordReaderIterator
```

---

### 2. What the old loop did

Previously, **`ReadOperator.processElement()`** used:

```java
while (iterator.hasNext()) {          // (A) hasNext() runs FIRST
    if (firstRecord) { ... }
    else { numRecordsIn.inc(); }      // (B) first row is NOT counted

    if (reachLimit()) return;         // (C) reachLimit() runs AFTER (A)

    output.collect(iterator.next());  // (D) emit
}
```

Execution order on each iteration: **(A) → (B) → (C) → (D)**.

---

### 3. Why `reachLimit()` inside the loop does not prevent the extra `hasNext()`

A common question: *after 10 rows are emitted and `numRecordsIn.inc()` has run, shouldn't `reachLimit()` return true and stop the loop?*

**No — for two reasons:**

**① `hasNext()` runs before `reachLimit()`**

The limit check is in the loop **body**, but `hasNext()` is in the **`while` condition**. After the 10th row is emitted, the loop starts iteration 11:

```text
Step 1: while (iterator.hasNext())   ← runs FIRST, triggers advanceIfNeeded()
Step 2: numRecordsIn.inc()
Step 3: if (reachLimit()) return     ← too late; hasNext() already ran
Step 4: output.collect(...)
```

So even if `reachLimit()` would eventually return true, **`hasNext()` has already been called** and the expensive scan may have started.

**② The old `reachLimit()` condition was wrong for this purpose**

```java
// old ReadOperator.reachLimit()
return limit != null && numRecordsIn.getCount() > limit;  // '>', not '>='
```

For `limit = 10`, after emitting 10 rows:

| Row emitted | `numRecordsIn` after `inc()` | `numRecordsIn > 10` |
|-------------|------------------------------|---------------------|
| 1st         | 0 (first row skipped)        | false               |
| 2nd–10th    | 1–9                          | false               |

After the 10th row, `numRecordsIn` is **9**, not 10 — so `reachLimit()` is still **false**. The loop proceeds to call `hasNext()` again.

---

### 4. Why one extra `hasNext()` scans the whole file

**`RecordReaderIterator.advanceIfNeeded()`** does:

```java
currentResult = currentIterator.next();
if (currentResult == null) {
    currentIterator.releaseBatch();
    currentIterator = reader.readBatch();  // repeat until EOF
}
```

With `withLimit(N)`, **`ApplyBitmapIndexFileRecordIterator.next()`** returns `null` once `position > last`. **`RecordReaderIterator`** treats that as batch exhaustion and keeps calling **`readBatch()`** until EOF.

Arthas on `LIMIT 10`:

```text
RecordReaderIterator.advanceIfNeeded()  cost ≈ 11.2s
```

This matches the ~19s Limit stage in Flink UI.

---

### 5. Why the non-dedicated path does not hit this

**`FileStoreSourceSplitReader.fetch()`** checks the limit **before** `readBatch()`:

```java
nextBatch = reachLimit() ? null : currentReader.recordReader().readBatch();
```

**`ReadOperator`** had no equivalent guard before **`hasNext()`**.

---

## Evidence

**Flink UI:** Limit operator ~19s, 10 records.
<img width="1936" height="1048" alt="image" src="https://github.com/user-attachments/assets/a03f8b90-60e6-49a9-b9a3-e68b1028baf4" />

**Arthas:**

```bash
[arthas@1]$ trace org.apache.paimon.reader.RecordReaderIterator advanceIfNeeded '#cost>500' -n 5
Press Q or Ctrl+C to abort.
Affect(class count: 1 , method count: 1) cost in 73 ms, listenerId: 40
`---ts=2026-05-27 16:52:28.536;thread_name=app10000004119_mainse_paimon_d20260526194436[127764] -> Limit[127765] (1/1)#0;id=778;is_daemon=false;priority=5;TCCL=org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader@5d9e511d
    `---[18665.861763ms] org.apache.paimon.reader.RecordReaderIterator:advanceIfNeeded()
        +---[0.00% min=0.003656ms,max=0.017421ms,total=0.61503ms,count=96] org.apache.paimon.reader.RecordReader$RecordIterator:next() #76
        +---[0.00% min=0.002026ms,max=0.059614ms,total=0.502581ms,count=96] org.apache.paimon.reader.RecordReader$RecordIterator:releaseBatch() #80
        `---[99.99% min=0.060719ms,max=1588.668747ms,total=18664.03164ms,count=96] org.apache.paimon.reader.RecordReader:readBatch() #84
```
**trace RecordReaderIterator.advanceIfNeeded shows a single call (~18.7s) containing 96 invocations of RecordReader.readBatch() (and 96 next()/releaseBatch() pairs), confirming the iterator loops until EOF after the limit bitmap stops yielding rows.**

## Fix

Align **`ReadOperator`** with **`FileStoreSourceSplitReader`**:

1. Use **`RecordLimiter`** — increment **after each emit** (1 row = 1 count), with `counter >= limit`.
2. Check limit **before** `hasNext()` via `&&` short-circuit:

```java
while (!reachLimit() && iterator.hasNext()) {
    output.collect(...);
    recordLimiter.increment();   // after emit; reachLimit() true on next iteration
}

private boolean reachLimit() {
    return recordLimiter != null && recordLimiter.reachLimit();
}
```

When `recordLimiter.reachLimit()` is true, **`iterator.hasNext()` is not evaluated**, so **`RecordReaderIterator.advanceIfNeeded()`** is never called and the full-file ORC scan is avoided.

## Testing

- `DedicatedSplitReadLimitTest` — 100-row split, `LIMIT 10` → 10 rows, `readBatch` called once
- `OperatorSourceTest.testReadOperatorWithLimit` — limit=2 → exactly 2 rows
- `BatchFileStoreITCase.testDedicatedPathLimitTenOnManyRows` — 100 rows INSERT, `LIMIT 10` → 10 rows

```bash
mvn test -pl paimon-flink/paimon-flink-common \
  -Dtest=DedicatedSplitReadLimitTest,OperatorSourceTest#testReadOperatorWithLimit,BatchFileStoreITCase#testDedicatedPathLimitTenOnManyRows
```

---