### PR TITLE
[filesystem] Fix hadoop uber shaded dependencies

### DIFF
--- a/paimon-filesystems/paimon-hadoop-uber/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-uber/pom.xml
@@ -650,6 +650,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <include>org.apache.paimon:paimon-hadoop-shaded</include>
                                     <include>com.google.guava:*</include>
                                     <include>com.google.protobuf:*</include>
                                     <include>com.google.code.findbugs:*</include>


### PR DESCRIPTION
### Purpose

  Fix `paimon-hadoop-uber` to make it a self-contained Hadoop uber jar.

  `paimon-hadoop-uber` is intended for applications without Hadoop dependencies. However, after #6327
  narrowed the shade includes, the internal `paimon-hadoop-shaded` artifact was not included in the final
  jar.

  This causes:

  1. Maven/Gradle dependency resolution failure, because the published POM references `paimon-hadoop-
  shaded`, which is intentionally not deployed.
  2. Runtime failure when users directly put `paimon-hadoop-uber.jar` on the classpath, for example:

  ```text
  java.lang.NoClassDefFoundError: com/ctc/wstx/io/InputBootstrapper
```

  This patch includes org.apache.paimon:paimon-hadoop-shaded in the paimon-hadoop-uber shade artifact set.

  ### Tests

  mvn -pl paimon-filesystems/paimon-hadoop-uber -am -Pfast-build -DskipTests package

  Also verified that the generated dependency-reduced POM no longer exposes paimon-hadoop-shaded, and a
  direct classpath smoke test can initialize Hadoop Configuration successfully.