### PR TITLE
[spark] Improve unsupported provider error message with catalog details

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -569,7 +569,13 @@ public class SparkCatalog extends SparkBaseCatalog
                 normalizedProperties.put(TYPE.key(), FORMAT_TABLE.toString());
                 normalizedProperties.put(FILE_FORMAT.key(), provider.toLowerCase());
             } else {
-                throw new UnsupportedOperationException("Provider is not supported: " + provider);
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Provider '%s' is not supported by catalog '%s' (implementation: %s). Supported providers: [paimon, %s]",
+                                provider,
+                                catalogName,
+                                getClass().getSimpleName(),
+                                SparkSource.FORMAT_NAMES().mkString(", ")));
             }
         }
         normalizedProperties.remove(TableCatalog.PROP_PROVIDER);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -860,7 +860,7 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
   test("Paimon DDL: create unsupported table") {
     assert(intercept[Exception] {
       sql("CREATE TABLE t (id INT) USING paimon1")
-    }.getMessage.contains("Provider is not supported: paimon1"))
+    }.getMessage.contains("Provider 'paimon1' is not supported"))
   }
 
   test("Paimon DDL: Drop Partition by partial spec") {


### PR DESCRIPTION
### Purpose

Improve the "Provider is not supported" error message in SparkCatalog to include the catalog name, implementation class, and supported providers list.

Before: `Provider is not supported: paimon1`
After: `Provider 'paimon1' is not supported by catalog 'my_catalog' (implementation: SparkCatalog). Supported providers: [paimon, orc, parquet, csv, text, json]`

### Tests

Update existing test in `DDLTestBase` to match the new error message format.