### PR TITLE
[spark] Avoid serializing known splits in read builder

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/KnownSplitsTable.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 
@@ -46,6 +47,14 @@ public class KnownSplitsTable implements ReadonlyTable {
 
     public Split[] splits() {
         return splits;
+    }
+
+    @Override
+    public ReadBuilder newReadBuilder() {
+        // ReadonlyTable's default implementation creates ReadBuilderImpl(this), which makes the
+        // ReadBuilder capture this KnownSplitsTable. ReadBuilder should not carry all splits, so
+        // delegate to origin.
+        return origin.newReadBuilder();
     }
 
     @Override


### PR DESCRIPTION
### Purpose

ReadonlyTable default implementation creates ReadBuilderImpl(this), which makes the ReadBuilder capture KnownSplitsTable. KnownSplitsTable contains all known splits, but the ReadBuilder returned from it should not carry all of those splits. Therefore, KnownSplitsTable delegates newReadBuilder to the origin table.

This issue can happen when merging into a data-evolution table. The Spark reader factory holds the ReadBuilder, ReadBuilderImpl holds the KnownSplitsTable through its table field, and KnownSplitsTable holds the full split list. As a result, each Spark task can become very large because it indirectly serializes all known splits.