### PR TITLE
[spark] Broadcast data evolution merge file map

### DIFF
--- a/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTest.scala
+++ b/paimon-spark/paimon-spark-3.5/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTest.scala
@@ -18,4 +18,129 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.spark.SparkCatalog
+import org.apache.paimon.spark.extensions.PaimonSparkSessionExtensions
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.{Row, SparkSession}
+
+import java.io.File
+
 class RowTrackingTest extends RowTrackingTestBase {}
+
+class RowTrackingKryoTest extends RowTrackingTestBase {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+  }
+}
+
+class RowTrackingKryoLocalClusterTest extends SparkFunSuite {
+
+  private var spark: SparkSession = _
+  private var warehouse: File = _
+  private var previousSparkHome: String = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    val sparkHome = sparkHomeDir
+    assume(sparkHome.exists(), s"Spark home does not exist: ${sparkHome.getAbsolutePath}")
+
+    warehouse = createTempDir("paimon-row-tracking-kryo")
+    previousSparkHome = System.getProperty("spark.test.home")
+    System.setProperty("spark.test.home", sparkHome.getAbsolutePath)
+
+    spark = SparkSession
+      .builder()
+      .master("local-cluster[2,1,1024]")
+      .appName("RowTrackingKryoLocalClusterTest")
+      .config("spark.ui.enabled", "false")
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .config("spark.sql.shuffle.partitions", "2")
+      .config("spark.sql.catalog.paimon", classOf[SparkCatalog].getName)
+      .config("spark.sql.catalog.paimon.warehouse", warehouse.getCanonicalPath)
+      .config("spark.sql.extensions", classOf[PaimonSparkSessionExtensions].getName)
+      .getOrCreate()
+
+    spark.sql("USE paimon")
+    spark.sql("CREATE DATABASE IF NOT EXISTS test")
+    spark.sql("USE test")
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      if (spark != null) {
+        spark.stop()
+        SparkSession.clearActiveSession()
+        SparkSession.clearDefaultSession()
+      }
+    } finally {
+      if (previousSparkHome == null) {
+        System.clearProperty("spark.test.home")
+      } else {
+        System.setProperty("spark.test.home", previousSparkHome)
+      }
+      if (warehouse != null) {
+        deleteRecursively(warehouse)
+      }
+      super.afterAll()
+    }
+  }
+
+  test("Data Evolution: partial fields merge with kryo broadcast") {
+    spark.sql("DROP TABLE IF EXISTS target")
+    spark.sql("DROP TABLE IF EXISTS source")
+
+    spark.sql("""
+                |CREATE TABLE target (id INT, b INT, c INT, pt STRING)
+                |TBLPROPERTIES (
+                |  'row-tracking.enabled' = 'true',
+                |  'data-evolution.enabled' = 'true')
+                |PARTITIONED BY (pt)
+                |""".stripMargin)
+    spark.sql("INSERT INTO target VALUES (1, 10, 100, 'p0'), (2, 20, 200, 'p0')")
+
+    spark.sql("CREATE TABLE source (id INT, b INT, pt STRING)")
+    spark.sql("INSERT INTO source VALUES (1, 11, 'p0')")
+
+    spark
+      .sql("""
+             |MERGE INTO target
+             |USING source
+             |ON target.id = source.id AND target.pt = source.pt
+             |WHEN MATCHED THEN UPDATE SET target.b = source.b
+             |""".stripMargin)
+      .collect()
+
+    assert(
+      spark.sql("SELECT id, b, c, pt FROM target ORDER BY id").collect().toSeq ==
+        Seq(Row(1, 11, 100, "p0"), Row(2, 20, 200, "p0")))
+  }
+
+  private def sparkHomeDir: File = {
+    Option(System.getProperty("spark.test.home"))
+      .orElse(sys.env.get("SPARK_HOME"))
+      .map(new File(_))
+      .getOrElse(new File(System.getProperty("user.home"), "Documents/program/spark"))
+  }
+
+  private def createTempDir(prefix: String): File = {
+    val dir = File.createTempFile(prefix, "")
+    assert(dir.delete())
+    assert(dir.mkdir())
+    dir
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.exists()) {
+      if (file.isDirectory) {
+        val children = file.listFiles()
+        if (children != null) {
+          children.foreach(deleteRecursively)
+        }
+      }
+      file.delete()
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
@@ -19,7 +19,6 @@
 package org.apache.paimon.spark.commands
 
 import org.apache.paimon.CoreOptions
-import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
 import org.apache.paimon.spark.write.{DataEvolutionTableDataWrite, WriteHelper, WriteTaskResult}
 import org.apache.paimon.table.FileStoreTable
@@ -28,6 +27,7 @@ import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.DataType
 import org.apache.paimon.types.DataTypeRoot.BLOB
 import org.apache.paimon.types.VectorType.isVectorStoreFile
+import org.apache.paimon.utils.SerializationUtils
 
 import org.apache.spark.sql._
 
@@ -38,21 +38,6 @@ import scala.collection.mutable
 
 case class DataEvolutionPaimonWriter(paimonTable: FileStoreTable, dataSplits: Seq[DataSplit])
   extends WriteHelper {
-
-  private lazy val firstRowIdToPartitionMap: mutable.HashMap[Long, (BinaryRow, Long)] = {
-    val firstRowIdToPartitionMap = new mutable.HashMap[Long, (BinaryRow, Long)]
-    dataSplits.foreach(
-      split =>
-        split
-          .dataFiles()
-          .asScala
-          .filter(file => !isBlobFile(file.fileName()) && !isVectorStoreFile(file.fileName()))
-          .foreach(
-            file =>
-              firstRowIdToPartitionMap
-                .put(file.firstRowId(), (split.partition(), file.rowCount()))))
-    firstRowIdToPartitionMap
-  }
 
   // File rolling will never be performed
   override val table: FileStoreTable =
@@ -77,14 +62,31 @@ case class DataEvolutionPaimonWriter(paimonTable: FileStoreTable, dataSplits: Se
           CoreOptions.BLOB_EXTERNAL_STORAGE_FIELD.key() + "') can be updated.")
     }
 
+    val firstRowIdToPartitionMap = new mutable.HashMap[Long, (Array[Byte], Long)]
+    dataSplits.foreach(
+      split =>
+        split
+          .dataFiles()
+          .asScala
+          .filter(file => !isBlobFile(file.fileName()) && !isVectorStoreFile(file.fileName()))
+          .foreach(
+            file =>
+              firstRowIdToPartitionMap
+                .put(
+                  file.firstRowId(),
+                  (SerializationUtils.serializeBinaryRow(split.partition()), file.rowCount()))))
+    val firstRowIdToPartitionMapBroadcast =
+      sparkSession.sparkContext.broadcast(firstRowIdToPartitionMap)
+    val writeBuilder = table.newBatchWriteBuilder()
+
     val written =
       data.mapPartitions {
         iter =>
           {
             val write = DataEvolutionTableDataWrite(
-              table.newBatchWriteBuilder(),
+              writeBuilder,
               writeType,
-              firstRowIdToPartitionMap,
+              firstRowIdToPartitionMapBroadcast.value,
               catalogContextForBlobDescriptor)
             try {
               iter.foreach(row => write.write(row))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
@@ -28,6 +28,7 @@ import org.apache.paimon.spark.util.SparkRowUtils
 import org.apache.paimon.table.sink.{BatchWriteBuilder, CommitMessage, CommitMessageImpl, TableWriteImpl}
 import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.RecordWriter
+import org.apache.paimon.utils.SerializationUtils
 
 import org.apache.spark.sql.Row
 
@@ -39,7 +40,7 @@ import scala.collection.mutable.ListBuffer
 case class DataEvolutionTableDataWrite(
     writeBuilder: BatchWriteBuilder,
     writeType: RowType,
-    firstRowIdToPartitionMap: mutable.HashMap[Long, (BinaryRow, Long)],
+    firstRowIdToPartitionMap: mutable.HashMap[Long, (Array[Byte], Long)],
     catalogContext: CatalogContext)
   extends InnerTableV1DataWrite {
 
@@ -73,7 +74,8 @@ case class DataEvolutionTableDataWrite(
           s"Available first row IDs: ${firstRowIdToPartitionMap.keys.mkString(", ")}")
     }
 
-    val (partition, numRecords) = pair
+    val (partitionBytes, numRecords) = pair
+    val partition = SerializationUtils.deserializeBinaryRow(partitionBytes)
 
     val writer = writeBuilder
       .newWrite()


### PR DESCRIPTION
### Purpose

Broadcast the data evolution MERGE INTO file map instead of embedding the full map in every task closure. This reduces Spark task serialization pressure for large merge plans.

### Tests

Added RowTrackingTest coverage in the Spark 3.5 module. Not run locally in this split step.