### PR TITLE
[Table] Fix copyWithLatestSchema option drop after table was opened

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -383,9 +383,10 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
     public FileStoreTable copyWithLatestSchema() {
         Optional<TableSchema> optionalLatestSchema = schemaManager().latest();
         if (optionalLatestSchema.isPresent()) {
-            Map<String, String> options = tableSchema.options();
-            TableSchema newTableSchema = optionalLatestSchema.get();
-            newTableSchema = newTableSchema.copy(options);
+            TableSchema latestSchema = optionalLatestSchema.get();
+            Map<String, String> mergedOptions = new HashMap<>(latestSchema.options());
+            mergedOptions.putAll(tableSchema.options());
+            TableSchema newTableSchema = latestSchema.copy(mergedOptions);
             SchemaValidation.validateTableSchema(newTableSchema);
             return copy(newTableSchema);
         } else {

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -616,6 +616,17 @@ public abstract class SimpleTableTestBase {
     }
 
     @Test
+    public void testCopyWithLatestSchemaPicksUpAlteredOptions() throws Exception {
+        FileStoreTable table = createFileStoreTable();
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+
+        schemaManager.commitChanges(SchemaChange.setOption("my-custom-key", "my-custom-value"));
+
+        FileStoreTable updated = table.copyWithLatestSchema();
+        assertThat(updated.schema().options()).containsEntry("my-custom-key", "my-custom-value");
+    }
+
+    @Test
     public void testConsumerIdNotBlank() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(


### PR DESCRIPTION
### Purpose
 - copyWithLatestSchema overwrites the latest schema options with the old handle options
 - Options committed via ALTER TABLE after the table was opened are silently dropped
 - Ensure that correct schema options are used when schema is refreshed via copyWithLatestSchema.
 - Closes user reported bug https://github.com/apache/paimon/issues/4957

### Tests
 - UT