### PR TITLE
[core] Validate schema after applying schema changes

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -609,14 +609,17 @@ public class SchemaManager implements Serializable {
                         applyRenameColumnsToOptions(newOptions, changes),
                         newComment);
 
-        return new TableSchema(
-                oldTableSchema.id() + 1,
-                newSchema.fields(),
-                highestFieldId.get(),
-                newSchema.partitionKeys(),
-                newSchema.primaryKeys(),
-                newSchema.options(),
-                newSchema.comment());
+        TableSchema newTableSchema =
+                new TableSchema(
+                        oldTableSchema.id() + 1,
+                        newSchema.fields(),
+                        highestFieldId.get(),
+                        newSchema.partitionKeys(),
+                        newSchema.primaryKeys(),
+                        newSchema.options(),
+                        newSchema.comment());
+        SchemaValidation.validateTableSchema(newTableSchema);
+        return newTableSchema;
     }
 
     // gets the rootType at the defined depth

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -179,7 +179,11 @@ public class SchemaManagerTest {
         options.put("fields.f3.sequence-group", "f2");
         Schema schema =
                 new Schema(
-                        rowTypeWithSequenceField.getFields(), partitionKeys, primaryKeys, options, "");
+                        rowTypeWithSequenceField.getFields(),
+                        partitionKeys,
+                        primaryKeys,
+                        options,
+                        "");
 
         retryArtificialException(() -> manager.createTable(schema));
 
@@ -204,7 +208,11 @@ public class SchemaManagerTest {
         options.put("fields.f3.sequence-group", "f2");
         Schema schema =
                 new Schema(
-                        rowTypeWithSequenceField.getFields(), partitionKeys, primaryKeys, options, "");
+                        rowTypeWithSequenceField.getFields(),
+                        partitionKeys,
+                        primaryKeys,
+                        options,
+                        "");
 
         retryArtificialException(() -> manager.createTable(schema));
         retryArtificialException(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -169,6 +169,47 @@ public class SchemaManagerTest {
     }
 
     @Test
+    public void testResetSequenceGroupForAggregateFunction() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put("fields.f2.aggregate-function", "sum");
+        options.put("fields.f1.sequence-group", "f2");
+        Schema schema = new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");
+
+        retryArtificialException(() -> manager.createTable(schema));
+
+        assertThatThrownBy(
+                        () ->
+                                retryArtificialException(
+                                        () ->
+                                                manager.commitChanges(
+                                                        SchemaChange.removeOption(
+                                                                "fields.f1.sequence-group"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Must use sequence group for aggregation functions but not found for field f2.");
+    }
+
+    @Test
+    public void testResetSequenceGroupForLastNonNullAggregateFunction() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put("fields.f2.aggregate-function", "last_non_null_value");
+        options.put("fields.f1.sequence-group", "f2");
+        Schema schema = new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");
+
+        retryArtificialException(() -> manager.createTable(schema));
+        retryArtificialException(
+                () -> manager.commitChanges(SchemaChange.removeOption("fields.f1.sequence-group")));
+
+        Optional<TableSchema> latest = retryArtificialException(() -> manager.latest());
+        assertThat(latest.isPresent()).isTrue();
+        assertThat(latest.get().options()).doesNotContainKey("fields.f1.sequence-group");
+    }
+
+    @Test
     public void testConcurrentCommit() throws Exception {
         retryArtificialException(
                 () ->

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -92,6 +92,8 @@ public class SchemaManagerTest {
     private final List<String> primaryKeys = Arrays.asList("f0", "f1");
     private final Map<String, String> options = Collections.singletonMap("key", "value");
     private final RowType rowType = RowType.of(new IntType(), new BigIntType(), new VarCharType());
+    private final RowType rowTypeWithSequenceField =
+            RowType.of(new IntType(), new BigIntType(), new VarCharType(), new BigIntType());
     private final Schema schema =
             new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");
 
@@ -174,8 +176,10 @@ public class SchemaManagerTest {
         options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
         options.put(CoreOptions.BUCKET.key(), "1");
         options.put("fields.f2.aggregate-function", "sum");
-        options.put("fields.f1.sequence-group", "f2");
-        Schema schema = new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");
+        options.put("fields.f3.sequence-group", "f2");
+        Schema schema =
+                new Schema(
+                        rowTypeWithSequenceField.getFields(), partitionKeys, primaryKeys, options, "");
 
         retryArtificialException(() -> manager.createTable(schema));
 
@@ -185,7 +189,7 @@ public class SchemaManagerTest {
                                         () ->
                                                 manager.commitChanges(
                                                         SchemaChange.removeOption(
-                                                                "fields.f1.sequence-group"))))
+                                                                "fields.f3.sequence-group"))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(
                         "Must use sequence group for aggregation functions but not found for field f2.");
@@ -197,16 +201,18 @@ public class SchemaManagerTest {
         options.put(CoreOptions.MERGE_ENGINE.key(), "partial-update");
         options.put(CoreOptions.BUCKET.key(), "1");
         options.put("fields.f2.aggregate-function", "last_non_null_value");
-        options.put("fields.f1.sequence-group", "f2");
-        Schema schema = new Schema(rowType.getFields(), partitionKeys, primaryKeys, options, "");
+        options.put("fields.f3.sequence-group", "f2");
+        Schema schema =
+                new Schema(
+                        rowTypeWithSequenceField.getFields(), partitionKeys, primaryKeys, options, "");
 
         retryArtificialException(() -> manager.createTable(schema));
         retryArtificialException(
-                () -> manager.commitChanges(SchemaChange.removeOption("fields.f1.sequence-group")));
+                () -> manager.commitChanges(SchemaChange.removeOption("fields.f3.sequence-group")));
 
         Optional<TableSchema> latest = retryArtificialException(() -> manager.latest());
         assertThat(latest.isPresent()).isTrue();
-        assertThat(latest.get().options()).doesNotContainKey("fields.f1.sequence-group");
+        assertThat(latest.get().options()).doesNotContainKey("fields.f3.sequence-group");
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkReadITCase.java
@@ -51,6 +51,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** ITCase for spark reader. */
 public class SparkReadITCase extends SparkReadTestBase {
 
+    private static final String CHANGELOG_PRODUCER_WITHOUT_PRIMARY_KEYS =
+            "Can not set changelog-producer on table without primary keys";
+
     @Test
     public void testNormal() {
         innerTestSimpleType(spark.table("t1"));
@@ -311,10 +314,7 @@ public class SparkReadITCase extends SparkReadTestBase {
                         () ->
                                 spark.sql(
                                         "CREATE TABLE T (a INT) TBLPROPERTIES ('changelog-producer' = 'input')"))
-                .rootCause()
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining(
-                        "Can not set changelog-producer on table without primary keys");
+                .satisfies(SparkReadITCase::assertChangelogProducerWithoutPrimaryKeys);
 
         spark.sql("CREATE TABLE T (a INT)");
 
@@ -322,10 +322,21 @@ public class SparkReadITCase extends SparkReadTestBase {
                         () ->
                                 spark.sql(
                                         "ALTER TABLE T SET TBLPROPERTIES('changelog-producer' 'input')"))
-                .rootCause()
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining(
-                        "Can not set changelog-producer on table without primary keys");
+                .satisfies(SparkReadITCase::assertChangelogProducerWithoutPrimaryKeys);
+    }
+
+    private static void assertChangelogProducerWithoutPrimaryKeys(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof RuntimeException
+                    && current.getMessage() != null
+                    && current.getMessage().contains(CHANGELOG_PRODUCER_WITHOUT_PRIMARY_KEYS)) {
+                return;
+            }
+            current = current.getCause();
+        }
+
+        assertThat(throwable).hasMessageContaining(CHANGELOG_PRODUCER_WITHOUT_PRIMARY_KEYS);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

`SchemaManager.generateTableSchema` can produce an invalid option combination after applying schema changes. For example, resetting `fields.<seq>.sequence-group` may leave a field-specific `aggregate-function` that requires that sequence group, and the failure is only exposed later when the table is loaded.

### Changes

- Validate the generated `TableSchema` before returning it from `SchemaManager.generateTableSchema`.
- Add regression coverage for resetting a sequence group used by `fields.<field>.aggregate-function`.
- Keep `last_non_null_value` behavior unchanged, since it does not require a sequence group.

### Tests

```bash
mvn -U -pl paimon-core -am -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dspotless.check.skip=true -DfailIfNoTests=false -Dtest=SchemaManagerTest#testResetSequenceGroupForAggregateFunction+testResetSequenceGroupForLastNonNullAggregateFunction test
```