### PR TITLE
[spark] Avoid serializing known splits in read builder

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 
@@ -46,6 +47,13 @@ public class KnownSplitsTable implements ReadonlyTable {
 
     public Split[] splits() {
         return splits;
+    }
+
+    @Override
+    public ReadBuilder newReadBuilder() {
+        // Do not let ReadBuilderImpl capture this KnownSplitsTable. The split list may be very
+        // large and is already carried by Spark input partitions.
+        return origin.newReadBuilder();
     }
 
     @Override


### PR DESCRIPTION
### Purpose

Avoid capturing `KnownSplitsTable` in the read builder. The known split list can be large and Spark already carries per-task splits through input partitions, so the read builder can delegate to the origin table.

### Tests

Not run locally in this split step.