### PR TITLE
[core] Disable snapshot expiry in testDiscardDuplicateFilesMultiThread

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/AppendOnlySimpleTableTest.java
@@ -320,7 +320,12 @@ public class AppendOnlySimpleTableTest extends SimpleTableTestBase {
     public void testDiscardDuplicateFilesMultiThread() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(
-                        options -> options.set(CoreOptions.COMMIT_DISCARD_DUPLICATE_FILES, true));
+                        options -> {
+                            options.set(CoreOptions.COMMIT_DISCARD_DUPLICATE_FILES, true);
+                            // Keep all snapshots so concurrent expiry does not race readers.
+                            options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MIN, 1000);
+                            options.set(CoreOptions.SNAPSHOT_NUM_RETAINED_MAX, 1000);
+                        });
         BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
         List<List<CommitMessage>> messages = new ArrayList<>();
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
### Purpose
 - Fix flaky testDiscardDuplicateFilesMultiThread CI failure.
 - Test runs 10 concurrent writers committing to same table, each writer also runs snapshot expiry.
 - However under load, a writer can read the latest snapshot id from a directory listing, then find that snapshot deleted by another writer's expiry before it can be opened.
 - Ensure that for testing purposes, we can raise num retained snapshots to 1k above to avoid the test race and ensure the test does not fail intermittently. 

### Tests
 - CI