### PR TITLE
[core] Remove debug print from compact buckets table

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
@@ -263,8 +263,6 @@ public class CompactBucketsTable implements DataTable, ReadonlyTable {
             DataSplit dataSplit = (DataSplit) split;
             // in case of schema evolution
             for (DataFileMeta file : dataSplit.dataFiles()) {
-                System.out.println(
-                        "File schema id " + file.schemaId() + ", base schema id " + baseSchemaId);
                 if (file.schemaId() > baseSchemaId) {
                     throw new RuntimeException(
                             String.format(


### PR DESCRIPTION
### Purpose

Remove an accidental debug print from `CompactBucketsTable`.

### Tests

- `mvn -pl paimon-core -DskipTests compile`
