### PR TITLE
[python][daft] Push down supported NOT predicates

### DIFF
--- a/paimon-python/pypaimon/common/predicate.py
+++ b/paimon-python/pypaimon/common/predicate.py
@@ -299,7 +299,7 @@ class NotIn(Tester):
         return not any(min_v == l == max_v for l in literals)
 
     def test_by_arrow(self, val, literals) -> bool:
-        return ~val.isin(literals)
+        return (~val.isin(literals)) & val.is_valid()
 
 
 class Between(Tester):

--- a/paimon-python/pypaimon/daft/daft_predicate_visitor.py
+++ b/paimon-python/pypaimon/daft/daft_predicate_visitor.py
@@ -156,7 +156,22 @@ class PaimonPredicateVisitor(PredicateVisitor[Any]):
             return self._builder.or_predicates([left_pred, right_pred])
         return _UNSUPPORTED
 
-    def visit_not(self, expr: Expression) -> _Unsupported:
+    def visit_not(self, expr: Expression) -> Predicate | _Unsupported:
+        predicate = self.visit(expr)
+        if not self._is_predicate(predicate):
+            return _UNSUPPORTED
+
+        if predicate.method == "equal":
+            return self._builder.not_equal(predicate.field, predicate.literals[0])
+        if predicate.method == "in":
+            return self._builder.is_not_in(predicate.field, predicate.literals)
+        if predicate.method == "between":
+            return self._builder.not_between(predicate.field, predicate.literals[0], predicate.literals[1])
+        if predicate.method == "isNull":
+            return self._builder.is_not_null(predicate.field)
+        if predicate.method == "isNotNull":
+            return self._builder.is_null(predicate.field)
+
         return _UNSUPPORTED
 
     # -- Comparison operators --

--- a/paimon-python/pypaimon/tests/daft/daft_data_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_data_test.py
@@ -458,6 +458,34 @@ def test_read_paimon_fallback_plans_pushdown_filter_without_push_filters(local_p
     assert batches == [{"id": [999], "name": ["match"]}]
 
 
+def test_read_paimon_fallback_not_in_filter_excludes_nulls_before_limit(local_paimon_catalog):
+    """Fallback datasource tasks must satisfy pushed NOT IN filters before limit."""
+    catalog, _ = local_paimon_catalog
+    pa_schema = pa.schema([
+        pa.field("id", pa.int64()),
+        pa.field("name", pa.string()),
+    ])
+    schema = pypaimon.Schema.from_pyarrow_schema(
+        pa_schema,
+        options={"file.format": "row"},
+    )
+    catalog.create_table("test_db.row_not_in_filter_limit", schema, ignore_if_exists=False)
+    table = catalog.get_table("test_db.row_not_in_filter_limit")
+    _write_to_paimon(table, pa.table({"id": [None], "name": ["null-row"]}, schema=pa_schema))
+    _write_to_paimon(table, pa.table({"id": [3], "name": ["match"]}, schema=pa_schema))
+
+    batches = asyncio.run(
+        _read_paimon_source_batches(
+            table,
+            filter_expr=~col("id").is_in([1, 2]),
+            limit=1,
+            call_push_filters=False,
+        )
+    )
+
+    assert batches == [{"id": [3], "name": ["match"]}]
+
+
 def test_read_paimon_fallback_keeps_limit_above_remaining_filter(local_paimon_catalog):
     """Fallback reads must not apply limit before Daft evaluates remaining filters."""
     catalog, _ = local_paimon_catalog
@@ -732,6 +760,67 @@ class TestFilterPushdown:
         assert predicate is not None
         assert predicate.method == "or"
         assert _predicate_leaves(predicate) == [("equal", "id", (1,)), ("equal", "id", (2,))]
+
+    def test_filter_pushdown_rewrites_supported_not_predicates(self, filter_table):
+        cases = [
+            (~(col("id") == 1), [("notEqual", "id", (1,))]),
+            (~col("id").is_in([1, 2]), [("notIn", "id", (1, 2))]),
+            (~col("id").between(1, 3), [("notBetween", "id", (1, 3))]),
+            (~col("value").is_null(), [("isNotNull", "value", ())]),
+            (~col("value").not_null(), [("isNull", "value", ())]),
+        ]
+
+        for expr, expected_leaves in cases:
+            pushed_filters, remaining_filters, predicate = convert_filters_to_paimon(filter_table, expr._expr)
+
+            assert len(pushed_filters) == 1
+            assert remaining_filters == []
+            assert _predicate_leaves(predicate) == expected_leaves
+
+    def test_filter_pushdown_supported_not_predicates_read_path(self, local_paimon_catalog):
+        catalog, tmp_path = local_paimon_catalog
+        pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("value", pa.string()),
+        ])
+        paimon_schema = pypaimon.Schema.from_pyarrow_schema(pa_schema)
+        catalog.create_table("test_db.filter_not_read", paimon_schema, ignore_if_exists=True)
+        table = catalog.get_table("test_db.filter_not_read")
+
+        data = pa.table(
+            {
+                "id": [1, 2, 3, 4, 5],
+                "value": ["a", "b", None, "d", None],
+            },
+            schema=pa_schema,
+        )
+        _write_to_paimon(table, data)
+
+        cases = [
+            (~(col("id") == 1), [2, 3, 4, 5]),
+            (~col("id").is_in([1, 3]), [2, 4, 5]),
+            (~col("id").between(2, 4), [1, 5]),
+            (~col("value").is_null(), [1, 2, 4]),
+            (~col("value").not_null(), [3, 5]),
+        ]
+
+        for expr, expected_ids in cases:
+            result = _read_table(table).where(expr).select("id").sort("id").to_pydict()
+
+            assert result["id"] == expected_ids
+
+    def test_filter_pushdown_does_not_demorgan_not_compound_predicates(self, filter_table):
+        expressions = [
+            ~((col("id") == 1) & (col("value") == "a")),
+            ~((col("id") == 1) | (col("value") == "a")),
+        ]
+
+        for expr in expressions:
+            pushed_filters, remaining_filters, predicate = convert_filters_to_paimon(filter_table, expr._expr)
+
+            assert pushed_filters == []
+            assert remaining_filters == [expr._expr]
+            assert predicate is None
 
     def test_unsupported_expression_remains_in_daft(self, filter_table):
         expressions = [

--- a/paimon-python/pypaimon/tests/daft/daft_explain_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_explain_test.py
@@ -183,7 +183,7 @@ def test_explain_scan_keeps_limit_above_remaining_filters(catalog_options):
     _write_arrow(table, pa.table({"id": [1, 2], "name": ["a", "b"]}, schema=pa_schema))
 
     result = PaimonTable(table, catalog_options=catalog_options).explain_scan(
-        filters=~(col("id") == 1),
+        filters=~((col("id") == 1) & (col("name") == "a")),
         limit=1,
     )
 
@@ -193,6 +193,34 @@ def test_explain_scan_keeps_limit_above_remaining_filters(catalog_options):
     assert any("id" in remaining for remaining in result.remaining_filters)
     assert result.source_limit is None
     assert result.limit_pushed is False
+    assert result.splits is None
+    assert result.paimon_scan.splits is None
+
+
+def test_explain_scan_pushes_supported_not_and_limit(catalog_options):
+    pa_schema = pa.schema([
+        ("id", pa.int64()),
+        ("name", pa.string()),
+    ])
+    identifier, table = _create_table(
+        catalog_options,
+        "explain_not_filter",
+        pa_schema,
+        options={"bucket": "-1", "file.format": "parquet"},
+    )
+    _write_arrow(table, pa.table({"id": [1, 2], "name": ["a", "b"]}, schema=pa_schema))
+
+    result = PaimonTable(table, catalog_options=catalog_options).explain_scan(
+        filters=~(col("id") == 1),
+        limit=1,
+    )
+
+    assert result.native_parquet_split_count == result.paimon_scan.split_count
+    assert result.pypaimon_fallback_split_count == 0
+    assert any("!=" in pushed or "not" in pushed for pushed in result.pushed_filters)
+    assert result.remaining_filters == []
+    assert result.source_limit == 1
+    assert result.limit_pushed is True
     assert result.splits is None
     assert result.paimon_scan.splits is None
 

--- a/paimon-python/pypaimon/tests/predicates_test.py
+++ b/paimon-python/pypaimon/tests/predicates_test.py
@@ -23,6 +23,7 @@ import unittest
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.dataset as ds
 
 from pypaimon import CatalogFactory, Schema
 from pypaimon.common.predicate import Predicate
@@ -462,6 +463,13 @@ class PredicateTest(unittest.TestCase):
         self.assertFalse(predicate.test(OffsetRow([5], 0, 1)))
         self.assertFalse(predicate.test(OffsetRow([3], 0, 1)))
         self.assertFalse(predicate.test(OffsetRow([None], 0, 1)))
+
+    def test_not_in_arrow_filter_excludes_nulls(self):
+        predicate = Predicate(method='notIn', index=0, field='val', literals=[1, 2])
+        table = pa.table({"val": [None, 1, 3]})
+        scanner = ds.InMemoryDataset(table).scanner(filter=predicate.to_arrow())
+
+        self.assertEqual(scanner.to_table().to_pydict(), {"val": [3]})
 
     def test_pk_reader_with_filter(self):
         pa_schema = pa.schema([


### PR DESCRIPTION
### Purpose

Daft predicate conversion previously treated every `NOT` expression as unsupported, so filters such as `NOT (col == lit)`, `NOT col.is_in(...)`, and `NOT col.is_null()` stayed above the datasource even though pypaimon already has matching predicate types.

This change adds a narrow leaf-only rewrite for supported `NOT` predicates:
- `NOT equal` -> `notEqual`
- `NOT in` -> `notIn`
- `NOT between` -> `notBetween`
- `NOT isNull` -> `isNotNull`
- `NOT isNotNull` -> `isNull`

It intentionally does not add De Morgan rewrites for compound expressions.

The change also fixes `notIn` Arrow evaluation to exclude null values. Without this, fallback datasource tasks could return null rows for pushed `NOT IN` filters, and pushed limits could then truncate valid rows.

### Tests

- `pytest paimon-python/pypaimon/tests/daft -q`
- `pytest paimon-python/pypaimon/tests/predicates_test.py -q`