### PR TITLE
[spark] Add data-evolution.merge-into.file-pruning option

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -471,6 +471,12 @@ under the License.
             <td>Whether enable data evolution for row tracking table.</td>
         </tr>
         <tr>
+            <td><h5>data-evolution.merge-into.skip-file-pruning</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, skips the file-level pruning step for MergeInto partial column update on data-evolution tables. Use this when most files in the target partition are expected to be updated, so that the overhead of collecting touched file IDs outweighs the benefit of pruning untouched files.</td>
+        </tr>
+        <tr>
             <td><h5>data-file.external-paths</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -471,10 +471,10 @@ under the License.
             <td>Whether enable data evolution for row tracking table.</td>
         </tr>
         <tr>
-            <td><h5>data-evolution.merge-into.skip-file-pruning</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td><h5>data-evolution.merge-into.file-pruning</h5></td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>If true, skips the file-level pruning step for MergeInto partial column update on data-evolution tables. Use this when most files in the target partition are expected to be updated, so that the overhead of collecting touched file IDs outweighs the benefit of pruning untouched files.</td>
+            <td>If true, enables the file-level pruning step for MergeInto partial column update on data-evolution tables. Set this to false when most files in the target partition are expected to be updated, so that the overhead of collecting touched file IDs outweighs the benefit of pruning untouched files.</td>
         </tr>
         <tr>
             <td><h5>data-file.external-paths</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2236,6 +2236,17 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_MERGE_INTO_SKIP_FILE_PRUNING =
+            key("data-evolution.merge-into.skip-file-pruning")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, skips the file-level pruning step for MergeInto partial column "
+                                    + "update on data-evolution tables. "
+                                    + "Use this when most files in the target partition are expected to be "
+                                    + "updated, so that the overhead of collecting touched file IDs outweighs "
+                                    + "the benefit of pruning untouched files.");
+
     public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
             key("blob-compaction.enabled")
                     .booleanType()
@@ -3728,6 +3739,10 @@ public class CoreOptions implements Serializable {
 
     public boolean dataEvolutionEnabled() {
         return options.get(DATA_EVOLUTION_ENABLED);
+    }
+
+    public boolean dataEvolutionMergeIntoSkipFilePruning() {
+        return options.get(DATA_EVOLUTION_MERGE_INTO_SKIP_FILE_PRUNING);
     }
 
     public boolean blobCompactionEnabled() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2236,16 +2236,16 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
-    public static final ConfigOption<Boolean> DATA_EVOLUTION_MERGE_INTO_SKIP_FILE_PRUNING =
-            key("data-evolution.merge-into.skip-file-pruning")
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_MERGE_INTO_FILE_PRUNING =
+            key("data-evolution.merge-into.file-pruning")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
-                            "If true, skips the file-level pruning step for MergeInto partial column "
+                            "If true, enables the file-level pruning step for MergeInto partial column "
                                     + "update on data-evolution tables. "
-                                    + "Use this when most files in the target partition are expected to be "
-                                    + "updated, so that the overhead of collecting touched file IDs outweighs "
-                                    + "the benefit of pruning untouched files.");
+                                    + "Set this to false when most files in the target partition are expected "
+                                    + "to be updated, so that the overhead of collecting touched file IDs "
+                                    + "outweighs the benefit of pruning untouched files.");
 
     public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
             key("blob-compaction.enabled")
@@ -3741,8 +3741,8 @@ public class CoreOptions implements Serializable {
         return options.get(DATA_EVOLUTION_ENABLED);
     }
 
-    public boolean dataEvolutionMergeIntoSkipFilePruning() {
-        return options.get(DATA_EVOLUTION_MERGE_INTO_SKIP_FILE_PRUNING);
+    public boolean dataEvolutionMergeIntoFilePruning() {
+        return options.get(DATA_EVOLUTION_MERGE_INTO_FILE_PRUNING);
     }
 
     public boolean blobCompactionEnabled() {

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -36,6 +36,7 @@ import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.types.RowType
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
@@ -64,7 +65,8 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
   with WithFileStoreTable
-  with ExpressionHelper {
+  with ExpressionHelper
+  with Logging {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -146,9 +148,7 @@ case class MergeIntoPaimonDataEvolutionTable(
 
   private def invokeMergeInto(sparkSession: SparkSession): Unit = {
     val snapshotReader = table.newSnapshotReader()
-    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
-      pushDownMergePartitionFilter(snapshotReader)
-    }
+    pushDownMergePartitionFilter(snapshotReader)
     val plan = snapshotReader.read()
     val tableSplits: Seq[DataSplit] = plan
       .splits()
@@ -254,7 +254,10 @@ case class MergeIntoPaimonDataEvolutionTable(
       return tableSplits
     }
 
-    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
+    if (!table.coreOptions().dataEvolutionMergeIntoFilePruning()) {
+      logInfo(
+        "Skip file-level pruning for MergeInto partial column update on data-evolution table " +
+          s"${table.name()}.")
       return tableSplits
     }
 

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -27,16 +27,19 @@ import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.catalyst.analysis.PaimonRelation
 import org.apache.paimon.spark.catalyst.analysis.PaimonRelation.isPaimonTable
 import org.apache.paimon.spark.catalyst.analysis.PaimonUpdateTable.toColumn
+import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
 import org.apache.paimon.spark.util.ScanPlanHelper.createNewScanPlan
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
+import org.apache.paimon.table.source.snapshot.SnapshotReader
+import org.apache.paimon.types.RowType
 
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, EqualTo, Expression, ExprId, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -60,7 +63,8 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedActions: Seq[MergeAction],
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
-  with WithFileStoreTable {
+  with WithFileStoreTable
+  with ExpressionHelper {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -141,7 +145,11 @@ case class MergeIntoPaimonDataEvolutionTable(
   }
 
   private def invokeMergeInto(sparkSession: SparkSession): Unit = {
-    val plan = table.newSnapshotReader().read()
+    val snapshotReader = table.newSnapshotReader()
+    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
+      pushDownMergePartitionFilter(snapshotReader)
+    }
+    val plan = snapshotReader.read()
     val tableSplits: Seq[DataSplit] = plan
       .splits()
       .asScala
@@ -200,6 +208,41 @@ case class MergeIntoPaimonDataEvolutionTable(
     writer.commit(updateCommit ++ insertCommit)
   }
 
+  private def pushDownMergePartitionFilter(snapshotReader: SnapshotReader): Unit = {
+    val partitionRowType = table.schema().logicalPartitionType()
+    if (partitionRowType.getFieldCount == 0) {
+      return
+    }
+
+    // matchedCondition comes from MergeIntoTable.mergeCondition, which is the MERGE ON condition.
+    val partitionPredicates = getExpressionOnlyRelated(matchedCondition, targetTable)
+      .map(splitConjunctivePredicates)
+      .map(extractMergePartitionFilters(_, partitionRowType))
+      .getOrElse(Seq.empty)
+
+    if (partitionPredicates.nonEmpty) {
+      val filter = convertConditionToPaimonPredicate(
+        partitionPredicates.reduce(And),
+        targetRelation.output,
+        rowType,
+        ignorePartialFailure = true)
+      filter.foreach(snapshotReader.withFilter)
+    }
+  }
+
+  private def extractMergePartitionFilters(
+      filters: Seq[Expression],
+      partitionRowType: RowType): Seq[Expression] = {
+    val partitionColumns = partitionRowType.getFieldNames.asScala.toSet
+    filters.filter {
+      f =>
+        f.deterministic &&
+        f.references.forall(attr => partitionColumns.exists(_.equalsIgnoreCase(attr.name))) &&
+        !SubqueryExpression.hasSubquery(f) &&
+        f.collect { case _: PythonUDF => true }.isEmpty
+    }
+  }
+
   private def targetRelatedSplits(
       sparkSession: SparkSession,
       tableSplits: Seq[DataSplit],
@@ -208,6 +251,10 @@ case class MergeIntoPaimonDataEvolutionTable(
     // Self-Merge shortcut:
     // In Self-Merge mode, every row in the table may be updated, so we scan all splits.
     if (isSelfMergeOnRowId) {
+      return tableSplits
+    }
+
+    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
       return tableSplits
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -37,6 +37,7 @@ import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.types.RowType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
@@ -65,7 +66,8 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
   with WithFileStoreTable
-  with ExpressionHelper {
+  with ExpressionHelper
+  with Logging {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -146,9 +148,7 @@ case class MergeIntoPaimonDataEvolutionTable(
 
   private def invokeMergeInto(sparkSession: SparkSession): Unit = {
     val snapshotReader = table.newSnapshotReader()
-    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
-      pushDownMergePartitionFilter(snapshotReader)
-    }
+    pushDownMergePartitionFilter(snapshotReader)
     val plan = snapshotReader.read()
     val tableSplits: Seq[DataSplit] = plan
       .splits()
@@ -259,7 +259,10 @@ case class MergeIntoPaimonDataEvolutionTable(
       return tableSplits
     }
 
-    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
+    if (!table.coreOptions().dataEvolutionMergeIntoFilePruning()) {
+      logInfo(
+        "Skip file-level pruning for MergeInto partial column update on data-evolution table " +
+          s"${table.name()}.")
       return tableSplits
     }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -27,17 +27,20 @@ import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.catalyst.analysis.PaimonRelation
 import org.apache.paimon.spark.catalyst.analysis.PaimonRelation.isPaimonTable
 import org.apache.paimon.spark.catalyst.analysis.PaimonUpdateTable.toColumn
+import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
 import org.apache.paimon.spark.util.ScanPlanHelper.createNewScanPlan
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
+import org.apache.paimon.table.source.snapshot.SnapshotReader
+import org.apache.paimon.types.RowType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, EqualTo, Expression, ExprId, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -61,7 +64,8 @@ case class MergeIntoPaimonDataEvolutionTable(
     notMatchedActions: Seq[MergeAction],
     notMatchedBySourceActions: Seq[MergeAction])
   extends PaimonLeafRunnableCommand
-  with WithFileStoreTable {
+  with WithFileStoreTable
+  with ExpressionHelper {
 
   private lazy val writer = PaimonSparkWriter(table)
 
@@ -141,7 +145,11 @@ case class MergeIntoPaimonDataEvolutionTable(
   }
 
   private def invokeMergeInto(sparkSession: SparkSession): Unit = {
-    val plan = table.newSnapshotReader().read()
+    val snapshotReader = table.newSnapshotReader()
+    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
+      pushDownMergePartitionFilter(snapshotReader)
+    }
+    val plan = snapshotReader.read()
     val tableSplits: Seq[DataSplit] = plan
       .splits()
       .asScala
@@ -205,6 +213,41 @@ case class MergeIntoPaimonDataEvolutionTable(
     writer.commit(updateCommit ++ insertCommit)
   }
 
+  private def pushDownMergePartitionFilter(snapshotReader: SnapshotReader): Unit = {
+    val partitionRowType = table.schema().logicalPartitionType()
+    if (partitionRowType.getFieldCount == 0) {
+      return
+    }
+
+    // matchedCondition comes from MergeIntoTable.mergeCondition, which is the MERGE ON condition.
+    val partitionPredicates = getExpressionOnlyRelated(matchedCondition, targetTable)
+      .map(splitConjunctivePredicates)
+      .map(extractMergePartitionFilters(_, partitionRowType))
+      .getOrElse(Seq.empty)
+
+    if (partitionPredicates.nonEmpty) {
+      val filter = convertConditionToPaimonPredicate(
+        partitionPredicates.reduce(And),
+        targetRelation.output,
+        rowType,
+        ignorePartialFailure = true)
+      filter.foreach(snapshotReader.withFilter)
+    }
+  }
+
+  private def extractMergePartitionFilters(
+      filters: Seq[Expression],
+      partitionRowType: RowType): Seq[Expression] = {
+    val partitionColumns = partitionRowType.getFieldNames.asScala.toSet
+    filters.filter {
+      f =>
+        f.deterministic &&
+        f.references.forall(attr => partitionColumns.exists(_.equalsIgnoreCase(attr.name))) &&
+        !SubqueryExpression.hasSubquery(f) &&
+        f.collect { case _: PythonUDF => true }.isEmpty
+    }
+  }
+
   private def targetRelatedSplits(
       sparkSession: SparkSession,
       tableSplits: Seq[DataSplit],
@@ -213,6 +256,10 @@ case class MergeIntoPaimonDataEvolutionTable(
     // Self-Merge shortcut:
     // In Self-Merge mode, every row in the table may be updated, so we scan all splits.
     if (isSelfMergeOnRowId) {
+      return tableSplits
+    }
+
+    if (table.coreOptions().dataEvolutionMergeIntoSkipFilePruning()) {
       return tableSplits
     }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -635,11 +635,11 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
   }
 
   Seq(false, true).foreach {
-    skipFilePruning =>
-      test(s"Data Evolution: merge into can skip file pruning: $skipFilePruning") {
+    filePruning =>
+      test(s"Data Evolution: merge into file pruning: $filePruning") {
         withSparkSQLConf(
-          "spark.paimon.data-evolution.merge-into.skip-file-pruning" ->
-            skipFilePruning.toString) {
+          "spark.paimon.data-evolution.merge-into.file-pruning" ->
+            filePruning.toString) {
           withTable("source", "target") {
             sql("CREATE TABLE source (id INT, b INT, dt STRING)")
             sql("INSERT INTO source VALUES (1, 100, '2026-05-28'), (3, 300, '2026-05-28')")
@@ -661,7 +661,7 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
                 |WHEN MATCHED THEN UPDATE SET target.b = source.b
                 |WHEN NOT MATCHED THEN INSERT (id, b, c, dt) VALUES (id, b, 'new', dt)
                 |""".stripMargin,
-              skipFilePruning
+              filePruning
             )
 
             checkAnswer(
@@ -677,9 +677,7 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
       }
   }
 
-  private def executeMergeIntoAndAssertFilePruning(
-      mergeSql: String,
-      skipFilePruning: Boolean): Unit = {
+  private def executeMergeIntoAndAssertFilePruning(mergeSql: String, filePruning: Boolean): Unit = {
     @volatile var hasTargetFilePruningJoin = false
     val listener = new QueryExecutionListener {
       override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
@@ -694,8 +692,8 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
         if (isTargetFilePruningJoinPlan(plan)) {
           hasTargetFilePruningJoin = true
           assert(
-            !skipFilePruning,
-            s"File pruning join should be skipped when skipFilePruning is enabled: $plan")
+            filePruning,
+            s"File pruning join should be skipped when file pruning is disabled: $plan")
         }
       }
     }
@@ -708,7 +706,7 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
       spark.listenerManager.unregister(listener)
     }
 
-    if (!skipFilePruning) {
+    if (filePruning) {
       assert(hasTargetFilePruningJoin, "Expected target file pruning join plan.")
     }
   }
@@ -723,7 +721,7 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
   }
 
   test("Data Evolution: merge into skip file pruning push down partition filter in on condition") {
-    withSparkSQLConf("spark.paimon.data-evolution.merge-into.skip-file-pruning" -> "true") {
+    withSparkSQLConf("spark.paimon.data-evolution.merge-into.file-pruning" -> "false") {
       withTempView("source") {
         withTable("target") {
           Seq((1, 100), (2, 200), (3, 300)).toDF("id", "b").createOrReplaceTempView("source")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -19,12 +19,18 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.Snapshot.CommitKind
+import org.apache.paimon.spark.PaimonMetrics.RESULTED_TABLE_FILES
 import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.spark.read.PaimonSplitScan
 import org.apache.paimon.table.source.DataSplit
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.plans.logical.{Deduplicate, Join, LogicalPlan, MergeRows, RepartitionByExpression, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{Deduplicate, Join, LogicalPlan, MergeRows, RepartitionByExpression, Sort, SubqueryAlias}
+import org.apache.spark.sql.connector.metric.CustomTaskMetric
 import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.paimon.Utils
 import org.apache.spark.sql.util.QueryExecutionListener
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
@@ -34,7 +40,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
-abstract class RowTrackingTestBase extends PaimonSparkTestBase {
+abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSparkPlanHelper {
 
   import testImplicits._
 
@@ -626,6 +632,176 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase {
           Row(9, 990, "c99", 6, 2))
       )
     }
+  }
+
+  Seq(false, true).foreach {
+    skipFilePruning =>
+      test(s"Data Evolution: merge into can skip file pruning: $skipFilePruning") {
+        withSparkSQLConf(
+          "spark.paimon.data-evolution.merge-into.skip-file-pruning" ->
+            skipFilePruning.toString) {
+          withTable("source", "target") {
+            sql("CREATE TABLE source (id INT, b INT, dt STRING)")
+            sql("INSERT INTO source VALUES (1, 100, '2026-05-28'), (3, 300, '2026-05-28')")
+
+            sql("""
+                  |CREATE TABLE target (id INT, b INT, c STRING, dt STRING)
+                  |TBLPROPERTIES (
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true')
+                  |PARTITIONED BY (dt)
+                  |""".stripMargin)
+            sql("INSERT INTO target VALUES (1, 10, 'old-1', '2026-05-28'), (2, 20, 'old-2', '2026-05-28'), (4, 40, 'old-4', '2026-05-29')")
+
+            executeMergeIntoAndAssertFilePruning(
+              """
+                |MERGE INTO target
+                |USING source
+                |ON target.id = source.id AND target.dt = source.dt
+                |WHEN MATCHED THEN UPDATE SET target.b = source.b
+                |WHEN NOT MATCHED THEN INSERT (id, b, c, dt) VALUES (id, b, 'new', dt)
+                |""".stripMargin,
+              skipFilePruning
+            )
+
+            checkAnswer(
+              sql("SELECT id, b, c, dt FROM target ORDER BY id"),
+              Seq(
+                Row(1, 100, "old-1", "2026-05-28"),
+                Row(2, 20, "old-2", "2026-05-28"),
+                Row(3, 300, "new", "2026-05-28"),
+                Row(4, 40, "old-4", "2026-05-29"))
+            )
+          }
+        }
+      }
+  }
+
+  private def executeMergeIntoAndAssertFilePruning(
+      mergeSql: String,
+      skipFilePruning: Boolean): Unit = {
+    @volatile var hasTargetFilePruningJoin = false
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        checkPlan(qe.analyzed)
+      }
+
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+        checkPlan(qe.analyzed)
+      }
+
+      private def checkPlan(plan: LogicalPlan): Unit = {
+        if (isTargetFilePruningJoinPlan(plan)) {
+          hasTargetFilePruningJoin = true
+          assert(
+            !skipFilePruning,
+            s"File pruning join should be skipped when skipFilePruning is enabled: $plan")
+        }
+      }
+    }
+
+    spark.listenerManager.register(listener)
+    try {
+      sql(mergeSql)
+      Utils.waitUntilEventEmpty(spark)
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+
+    if (!skipFilePruning) {
+      assert(hasTargetFilePruningJoin, "Expected target file pruning join plan.")
+    }
+  }
+
+  private def isTargetFilePruningJoinPlan(plan: LogicalPlan): Boolean = {
+    plan.collectFirst { case _: Deduplicate => true }.nonEmpty &&
+    plan.collectFirst { case _: Join => true }.nonEmpty &&
+    plan.collectFirst {
+      case SubqueryAlias(identifier, _) if identifier.name == "_left" => true
+    }.nonEmpty &&
+    plan.collectFirst { case _: MergeRows => true }.isEmpty
+  }
+
+  test("Data Evolution: merge into skip file pruning push down partition filter in on condition") {
+    withSparkSQLConf("spark.paimon.data-evolution.merge-into.skip-file-pruning" -> "true") {
+      withTempView("source") {
+        withTable("target") {
+          Seq((1, 100), (2, 200), (3, 300)).toDF("id", "b").createOrReplaceTempView("source")
+
+          sql("""
+                |CREATE TABLE target (id INT, b INT, dt STRING)
+                |TBLPROPERTIES (
+                |  'row-tracking.enabled' = 'true',
+                |  'data-evolution.enabled' = 'true')
+                |PARTITIONED BY (dt)
+                |""".stripMargin)
+          sql("""
+                |INSERT INTO target VALUES
+                |  (1, 10, '2026-05-28'),
+                |  (2, 20, '2026-05-29'),
+                |  (3, 30, '2026-05-30')
+                |""".stripMargin)
+
+          val mergeSql =
+            """
+              |MERGE INTO target
+              |USING source
+              |ON target.id = source.id AND target.dt = '2026-05-28'
+              |WHEN MATCHED THEN UPDATE SET target.b = source.b
+              |""".stripMargin
+
+          executeMergeIntoAndAssertPartitionPruned(mergeSql)
+          checkAnswer(
+            sql("SELECT id, b, dt FROM target ORDER BY id"),
+            Seq(Row(1, 100, "2026-05-28"), Row(2, 20, "2026-05-29"), Row(3, 30, "2026-05-30"))
+          )
+        }
+      }
+    }
+  }
+
+  private def executeMergeIntoAndAssertPartitionPruned(mergeSql: String): Unit = {
+    val resultedTableFiles = new java.util.concurrent.CopyOnWriteArrayList[Long]()
+
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        checkPlan(qe)
+      }
+
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+        checkPlan(qe)
+      }
+
+      private def checkPlan(qe: QueryExecution): Unit = {
+        collect(qe.executedPlan) {
+          case scanExec: BatchScanExec
+              if scanExec.scan.isInstanceOf[PaimonSplitScan] &&
+                scanExec.scan.description().startsWith("PaimonSplitScan: [target]") =>
+            val scan = scanExec.scan.asInstanceOf[PaimonSplitScan]
+            metric(scan.reportDriverMetrics(), RESULTED_TABLE_FILES)
+        }.foreach(resultedTableFile => resultedTableFiles.add(resultedTableFile))
+      }
+    }
+
+    spark.listenerManager.register(listener)
+    try {
+      sql(mergeSql)
+      Utils.waitUntilEventEmpty(spark)
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+
+    val metrics = resultedTableFiles.asScala
+    assert(metrics.nonEmpty, "Expected target PaimonSplitScan in merge into executed plans.")
+    assert(
+      metrics.contains(1),
+      s"Expected target scan to read only one partition file, but got resulted table files: " +
+        metrics.mkString(", ")
+    )
+  }
+
+  private def metric(metrics: Array[CustomTaskMetric], name: String): Long = {
+    metrics.find(_.name() == name).get.value()
   }
 
   test("Data Evolution: merge into table with data-evolution on _ROW_ID") {


### PR DESCRIPTION
### Purpose

Add `data-evolution.merge-into.file-pruning` for MergeInto partial column update on data-evolution tables. When     disabled, this option skips the file-level pruning step. It is useful when most files in the target partition are expected to be updated, so the overhead of collecting touched file IDs outweighs the benefit of pruning untouched files.

When file pruning is skipped, Spark merge into still pushes down target-table partition filters from the MERGE ON condition to avoid scanning unrelated partitions.

### Tests

- Added RowTrackingTest cases for enabling/disabling `data-evolution.merge-into.file-pruning`, including result correctness and file-pruning join behavior.
- Added RowTrackingTest coverage for target partition filter pushdown from the MERGE ON condition when skip file pruning.