### PR TITLE
[python] Fix empty Ray overwrite commit

### DIFF
--- a/paimon-python/pypaimon/tests/ray_integration_test.py
+++ b/paimon-python/pypaimon/tests/ray_integration_test.py
@@ -306,6 +306,33 @@ class RayIntegrationTest(unittest.TestCase):
         df = result.to_pandas()
         self.assertEqual(list(df['id']), [3])
 
+    def test_write_paimon_empty_overwrite_unpartitioned(self):
+        """write_paimon(overwrite=True) with empty data clears an unpartitioned table."""
+        from pypaimon.ray import read_paimon, write_paimon
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('val', pa.int64()),
+        ])
+        identifier = 'default.test_write_empty_overwrite_unpartitioned'
+        catalog = CatalogFactory.create(self.catalog_options)
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        catalog.create_table(identifier, schema, False)
+
+        initial = ray.data.from_arrow(
+            pa.Table.from_pydict({'id': [1, 2], 'val': [10, 20]}, schema=pa_schema)
+        )
+        write_paimon(initial, identifier, self.catalog_options)
+        self.assertEqual(read_paimon(identifier, self.catalog_options).count(), 2)
+
+        empty = ray.data.from_arrow(
+            pa.Table.from_pydict({'id': [], 'val': []}, schema=pa_schema)
+        )
+        write_paimon(empty, identifier, self.catalog_options, overwrite=True)
+
+        result = read_paimon(identifier, self.catalog_options)
+        self.assertEqual(result.count(), 0)
+
     def test_read_paimon_primary_key(self):
         """read_paimon() merges PK rows correctly after an upsert."""
         from pypaimon.ray import read_paimon

--- a/paimon-python/pypaimon/tests/ray_sink_test.py
+++ b/paimon-python/pypaimon/tests/ray_sink_test.py
@@ -225,6 +225,22 @@ class RaySinkTest(unittest.TestCase):
         )
         datasink.on_write_complete(write_result)
 
+        # Empty overwrite must still reach TableCommit so overwrite semantics
+        # can delete the target range.
+        datasink = PaimonDatasink(self.table, overwrite=True)
+        datasink.on_write_start()
+        write_result = WriteResult(
+            num_rows=0,
+            size_bytes=0,
+            write_returns=[[], []]
+        )
+        mock_commit = Mock()
+        datasink._writer_builder.new_commit = Mock(return_value=mock_commit)
+        datasink.on_write_complete(write_result)
+
+        mock_commit.commit.assert_called_once_with([])
+        mock_commit.close.assert_called_once()
+
         # Test with messages and filtering empty messages
         datasink = PaimonDatasink(self.table, overwrite=False)
         datasink.on_write_start()

--- a/paimon-python/pypaimon/write/ray_datasink.py
+++ b/paimon-python/pypaimon/write/ray_datasink.py
@@ -163,7 +163,7 @@ class PaimonDatasink(_DatasinkBase):
 
             self._pending_commit_messages = non_empty_messages
 
-            if not non_empty_messages:
+            if not non_empty_messages and not self.overwrite:
                 logger.info("No data to commit (all commit messages are empty)")
                 self._pending_commit_messages = []
                 return


### PR DESCRIPTION
### Purpose

`PaimonDatasink.on_write_complete()` previously returned early when all Ray write tasks produced empty commit messages. This made `write_paimon(empty_ds, table, overwrite=True)` a silent no-op, so existing data was kept even though Paimon overwrite commit semantics require empty overwrite commits to reach `TableCommit`.

This PR keeps the empty-message fast path only for append writes. For overwrite writes, Ray now calls `TableCommit.commit([])`, allowing `FileStoreCommit.overwrite()` to delete the target range for static/unpartitioned overwrite and preserve dynamic-partition empty overwrite no-op semantics.

### Tests

- `python -m pytest pypaimon/tests/ray_sink_test.py pypaimon/tests/ray_integration_test.py::RayIntegrationTest::test_write_paimon_empty_overwrite_unpartitioned`