### PR TITLE
[core] Require database for blob view serialization

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobViewStruct.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobViewStruct.java
@@ -26,6 +26,7 @@ import java.nio.ByteOrder;
 import java.util.Objects;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.paimon.catalog.Identifier.UNKNOWN_DATABASE;
 
 /**
  * Serialized metadata for a BLOB view field.
@@ -64,6 +65,11 @@ public class BlobViewStruct implements Serializable {
     }
 
     public byte[] serialize() {
+        if (UNKNOWN_DATABASE.equals(identifier.getDatabaseName())) {
+            throw new IllegalArgumentException(
+                    "Blob view upstream table identifier must include database name: "
+                            + identifier.getFullName());
+        }
         byte[] identifierBytes = identifier.getFullName().getBytes(UTF_8);
 
         int totalSize = 1 + 8 + 4 + identifierBytes.length + 4 + 8;

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobViewStructTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobViewStructTest.java
@@ -41,6 +41,17 @@ public class BlobViewStructTest {
     }
 
     @Test
+    public void testRejectUnknownDatabase() {
+        BlobViewStruct viewStruct =
+                new BlobViewStruct(Identifier.create(Identifier.UNKNOWN_DATABASE, "source"), 7, 5L);
+
+        assertThatThrownBy(viewStruct::serialize)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Blob view upstream table identifier must include database name");
+    }
+
+    @Test
     public void testRejectUnexpectedVersion() {
         BlobViewStruct viewStruct =
                 new BlobViewStruct(Identifier.fromString("default.source"), 7, 5L);


### PR DESCRIPTION
### Purpose

`BlobViewStruct` serializes the upstream table identifier through `Identifier#getFullName`. If the identifier uses `UNKNOWN_DATABASE`, the serialized form only contains the table name, but deserialization goes through `Identifier#fromString`, which requires `database.table`.

This patch fails earlier during serialization when the upstream table identifier does not include a database name.

### Changes

- Validate `BlobViewStruct#serialize` and reject `UNKNOWN_DATABASE` identifiers.
- Add a regression test covering serialization with `Identifier.UNKNOWN_DATABASE`.

### Tests

- `mvn -pl paimon-common -Pfast-build -Dtest=BlobViewStructTest test`
- `mvn -pl paimon-common spotless:check -DskipTests`
- `mvn -pl paimon-common -DskipTests compile`
