### PR TITLE
[python] Fix missing HTTP runtime dependencies

### DIFF
--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -33,6 +33,8 @@ pyroaring<=0.3.3; python_version < "3.7"
 pyroaring<=0.4.5; python_version == "3.7"
 pyroaring>=1.0.0; python_version >= "3.8"
 readerwriterlock>=1,<2
+requests>=2.20,<3
+urllib3>=1.26,<3
 zstandard>=0.19,<1
 backports.zstd>=1.0.0,<1.4.0; python_version >= "3.9" and python_version < "3.14"
 cramjam>=1.3.0,<3; python_version>="3.7"


### PR DESCRIPTION
### Purpose
When users install PyPaimon in a clean environment with `pip install pypaimon`, importing `pypaimon` can
  fail because `requests` is missing:

  ```text
  ModuleNotFoundError: No module named 'requests'
```

  This was not obvious in 1.3.x because ossfs was still a runtime dependency, and it pulled in requests
  and urllib3 transitively. In 1.4.x, ossfs was moved to optional dependencies, so clean installations no
  longer get these HTTP dependencies for free.

  The issue also tends to be hidden in many user/dev environments because requests and urllib3 are very
  common packages and are often already installed by other tools or dependencies.

`urllib3` is also declared explicitly because PyPaimon directly imports `urllib3.Retry`, so we should
  not rely on the transitive dependency from `requests`.
### Tests
