### PR TITLE
[core] Fix format table date partition pruning

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableScan.java
@@ -19,7 +19,10 @@
 package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.casting.CastExecutor;
+import org.apache.paimon.casting.CastExecutors;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.format.csv.CsvOptions;
@@ -43,7 +46,9 @@ import org.apache.paimon.table.format.predicate.PredicateUtils;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.PartitionPathUtils;
@@ -245,7 +250,8 @@ public class FormatTableScan implements InnerTableScan {
                 Map<String, String> equalityPrefix =
                         extractLeadingEqualityPartitionSpecWhenOnlyAnd(
                                 partitionKeys,
-                                ((DefaultPartitionPredicate) partitionFilter).predicate());
+                                ((DefaultPartitionPredicate) partitionFilter).predicate(),
+                                partitionType);
                 if (!equalityPrefix.isEmpty()) {
                     // Use optimized scan for specific partition path
                     String partitionPath =
@@ -313,7 +319,7 @@ public class FormatTableScan implements InnerTableScan {
     }
 
     public static Map<String, String> extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-            List<String> partitionKeys, Predicate predicate) {
+            List<String> partitionKeys, Predicate predicate, RowType partitionType) {
         List<Predicate> predicates = PredicateBuilder.splitAnd(predicate);
         Map<String, String> equals = new HashMap<>();
         for (Predicate sub : predicates) {
@@ -324,7 +330,10 @@ public class FormatTableScan implements InnerTableScan {
                     LeafFunction function = ((LeafPredicate) sub).function();
                     String field = fieldRef.name();
                     if (function instanceof Equal && partitionKeys.contains(field)) {
-                        equals.put(field, ((LeafPredicate) sub).literals().get(0).toString());
+                        equals.put(
+                                field,
+                                partitionLiteralToString(
+                                        fieldRef.type(), ((LeafPredicate) sub).literals().get(0)));
                     }
                 }
             }
@@ -338,5 +347,17 @@ public class FormatTableScan implements InnerTableScan {
             }
         }
         return result;
+    }
+
+    private static String partitionLiteralToString(DataType type, Object literal) {
+        if (literal == null) {
+            return null;
+        }
+
+        CastExecutor<Object, BinaryString> executor =
+                (CastExecutor<Object, BinaryString>)
+                        CastExecutors.resolve(type, VarCharType.STRING_TYPE);
+        BinaryString value = executor.cast(literal);
+        return value == null ? null : value.toString();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableScanTest.java
@@ -238,6 +238,31 @@ public class FormatTableScanTest {
     }
 
     @TestTemplate
+    void testComputeScanPathWithDateEqualityFilter() {
+        Path tableLocation = new Path(tmpPath.toUri());
+        RowType datePartitionType = RowType.builder().field("dt", DataTypes.DATE()).build();
+        List<String> datePartitionKeys = datePartitionType.getFieldNames();
+
+        PredicateBuilder builder = new PredicateBuilder(datePartitionType);
+        Predicate equalityPredicate =
+                builder.equal(0, (int) java.time.LocalDate.parse("2026-05-01").toEpochDay());
+        PartitionPredicate partitionFilter =
+                PartitionPredicate.fromPredicate(datePartitionType, equalityPredicate);
+
+        Pair<Path, Integer> result =
+                FormatTableScan.computeScanPathAndLevel(
+                        tableLocation,
+                        datePartitionKeys,
+                        partitionFilter,
+                        datePartitionType,
+                        enablePartitionValueOnly);
+        String partitionPath = enablePartitionValueOnly ? "2026-05-01" : "dt=2026-05-01";
+
+        assertThat(result.getLeft().toString()).isEqualTo(tableLocation + partitionPath);
+        assertThat(result.getRight()).isEqualTo(0);
+    }
+
+    @TestTemplate
     void testComputeScanPathWithFirstLevel() throws IOException {
         Path tableLocation = new Path(tmpPath.toUri());
         // Create equality predicate for only the first partition key
@@ -554,7 +579,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, equalityPredicate);
+                        partitionKeys, equalityPredicate, type);
 
         assertThat(result).hasSize(3);
         assertThat(result.get("year")).isEqualTo("2023");
@@ -581,7 +606,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, mixedPredicate);
+                        partitionKeys, mixedPredicate, type);
 
         assertThat(result).isNotNull();
         assertThat(result).hasSize(2);
@@ -609,7 +634,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, mixedPredicate);
+                        partitionKeys, mixedPredicate, type);
         assertThat(result).hasSize(1);
         assertThat(result.get("year")).isEqualTo("2023");
         assertThat(result.containsKey("month")).isFalse();
@@ -635,7 +660,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, mixedPredicate);
+                        partitionKeys, mixedPredicate, type);
 
         assertThat(result).isEmpty();
     }
@@ -656,7 +681,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, nonEqualityPredicate);
+                        partitionKeys, nonEqualityPredicate, type);
 
         assertThat(result).isEmpty();
     }
@@ -676,7 +701,7 @@ public class FormatTableScanTest {
 
         Map<String, String> result =
                 FormatTableScan.extractLeadingEqualityPartitionSpecWhenOnlyAnd(
-                        partitionKeys, orPredicate);
+                        partitionKeys, orPredicate, type);
 
         assertThat(result).isEmpty();
     }


### PR DESCRIPTION
### Purpose

Fix `FormatTableScan` equality partition path optimization for partition columns whose internal literal representation differs from the partition directory string.

For example, a DATE partition predicate `dt = DATE '2026-05-01'` is represented internally as epoch days (`20574`). The previous code used `literal.toString()` when building the optimized partition path, producing `dt=20574/` instead of the actual `dt=2026-05-01/`, which caused zero splits to be returned.

### Changes

- Convert equality partition literals to their partition string representation via Paimon's cast framework before generating the partition path.
- Pass `partitionType` into `extractLeadingEqualityPartitionSpecWhenOnlyAnd` so the literal can be formatted according to its field type.
- Add a regression test covering DATE partition equality pruning for both normal partition paths and value-only partition paths.

### Tests

- `mvn -pl paimon-core -Pfast-build -DfailIfNoTests=false -Dtest=FormatTableScanTest#testComputeScanPathWithDateEqualityFilter test`
- `mvn -pl paimon-core -Pfast-build -DfailIfNoTests=false -Dtest=FormatTableScanTest test`
- `mvn -pl paimon-core spotless:apply`
