### PR TITLE
[tantivy] Support configurable full-text analyzers

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -1031,7 +1031,13 @@ All available procedures are listed below.
             `table` => 'default.T',<br/>
             `index_column` => 'content',<br/>
             `index_type` => 'tantivy-fulltext',<br/>
-            `options` => 'tantivy.tokenizer=jieba')
+            `options` => 'tantivy.tokenizer=jieba')<br/><br/>
+         -- Create Tantivy full-text index with a custom analyzer<br/>
+         CALL sys.create_global_index(<br/>
+            `table` => 'default.T',<br/>
+            `index_column` => 'content',<br/>
+            `index_type` => 'tantivy-fulltext',<br/>
+            `options` => 'tantivy.tokenizer=simple,tantivy.stem=true,tantivy.remove-stop-words=true')
       </td>
    </tr>
    <tr>

--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -1019,7 +1019,19 @@ All available procedures are listed below.
             `table` => 'default.T',<br/>
             `index_column` => 'name',<br/>
             `index_type` => 'btree',<br/>
-            `partitions` => 'pt=p1;pt=p2')
+            `partitions` => 'pt=p1;pt=p2')<br/><br/>
+         -- Create Tantivy full-text index with ngram tokenizer<br/>
+         CALL sys.create_global_index(<br/>
+            `table` => 'default.T',<br/>
+            `index_column` => 'content',<br/>
+            `index_type` => 'tantivy-fulltext',<br/>
+            `options` => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2')<br/><br/>
+         -- Create Tantivy full-text index with jieba tokenizer<br/>
+         CALL sys.create_global_index(<br/>
+            `table` => 'default.T',<br/>
+            `index_column` => 'content',<br/>
+            `index_type` => 'tantivy-fulltext',<br/>
+            `options` => 'tantivy.tokenizer=jieba')
       </td>
    </tr>
    <tr>

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -187,6 +187,43 @@ CALL sys.create_global_index(
 );
 ```
 
+For other content where users often search by short character fragments, build the
+index with Tantivy's `ngram` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2'
+);
+```
+
+For Chinese word segmentation, build the index with the `jieba` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=jieba'
+);
+```
+
+Supported tokenizer options:
+
+| Option | Default | Description |
+|---|---|---|
+| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `ngram`, `jieba`. |
+| `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
+| `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+
+Tokenizer settings are persisted in global index metadata. Existing index files keep using the
+tokenizer they were built with, even if later index builds use different options.
+PyPaimon can query `jieba` indexes when the Python `jieba` package is installed.
+
 **Full-Text Search**
 
 <Tabs groupId="fulltext-search">

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -210,19 +210,39 @@ CALL sys.create_global_index(
 );
 ```
 
+For LanceDB-style analyzer customization, choose a base tokenizer and compose token filters:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=simple,tantivy.stem=true,tantivy.remove-stop-words=true'
+);
+```
+
 Supported tokenizer options:
 
 | Option | Default | Description |
 |---|---|---|
-| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `ngram`, `jieba`. |
+| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `simple`, `whitespace`, `raw`, `ngram`, `jieba`. |
 | `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
 | `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
 | `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
 | `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+| `tantivy.max-token-length` | `40` | Maximum token length kept by configurable tokenizers. |
+| `tantivy.ascii-folding` | `false` | Whether to normalize non-ASCII Latin characters to ASCII. |
+| `tantivy.stem` | `false` | Whether to apply stemming to emitted tokens. |
+| `tantivy.language` | `english` | Language used by stemming and built-in stop word filters. |
+| `tantivy.remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
+| `tantivy.stop-words` | ` ` | Semicolon-separated custom stop words to remove. |
+| `tantivy.with-position` | `true` | Whether to store term positions for phrase queries. Disable it to reduce index size when phrase queries are not needed. |
 
 Tokenizer settings are persisted in global index metadata. Existing index files keep using the
 tokenizer they were built with, even if later index builds use different options.
-PyPaimon can query `jieba` indexes when the Python `jieba` package is installed.
+Paimon does not load arbitrary Rust tokenizer plugins from configuration; custom analysis is
+provided by composing the supported tokenizer and filter options above. PyPaimon can query
+`jieba` indexes when the Python `jieba` package is installed.
 
 **Full-Text Search**
 
@@ -245,6 +265,7 @@ Table table = catalog.getTable(identifier);
 // Step 1: Build full-text search
 GlobalIndexResult result = table.newFullTextSearchBuilder()
         .withQueryText("paimon lake format")
+        .withQueryOperator("and")
         .withLimit(10)
         .withTextColumn("content")
         .executeLocal();
@@ -270,6 +291,7 @@ table = catalog.get_table('db.my_table')
 builder = table.new_full_text_search_builder()
 builder.with_text_column('content')
 builder.with_query_text('paimon lake format')
+builder.with_query_operator('and')
 builder.with_limit(10)
 result = builder.execute_local()
 

--- a/docs/docs/pypaimon/cli.md
+++ b/docs/docs/pypaimon/cli.md
@@ -461,7 +461,10 @@ Output:
   4  Data lake platforms like Paimon handle large-...
 ```
 
-**Note:** The table must have a Tantivy full-text index built on the target column. See [Global Index](../multimodal-table/global-index) for how to create full-text indexes.
+**Note:** The table must have a Tantivy full-text index built on the target column. PyPaimon uses
+the tokenizer settings stored in the index metadata; ngram full-text indexes require a `tantivy-py`
+package with custom tokenizer support, and jieba full-text indexes require the Python `jieba`
+package. See [Global Index](../multimodal-table/global-index) for how to create full-text indexes.
 
 ### Table Drop
 

--- a/docs/docs/pypaimon/global-index.md
+++ b/docs/docs/pypaimon/global-index.md
@@ -111,9 +111,11 @@ data = read.to_arrow(scan.plan().splits)
 Use `FullTextSearchBuilder` to perform full-text search on a text column, then read the matched rows.
 PyPaimon reads the Tantivy tokenizer settings stored in the global index metadata. Indexes built
 with `tantivy.tokenizer=ngram` can be queried from Python when the installed `tantivy-py` package
-provides custom tokenizer support, including `Tokenizer.ngram`, `TextAnalyzerBuilder`, and
+provides custom tokenizer support, including `Tokenizer.ngram`, `Tokenizer.simple`,
+`Tokenizer.whitespace`, `Tokenizer.raw`, `TextAnalyzerBuilder`, tokenizer filters, and
 `Index.register_tokenizer`. Indexes built with `tantivy.tokenizer=jieba` can be queried from Python
-when the `jieba` package is installed.
+when the `jieba` package is installed. Query terms use OR semantics by default; use
+`with_query_operator("and")` to require all terms.
 
 ```python
 table = catalog.get_table("db.my_table")
@@ -124,6 +126,7 @@ index_result = (
     builder
     .with_text_column("content")
     .with_query_text("search keywords")
+    .with_query_operator("and")
     .with_limit(20)
     .execute_local()
 )

--- a/docs/docs/pypaimon/global-index.md
+++ b/docs/docs/pypaimon/global-index.md
@@ -109,6 +109,11 @@ data = read.to_arrow(scan.plan().splits)
 ## Full-Text Index (Tantivy)
 
 Use `FullTextSearchBuilder` to perform full-text search on a text column, then read the matched rows.
+PyPaimon reads the Tantivy tokenizer settings stored in the global index metadata. Indexes built
+with `tantivy.tokenizer=ngram` can be queried from Python when the installed `tantivy-py` package
+provides custom tokenizer support, including `Tokenizer.ngram`, `TextAnalyzerBuilder`, and
+`Index.register_tokenizer`. Indexes built with `tantivy.tokenizer=jieba` can be queried from Python
+when the `jieba` package is installed.
 
 ```python
 table = catalog.get_table("db.my_table")

--- a/docs/docs/spark/procedures.md
+++ b/docs/docs/spark/procedures.md
@@ -525,7 +525,8 @@ This section introduce all available spark procedures about paimon.
          CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1;pt=p2')<br/><br/>
          CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=jieba')
+         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=jieba')<br/><br/>
+         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=simple,tantivy.stem=true,tantivy.remove-stop-words=true')
       </td>
    </tr>
    <tr>

--- a/docs/docs/spark/procedures.md
+++ b/docs/docs/spark/procedures.md
@@ -523,7 +523,9 @@ This section introduce all available spark procedures about paimon.
       </td>
       <td>
          CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree')<br/><br/>
-         CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1;pt=p2')
+         CALL sys.create_global_index(table => 'default.T', index_column => 'name', index_type => 'btree', partitions => 'pt=p1;pt=p2')<br/><br/>
+         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2')<br/><br/>
+         CALL sys.create_global_index(table => 'default.T', index_column => 'content', index_type => 'tantivy-fulltext', options => 'tantivy.tokenizer=jieba')
       </td>
    </tr>
    <tr>

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/FullTextSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/FullTextSearch.java
@@ -28,8 +28,13 @@ public class FullTextSearch implements Serializable {
     private final String queryText;
     private final String fieldName;
     private final int limit;
+    private final String queryOperator;
 
     public FullTextSearch(String queryText, int limit, String fieldName) {
+        this(queryText, limit, fieldName, "or");
+    }
+
+    public FullTextSearch(String queryText, int limit, String fieldName, String queryOperator) {
         if (queryText == null || queryText.isEmpty()) {
             throw new IllegalArgumentException("Query text cannot be null or empty");
         }
@@ -42,6 +47,13 @@ public class FullTextSearch implements Serializable {
         this.queryText = queryText;
         this.limit = limit;
         this.fieldName = fieldName;
+        String normalizedOperator =
+                queryOperator == null ? "or" : queryOperator.trim().toLowerCase();
+        if (!"or".equals(normalizedOperator) && !"and".equals(normalizedOperator)) {
+            throw new IllegalArgumentException(
+                    "Query operator must be 'or' or 'and', got: " + queryOperator);
+        }
+        this.queryOperator = normalizedOperator;
     }
 
     public String queryText() {
@@ -56,9 +68,14 @@ public class FullTextSearch implements Serializable {
         return fieldName;
     }
 
+    public String queryOperator() {
+        return queryOperator;
+    }
+
     @Override
     public String toString() {
         return String.format(
-                "FullTextSearch{field=%s, query='%s', limit=%d}", fieldName, queryText, limit);
+                "FullTextSearch{field=%s, query='%s', limit=%d, operator=%s}",
+                fieldName, queryText, limit, queryOperator);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextReadImpl.java
@@ -52,13 +52,24 @@ public class FullTextReadImpl implements FullTextRead {
     private final int limit;
     private final DataField textColumn;
     private final String queryText;
+    private final String queryOperator;
 
     public FullTextReadImpl(
             FileStoreTable table, int limit, DataField textColumn, String queryText) {
+        this(table, limit, textColumn, queryText, "or");
+    }
+
+    public FullTextReadImpl(
+            FileStoreTable table,
+            int limit,
+            DataField textColumn,
+            String queryText,
+            String queryOperator) {
         this.table = table;
         this.limit = limit;
         this.textColumn = textColumn;
         this.queryText = queryText;
+        this.queryOperator = queryOperator;
     }
 
     @Override
@@ -123,7 +134,8 @@ public class FullTextReadImpl implements FullTextRead {
         GlobalIndexFileReader indexFileReader = m -> fileIO.newInputStream(m.filePath());
         GlobalIndexReader reader =
                 globalIndexer.createReader(indexFileReader, indexIOMetaList, executor);
-        FullTextSearch fullTextSearch = new FullTextSearch(queryText, limit, textColumn.name());
+        FullTextSearch fullTextSearch =
+                new FullTextSearch(queryText, limit, textColumn.name(), queryOperator);
         return new OffsetGlobalIndexReader(reader, rowRangeStart, rowRangeEnd)
                 .visitFullTextSearch(fullTextSearch)
                 .whenComplete((r, t) -> IOUtils.closeQuietly(reader));

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilder.java
@@ -34,6 +34,9 @@ public interface FullTextSearchBuilder extends Serializable {
     /** The query text to search. */
     FullTextSearchBuilder withQueryText(String queryText);
 
+    /** The default query operator. Supported values are 'or' and 'and'. */
+    FullTextSearchBuilder withQueryOperator(String queryOperator);
+
     /** Create full-text scan to scan index files. */
     FullTextScan newFullTextScan();
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -35,6 +35,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     private int limit;
     private DataField textColumn;
     private String queryText;
+    private String queryOperator = "or";
 
     public FullTextSearchBuilderImpl(InnerTable table) {
         this.table = (FileStoreTable) table;
@@ -59,6 +60,12 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     }
 
     @Override
+    public FullTextSearchBuilder withQueryOperator(String queryOperator) {
+        this.queryOperator = queryOperator;
+        return this;
+    }
+
+    @Override
     public FullTextScan newFullTextScan() {
         checkNotNull(textColumn, "Text column must be set via withTextColumn()");
         return new FullTextScanImpl(table, textColumn);
@@ -69,6 +76,6 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
         checkNotNull(textColumn, "Text column must be set via withTextColumn()");
         checkNotNull(queryText, "Query text must be set via withQueryText()");
-        return new FullTextReadImpl(table, limit, textColumn, queryText);
+        return new FullTextReadImpl(table, limit, textColumn, queryText, queryOperator);
     }
 }

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -373,6 +373,11 @@ run_tantivy_fulltext_test() {
         return 1
     fi
     cd "$PAIMON_PYTHON_DIR"
+    echo "Installing Python jieba tokenizer dependency for Tantivy jieba index reads..."
+    if ! python -m pip install 'jieba>=0.42,<1'; then
+        echo -e "${RED}✗ Failed to install jieba${NC}"
+        return 1
+    fi
     echo "Running Python test for JavaPyReadWriteTest.test_read_tantivy_full_text_index..."
     if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_read_tantivy_full_text_index -v; then
         echo -e "${GREEN}✓ Python test completed successfully${NC}"

--- a/paimon-python/pypaimon/globalindex/full_text_search.py
+++ b/paimon-python/pypaimon/globalindex/full_text_search.py
@@ -36,6 +36,7 @@ class FullTextSearch:
     query_text: str
     limit: int
     field_name: str
+    query_operator: str = "or"
 
     def __post_init__(self):
         if not self.query_text:
@@ -44,10 +45,21 @@ class FullTextSearch:
             raise ValueError(f"Limit must be positive, got: {self.limit}")
         if not self.field_name:
             raise ValueError("Field name cannot be null or empty")
+        query_operator = (
+            "or" if self.query_operator is None else self.query_operator.strip().lower()
+        )
+        if query_operator not in ("or", "and"):
+            raise ValueError(
+                "Query operator must be 'or' or 'and', got: %s" % self.query_operator
+            )
+        self.query_operator = query_operator
 
     def visit(self, visitor: 'GlobalIndexReader') -> 'Future[Optional[ScoredGlobalIndexResult]]':
         """Visit the global index reader with this full-text search."""
         return visitor.visit_full_text_search(self)
 
     def __repr__(self) -> str:
-        return f"FullTextSearch(field={self.field_name}, query='{self.query_text}', limit={self.limit})"
+        return (
+            f"FullTextSearch(field={self.field_name}, query='{self.query_text}', "
+            f"limit={self.limit}, operator={self.query_operator})"
+        )

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -36,7 +36,28 @@ from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta
 TANTIVY_FULLTEXT_IDENTIFIER = "tantivy-fulltext"
 TANTIVY_NGRAM_TOKENIZER = "paimon_ngram"
 TANTIVY_JIEBA_TOKENIZER = "paimon_jieba"
+TANTIVY_CUSTOM_TOKENIZER = "paimon_custom"
 _META_VERSION = 1
+_SUPPORTED_LANGUAGES = {
+    "arabic",
+    "danish",
+    "dutch",
+    "english",
+    "finnish",
+    "french",
+    "german",
+    "greek",
+    "hungarian",
+    "italian",
+    "norwegian",
+    "portuguese",
+    "romanian",
+    "russian",
+    "spanish",
+    "swedish",
+    "tamil",
+    "turkish",
+}
 
 
 @dataclass(frozen=True)
@@ -48,6 +69,13 @@ class TantivyFullTextIndexOptions:
     ngram_max_gram: int = 2
     ngram_prefix_only: bool = False
     lower_case: bool = True
+    max_token_length: int = 40
+    ascii_folding: bool = False
+    stem: bool = False
+    language: str = "english"
+    remove_stop_words: bool = False
+    stop_words: str = ""
+    with_position: bool = True
 
     @staticmethod
     def deserialize(data):
@@ -65,19 +93,45 @@ class TantivyFullTextIndexOptions:
         ngram_max_gram, offset = _read_meta_int(data, offset)
         ngram_prefix_only, offset = _read_meta_bool(data, offset)
         lower_case, offset = _read_meta_bool(data, offset)
+        max_token_length = 40
+        ascii_folding = False
+        stem = False
+        language = "english"
+        remove_stop_words = False
+        stop_words = ""
+        with_position = True
+        if offset < len(data):
+            max_token_length, offset = _read_meta_int(data, offset)
+            ascii_folding, offset = _read_meta_bool(data, offset)
+            stem, offset = _read_meta_bool(data, offset)
+            language, offset = _read_meta_utf(data, offset)
+            remove_stop_words, offset = _read_meta_bool(data, offset)
+            stop_words, offset = _read_meta_utf(data, offset)
+            with_position, offset = _read_meta_bool(data, offset)
 
         return TantivyFullTextIndexOptions(
             tokenizer=tokenizer,
             ngram_min_gram=ngram_min_gram,
             ngram_max_gram=ngram_max_gram,
             ngram_prefix_only=ngram_prefix_only,
-            lower_case=lower_case)
+            lower_case=lower_case,
+            max_token_length=max_token_length,
+            ascii_folding=ascii_folding,
+            stem=stem,
+            language=language,
+            remove_stop_words=remove_stop_words,
+            stop_words=stop_words,
+            with_position=with_position)
 
     def __post_init__(self):
         tokenizer = "" if self.tokenizer is None else self.tokenizer.strip().lower()
         object.__setattr__(self, "tokenizer", tokenizer)
+        language = "" if self.language is None else self.language.strip().lower()
+        object.__setattr__(self, "language", language)
+        object.__setattr__(self, "stop_words", _normalize_stop_words(self.stop_words))
 
-        if tokenizer not in ("default", "ngram", "jieba"):
+        supported_tokenizers = ("default", "simple", "whitespace", "raw", "ngram", "jieba")
+        if tokenizer not in supported_tokenizers:
             raise ValueError("Unsupported Tantivy tokenizer: %s" % tokenizer)
         if self.ngram_min_gram <= 0:
             raise ValueError("ngram min gram must be positive.")
@@ -86,13 +140,39 @@ class TantivyFullTextIndexOptions:
         if self.ngram_min_gram > self.ngram_max_gram:
             raise ValueError(
                 "ngram min gram must not be greater than max gram.")
+        if self.max_token_length <= 0:
+            raise ValueError("max token length must be positive.")
+        if self.language not in _SUPPORTED_LANGUAGES:
+            raise ValueError("Unsupported Tantivy language: %s" % self.language)
 
     def tokenizer_name(self):
         if self.tokenizer == "ngram":
             return TANTIVY_NGRAM_TOKENIZER
         if self.tokenizer == "jieba":
             return TANTIVY_JIEBA_TOKENIZER
+        if self._needs_custom_tokenizer():
+            return TANTIVY_CUSTOM_TOKENIZER
         return self.tokenizer
+
+    def stop_word_list(self):
+        if not self.stop_words:
+            return []
+        return [
+            word.strip()
+            for word in self.stop_words.split(";")
+            if word.strip()
+        ]
+
+    def _needs_custom_tokenizer(self):
+        return (
+            self.tokenizer in ("simple", "whitespace", "raw")
+            or self.max_token_length != 40
+            or not self.lower_case
+            or self.ascii_folding
+            or self.stem
+            or self.remove_stop_words
+            or bool(self.stop_word_list())
+        )
 
 
 class StreamDirectory:
@@ -208,13 +288,12 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
     def visit_full_text_search(self, full_text_search):
         self._ensure_loaded()
 
-        query_text = full_text_search.query_text
         limit = full_text_search.limit
 
         searcher = self._searcher
         import tantivy
 
-        query = self._parse_query(tantivy, query_text)
+        query = self._parse_query(tantivy, full_text_search)
 
         results = searcher.search(query, limit)
         if not results.hits:
@@ -266,28 +345,61 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
     def _add_text_field(self, schema_builder):
         tokenizer_name = self._index_options.tokenizer_name()
+        index_option = None if self._index_options.with_position else "freq"
         if tokenizer_name == "default":
-            schema_builder.add_text_field("text", stored=False)
+            schema_builder.add_text_field("text", stored=False, index_option=index_option)
         else:
             schema_builder.add_text_field(
-                "text", stored=False, tokenizer_name=tokenizer_name)
+                "text", stored=False, tokenizer_name=tokenizer_name,
+                index_option=index_option)
 
     def _register_tokenizer(self, tantivy, index):
-        if self._index_options.tokenizer != "ngram":
+        if (self._index_options.tokenizer == "default"
+                and self._index_options.tokenizer_name() == "default"):
             return
 
-        analyzer_builder = tantivy.TextAnalyzerBuilder(
-            tantivy.Tokenizer.ngram(
+        if self._index_options.tokenizer == "ngram":
+            tokenizer = tantivy.Tokenizer.ngram(
                 min_gram=self._index_options.ngram_min_gram,
                 max_gram=self._index_options.ngram_max_gram,
-                prefix_only=self._index_options.ngram_prefix_only))
+                prefix_only=self._index_options.ngram_prefix_only)
+        elif self._index_options.tokenizer in ("default", "simple"):
+            tokenizer = tantivy.Tokenizer.simple()
+        elif self._index_options.tokenizer == "whitespace":
+            tokenizer = tantivy.Tokenizer.whitespace()
+        elif self._index_options.tokenizer == "raw":
+            tokenizer = tantivy.Tokenizer.raw()
+        else:
+            return
+
+        analyzer_builder = tantivy.TextAnalyzerBuilder(tokenizer)
+        if self._index_options.max_token_length != 40:
+            analyzer_builder = analyzer_builder.filter(
+                tantivy.Filter.remove_long(self._index_options.max_token_length))
         if self._index_options.lower_case:
             analyzer_builder = analyzer_builder.filter(tantivy.Filter.lowercase())
+        if self._index_options.ascii_folding:
+            analyzer_builder = analyzer_builder.filter(tantivy.Filter.ascii_fold())
+        if self._index_options.stem:
+            analyzer_builder = analyzer_builder.filter(
+                tantivy.Filter.stemmer(self._index_options.language))
+        if self._index_options.remove_stop_words:
+            analyzer_builder = analyzer_builder.filter(
+                tantivy.Filter.stopword(self._index_options.language))
+        stop_words = self._index_options.stop_word_list()
+        if stop_words:
+            analyzer_builder = analyzer_builder.filter(
+                tantivy.Filter.custom_stopword(stop_words))
         analyzer = analyzer_builder.build()
-        index.register_tokenizer(TANTIVY_NGRAM_TOKENIZER, analyzer)
+        index.register_tokenizer(self._index_options.tokenizer_name(), analyzer)
 
-    def _parse_query(self, tantivy, query_text):
+    def _parse_query(self, tantivy, full_text_search):
+        query_text = full_text_search.query_text
+        conjunction_by_default = full_text_search.query_operator == "and"
         if self._index_options.tokenizer != "jieba":
+            if conjunction_by_default:
+                return self._index.parse_query(
+                    query_text, ["text"], conjunction_by_default=True)
             return self._index.parse_query(query_text, ["text"])
 
         tokens = self._jieba_query_tokens(query_text)
@@ -300,8 +412,9 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         ]
         if len(term_queries) == 1:
             return term_queries[0]
+        occur = tantivy.Occur.Must if conjunction_by_default else tantivy.Occur.Should
         return tantivy.Query.boolean_query([
-            (tantivy.Occur.Should, query)
+            (occur, query)
             for query in term_queries
         ])
 
@@ -326,13 +439,19 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         return tokens
 
     def _verify_tantivy_tokenizer_api(self, tantivy):
-        if self._index_options.tokenizer not in ("ngram", "jieba"):
+        if (self._index_options.tokenizer == "default"
+                and self._index_options.tokenizer_name() == "default"):
             return
 
         missing = []
-        if self._index_options.tokenizer == "ngram":
+        if self._index_options.tokenizer != "jieba":
             required_classes = ["TextAnalyzerBuilder", "Tokenizer"]
-            if self._index_options.lower_case:
+            if (self._index_options.lower_case
+                    or self._index_options.max_token_length != 40
+                    or self._index_options.ascii_folding
+                    or self._index_options.stem
+                    or self._index_options.remove_stop_words
+                    or self._index_options.stop_word_list()):
                 required_classes.append("Filter")
         else:
             required_classes = ["Query", "Occur"]
@@ -344,20 +463,42 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         filter_ = getattr(tantivy, "Filter", None)
         query = getattr(tantivy, "Query", None)
         occur = getattr(tantivy, "Occur", None)
-        if (self._index_options.tokenizer == "ngram" and tokenizer is not None
-                and not hasattr(tokenizer, "ngram")):
-            missing.append("Tokenizer.ngram")
-        if (self._index_options.tokenizer == "ngram"
-                and self._index_options.lower_case and filter_ is not None
-                and not hasattr(filter_, "lowercase")):
-            missing.append("Filter.lowercase")
+        tokenizer_apis = {
+            "default": "simple",
+            "ngram": "ngram",
+            "simple": "simple",
+            "whitespace": "whitespace",
+            "raw": "raw",
+        }
+        tokenizer_api = tokenizer_apis.get(self._index_options.tokenizer)
+        if (tokenizer_api is not None and tokenizer is not None
+                and not hasattr(tokenizer, tokenizer_api)):
+            missing.append("Tokenizer.%s" % tokenizer_api)
+        if self._index_options.tokenizer != "jieba" and filter_ is not None:
+            filter_checks = []
+            if self._index_options.max_token_length != 40:
+                filter_checks.append(("remove_long", "Filter.remove_long"))
+            if self._index_options.lower_case:
+                filter_checks.append(("lowercase", "Filter.lowercase"))
+            if self._index_options.ascii_folding:
+                filter_checks.append(("ascii_fold", "Filter.ascii_fold"))
+            if self._index_options.stem:
+                filter_checks.append(("stemmer", "Filter.stemmer"))
+            if self._index_options.remove_stop_words:
+                filter_checks.append(("stopword", "Filter.stopword"))
+            if self._index_options.stop_word_list():
+                filter_checks.append(("custom_stopword", "Filter.custom_stopword"))
+            for attr, api_name in filter_checks:
+                if not hasattr(filter_, attr):
+                    missing.append(api_name)
         if self._index_options.tokenizer == "jieba" and query is not None:
             for name in ("empty_query", "term_query", "boolean_query"):
                 if not hasattr(query, name):
                     missing.append("Query.%s" % name)
-        if (self._index_options.tokenizer == "jieba" and occur is not None
-                and not hasattr(occur, "Should")):
-            missing.append("Occur.Should")
+        if self._index_options.tokenizer == "jieba" and occur is not None:
+            for name in ("Should", "Must"):
+                if not hasattr(occur, name):
+                    missing.append("Occur.%s" % name)
         if missing:
             tokenizer_name = self._index_options.tokenizer
             raise RuntimeError(
@@ -486,6 +627,16 @@ def _read_meta_utf(data: bytes, offset: int):
     offset += 2
     _check_meta_remaining(data, offset, utf_len)
     return data[offset:offset + utf_len].decode('utf-8'), offset + utf_len
+
+
+def _normalize_stop_words(stop_words):
+    if stop_words is None:
+        return ""
+    return ";".join(
+        word.strip()
+        for word in stop_words.split(";")
+        if word.strip()
+    )
 
 
 def _check_meta_remaining(data: bytes, offset: int, length: int):

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -345,13 +345,15 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
     def _add_text_field(self, schema_builder):
         tokenizer_name = self._index_options.tokenizer_name()
-        index_option = None if self._index_options.with_position else "freq"
+        field_kwargs = {}
+        if not self._index_options.with_position:
+            field_kwargs["index_option"] = "freq"
         if tokenizer_name == "default":
-            schema_builder.add_text_field("text", stored=False, index_option=index_option)
+            schema_builder.add_text_field("text", stored=False, **field_kwargs)
         else:
             schema_builder.add_text_field(
                 "text", stored=False, tokenizer_name=tokenizer_name,
-                index_option=index_option)
+                **field_kwargs)
 
     def _register_tokenizer(self, tantivy, index):
         if (self._index_options.tokenizer == "default"

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -24,6 +24,7 @@ backed by a stream-based Directory. No temp files are created on disk.
 import os
 import struct
 import threading
+from dataclasses import dataclass
 from typing import Dict, List
 
 from pypaimon.globalindex.global_index_reader import GlobalIndexReader, FieldRef, _completed_future
@@ -33,6 +34,65 @@ from pypaimon.globalindex.vector_search_result import (
 from pypaimon.globalindex.global_index_meta import GlobalIndexIOMeta
 
 TANTIVY_FULLTEXT_IDENTIFIER = "tantivy-fulltext"
+TANTIVY_NGRAM_TOKENIZER = "paimon_ngram"
+TANTIVY_JIEBA_TOKENIZER = "paimon_jieba"
+_META_VERSION = 1
+
+
+@dataclass(frozen=True)
+class TantivyFullTextIndexOptions:
+    """Tokenizer options serialized by the Java Tantivy full-text index."""
+
+    tokenizer: str = "default"
+    ngram_min_gram: int = 2
+    ngram_max_gram: int = 2
+    ngram_prefix_only: bool = False
+    lower_case: bool = True
+
+    @staticmethod
+    def deserialize(data):
+        if not data:
+            return TantivyFullTextIndexOptions()
+
+        offset = 0
+        version, offset = _read_meta_int(data, offset)
+        if version != _META_VERSION:
+            raise ValueError(
+                "Unsupported Tantivy full-text index meta version: %s" % version)
+
+        tokenizer, offset = _read_meta_utf(data, offset)
+        ngram_min_gram, offset = _read_meta_int(data, offset)
+        ngram_max_gram, offset = _read_meta_int(data, offset)
+        ngram_prefix_only, offset = _read_meta_bool(data, offset)
+        lower_case, offset = _read_meta_bool(data, offset)
+
+        return TantivyFullTextIndexOptions(
+            tokenizer=tokenizer,
+            ngram_min_gram=ngram_min_gram,
+            ngram_max_gram=ngram_max_gram,
+            ngram_prefix_only=ngram_prefix_only,
+            lower_case=lower_case)
+
+    def __post_init__(self):
+        tokenizer = "" if self.tokenizer is None else self.tokenizer.strip().lower()
+        object.__setattr__(self, "tokenizer", tokenizer)
+
+        if tokenizer not in ("default", "ngram", "jieba"):
+            raise ValueError("Unsupported Tantivy tokenizer: %s" % tokenizer)
+        if self.ngram_min_gram <= 0:
+            raise ValueError("ngram min gram must be positive.")
+        if self.ngram_max_gram <= 0:
+            raise ValueError("ngram max gram must be positive.")
+        if self.ngram_min_gram > self.ngram_max_gram:
+            raise ValueError(
+                "ngram min gram must not be greater than max gram.")
+
+    def tokenizer_name(self):
+        if self.tokenizer == "ngram":
+            return TANTIVY_NGRAM_TOKENIZER
+        if self.tokenizer == "jieba":
+            return TANTIVY_JIEBA_TOKENIZER
+        return self.tokenizer
 
 
 class StreamDirectory:
@@ -137,8 +197,11 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         self._file_io = file_io
         self._index_path = index_path
         self._io_meta = io_metas[0]
+        self._index_options = TantivyFullTextIndexOptions.deserialize(
+            self._io_meta.metadata)
         self._searcher = None
         self._index = None
+        self._schema = None
         self._stream = None
         self._load_lock = threading.Lock()
 
@@ -149,7 +212,9 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
         limit = full_text_search.limit
 
         searcher = self._searcher
-        query = self._index.parse_query(query_text, ["text"])
+        import tantivy
+
+        query = self._parse_query(tantivy, query_text)
 
         results = searcher.search(query, limit)
         if not results.hits:
@@ -175,6 +240,7 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
             import tantivy
 
+            self._verify_tantivy_tokenizer_api(tantivy)
             file_path = (self._io_meta.external_path
                          if self._io_meta.external_path
                          else os.path.join(self._index_path, self._io_meta.file_name))
@@ -185,16 +251,119 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
 
                 schema_builder = tantivy.SchemaBuilder()
                 schema_builder.add_unsigned_field("row_id", stored=False, indexed=True, fast=True)
-                schema_builder.add_text_field("text", stored=False)
+                self._add_text_field(schema_builder)
                 schema = schema_builder.build()
 
+                self._schema = schema
                 self._index = tantivy.Index(schema, directory=directory)
+                self._register_tokenizer(tantivy, self._index)
                 self._index.reload()
                 self._searcher = self._index.searcher()
                 self._stream = stream
             except Exception:
                 stream.close()
                 raise
+
+    def _add_text_field(self, schema_builder):
+        tokenizer_name = self._index_options.tokenizer_name()
+        if tokenizer_name == "default":
+            schema_builder.add_text_field("text", stored=False)
+        else:
+            schema_builder.add_text_field(
+                "text", stored=False, tokenizer_name=tokenizer_name)
+
+    def _register_tokenizer(self, tantivy, index):
+        if self._index_options.tokenizer != "ngram":
+            return
+
+        analyzer_builder = tantivy.TextAnalyzerBuilder(
+            tantivy.Tokenizer.ngram(
+                min_gram=self._index_options.ngram_min_gram,
+                max_gram=self._index_options.ngram_max_gram,
+                prefix_only=self._index_options.ngram_prefix_only))
+        if self._index_options.lower_case:
+            analyzer_builder = analyzer_builder.filter(tantivy.Filter.lowercase())
+        analyzer = analyzer_builder.build()
+        index.register_tokenizer(TANTIVY_NGRAM_TOKENIZER, analyzer)
+
+    def _parse_query(self, tantivy, query_text):
+        if self._index_options.tokenizer != "jieba":
+            return self._index.parse_query(query_text, ["text"])
+
+        tokens = self._jieba_query_tokens(query_text)
+        if not tokens:
+            return tantivy.Query.empty_query()
+
+        term_queries = [
+            tantivy.Query.term_query(self._schema, "text", token)
+            for token in tokens
+        ]
+        if len(term_queries) == 1:
+            return term_queries[0]
+        return tantivy.Query.boolean_query([
+            (tantivy.Occur.Should, query)
+            for query in term_queries
+        ])
+
+    def _jieba_query_tokens(self, query_text):
+        try:
+            import jieba
+        except ImportError as e:
+            raise RuntimeError(
+                "PyPaimon Tantivy full-text search requires Python package "
+                "'jieba' to query jieba tokenizer indexes. Install it with "
+                "`pip install jieba`.") from e
+
+        seen = set()
+        tokens = []
+        for word, _, _ in jieba.tokenize(query_text, mode="search", HMM=True):
+            token = word.strip()
+            if self._index_options.lower_case:
+                token = token.lower()
+            if token and token not in seen:
+                seen.add(token)
+                tokens.append(token)
+        return tokens
+
+    def _verify_tantivy_tokenizer_api(self, tantivy):
+        if self._index_options.tokenizer not in ("ngram", "jieba"):
+            return
+
+        missing = []
+        if self._index_options.tokenizer == "ngram":
+            required_classes = ["TextAnalyzerBuilder", "Tokenizer"]
+            if self._index_options.lower_case:
+                required_classes.append("Filter")
+        else:
+            required_classes = ["Query", "Occur"]
+        for name in required_classes:
+            if not hasattr(tantivy, name):
+                missing.append(name)
+
+        tokenizer = getattr(tantivy, "Tokenizer", None)
+        filter_ = getattr(tantivy, "Filter", None)
+        query = getattr(tantivy, "Query", None)
+        occur = getattr(tantivy, "Occur", None)
+        if (self._index_options.tokenizer == "ngram" and tokenizer is not None
+                and not hasattr(tokenizer, "ngram")):
+            missing.append("Tokenizer.ngram")
+        if (self._index_options.tokenizer == "ngram"
+                and self._index_options.lower_case and filter_ is not None
+                and not hasattr(filter_, "lowercase")):
+            missing.append("Filter.lowercase")
+        if self._index_options.tokenizer == "jieba" and query is not None:
+            for name in ("empty_query", "term_query", "boolean_query"):
+                if not hasattr(query, name):
+                    missing.append("Query.%s" % name)
+        if (self._index_options.tokenizer == "jieba" and occur is not None
+                and not hasattr(occur, "Should")):
+            missing.append("Occur.Should")
+        if missing:
+            tokenizer_name = self._index_options.tokenizer
+            raise RuntimeError(
+                "PyPaimon Tantivy full-text search requires a tantivy-py "
+                "version with %s tokenizer support. Missing API(s): %s"
+                % (tokenizer_name, ", ".join(missing)))
 
     @staticmethod
     def _parse_archive_header(stream):
@@ -273,6 +442,7 @@ class TantivyFullTextGlobalIndexReader(GlobalIndexReader):
     def close(self) -> None:
         self._searcher = None
         self._index = None
+        self._schema = None
         if self._stream is not None:
             self._stream.close()
             self._stream = None
@@ -298,3 +468,26 @@ def _read_fully(stream, length: int) -> bytes:
         buf.extend(chunk)
         remaining -= len(chunk)
     return bytes(buf)
+
+
+def _read_meta_int(data: bytes, offset: int):
+    _check_meta_remaining(data, offset, 4)
+    return struct.unpack_from('>i', data, offset)[0], offset + 4
+
+
+def _read_meta_bool(data: bytes, offset: int):
+    _check_meta_remaining(data, offset, 1)
+    return data[offset] != 0, offset + 1
+
+
+def _read_meta_utf(data: bytes, offset: int):
+    _check_meta_remaining(data, offset, 2)
+    utf_len = struct.unpack_from('>H', data, offset)[0]
+    offset += 2
+    _check_meta_remaining(data, offset, utf_len)
+    return data[offset:offset + utf_len].decode('utf-8'), offset + utf_len
+
+
+def _check_meta_remaining(data: bytes, offset: int, length: int):
+    if len(data) - offset < length:
+        raise ValueError("Malformed Tantivy full-text index metadata.")

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -38,7 +38,6 @@ TANTIVY_FULLTEXT_IDENTIFIER = "tantivy-fulltext"
 TANTIVY_NGRAM_TOKENIZER = "paimon_ngram"
 TANTIVY_JIEBA_TOKENIZER = "paimon_jieba"
 TANTIVY_CUSTOM_TOKENIZER = "paimon_custom"
-_META_VERSION = 1
 _SUPPORTED_LANGUAGES = {
     "arabic",
     "danish",
@@ -82,71 +81,29 @@ class TantivyFullTextIndexOptions:
     def deserialize(data):
         if not data:
             return TantivyFullTextIndexOptions()
-        if data.lstrip().startswith(b"{"):
-            return TantivyFullTextIndexOptions._deserialize_json(data)
-
-        offset = 0
-        version, offset = _read_meta_int(data, offset)
-        if version != _META_VERSION:
-            raise ValueError(
-                "Unsupported Tantivy full-text index meta version: %s" % version)
-
-        tokenizer, offset = _read_meta_utf(data, offset)
-        ngram_min_gram, offset = _read_meta_int(data, offset)
-        ngram_max_gram, offset = _read_meta_int(data, offset)
-        ngram_prefix_only, offset = _read_meta_bool(data, offset)
-        lower_case, offset = _read_meta_bool(data, offset)
-        max_token_length = 40
-        ascii_folding = False
-        stem = False
-        language = "english"
-        remove_stop_words = False
-        stop_words = ""
-        with_position = True
-        if offset < len(data):
-            max_token_length, offset = _read_meta_int(data, offset)
-            ascii_folding, offset = _read_meta_bool(data, offset)
-            stem, offset = _read_meta_bool(data, offset)
-            language, offset = _read_meta_utf(data, offset)
-            remove_stop_words, offset = _read_meta_bool(data, offset)
-            stop_words, offset = _read_meta_utf(data, offset)
-            with_position, offset = _read_meta_bool(data, offset)
-
-        return TantivyFullTextIndexOptions(
-            tokenizer=tokenizer,
-            ngram_min_gram=ngram_min_gram,
-            ngram_max_gram=ngram_max_gram,
-            ngram_prefix_only=ngram_prefix_only,
-            lower_case=lower_case,
-            max_token_length=max_token_length,
-            ascii_folding=ascii_folding,
-            stem=stem,
-            language=language,
-            remove_stop_words=remove_stop_words,
-            stop_words=stop_words,
-            with_position=with_position)
+        return TantivyFullTextIndexOptions._deserialize_json(data)
 
     @staticmethod
     def _deserialize_json(data):
         config = json.loads(data.decode("utf-8"))
-        stop_words = config.get("stopWords", [])
+        stop_words = config.get("stop-words", [])
         if isinstance(stop_words, list):
             stop_words = ";".join(
                 word for word in stop_words if word is not None)
 
         return TantivyFullTextIndexOptions(
             tokenizer=config.get("tokenizer", "default"),
-            ngram_min_gram=config.get("ngramMinGram", 2),
-            ngram_max_gram=config.get("ngramMaxGram", 2),
-            ngram_prefix_only=config.get("ngramPrefixOnly", False),
-            lower_case=config.get("lowerCase", True),
-            max_token_length=config.get("maxTokenLength", 40),
-            ascii_folding=config.get("asciiFolding", False),
+            ngram_min_gram=config.get("ngram.min-gram", 2),
+            ngram_max_gram=config.get("ngram.max-gram", 2),
+            ngram_prefix_only=config.get("ngram.prefix-only", False),
+            lower_case=config.get("lower-case", True),
+            max_token_length=config.get("max-token-length", 40),
+            ascii_folding=config.get("ascii-folding", False),
             stem=config.get("stem", False),
             language=config.get("language", "english"),
-            remove_stop_words=config.get("removeStopWords", False),
+            remove_stop_words=config.get("remove-stop-words", False),
             stop_words=stop_words,
-            with_position=config.get("withPosition", True))
+            with_position=config.get("with-position", True))
 
     def __post_init__(self):
         tokenizer = "" if self.tokenizer is None else self.tokenizer.strip().lower()
@@ -638,34 +595,17 @@ def _read_fully(stream, length: int) -> bytes:
     return bytes(buf)
 
 
-def _read_meta_int(data: bytes, offset: int):
-    _check_meta_remaining(data, offset, 4)
-    return struct.unpack_from('>i', data, offset)[0], offset + 4
-
-
-def _read_meta_bool(data: bytes, offset: int):
-    _check_meta_remaining(data, offset, 1)
-    return data[offset] != 0, offset + 1
-
-
-def _read_meta_utf(data: bytes, offset: int):
-    _check_meta_remaining(data, offset, 2)
-    utf_len = struct.unpack_from('>H', data, offset)[0]
-    offset += 2
-    _check_meta_remaining(data, offset, utf_len)
-    return data[offset:offset + utf_len].decode('utf-8'), offset + utf_len
-
-
 def _normalize_stop_words(stop_words):
     if stop_words is None:
         return ""
+    if isinstance(stop_words, list):
+        return ";".join(
+            word.strip()
+            for word in stop_words
+            if word is not None and word.strip()
+        )
     return ";".join(
         word.strip()
         for word in stop_words.split(";")
         if word.strip()
     )
-
-
-def _check_meta_remaining(data: bytes, offset: int, length: int):
-    if len(data) - offset < length:
-        raise ValueError("Malformed Tantivy full-text index metadata.")

--- a/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
+++ b/paimon-python/pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py
@@ -21,6 +21,7 @@ Reads the archive header to get file layout, then opens a Tantivy searcher
 backed by a stream-based Directory. No temp files are created on disk.
 """
 
+import json
 import os
 import struct
 import threading
@@ -81,6 +82,8 @@ class TantivyFullTextIndexOptions:
     def deserialize(data):
         if not data:
             return TantivyFullTextIndexOptions()
+        if data.lstrip().startswith(b"{"):
+            return TantivyFullTextIndexOptions._deserialize_json(data)
 
         offset = 0
         version, offset = _read_meta_int(data, offset)
@@ -122,6 +125,28 @@ class TantivyFullTextIndexOptions:
             remove_stop_words=remove_stop_words,
             stop_words=stop_words,
             with_position=with_position)
+
+    @staticmethod
+    def _deserialize_json(data):
+        config = json.loads(data.decode("utf-8"))
+        stop_words = config.get("stopWords", [])
+        if isinstance(stop_words, list):
+            stop_words = ";".join(
+                word for word in stop_words if word is not None)
+
+        return TantivyFullTextIndexOptions(
+            tokenizer=config.get("tokenizer", "default"),
+            ngram_min_gram=config.get("ngramMinGram", 2),
+            ngram_max_gram=config.get("ngramMaxGram", 2),
+            ngram_prefix_only=config.get("ngramPrefixOnly", False),
+            lower_case=config.get("lowerCase", True),
+            max_token_length=config.get("maxTokenLength", 40),
+            ascii_folding=config.get("asciiFolding", False),
+            stem=config.get("stem", False),
+            language=config.get("language", "english"),
+            remove_stop_words=config.get("removeStopWords", False),
+            stop_words=stop_words,
+            with_position=config.get("withPosition", True))
 
     def __post_init__(self):
         tokenizer = "" if self.tokenizer is None else self.tokenizer.strip().lower()

--- a/paimon-python/pypaimon/table/source/full_text_read.py
+++ b/paimon-python/pypaimon/table/source/full_text_read.py
@@ -49,12 +49,14 @@ class FullTextReadImpl(FullTextRead):
         table: 'FileStoreTable',
         limit: int,
         text_column: 'DataField',
-        query_text: str
+        query_text: str,
+        query_operator: str = "or"
     ):
         self._table = table
         self._limit = limit
         self._text_column = text_column
         self._query_text = query_text
+        self._query_operator = query_operator
 
     def read(self, splits: List[FullTextSearchSplit]) -> GlobalIndexResult:
         if not splits:
@@ -106,7 +108,8 @@ class FullTextReadImpl(FullTextRead):
         full_text_search = FullTextSearch(
             query_text=self._query_text,
             limit=self._limit,
-            field_name=self._text_column.name
+            field_name=self._text_column.name,
+            query_operator=self._query_operator
         )
 
         offset_reader = OffsetGlobalIndexReader(reader, row_range_start, row_range_end)

--- a/paimon-python/pypaimon/table/source/full_text_read.py
+++ b/paimon-python/pypaimon/table/source/full_text_read.py
@@ -92,7 +92,8 @@ class FullTextReadImpl(FullTextRead):
                 GlobalIndexIOMeta(
                     file_name=index_file.file_name,
                     file_size=index_file.file_size,
-                    metadata=meta.index_meta
+                    metadata=meta.index_meta,
+                    external_path=index_file.external_path,
                 )
             )
 

--- a/paimon-python/pypaimon/table/source/full_text_search_builder.py
+++ b/paimon-python/pypaimon/table/source/full_text_search_builder.py
@@ -44,6 +44,11 @@ class FullTextSearchBuilder(ABC):
         pass
 
     @abstractmethod
+    def with_query_operator(self, query_operator: str) -> 'FullTextSearchBuilder':
+        """The default operator for query terms. Supported values are 'or' and 'and'."""
+        pass
+
+    @abstractmethod
     def new_full_text_scan(self) -> FullTextScan:
         """Create full-text scan to scan index files."""
         pass
@@ -66,6 +71,7 @@ class FullTextSearchBuilderImpl(FullTextSearchBuilder):
         self._limit: int = 0
         self._text_column: Optional['DataField'] = None
         self._query_text: Optional[str] = None
+        self._query_operator: str = "or"
 
     def with_limit(self, limit: int) -> 'FullTextSearchBuilder':
         self._limit = limit
@@ -82,6 +88,10 @@ class FullTextSearchBuilderImpl(FullTextSearchBuilder):
         self._query_text = query_text
         return self
 
+    def with_query_operator(self, query_operator: str) -> 'FullTextSearchBuilder':
+        self._query_operator = query_operator
+        return self
+
     def new_full_text_scan(self) -> FullTextScan:
         if self._text_column is None:
             raise ValueError("Text column must be set via with_text_column()")
@@ -95,5 +105,6 @@ class FullTextSearchBuilderImpl(FullTextSearchBuilder):
         if self._query_text is None:
             raise ValueError("Query text must be set via with_query_text()")
         return FullTextReadImpl(
-            self._table, self._limit, self._text_column, self._query_text
+            self._table, self._limit, self._text_column,
+            self._query_text, self._query_operator
         )

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -981,6 +981,28 @@ class JavaPyReadWriteTest(unittest.TestCase):
         print(f"Tantivy ngram search for '片段': row_ids={fragment_row_ids}")
         self.assertEqual(fragment_row_ids, [4])
 
+        ngram_and_builder = ngram_table.new_full_text_search_builder()
+        ngram_and_builder.with_text_column('content')
+        ngram_and_builder.with_query_text('中文 片段')
+        ngram_and_builder.with_query_operator('and')
+        ngram_and_builder.with_limit(10)
+
+        ngram_and_result = ngram_and_builder.execute_local()
+        ngram_and_row_ids = sorted(list(ngram_and_result.results()))
+        print(f"Tantivy ngram AND search for '中文 片段': row_ids={ngram_and_row_ids}")
+        self.assertEqual(ngram_and_row_ids, [4])
+
+        simple_table = self.catalog.get_table('default.test_tantivy_fulltext_simple')
+        simple_builder = simple_table.new_full_text_search_builder()
+        simple_builder.with_text_column('content')
+        simple_builder.with_query_text('running')
+        simple_builder.with_limit(10)
+
+        simple_result = simple_builder.execute_local()
+        simple_row_ids = sorted(list(simple_result.results()))
+        print(f"Tantivy simple stemmed search for 'running': row_ids={simple_row_ids}")
+        self.assertEqual(simple_row_ids, [0, 1, 2])
+
         jieba_table = self.catalog.get_table('default.test_tantivy_fulltext_jieba')
 
         # Search for Chinese words using the jieba tokenizer metadata written by Java.
@@ -1012,6 +1034,17 @@ class JavaPyReadWriteTest(unittest.TestCase):
         jieba_phrase_row_ids = sorted(list(jieba_phrase_result.results()))
         print(f"Tantivy jieba search for '自然': row_ids={jieba_phrase_row_ids}")
         self.assertEqual(jieba_phrase_row_ids, [3])
+
+        jieba_and_builder = jieba_table.new_full_text_search_builder()
+        jieba_and_builder.with_text_column('content')
+        jieba_and_builder.with_query_text('中文 自然')
+        jieba_and_builder.with_query_operator('and')
+        jieba_and_builder.with_limit(10)
+
+        jieba_and_result = jieba_and_builder.execute_local()
+        jieba_and_row_ids = sorted(list(jieba_and_result.results()))
+        print(f"Tantivy jieba AND search for '中文 自然': row_ids={jieba_and_row_ids}")
+        self.assertEqual(jieba_and_row_ids, [3])
 
     def test_read_lumina_vector_index(self):
         """Test reading a Lumina vector index built by Java (orc and lance formats)."""

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -1005,12 +1005,12 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
         jieba_phrase_builder = jieba_table.new_full_text_search_builder()
         jieba_phrase_builder.with_text_column('content')
-        jieba_phrase_builder.with_query_text('中文分词')
+        jieba_phrase_builder.with_query_text('自然')
         jieba_phrase_builder.with_limit(10)
 
         jieba_phrase_result = jieba_phrase_builder.execute_local()
         jieba_phrase_row_ids = sorted(list(jieba_phrase_result.results()))
-        print(f"Tantivy jieba search for '中文分词': row_ids={jieba_phrase_row_ids}")
+        print(f"Tantivy jieba search for '自然': row_ids={jieba_phrase_row_ids}")
         self.assertEqual(jieba_phrase_row_ids, [3])
 
     def test_read_lumina_vector_index(self):

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -949,6 +949,70 @@ class JavaPyReadWriteTest(unittest.TestCase):
         self.assertIn(1, ids3)
         self.assertIn(3, ids3)
 
+        ngram_table = self.catalog.get_table('default.test_tantivy_fulltext_ngram')
+
+        # Search for Chinese fragments using the ngram tokenizer metadata written by Java.
+        ngram_builder = ngram_table.new_full_text_search_builder()
+        ngram_builder.with_text_column('content')
+        ngram_builder.with_query_text('中文')
+        ngram_builder.with_limit(10)
+
+        ngram_result = ngram_builder.execute_local()
+        ngram_row_ids = sorted(list(ngram_result.results()))
+        print(f"Tantivy ngram search for '中文': row_ids={ngram_row_ids}")
+        self.assertEqual(ngram_row_ids, [0, 4])
+
+        ngram_read_builder = ngram_table.new_read_builder()
+        ngram_scan = ngram_read_builder.new_scan().with_global_index_result(ngram_result)
+        ngram_pa_table = ngram_read_builder.new_read().to_arrow(ngram_scan.plan().splits())
+        ngram_pa_table = table_sort_by(ngram_pa_table, 'id')
+        self.assertEqual(ngram_pa_table.column('id').to_pylist(), [0, 4])
+        self.assertEqual(
+            ngram_pa_table.column('content').to_pylist(),
+            ['Apache Paimon 支持中文全文检索', '中文索引支持片段查询'])
+
+        fragment_builder = ngram_table.new_full_text_search_builder()
+        fragment_builder.with_text_column('content')
+        fragment_builder.with_query_text('片段')
+        fragment_builder.with_limit(10)
+
+        fragment_result = fragment_builder.execute_local()
+        fragment_row_ids = sorted(list(fragment_result.results()))
+        print(f"Tantivy ngram search for '片段': row_ids={fragment_row_ids}")
+        self.assertEqual(fragment_row_ids, [4])
+
+        jieba_table = self.catalog.get_table('default.test_tantivy_fulltext_jieba')
+
+        # Search for Chinese words using the jieba tokenizer metadata written by Java.
+        jieba_builder = jieba_table.new_full_text_search_builder()
+        jieba_builder.with_text_column('content')
+        jieba_builder.with_query_text('售货员')
+        jieba_builder.with_limit(10)
+
+        jieba_result = jieba_builder.execute_local()
+        jieba_row_ids = sorted(list(jieba_result.results()))
+        print(f"Tantivy jieba search for '售货员': row_ids={jieba_row_ids}")
+        self.assertEqual(jieba_row_ids, [0])
+
+        jieba_read_builder = jieba_table.new_read_builder()
+        jieba_scan = jieba_read_builder.new_scan().with_global_index_result(jieba_result)
+        jieba_pa_table = jieba_read_builder.new_read().to_arrow(jieba_scan.plan().splits())
+        jieba_pa_table = table_sort_by(jieba_pa_table, 'id')
+        self.assertEqual(jieba_pa_table.column('id').to_pylist(), [0])
+        self.assertEqual(
+            jieba_pa_table.column('content').to_pylist(),
+            ['张华在百货公司当售货员'])
+
+        jieba_phrase_builder = jieba_table.new_full_text_search_builder()
+        jieba_phrase_builder.with_text_column('content')
+        jieba_phrase_builder.with_query_text('中文分词')
+        jieba_phrase_builder.with_limit(10)
+
+        jieba_phrase_result = jieba_phrase_builder.execute_local()
+        jieba_phrase_row_ids = sorted(list(jieba_phrase_result.results()))
+        print(f"Tantivy jieba search for '中文分词': row_ids={jieba_phrase_row_ids}")
+        self.assertEqual(jieba_phrase_row_ids, [3])
+
     def test_read_lumina_vector_index(self):
         """Test reading a Lumina vector index built by Java (orc and lance formats)."""
         test_cases = [('default.test_lumina_vector', 'orc')]

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -155,20 +155,32 @@ def _java_tantivy_json_meta(tokenizer="ngram", min_gram=2, max_gram=2,
                             with_position=True):
     if stop_words is None:
         stop_words = []
-    return json.dumps({
-        "tokenizer": tokenizer,
-        "ngramMinGram": min_gram,
-        "ngramMaxGram": max_gram,
-        "ngramPrefixOnly": prefix_only,
-        "lowerCase": lower_case,
-        "maxTokenLength": max_token_length,
-        "asciiFolding": ascii_folding,
-        "stem": stem,
-        "language": language,
-        "removeStopWords": remove_stop_words,
-        "stopWords": stop_words,
-        "withPosition": with_position,
-    }, separators=(",", ":")).encode("utf-8")
+    config = {}
+    if tokenizer != "default":
+        config["tokenizer"] = tokenizer
+    if min_gram != 2:
+        config["ngramMinGram"] = min_gram
+    if max_gram != 2:
+        config["ngramMaxGram"] = max_gram
+    if prefix_only:
+        config["ngramPrefixOnly"] = prefix_only
+    if not lower_case:
+        config["lowerCase"] = lower_case
+    if max_token_length != 40:
+        config["maxTokenLength"] = max_token_length
+    if ascii_folding:
+        config["asciiFolding"] = ascii_folding
+    if stem:
+        config["stem"] = stem
+    if language != "english":
+        config["language"] = language
+    if remove_stop_words:
+        config["removeStopWords"] = remove_stop_words
+    if stop_words:
+        config["stopWords"] = stop_words
+    if not with_position:
+        config["withPosition"] = with_position
+    return json.dumps(config, separators=(",", ":")).encode("utf-8")
 
 
 class _FakeFileIO:
@@ -377,6 +389,27 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         )
 
         options = TantivyFullTextIndexOptions.deserialize(b"")
+
+        self.assertEqual("default", options.tokenizer)
+        self.assertEqual(2, options.ngram_min_gram)
+        self.assertEqual(2, options.ngram_max_gram)
+        self.assertFalse(options.ngram_prefix_only)
+        self.assertTrue(options.lower_case)
+        self.assertEqual(40, options.max_token_length)
+        self.assertFalse(options.ascii_folding)
+        self.assertFalse(options.stem)
+        self.assertEqual("english", options.language)
+        self.assertFalse(options.remove_stop_words)
+        self.assertEqual("", options.stop_words)
+        self.assertTrue(options.with_position)
+        self.assertEqual("default", options.tokenizer_name())
+
+    def test_empty_json_metadata_uses_default_tokenizer(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(b"{}")
 
         self.assertEqual("default", options.tokenizer)
         self.assertEqual(2, options.ngram_min_gram)

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -130,56 +130,31 @@ def _java_tantivy_meta(tokenizer="ngram", min_gram=2, max_gram=2,
                        stem=False, language="english",
                        remove_stop_words=False, stop_words="",
                        with_position=True):
-    tokenizer_bytes = tokenizer.encode("utf-8")
-    language_bytes = language.encode("utf-8")
-    stop_words_bytes = stop_words.encode("utf-8")
-    return (
-        struct.pack(">iH", 1, len(tokenizer_bytes)) +
-        tokenizer_bytes +
-        struct.pack(">ii??i??H", min_gram, max_gram, prefix_only,
-                    lower_case, max_token_length, ascii_folding, stem,
-                    len(language_bytes)) +
-        language_bytes +
-        struct.pack(">?", remove_stop_words) +
-        struct.pack(">H", len(stop_words_bytes)) +
-        stop_words_bytes +
-        struct.pack(">?", with_position)
-    )
-
-
-def _java_tantivy_json_meta(tokenizer="ngram", min_gram=2, max_gram=2,
-                            prefix_only=False, lower_case=True,
-                            max_token_length=40, ascii_folding=False,
-                            stem=False, language="english",
-                            remove_stop_words=False, stop_words=None,
-                            with_position=True):
-    if stop_words is None:
-        stop_words = []
     config = {}
     if tokenizer != "default":
         config["tokenizer"] = tokenizer
     if min_gram != 2:
-        config["ngramMinGram"] = min_gram
+        config["ngram.min-gram"] = min_gram
     if max_gram != 2:
-        config["ngramMaxGram"] = max_gram
+        config["ngram.max-gram"] = max_gram
     if prefix_only:
-        config["ngramPrefixOnly"] = prefix_only
+        config["ngram.prefix-only"] = prefix_only
     if not lower_case:
-        config["lowerCase"] = lower_case
+        config["lower-case"] = lower_case
     if max_token_length != 40:
-        config["maxTokenLength"] = max_token_length
+        config["max-token-length"] = max_token_length
     if ascii_folding:
-        config["asciiFolding"] = ascii_folding
+        config["ascii-folding"] = ascii_folding
     if stem:
         config["stem"] = stem
     if language != "english":
         config["language"] = language
     if remove_stop_words:
-        config["removeStopWords"] = remove_stop_words
+        config["remove-stop-words"] = remove_stop_words
     if stop_words:
-        config["stopWords"] = stop_words
+        config["stop-words"] = stop_words
     if not with_position:
-        config["withPosition"] = with_position
+        config["with-position"] = with_position
     return json.dumps(config, separators=(",", ":")).encode("utf-8")
 
 
@@ -450,7 +425,7 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         )
 
         options = TantivyFullTextIndexOptions.deserialize(
-            _java_tantivy_json_meta(
+            _java_tantivy_meta(
                 tokenizer=" NGRAM ", min_gram=2, max_gram=3,
                 prefix_only=True, lower_case=False))
 
@@ -491,7 +466,7 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         )
 
         options = TantivyFullTextIndexOptions.deserialize(
-            _java_tantivy_json_meta(
+            _java_tantivy_meta(
                 tokenizer=" WHITESPACE ", lower_case=False, max_token_length=12,
                 ascii_folding=True, stem=True, language="English",
                 remove_stop_words=True, stop_words=["paimon", "lake"],

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -22,6 +22,7 @@ redundancy.
 """
 
 import io
+import json
 import struct
 import sys
 import types
@@ -144,6 +145,30 @@ def _java_tantivy_meta(tokenizer="ngram", min_gram=2, max_gram=2,
         stop_words_bytes +
         struct.pack(">?", with_position)
     )
+
+
+def _java_tantivy_json_meta(tokenizer="ngram", min_gram=2, max_gram=2,
+                            prefix_only=False, lower_case=True,
+                            max_token_length=40, ascii_folding=False,
+                            stem=False, language="english",
+                            remove_stop_words=False, stop_words=None,
+                            with_position=True):
+    if stop_words is None:
+        stop_words = []
+    return json.dumps({
+        "tokenizer": tokenizer,
+        "ngramMinGram": min_gram,
+        "ngramMaxGram": max_gram,
+        "ngramPrefixOnly": prefix_only,
+        "lowerCase": lower_case,
+        "maxTokenLength": max_token_length,
+        "asciiFolding": ascii_folding,
+        "stem": stem,
+        "language": language,
+        "removeStopWords": remove_stop_words,
+        "stopWords": stop_words,
+        "withPosition": with_position,
+    }, separators=(",", ":")).encode("utf-8")
 
 
 class _FakeFileIO:
@@ -385,6 +410,24 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         self.assertFalse(options.lower_case)
         self.assertEqual(TANTIVY_NGRAM_TOKENIZER, options.tokenizer_name())
 
+    def test_deserializes_java_json_ngram_metadata(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_NGRAM_TOKENIZER,
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(
+            _java_tantivy_json_meta(
+                tokenizer=" NGRAM ", min_gram=2, max_gram=3,
+                prefix_only=True, lower_case=False))
+
+        self.assertEqual("ngram", options.tokenizer)
+        self.assertEqual(2, options.ngram_min_gram)
+        self.assertEqual(3, options.ngram_max_gram)
+        self.assertTrue(options.ngram_prefix_only)
+        self.assertFalse(options.lower_case)
+        self.assertEqual(TANTIVY_NGRAM_TOKENIZER, options.tokenizer_name())
+
     def test_deserializes_extended_analyzer_metadata(self):
         from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
             TantivyFullTextIndexOptions,
@@ -395,6 +438,30 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
                 tokenizer=" WHITESPACE ", lower_case=False, max_token_length=12,
                 ascii_folding=True, stem=True, language="English",
                 remove_stop_words=True, stop_words="paimon;lake",
+                with_position=False))
+
+        self.assertEqual("whitespace", options.tokenizer)
+        self.assertFalse(options.lower_case)
+        self.assertEqual(12, options.max_token_length)
+        self.assertTrue(options.ascii_folding)
+        self.assertTrue(options.stem)
+        self.assertEqual("english", options.language)
+        self.assertTrue(options.remove_stop_words)
+        self.assertEqual("paimon;lake", options.stop_words)
+        self.assertEqual(["paimon", "lake"], options.stop_word_list())
+        self.assertFalse(options.with_position)
+        self.assertEqual("paimon_custom", options.tokenizer_name())
+
+    def test_deserializes_java_json_analyzer_metadata(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(
+            _java_tantivy_json_meta(
+                tokenizer=" WHITESPACE ", lower_case=False, max_token_length=12,
+                ascii_folding=True, stem=True, language="English",
+                remove_stop_words=True, stop_words=["paimon", "lake"],
                 with_position=False))
 
         self.assertEqual("whitespace", options.tokenizer)

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -167,13 +167,15 @@ class _FakeSchemaBuilder:
     def add_unsigned_field(self, name, stored=False, indexed=True, fast=False):
         self.fields[name] = {"fast": fast}
 
-    def add_text_field(self, name, stored=False, tokenizer_name=None, index_option=None):
+    def add_text_field(self, name, stored=False, tokenizer_name=None, **kwargs):
+        if "index_option" in kwargs and kwargs["index_option"] is None:
+            raise TypeError("index_option must not be None")
         self.fields[name] = {
             "stored": stored,
             "tokenizer_name": tokenizer_name or "default",
         }
-        if index_option is not None:
-            self.fields[name]["index_option"] = index_option
+        if "index_option" in kwargs:
+            self.fields[name]["index_option"] = kwargs["index_option"]
 
     def build(self):
         return types.SimpleNamespace(fields=self.fields)
@@ -1111,6 +1113,48 @@ class VectorSearchManySplitsTest(unittest.TestCase):
 
 
 class FullTextSearchManySplitsTest(unittest.TestCase):
+
+    def test_full_text_read_threads_external_path_to_reader(self):
+        from pypaimon.table.source.full_text_read import FullTextReadImpl
+        from pypaimon.table.source.full_text_search_split import (
+            FullTextSearchSplit,
+        )
+
+        text_field = _field(1, "content", "STRING")
+        entry = _entry(None, field_id=1, index_type="tantivy-fulltext",
+                       file_name="ft.index",
+                       row_range_start=0, row_range_end=9,
+                       external_path="oss://bucket/ft.index")
+        table = _StubTable(fields=[text_field], entries=[entry])
+        captured_io_metas = []
+
+        def _fake_create(index_type, file_io, index_path,
+                         index_io_meta_list):
+            captured_io_metas.append(list(index_io_meta_list))
+
+            class _FakeReader:
+                def visit_full_text_search(self_inner, fts):
+                    return _completed_future(None)
+
+                def close(self_inner):
+                    pass
+            return _FakeReader()
+
+        split = FullTextSearchSplit(
+            row_range_start=0, row_range_end=9,
+            full_text_index_files=[entry.index_file])
+
+        with mock.patch(
+                "pypaimon.table.source.full_text_read._create_full_text_reader",
+                side_effect=_fake_create):
+            reader = FullTextReadImpl(
+                table, limit=10, text_column=text_field,
+                query_text="test")
+            reader.read([split])
+
+        self.assertEqual(1, len(captured_io_metas))
+        self.assertEqual("oss://bucket/ft.index",
+                         captured_io_metas[0][0].external_path)
 
     def test_full_text_search_with_many_splits(self):
         from pypaimon.globalindex.vector_search_result import (

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -124,12 +124,25 @@ def _patch_snapshot(testcase, entries):
 
 
 def _java_tantivy_meta(tokenizer="ngram", min_gram=2, max_gram=2,
-                       prefix_only=False, lower_case=True):
+                       prefix_only=False, lower_case=True,
+                       max_token_length=40, ascii_folding=False,
+                       stem=False, language="english",
+                       remove_stop_words=False, stop_words="",
+                       with_position=True):
     tokenizer_bytes = tokenizer.encode("utf-8")
+    language_bytes = language.encode("utf-8")
+    stop_words_bytes = stop_words.encode("utf-8")
     return (
         struct.pack(">iH", 1, len(tokenizer_bytes)) +
         tokenizer_bytes +
-        struct.pack(">ii??", min_gram, max_gram, prefix_only, lower_case)
+        struct.pack(">ii??i??H", min_gram, max_gram, prefix_only,
+                    lower_case, max_token_length, ascii_folding, stem,
+                    len(language_bytes)) +
+        language_bytes +
+        struct.pack(">?", remove_stop_words) +
+        struct.pack(">H", len(stop_words_bytes)) +
+        stop_words_bytes +
+        struct.pack(">?", with_position)
     )
 
 
@@ -154,11 +167,13 @@ class _FakeSchemaBuilder:
     def add_unsigned_field(self, name, stored=False, indexed=True, fast=False):
         self.fields[name] = {"fast": fast}
 
-    def add_text_field(self, name, stored=False, tokenizer_name=None):
+    def add_text_field(self, name, stored=False, tokenizer_name=None, index_option=None):
         self.fields[name] = {
             "stored": stored,
             "tokenizer_name": tokenizer_name or "default",
         }
+        if index_option is not None:
+            self.fields[name]["index_option"] = index_option
 
     def build(self):
         return types.SimpleNamespace(fields=self.fields)
@@ -169,11 +184,43 @@ class _FakeTokenizer:
     def ngram(min_gram=2, max_gram=3, prefix_only=False):
         return ("ngram", min_gram, max_gram, prefix_only)
 
+    @staticmethod
+    def simple():
+        return ("simple",)
+
+    @staticmethod
+    def whitespace():
+        return ("whitespace",)
+
+    @staticmethod
+    def raw():
+        return ("raw",)
+
 
 class _FakeFilter:
     @staticmethod
     def lowercase():
         return "lowercase"
+
+    @staticmethod
+    def remove_long(length_limit):
+        return ("remove_long", length_limit)
+
+    @staticmethod
+    def ascii_fold():
+        return "ascii_fold"
+
+    @staticmethod
+    def stemmer(language):
+        return ("stemmer", language)
+
+    @staticmethod
+    def stopword(language):
+        return ("stopword", language)
+
+    @staticmethod
+    def custom_stopword(stopwords):
+        return ("custom_stopword", tuple(stopwords))
 
 
 class _FakeTextAnalyzerBuilder:
@@ -206,6 +253,7 @@ class _FakeQuery:
 
 class _FakeOccur:
     Should = "should"
+    Must = "must"
 
 
 class _FakeSearchResults:
@@ -240,8 +288,8 @@ class _FakeIndex:
         self.searcher_instance = _FakeSearcher()
         return self.searcher_instance
 
-    def parse_query(self, query_text, fields):
-        return (query_text, tuple(fields))
+    def parse_query(self, query_text, fields, **kwargs):
+        return (query_text, tuple(fields), kwargs)
 
 
 class _FakeTantivy(types.SimpleNamespace):
@@ -308,6 +356,13 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         self.assertEqual(2, options.ngram_max_gram)
         self.assertFalse(options.ngram_prefix_only)
         self.assertTrue(options.lower_case)
+        self.assertEqual(40, options.max_token_length)
+        self.assertFalse(options.ascii_folding)
+        self.assertFalse(options.stem)
+        self.assertEqual("english", options.language)
+        self.assertFalse(options.remove_stop_words)
+        self.assertEqual("", options.stop_words)
+        self.assertTrue(options.with_position)
         self.assertEqual("default", options.tokenizer_name())
 
     def test_deserializes_java_ngram_metadata(self):
@@ -327,6 +382,30 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         self.assertTrue(options.ngram_prefix_only)
         self.assertFalse(options.lower_case)
         self.assertEqual(TANTIVY_NGRAM_TOKENIZER, options.tokenizer_name())
+
+    def test_deserializes_extended_analyzer_metadata(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(
+            _java_tantivy_meta(
+                tokenizer=" WHITESPACE ", lower_case=False, max_token_length=12,
+                ascii_folding=True, stem=True, language="English",
+                remove_stop_words=True, stop_words="paimon;lake",
+                with_position=False))
+
+        self.assertEqual("whitespace", options.tokenizer)
+        self.assertFalse(options.lower_case)
+        self.assertEqual(12, options.max_token_length)
+        self.assertTrue(options.ascii_folding)
+        self.assertTrue(options.stem)
+        self.assertEqual("english", options.language)
+        self.assertTrue(options.remove_stop_words)
+        self.assertEqual("paimon;lake", options.stop_words)
+        self.assertEqual(["paimon", "lake"], options.stop_word_list())
+        self.assertFalse(options.with_position)
+        self.assertEqual("paimon_custom", options.tokenizer_name())
 
     def test_deserializes_java_jieba_metadata(self):
         from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
@@ -385,6 +464,54 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
             tantivy.last_index.registered_tokenizer)
         self.assertEqual([7], sorted(list(result.results())))
 
+        query = tantivy.last_index.searcher_instance.query
+        self.assertEqual(("中文", ("text",), {}), query)
+
+    def test_custom_analyzer_reader_registers_matching_tantivy_analyzer(self):
+        from pypaimon.globalindex.full_text_search import FullTextSearch
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_CUSTOM_TOKENIZER,
+            TantivyFullTextGlobalIndexReader,
+        )
+
+        tantivy = _FakeTantivy()
+        old_tantivy = sys.modules.get("tantivy")
+        sys.modules["tantivy"] = tantivy
+        try:
+            reader = TantivyFullTextGlobalIndexReader(
+                _FakeFileIO(),
+                "/unused",
+                [GlobalIndexIOMeta(
+                    file_name="ft.index",
+                    file_size=1,
+                    metadata=_java_tantivy_meta(
+                        tokenizer="simple", max_token_length=16,
+                        ascii_folding=True, stem=True, language="english",
+                        remove_stop_words=True, stop_words="paimon;lake",
+                        with_position=False))])
+            try:
+                reader.visit_full_text_search(
+                    FullTextSearch("running", 10, "content")).result()
+            finally:
+                reader.close()
+        finally:
+            if old_tantivy is None:
+                sys.modules.pop("tantivy", None)
+            else:
+                sys.modules["tantivy"] = old_tantivy
+
+        self.assertEqual({"row_id": {"fast": True},
+                          "text": {"stored": False,
+                                   "tokenizer_name": TANTIVY_CUSTOM_TOKENIZER,
+                                   "index_option": "freq"}},
+                         tantivy.last_schema.fields)
+        self.assertEqual(
+            (TANTIVY_CUSTOM_TOKENIZER,
+             ("simple",
+              (("remove_long", 16), "lowercase", "ascii_fold", ("stemmer", "english"),
+               ("stopword", "english"), ("custom_stopword", ("paimon", "lake"))))),
+            tantivy.last_index.registered_tokenizer)
+
     def test_ngram_reader_requires_custom_tokenizer_api(self):
         from pypaimon.globalindex.full_text_search import FullTextSearch
         from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
@@ -439,7 +566,7 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
                     metadata=_java_tantivy_meta(tokenizer="jieba"))])
             try:
                 result = reader.visit_full_text_search(
-                    FullTextSearch("售货员", 10, "content")).result()
+                    FullTextSearch("售货员", 10, "content", "and")).result()
             finally:
                 reader.close()
         finally:
@@ -464,6 +591,9 @@ class TantivyFullTextIndexOptionsTest(unittest.TestCase):
         self.assertEqual(
             ("售货", "货员", "售货员"),
             tuple(sub_query[1][3] for sub_query in query[1]))
+        self.assertEqual(
+            ("must", "must", "must"),
+            tuple(sub_query[0] for sub_query in query[1]))
 
     def test_jieba_reader_requires_jieba_package(self):
         from pypaimon.globalindex.full_text_search import FullTextSearch

--- a/paimon-python/pypaimon/tests/vector_search_filter_test.py
+++ b/paimon-python/pypaimon/tests/vector_search_filter_test.py
@@ -21,6 +21,10 @@ Each test protects a distinct behavior introduced by this feature; no
 redundancy.
 """
 
+import io
+import struct
+import sys
+import types
 import unittest
 from typing import List
 from unittest import mock
@@ -119,6 +123,153 @@ def _patch_snapshot(testcase, entries):
     testcase._travel_patch.start()
 
 
+def _java_tantivy_meta(tokenizer="ngram", min_gram=2, max_gram=2,
+                       prefix_only=False, lower_case=True):
+    tokenizer_bytes = tokenizer.encode("utf-8")
+    return (
+        struct.pack(">iH", 1, len(tokenizer_bytes)) +
+        tokenizer_bytes +
+        struct.pack(">ii??", min_gram, max_gram, prefix_only, lower_case)
+    )
+
+
+class _FakeFileIO:
+    def new_input_stream(self, path):
+        buf = io.BytesIO()
+        buf.write(struct.pack(">i", 1))
+        name = b"meta.json"
+        buf.write(struct.pack(">i", len(name)))
+        buf.write(name)
+        data = b"{}"
+        buf.write(struct.pack(">q", len(data)))
+        buf.write(data)
+        buf.seek(0)
+        return buf
+
+
+class _FakeSchemaBuilder:
+    def __init__(self):
+        self.fields = {}
+
+    def add_unsigned_field(self, name, stored=False, indexed=True, fast=False):
+        self.fields[name] = {"fast": fast}
+
+    def add_text_field(self, name, stored=False, tokenizer_name=None):
+        self.fields[name] = {
+            "stored": stored,
+            "tokenizer_name": tokenizer_name or "default",
+        }
+
+    def build(self):
+        return types.SimpleNamespace(fields=self.fields)
+
+
+class _FakeTokenizer:
+    @staticmethod
+    def ngram(min_gram=2, max_gram=3, prefix_only=False):
+        return ("ngram", min_gram, max_gram, prefix_only)
+
+
+class _FakeFilter:
+    @staticmethod
+    def lowercase():
+        return "lowercase"
+
+
+class _FakeTextAnalyzerBuilder:
+    def __init__(self, tokenizer):
+        self._tokenizer = tokenizer
+        self._filters = []
+
+    def filter(self, filter_):
+        result = _FakeTextAnalyzerBuilder(self._tokenizer)
+        result._filters = self._filters + [filter_]
+        return result
+
+    def build(self):
+        return self._tokenizer + (tuple(self._filters),)
+
+
+class _FakeQuery:
+    @staticmethod
+    def empty_query():
+        return ("empty",)
+
+    @staticmethod
+    def term_query(schema, field_name, field_value, index_option="position"):
+        return ("term", schema, field_name, field_value, index_option)
+
+    @staticmethod
+    def boolean_query(subqueries, minimum_number_should_match=None):
+        return ("boolean", tuple(subqueries), minimum_number_should_match)
+
+
+class _FakeOccur:
+    Should = "should"
+
+
+class _FakeSearchResults:
+    hits = [(2.0, "addr")]
+
+
+class _FakeSearcher:
+    def __init__(self):
+        self.query = None
+
+    def search(self, query, limit):
+        self.query = query
+        return _FakeSearchResults()
+
+    def fast_field_values(self, name, addresses):
+        return [7]
+
+
+class _FakeIndex:
+    def __init__(self, schema, directory=None):
+        self.schema = schema
+        self.directory = directory
+        self.registered_tokenizer = None
+
+    def register_tokenizer(self, name, analyzer):
+        self.registered_tokenizer = (name, analyzer)
+
+    def reload(self):
+        pass
+
+    def searcher(self):
+        self.searcher_instance = _FakeSearcher()
+        return self.searcher_instance
+
+    def parse_query(self, query_text, fields):
+        return (query_text, tuple(fields))
+
+
+class _FakeTantivy(types.SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.Tokenizer = _FakeTokenizer
+        self.Filter = _FakeFilter
+        self.TextAnalyzerBuilder = _FakeTextAnalyzerBuilder
+        self.Query = _FakeQuery
+        self.Occur = _FakeOccur
+        self.last_schema = None
+        self.last_index = None
+        parent = self
+
+        class SchemaBuilder(_FakeSchemaBuilder):
+            def build(self_inner):
+                parent.last_schema = super().build()
+                return parent.last_schema
+
+        class Index(_FakeIndex):
+            def __init__(self_inner, schema, directory=None):
+                super().__init__(schema, directory=directory)
+                parent.last_index = self_inner
+
+        self.SchemaBuilder = SchemaBuilder
+        self.Index = Index
+
+
 # ----------------------------- tests ---------------------------------------
 
 
@@ -140,6 +291,214 @@ class VectorReaderFactoryTest(unittest.TestCase):
                 self.assertIsInstance(reader, LuminaVectorGlobalIndexReader)
             finally:
                 reader.close()
+
+
+class TantivyFullTextIndexOptionsTest(unittest.TestCase):
+    """Tantivy full-text tokenizer metadata compatibility."""
+
+    def test_empty_metadata_uses_default_tokenizer(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(b"")
+
+        self.assertEqual("default", options.tokenizer)
+        self.assertEqual(2, options.ngram_min_gram)
+        self.assertEqual(2, options.ngram_max_gram)
+        self.assertFalse(options.ngram_prefix_only)
+        self.assertTrue(options.lower_case)
+        self.assertEqual("default", options.tokenizer_name())
+
+    def test_deserializes_java_ngram_metadata(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_NGRAM_TOKENIZER,
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(
+            _java_tantivy_meta(
+                tokenizer=" NGRAM ", min_gram=2, max_gram=3,
+                prefix_only=True, lower_case=False))
+
+        self.assertEqual("ngram", options.tokenizer)
+        self.assertEqual(2, options.ngram_min_gram)
+        self.assertEqual(3, options.ngram_max_gram)
+        self.assertTrue(options.ngram_prefix_only)
+        self.assertFalse(options.lower_case)
+        self.assertEqual(TANTIVY_NGRAM_TOKENIZER, options.tokenizer_name())
+
+    def test_deserializes_java_jieba_metadata(self):
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_JIEBA_TOKENIZER,
+            TantivyFullTextIndexOptions,
+        )
+
+        options = TantivyFullTextIndexOptions.deserialize(
+            _java_tantivy_meta(tokenizer=" JIEBA "))
+
+        self.assertEqual("jieba", options.tokenizer)
+        self.assertEqual(2, options.ngram_min_gram)
+        self.assertEqual(2, options.ngram_max_gram)
+        self.assertFalse(options.ngram_prefix_only)
+        self.assertTrue(options.lower_case)
+        self.assertEqual(TANTIVY_JIEBA_TOKENIZER, options.tokenizer_name())
+
+    def test_ngram_reader_registers_matching_tantivy_analyzer(self):
+        from pypaimon.globalindex.full_text_search import FullTextSearch
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_NGRAM_TOKENIZER,
+            TantivyFullTextGlobalIndexReader,
+        )
+
+        tantivy = _FakeTantivy()
+        old_tantivy = sys.modules.get("tantivy")
+        sys.modules["tantivy"] = tantivy
+        try:
+            reader = TantivyFullTextGlobalIndexReader(
+                _FakeFileIO(),
+                "/unused",
+                [GlobalIndexIOMeta(
+                    file_name="ft.index",
+                    file_size=1,
+                    metadata=_java_tantivy_meta(
+                        min_gram=2, max_gram=3,
+                        prefix_only=True, lower_case=True))])
+            try:
+                result = reader.visit_full_text_search(
+                    FullTextSearch("中文", 10, "content")).result()
+            finally:
+                reader.close()
+        finally:
+            if old_tantivy is None:
+                sys.modules.pop("tantivy", None)
+            else:
+                sys.modules["tantivy"] = old_tantivy
+
+        self.assertEqual({"row_id": {"fast": True},
+                          "text": {"stored": False,
+                                   "tokenizer_name": TANTIVY_NGRAM_TOKENIZER}},
+                         tantivy.last_schema.fields)
+        self.assertEqual(
+            (TANTIVY_NGRAM_TOKENIZER,
+             ("ngram", 2, 3, True, ("lowercase",))),
+            tantivy.last_index.registered_tokenizer)
+        self.assertEqual([7], sorted(list(result.results())))
+
+    def test_ngram_reader_requires_custom_tokenizer_api(self):
+        from pypaimon.globalindex.full_text_search import FullTextSearch
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextGlobalIndexReader,
+        )
+
+        old_tantivy = sys.modules.get("tantivy")
+        sys.modules["tantivy"] = types.SimpleNamespace(SchemaBuilder=object)
+        try:
+            reader = TantivyFullTextGlobalIndexReader(
+                _FakeFileIO(),
+                "/unused",
+                [GlobalIndexIOMeta(
+                    file_name="ft.index",
+                    file_size=1,
+                    metadata=_java_tantivy_meta())])
+            with self.assertRaisesRegex(
+                    RuntimeError, "ngram tokenizer support"):
+                reader.visit_full_text_search(
+                    FullTextSearch("中文", 10, "content")).result()
+        finally:
+            if old_tantivy is None:
+                sys.modules.pop("tantivy", None)
+            else:
+                sys.modules["tantivy"] = old_tantivy
+
+    def test_jieba_reader_builds_token_query(self):
+        from pypaimon.globalindex.full_text_search import FullTextSearch
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TANTIVY_JIEBA_TOKENIZER,
+            TantivyFullTextGlobalIndexReader,
+        )
+
+        tantivy = _FakeTantivy()
+        jieba = types.SimpleNamespace(
+            tokenize=lambda text, mode, HMM: [
+                ("售货", 0, 2),
+                ("货员", 1, 3),
+                ("售货员", 0, 3),
+                ("售货员", 0, 3)])
+        old_tantivy = sys.modules.get("tantivy")
+        old_jieba = sys.modules.get("jieba")
+        sys.modules["tantivy"] = tantivy
+        sys.modules["jieba"] = jieba
+        try:
+            reader = TantivyFullTextGlobalIndexReader(
+                _FakeFileIO(),
+                "/unused",
+                [GlobalIndexIOMeta(
+                    file_name="ft.index",
+                    file_size=1,
+                    metadata=_java_tantivy_meta(tokenizer="jieba"))])
+            try:
+                result = reader.visit_full_text_search(
+                    FullTextSearch("售货员", 10, "content")).result()
+            finally:
+                reader.close()
+        finally:
+            if old_tantivy is None:
+                sys.modules.pop("tantivy", None)
+            else:
+                sys.modules["tantivy"] = old_tantivy
+            if old_jieba is None:
+                sys.modules.pop("jieba", None)
+            else:
+                sys.modules["jieba"] = old_jieba
+
+        self.assertEqual({"row_id": {"fast": True},
+                          "text": {"stored": False,
+                                   "tokenizer_name": TANTIVY_JIEBA_TOKENIZER}},
+                         tantivy.last_schema.fields)
+        self.assertIsNone(tantivy.last_index.registered_tokenizer)
+        self.assertEqual([7], sorted(list(result.results())))
+
+        query = tantivy.last_index.searcher_instance.query
+        self.assertEqual("boolean", query[0])
+        self.assertEqual(
+            ("售货", "货员", "售货员"),
+            tuple(sub_query[1][3] for sub_query in query[1]))
+
+    def test_jieba_reader_requires_jieba_package(self):
+        from pypaimon.globalindex.full_text_search import FullTextSearch
+        from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
+            TantivyFullTextGlobalIndexReader,
+        )
+
+        tantivy = _FakeTantivy()
+        old_tantivy = sys.modules.get("tantivy")
+        old_jieba = sys.modules.get("jieba")
+        sys.modules["tantivy"] = tantivy
+        sys.modules["jieba"] = None
+        try:
+            reader = TantivyFullTextGlobalIndexReader(
+                _FakeFileIO(),
+                "/unused",
+                [GlobalIndexIOMeta(
+                    file_name="ft.index",
+                    file_size=1,
+                    metadata=_java_tantivy_meta(tokenizer="jieba"))])
+            try:
+                with self.assertRaisesRegex(RuntimeError, "pip install jieba"):
+                    reader.visit_full_text_search(
+                        FullTextSearch("售货员", 10, "content")).result()
+            finally:
+                reader.close()
+        finally:
+            if old_tantivy is None:
+                sys.modules.pop("tantivy", None)
+            else:
+                sys.modules["tantivy"] = old_tantivy
+            if old_jieba is None:
+                sys.modules.pop("jieba", None)
+            else:
+                sys.modules["jieba"] = old_jieba
 
 
 class VectorSearchFilterTest(unittest.TestCase):

--- a/paimon-tantivy/paimon-tantivy-index/README.md
+++ b/paimon-tantivy/paimon-tantivy-index/README.md
@@ -142,15 +142,24 @@ Available tokenizer options:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `ngram`, `jieba`. |
+| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `simple`, `whitespace`, `raw`, `ngram`, `jieba`. |
 | `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
 | `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
 | `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
 | `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+| `tantivy.max-token-length` | `40` | Maximum token length kept by configurable tokenizers. |
+| `tantivy.ascii-folding` | `false` | Whether to normalize non-ASCII Latin characters to ASCII. |
+| `tantivy.stem` | `false` | Whether to apply stemming to emitted tokens. |
+| `tantivy.language` | `english` | Language used by stemming and built-in stop word filters. |
+| `tantivy.remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
+| `tantivy.stop-words` | ` ` | Semicolon-separated custom stop words to remove. |
+| `tantivy.with-position` | `true` | Whether to store term positions for phrase queries. |
 
 Tokenizer settings are persisted in each global index file's metadata. Readers use that metadata
 when reopening an index, so changing table/procedure options later does not make existing index
 files use a different analyzer.
+Custom analysis is provided by composing the supported tokenizer and filter options above; Paimon
+does not load arbitrary Rust tokenizer plugins from configuration.
 PyPaimon can query `jieba` indexes when the Python `jieba` package is installed.
 
 ### Search

--- a/paimon-tantivy/paimon-tantivy-index/README.md
+++ b/paimon-tantivy/paimon-tantivy-index/README.md
@@ -113,6 +113,46 @@ CALL sys.create_global_index(
 );
 ```
 
+### Tokenizers
+
+By default, Tantivy uses its built-in tokenizer. For Chinese or other languages where users often
+search by short character fragments, build the index with the `ngram` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2'
+);
+```
+
+For Chinese word segmentation, build the index with the `jieba` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=jieba'
+);
+```
+
+Available tokenizer options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `ngram`, `jieba`. |
+| `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
+| `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+
+Tokenizer settings are persisted in each global index file's metadata. Readers use that metadata
+when reopening an index, so changing table/procedure options later does not make existing index
+files use a different analyzer.
+PyPaimon can query `jieba` indexes when the Python `jieba` package is installed.
+
 ### Search
 
 ```sql

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexReader.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexReader.java
@@ -95,7 +95,9 @@ public class TantivyFullTextGlobalIndexReader implements GlobalIndexReader {
                         ensureLoaded();
                         SearchResult result =
                                 borrowed.searcher.search(
-                                        fullTextSearch.queryText(), fullTextSearch.limit());
+                                        fullTextSearch.queryText(),
+                                        fullTextSearch.limit(),
+                                        fullTextSearch.queryOperator());
                         return Optional.of(toScoredResult(result));
                     } catch (IOException e) {
                         throw new RuntimeException("Failed to search Tantivy full-text index", e);
@@ -144,11 +146,7 @@ public class TantivyFullTextGlobalIndexReader implements GlobalIndexReader {
                             layout.fileOffsets,
                             layout.fileLengths,
                             streamInput,
-                            indexOptions.tokenizer(),
-                            indexOptions.ngramMinGram(),
-                            indexOptions.ngramMaxGram(),
-                            indexOptions.ngramPrefixOnly(),
-                            indexOptions.lowerCase());
+                            indexOptions.toNativeConfigJson());
             return new TantivySearcherPool.PooledEntry(searcher, in);
         } catch (Exception e) {
             in.close();

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexReader.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexReader.java
@@ -34,6 +34,7 @@ import org.apache.paimon.utils.RoaringNavigableMap64;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,7 @@ public class TantivyFullTextGlobalIndexReader implements GlobalIndexReader {
     private final TantivySearcherPool searcherPool;
     private final String poolKey;
     private final ExecutorService executor;
+    private final TantivyFullTextIndexOptions indexOptions;
 
     private volatile TantivySearcherPool.PooledEntry borrowed;
 
@@ -75,7 +77,13 @@ public class TantivyFullTextGlobalIndexReader implements GlobalIndexReader {
         this.ioMeta = ioMetas.get(0);
         this.layoutCache = layoutCache;
         this.searcherPool = searcherPool;
-        this.poolKey = this.ioMeta.filePath().toString() + "@" + this.ioMeta.fileSize();
+        this.poolKey =
+                this.ioMeta.filePath().toString()
+                        + "@"
+                        + this.ioMeta.fileSize()
+                        + "#"
+                        + Arrays.hashCode(this.ioMeta.metadata());
+        this.indexOptions = deserializeIndexOptions(this.ioMeta.metadata());
     }
 
     @Override
@@ -132,11 +140,28 @@ public class TantivyFullTextGlobalIndexReader implements GlobalIndexReader {
             StreamFileInput streamInput = new SynchronizedStreamFileInput(in);
             TantivySearcher searcher =
                     new TantivySearcher(
-                            layout.fileNames, layout.fileOffsets, layout.fileLengths, streamInput);
+                            layout.fileNames,
+                            layout.fileOffsets,
+                            layout.fileLengths,
+                            streamInput,
+                            indexOptions.tokenizer(),
+                            indexOptions.ngramMinGram(),
+                            indexOptions.ngramMaxGram(),
+                            indexOptions.ngramPrefixOnly(),
+                            indexOptions.lowerCase());
             return new TantivySearcherPool.PooledEntry(searcher, in);
         } catch (Exception e) {
             in.close();
             throw e;
+        }
+    }
+
+    static TantivyFullTextIndexOptions deserializeIndexOptions(byte[] metadata) {
+        try {
+            return TantivyFullTextIndexOptions.deserialize(metadata);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Failed to deserialize Tantivy full-text index meta", e);
         }
     }
 

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
@@ -77,12 +77,7 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
             this.tempIndexDir.deleteOnExit();
             this.writer =
                     new TantivyIndexWriter(
-                            tempIndexDir.getAbsolutePath(),
-                            indexOptions.tokenizer(),
-                            indexOptions.ngramMinGram(),
-                            indexOptions.ngramMaxGram(),
-                            indexOptions.ngramPrefixOnly(),
-                            indexOptions.lowerCase());
+                            tempIndexDir.getAbsolutePath(), indexOptions.toNativeConfigJson());
         } catch (IOException e) {
             throw new RuntimeException("Failed to create temp index directory", e);
         }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
@@ -55,20 +55,34 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
             LoggerFactory.getLogger(TantivyFullTextGlobalIndexWriter.class);
 
     private final GlobalIndexFileWriter fileWriter;
+    private final TantivyFullTextIndexOptions indexOptions;
     private File tempIndexDir;
     private TantivyIndexWriter writer;
     private long rowId;
     private boolean closed;
 
     public TantivyFullTextGlobalIndexWriter(GlobalIndexFileWriter fileWriter) {
+        this(fileWriter, TantivyFullTextIndexOptions.defaults());
+    }
+
+    public TantivyFullTextGlobalIndexWriter(
+            GlobalIndexFileWriter fileWriter, TantivyFullTextIndexOptions indexOptions) {
         this.fileWriter = fileWriter;
+        this.indexOptions = indexOptions;
         this.rowId = 0;
         this.closed = false;
 
         try {
             this.tempIndexDir = Files.createTempDirectory("tantivy-index-").toFile();
             this.tempIndexDir.deleteOnExit();
-            this.writer = new TantivyIndexWriter(tempIndexDir.getAbsolutePath());
+            this.writer =
+                    new TantivyIndexWriter(
+                            tempIndexDir.getAbsolutePath(),
+                            indexOptions.tokenizer(),
+                            indexOptions.ngramMinGram(),
+                            indexOptions.ngramMaxGram(),
+                            indexOptions.ngramPrefixOnly(),
+                            indexOptions.lowerCase());
         } catch (IOException e) {
             throw new RuntimeException("Failed to create temp index directory", e);
         }
@@ -162,7 +176,7 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
         }
 
         LOG.info("Tantivy index packed: {} documents", rowId);
-        return new ResultEntry(fileName, rowId, null);
+        return new ResultEntry(fileName, rowId, indexOptions.serialize());
     }
 
     private static void writeInt(PositionOutputStream out, int value) throws IOException {

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexer.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexer.java
@@ -35,14 +35,21 @@ public class TantivyFullTextGlobalIndexer implements GlobalIndexer {
 
     private final Map<String, ArchiveLayout> layoutCache = new ConcurrentHashMap<>();
     private final TantivySearcherPool searcherPool;
+    private final TantivyFullTextIndexOptions indexOptions;
+
+    public TantivyFullTextGlobalIndexer(
+            TantivySearcherPool searcherPool, TantivyFullTextIndexOptions indexOptions) {
+        this.searcherPool = searcherPool;
+        this.indexOptions = indexOptions;
+    }
 
     public TantivyFullTextGlobalIndexer(TantivySearcherPool searcherPool) {
-        this.searcherPool = searcherPool;
+        this(searcherPool, TantivyFullTextIndexOptions.defaults());
     }
 
     @Override
     public GlobalIndexWriter createWriter(GlobalIndexFileWriter fileWriter) {
-        return new TantivyFullTextGlobalIndexWriter(fileWriter);
+        return new TantivyFullTextGlobalIndexWriter(fileWriter, indexOptions);
     }
 
     @Override

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexerFactory.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexerFactory.java
@@ -45,6 +45,7 @@ public class TantivyFullTextGlobalIndexerFactory implements GlobalIndexerFactory
                 }
             }
         }
-        return new TantivyFullTextGlobalIndexer(searcherPool);
+        return new TantivyFullTextGlobalIndexer(
+                searcherPool, TantivyFullTextIndexOptions.from(options));
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexerFactory.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexerFactory.java
@@ -23,6 +23,9 @@ import org.apache.paimon.globalindex.GlobalIndexerFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataField;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /** Factory for creating Tantivy full-text index. */
 public class TantivyFullTextGlobalIndexerFactory implements GlobalIndexerFactory {
 
@@ -46,6 +49,18 @@ public class TantivyFullTextGlobalIndexerFactory implements GlobalIndexerFactory
             }
         }
         return new TantivyFullTextGlobalIndexer(
-                searcherPool, TantivyFullTextIndexOptions.from(options));
+                searcherPool, new TantivyFullTextIndexOptions(removeTantivyPrefix(options)));
+    }
+
+    static Map<String, Object> removeTantivyPrefix(Options options) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String key : options.keySet()) {
+            if (key.startsWith(TantivyFullTextIndexOptions.TANTIVY_PREFIX)) {
+                result.put(
+                        key.substring(TantivyFullTextIndexOptions.TANTIVY_PREFIX.length()),
+                        options.get(key));
+            }
+        }
+        return result;
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -27,7 +27,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 /** Options for the Tantivy full-text index. */
 public class TantivyFullTextIndexOptions {
@@ -39,7 +44,7 @@ public class TantivyFullTextIndexOptions {
                     .stringType()
                     .defaultValue("default")
                     .withDescription(
-                            "Tokenizer for Tantivy full-text index. Supported values are 'default', 'ngram', and 'jieba'.");
+                            "Tokenizer for Tantivy full-text index. Supported values are 'default', 'simple', 'whitespace', 'raw', 'ngram', and 'jieba'.");
 
     public static final ConfigOption<Integer> NGRAM_MIN_GRAM =
             ConfigOptions.key("tantivy.ngram.min-gram")
@@ -66,6 +71,49 @@ public class TantivyFullTextIndexOptions {
                     .defaultValue(true)
                     .withDescription("Whether to lowercase tokens for configurable tokenizers.");
 
+    public static final ConfigOption<Integer> MAX_TOKEN_LENGTH =
+            ConfigOptions.key("tantivy.max-token-length")
+                    .intType()
+                    .defaultValue(40)
+                    .withDescription("Maximum token length kept by configurable tokenizers.");
+
+    public static final ConfigOption<Boolean> ASCII_FOLDING =
+            ConfigOptions.key("tantivy.ascii-folding")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to normalize non-ASCII latin characters to ASCII.");
+
+    public static final ConfigOption<Boolean> STEM =
+            ConfigOptions.key("tantivy.stem")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to apply stemming to emitted tokens.");
+
+    public static final ConfigOption<String> LANGUAGE =
+            ConfigOptions.key("tantivy.language")
+                    .stringType()
+                    .defaultValue("english")
+                    .withDescription("Language used by stemming and built-in stop word filters.");
+
+    public static final ConfigOption<Boolean> REMOVE_STOP_WORDS =
+            ConfigOptions.key("tantivy.remove-stop-words")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to remove built-in stop words for the configured language.");
+
+    public static final ConfigOption<String> STOP_WORDS =
+            ConfigOptions.key("tantivy.stop-words")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Semicolon-separated custom stop words to remove.");
+
+    public static final ConfigOption<Boolean> WITH_POSITION =
+            ConfigOptions.key("tantivy.with-position")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether to store term positions for phrase queries.");
+
     public static final ConfigOption<Integer> SEARCHER_POOL_MAX_SIZE =
             ConfigOptions.key("tantivy.searcher-pool.max-size")
                     .intType()
@@ -82,6 +130,13 @@ public class TantivyFullTextIndexOptions {
     private final int ngramMaxGram;
     private final boolean ngramPrefixOnly;
     private final boolean lowerCase;
+    private final int maxTokenLength;
+    private final boolean asciiFolding;
+    private final boolean stem;
+    private final String language;
+    private final boolean removeStopWords;
+    private final String stopWords;
+    private final boolean withPosition;
 
     public TantivyFullTextIndexOptions(
             String tokenizer,
@@ -89,16 +144,52 @@ public class TantivyFullTextIndexOptions {
             int ngramMaxGram,
             boolean ngramPrefixOnly,
             boolean lowerCase) {
+        this(
+                tokenizer,
+                ngramMinGram,
+                ngramMaxGram,
+                ngramPrefixOnly,
+                lowerCase,
+                40,
+                false,
+                false,
+                "english",
+                false,
+                "",
+                true);
+    }
+
+    public TantivyFullTextIndexOptions(
+            String tokenizer,
+            int ngramMinGram,
+            int ngramMaxGram,
+            boolean ngramPrefixOnly,
+            boolean lowerCase,
+            int maxTokenLength,
+            boolean asciiFolding,
+            boolean stem,
+            String language,
+            boolean removeStopWords,
+            String stopWords,
+            boolean withPosition) {
         this.tokenizer = normalizeTokenizer(tokenizer);
         this.ngramMinGram = ngramMinGram;
         this.ngramMaxGram = ngramMaxGram;
         this.ngramPrefixOnly = ngramPrefixOnly;
         this.lowerCase = lowerCase;
+        this.maxTokenLength = maxTokenLength;
+        this.asciiFolding = asciiFolding;
+        this.stem = stem;
+        this.language = normalizeLanguage(language);
+        this.removeStopWords = removeStopWords;
+        this.stopWords = normalizeStopWords(stopWords);
+        this.withPosition = withPosition;
         validate();
     }
 
     public static TantivyFullTextIndexOptions defaults() {
-        return new TantivyFullTextIndexOptions("default", 2, 2, false, true);
+        return new TantivyFullTextIndexOptions(
+                "default", 2, 2, false, true, 40, false, false, "english", false, "", true);
     }
 
     public static TantivyFullTextIndexOptions from(Options options) {
@@ -107,7 +198,14 @@ public class TantivyFullTextIndexOptions {
                 options.get(NGRAM_MIN_GRAM),
                 options.get(NGRAM_MAX_GRAM),
                 options.get(NGRAM_PREFIX_ONLY),
-                options.get(LOWER_CASE));
+                options.get(LOWER_CASE),
+                options.get(MAX_TOKEN_LENGTH),
+                options.get(ASCII_FOLDING),
+                options.get(STEM),
+                options.get(LANGUAGE),
+                options.get(REMOVE_STOP_WORDS),
+                options.get(STOP_WORDS),
+                options.get(WITH_POSITION));
     }
 
     public String tokenizer() {
@@ -130,6 +228,76 @@ public class TantivyFullTextIndexOptions {
         return lowerCase;
     }
 
+    public int maxTokenLength() {
+        return maxTokenLength;
+    }
+
+    public boolean asciiFolding() {
+        return asciiFolding;
+    }
+
+    public boolean stem() {
+        return stem;
+    }
+
+    public String language() {
+        return language;
+    }
+
+    public boolean removeStopWords() {
+        return removeStopWords;
+    }
+
+    public String stopWords() {
+        return stopWords;
+    }
+
+    public boolean withPosition() {
+        return withPosition;
+    }
+
+    public List<String> stopWordList() {
+        if (stopWords.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<String> words = new ArrayList<>();
+        for (String word : stopWords.split(";")) {
+            String trimmed = word.trim();
+            if (!trimmed.isEmpty()) {
+                words.add(trimmed);
+            }
+        }
+        return words;
+    }
+
+    public String toNativeConfigJson() {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{');
+        appendJsonField(builder, "tokenizer", tokenizer).append(',');
+        appendJsonField(builder, "ngramMinGram", ngramMinGram).append(',');
+        appendJsonField(builder, "ngramMaxGram", ngramMaxGram).append(',');
+        appendJsonField(builder, "ngramPrefixOnly", ngramPrefixOnly).append(',');
+        appendJsonField(builder, "lowerCase", lowerCase).append(',');
+        appendJsonField(builder, "maxTokenLength", maxTokenLength).append(',');
+        appendJsonField(builder, "asciiFolding", asciiFolding).append(',');
+        appendJsonField(builder, "stem", stem).append(',');
+        appendJsonField(builder, "language", language).append(',');
+        appendJsonField(builder, "removeStopWords", removeStopWords).append(',');
+        builder.append("\"stopWords\":[");
+        List<String> stopWordList = stopWordList();
+        for (int i = 0; i < stopWordList.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            appendJsonString(builder, stopWordList.get(i));
+        }
+        builder.append("],");
+        appendJsonField(builder, "withPosition", withPosition);
+        builder.append('}');
+        return builder.toString();
+    }
+
     public byte[] serialize() throws IOException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bytes);
@@ -139,6 +307,13 @@ public class TantivyFullTextIndexOptions {
         out.writeInt(ngramMaxGram);
         out.writeBoolean(ngramPrefixOnly);
         out.writeBoolean(lowerCase);
+        out.writeInt(maxTokenLength);
+        out.writeBoolean(asciiFolding);
+        out.writeBoolean(stem);
+        out.writeUTF(language);
+        out.writeBoolean(removeStopWords);
+        out.writeUTF(stopWords);
+        out.writeBoolean(withPosition);
         out.flush();
         return bytes.toByteArray();
     }
@@ -154,21 +329,59 @@ public class TantivyFullTextIndexOptions {
                 version == META_VERSION,
                 "Unsupported Tantivy full-text index meta version: %s",
                 version);
-        return new TantivyFullTextIndexOptions(
-                normalizeTokenizer(in.readUTF()),
-                in.readInt(),
-                in.readInt(),
-                in.readBoolean(),
-                in.readBoolean());
+        String tokenizer = normalizeTokenizer(in.readUTF());
+        int ngramMinGram = in.readInt();
+        int ngramMaxGram = in.readInt();
+        boolean ngramPrefixOnly = in.readBoolean();
+        boolean lowerCase = in.readBoolean();
+        try {
+            return new TantivyFullTextIndexOptions(
+                    tokenizer,
+                    ngramMinGram,
+                    ngramMaxGram,
+                    ngramPrefixOnly,
+                    lowerCase,
+                    in.readInt(),
+                    in.readBoolean(),
+                    in.readBoolean(),
+                    in.readUTF(),
+                    in.readBoolean(),
+                    in.readUTF(),
+                    in.readBoolean());
+        } catch (EOFException e) {
+            return new TantivyFullTextIndexOptions(
+                    tokenizer, ngramMinGram, ngramMaxGram, ngramPrefixOnly, lowerCase);
+        }
     }
 
     private static String normalizeTokenizer(String tokenizer) {
         return tokenizer == null ? "" : tokenizer.trim().toLowerCase();
     }
 
+    private static String normalizeLanguage(String language) {
+        return language == null ? "" : language.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String normalizeStopWords(String stopWords) {
+        if (stopWords == null) {
+            return "";
+        }
+        List<String> words = new ArrayList<>();
+        for (String word : stopWords.split(";")) {
+            String trimmed = word.trim();
+            if (!trimmed.isEmpty()) {
+                words.add(trimmed);
+            }
+        }
+        return String.join(";", words);
+    }
+
     private void validate() {
         Preconditions.checkArgument(
                 "default".equals(tokenizer)
+                        || "simple".equals(tokenizer)
+                        || "whitespace".equals(tokenizer)
+                        || "raw".equals(tokenizer)
                         || "ngram".equals(tokenizer)
                         || "jieba".equals(tokenizer),
                 "Unsupported Tantivy tokenizer: %s",
@@ -177,5 +390,86 @@ public class TantivyFullTextIndexOptions {
         Preconditions.checkArgument(ngramMaxGram > 0, "ngram max gram must be positive.");
         Preconditions.checkArgument(
                 ngramMinGram <= ngramMaxGram, "ngram min gram must not be greater than max gram.");
+        Preconditions.checkArgument(maxTokenLength > 0, "max token length must be positive.");
+        Preconditions.checkArgument(
+                supportedLanguages().contains(language),
+                "Unsupported Tantivy language: %s",
+                language);
+    }
+
+    private static List<String> supportedLanguages() {
+        return Arrays.asList(
+                "arabic",
+                "danish",
+                "dutch",
+                "english",
+                "finnish",
+                "french",
+                "german",
+                "greek",
+                "hungarian",
+                "italian",
+                "norwegian",
+                "portuguese",
+                "romanian",
+                "russian",
+                "spanish",
+                "swedish",
+                "tamil",
+                "turkish");
+    }
+
+    private static StringBuilder appendJsonField(StringBuilder builder, String key, String value) {
+        appendJsonString(builder, key).append(':');
+        appendJsonString(builder, value);
+        return builder;
+    }
+
+    private static StringBuilder appendJsonField(StringBuilder builder, String key, int value) {
+        appendJsonString(builder, key).append(':').append(value);
+        return builder;
+    }
+
+    private static StringBuilder appendJsonField(StringBuilder builder, String key, boolean value) {
+        appendJsonString(builder, key).append(':').append(value);
+        return builder;
+    }
+
+    private static StringBuilder appendJsonString(StringBuilder builder, String value) {
+        builder.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                case '\\':
+                    builder.append("\\\\");
+                    break;
+                case '\b':
+                    builder.append("\\b");
+                    break;
+                case '\f':
+                    builder.append("\\f");
+                    break;
+                case '\n':
+                    builder.append("\\n");
+                    break;
+                case '\r':
+                    builder.append("\\r");
+                    break;
+                case '\t':
+                    builder.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        builder.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        builder.append(c);
+                    }
+            }
+        }
+        builder.append('"');
+        return builder;
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -32,8 +32,10 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /** Options for the Tantivy full-text index. */
 public class TantivyFullTextIndexOptions {
@@ -273,7 +275,7 @@ public class TantivyFullTextIndexOptions {
     }
 
     public String toNativeConfigJson() {
-        return JsonSerdeUtil.toFlatJson(toNativeConfig());
+        return JsonSerdeUtil.toFlatJson(toNativeConfigMap());
     }
 
     public byte[] serialize() throws IOException {
@@ -325,20 +327,46 @@ public class TantivyFullTextIndexOptions {
         }
     }
 
-    private NativeConfig toNativeConfig() {
-        NativeConfig config = new NativeConfig();
-        config.tokenizer = tokenizer;
-        config.ngramMinGram = ngramMinGram;
-        config.ngramMaxGram = ngramMaxGram;
-        config.ngramPrefixOnly = ngramPrefixOnly;
-        config.lowerCase = lowerCase;
-        config.maxTokenLength = maxTokenLength;
-        config.asciiFolding = asciiFolding;
-        config.stem = stem;
-        config.language = language;
-        config.removeStopWords = removeStopWords;
-        config.stopWords = stopWordList();
-        config.withPosition = withPosition;
+    private Map<String, Object> toNativeConfigMap() {
+        Map<String, Object> config = new LinkedHashMap<>();
+        TantivyFullTextIndexOptions defaults = defaults();
+        if (!tokenizer.equals(defaults.tokenizer)) {
+            config.put("tokenizer", tokenizer);
+        }
+        if (ngramMinGram != defaults.ngramMinGram) {
+            config.put("ngramMinGram", ngramMinGram);
+        }
+        if (ngramMaxGram != defaults.ngramMaxGram) {
+            config.put("ngramMaxGram", ngramMaxGram);
+        }
+        if (ngramPrefixOnly != defaults.ngramPrefixOnly) {
+            config.put("ngramPrefixOnly", ngramPrefixOnly);
+        }
+        if (lowerCase != defaults.lowerCase) {
+            config.put("lowerCase", lowerCase);
+        }
+        if (maxTokenLength != defaults.maxTokenLength) {
+            config.put("maxTokenLength", maxTokenLength);
+        }
+        if (asciiFolding != defaults.asciiFolding) {
+            config.put("asciiFolding", asciiFolding);
+        }
+        if (stem != defaults.stem) {
+            config.put("stem", stem);
+        }
+        if (!language.equals(defaults.language)) {
+            config.put("language", language);
+        }
+        if (removeStopWords != defaults.removeStopWords) {
+            config.put("removeStopWords", removeStopWords);
+        }
+        List<String> stopWordList = stopWordList();
+        if (!stopWordList.isEmpty()) {
+            config.put("stopWords", stopWordList);
+        }
+        if (withPosition != defaults.withPosition) {
+            config.put("withPosition", withPosition);
+        }
         return config;
     }
 

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -21,14 +21,15 @@ package org.apache.paimon.tantivy.index;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Preconditions;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -272,50 +273,11 @@ public class TantivyFullTextIndexOptions {
     }
 
     public String toNativeConfigJson() {
-        StringBuilder builder = new StringBuilder();
-        builder.append('{');
-        appendJsonField(builder, "tokenizer", tokenizer).append(',');
-        appendJsonField(builder, "ngramMinGram", ngramMinGram).append(',');
-        appendJsonField(builder, "ngramMaxGram", ngramMaxGram).append(',');
-        appendJsonField(builder, "ngramPrefixOnly", ngramPrefixOnly).append(',');
-        appendJsonField(builder, "lowerCase", lowerCase).append(',');
-        appendJsonField(builder, "maxTokenLength", maxTokenLength).append(',');
-        appendJsonField(builder, "asciiFolding", asciiFolding).append(',');
-        appendJsonField(builder, "stem", stem).append(',');
-        appendJsonField(builder, "language", language).append(',');
-        appendJsonField(builder, "removeStopWords", removeStopWords).append(',');
-        builder.append("\"stopWords\":[");
-        List<String> stopWordList = stopWordList();
-        for (int i = 0; i < stopWordList.size(); i++) {
-            if (i > 0) {
-                builder.append(',');
-            }
-            appendJsonString(builder, stopWordList.get(i));
-        }
-        builder.append("],");
-        appendJsonField(builder, "withPosition", withPosition);
-        builder.append('}');
-        return builder.toString();
+        return JsonSerdeUtil.toFlatJson(toNativeConfig());
     }
 
     public byte[] serialize() throws IOException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(bytes);
-        out.writeInt(META_VERSION);
-        out.writeUTF(tokenizer);
-        out.writeInt(ngramMinGram);
-        out.writeInt(ngramMaxGram);
-        out.writeBoolean(ngramPrefixOnly);
-        out.writeBoolean(lowerCase);
-        out.writeInt(maxTokenLength);
-        out.writeBoolean(asciiFolding);
-        out.writeBoolean(stem);
-        out.writeUTF(language);
-        out.writeBoolean(removeStopWords);
-        out.writeUTF(stopWords);
-        out.writeBoolean(withPosition);
-        out.flush();
-        return bytes.toByteArray();
+        return toNativeConfigJson().getBytes(StandardCharsets.UTF_8);
     }
 
     public static TantivyFullTextIndexOptions deserialize(byte[] data) throws IOException {
@@ -323,6 +285,15 @@ public class TantivyFullTextIndexOptions {
             return defaults();
         }
 
+        if (isJsonConfig(data)) {
+            return fromNativeConfigJson(new String(data, StandardCharsets.UTF_8));
+        }
+
+        return deserializeLegacyBinary(data);
+    }
+
+    private static TantivyFullTextIndexOptions deserializeLegacyBinary(byte[] data)
+            throws IOException {
         DataInputStream in = new DataInputStream(new ByteArrayInputStream(data));
         int version = in.readInt();
         Preconditions.checkArgument(
@@ -352,6 +323,70 @@ public class TantivyFullTextIndexOptions {
             return new TantivyFullTextIndexOptions(
                     tokenizer, ngramMinGram, ngramMaxGram, ngramPrefixOnly, lowerCase);
         }
+    }
+
+    private NativeConfig toNativeConfig() {
+        NativeConfig config = new NativeConfig();
+        config.tokenizer = tokenizer;
+        config.ngramMinGram = ngramMinGram;
+        config.ngramMaxGram = ngramMaxGram;
+        config.ngramPrefixOnly = ngramPrefixOnly;
+        config.lowerCase = lowerCase;
+        config.maxTokenLength = maxTokenLength;
+        config.asciiFolding = asciiFolding;
+        config.stem = stem;
+        config.language = language;
+        config.removeStopWords = removeStopWords;
+        config.stopWords = stopWordList();
+        config.withPosition = withPosition;
+        return config;
+    }
+
+    private static TantivyFullTextIndexOptions fromNativeConfigJson(String json) throws IOException {
+        try {
+            return fromNativeConfig(JsonSerdeUtil.fromJson(json, NativeConfig.class));
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    private static TantivyFullTextIndexOptions fromNativeConfig(NativeConfig config) {
+        return new TantivyFullTextIndexOptions(
+                config.tokenizer,
+                config.ngramMinGram,
+                config.ngramMaxGram,
+                config.ngramPrefixOnly,
+                config.lowerCase,
+                config.maxTokenLength,
+                config.asciiFolding,
+                config.stem,
+                config.language,
+                config.removeStopWords,
+                joinStopWords(config.stopWords),
+                config.withPosition);
+    }
+
+    private static boolean isJsonConfig(byte[] data) {
+        for (byte datum : data) {
+            if (!Character.isWhitespace((char) datum)) {
+                return datum == '{';
+            }
+        }
+        return false;
+    }
+
+    private static String joinStopWords(List<String> stopWords) {
+        if (stopWords == null || stopWords.isEmpty()) {
+            return "";
+        }
+
+        List<String> words = new ArrayList<>();
+        for (String stopWord : stopWords) {
+            if (stopWord != null) {
+                words.add(stopWord);
+            }
+        }
+        return String.join(";", words);
     }
 
     private static String normalizeTokenizer(String tokenizer) {
@@ -419,57 +454,19 @@ public class TantivyFullTextIndexOptions {
                 "turkish");
     }
 
-    private static StringBuilder appendJsonField(StringBuilder builder, String key, String value) {
-        appendJsonString(builder, key).append(':');
-        appendJsonString(builder, value);
-        return builder;
-    }
-
-    private static StringBuilder appendJsonField(StringBuilder builder, String key, int value) {
-        appendJsonString(builder, key).append(':').append(value);
-        return builder;
-    }
-
-    private static StringBuilder appendJsonField(StringBuilder builder, String key, boolean value) {
-        appendJsonString(builder, key).append(':').append(value);
-        return builder;
-    }
-
-    private static StringBuilder appendJsonString(StringBuilder builder, String value) {
-        builder.append('"');
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            switch (c) {
-                case '"':
-                    builder.append("\\\"");
-                    break;
-                case '\\':
-                    builder.append("\\\\");
-                    break;
-                case '\b':
-                    builder.append("\\b");
-                    break;
-                case '\f':
-                    builder.append("\\f");
-                    break;
-                case '\n':
-                    builder.append("\\n");
-                    break;
-                case '\r':
-                    builder.append("\\r");
-                    break;
-                case '\t':
-                    builder.append("\\t");
-                    break;
-                default:
-                    if (c < 0x20) {
-                        builder.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        builder.append(c);
-                    }
-            }
-        }
-        builder.append('"');
-        return builder;
+    /** Native JSON config consumed by both Java metadata readers and the Rust Tantivy writer. */
+    private static class NativeConfig {
+        public String tokenizer = "default";
+        public int ngramMinGram = 2;
+        public int ngramMaxGram = 2;
+        public boolean ngramPrefixOnly = false;
+        public boolean lowerCase = true;
+        public int maxTokenLength = 40;
+        public boolean asciiFolding = false;
+        public boolean stem = false;
+        public String language = "english";
+        public boolean removeStopWords = false;
+        public List<String> stopWords = new ArrayList<>();
+        public boolean withPosition = true;
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -370,7 +370,8 @@ public class TantivyFullTextIndexOptions {
         return config;
     }
 
-    private static TantivyFullTextIndexOptions fromNativeConfigJson(String json) throws IOException {
+    private static TantivyFullTextIndexOptions fromNativeConfigJson(String json)
+            throws IOException {
         try {
             return fromNativeConfig(JsonSerdeUtil.fromJson(json, NativeConfig.class));
         } catch (UncheckedIOException e) {

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -20,9 +20,51 @@ package org.apache.paimon.tantivy.index;
 
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 /** Options for the Tantivy full-text index. */
 public class TantivyFullTextIndexOptions {
+
+    private static final int META_VERSION = 1;
+
+    public static final ConfigOption<String> TOKENIZER =
+            ConfigOptions.key("tantivy.tokenizer")
+                    .stringType()
+                    .defaultValue("default")
+                    .withDescription(
+                            "Tokenizer for Tantivy full-text index. Supported values are 'default', 'ngram', and 'jieba'.");
+
+    public static final ConfigOption<Integer> NGRAM_MIN_GRAM =
+            ConfigOptions.key("tantivy.ngram.min-gram")
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription("Minimum ngram length when 'tantivy.tokenizer' is 'ngram'.");
+
+    public static final ConfigOption<Integer> NGRAM_MAX_GRAM =
+            ConfigOptions.key("tantivy.ngram.max-gram")
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription("Maximum ngram length when 'tantivy.tokenizer' is 'ngram'.");
+
+    public static final ConfigOption<Boolean> NGRAM_PREFIX_ONLY =
+            ConfigOptions.key("tantivy.ngram.prefix-only")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether ngram tokenizer should only emit prefix ngrams when 'tantivy.tokenizer' is 'ngram'.");
+
+    public static final ConfigOption<Boolean> LOWER_CASE =
+            ConfigOptions.key("tantivy.lower-case")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether to lowercase tokens for configurable tokenizers.");
 
     public static final ConfigOption<Integer> SEARCHER_POOL_MAX_SIZE =
             ConfigOptions.key("tantivy.searcher-pool.max-size")
@@ -34,4 +76,106 @@ public class TantivyFullTextIndexOptions {
                                     + "Rust memory (including the FST term dictionary), so memory "
                                     + "usage scales with this value times the index size per shard. "
                                     + "Set to 0 to disable pooling.");
+
+    private final String tokenizer;
+    private final int ngramMinGram;
+    private final int ngramMaxGram;
+    private final boolean ngramPrefixOnly;
+    private final boolean lowerCase;
+
+    public TantivyFullTextIndexOptions(
+            String tokenizer,
+            int ngramMinGram,
+            int ngramMaxGram,
+            boolean ngramPrefixOnly,
+            boolean lowerCase) {
+        this.tokenizer = normalizeTokenizer(tokenizer);
+        this.ngramMinGram = ngramMinGram;
+        this.ngramMaxGram = ngramMaxGram;
+        this.ngramPrefixOnly = ngramPrefixOnly;
+        this.lowerCase = lowerCase;
+        validate();
+    }
+
+    public static TantivyFullTextIndexOptions defaults() {
+        return new TantivyFullTextIndexOptions("default", 2, 2, false, true);
+    }
+
+    public static TantivyFullTextIndexOptions from(Options options) {
+        return new TantivyFullTextIndexOptions(
+                normalizeTokenizer(options.get(TOKENIZER)),
+                options.get(NGRAM_MIN_GRAM),
+                options.get(NGRAM_MAX_GRAM),
+                options.get(NGRAM_PREFIX_ONLY),
+                options.get(LOWER_CASE));
+    }
+
+    public String tokenizer() {
+        return tokenizer;
+    }
+
+    public int ngramMinGram() {
+        return ngramMinGram;
+    }
+
+    public int ngramMaxGram() {
+        return ngramMaxGram;
+    }
+
+    public boolean ngramPrefixOnly() {
+        return ngramPrefixOnly;
+    }
+
+    public boolean lowerCase() {
+        return lowerCase;
+    }
+
+    public byte[] serialize() throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bytes);
+        out.writeInt(META_VERSION);
+        out.writeUTF(tokenizer);
+        out.writeInt(ngramMinGram);
+        out.writeInt(ngramMaxGram);
+        out.writeBoolean(ngramPrefixOnly);
+        out.writeBoolean(lowerCase);
+        out.flush();
+        return bytes.toByteArray();
+    }
+
+    public static TantivyFullTextIndexOptions deserialize(byte[] data) throws IOException {
+        if (data == null || data.length == 0) {
+            return defaults();
+        }
+
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(data));
+        int version = in.readInt();
+        Preconditions.checkArgument(
+                version == META_VERSION,
+                "Unsupported Tantivy full-text index meta version: %s",
+                version);
+        return new TantivyFullTextIndexOptions(
+                normalizeTokenizer(in.readUTF()),
+                in.readInt(),
+                in.readInt(),
+                in.readBoolean(),
+                in.readBoolean());
+    }
+
+    private static String normalizeTokenizer(String tokenizer) {
+        return tokenizer == null ? "" : tokenizer.trim().toLowerCase();
+    }
+
+    private void validate() {
+        Preconditions.checkArgument(
+                "default".equals(tokenizer)
+                        || "ngram".equals(tokenizer)
+                        || "jieba".equals(tokenizer),
+                "Unsupported Tantivy tokenizer: %s",
+                tokenizer);
+        Preconditions.checkArgument(ngramMinGram > 0, "ngram min gram must be positive.");
+        Preconditions.checkArgument(ngramMaxGram > 0, "ngram max gram must be positive.");
+        Preconditions.checkArgument(
+                ngramMinGram <= ngramMaxGram, "ngram min gram must not be greater than max gram.");
+    }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptions.java
@@ -20,18 +20,17 @@ package org.apache.paimon.tantivy.index;
 
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
-import org.apache.paimon.options.Options;
 import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Preconditions;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.EOFException;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -40,7 +39,7 @@ import java.util.Map;
 /** Options for the Tantivy full-text index. */
 public class TantivyFullTextIndexOptions {
 
-    private static final int META_VERSION = 1;
+    static final String TANTIVY_PREFIX = "tantivy.";
 
     public static final ConfigOption<String> TOKENIZER =
             ConfigOptions.key("tantivy.tokenizer")
@@ -128,154 +127,71 @@ public class TantivyFullTextIndexOptions {
                                     + "usage scales with this value times the index size per shard. "
                                     + "Set to 0 to disable pooling.");
 
-    private final String tokenizer;
-    private final int ngramMinGram;
-    private final int ngramMaxGram;
-    private final boolean ngramPrefixOnly;
-    private final boolean lowerCase;
-    private final int maxTokenLength;
-    private final boolean asciiFolding;
-    private final boolean stem;
-    private final String language;
-    private final boolean removeStopWords;
-    private final String stopWords;
-    private final boolean withPosition;
+    private final Map<String, Object> config;
 
-    public TantivyFullTextIndexOptions(
-            String tokenizer,
-            int ngramMinGram,
-            int ngramMaxGram,
-            boolean ngramPrefixOnly,
-            boolean lowerCase) {
-        this(
-                tokenizer,
-                ngramMinGram,
-                ngramMaxGram,
-                ngramPrefixOnly,
-                lowerCase,
-                40,
-                false,
-                false,
-                "english",
-                false,
-                "",
-                true);
-    }
-
-    public TantivyFullTextIndexOptions(
-            String tokenizer,
-            int ngramMinGram,
-            int ngramMaxGram,
-            boolean ngramPrefixOnly,
-            boolean lowerCase,
-            int maxTokenLength,
-            boolean asciiFolding,
-            boolean stem,
-            String language,
-            boolean removeStopWords,
-            String stopWords,
-            boolean withPosition) {
-        this.tokenizer = normalizeTokenizer(tokenizer);
-        this.ngramMinGram = ngramMinGram;
-        this.ngramMaxGram = ngramMaxGram;
-        this.ngramPrefixOnly = ngramPrefixOnly;
-        this.lowerCase = lowerCase;
-        this.maxTokenLength = maxTokenLength;
-        this.asciiFolding = asciiFolding;
-        this.stem = stem;
-        this.language = normalizeLanguage(language);
-        this.removeStopWords = removeStopWords;
-        this.stopWords = normalizeStopWords(stopWords);
-        this.withPosition = withPosition;
-        validate();
+    public TantivyFullTextIndexOptions(Map<String, Object> options) {
+        this.config =
+                Collections.unmodifiableMap(toNativeConfigMap(Preconditions.checkNotNull(options)));
     }
 
     public static TantivyFullTextIndexOptions defaults() {
-        return new TantivyFullTextIndexOptions(
-                "default", 2, 2, false, true, 40, false, false, "english", false, "", true);
-    }
-
-    public static TantivyFullTextIndexOptions from(Options options) {
-        return new TantivyFullTextIndexOptions(
-                normalizeTokenizer(options.get(TOKENIZER)),
-                options.get(NGRAM_MIN_GRAM),
-                options.get(NGRAM_MAX_GRAM),
-                options.get(NGRAM_PREFIX_ONLY),
-                options.get(LOWER_CASE),
-                options.get(MAX_TOKEN_LENGTH),
-                options.get(ASCII_FOLDING),
-                options.get(STEM),
-                options.get(LANGUAGE),
-                options.get(REMOVE_STOP_WORDS),
-                options.get(STOP_WORDS),
-                options.get(WITH_POSITION));
+        return new TantivyFullTextIndexOptions(Collections.emptyMap());
     }
 
     public String tokenizer() {
-        return tokenizer;
+        return getString(optionKey(TOKENIZER), TOKENIZER.defaultValue());
     }
 
     public int ngramMinGram() {
-        return ngramMinGram;
+        return getInt(optionKey(NGRAM_MIN_GRAM), NGRAM_MIN_GRAM.defaultValue());
     }
 
     public int ngramMaxGram() {
-        return ngramMaxGram;
+        return getInt(optionKey(NGRAM_MAX_GRAM), NGRAM_MAX_GRAM.defaultValue());
     }
 
     public boolean ngramPrefixOnly() {
-        return ngramPrefixOnly;
+        return getBoolean(optionKey(NGRAM_PREFIX_ONLY), NGRAM_PREFIX_ONLY.defaultValue());
     }
 
     public boolean lowerCase() {
-        return lowerCase;
+        return getBoolean(optionKey(LOWER_CASE), LOWER_CASE.defaultValue());
     }
 
     public int maxTokenLength() {
-        return maxTokenLength;
+        return getInt(optionKey(MAX_TOKEN_LENGTH), MAX_TOKEN_LENGTH.defaultValue());
     }
 
     public boolean asciiFolding() {
-        return asciiFolding;
+        return getBoolean(optionKey(ASCII_FOLDING), ASCII_FOLDING.defaultValue());
     }
 
     public boolean stem() {
-        return stem;
+        return getBoolean(optionKey(STEM), STEM.defaultValue());
     }
 
     public String language() {
-        return language;
+        return getString(optionKey(LANGUAGE), LANGUAGE.defaultValue());
     }
 
     public boolean removeStopWords() {
-        return removeStopWords;
+        return getBoolean(optionKey(REMOVE_STOP_WORDS), REMOVE_STOP_WORDS.defaultValue());
     }
 
     public String stopWords() {
-        return stopWords;
+        return joinStopWords(stopWordList());
     }
 
     public boolean withPosition() {
-        return withPosition;
+        return getBoolean(optionKey(WITH_POSITION), WITH_POSITION.defaultValue());
     }
 
     public List<String> stopWordList() {
-        if (stopWords.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        List<String> words = new ArrayList<>();
-        for (String word : stopWords.split(";")) {
-            String trimmed = word.trim();
-            if (!trimmed.isEmpty()) {
-                words.add(trimmed);
-            }
-        }
-        return words;
+        return getStringList(optionKey(STOP_WORDS));
     }
 
     public String toNativeConfigJson() {
-        return JsonSerdeUtil.toFlatJson(toNativeConfigMap());
+        return JsonSerdeUtil.toFlatJson(config);
     }
 
     public byte[] serialize() throws IOException {
@@ -287,85 +203,72 @@ public class TantivyFullTextIndexOptions {
             return defaults();
         }
 
-        if (isJsonConfig(data)) {
-            return fromNativeConfigJson(new String(data, StandardCharsets.UTF_8));
-        }
-
-        return deserializeLegacyBinary(data);
+        return fromNativeConfigJson(new String(data, StandardCharsets.UTF_8));
     }
 
-    private static TantivyFullTextIndexOptions deserializeLegacyBinary(byte[] data)
-            throws IOException {
-        DataInputStream in = new DataInputStream(new ByteArrayInputStream(data));
-        int version = in.readInt();
-        Preconditions.checkArgument(
-                version == META_VERSION,
-                "Unsupported Tantivy full-text index meta version: %s",
-                version);
-        String tokenizer = normalizeTokenizer(in.readUTF());
-        int ngramMinGram = in.readInt();
-        int ngramMaxGram = in.readInt();
-        boolean ngramPrefixOnly = in.readBoolean();
-        boolean lowerCase = in.readBoolean();
-        try {
-            return new TantivyFullTextIndexOptions(
-                    tokenizer,
-                    ngramMinGram,
-                    ngramMaxGram,
-                    ngramPrefixOnly,
-                    lowerCase,
-                    in.readInt(),
-                    in.readBoolean(),
-                    in.readBoolean(),
-                    in.readUTF(),
-                    in.readBoolean(),
-                    in.readUTF(),
-                    in.readBoolean());
-        } catch (EOFException e) {
-            return new TantivyFullTextIndexOptions(
-                    tokenizer, ngramMinGram, ngramMaxGram, ngramPrefixOnly, lowerCase);
-        }
-    }
-
-    private Map<String, Object> toNativeConfigMap() {
+    private static Map<String, Object> toNativeConfigMap(Map<String, Object> options) {
         Map<String, Object> config = new LinkedHashMap<>();
-        TantivyFullTextIndexOptions defaults = defaults();
-        if (!tokenizer.equals(defaults.tokenizer)) {
-            config.put("tokenizer", tokenizer);
+        String tokenizer =
+                normalizeTokenizer(
+                        getString(options, optionKey(TOKENIZER), TOKENIZER.defaultValue()));
+        validateTokenizer(tokenizer);
+        if (!tokenizer.equals(TOKENIZER.defaultValue())) {
+            config.put(optionKey(TOKENIZER), tokenizer);
         }
-        if (ngramMinGram != defaults.ngramMinGram) {
-            config.put("ngramMinGram", ngramMinGram);
+        int ngramMinGram =
+                getInt(options, optionKey(NGRAM_MIN_GRAM), NGRAM_MIN_GRAM.defaultValue());
+        int ngramMaxGram =
+                getInt(options, optionKey(NGRAM_MAX_GRAM), NGRAM_MAX_GRAM.defaultValue());
+        validateNgramGrams(ngramMinGram, ngramMaxGram);
+        if (ngramMinGram != NGRAM_MIN_GRAM.defaultValue()) {
+            config.put(optionKey(NGRAM_MIN_GRAM), ngramMinGram);
         }
-        if (ngramMaxGram != defaults.ngramMaxGram) {
-            config.put("ngramMaxGram", ngramMaxGram);
+        if (ngramMaxGram != NGRAM_MAX_GRAM.defaultValue()) {
+            config.put(optionKey(NGRAM_MAX_GRAM), ngramMaxGram);
         }
-        if (ngramPrefixOnly != defaults.ngramPrefixOnly) {
-            config.put("ngramPrefixOnly", ngramPrefixOnly);
+        boolean ngramPrefixOnly =
+                getBoolean(options, optionKey(NGRAM_PREFIX_ONLY), NGRAM_PREFIX_ONLY.defaultValue());
+        if (ngramPrefixOnly != NGRAM_PREFIX_ONLY.defaultValue()) {
+            config.put(optionKey(NGRAM_PREFIX_ONLY), ngramPrefixOnly);
         }
-        if (lowerCase != defaults.lowerCase) {
-            config.put("lowerCase", lowerCase);
+        boolean lowerCase = getBoolean(options, optionKey(LOWER_CASE), LOWER_CASE.defaultValue());
+        if (lowerCase != LOWER_CASE.defaultValue()) {
+            config.put(optionKey(LOWER_CASE), lowerCase);
         }
-        if (maxTokenLength != defaults.maxTokenLength) {
-            config.put("maxTokenLength", maxTokenLength);
+        int maxTokenLength =
+                getInt(options, optionKey(MAX_TOKEN_LENGTH), MAX_TOKEN_LENGTH.defaultValue());
+        validateMaxTokenLength(maxTokenLength);
+        if (maxTokenLength != MAX_TOKEN_LENGTH.defaultValue()) {
+            config.put(optionKey(MAX_TOKEN_LENGTH), maxTokenLength);
         }
-        if (asciiFolding != defaults.asciiFolding) {
-            config.put("asciiFolding", asciiFolding);
+        boolean asciiFolding =
+                getBoolean(options, optionKey(ASCII_FOLDING), ASCII_FOLDING.defaultValue());
+        if (asciiFolding != ASCII_FOLDING.defaultValue()) {
+            config.put(optionKey(ASCII_FOLDING), asciiFolding);
         }
-        if (stem != defaults.stem) {
-            config.put("stem", stem);
+        boolean stem = getBoolean(options, optionKey(STEM), STEM.defaultValue());
+        if (stem != STEM.defaultValue()) {
+            config.put(optionKey(STEM), stem);
         }
-        if (!language.equals(defaults.language)) {
-            config.put("language", language);
+        String language =
+                normalizeLanguage(getString(options, optionKey(LANGUAGE), LANGUAGE.defaultValue()));
+        validateLanguage(language);
+        if (!language.equals(LANGUAGE.defaultValue())) {
+            config.put(optionKey(LANGUAGE), language);
         }
-        if (removeStopWords != defaults.removeStopWords) {
-            config.put("removeStopWords", removeStopWords);
+        boolean removeStopWords =
+                getBoolean(options, optionKey(REMOVE_STOP_WORDS), REMOVE_STOP_WORDS.defaultValue());
+        if (removeStopWords != REMOVE_STOP_WORDS.defaultValue()) {
+            config.put(optionKey(REMOVE_STOP_WORDS), removeStopWords);
         }
-        List<String> stopWordList = stopWordList();
+        List<String> stopWordList = getStopWordList(options, optionKey(STOP_WORDS));
         if (!stopWordList.isEmpty()) {
-            config.put("stopWords", stopWordList);
+            config.put(optionKey(STOP_WORDS), Collections.unmodifiableList(stopWordList));
         }
-        if (withPosition != defaults.withPosition) {
-            config.put("withPosition", withPosition);
+        boolean withPosition =
+                getBoolean(options, optionKey(WITH_POSITION), WITH_POSITION.defaultValue());
+        if (withPosition != WITH_POSITION.defaultValue()) {
+            config.put(optionKey(WITH_POSITION), withPosition);
         }
         return config;
     }
@@ -373,35 +276,36 @@ public class TantivyFullTextIndexOptions {
     private static TantivyFullTextIndexOptions fromNativeConfigJson(String json)
             throws IOException {
         try {
-            return fromNativeConfig(JsonSerdeUtil.fromJson(json, NativeConfig.class));
+            Map<String, Object> config =
+                    JsonSerdeUtil.fromJson(json, new TypeReference<Map<String, Object>>() {});
+            return new TantivyFullTextIndexOptions(config);
         } catch (UncheckedIOException e) {
             throw e.getCause();
         }
     }
 
-    private static TantivyFullTextIndexOptions fromNativeConfig(NativeConfig config) {
-        return new TantivyFullTextIndexOptions(
-                config.tokenizer,
-                config.ngramMinGram,
-                config.ngramMaxGram,
-                config.ngramPrefixOnly,
-                config.lowerCase,
-                config.maxTokenLength,
-                config.asciiFolding,
-                config.stem,
-                config.language,
-                config.removeStopWords,
-                joinStopWords(config.stopWords),
-                config.withPosition);
+    private String getString(String key, String defaultValue) {
+        Object value = config.get(key);
+        return value == null ? defaultValue : (String) value;
     }
 
-    private static boolean isJsonConfig(byte[] data) {
-        for (byte datum : data) {
-            if (!Character.isWhitespace((char) datum)) {
-                return datum == '{';
-            }
+    private int getInt(String key, int defaultValue) {
+        Object value = config.get(key);
+        return value == null ? defaultValue : (int) value;
+    }
+
+    private boolean getBoolean(String key, boolean defaultValue) {
+        Object value = config.get(key);
+        return value == null ? defaultValue : (boolean) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getStringList(String key) {
+        Object value = config.get(key);
+        if (value == null) {
+            return new ArrayList<>();
         }
-        return false;
+        return new ArrayList<>((List<String>) value);
     }
 
     private static String joinStopWords(List<String> stopWords) {
@@ -418,6 +322,65 @@ public class TantivyFullTextIndexOptions {
         return String.join(";", words);
     }
 
+    private static List<String> toStopWordList(Object value) {
+        if (value == null) {
+            return new ArrayList<>();
+        }
+        if (value instanceof List) {
+            List<String> words = new ArrayList<>();
+            for (Object word : (List<?>) value) {
+                if (word != null) {
+                    words.add(word.toString());
+                }
+            }
+            return words;
+        }
+        return normalizeStopWordList(value.toString());
+    }
+
+    private static String getString(Map<String, Object> options, String key, String defaultValue) {
+        Object value = options.get(key);
+        return value == null ? defaultValue : value.toString();
+    }
+
+    private static int getInt(Map<String, Object> options, String key, int defaultValue) {
+        Object value = options.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return Integer.parseInt(value.toString());
+    }
+
+    private static boolean getBoolean(
+            Map<String, Object> options, String key, boolean defaultValue) {
+        Object value = options.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        if (value instanceof Boolean) {
+            return (boolean) value;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    private static List<String> getStopWordList(Map<String, Object> options, String key) {
+        Object value = options.get(key);
+        if (value == null) {
+            return new ArrayList<>();
+        }
+        if (value instanceof List) {
+            return toStopWordList(value);
+        }
+        return normalizeStopWordList(value.toString());
+    }
+
+    private static String optionKey(ConfigOption<?> option) {
+        return option.key().substring(TANTIVY_PREFIX.length());
+    }
+
     private static String normalizeTokenizer(String tokenizer) {
         return tokenizer == null ? "" : tokenizer.trim().toLowerCase();
     }
@@ -426,21 +389,21 @@ public class TantivyFullTextIndexOptions {
         return language == null ? "" : language.trim().toLowerCase(Locale.ROOT);
     }
 
-    private static String normalizeStopWords(String stopWords) {
-        if (stopWords == null) {
-            return "";
-        }
+    private static List<String> normalizeStopWordList(String stopWords) {
         List<String> words = new ArrayList<>();
+        if (stopWords == null) {
+            return words;
+        }
         for (String word : stopWords.split(";")) {
             String trimmed = word.trim();
             if (!trimmed.isEmpty()) {
                 words.add(trimmed);
             }
         }
-        return String.join(";", words);
+        return words;
     }
 
-    private void validate() {
+    private static void validateTokenizer(String tokenizer) {
         Preconditions.checkArgument(
                 "default".equals(tokenizer)
                         || "simple".equals(tokenizer)
@@ -450,11 +413,20 @@ public class TantivyFullTextIndexOptions {
                         || "jieba".equals(tokenizer),
                 "Unsupported Tantivy tokenizer: %s",
                 tokenizer);
+    }
+
+    private static void validateNgramGrams(int ngramMinGram, int ngramMaxGram) {
         Preconditions.checkArgument(ngramMinGram > 0, "ngram min gram must be positive.");
         Preconditions.checkArgument(ngramMaxGram > 0, "ngram max gram must be positive.");
         Preconditions.checkArgument(
                 ngramMinGram <= ngramMaxGram, "ngram min gram must not be greater than max gram.");
+    }
+
+    private static void validateMaxTokenLength(int maxTokenLength) {
         Preconditions.checkArgument(maxTokenLength > 0, "max token length must be positive.");
+    }
+
+    private static void validateLanguage(String language) {
         Preconditions.checkArgument(
                 supportedLanguages().contains(language),
                 "Unsupported Tantivy language: %s",
@@ -481,21 +453,5 @@ public class TantivyFullTextIndexOptions {
                 "swedish",
                 "tamil",
                 "turkish");
-    }
-
-    /** Native JSON config consumed by both Java metadata readers and the Rust Tantivy writer. */
-    private static class NativeConfig {
-        public String tokenizer = "default";
-        public int ngramMinGram = 2;
-        public int ngramMaxGram = 2;
-        public boolean ngramPrefixOnly = false;
-        public boolean lowerCase = true;
-        public int maxTokenLength = 40;
-        public boolean asciiFolding = false;
-        public boolean stem = false;
-        public String language = "english";
-        public boolean removeStopWords = false;
-        public List<String> stopWords = new ArrayList<>();
-        public boolean withPosition = true;
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -103,7 +104,39 @@ public class JavaPyTantivyE2ETest {
     @Test
     @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
     public void testTantivyFullTextIndexWrite() throws Exception {
-        String tableName = "test_tantivy_fulltext";
+        writeTableWithTantivyIndex(
+                "test_tantivy_fulltext",
+                Arrays.asList(
+                        "Apache Paimon is a streaming data lake platform",
+                        "Tantivy is a full-text search engine written in Rust",
+                        "Paimon supports real-time data ingestion and analytics",
+                        "Full-text search enables efficient text retrieval",
+                        "Data lake platforms like Paimon handle large-scale data"),
+                "default");
+
+        writeTableWithTantivyIndex(
+                "test_tantivy_fulltext_ngram",
+                Arrays.asList(
+                        "Apache Paimon 支持中文全文检索",
+                        "Tantivy ngram tokenizer helps Chinese search",
+                        "湖仓表支持实时数据分析",
+                        "默认分词适合英文内容",
+                        "中文索引支持片段查询"),
+                "ngram");
+
+        writeTableWithTantivyIndex(
+                "test_tantivy_fulltext_jieba",
+                Arrays.asList(
+                        "张华在百货公司当售货员",
+                        "Apache Paimon supports full text search",
+                        "李萍进入中等技术学校学习",
+                        "中文分词支持更自然的全文检索",
+                        "默认英文分词不适合中文语义"),
+                "jieba");
+    }
+
+    private void writeTableWithTantivyIndex(
+            String tableName, List<String> contents, String tokenizer) throws Exception {
         Path tablePath = new Path(warehouse.toString() + "/default.db/" + tableName);
 
         RowType rowType =
@@ -138,37 +171,22 @@ public class JavaPyTantivyE2ETest {
         BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
         try (BatchTableWrite write = writeBuilder.newWrite();
                 BatchTableCommit commit = writeBuilder.newCommit()) {
-            write.write(
-                    GenericRow.of(
-                            0,
-                            BinaryString.fromString(
-                                    "Apache Paimon is a streaming data lake platform")));
-            write.write(
-                    GenericRow.of(
-                            1,
-                            BinaryString.fromString(
-                                    "Tantivy is a full-text search engine written in Rust")));
-            write.write(
-                    GenericRow.of(
-                            2,
-                            BinaryString.fromString(
-                                    "Paimon supports real-time data ingestion and analytics")));
-            write.write(
-                    GenericRow.of(
-                            3,
-                            BinaryString.fromString(
-                                    "Full-text search enables efficient text retrieval")));
-            write.write(
-                    GenericRow.of(
-                            4,
-                            BinaryString.fromString(
-                                    "Data lake platforms like Paimon handle large-scale data")));
+            for (int i = 0; i < contents.size(); i++) {
+                write.write(GenericRow.of(i, BinaryString.fromString(contents.get(i))));
+            }
             commit.commit(write.prepareCommit());
         }
 
         // Build tantivy full-text index on the "content" column
         DataField contentField = table.rowType().getField("content");
         Options indexOptions = table.coreOptions().toConfiguration();
+        if (!"default".equals(tokenizer)) {
+            indexOptions.set(TantivyFullTextIndexOptions.TOKENIZER, tokenizer);
+        }
+        if ("ngram".equals(tokenizer)) {
+            indexOptions.set(TantivyFullTextIndexOptions.NGRAM_MIN_GRAM, 2);
+            indexOptions.set(TantivyFullTextIndexOptions.NGRAM_MAX_GRAM, 2);
+        }
 
         GlobalIndexSingletonWriter writer =
                 (GlobalIndexSingletonWriter)
@@ -178,21 +196,21 @@ public class JavaPyTantivyE2ETest {
                                 contentField,
                                 indexOptions);
 
-        // Write the same text data to the index
-        writer.write(BinaryString.fromString("Apache Paimon is a streaming data lake platform"));
-        writer.write(
-                BinaryString.fromString("Tantivy is a full-text search engine written in Rust"));
-        writer.write(
-                BinaryString.fromString("Paimon supports real-time data ingestion and analytics"));
-        writer.write(BinaryString.fromString("Full-text search enables efficient text retrieval"));
-        writer.write(
-                BinaryString.fromString("Data lake platforms like Paimon handle large-scale data"));
+        // Write the same text data to the index.
+        for (String content : contents) {
+            writer.write(BinaryString.fromString(content));
+        }
 
         List<ResultEntry> entries = writer.finish();
         assertThat(entries).hasSize(1);
-        assertThat(entries.get(0).rowCount()).isEqualTo(5);
+        assertThat(entries.get(0).rowCount()).isEqualTo(contents.size());
+        TantivyFullTextIndexOptions persistedOptions =
+                TantivyFullTextIndexOptions.deserialize(entries.get(0).meta());
+        assertThat(persistedOptions.tokenizer()).isEqualTo(tokenizer);
+        assertThat(persistedOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(persistedOptions.ngramMaxGram()).isEqualTo(2);
 
-        Range rowRange = new Range(0, 4);
+        Range rowRange = new Range(0, contents.size() - 1);
         List<IndexFileMeta> indexFiles =
                 GlobalIndexBuilderUtils.toIndexFileMetas(
                         table.fileIO(),

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
@@ -125,6 +125,14 @@ public class JavaPyTantivyE2ETest {
                 "ngram");
 
         writeTableWithTantivyIndex(
+                "test_tantivy_fulltext_simple",
+                Arrays.asList(
+                        "Running runners search Apache Paimon",
+                        "Run search with Paimon lake",
+                        "The connector runs analytics"),
+                "simple");
+
+        writeTableWithTantivyIndex(
                 "test_tantivy_fulltext_jieba",
                 Arrays.asList(
                         "张华在百货公司当售货员",
@@ -186,6 +194,9 @@ public class JavaPyTantivyE2ETest {
         if ("ngram".equals(tokenizer)) {
             indexOptions.set(TantivyFullTextIndexOptions.NGRAM_MIN_GRAM, 2);
             indexOptions.set(TantivyFullTextIndexOptions.NGRAM_MAX_GRAM, 2);
+        } else if ("simple".equals(tokenizer)) {
+            indexOptions.set(TantivyFullTextIndexOptions.STEM, true);
+            indexOptions.set(TantivyFullTextIndexOptions.REMOVE_STOP_WORDS, true);
         }
 
         GlobalIndexSingletonWriter writer =
@@ -209,6 +220,10 @@ public class JavaPyTantivyE2ETest {
         assertThat(persistedOptions.tokenizer()).isEqualTo(tokenizer);
         assertThat(persistedOptions.ngramMinGram()).isEqualTo(2);
         assertThat(persistedOptions.ngramMaxGram()).isEqualTo(2);
+        if ("simple".equals(tokenizer)) {
+            assertThat(persistedOptions.stem()).isTrue();
+            assertThat(persistedOptions.removeStopWords()).isTrue();
+        }
 
         Range rowRange = new Range(0, contents.size() - 1);
         List<IndexFileMeta> indexFiles =

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
@@ -167,7 +167,9 @@ public class TantivyFullTextGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer =
                 new TantivyFullTextGlobalIndexWriter(
-                        fileWriter, TantivyFullTextIndexOptions.from(options));
+                        fileWriter,
+                        new TantivyFullTextIndexOptions(
+                                TantivyFullTextGlobalIndexerFactory.removeTantivyPrefix(options)));
 
         writer.write(BinaryString.fromString("Apache Paimon supports Chinese text"));
         List<ResultEntry> results = writer.finish();
@@ -188,7 +190,9 @@ public class TantivyFullTextGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer =
                 new TantivyFullTextGlobalIndexWriter(
-                        fileWriter, TantivyFullTextIndexOptions.from(options));
+                        fileWriter,
+                        new TantivyFullTextIndexOptions(
+                                TantivyFullTextGlobalIndexerFactory.removeTantivyPrefix(options)));
 
         writer.write(BinaryString.fromString("张华在百货公司当售货员"));
         writer.write(BinaryString.fromString("Apache Paimon supports full text search"));

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
@@ -28,12 +28,12 @@ import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.tantivy.NativeLoader;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -55,11 +55,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  */
 public class TantivyFullTextGlobalIndexTest {
 
-    @BeforeAll
-    static void checkNativeLibrary() {
-        assumeTrue(isNativeAvailable(), "Tantivy native library not available, skipping tests");
-    }
-
     private static boolean isNativeAvailable() {
         try {
             NativeLoader.loadJni();
@@ -78,6 +73,7 @@ public class TantivyFullTextGlobalIndexTest {
 
     @BeforeEach
     public void setup() {
+        assumeTrue(isNativeAvailable(), "Tantivy native library not available, skipping tests");
         fileIO = new LocalFileIO();
         indexPath = new Path(tempDir.toString());
         layoutCache = new ConcurrentHashMap<>();
@@ -158,6 +154,62 @@ public class TantivyFullTextGlobalIndexTest {
             float score2 = scored.scoreGetter().score(2L);
             assertThat(score0).isGreaterThan(0);
             assertThat(score2).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    public void testWriterPersistsTokenizerMeta() throws IOException {
+        Options options = new Options();
+        options.set(TantivyFullTextIndexOptions.TOKENIZER, "ngram");
+        options.set(TantivyFullTextIndexOptions.NGRAM_MIN_GRAM, 2);
+        options.set(TantivyFullTextIndexOptions.NGRAM_MAX_GRAM, 2);
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        TantivyFullTextGlobalIndexWriter writer =
+                new TantivyFullTextGlobalIndexWriter(
+                        fileWriter, TantivyFullTextIndexOptions.from(options));
+
+        writer.write(BinaryString.fromString("Apache Paimon supports Chinese text"));
+        List<ResultEntry> results = writer.finish();
+
+        assertThat(results).hasSize(1);
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(results.get(0).meta());
+        assertThat(indexOptions.tokenizer()).isEqualTo("ngram");
+        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramMaxGram()).isEqualTo(2);
+    }
+
+    @Test
+    public void testJiebaTokenizerFindsChineseWord() throws IOException {
+        Options options = new Options();
+        options.set(TantivyFullTextIndexOptions.TOKENIZER, "jieba");
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        TantivyFullTextGlobalIndexWriter writer =
+                new TantivyFullTextGlobalIndexWriter(
+                        fileWriter, TantivyFullTextIndexOptions.from(options));
+
+        writer.write(BinaryString.fromString("张华在百货公司当售货员"));
+        writer.write(BinaryString.fromString("Apache Paimon supports full text search"));
+
+        List<ResultEntry> results = writer.finish();
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(results.get(0).meta());
+        assertThat(indexOptions.tokenizer()).isEqualTo("jieba");
+
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+        GlobalIndexFileReader fileReader = createFileReader();
+
+        try (TantivyFullTextGlobalIndexReader reader = createReader(fileReader, metas)) {
+            FullTextSearch search = new FullTextSearch("售货员", 10, "text");
+            Optional<ScoredGlobalIndexResult> searchResult =
+                    reader.visitFullTextSearch(search).join();
+            assertThat(searchResult).isPresent();
+
+            RoaringNavigableMap64 rowIds = searchResult.get().results();
+            assertThat(rowIds.getLongCardinality()).isEqualTo(1);
+            assertThat(rowIds.contains(0L)).isTrue();
         }
     }
 

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tantivy.index;
+
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link TantivyFullTextIndexOptions}. */
+public class TantivyFullTextIndexOptionsTest {
+
+    @Test
+    public void testDeserializeEmptyMetaUsesDefaults() throws Exception {
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(new byte[0]);
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("default");
+        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramMaxGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramPrefixOnly()).isFalse();
+        assertThat(indexOptions.lowerCase()).isTrue();
+    }
+
+    @Test
+    public void testSerializeDeserializeNgramOptions() throws Exception {
+        Options options = new Options();
+        options.set(TantivyFullTextIndexOptions.TOKENIZER, " NGRAM ");
+        options.set(TantivyFullTextIndexOptions.NGRAM_MIN_GRAM, 2);
+        options.set(TantivyFullTextIndexOptions.NGRAM_MAX_GRAM, 3);
+        options.set(TantivyFullTextIndexOptions.NGRAM_PREFIX_ONLY, true);
+        options.set(TantivyFullTextIndexOptions.LOWER_CASE, false);
+
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(
+                        TantivyFullTextIndexOptions.from(options).serialize());
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("ngram");
+        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramMaxGram()).isEqualTo(3);
+        assertThat(indexOptions.ngramPrefixOnly()).isTrue();
+        assertThat(indexOptions.lowerCase()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeJiebaOptions() throws Exception {
+        Options options = new Options();
+        options.set(TantivyFullTextIndexOptions.TOKENIZER, " JIEBA ");
+        options.set(TantivyFullTextIndexOptions.LOWER_CASE, true);
+
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(
+                        TantivyFullTextIndexOptions.from(options).serialize());
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("jieba");
+        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramMaxGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramPrefixOnly()).isFalse();
+        assertThat(indexOptions.lowerCase()).isTrue();
+    }
+
+    @Test
+    public void testValidateTokenizerOptions() {
+        assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ik", 2, 2, false, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported Tantivy tokenizer");
+
+        assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ngram", 3, 2, false, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ngram min gram must not be greater than max gram");
+    }
+}

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
@@ -22,6 +22,10 @@ import org.apache.paimon.options.Options;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -95,6 +99,8 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.stopWordList()).containsExactly("paimon", "lake");
         assertThat(indexOptions.withPosition()).isFalse();
         assertThat(indexOptions.toNativeConfigJson()).contains("\"tokenizer\":\"whitespace\"");
+        assertThat(indexOptions.serialize())
+                .isEqualTo(indexOptions.toNativeConfigJson().getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -115,6 +121,55 @@ public class TantivyFullTextIndexOptionsTest {
     }
 
     @Test
+    public void testDeserializeLegacyBinaryNgramOptions() throws Exception {
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(
+                        legacyBinaryMeta(" NGRAM ", 2, 3, true, false));
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("ngram");
+        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
+        assertThat(indexOptions.ngramMaxGram()).isEqualTo(3);
+        assertThat(indexOptions.ngramPrefixOnly()).isTrue();
+        assertThat(indexOptions.lowerCase()).isFalse();
+        assertThat(indexOptions.maxTokenLength()).isEqualTo(40);
+        assertThat(indexOptions.asciiFolding()).isFalse();
+        assertThat(indexOptions.stem()).isFalse();
+        assertThat(indexOptions.language()).isEqualTo("english");
+        assertThat(indexOptions.removeStopWords()).isFalse();
+        assertThat(indexOptions.stopWords()).isEmpty();
+        assertThat(indexOptions.withPosition()).isTrue();
+    }
+
+    @Test
+    public void testDeserializeLegacyBinaryAnalyzerOptions() throws Exception {
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(
+                        legacyBinaryMeta(
+                                " WHITESPACE ",
+                                2,
+                                2,
+                                false,
+                                false,
+                                12,
+                                true,
+                                true,
+                                "English",
+                                true,
+                                "paimon;lake",
+                                false));
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("whitespace");
+        assertThat(indexOptions.lowerCase()).isFalse();
+        assertThat(indexOptions.maxTokenLength()).isEqualTo(12);
+        assertThat(indexOptions.asciiFolding()).isTrue();
+        assertThat(indexOptions.stem()).isTrue();
+        assertThat(indexOptions.language()).isEqualTo("english");
+        assertThat(indexOptions.removeStopWords()).isTrue();
+        assertThat(indexOptions.stopWords()).isEqualTo("paimon;lake");
+        assertThat(indexOptions.withPosition()).isFalse();
+    }
+
+    @Test
     public void testValidateTokenizerOptions() {
         assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ik", 2, 2, false, true))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -131,5 +186,57 @@ public class TantivyFullTextIndexOptionsTest {
                                         false, "", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported Tantivy language");
+    }
+
+    private static byte[] legacyBinaryMeta(
+            String tokenizer,
+            int ngramMinGram,
+            int ngramMaxGram,
+            boolean ngramPrefixOnly,
+            boolean lowerCase)
+            throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bytes);
+        out.writeInt(1);
+        out.writeUTF(tokenizer);
+        out.writeInt(ngramMinGram);
+        out.writeInt(ngramMaxGram);
+        out.writeBoolean(ngramPrefixOnly);
+        out.writeBoolean(lowerCase);
+        out.flush();
+        return bytes.toByteArray();
+    }
+
+    private static byte[] legacyBinaryMeta(
+            String tokenizer,
+            int ngramMinGram,
+            int ngramMaxGram,
+            boolean ngramPrefixOnly,
+            boolean lowerCase,
+            int maxTokenLength,
+            boolean asciiFolding,
+            boolean stem,
+            String language,
+            boolean removeStopWords,
+            String stopWords,
+            boolean withPosition)
+            throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bytes);
+        out.writeInt(1);
+        out.writeUTF(tokenizer);
+        out.writeInt(ngramMinGram);
+        out.writeInt(ngramMaxGram);
+        out.writeBoolean(ngramPrefixOnly);
+        out.writeBoolean(lowerCase);
+        out.writeInt(maxTokenLength);
+        out.writeBoolean(asciiFolding);
+        out.writeBoolean(stem);
+        out.writeUTF(language);
+        out.writeBoolean(removeStopWords);
+        out.writeUTF(stopWords);
+        out.writeBoolean(withPosition);
+        out.flush();
+        return bytes.toByteArray();
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
@@ -52,6 +52,16 @@ public class TantivyFullTextIndexOptionsTest {
     }
 
     @Test
+    public void testDefaultOptionsSerializeSparseJson() throws Exception {
+        TantivyFullTextIndexOptions indexOptions = TantivyFullTextIndexOptions.defaults();
+
+        assertThat(indexOptions.toNativeConfigJson()).isEqualTo("{}");
+        assertThat(indexOptions.serialize()).isEqualTo("{}".getBytes(StandardCharsets.UTF_8));
+        assertThat(TantivyFullTextIndexOptions.deserialize(indexOptions.serialize()).tokenizer())
+                .isEqualTo("default");
+    }
+
+    @Test
     public void testSerializeDeserializeNgramOptions() throws Exception {
         Options options = new Options();
         options.set(TantivyFullTextIndexOptions.TOKENIZER, " NGRAM ");
@@ -69,6 +79,10 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.ngramMaxGram()).isEqualTo(3);
         assertThat(indexOptions.ngramPrefixOnly()).isTrue();
         assertThat(indexOptions.lowerCase()).isFalse();
+        assertThat(indexOptions.toNativeConfigJson())
+                .isEqualTo(
+                        "{\"tokenizer\":\"ngram\",\"ngramMaxGram\":3,"
+                                + "\"ngramPrefixOnly\":true,\"lowerCase\":false}");
     }
 
     @Test
@@ -99,6 +113,8 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.stopWordList()).containsExactly("paimon", "lake");
         assertThat(indexOptions.withPosition()).isFalse();
         assertThat(indexOptions.toNativeConfigJson()).contains("\"tokenizer\":\"whitespace\"");
+        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngramMinGram\"");
+        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngramMaxGram\"");
         assertThat(indexOptions.serialize())
                 .isEqualTo(indexOptions.toNativeConfigJson().getBytes(StandardCharsets.UTF_8));
     }

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
@@ -38,6 +38,13 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.ngramMaxGram()).isEqualTo(2);
         assertThat(indexOptions.ngramPrefixOnly()).isFalse();
         assertThat(indexOptions.lowerCase()).isTrue();
+        assertThat(indexOptions.maxTokenLength()).isEqualTo(40);
+        assertThat(indexOptions.asciiFolding()).isFalse();
+        assertThat(indexOptions.stem()).isFalse();
+        assertThat(indexOptions.language()).isEqualTo("english");
+        assertThat(indexOptions.removeStopWords()).isFalse();
+        assertThat(indexOptions.stopWords()).isEmpty();
+        assertThat(indexOptions.withPosition()).isTrue();
     }
 
     @Test
@@ -58,6 +65,36 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.ngramMaxGram()).isEqualTo(3);
         assertThat(indexOptions.ngramPrefixOnly()).isTrue();
         assertThat(indexOptions.lowerCase()).isFalse();
+    }
+
+    @Test
+    public void testSerializeDeserializeAnalyzerOptions() throws Exception {
+        Options options = new Options();
+        options.set(TantivyFullTextIndexOptions.TOKENIZER, " WHITESPACE ");
+        options.set(TantivyFullTextIndexOptions.LOWER_CASE, false);
+        options.set(TantivyFullTextIndexOptions.MAX_TOKEN_LENGTH, 12);
+        options.set(TantivyFullTextIndexOptions.ASCII_FOLDING, true);
+        options.set(TantivyFullTextIndexOptions.STEM, true);
+        options.set(TantivyFullTextIndexOptions.LANGUAGE, "English");
+        options.set(TantivyFullTextIndexOptions.REMOVE_STOP_WORDS, true);
+        options.set(TantivyFullTextIndexOptions.STOP_WORDS, "paimon;lake");
+        options.set(TantivyFullTextIndexOptions.WITH_POSITION, false);
+
+        TantivyFullTextIndexOptions indexOptions =
+                TantivyFullTextIndexOptions.deserialize(
+                        TantivyFullTextIndexOptions.from(options).serialize());
+
+        assertThat(indexOptions.tokenizer()).isEqualTo("whitespace");
+        assertThat(indexOptions.lowerCase()).isFalse();
+        assertThat(indexOptions.maxTokenLength()).isEqualTo(12);
+        assertThat(indexOptions.asciiFolding()).isTrue();
+        assertThat(indexOptions.stem()).isTrue();
+        assertThat(indexOptions.language()).isEqualTo("english");
+        assertThat(indexOptions.removeStopWords()).isTrue();
+        assertThat(indexOptions.stopWords()).isEqualTo("paimon;lake");
+        assertThat(indexOptions.stopWordList()).containsExactly("paimon", "lake");
+        assertThat(indexOptions.withPosition()).isFalse();
+        assertThat(indexOptions.toNativeConfigJson()).contains("\"tokenizer\":\"whitespace\"");
     }
 
     @Test
@@ -86,5 +123,13 @@ public class TantivyFullTextIndexOptionsTest {
         assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ngram", 3, 2, false, true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("ngram min gram must not be greater than max gram");
+
+        assertThatThrownBy(
+                        () ->
+                                new TantivyFullTextIndexOptions(
+                                        "default", 2, 2, false, true, 40, false, true, "klingon",
+                                        false, "", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported Tantivy language");
     }
 }

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextIndexOptionsTest.java
@@ -18,13 +18,11 @@
 
 package org.apache.paimon.tantivy.index;
 
-import org.apache.paimon.options.Options;
-
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,16 +61,16 @@ public class TantivyFullTextIndexOptionsTest {
 
     @Test
     public void testSerializeDeserializeNgramOptions() throws Exception {
-        Options options = new Options();
-        options.set(TantivyFullTextIndexOptions.TOKENIZER, " NGRAM ");
-        options.set(TantivyFullTextIndexOptions.NGRAM_MIN_GRAM, 2);
-        options.set(TantivyFullTextIndexOptions.NGRAM_MAX_GRAM, 3);
-        options.set(TantivyFullTextIndexOptions.NGRAM_PREFIX_ONLY, true);
-        options.set(TantivyFullTextIndexOptions.LOWER_CASE, false);
+        Map<String, Object> options = new HashMap<>();
+        options.put("tokenizer", " NGRAM ");
+        options.put("ngram.min-gram", 2);
+        options.put("ngram.max-gram", 3);
+        options.put("ngram.prefix-only", true);
+        options.put("lower-case", false);
 
         TantivyFullTextIndexOptions indexOptions =
                 TantivyFullTextIndexOptions.deserialize(
-                        TantivyFullTextIndexOptions.from(options).serialize());
+                        new TantivyFullTextIndexOptions(options).serialize());
 
         assertThat(indexOptions.tokenizer()).isEqualTo("ngram");
         assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
@@ -81,26 +79,26 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.lowerCase()).isFalse();
         assertThat(indexOptions.toNativeConfigJson())
                 .isEqualTo(
-                        "{\"tokenizer\":\"ngram\",\"ngramMaxGram\":3,"
-                                + "\"ngramPrefixOnly\":true,\"lowerCase\":false}");
+                        "{\"tokenizer\":\"ngram\",\"ngram.max-gram\":3,"
+                                + "\"ngram.prefix-only\":true,\"lower-case\":false}");
     }
 
     @Test
     public void testSerializeDeserializeAnalyzerOptions() throws Exception {
-        Options options = new Options();
-        options.set(TantivyFullTextIndexOptions.TOKENIZER, " WHITESPACE ");
-        options.set(TantivyFullTextIndexOptions.LOWER_CASE, false);
-        options.set(TantivyFullTextIndexOptions.MAX_TOKEN_LENGTH, 12);
-        options.set(TantivyFullTextIndexOptions.ASCII_FOLDING, true);
-        options.set(TantivyFullTextIndexOptions.STEM, true);
-        options.set(TantivyFullTextIndexOptions.LANGUAGE, "English");
-        options.set(TantivyFullTextIndexOptions.REMOVE_STOP_WORDS, true);
-        options.set(TantivyFullTextIndexOptions.STOP_WORDS, "paimon;lake");
-        options.set(TantivyFullTextIndexOptions.WITH_POSITION, false);
+        Map<String, Object> options = new HashMap<>();
+        options.put("tokenizer", " WHITESPACE ");
+        options.put("lower-case", false);
+        options.put("max-token-length", 12);
+        options.put("ascii-folding", true);
+        options.put("stem", true);
+        options.put("language", "English");
+        options.put("remove-stop-words", true);
+        options.put("stop-words", "paimon;lake");
+        options.put("with-position", false);
 
         TantivyFullTextIndexOptions indexOptions =
                 TantivyFullTextIndexOptions.deserialize(
-                        TantivyFullTextIndexOptions.from(options).serialize());
+                        new TantivyFullTextIndexOptions(options).serialize());
 
         assertThat(indexOptions.tokenizer()).isEqualTo("whitespace");
         assertThat(indexOptions.lowerCase()).isFalse();
@@ -113,21 +111,21 @@ public class TantivyFullTextIndexOptionsTest {
         assertThat(indexOptions.stopWordList()).containsExactly("paimon", "lake");
         assertThat(indexOptions.withPosition()).isFalse();
         assertThat(indexOptions.toNativeConfigJson()).contains("\"tokenizer\":\"whitespace\"");
-        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngramMinGram\"");
-        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngramMaxGram\"");
+        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngram.min-gram\"");
+        assertThat(indexOptions.toNativeConfigJson()).doesNotContain("\"ngram.max-gram\"");
         assertThat(indexOptions.serialize())
                 .isEqualTo(indexOptions.toNativeConfigJson().getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
     public void testSerializeDeserializeJiebaOptions() throws Exception {
-        Options options = new Options();
-        options.set(TantivyFullTextIndexOptions.TOKENIZER, " JIEBA ");
-        options.set(TantivyFullTextIndexOptions.LOWER_CASE, true);
+        Map<String, Object> options = new HashMap<>();
+        options.put("tokenizer", " JIEBA ");
+        options.put("lower-case", true);
 
         TantivyFullTextIndexOptions indexOptions =
                 TantivyFullTextIndexOptions.deserialize(
-                        TantivyFullTextIndexOptions.from(options).serialize());
+                        new TantivyFullTextIndexOptions(options).serialize());
 
         assertThat(indexOptions.tokenizer()).isEqualTo("jieba");
         assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
@@ -137,122 +135,26 @@ public class TantivyFullTextIndexOptionsTest {
     }
 
     @Test
-    public void testDeserializeLegacyBinaryNgramOptions() throws Exception {
-        TantivyFullTextIndexOptions indexOptions =
-                TantivyFullTextIndexOptions.deserialize(
-                        legacyBinaryMeta(" NGRAM ", 2, 3, true, false));
-
-        assertThat(indexOptions.tokenizer()).isEqualTo("ngram");
-        assertThat(indexOptions.ngramMinGram()).isEqualTo(2);
-        assertThat(indexOptions.ngramMaxGram()).isEqualTo(3);
-        assertThat(indexOptions.ngramPrefixOnly()).isTrue();
-        assertThat(indexOptions.lowerCase()).isFalse();
-        assertThat(indexOptions.maxTokenLength()).isEqualTo(40);
-        assertThat(indexOptions.asciiFolding()).isFalse();
-        assertThat(indexOptions.stem()).isFalse();
-        assertThat(indexOptions.language()).isEqualTo("english");
-        assertThat(indexOptions.removeStopWords()).isFalse();
-        assertThat(indexOptions.stopWords()).isEmpty();
-        assertThat(indexOptions.withPosition()).isTrue();
-    }
-
-    @Test
-    public void testDeserializeLegacyBinaryAnalyzerOptions() throws Exception {
-        TantivyFullTextIndexOptions indexOptions =
-                TantivyFullTextIndexOptions.deserialize(
-                        legacyBinaryMeta(
-                                " WHITESPACE ",
-                                2,
-                                2,
-                                false,
-                                false,
-                                12,
-                                true,
-                                true,
-                                "English",
-                                true,
-                                "paimon;lake",
-                                false));
-
-        assertThat(indexOptions.tokenizer()).isEqualTo("whitespace");
-        assertThat(indexOptions.lowerCase()).isFalse();
-        assertThat(indexOptions.maxTokenLength()).isEqualTo(12);
-        assertThat(indexOptions.asciiFolding()).isTrue();
-        assertThat(indexOptions.stem()).isTrue();
-        assertThat(indexOptions.language()).isEqualTo("english");
-        assertThat(indexOptions.removeStopWords()).isTrue();
-        assertThat(indexOptions.stopWords()).isEqualTo("paimon;lake");
-        assertThat(indexOptions.withPosition()).isFalse();
-    }
-
-    @Test
     public void testValidateTokenizerOptions() {
-        assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ik", 2, 2, false, true))
+        Map<String, Object> unsupportedTokenizerOptions = new HashMap<>();
+        unsupportedTokenizerOptions.put("tokenizer", "ik");
+        assertThatThrownBy(() -> new TantivyFullTextIndexOptions(unsupportedTokenizerOptions))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported Tantivy tokenizer");
 
-        assertThatThrownBy(() -> new TantivyFullTextIndexOptions("ngram", 3, 2, false, true))
+        Map<String, Object> invalidNgramOptions = new HashMap<>();
+        invalidNgramOptions.put("tokenizer", "ngram");
+        invalidNgramOptions.put("ngram.min-gram", 3);
+        invalidNgramOptions.put("ngram.max-gram", 2);
+        assertThatThrownBy(() -> new TantivyFullTextIndexOptions(invalidNgramOptions))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("ngram min gram must not be greater than max gram");
 
-        assertThatThrownBy(
-                        () ->
-                                new TantivyFullTextIndexOptions(
-                                        "default", 2, 2, false, true, 40, false, true, "klingon",
-                                        false, "", true))
+        Map<String, Object> unsupportedLanguageOptions = new HashMap<>();
+        unsupportedLanguageOptions.put("stem", true);
+        unsupportedLanguageOptions.put("language", "klingon");
+        assertThatThrownBy(() -> new TantivyFullTextIndexOptions(unsupportedLanguageOptions))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unsupported Tantivy language");
-    }
-
-    private static byte[] legacyBinaryMeta(
-            String tokenizer,
-            int ngramMinGram,
-            int ngramMaxGram,
-            boolean ngramPrefixOnly,
-            boolean lowerCase)
-            throws Exception {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(bytes);
-        out.writeInt(1);
-        out.writeUTF(tokenizer);
-        out.writeInt(ngramMinGram);
-        out.writeInt(ngramMaxGram);
-        out.writeBoolean(ngramPrefixOnly);
-        out.writeBoolean(lowerCase);
-        out.flush();
-        return bytes.toByteArray();
-    }
-
-    private static byte[] legacyBinaryMeta(
-            String tokenizer,
-            int ngramMinGram,
-            int ngramMaxGram,
-            boolean ngramPrefixOnly,
-            boolean lowerCase,
-            int maxTokenLength,
-            boolean asciiFolding,
-            boolean stem,
-            String language,
-            boolean removeStopWords,
-            String stopWords,
-            boolean withPosition)
-            throws Exception {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(bytes);
-        out.writeInt(1);
-        out.writeUTF(tokenizer);
-        out.writeInt(ngramMinGram);
-        out.writeInt(ngramMaxGram);
-        out.writeBoolean(ngramPrefixOnly);
-        out.writeBoolean(lowerCase);
-        out.writeInt(maxTokenLength);
-        out.writeBoolean(asciiFolding);
-        out.writeBoolean(stem);
-        out.writeUTF(language);
-        out.writeBoolean(removeStopWords);
-        out.writeUTF(stopWords);
-        out.writeBoolean(withPosition);
-        out.flush();
-        return bytes.toByteArray();
     }
 }

--- a/paimon-tantivy/paimon-tantivy-jni/README.md
+++ b/paimon-tantivy/paimon-tantivy-jni/README.md
@@ -104,3 +104,19 @@ try (TantivySearcher searcher =
     System.out.println(result.size());
 }
 ```
+
+For analyzer customization, pass a JSON tokenizer config. This supports the same base tokenizers
+and token filters as the global index options:
+
+```java
+String configJson =
+        "{\"tokenizer\":\"simple\",\"stem\":true,\"removeStopWords\":true,"
+                + "\"language\":\"english\"}";
+try (TantivyIndexWriter writer = new TantivyIndexWriter("/tmp/my_index", configJson);
+        TantivySearcher searcher = new TantivySearcher("/tmp/my_index", configJson)) {
+    writer.addDocument(1L, "running with Apache Paimon");
+    writer.commit();
+    SearchResult result = searcher.search("run", 10, "and");
+    System.out.println(result.size());
+}
+```

--- a/paimon-tantivy/paimon-tantivy-jni/README.md
+++ b/paimon-tantivy/paimon-tantivy-jni/README.md
@@ -110,7 +110,7 @@ and token filters as the global index options:
 
 ```java
 String configJson =
-        "{\"tokenizer\":\"simple\",\"stem\":true,\"removeStopWords\":true,"
+        "{\"tokenizer\":\"simple\",\"stem\":true,\"remove-stop-words\":true,"
                 + "\"language\":\"english\"}";
 try (TantivyIndexWriter writer = new TantivyIndexWriter("/tmp/my_index", configJson);
         TantivySearcher searcher = new TantivySearcher("/tmp/my_index", configJson)) {

--- a/paimon-tantivy/paimon-tantivy-jni/README.md
+++ b/paimon-tantivy/paimon-tantivy-jni/README.md
@@ -69,3 +69,38 @@ try (TantivySearcher searcher = new TantivySearcher("/tmp/my_index")) {
     }
 }
 ```
+
+### Tokenizers
+
+Use the tokenizer-aware constructors when indexing Chinese text or other content that should match
+short character fragments:
+
+```java
+try (TantivyIndexWriter writer =
+        new TantivyIndexWriter("/tmp/my_index", "ngram", 2, 2, false, true)) {
+    writer.addDocument(1L, "Apache Paimon 支持中文全文检索");
+    writer.commit();
+}
+
+try (TantivySearcher searcher =
+        new TantivySearcher("/tmp/my_index", "ngram", 2, 2, false, true)) {
+    SearchResult result = searcher.search("中文", 10);
+    System.out.println(result.size());
+}
+```
+
+Use `jieba` for Chinese word segmentation:
+
+```java
+try (TantivyIndexWriter writer =
+        new TantivyIndexWriter("/tmp/my_index", "jieba", 2, 2, false, true)) {
+    writer.addDocument(1L, "张华在百货公司当售货员");
+    writer.commit();
+}
+
+try (TantivySearcher searcher =
+        new TantivySearcher("/tmp/my_index", "jieba", 2, 2, false, true)) {
+    SearchResult result = searcher.search("售货员", 10);
+    System.out.println(result.size());
+}
+```

--- a/paimon-tantivy/paimon-tantivy-jni/rust/Cargo.toml
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 jni = "0.21"
 tantivy = "0.22"
+tantivy-jieba = "0.11.0"
 serde_json = "1"

--- a/paimon-tantivy/paimon-tantivy-jni/rust/Cargo.toml
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 jni = "0.21"
 tantivy = "0.22"
 tantivy-jieba = "0.11.0"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
@@ -20,13 +20,18 @@ mod jni_directory;
 use jni::objects::{JClass, JObject, JString, JValue};
 use jni::sys::{jboolean, jfloat, jint, jlong, jobject};
 use jni::JNIEnv;
+use serde::Deserialize;
 use std::ptr;
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::{
     Field, IndexRecordOption, NumericOptions, Schema, TextFieldIndexing, TextOptions,
 };
-use tantivy::tokenizer::{LowerCaser, NgramTokenizer, TextAnalyzer};
+use tantivy::tokenizer::{
+    AsciiFoldingFilter, Language, LowerCaser, NgramTokenizer, RawTokenizer, RemoveLongFilter,
+    SimpleTokenizer, Stemmer, StopWordFilter, TextAnalyzer, TextAnalyzerBuilder,
+    WhitespaceTokenizer,
+};
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy};
 use tantivy_jieba::JiebaTokenizer;
 
@@ -56,63 +61,176 @@ struct TantivySearcherHandle {
     text_field: Field,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
 struct TokenizerConfig {
-    name: String,
-    min_gram: usize,
-    max_gram: usize,
-    prefix_only: bool,
+    tokenizer: String,
+    ngram_min_gram: usize,
+    ngram_max_gram: usize,
+    ngram_prefix_only: bool,
     lower_case: bool,
+    max_token_length: usize,
+    ascii_folding: bool,
+    stem: bool,
+    language: String,
+    remove_stop_words: bool,
+    stop_words: Vec<String>,
+    with_position: bool,
 }
 
 impl Default for TokenizerConfig {
     fn default() -> Self {
         Self {
-            name: "default".to_string(),
-            min_gram: 2,
-            max_gram: 2,
-            prefix_only: false,
+            tokenizer: "default".to_string(),
+            ngram_min_gram: 2,
+            ngram_max_gram: 2,
+            ngram_prefix_only: false,
             lower_case: true,
+            max_token_length: 40,
+            ascii_folding: false,
+            stem: false,
+            language: "english".to_string(),
+            remove_stop_words: false,
+            stop_words: Vec::new(),
+            with_position: true,
         }
     }
 }
 
 impl TokenizerConfig {
     fn tokenizer_name(&self) -> &str {
-        match self.name.as_str() {
+        match self.tokenizer.as_str() {
             "ngram" => "paimon_ngram",
             "jieba" => "paimon_jieba",
-            _ => &self.name,
+            "simple" | "whitespace" | "raw" => "paimon_custom",
+            "default" if self.needs_custom_default_tokenizer() => "paimon_custom",
+            _ => &self.tokenizer,
+        }
+    }
+
+    fn needs_custom_default_tokenizer(&self) -> bool {
+        self.max_token_length != 40
+            || !self.lower_case
+            || self.ascii_folding
+            || self.stem
+            || self.remove_stop_words
+            || !self.stop_words.is_empty()
+    }
+
+    fn normalize(mut self) -> Result<Self, String> {
+        self.tokenizer = self.tokenizer.trim().to_lowercase();
+        self.language = self.language.trim().to_lowercase();
+        self.stop_words = self
+            .stop_words
+            .into_iter()
+            .map(|word| word.trim().to_string())
+            .filter(|word| !word.is_empty())
+            .collect();
+        self.validate()?;
+        Ok(self)
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        match self.tokenizer.as_str() {
+            "default" | "simple" | "whitespace" | "raw" | "ngram" | "jieba" => {}
+            _ => return Err(format!("Unsupported tokenizer: {}", self.tokenizer)),
+        }
+        if self.ngram_min_gram == 0 {
+            return Err("minGram must be positive, got 0".to_string());
+        }
+        if self.ngram_max_gram == 0 {
+            return Err("maxGram must be positive, got 0".to_string());
+        }
+        if self.ngram_min_gram > self.ngram_max_gram {
+            return Err(format!(
+                "minGram must not be greater than maxGram, got {} > {}",
+                self.ngram_min_gram, self.ngram_max_gram
+            ));
+        }
+        if self.max_token_length == 0 {
+            return Err("maxTokenLength must be positive, got 0".to_string());
+        }
+        self.language()?;
+        Ok(())
+    }
+
+    fn language(&self) -> Result<Language, String> {
+        match self.language.as_str() {
+            "arabic" => Ok(Language::Arabic),
+            "danish" => Ok(Language::Danish),
+            "dutch" => Ok(Language::Dutch),
+            "english" => Ok(Language::English),
+            "finnish" => Ok(Language::Finnish),
+            "french" => Ok(Language::French),
+            "german" => Ok(Language::German),
+            "greek" => Ok(Language::Greek),
+            "hungarian" => Ok(Language::Hungarian),
+            "italian" => Ok(Language::Italian),
+            "norwegian" => Ok(Language::Norwegian),
+            "portuguese" => Ok(Language::Portuguese),
+            "romanian" => Ok(Language::Romanian),
+            "russian" => Ok(Language::Russian),
+            "spanish" => Ok(Language::Spanish),
+            "swedish" => Ok(Language::Swedish),
+            "tamil" => Ok(Language::Tamil),
+            "turkish" => Ok(Language::Turkish),
+            _ => Err(format!("Unsupported language: {}", self.language)),
         }
     }
 }
 
-fn register_tokenizer(index: &Index, config: &TokenizerConfig) -> tantivy::Result<()> {
-    if config.name == "ngram" {
-        let tokenizer = NgramTokenizer::new(config.min_gram, config.max_gram, config.prefix_only)?;
-        if config.lower_case {
-            index.tokenizers().register(
-                config.tokenizer_name(),
-                TextAnalyzer::builder(tokenizer).filter(LowerCaser).build(),
-            );
-        } else {
-            index
-                .tokenizers()
-                .register(config.tokenizer_name(), tokenizer);
-        }
-    } else if config.name == "jieba" {
-        let tokenizer = JiebaTokenizer {};
-        if config.lower_case {
-            index.tokenizers().register(
-                config.tokenizer_name(),
-                TextAnalyzer::builder(tokenizer).filter(LowerCaser).build(),
-            );
-        } else {
-            index
-                .tokenizers()
-                .register(config.tokenizer_name(), tokenizer);
-        }
+fn build_base_analyzer(config: &TokenizerConfig) -> Result<TextAnalyzerBuilder, String> {
+    match config.tokenizer.as_str() {
+        "default" | "simple" => Ok(TextAnalyzer::builder(SimpleTokenizer::default()).dynamic()),
+        "whitespace" => Ok(TextAnalyzer::builder(WhitespaceTokenizer::default()).dynamic()),
+        "raw" => Ok(TextAnalyzer::builder(RawTokenizer::default()).dynamic()),
+        "ngram" => Ok(TextAnalyzer::builder(
+            NgramTokenizer::new(
+                config.ngram_min_gram,
+                config.ngram_max_gram,
+                config.ngram_prefix_only,
+            )
+            .map_err(|e| e.to_string())?,
+        )
+        .dynamic()),
+        "jieba" => Ok(TextAnalyzer::builder(JiebaTokenizer {}).dynamic()),
+        _ => Err(format!("Unsupported tokenizer: {}", config.tokenizer)),
     }
+}
+
+fn build_analyzer(config: &TokenizerConfig) -> Result<TextAnalyzer, String> {
+    let mut analyzer_builder = build_base_analyzer(config)?;
+    analyzer_builder =
+        analyzer_builder.filter_dynamic(RemoveLongFilter::limit(config.max_token_length));
+    if config.lower_case {
+        analyzer_builder = analyzer_builder.filter_dynamic(LowerCaser);
+    }
+    if config.ascii_folding {
+        analyzer_builder = analyzer_builder.filter_dynamic(AsciiFoldingFilter);
+    }
+    if config.stem {
+        analyzer_builder = analyzer_builder.filter_dynamic(Stemmer::new(config.language()?));
+    }
+    if config.remove_stop_words {
+        let stop_word_filter = StopWordFilter::new(config.language()?).ok_or_else(|| {
+            format!(
+                "Removing stop words for language '{}' is not supported",
+                config.language
+            )
+        })?;
+        analyzer_builder = analyzer_builder.filter_dynamic(stop_word_filter);
+    }
+    if !config.stop_words.is_empty() {
+        analyzer_builder =
+            analyzer_builder.filter_dynamic(StopWordFilter::remove(config.stop_words.clone()));
+    }
+    Ok(analyzer_builder.build())
+}
+
+fn register_tokenizer(index: &Index, config: &TokenizerConfig) -> Result<(), String> {
+    index
+        .tokenizers()
+        .register(config.tokenizer_name(), build_analyzer(config)?);
     Ok(())
 }
 
@@ -129,38 +247,43 @@ fn tokenizer_config_from_java(
         .map_err(|e| format!("Failed to get tokenizer name: {}", e))?
         .into();
     let name = name.trim().to_lowercase();
-    if name != "default" && name != "ngram" && name != "jieba" {
-        return Err(format!("Unsupported tokenizer: {}", name));
-    }
-    if min_gram <= 0 {
-        return Err(format!("minGram must be positive, got {}", min_gram));
-    }
-    if max_gram <= 0 {
-        return Err(format!("maxGram must be positive, got {}", max_gram));
-    }
-    if min_gram > max_gram {
-        return Err(format!(
-            "minGram must not be greater than maxGram, got {} > {}",
-            min_gram, max_gram
-        ));
-    }
-    Ok(TokenizerConfig {
-        name,
-        min_gram: min_gram as usize,
-        max_gram: max_gram as usize,
-        prefix_only: prefix_only != 0,
+    TokenizerConfig {
+        tokenizer: name,
+        ngram_min_gram: min_gram as usize,
+        ngram_max_gram: max_gram as usize,
+        ngram_prefix_only: prefix_only != 0,
         lower_case: lower_case != 0,
-    })
+        ..TokenizerConfig::default()
+    }
+    .normalize()
+}
+
+fn tokenizer_config_from_json(
+    env: &mut JNIEnv,
+    config_json: JString,
+) -> Result<TokenizerConfig, String> {
+    let json: String = env
+        .get_string(&config_json)
+        .map_err(|e| format!("Failed to get tokenizer config: {}", e))?
+        .into();
+    serde_json::from_str::<TokenizerConfig>(&json)
+        .map_err(|e| format!("Failed to parse tokenizer config: {}", e))?
+        .normalize()
 }
 
 fn build_schema(config: &TokenizerConfig) -> (Schema, Field, Field) {
     let mut builder = Schema::builder();
     let row_id_field =
         builder.add_u64_field("row_id", NumericOptions::default().set_indexed().set_fast());
+    let index_option = if config.with_position {
+        IndexRecordOption::WithFreqsAndPositions
+    } else {
+        IndexRecordOption::WithFreqs
+    };
     let text_options = TextOptions::default().set_indexing_options(
         TextFieldIndexing::default()
             .set_tokenizer(config.tokenizer_name())
-            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+            .set_index_option(index_option),
     );
     let text_field = builder.add_text_field("text", text_options);
     (builder.build(), row_id_field, text_field)
@@ -350,6 +473,20 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createI
 }
 
 #[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createIndexWithTokenizerConfig(
+    mut env: JNIEnv,
+    _class: JClass,
+    index_path: JString,
+    config_json: JString,
+) -> jlong {
+    let config = match tokenizer_config_from_json(&mut env, config_json) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
+    };
+    create_index_internal(env, index_path, config)
+}
+
+#[no_mangle]
 pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_writeDocument(
     mut env: JNIEnv,
     _class: JClass,
@@ -435,6 +572,20 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openIndexW
     open_index_internal(env, index_path, config)
 }
 
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openIndexWithTokenizerConfig(
+    mut env: JNIEnv,
+    _class: JClass,
+    index_path: JString,
+    config_json: JString,
+) -> jlong {
+    let config = match tokenizer_config_from_json(&mut env, config_json) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
+    };
+    open_index_internal(env, index_path, config)
+}
+
 /// Open an index from a Java StreamFileInput callback object.
 ///
 /// fileNames: String[] — names of files in the archive
@@ -495,6 +646,30 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openFromSt
     )
 }
 
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openFromStreamWithTokenizerConfig(
+    mut env: JNIEnv,
+    _class: JClass,
+    file_names: jni::objects::JObjectArray,
+    file_offsets: jni::objects::JLongArray,
+    file_lengths: jni::objects::JLongArray,
+    stream_input: JObject,
+    config_json: JString,
+) -> jlong {
+    let config = match tokenizer_config_from_json(&mut env, config_json) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
+    };
+    open_from_stream_internal(
+        env,
+        file_names,
+        file_offsets,
+        file_lengths,
+        stream_input,
+        config,
+    )
+}
+
 /// Search and return a SearchResult(long[] rowIds, float[] scores).
 #[no_mangle]
 pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchIndex(
@@ -503,6 +678,7 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
     searcher_ptr: jlong,
     query_string: JString,
     limit: jint,
+    query_operator: JString,
 ) -> jobject {
     let handle = unsafe { &*(searcher_ptr as *const TantivySearcherHandle) };
     let query_str: String = match env.get_string(&query_string) {
@@ -511,9 +687,28 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
             return throw_and_return_null(&mut env, &format!("Failed to get query string: {}", e))
         }
     };
+    let query_operator_str: String = match env.get_string(&query_operator) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            return throw_and_return_null(&mut env, &format!("Failed to get query operator: {}", e))
+        }
+    };
+    let query_operator_str = query_operator_str.trim().to_lowercase();
+    if query_operator_str != "or" && query_operator_str != "and" {
+        return throw_and_return_null(
+            &mut env,
+            &format!(
+                "Query operator must be 'or' or 'and', got: {}",
+                query_operator_str
+            ),
+        );
+    }
 
     let searcher = handle.reader.searcher();
-    let query_parser = QueryParser::for_index(&searcher.index(), vec![handle.text_field]);
+    let mut query_parser = QueryParser::for_index(&searcher.index(), vec![handle.text_field]);
+    if query_operator_str == "and" {
+        query_parser.set_conjunction_by_default();
+    }
     let query = match query_parser.parse_query(&query_str) {
         Ok(q) => q,
         Err(e) => {

--- a/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
@@ -18,13 +18,17 @@
 mod jni_directory;
 
 use jni::objects::{JClass, JObject, JString, JValue};
-use jni::sys::{jfloat, jint, jlong, jobject};
+use jni::sys::{jboolean, jfloat, jint, jlong, jobject};
 use jni::JNIEnv;
 use std::ptr;
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
-use tantivy::schema::{Field, IndexRecordOption, NumericOptions, Schema, TextFieldIndexing, TextOptions};
+use tantivy::schema::{
+    Field, IndexRecordOption, NumericOptions, Schema, TextFieldIndexing, TextOptions,
+};
+use tantivy::tokenizer::{LowerCaser, NgramTokenizer, TextAnalyzer};
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy};
+use tantivy_jieba::JiebaTokenizer;
 
 use crate::jni_directory::JniDirectory;
 
@@ -52,36 +56,122 @@ struct TantivySearcherHandle {
     text_field: Field,
 }
 
-fn build_schema() -> (Schema, Field, Field) {
+#[derive(Clone)]
+struct TokenizerConfig {
+    name: String,
+    min_gram: usize,
+    max_gram: usize,
+    prefix_only: bool,
+    lower_case: bool,
+}
+
+impl Default for TokenizerConfig {
+    fn default() -> Self {
+        Self {
+            name: "default".to_string(),
+            min_gram: 2,
+            max_gram: 2,
+            prefix_only: false,
+            lower_case: true,
+        }
+    }
+}
+
+impl TokenizerConfig {
+    fn tokenizer_name(&self) -> &str {
+        match self.name.as_str() {
+            "ngram" => "paimon_ngram",
+            "jieba" => "paimon_jieba",
+            _ => &self.name,
+        }
+    }
+}
+
+fn register_tokenizer(index: &Index, config: &TokenizerConfig) -> tantivy::Result<()> {
+    if config.name == "ngram" {
+        let tokenizer = NgramTokenizer::new(config.min_gram, config.max_gram, config.prefix_only)?;
+        if config.lower_case {
+            index.tokenizers().register(
+                config.tokenizer_name(),
+                TextAnalyzer::builder(tokenizer).filter(LowerCaser).build(),
+            );
+        } else {
+            index
+                .tokenizers()
+                .register(config.tokenizer_name(), tokenizer);
+        }
+    } else if config.name == "jieba" {
+        let tokenizer = JiebaTokenizer {};
+        if config.lower_case {
+            index.tokenizers().register(
+                config.tokenizer_name(),
+                TextAnalyzer::builder(tokenizer).filter(LowerCaser).build(),
+            );
+        } else {
+            index
+                .tokenizers()
+                .register(config.tokenizer_name(), tokenizer);
+        }
+    }
+    Ok(())
+}
+
+fn tokenizer_config_from_java(
+    env: &mut JNIEnv,
+    tokenizer_name: JString,
+    min_gram: jint,
+    max_gram: jint,
+    prefix_only: jboolean,
+    lower_case: jboolean,
+) -> Result<TokenizerConfig, String> {
+    let name: String = env
+        .get_string(&tokenizer_name)
+        .map_err(|e| format!("Failed to get tokenizer name: {}", e))?
+        .into();
+    let name = name.trim().to_lowercase();
+    if name != "default" && name != "ngram" && name != "jieba" {
+        return Err(format!("Unsupported tokenizer: {}", name));
+    }
+    if min_gram <= 0 {
+        return Err(format!("minGram must be positive, got {}", min_gram));
+    }
+    if max_gram <= 0 {
+        return Err(format!("maxGram must be positive, got {}", max_gram));
+    }
+    if min_gram > max_gram {
+        return Err(format!(
+            "minGram must not be greater than maxGram, got {} > {}",
+            min_gram, max_gram
+        ));
+    }
+    Ok(TokenizerConfig {
+        name,
+        min_gram: min_gram as usize,
+        max_gram: max_gram as usize,
+        prefix_only: prefix_only != 0,
+        lower_case: lower_case != 0,
+    })
+}
+
+fn build_schema(config: &TokenizerConfig) -> (Schema, Field, Field) {
     let mut builder = Schema::builder();
-    let row_id_field = builder.add_u64_field(
-        "row_id",
-        NumericOptions::default().set_indexed().set_fast(),
-    );
+    let row_id_field =
+        builder.add_u64_field("row_id", NumericOptions::default().set_indexed().set_fast());
     let text_options = TextOptions::default().set_indexing_options(
         TextFieldIndexing::default()
-            .set_tokenizer("default")
+            .set_tokenizer(config.tokenizer_name())
             .set_index_option(IndexRecordOption::WithFreqsAndPositions),
     );
     let text_field = builder.add_text_field("text", text_options);
     (builder.build(), row_id_field, text_field)
 }
 
-// ---------------------------------------------------------------------------
-// TantivyIndexWriter native methods
-// ---------------------------------------------------------------------------
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createIndex(
-    mut env: JNIEnv,
-    _class: JClass,
-    index_path: JString,
-) -> jlong {
+fn create_index_internal(mut env: JNIEnv, index_path: JString, config: TokenizerConfig) -> jlong {
     let path: String = match env.get_string(&index_path) {
         Ok(s) => s.into(),
         Err(e) => return throw_and_return(&mut env, &format!("Failed to get index path: {}", e)),
     };
-    let (schema, row_id_field, text_field) = build_schema();
+    let (schema, row_id_field, text_field) = build_schema(&config);
 
     let dir = std::path::Path::new(&path);
     if let Err(e) = std::fs::create_dir_all(dir) {
@@ -91,6 +181,9 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createI
         Ok(i) => i,
         Err(e) => return throw_and_return(&mut env, &format!("Failed to create index: {}", e)),
     };
+    if let Err(e) = register_tokenizer(&index, &config) {
+        return throw_and_return(&mut env, &format!("Failed to register tokenizer: {}", e));
+    }
     let writer = match index.writer(50_000_000) {
         Ok(w) => w,
         Err(e) => return throw_and_return(&mut env, &format!("Failed to create writer: {}", e)),
@@ -102,6 +195,158 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createI
         text_field,
     });
     Box::into_raw(handle) as jlong
+}
+
+fn open_index_internal(mut env: JNIEnv, index_path: JString, config: TokenizerConfig) -> jlong {
+    let path: String = match env.get_string(&index_path) {
+        Ok(s) => s.into(),
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to get index path: {}", e)),
+    };
+    let index = match Index::open_in_dir(&path) {
+        Ok(i) => i,
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to open index: {}", e)),
+    };
+    if let Err(e) = register_tokenizer(&index, &config) {
+        return throw_and_return(&mut env, &format!("Failed to register tokenizer: {}", e));
+    }
+    let schema = index.schema();
+
+    let text_field = schema.get_field("text").unwrap();
+
+    let reader = match index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
+        .try_into()
+    {
+        Ok(r) => r,
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to create reader: {}", e)),
+    };
+
+    let handle = Box::new(TantivySearcherHandle { reader, text_field });
+    Box::into_raw(handle) as jlong
+}
+
+fn open_from_stream_internal(
+    mut env: JNIEnv,
+    file_names: jni::objects::JObjectArray,
+    file_offsets: jni::objects::JLongArray,
+    file_lengths: jni::objects::JLongArray,
+    stream_input: JObject,
+    config: TokenizerConfig,
+) -> jlong {
+    // Parse file metadata from Java arrays
+    let count = match env.get_array_length(&file_names) {
+        Ok(c) => c as usize,
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to get array length: {}", e)),
+    };
+    let mut offsets_buf = vec![0i64; count];
+    let mut lengths_buf = vec![0i64; count];
+    if let Err(e) = env.get_long_array_region(&file_offsets, 0, &mut offsets_buf) {
+        return throw_and_return(&mut env, &format!("Failed to get offsets: {}", e));
+    }
+    if let Err(e) = env.get_long_array_region(&file_lengths, 0, &mut lengths_buf) {
+        return throw_and_return(&mut env, &format!("Failed to get lengths: {}", e));
+    }
+
+    let mut files = Vec::with_capacity(count);
+    for i in 0..count {
+        let obj = match env.get_object_array_element(&file_names, i as i32) {
+            Ok(o) => o,
+            Err(e) => {
+                return throw_and_return(
+                    &mut env,
+                    &format!("Failed to get file name at {}: {}", i, e),
+                )
+            }
+        };
+        let jstr = JString::from(obj);
+        let name: String = match env.get_string(&jstr) {
+            Ok(s) => s.into(),
+            Err(e) => {
+                return throw_and_return(&mut env, &format!("Failed to convert file name: {}", e))
+            }
+        };
+        files.push((name, offsets_buf[i] as u64, lengths_buf[i] as u64));
+    }
+
+    // Create a global ref to the Java stream callback
+    let jvm = match env.get_java_vm() {
+        Ok(v) => v,
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to get JVM: {}", e)),
+    };
+    let stream_ref = match env.new_global_ref(stream_input) {
+        Ok(r) => r,
+        Err(e) => {
+            return throw_and_return(&mut env, &format!("Failed to create global ref: {}", e))
+        }
+    };
+
+    let directory = JniDirectory::new(jvm, stream_ref, files);
+    let index = match Index::open(directory) {
+        Ok(i) => i,
+        Err(e) => {
+            return throw_and_return(
+                &mut env,
+                &format!("Failed to open index from stream: {}", e),
+            )
+        }
+    };
+    if let Err(e) = register_tokenizer(&index, &config) {
+        return throw_and_return(&mut env, &format!("Failed to register tokenizer: {}", e));
+    }
+    let schema = index.schema();
+
+    let text_field = schema.get_field("text").unwrap();
+
+    let reader = match index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()
+    {
+        Ok(r) => r,
+        Err(e) => return throw_and_return(&mut env, &format!("Failed to create reader: {}", e)),
+    };
+
+    let handle = Box::new(TantivySearcherHandle { reader, text_field });
+    Box::into_raw(handle) as jlong
+}
+
+// ---------------------------------------------------------------------------
+// TantivyIndexWriter native methods
+// ---------------------------------------------------------------------------
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createIndex(
+    env: JNIEnv,
+    _class: JClass,
+    index_path: JString,
+) -> jlong {
+    create_index_internal(env, index_path, TokenizerConfig::default())
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_createIndexWithTokenizer(
+    mut env: JNIEnv,
+    _class: JClass,
+    index_path: JString,
+    tokenizer_name: JString,
+    min_gram: jint,
+    max_gram: jint,
+    prefix_only: jboolean,
+    lower_case: jboolean,
+) -> jlong {
+    let config = match tokenizer_config_from_java(
+        &mut env,
+        tokenizer_name,
+        min_gram,
+        max_gram,
+        prefix_only,
+        lower_case,
+    ) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
+    };
+    create_index_internal(env, index_path, config)
 }
 
 #[no_mangle]
@@ -158,36 +403,36 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivyIndexWriter_freeInd
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openIndex(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
     index_path: JString,
 ) -> jlong {
-    let path: String = match env.get_string(&index_path) {
-        Ok(s) => s.into(),
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to get index path: {}", e)),
-    };
-    let index = match Index::open_in_dir(&path) {
-        Ok(i) => i,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to open index: {}", e)),
-    };
-    let schema = index.schema();
+    open_index_internal(env, index_path, TokenizerConfig::default())
+}
 
-    let text_field = schema.get_field("text").unwrap();
-
-    let reader = match index
-        .reader_builder()
-        .reload_policy(ReloadPolicy::OnCommitWithDelay)
-        .try_into()
-    {
-        Ok(r) => r,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to create reader: {}", e)),
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openIndexWithTokenizer(
+    mut env: JNIEnv,
+    _class: JClass,
+    index_path: JString,
+    tokenizer_name: JString,
+    min_gram: jint,
+    max_gram: jint,
+    prefix_only: jboolean,
+    lower_case: jboolean,
+) -> jlong {
+    let config = match tokenizer_config_from_java(
+        &mut env,
+        tokenizer_name,
+        min_gram,
+        max_gram,
+        prefix_only,
+        lower_case,
+    ) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
     };
-
-    let handle = Box::new(TantivySearcherHandle {
-        reader,
-        text_field,
-    });
-    Box::into_raw(handle) as jlong
+    open_index_internal(env, index_path, config)
 }
 
 /// Open an index from a Java StreamFileInput callback object.
@@ -198,74 +443,56 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openIndex(
 /// streamInput: StreamFileInput — Java object with seek(long) and read(byte[], int, int) methods
 #[no_mangle]
 pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openFromStream(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
     file_names: jni::objects::JObjectArray,
     file_offsets: jni::objects::JLongArray,
     file_lengths: jni::objects::JLongArray,
     stream_input: JObject,
 ) -> jlong {
-    // Parse file metadata from Java arrays
-    let count = match env.get_array_length(&file_names) {
-        Ok(c) => c as usize,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to get array length: {}", e)),
+    open_from_stream_internal(
+        env,
+        file_names,
+        file_offsets,
+        file_lengths,
+        stream_input,
+        TokenizerConfig::default(),
+    )
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_openFromStreamWithTokenizer(
+    mut env: JNIEnv,
+    _class: JClass,
+    file_names: jni::objects::JObjectArray,
+    file_offsets: jni::objects::JLongArray,
+    file_lengths: jni::objects::JLongArray,
+    stream_input: JObject,
+    tokenizer_name: JString,
+    min_gram: jint,
+    max_gram: jint,
+    prefix_only: jboolean,
+    lower_case: jboolean,
+) -> jlong {
+    let config = match tokenizer_config_from_java(
+        &mut env,
+        tokenizer_name,
+        min_gram,
+        max_gram,
+        prefix_only,
+        lower_case,
+    ) {
+        Ok(config) => config,
+        Err(e) => return throw_and_return(&mut env, &e),
     };
-    let mut offsets_buf = vec![0i64; count];
-    let mut lengths_buf = vec![0i64; count];
-    if let Err(e) = env.get_long_array_region(&file_offsets, 0, &mut offsets_buf) {
-        return throw_and_return(&mut env, &format!("Failed to get offsets: {}", e));
-    }
-    if let Err(e) = env.get_long_array_region(&file_lengths, 0, &mut lengths_buf) {
-        return throw_and_return(&mut env, &format!("Failed to get lengths: {}", e));
-    }
-
-    let mut files = Vec::with_capacity(count);
-    for i in 0..count {
-        let obj = match env.get_object_array_element(&file_names, i as i32) {
-            Ok(o) => o,
-            Err(e) => return throw_and_return(&mut env, &format!("Failed to get file name at {}: {}", i, e)),
-        };
-        let jstr = JString::from(obj);
-        let name: String = match env.get_string(&jstr) {
-            Ok(s) => s.into(),
-            Err(e) => return throw_and_return(&mut env, &format!("Failed to convert file name: {}", e)),
-        };
-        files.push((name, offsets_buf[i] as u64, lengths_buf[i] as u64));
-    }
-
-    // Create a global ref to the Java stream callback
-    let jvm = match env.get_java_vm() {
-        Ok(v) => v,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to get JVM: {}", e)),
-    };
-    let stream_ref = match env.new_global_ref(stream_input) {
-        Ok(r) => r,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to create global ref: {}", e)),
-    };
-
-    let directory = JniDirectory::new(jvm, stream_ref, files);
-    let index = match Index::open(directory) {
-        Ok(i) => i,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to open index from stream: {}", e)),
-    };
-    let schema = index.schema();
-
-    let text_field = schema.get_field("text").unwrap();
-
-    let reader = match index
-        .reader_builder()
-        .reload_policy(ReloadPolicy::Manual)
-        .try_into()
-    {
-        Ok(r) => r,
-        Err(e) => return throw_and_return(&mut env, &format!("Failed to create reader: {}", e)),
-    };
-
-    let handle = Box::new(TantivySearcherHandle {
-        reader,
-        text_field,
-    });
-    Box::into_raw(handle) as jlong
+    open_from_stream_internal(
+        env,
+        file_names,
+        file_offsets,
+        file_lengths,
+        stream_input,
+        config,
+    )
 }
 
 /// Search and return a SearchResult(long[] rowIds, float[] scores).
@@ -280,14 +507,21 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
     let handle = unsafe { &*(searcher_ptr as *const TantivySearcherHandle) };
     let query_str: String = match env.get_string(&query_string) {
         Ok(s) => s.into(),
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to get query string: {}", e)),
+        Err(e) => {
+            return throw_and_return_null(&mut env, &format!("Failed to get query string: {}", e))
+        }
     };
 
     let searcher = handle.reader.searcher();
     let query_parser = QueryParser::for_index(&searcher.index(), vec![handle.text_field]);
     let query = match query_parser.parse_query(&query_str) {
         Ok(q) => q,
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to parse query '{}': {}", query_str, e)),
+        Err(e) => {
+            return throw_and_return_null(
+                &mut env,
+                &format!("Failed to parse query '{}': {}", query_str, e),
+            )
+        }
     };
     let top_docs = match searcher.search(&query, &TopDocs::with_limit(limit as usize)) {
         Ok(d) => d,
@@ -299,11 +533,15 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
     // Build Java long[] and float[]
     let row_id_array = match env.new_long_array(count as i32) {
         Ok(a) => a,
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to create long array: {}", e)),
+        Err(e) => {
+            return throw_and_return_null(&mut env, &format!("Failed to create long array: {}", e))
+        }
     };
     let score_array = match env.new_float_array(count as i32) {
         Ok(a) => a,
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to create float array: {}", e)),
+        Err(e) => {
+            return throw_and_return_null(&mut env, &format!("Failed to create float array: {}", e))
+        }
     };
 
     let mut row_ids: Vec<jlong> = Vec::with_capacity(count);
@@ -314,7 +552,9 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
         let segment_reader = searcher.segment_reader(doc_address.segment_ord);
         let fast_fields = match segment_reader.fast_fields().u64("row_id") {
             Ok(f) => f,
-            Err(e) => return throw_and_return_null(&mut env, &format!("Failed to get fast field: {}", e)),
+            Err(e) => {
+                return throw_and_return_null(&mut env, &format!("Failed to get fast field: {}", e))
+            }
         };
         let row_id = fast_fields.first(doc_address.doc_id).unwrap_or(0) as jlong;
         row_ids.push(row_id);
@@ -331,7 +571,12 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
     // Construct SearchResult object
     let class = match env.find_class("org/apache/paimon/tantivy/SearchResult") {
         Ok(c) => c,
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to find SearchResult class: {}", e)),
+        Err(e) => {
+            return throw_and_return_null(
+                &mut env,
+                &format!("Failed to find SearchResult class: {}", e),
+            )
+        }
     };
     let obj = match env.new_object(
         class,
@@ -342,7 +587,12 @@ pub extern "system" fn Java_org_apache_paimon_tantivy_TantivySearcher_searchInde
         ],
     ) {
         Ok(o) => o,
-        Err(e) => return throw_and_return_null(&mut env, &format!("Failed to create SearchResult: {}", e)),
+        Err(e) => {
+            return throw_and_return_null(
+                &mut env,
+                &format!("Failed to create SearchResult: {}", e),
+            )
+        }
     };
 
     obj.into_raw()

--- a/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
+++ b/paimon-tantivy/paimon-tantivy-jni/rust/src/lib.rs
@@ -62,19 +62,28 @@ struct TantivySearcherHandle {
 }
 
 #[derive(Clone, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[serde(default)]
 struct TokenizerConfig {
     tokenizer: String,
+    #[serde(rename = "ngram.min-gram")]
     ngram_min_gram: usize,
+    #[serde(rename = "ngram.max-gram")]
     ngram_max_gram: usize,
+    #[serde(rename = "ngram.prefix-only")]
     ngram_prefix_only: bool,
+    #[serde(rename = "lower-case")]
     lower_case: bool,
+    #[serde(rename = "max-token-length")]
     max_token_length: usize,
+    #[serde(rename = "ascii-folding")]
     ascii_folding: bool,
     stem: bool,
     language: String,
+    #[serde(rename = "remove-stop-words")]
     remove_stop_words: bool,
+    #[serde(rename = "stop-words")]
     stop_words: Vec<String>,
+    #[serde(rename = "with-position")]
     with_position: bool,
 }
 
@@ -136,19 +145,19 @@ impl TokenizerConfig {
             _ => return Err(format!("Unsupported tokenizer: {}", self.tokenizer)),
         }
         if self.ngram_min_gram == 0 {
-            return Err("minGram must be positive, got 0".to_string());
+            return Err("ngram.min-gram must be positive, got 0".to_string());
         }
         if self.ngram_max_gram == 0 {
-            return Err("maxGram must be positive, got 0".to_string());
+            return Err("ngram.max-gram must be positive, got 0".to_string());
         }
         if self.ngram_min_gram > self.ngram_max_gram {
             return Err(format!(
-                "minGram must not be greater than maxGram, got {} > {}",
+                "ngram.min-gram must not be greater than ngram.max-gram, got {} > {}",
                 self.ngram_min_gram, self.ngram_max_gram
             ));
         }
         if self.max_token_length == 0 {
-            return Err("maxTokenLength must be positive, got 0".to_string());
+            return Err("max-token-length must be positive, got 0".to_string());
         }
         self.language()?;
         Ok(())

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
@@ -40,21 +40,10 @@ public class TantivyIndexWriter implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
-        this(
-                indexPath,
-                "{\"tokenizer\":\""
-                        + tokenizerName
-                        + "\",\"ngramMinGram\":"
-                        + minGram
-                        + ",\"ngramMaxGram\":"
-                        + maxGram
-                        + ",\"ngramPrefixOnly\":"
-                        + prefixOnly
-                        + ",\"lowerCase\":"
-                        + lowerCase
-                        + ",\"maxTokenLength\":40,\"asciiFolding\":false,\"stem\":false,"
-                        + "\"language\":\"english\",\"removeStopWords\":false,"
-                        + "\"stopWords\":[],\"withPosition\":true}");
+        this.indexPtr =
+                createIndexWithTokenizer(
+                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+        this.closed = false;
     }
 
     public TantivyIndexWriter(String indexPath, String configJson) {

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
@@ -33,6 +33,19 @@ public class TantivyIndexWriter implements AutoCloseable {
         this.closed = false;
     }
 
+    public TantivyIndexWriter(
+            String indexPath,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase) {
+        this.indexPtr =
+                createIndexWithTokenizer(
+                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+        this.closed = false;
+    }
+
     public void addDocument(long rowId, String text) {
         checkNotClosed();
         writeDocument(indexPtr, rowId, text);
@@ -61,6 +74,14 @@ public class TantivyIndexWriter implements AutoCloseable {
     // ---- native methods ----
 
     static native long createIndex(String indexPath);
+
+    static native long createIndexWithTokenizer(
+            String indexPath,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase);
 
     static native void writeDocument(long indexPtr, long rowId, String text);
 

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivyIndexWriter.java
@@ -40,9 +40,26 @@ public class TantivyIndexWriter implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
+        this(
+                indexPath,
+                "{\"tokenizer\":\""
+                        + tokenizerName
+                        + "\",\"ngramMinGram\":"
+                        + minGram
+                        + ",\"ngramMaxGram\":"
+                        + maxGram
+                        + ",\"ngramPrefixOnly\":"
+                        + prefixOnly
+                        + ",\"lowerCase\":"
+                        + lowerCase
+                        + ",\"maxTokenLength\":40,\"asciiFolding\":false,\"stem\":false,"
+                        + "\"language\":\"english\",\"removeStopWords\":false,"
+                        + "\"stopWords\":[],\"withPosition\":true}");
+    }
+
+    public TantivyIndexWriter(String indexPath, String configJson) {
         this.indexPtr =
-                createIndexWithTokenizer(
-                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+                createIndexWithTokenizerConfig(indexPath, configJson);
         this.closed = false;
     }
 
@@ -82,6 +99,8 @@ public class TantivyIndexWriter implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase);
+
+    static native long createIndexWithTokenizerConfig(String indexPath, String configJson);
 
     static native void writeDocument(long indexPtr, long rowId, String text);
 

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
@@ -41,7 +41,10 @@ public class TantivySearcher implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
-        this(indexPath, defaultConfigJson(tokenizerName, minGram, maxGram, prefixOnly, lowerCase));
+        this.searcherPtr =
+                openIndexWithTokenizer(
+                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+        this.closed = false;
     }
 
     public TantivySearcher(String indexPath, String configJson) {
@@ -76,12 +79,18 @@ public class TantivySearcher implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
-        this(
-                fileNames,
-                fileOffsets,
-                fileLengths,
-                streamInput,
-                defaultConfigJson(tokenizerName, minGram, maxGram, prefixOnly, lowerCase));
+        this.searcherPtr =
+                openFromStreamWithTokenizer(
+                        fileNames,
+                        fileOffsets,
+                        fileLengths,
+                        streamInput,
+                        tokenizerName,
+                        minGram,
+                        maxGram,
+                        prefixOnly,
+                        lowerCase);
+        this.closed = false;
     }
 
     public TantivySearcher(
@@ -171,20 +180,4 @@ public class TantivySearcher implements AutoCloseable {
 
     static native void freeSearcher(long searcherPtr);
 
-    private static String defaultConfigJson(
-            String tokenizerName, int minGram, int maxGram, boolean prefixOnly, boolean lowerCase) {
-        return "{\"tokenizer\":\""
-                + tokenizerName
-                + "\",\"ngramMinGram\":"
-                + minGram
-                + ",\"ngramMaxGram\":"
-                + maxGram
-                + ",\"ngramPrefixOnly\":"
-                + prefixOnly
-                + ",\"lowerCase\":"
-                + lowerCase
-                + ",\"maxTokenLength\":40,\"asciiFolding\":false,\"stem\":false,"
-                + "\"language\":\"english\",\"removeStopWords\":false,"
-                + "\"stopWords\":[],\"withPosition\":true}";
-    }
 }

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
@@ -41,9 +41,11 @@ public class TantivySearcher implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
-        this.searcherPtr =
-                openIndexWithTokenizer(
-                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+        this(indexPath, defaultConfigJson(tokenizerName, minGram, maxGram, prefixOnly, lowerCase));
+    }
+
+    public TantivySearcher(String indexPath, String configJson) {
+        this.searcherPtr = openIndexWithTokenizerConfig(indexPath, configJson);
         this.closed = false;
     }
 
@@ -74,17 +76,23 @@ public class TantivySearcher implements AutoCloseable {
             int maxGram,
             boolean prefixOnly,
             boolean lowerCase) {
+        this(
+                fileNames,
+                fileOffsets,
+                fileLengths,
+                streamInput,
+                defaultConfigJson(tokenizerName, minGram, maxGram, prefixOnly, lowerCase));
+    }
+
+    public TantivySearcher(
+            String[] fileNames,
+            long[] fileOffsets,
+            long[] fileLengths,
+            StreamFileInput streamInput,
+            String configJson) {
         this.searcherPtr =
-                openFromStreamWithTokenizer(
-                        fileNames,
-                        fileOffsets,
-                        fileLengths,
-                        streamInput,
-                        tokenizerName,
-                        minGram,
-                        maxGram,
-                        prefixOnly,
-                        lowerCase);
+                openFromStreamWithTokenizerConfig(
+                        fileNames, fileOffsets, fileLengths, streamInput, configJson);
         this.closed = false;
     }
 
@@ -96,8 +104,12 @@ public class TantivySearcher implements AutoCloseable {
      * @return search results containing rowIds and scores
      */
     public SearchResult search(String queryString, int limit) {
+        return search(queryString, limit, "or");
+    }
+
+    public SearchResult search(String queryString, int limit, String queryOperator) {
         checkNotClosed();
-        return searchIndex(searcherPtr, queryString, limit);
+        return searchIndex(searcherPtr, queryString, limit, queryOperator);
     }
 
     @Override
@@ -131,6 +143,8 @@ public class TantivySearcher implements AutoCloseable {
             boolean prefixOnly,
             boolean lowerCase);
 
+    static native long openIndexWithTokenizerConfig(String indexPath, String configJson);
+
     static native long openFromStream(
             String[] fileNames, long[] fileOffsets, long[] fileLengths, StreamFileInput streamInput);
 
@@ -145,7 +159,32 @@ public class TantivySearcher implements AutoCloseable {
             boolean prefixOnly,
             boolean lowerCase);
 
-    static native SearchResult searchIndex(long searcherPtr, String queryString, int limit);
+    static native long openFromStreamWithTokenizerConfig(
+            String[] fileNames,
+            long[] fileOffsets,
+            long[] fileLengths,
+            StreamFileInput streamInput,
+            String configJson);
+
+    static native SearchResult searchIndex(
+            long searcherPtr, String queryString, int limit, String queryOperator);
 
     static native void freeSearcher(long searcherPtr);
+
+    private static String defaultConfigJson(
+            String tokenizerName, int minGram, int maxGram, boolean prefixOnly, boolean lowerCase) {
+        return "{\"tokenizer\":\""
+                + tokenizerName
+                + "\",\"ngramMinGram\":"
+                + minGram
+                + ",\"ngramMaxGram\":"
+                + maxGram
+                + ",\"ngramPrefixOnly\":"
+                + prefixOnly
+                + ",\"lowerCase\":"
+                + lowerCase
+                + ",\"maxTokenLength\":40,\"asciiFolding\":false,\"stem\":false,"
+                + "\"language\":\"english\",\"removeStopWords\":false,"
+                + "\"stopWords\":[],\"withPosition\":true}";
+    }
 }

--- a/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/main/java/org/apache/paimon/tantivy/TantivySearcher.java
@@ -34,6 +34,19 @@ public class TantivySearcher implements AutoCloseable {
         this.closed = false;
     }
 
+    public TantivySearcher(
+            String indexPath,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase) {
+        this.searcherPtr =
+                openIndexWithTokenizer(
+                        indexPath, tokenizerName, minGram, maxGram, prefixOnly, lowerCase);
+        this.closed = false;
+    }
+
     /**
      * Open a searcher from a stream-backed archive.
      *
@@ -48,6 +61,30 @@ public class TantivySearcher implements AutoCloseable {
             long[] fileLengths,
             StreamFileInput streamInput) {
         this.searcherPtr = openFromStream(fileNames, fileOffsets, fileLengths, streamInput);
+        this.closed = false;
+    }
+
+    public TantivySearcher(
+            String[] fileNames,
+            long[] fileOffsets,
+            long[] fileLengths,
+            StreamFileInput streamInput,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase) {
+        this.searcherPtr =
+                openFromStreamWithTokenizer(
+                        fileNames,
+                        fileOffsets,
+                        fileLengths,
+                        streamInput,
+                        tokenizerName,
+                        minGram,
+                        maxGram,
+                        prefixOnly,
+                        lowerCase);
         this.closed = false;
     }
 
@@ -86,8 +123,27 @@ public class TantivySearcher implements AutoCloseable {
 
     static native long openIndex(String indexPath);
 
+    static native long openIndexWithTokenizer(
+            String indexPath,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase);
+
     static native long openFromStream(
             String[] fileNames, long[] fileOffsets, long[] fileLengths, StreamFileInput streamInput);
+
+    static native long openFromStreamWithTokenizer(
+            String[] fileNames,
+            long[] fileOffsets,
+            long[] fileLengths,
+            StreamFileInput streamInput,
+            String tokenizerName,
+            int minGram,
+            int maxGram,
+            boolean prefixOnly,
+            boolean lowerCase);
 
     static native SearchResult searchIndex(long searcherPtr, String queryString, int limit);
 

--- a/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.tantivy;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -28,10 +27,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Smoke test for Tantivy JNI. */
-class TantivyJniTest {
+public class TantivyJniTest {
 
-    @BeforeAll
-    static void checkNativeLibrary() {
+    private static void assumeNativeAvailable() {
         assumeTrue(isNativeAvailable(), "Tantivy native library not available, skipping tests");
     }
 
@@ -45,7 +43,8 @@ class TantivyJniTest {
     }
 
     @Test
-    void testWriteAndSearch(@TempDir Path tempDir) {
+    public void testWriteAndSearch(@TempDir Path tempDir) {
+        assumeNativeAvailable();
         String indexPath = tempDir.resolve("test_index").toString();
 
         try (TantivyIndexWriter writer = new TantivyIndexWriter(indexPath)) {
@@ -72,6 +71,46 @@ class TantivyJniTest {
             if (result.size() > 1) {
                 assertTrue(result.getScores()[0] >= result.getScores()[1]);
             }
+        }
+    }
+
+    @Test
+    public void testNgramTokenizerFindsChineseFragment(@TempDir Path tempDir) {
+        assumeNativeAvailable();
+        String indexPath = tempDir.resolve("ngram_index").toString();
+
+        try (TantivyIndexWriter writer =
+                new TantivyIndexWriter(indexPath, "ngram", 2, 2, false, true)) {
+            writer.addDocument(1L, "Apache Paimon 支持中文全文检索");
+            writer.addDocument(2L, "Tantivy full text search engine");
+            writer.commit();
+        }
+
+        try (TantivySearcher searcher =
+                new TantivySearcher(indexPath, "ngram", 2, 2, false, true)) {
+            SearchResult result = searcher.search("中文", 10);
+            assertEquals(1, result.size());
+            assertEquals(1L, result.getRowIds()[0]);
+        }
+    }
+
+    @Test
+    public void testJiebaTokenizerFindsChineseWord(@TempDir Path tempDir) {
+        assumeNativeAvailable();
+        String indexPath = tempDir.resolve("jieba_index").toString();
+
+        try (TantivyIndexWriter writer =
+                new TantivyIndexWriter(indexPath, "jieba", 2, 2, false, true)) {
+            writer.addDocument(1L, "张华在百货公司当售货员");
+            writer.addDocument(2L, "Apache Paimon supports full text search");
+            writer.commit();
+        }
+
+        try (TantivySearcher searcher =
+                new TantivySearcher(indexPath, "jieba", 2, 2, false, true)) {
+            SearchResult result = searcher.search("售货员", 10);
+            assertEquals(1, result.size());
+            assertEquals(1L, result.getRowIds()[0]);
         }
     }
 }

--- a/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
@@ -119,7 +119,7 @@ public class TantivyJniTest {
         assumeNativeAvailable();
         String indexPath = tempDir.resolve("config_index").toString();
         String configJson =
-                "{\"tokenizer\":\"simple\",\"stem\":true,\"removeStopWords\":true,"
+                "{\"tokenizer\":\"simple\",\"stem\":true,\"remove-stop-words\":true,"
                         + "\"language\":\"english\"}";
 
         try (TantivyIndexWriter writer = new TantivyIndexWriter(indexPath, configJson)) {

--- a/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
+++ b/paimon-tantivy/paimon-tantivy-jni/src/test/java/org/apache/paimon/tantivy/TantivyJniTest.java
@@ -113,4 +113,29 @@ public class TantivyJniTest {
             assertEquals(1L, result.getRowIds()[0]);
         }
     }
+
+    @Test
+    public void testTokenizerConfigAndQueryOperator(@TempDir Path tempDir) {
+        assumeNativeAvailable();
+        String indexPath = tempDir.resolve("config_index").toString();
+        String configJson =
+                "{\"tokenizer\":\"simple\",\"stem\":true,\"removeStopWords\":true,"
+                        + "\"language\":\"english\"}";
+
+        try (TantivyIndexWriter writer = new TantivyIndexWriter(indexPath, configJson)) {
+            writer.addDocument(1L, "Apache Paimon runs streaming jobs");
+            writer.addDocument(2L, "Apache Spark runs batch jobs");
+            writer.addDocument(3L, "Paimon lake stores data");
+            writer.commit();
+        }
+
+        try (TantivySearcher searcher = new TantivySearcher(indexPath, configJson)) {
+            SearchResult orResult = searcher.search("paimon spark", 10);
+            assertEquals(3, orResult.size());
+
+            SearchResult andResult = searcher.search("paimon run", 10, "and");
+            assertEquals(1, andResult.size());
+            assertEquals(1L, andResult.getRowIds()[0]);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR expands Tantivy full-text global index tokenizer support into a configurable analyzer pipeline. It keeps the existing ngram and Jieba support, adds common LanceDB-style tokenizer/filter options, and wires the same metadata through Java, Rust JNI, and PyPaimon readers.

## Changes

- Support `default`, `simple`, `whitespace`, `raw`, `ngram`, and `jieba` tokenizers for Tantivy full-text indexes.
- Add analyzer options for max token length, lower casing, ASCII folding, stemming, language, built-in/custom stop words, and position storage.
- Persist the new analyzer metadata without bumping `META_VERSION`, since version 1 has not been released, while still reading metadata written with the earlier v1 layout.
- Add `and` / `or` query operator support to Java and Python full-text search builders; default remains `or`.
- Wire JSON tokenizer config through Java JNI wrappers and Rust Tantivy analyzer registration, including stream-backed readers.
- Teach PyPaimon to deserialize the extended metadata, register matching tantivy-py analyzers for ngram/custom tokenizers, and query Jieba indexes with AND semantics.
- Update global-index docs, PyPaimon docs, procedure examples, and Tantivy README notes for tokenizer/analyzer configuration.

## Testing

- `PYTHONPATH=. /Users/lijingsong/.venvs/paimon-py311/bin/pytest pypaimon/tests/vector_search_filter_test.py::TantivyFullTextIndexOptionsTest -q`
- `PATH=/Users/lijingsong/.venvs/paimon-py311/bin:$PATH /Users/lijingsong/.venvs/paimon-py311/bin/flake8 --config=./dev/cfg.ini pypaimon/tests/vector_search_filter_test.py pypaimon/globalindex/tantivy/tantivy_full_text_global_index_reader.py pypaimon/globalindex/full_text_search.py pypaimon/table/source/full_text_search_builder.py pypaimon/table/source/full_text_read.py pypaimon/tests/e2e/java_py_read_write_test.py`
- `CARGO_BUILD_JOBS=1 cargo check --quiet` in `paimon-tantivy/paimon-tantivy-jni/rust`
- `mvn -pl paimon-tantivy/paimon-tantivy-jni -am -Pfast-build -DfailIfNoTests=false -Dtest=TantivyJniTest test -q`
- `mvn -pl paimon-tantivy/paimon-tantivy-index -am -Pfast-build -DfailIfNoTests=false -Dtest=TantivyFullTextIndexOptionsTest,TantivyFullTextGlobalIndexTest test -q`
- `git diff --check`

## Notes

- PyPaimon Jieba query support requires the optional Python `jieba` package.
- Custom analysis is exposed by composing supported tokenizer/filter options; this PR does not load arbitrary Rust tokenizer plugins from configuration.
