### PR TITLE
[python] Add bloom-filter file index pushdown for PyPaimon read path

### DIFF
--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -74,6 +74,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -756,6 +757,122 @@ public class JavaPyE2ETest {
                 .createReader(readBuilder.newScan().plan())
                 .forEachRemaining(r -> result.add(r.getString(1).toString()));
         assertThat(result).containsExactlyInAnyOrder("v3", "v5");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testBloomFilterIndexWrite() throws Exception {
+        // Keys are spaced (10/20/30) so an in-range-but-absent key exists between
+        // them; the read-side tests query that key to exercise the bloom SKIP
+        // path rather than value-stats pruning.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.BIGINT(), "test_bloom_index_bigint", 10L, 20L, 30L, 15L);
+        testBloomFilterIndexWriteGeneric(DataTypes.INT(), "test_bloom_index_int", 10, 20, 30, 15);
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.STRING(),
+                "test_bloom_index_string",
+                BinaryString.fromString("foo"),
+                BinaryString.fromString("bar"),
+                BinaryString.fromString("baz"),
+                BinaryString.fromString("bay"));
+
+        // Anchor the temporal / float / binary conversion layers against the real
+        // Java writer (not just self-referential Python tests). Values mirror the
+        // pypaimon read-side test; absent keys lie inside [key1, key3] so value
+        // stats cannot prune them and the bloom must.
+        // DATE: internal repr is epoch-day (int). 18637/18647/18657 = 2021-01-10/20/30,
+        // absent 18642 = 2021-01-15.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.DATE(), "test_bloom_index_date", 18637, 18647, 18657, 18642);
+        // TIME: internal repr is millis-of-day (int). 01:00/02:00/03:00, absent 01:30.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.TIME(3), "test_bloom_index_time", 3600000, 7200000, 10800000, 5400000);
+        // TIMESTAMP(3): hashed as millis.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.TIMESTAMP(3),
+                "test_bloom_index_timestamp",
+                org.apache.paimon.data.Timestamp.fromEpochMillis(1609462800000L),
+                org.apache.paimon.data.Timestamp.fromEpochMillis(1609466400000L),
+                org.apache.paimon.data.Timestamp.fromEpochMillis(1609470000000L),
+                org.apache.paimon.data.Timestamp.fromEpochMillis(1609464600000L));
+        // DOUBLE / FLOAT: hashed via their IEEE-754 bit patterns.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.DOUBLE(), "test_bloom_index_double", 10.0d, 20.0d, 30.0d, 15.0d);
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.FLOAT(), "test_bloom_index_float", 10.0f, 20.0f, 30.0f, 15.0f);
+        // BINARY: hashed via xxhash over the raw bytes.
+        testBloomFilterIndexWriteGeneric(
+                DataTypes.BINARY(4),
+                "test_bloom_index_binary",
+                "aaaa".getBytes(StandardCharsets.UTF_8),
+                "cccc".getBytes(StandardCharsets.UTF_8),
+                "eeee".getBytes(StandardCharsets.UTF_8),
+                "bbbb".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void testBloomFilterIndexWriteGeneric(
+            DataType keyType,
+            String tableName,
+            Object key1,
+            Object key2,
+            Object key3,
+            Object absentInRangeKey)
+            throws Exception {
+        RowType rowType =
+                RowType.of(new DataType[] {keyType, DataTypes.STRING()}, new String[] {"k", "v"});
+        Options options = new Options();
+        Path tablePath = new Path(warehouse.toString() + "/default.db/" + tableName);
+        options.set(PATH, tablePath.toString());
+        // Write a bloom-filter file index over column "k" and force it to be
+        // stored embedded in the manifest (large threshold) so the pypaimon read
+        // path, which only consumes embedded indexes, can decode it.
+        options.set("file-index.bloom-filter.columns", "k");
+        options.set("file-index.in-manifest-threshold", "1 MB");
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(LocalFileIO.create(), tablePath),
+                        new Schema(
+                                rowType.getFields(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                options.toMap(),
+                                ""));
+        AppendOnlyFileStoreTable table =
+                new AppendOnlyFileStoreTable(
+                        FileIOFinder.find(tablePath),
+                        tablePath,
+                        tableSchema,
+                        CatalogEnvironment.empty());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(GenericRow.of(key1, BinaryString.fromString("v1")));
+            write.write(GenericRow.of(key2, BinaryString.fromString("v2")));
+            write.write(GenericRow.of(key3, BinaryString.fromString("v3")));
+            commit.commit(write.prepareCommit());
+        }
+
+        // Sanity check on the Java side: the embedded index must let an existing
+        // key through.
+        PredicateBuilder predicateBuilder = new PredicateBuilder(table.rowType());
+        ReadBuilder hit = table.newReadBuilder().withFilter(predicateBuilder.equal(0, key2));
+        List<String> hitRows = new ArrayList<>();
+        hit.newRead()
+                .createReader(hit.newScan().plan())
+                .forEachRemaining(r -> hitRows.add(r.getString(1).toString()));
+        assertThat(hitRows).containsOnly("v2");
+
+        // And it must prune an in-range-but-absent key: value stats alone could
+        // not drop it (it lies within [key1, key3]), so a non-empty result here
+        // would mean the embedded bloom is not actually pruning.
+        ReadBuilder miss =
+                table.newReadBuilder().withFilter(predicateBuilder.equal(0, absentInRangeKey));
+        List<String> missRows = new ArrayList<>();
+        miss.newRead()
+                .createReader(miss.newScan().plan())
+                .forEachRemaining(r -> missRows.add(r.getString(1).toString()));
+        assertThat(missRows).isEmpty();
     }
 
     @Test

--- a/paimon-python/dev/requirements.txt
+++ b/paimon-python/dev/requirements.txt
@@ -39,3 +39,4 @@ zstandard>=0.19,<1
 backports.zstd>=1.0.0,<1.4.0; python_version >= "3.9" and python_version < "3.14"
 cramjam>=1.3.0,<3; python_version>="3.7"
 pyyaml>=5.4,<7
+xxhash>=1.4,<4

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -219,6 +219,30 @@ run_btree_index_test() {
     fi
 }
 
+# Function to run bloom-filter file index test (Java write, Python read)
+run_bloom_filter_index_test() {
+    echo -e "${YELLOW}=== Running Bloom Filter Index Test (Java Write, Python Read) ===${NC}"
+
+    cd "$PROJECT_ROOT"
+
+    echo "Running Maven test for JavaPyE2ETest.testBloomFilterIndexWrite..."
+    if mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testBloomFilterIndexWrite -pl paimon-core -q -Drun.e2e.tests=true; then
+        echo -e "${GREEN}✓ Java test completed successfully${NC}"
+    else
+        echo -e "${RED}✗ Java test failed${NC}"
+        return 1
+    fi
+    cd "$PAIMON_PYTHON_DIR"
+    echo "Running Python test for JavaPyReadWriteTest.test_read_bloom_filter_index_table..."
+    if python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_read_bloom_filter_index_table -v; then
+        echo -e "${GREEN}✓ Python test completed successfully${NC}"
+        return 0
+    else
+        echo -e "${RED}✗ Python test failed${NC}"
+        return 1
+    fi
+}
+
 run_compressed_text_test() {
     echo -e "${YELLOW}=== Step 7: Running Compressed Text Test (Java Write, Python Read) ===${NC}"
 
@@ -662,6 +686,7 @@ main() {
     local java_read_result=0
     local pk_dv_result=0
     local btree_index_result=0
+    local bloom_filter_index_result=0
     local compressed_text_result=0
     local vector_append_table_result=0
     local tantivy_fulltext_result=0
@@ -731,6 +756,13 @@ main() {
     # Run BTree index test (Java write, Python read)
     if ! run_btree_index_test; then
         btree_index_result=1
+    fi
+
+    echo ""
+
+    # Run bloom-filter index test (Java write, Python read)
+    if ! run_bloom_filter_index_test; then
+        bloom_filter_index_result=1
     fi
 
     echo ""
@@ -903,6 +935,12 @@ main() {
         echo -e "${RED}✗ BTree Index Test (Java Write, Python Read): FAILED${NC}"
     fi
 
+    if [[ $bloom_filter_index_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ Bloom Filter Index Test (Java Write, Python Read): PASSED${NC}"
+    else
+        echo -e "${RED}✗ Bloom Filter Index Test (Java Write, Python Read): FAILED${NC}"
+    fi
+
     if [[ $compressed_text_result -eq 0 ]]; then
         echo -e "${GREEN}✓ Compressed Text Test (Java Write, Python Read): PASSED${NC}"
     else
@@ -1004,7 +1042,7 @@ main() {
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $bloom_filter_index_result -eq 0 && $compressed_text_result -eq 0 && $tantivy_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -575,6 +575,13 @@ class CoreOptions:
         )
     )
 
+    FILE_INDEX_READ_ENABLED: ConfigOption[bool] = (
+        ConfigOptions.key("file-index.read.enabled")
+        .boolean_type()
+        .default_value(True)
+        .with_description("Whether to enable file index pushdown during reads.")
+    )
+
     READ_BATCH_SIZE: ConfigOption[int] = (
         ConfigOptions.key("read.batch-size")
         .int_type()
@@ -922,6 +929,9 @@ class CoreOptions:
 
     def local_cache_whitelist(self) -> str:
         return self.options.get(CoreOptions.LOCAL_CACHE_WHITELIST)
+
+    def file_index_read_enabled(self) -> bool:
+        return self.options.get(CoreOptions.FILE_INDEX_READ_ENABLED, True)
 
     def read_batch_size(self, default=None) -> int:
         return self.options.get(CoreOptions.READ_BATCH_SIZE, default or 1024)

--- a/paimon-python/pypaimon/fileindex/__init__.py
+++ b/paimon-python/pypaimon/fileindex/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""File index module for PyPaimon."""

--- a/paimon-python/pypaimon/fileindex/bloom_filter.py
+++ b/paimon-python/pypaimon/fileindex/bloom_filter.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Bloom filter implementation for file index."""
+
+import math
+
+
+def _to_signed_32(value: int) -> int:
+    """Reinterpret the low 32 bits of ``value`` as a signed 32-bit integer.
+
+    Mirrors Java's silent overflow on ``int`` arithmetic. The combined hash in
+    ``BloomFilter64`` is computed with ``int`` in Java, so ``hash1 + i * hash2``
+    wraps modulo 2**32 before the negativity check; without this wrap the modulo
+    lands on a different bit and the filter probes the wrong positions.
+    """
+    value &= 0xFFFFFFFF
+    if value >= 0x80000000:
+        value -= 0x100000000
+    return value
+
+
+class BitSet:
+    """Bit set used for bloom filter 64."""
+
+    MASK = 0x07  # Lower 3 bits
+
+    def __init__(self, data: bytearray, offset: int):
+        assert len(data) > 0, "data length is zero!"
+        assert offset >= 0, "offset is negative!"
+        self.data = data
+        self.offset = offset
+
+    def set(self, index: int):
+        """Set bit at index to 1."""
+        byte_idx = (index >> 3) + self.offset
+        bit_idx = index & self.MASK
+        self.data[byte_idx] |= (1 << bit_idx)
+
+    def get(self, index: int) -> bool:
+        """Get bit at index."""
+        byte_idx = (index >> 3) + self.offset
+        bit_idx = index & self.MASK
+        return (self.data[byte_idx] & (1 << bit_idx)) != 0
+
+    def bit_size(self) -> int:
+        """Return total number of bits."""
+        return (len(self.data) - self.offset) * 8
+
+
+class BloomFilter64:
+    """Bloom filter handling 64-bit hashes."""
+
+    def __init__(self, items_or_num_hash, fpp_or_bitset):
+        if isinstance(fpp_or_bitset, float):
+            # Constructor: BloomFilter64(items, fpp)
+            items = items_or_num_hash
+            fpp = fpp_or_bitset
+
+            nb = int(-items * math.log(fpp) / (math.log(2) * math.log(2)))
+            self.num_bits = nb + (8 - (nb % 8))
+            self.num_hash_functions = max(1, int(round(
+                (self.num_bits / items) * math.log(2)
+            )))
+            self.bitset = BitSet(bytearray(self.num_bits // 8), 0)
+        else:
+            # Constructor: BloomFilter64(num_hash_functions, bitset)
+            self.num_hash_functions = items_or_num_hash
+            self.bitset = fpp_or_bitset
+            self.num_bits = self.bitset.bit_size()
+
+    def add_hash(self, hash64: int):
+        """Add a 64-bit hash to the filter."""
+        # Split into two signed 32-bit hashes (Java: (int) hash64, (int) (hash64 >>> 32))
+        hash1 = _to_signed_32(hash64)
+        hash2 = _to_signed_32(hash64 >> 32)
+
+        for i in range(1, self.num_hash_functions + 1):
+            combined_hash = _to_signed_32(hash1 + (i * hash2))
+            # Flip bits if negative
+            if combined_hash < 0:
+                combined_hash = ~combined_hash
+            pos = combined_hash % self.num_bits
+            self.bitset.set(pos)
+
+    def test_hash(self, hash64: int) -> bool:
+        """Test if a 64-bit hash might be in the filter."""
+        # Split into two signed 32-bit hashes (Java: (int) hash64, (int) (hash64 >>> 32))
+        hash1 = _to_signed_32(hash64)
+        hash2 = _to_signed_32(hash64 >> 32)
+
+        for i in range(1, self.num_hash_functions + 1):
+            combined_hash = _to_signed_32(hash1 + (i * hash2))
+            # Flip bits if negative
+            if combined_hash < 0:
+                combined_hash = ~combined_hash
+            pos = combined_hash % self.num_bits
+            if not self.bitset.get(pos):
+                return False
+        return True
+
+    def get_num_hash_functions(self) -> int:
+        return self.num_hash_functions
+
+    def get_bitset(self) -> BitSet:
+        return self.bitset

--- a/paimon-python/pypaimon/fileindex/fast_hash.py
+++ b/paimon-python/pypaimon/fileindex/fast_hash.py
@@ -1,0 +1,272 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Fast hash functions for bloom filter file index."""
+
+from typing import Callable
+import calendar
+import struct
+from datetime import date, datetime, time
+
+try:
+    import xxhash
+    HAS_XXHASH = True
+except ImportError:
+    HAS_XXHASH = False
+
+from pypaimon.schema.data_types import DataType
+
+_EPOCH_DATE = date(1970, 1, 1)
+
+
+def _to_signed_64(value: int) -> int:
+    """Reinterpret the low 64 bits of ``value`` as a signed 64-bit integer.
+
+    This mirrors Java's silent overflow on ``long`` arithmetic: every ``+`` and
+    ``<<`` wraps modulo 2**64. Applying this after each step keeps intermediate
+    values in the same domain as the JVM, and because Python's ``>>`` on a
+    negative int is already an arithmetic (sign-extending) shift, the right
+    shifts then match Java's ``>>`` on a signed long.
+    """
+    value &= 0xFFFFFFFFFFFFFFFF
+    if value >= 0x8000000000000000:
+        value -= 0x10000000000000000
+    return value
+
+
+def get_long_hash(key: int) -> int:
+    """Thomas Wang's 64-bit integer hash function (matches Java FastHash.getLongHash).
+
+    Java performs this entirely in signed 64-bit ``long`` arithmetic, so each
+    operation must be truncated to 64 bits to reproduce its overflow behavior;
+    otherwise the subsequent arithmetic right shifts see high bits the JVM never
+    has and the hash diverges (e.g. for key=2**40).
+    """
+    key = _to_signed_64(key)
+
+    key = _to_signed_64((~key) + _to_signed_64(key << 21))
+    key = _to_signed_64(key ^ (key >> 24))
+    key = _to_signed_64((key + _to_signed_64(key << 3)) + _to_signed_64(key << 8))
+    key = _to_signed_64(key ^ (key >> 14))
+    key = _to_signed_64((key + _to_signed_64(key << 2)) + _to_signed_64(key << 4))
+    key = _to_signed_64(key ^ (key >> 28))
+    key = _to_signed_64(key + _to_signed_64(key << 31))
+
+    # Return as unsigned 64-bit
+    return key & 0xFFFFFFFFFFFFFFFF
+
+
+def hash64_bytes(data: bytes) -> int:
+    """Hash bytes using xxhash."""
+    if not HAS_XXHASH:
+        raise RuntimeError("xxhash library is required for file index. Install with: pip install xxhash")
+    return xxhash.xxh64(data).intdigest()
+
+
+def _parse_base_type(type_str: str):
+    """Split a type string into (base name, precision).
+
+    Examples: ``"INT"`` -> ``("INT", None)``, ``"VARCHAR(10)"`` -> ``("VARCHAR", 10)``,
+    ``"TIMESTAMP(6) NOT NULL"`` -> ``("TIMESTAMP", 6)``. Matching the parsed base
+    name (rather than substring containment) avoids collisions such as ``"TIME"``
+    being found inside ``"TIMESTAMP"`` or ``"INT"`` inside ``"BIGINT"``.
+    """
+    s = type_str.upper().strip()
+    if s.endswith(" NOT NULL"):
+        s = s[: -len(" NOT NULL")].strip()
+    precision = None
+    if "(" in s:
+        base, _, rest = s.partition("(")
+        base = base.strip()
+        digits = rest.split(")")[0].split(",")[0].strip()
+        if digits.isdigit():
+            precision = int(digits)
+    else:
+        base = s
+    return base, precision
+
+
+def _truncate_signed(value: int, bits: int) -> int:
+    """Reinterpret the low ``bits`` of ``value`` as a signed integer.
+
+    Mirrors Java's narrowing cast ``(byte)``/``(short)`` applied before hashing
+    TINYINT/SMALLINT values.
+    """
+    mask = (1 << bits) - 1
+    value &= mask
+    sign_bit = 1 << (bits - 1)
+    if value >= sign_bit:
+        value -= (1 << bits)
+    return value
+
+
+def _date_to_epoch_day(value) -> int:
+    """Convert a Python ``date``/``datetime`` to Java's DATE internal repr (epoch day)."""
+    if isinstance(value, datetime):
+        value = value.date()
+    if isinstance(value, date):
+        return (value - _EPOCH_DATE).days
+    # Already an int (epoch day) -> pass through.
+    return int(value)
+
+
+def _time_to_millis_of_day(value) -> int:
+    """Convert a Python ``time`` to Java's TIME internal repr (millis of day)."""
+    if isinstance(value, time):
+        return (value.hour * 3600 + value.minute * 60 + value.second) * 1000 + value.microsecond // 1000
+    # Already an int (millis of day) -> pass through.
+    return int(value)
+
+
+def _timestamp_hash(value, precision) -> int:
+    """Hash a timestamp value, mirroring Java: millis for precision<=3, else micros.
+
+    Accepts pypaimon ``Timestamp`` objects (``get_millisecond``/``to_micros``) as
+    well as native ``datetime``. Raw ints are rejected, because the correct unit
+    (millis vs micros) cannot be inferred from an int alone and guessing would
+    silently hash the wrong value (and could drop rows).
+    """
+    if value is None:
+        return 0
+
+    use_millis = precision is not None and precision <= 3
+
+    if hasattr(value, 'get_millisecond') and hasattr(value, 'to_micros'):
+        return get_long_hash(value.get_millisecond() if use_millis else value.to_micros())
+
+    if isinstance(value, datetime):
+        # A timezone-aware datetime carries an instant, but ``timetuple()``
+        # exposes only the wall-clock fields and silently drops the offset, so
+        # hashing it would match the wrong instant (e.g. 1970-01-01T00:00+08:00
+        # would hash as epoch 0 instead of -28800s) and could false-SKIP a file.
+        # Java's TIMESTAMP is offset-free; proper TIMESTAMP_LTZ handling (UTC
+        # normalization) is out of scope here, so refuse aware values and let
+        # the caller fail open.
+        if value.tzinfo is not None:
+            raise TypeError(
+                "Cannot hash a timezone-aware datetime for file index; "
+                "TIMESTAMP_LTZ pushdown is not supported"
+            )
+        epoch_seconds = calendar.timegm(value.timetuple())
+        millis = epoch_seconds * 1000 + value.microsecond // 1000
+        if use_millis:
+            return get_long_hash(millis)
+        micros = epoch_seconds * 1_000_000 + value.microsecond
+        return get_long_hash(micros)
+
+    raise TypeError(
+        f"Cannot hash timestamp literal of type {type(value).__name__}; "
+        "expected a Timestamp or datetime"
+    )
+
+
+def get_hash_function(data_type: DataType) -> Callable:
+    """Get appropriate hash function for the given data type.
+
+    Dispatch mirrors Java's ``FastHash.FastHashVisitor``: string/char via xxhash,
+    binary via xxhash, integral/date/time via Thomas Wang long hash, float/double
+    via their IEEE-754 bit patterns, and timestamps via millis or micros depending
+    on precision.
+    """
+    base, precision = _parse_base_type(str(data_type))
+
+    # String types
+    if base in ('VARCHAR', 'CHAR', 'STRING'):
+        def hash_fn(value):
+            if value is None:
+                return 0
+            if isinstance(value, str):
+                return hash64_bytes(value.encode('utf-8'))
+            return hash64_bytes(value)
+        return hash_fn
+
+    # Binary types
+    if base in ('BINARY', 'VARBINARY', 'BYTES'):
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return hash64_bytes(value)
+        return hash_fn
+
+    # Float type (hash the 32-bit IEEE-754 representation, like Float.floatToIntBits)
+    if base == 'FLOAT':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            float_bits = struct.unpack('>i', struct.pack('>f', float(value)))[0]
+            return get_long_hash(float_bits)
+        return hash_fn
+
+    # Double type (hash the 64-bit IEEE-754 representation, like Double.doubleToLongBits)
+    if base == 'DOUBLE':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            double_bits = struct.unpack('>q', struct.pack('>d', float(value)))[0]
+            return get_long_hash(double_bits)
+        return hash_fn
+
+    # Timestamp types (precision decides millis vs micros, matching Java)
+    if base in ('TIMESTAMP', 'TIMESTAMP_LTZ'):
+        def hash_fn(value):
+            return _timestamp_hash(value, precision)
+        return hash_fn
+
+    # Date type (Java internal repr: epoch day as int)
+    if base == 'DATE':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return get_long_hash(_date_to_epoch_day(value))
+        return hash_fn
+
+    # Time type (Java internal repr: millis of day as int)
+    if base == 'TIME':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return get_long_hash(_time_to_millis_of_day(value))
+        return hash_fn
+
+    # Byte / short integral types: Java casts to (byte)/(short) before hashing,
+    # i.e. sign-truncates to 8/16 bits. In-range pyarrow literals are unaffected;
+    # this only matters for out-of-range literals, where it keeps us bit-for-bit
+    # consistent with the Java writer.
+    if base == 'TINYINT':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return get_long_hash(_truncate_signed(int(value), 8))
+        return hash_fn
+
+    if base == 'SMALLINT':
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return get_long_hash(_truncate_signed(int(value), 16))
+        return hash_fn
+
+    # Remaining integral types (Java hashes the int/long value directly)
+    if base in ('INT', 'INTEGER', 'BIGINT'):
+        def hash_fn(value):
+            if value is None:
+                return 0
+            return get_long_hash(int(value))
+        return hash_fn
+
+    # Default fallback
+    raise ValueError(f"Unsupported data type for file index: {data_type}")

--- a/paimon-python/pypaimon/fileindex/file_index_format.py
+++ b/paimon-python/pypaimon/fileindex/file_index_format.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""File index format reader for PyPaimon."""
+
+import struct
+from typing import Dict, Tuple, Optional
+
+
+MAGIC = 1493475289347502
+VERSION_1 = 1
+EMPTY_INDEX_FLAG = -1
+
+
+class FileIndexFormatReader:
+    """
+    Reader for file index format.
+
+    Format:
+    - magic (8 bytes long, big-endian)
+    - version (4 bytes int, big-endian)
+    - head_length (4 bytes int, big-endian)
+    - column_count (4 bytes int)
+    - For each column:
+      - column_name (2 bytes length + utf-8 bytes)
+      - index_count (4 bytes int)
+      - For each index:
+        - index_name (2 bytes length + utf-8 bytes)
+        - start_pos (4 bytes int)
+        - length (4 bytes int)
+    - redundant_length (4 bytes int)
+    - redundant_bytes (variable)
+    - body (variable)
+    """
+
+    def __init__(self, data: bytes):
+        self.data = data
+        self.offset = 0
+        self.header: Dict[str, Dict[str, Tuple[int, int]]] = {}
+        self._parse_header()
+
+    def _read_long(self) -> int:
+        """Read 8-byte big-endian long."""
+        val = struct.unpack('>Q', self.data[self.offset:self.offset + 8])[0]
+        self.offset += 8
+        return val
+
+    def _read_int(self) -> int:
+        """Read 4-byte big-endian signed int.
+
+        Java writes these with ``DataOutputStream.writeInt`` (signed), and uses
+        ``-1`` (:data:`EMPTY_INDEX_FLAG`) as a sentinel for empty index columns,
+        so the value must be read as signed to round-trip that flag.
+        """
+        val = struct.unpack('>i', self.data[self.offset:self.offset + 4])[0]
+        self.offset += 4
+        return val
+
+    def _read_utf(self) -> str:
+        """Read a Java ``DataOutput.writeUTF`` string (2-byte length + bytes).
+
+        Java encodes these as *modified* UTF-8 (NUL is two bytes, and characters
+        outside the BMP are written as a CESU-8 surrogate pair), which is not
+        byte-identical to standard UTF-8. We decode as standard UTF-8, which is
+        correct for ASCII column names (the only case in practice) but would
+        raise on a column name containing NUL or a non-BMP character. Such a
+        failure propagates up and is handled fail-open by the caller (the file
+        is kept), so it degrades safely rather than mis-decoding.
+        """
+        length = struct.unpack('>H', self.data[self.offset:self.offset + 2])[0]
+        self.offset += 2
+        s = self.data[self.offset:self.offset + length].decode('utf-8')
+        self.offset += length
+        return s
+
+    def _parse_header(self):
+        """Parse the header section."""
+        # Read and verify magic
+        magic = self._read_long()
+        if magic != MAGIC:
+            raise ValueError(f"Invalid magic number: {magic}")
+
+        # Read version
+        version = self._read_int()
+        if version != VERSION_1:
+            raise ValueError(f"Unsupported version: {version}")
+
+        # Read head length (consumed to advance the offset; value not needed here)
+        self._read_int()
+
+        # Read column count
+        column_count = self._read_int()
+
+        # Parse each column
+        for _ in range(column_count):
+            column_name = self._read_utf()
+            index_count = self._read_int()
+
+            column_indexes = {}
+            for _ in range(index_count):
+                index_name = self._read_utf()
+                start_pos = self._read_int()
+                length = self._read_int()
+                column_indexes[index_name] = (start_pos, length)
+
+            self.header[column_name] = column_indexes
+
+        # Read redundant length and skip redundant bytes
+        redundant_length = self._read_int()
+        self.offset += redundant_length
+
+    def read_column_index(self, column_name: str, index_type: str = "bloom-filter") -> Optional[bytes]:
+        """
+        Read the index bytes for a specific column and index type.
+
+        Args:
+            column_name: Name of the column
+            index_type: Type of index (default: "bloom-filter")
+
+        Returns:
+            Index bytes or None if not found
+        """
+        if column_name not in self.header:
+            return None
+
+        column_indexes = self.header[column_name]
+        if index_type not in column_indexes:
+            return None
+
+        start_pos, length = column_indexes[index_type]
+        # Java writes EMPTY_INDEX_FLAG (-1) as the start for columns with no
+        # actual index body. Treat that as "no index".
+        if start_pos == EMPTY_INDEX_FLAG or length <= 0:
+            return None
+        # Bounds-check before slicing: Python slicing silently truncates an
+        # out-of-range range, which on a corrupt/truncated blob would hand back
+        # fewer bytes than were written. A short bitset yields the wrong
+        # num_bits and makes the bloom filter probe wrong positions, which can
+        # turn into false SKIPs (dropped rows). Refuse such input instead.
+        if start_pos < 0 or start_pos + length > len(self.data):
+            return None
+        return self.data[start_pos:start_pos + length]
+
+    def get_columns(self):
+        """Get all column names in the index."""
+        return list(self.header.keys())

--- a/paimon-python/pypaimon/fileindex/file_index_predicate.py
+++ b/paimon-python/pypaimon/fileindex/file_index_predicate.py
@@ -1,0 +1,185 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""File index predicate evaluation."""
+
+import struct
+from typing import Optional, Dict
+
+from pypaimon.common.predicate import Predicate
+from pypaimon.fileindex.file_index_format import FileIndexFormatReader
+from pypaimon.fileindex.file_index_result import FileIndexResult, REMAIN, SKIP
+from pypaimon.fileindex.bloom_filter import BloomFilter64, BitSet
+from pypaimon.fileindex.fast_hash import get_hash_function
+
+
+class FileIndexPredicate:
+    """Evaluator for file index predicates."""
+
+    def __init__(self, embedded_index: bytes, schema_fields: Dict):
+        """
+        Initialize file index predicate evaluator.
+
+        Args:
+            embedded_index: Embedded file index bytes from DataFileMeta
+            schema_fields: Schema fields dictionary for type lookup
+        """
+        self.reader = FileIndexFormatReader(embedded_index)
+        self.schema_fields = schema_fields
+
+    def evaluate(self, predicate: Optional[Predicate]) -> FileIndexResult:
+        """
+        Evaluate predicate against file index.
+
+        Args:
+            predicate: Filter predicate to evaluate
+
+        Returns:
+            REMAIN if file might contain matching rows, SKIP if definitely not
+        """
+        if predicate is None:
+            return REMAIN
+
+        return self._evaluate_predicate(predicate)
+
+    def _evaluate_predicate(self, predicate: Predicate) -> FileIndexResult:
+        """Recursively evaluate predicate."""
+        method = predicate.method
+
+        # Handle AND
+        if method == 'and':
+            result = REMAIN
+            for child in predicate.literals:
+                child_result = self._evaluate_predicate(child)
+                result = result.and_(child_result)
+                if not result.remain():
+                    return SKIP
+            return result
+
+        # Handle OR
+        elif method == 'or':
+            children = predicate.literals or []
+            # An empty OR has no evidence to skip on; fail open. (Seeding with
+            # SKIP and returning it for an empty list would be the only
+            # non-fail-open path in this evaluator.)
+            if not children:
+                return REMAIN
+            result = SKIP
+            for child in children:
+                child_result = self._evaluate_predicate(child)
+                result = result.or_(child_result)
+                if result.remain():
+                    return REMAIN
+            return result
+
+        # Handle leaf predicates
+        elif method in ('equal', 'in'):
+            return self._evaluate_leaf(predicate)
+
+        # Unsupported predicates: remain
+        return REMAIN
+
+    def _evaluate_leaf(self, predicate: Predicate) -> FileIndexResult:
+        """Evaluate leaf predicate (equal, in)."""
+        field_name = predicate.field
+        literals = predicate.literals
+
+        # Read bloom filter for this column
+        bloom_bytes = self.reader.read_column_index(field_name, "bloom-filter")
+        if bloom_bytes is None:
+            return REMAIN
+
+        # Parse bloom filter
+        try:
+            bloom_filter = self._parse_bloom_filter(bloom_bytes)
+        except Exception:
+            return REMAIN
+
+        # Get hash function for field type
+        field_type = self.schema_fields.get(field_name)
+        if field_type is None:
+            return REMAIN
+
+        try:
+            hash_fn = get_hash_function(field_type)
+        except ValueError:
+            return REMAIN
+
+        # Check each literal
+        if predicate.method == 'equal':
+            # Equal: check single value
+            if not literals:
+                return REMAIN
+            value = literals[0]
+            if value is None:
+                return REMAIN
+            hash_val = self._safe_hash(hash_fn, value)
+            if hash_val is None:
+                # Could not hash the literal in a Java-compatible way (e.g. a
+                # CLI string literal on a temporal column). Fail open.
+                return REMAIN
+            return REMAIN if bloom_filter.test_hash(hash_val) else SKIP
+
+        elif predicate.method == 'in':
+            # An empty IN has no value to probe; fail open rather than SKIP.
+            if not literals:
+                return REMAIN
+            # IN: any literal matches -> REMAIN
+            for value in literals:
+                if value is None:
+                    continue
+                hash_val = self._safe_hash(hash_fn, value)
+                if hash_val is None:
+                    # Cannot evaluate this literal safely; keep the file.
+                    return REMAIN
+                if bloom_filter.test_hash(hash_val):
+                    return REMAIN
+            return SKIP
+
+        return REMAIN
+
+    @staticmethod
+    def _safe_hash(hash_fn, value):
+        """Hash ``value``, returning ``None`` if it cannot be hashed in a
+        Java-compatible way.
+
+        Keeping this fail-open inside the evaluator (rather than relying on
+        ``FileScanner._test_file_index``'s broad ``except``) means a literal we
+        cannot hash — for example a temporal column compared against a raw
+        string literal from the CLI WHERE parser — degrades to REMAIN here,
+        while genuine implementation bugs elsewhere still surface.
+        """
+        try:
+            return hash_fn(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _parse_bloom_filter(self, bloom_bytes: bytes) -> BloomFilter64:
+        """
+        Parse bloom filter from bytes.
+
+        Format: 4 bytes num_hash_functions (big-endian) + bitset bytes
+        """
+        # Read num_hash_functions (big-endian)
+        num_hash = struct.unpack('>I', bloom_bytes[0:4])[0]
+
+        # Create bitset from remaining bytes
+        bitset_data = bytearray(bloom_bytes[4:])
+        bitset = BitSet(bitset_data, 0)
+
+        # Create bloom filter
+        return BloomFilter64(num_hash, bitset)

--- a/paimon-python/pypaimon/fileindex/file_index_result.py
+++ b/paimon-python/pypaimon/fileindex/file_index_result.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""File index evaluation results."""
+
+from enum import Enum
+
+
+class FileIndexResult(Enum):
+    """Result of file index predicate evaluation."""
+
+    REMAIN = "REMAIN"  # File must be read
+    SKIP = "SKIP"      # File can be skipped
+
+    def remain(self) -> bool:
+        """Check if file should remain (be read)."""
+        return self == FileIndexResult.REMAIN
+
+    def and_(self, other: 'FileIndexResult') -> 'FileIndexResult':
+        """Combine with AND logic."""
+        if self == FileIndexResult.SKIP or other == FileIndexResult.SKIP:
+            return FileIndexResult.SKIP
+        return FileIndexResult.REMAIN
+
+    def or_(self, other: 'FileIndexResult') -> 'FileIndexResult':
+        """Combine with OR logic."""
+        if self == FileIndexResult.REMAIN or other == FileIndexResult.REMAIN:
+            return FileIndexResult.REMAIN
+        return FileIndexResult.SKIP
+
+
+# Constants for convenience
+REMAIN = FileIndexResult.REMAIN
+SKIP = FileIndexResult.SKIP

--- a/paimon-python/pypaimon/read/explain.py
+++ b/paimon-python/pypaimon/read/explain.py
@@ -98,6 +98,11 @@ class ExplainResult:
     partition_pruning: Optional[PruningStat] = None
     bucket_pruning: Optional[PruningStat] = None
     file_skipping: Optional[PruningStat] = None
+    file_index_pruning: Optional[PruningStat] = None
+
+    # Number of entries that hit the file-index fail-safe (unexpected error,
+    # kept the file). Shown in explain only when non-zero.
+    file_index_fail_open_count: int = 0
 
     # File-level aggregates over final splits
     file_count: int = 0
@@ -163,6 +168,11 @@ def render_explain(result: ExplainResult) -> str:
           result.bucket_pruning.format() if result.bucket_pruning else "n/a")
     _line(out, "File skipping",
           result.file_skipping.format() if result.file_skipping else "n/a")
+    _line(out, "File index pruning",
+          result.file_index_pruning.format() if result.file_index_pruning else "n/a")
+    if result.file_index_fail_open_count:
+        _line(out, "File index fail-open",
+              "{}  (evaluation errored, files kept)".format(result.file_index_fail_open_count))
 
     out.write("\n")
     _line(out, "Splits", str(result.split_count))

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -210,6 +210,7 @@ def _build_explain_result(table, scan: TableScan, plan, stats: ScanStats,
     partition_pruning = _partition_pruning(stats, scan)
     bucket_pruning = _bucket_pruning(stats, scan)
     file_skipping = _file_skipping(stats, scan)
+    file_index_pruning = _file_index_pruning(stats, scan)
 
     files_per_split = [len(getattr(s, 'files', []) or []) for s in splits]
     sizes = [int(getattr(s, 'file_size', 0) or 0) for s in splits]
@@ -283,6 +284,8 @@ def _build_explain_result(table, scan: TableScan, plan, stats: ScanStats,
         partition_pruning=partition_pruning,
         bucket_pruning=bucket_pruning,
         file_skipping=file_skipping,
+        file_index_pruning=file_index_pruning,
+        file_index_fail_open_count=stats.file_index_fail_open_count,
         file_count=file_count,
         total_file_size=total_size,
         estimated_row_count=rows_total,
@@ -343,6 +346,18 @@ def _file_skipping(stats: ScanStats, scan: TableScan) -> Optional[PruningStat]:
     if scan.predicate is None:
         return None
     return PruningStat(before=stats.entries_after_bucket, after=stats.entries_after_stats)
+
+
+def _file_index_pruning(stats: ScanStats, scan: TableScan) -> Optional[PruningStat]:
+    # Captures the funnel between stats-stage survivors and the entries that
+    # survived file index (bloom-filter) pushdown. Rather than re-deriving the
+    # apply-gate (feature flag, data-evolution, PK/DV), which would drift from
+    # FileScanner._should_apply_file_index, we key off the recorded counter: if
+    # the index was never actually evaluated on any entry, the stage did no work
+    # and rendering "N -> N" would be misleading, so we report ``None``.
+    if scan.predicate is None or stats.entries_file_index_applied == 0:
+        return None
+    return PruningStat(before=stats.entries_after_stats, after=stats.entries_after_file_index)
 
 
 def _safe_bucket_mode(table) -> str:

--- a/paimon-python/pypaimon/read/scan_stats.py
+++ b/paimon-python/pypaimon/read/scan_stats.py
@@ -43,6 +43,21 @@ class ScanStats:
     entries_after_partition: int = 0
     entries_after_bucket: int = 0
     entries_after_stats: int = 0
+    entries_after_file_index: int = 0
+
+    # Number of entries on which the file index was actually evaluated (feature
+    # enabled, predicate present, and the file carried an embedded index). Used
+    # by ``explain`` to decide whether to render the file-index pruning line at
+    # all — if nothing was ever evaluated, the stage is reported as ``n/a``
+    # rather than a misleading ``N -> N``.
+    entries_file_index_applied: int = 0
+
+    # Number of entries where file index evaluation hit the FileScanner-level
+    # fail-safe (an unexpected error, kept the file). Expected "cannot hash this
+    # literal" cases fail open inside the evaluator and are NOT counted here, so
+    # a non-zero value indicates pushdown silently degraded and is worth seeing
+    # in explain.
+    file_index_fail_open_count: int = 0
 
     partition_keys_before: Set[Tuple] = field(default_factory=set)
     partition_keys_after: Set[Tuple] = field(default_factory=set)

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -211,6 +211,10 @@ class FileScanner:
         self._global_index_result = None
         self._scanned_snapshot = None
         self._scanned_snapshot_id = None
+        # Cache of {schema_id: {field_name: field_type}} for file-index type
+        # lookup. A scan typically covers many files sharing one schema_id, so
+        # this avoids re-fetching the schema and rebuilding the dict per entry.
+        self._file_index_schema_fields = {}
         # Opt-in scan-plan tracking. Stays ``None`` for the read hot path;
         # ``scan_with_stats()`` flips it on for a single explain pass and
         # the filter callbacks below increment counters when present.
@@ -603,17 +607,18 @@ class FileScanner:
                     return False
             if stats is not None:
                 stats.entries_after_stats += 1
-            return True
+
+            return self._passes_file_index(entry, stats)
         else:
             if not self.predicate or self.predicate_for_stats is None:
                 if stats is not None:
                     stats.entries_after_stats += 1
-                return True
+                return self._passes_file_index(entry, stats)
             # Data evolution: file stats may be from another schema, skip stats filter and filter in reader.
             if self.data_evolution:
                 if stats is not None:
                     stats.entries_after_stats += 1
-                return True
+                return self._passes_file_index(entry, stats)
             if entry.file.value_stats_cols is None and entry.file.write_cols is not None:
                 stats_fields = entry.file.write_cols
             else:
@@ -627,9 +632,124 @@ class FileScanner:
                 evolved_stats,
                 entry.file.row_count
             )
-            if kept and stats is not None:
+            if not kept:
+                return False
+            if stats is not None:
                 stats.entries_after_stats += 1
-            return kept
+
+            return self._passes_file_index(entry, stats)
+
+    def _passes_file_index(self, entry: ManifestEntry, stats) -> bool:
+        """Apply file index (bloom-filter) pushdown to an entry that has already
+        survived the stats stage.
+
+        Returns True if the file should be kept. The survivor counter
+        ``entries_after_file_index`` is incremented for every kept entry that
+        reached this stage — whether or not the index actually applied — so it
+        stays consistent with the other ``entries_after_*`` survivor counters
+        and the explain funnel reads ``entries_after_stats -> entries_after_file_index``.
+        ``entries_file_index_applied`` separately tracks the entries the index
+        was actually evaluated on, so explain can tell "nothing to do" apart from
+        "evaluated, pruned nothing".
+        """
+        if self._should_apply_file_index(entry):
+            if stats is not None:
+                stats.entries_file_index_applied += 1
+            if not self._test_file_index(entry, stats):
+                return False
+        if stats is not None:
+            stats.entries_after_file_index += 1
+        return True
+
+    def _should_apply_file_index(self, entry: ManifestEntry) -> bool:
+        """Check if file index filtering should be applied."""
+        # Check if feature is enabled
+        if not self.table.options.file_index_read_enabled():
+            return False
+
+        # Check if predicate exists
+        if self.predicate is None:
+            return False
+
+        # Check if file has embedded index
+        if entry.file.embedded_index is None:
+            return False
+
+        # Under data evolution, a file's stats/index belong to its own (older)
+        # schema while the predicate is expressed against the query schema. We
+        # look indexes up by column name, but column names can be reused for
+        # different field ids across schema evolution (drop x, add a new x), so
+        # a name match could probe an unrelated column's bloom filter and wrongly
+        # SKIP a file. Java handles this by devolving the filter to the file's
+        # schema by field id before evaluating the index; this Python first
+        # version intentionally disables file-index pushdown under data evolution
+        # instead (out of scope) rather than risk dropping rows.
+        if self.data_evolution:
+            return False
+
+        # Outside data evolution, the file index is still resolved by column
+        # name (in the file's own schema), whereas Java resolves by field id.
+        # The risky case is name reuse across schema changes — drop column "x"
+        # then add a new "x" with a different field id. This stays safe here:
+        # a file written before the re-add carries no bloom entry for the new
+        # "x" (the index is over the old column), so read_column_index finds no
+        # matching index for the queried column and returns REMAIN rather than
+        # probing an unrelated bloom. The only way a stale name could collide is
+        # if both old and new columns carried a "bloom-filter" index AND the old
+        # file's blob were keyed by the reused name with different semantics,
+        # which the writer does not produce. If that assumption ever changes,
+        # this must move to id-based resolution like Java.
+
+        # Bloom filter is a *value* index. On primary-key tables, files within a
+        # bucket may overlap (a key can be updated across files), so dropping an
+        # individual file by a value predicate can keep a stale older value while
+        # skipping the newer overwrite -> wrong results. Java only applies the
+        # value file-index on the whole bucket (or per-file when files do not
+        # overlap). We mirror the existing value-stats gate here and only apply
+        # the file index on PK tables in deletion-vector mode, where level-0
+        # files are excluded and the remaining files within a bucket do not
+        # overlap, making per-file pruning safe.
+        if self.table.is_primary_key_table and not self.deletion_vectors_enabled:
+            return False
+
+        return True
+
+    def _test_file_index(self, entry: ManifestEntry, stats=None) -> bool:
+        """
+        Test if file passes file index filter.
+
+        Returns:
+            True if file should be kept, False if it can be skipped
+        """
+        try:
+            from pypaimon.fileindex.file_index_predicate import FileIndexPredicate
+
+            # Build schema fields dict for type lookup, cached per schema_id
+            # since a scan usually covers many files of the same schema.
+            schema_id = entry.file.schema_id
+            schema_fields = self._file_index_schema_fields.get(schema_id)
+            if schema_fields is None:
+                schema = self.table.schema_manager.get_schema(schema_id)
+                schema_fields = {field.name: field.type for field in schema.fields}
+                self._file_index_schema_fields[schema_id] = schema_fields
+
+            # Create evaluator
+            evaluator = FileIndexPredicate(entry.file.embedded_index, schema_fields)
+
+            # Evaluate predicate
+            result = evaluator.evaluate(self.predicate)
+
+            # REMAIN means keep file, SKIP means drop it
+            return result.remain()
+        except Exception as e:
+            # On any error, keep the file (fail-safe). This is a backstop only:
+            # expected "cannot evaluate this literal" cases already fail open
+            # inside the evaluator, so reaching here points at an unexpected bug.
+            # Count it so explain can surface that pushdown silently degraded.
+            if stats is not None:
+                stats.file_index_fail_open_count += 1
+            logger.debug(f"File index evaluation failed, keeping file: {e}")
+            return True
 
     def _scan_dv_index(self, snapshot, buckets: Set[tuple]) -> Dict[tuple, Dict[str, DeletionFile]]:
         """

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -633,6 +633,100 @@ class JavaPyReadWriteTest(unittest.TestCase):
             "partial append should not drop index manifest"
         )
 
+    def test_read_bloom_filter_index_table(self):
+        # Tables written by JavaPyE2ETest.testBloomFilterIndexWrite, each with an
+        # embedded bloom-filter file index over column 'k'. This is the
+        # authoritative cross-language guard: pypaimon decodes a bloom blob that
+        # the real Java writer produced and must prune exactly the same way.
+        #
+        # The absent keys are chosen to fall *inside* each file's value-stats
+        # min/max (e.g. keys 10/20/30 -> [10,30]), so value-stats pruning cannot
+        # drop them first. That forces the prune decision onto the Java-written
+        # bloom blob, which is the path under test.
+        import datetime as _dt
+
+        self._test_read_bloom_index_generic(
+            'test_bloom_index_bigint', present=20, absent=15, k_type=pa.int64())
+        self._test_read_bloom_index_generic(
+            'test_bloom_index_int', present=20, absent=15, k_type=pa.int32())
+        self._test_read_bloom_index_generic(
+            'test_bloom_index_string', present='bar', absent='bay', k_type=pa.string())
+
+        # Temporal / float / binary types: anchor the conversion layers against
+        # the real Java writer. We assert the prune *behavior* (present kept,
+        # absent pruned, disabled not pruned) rather than the exact value
+        # round-trip, which is already covered by test_read_append_table; the
+        # point here is that the bloom hash matches Java for these types.
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_date',
+            present=_dt.date(2021, 1, 20), absent=_dt.date(2021, 1, 15))
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_time',
+            present=_dt.time(2, 0, 0), absent=_dt.time(1, 30, 0))
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_timestamp',
+            present=_dt.datetime(2021, 1, 1, 2, 0), absent=_dt.datetime(2021, 1, 1, 1, 30))
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_double', present=20.0, absent=15.0)
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_float', present=20.0, absent=15.0)
+        self._test_read_bloom_index_prune_only(
+            'test_bloom_index_binary', present=b'cccc', absent=b'bbbb')
+
+    def _test_read_bloom_index_prune_only(self, table_name, present, absent):
+        """Assert bloom prune behavior without asserting the exact value
+        round-trip (used for temporal/float/binary columns)."""
+        table = self.catalog.get_table('default.' + table_name)
+
+        # Present key (inside min/max, in the bloom): file kept.
+        rb = table.new_read_builder()
+        rb.with_filter(rb.new_predicate_builder().equal('k', present))
+        self.assertGreater(len(rb.new_scan().plan().splits()), 0,
+                           f"{table_name}: present key {present!r} should keep the file")
+
+        # Absent key (inside min/max, NOT in the bloom): file pruned by the bloom.
+        rb2 = table.new_read_builder()
+        rb2.with_filter(rb2.new_predicate_builder().equal('k', absent))
+        self.assertEqual(len(rb2.new_scan().plan().splits()), 0,
+                         f"{table_name}: absent key {absent!r} should be pruned by bloom index")
+
+        # Feature flag off: pruning must not happen even for an absent key.
+        rb3 = table.new_read_builder()
+        rb3.with_filter(rb3.new_predicate_builder().equal('k', absent))
+        scan3 = rb3.new_scan()
+        scan3.file_scanner.table.options.options.data['file-index.read.enabled'] = 'false'
+        self.assertGreater(len(scan3.plan().splits()), 0,
+                           f"{table_name}: disabled file index must not prune")
+
+    def _test_read_bloom_index_generic(self, table_name, present, absent, k_type):
+        table = self.catalog.get_table('default.' + table_name)
+
+        # Present key: the bloom filter keeps the file and the row is returned.
+        rb = table.new_read_builder()
+        rb.with_filter(rb.new_predicate_builder().equal('k', present))
+        present_splits = rb.new_scan().plan().splits()
+        self.assertGreater(len(present_splits), 0,
+                           f"{table_name}: present key {present} should keep the file")
+        actual = rb.new_read().to_arrow(present_splits)
+        self.assertEqual(actual.num_rows, 1)
+        self.assertEqual(actual.column('k')[0].as_py(), present)
+
+        # Absent key: the bloom filter proves the value is missing, so the only
+        # data file is pruned and no splits remain.
+        rb2 = table.new_read_builder()
+        rb2.with_filter(rb2.new_predicate_builder().equal('k', absent))
+        absent_splits = rb2.new_scan().plan().splits()
+        self.assertEqual(len(absent_splits), 0,
+                         f"{table_name}: absent key {absent} should be pruned by bloom index")
+
+        # Feature flag off: pruning must not happen even for an absent key.
+        rb3 = table.new_read_builder()
+        rb3.with_filter(rb3.new_predicate_builder().equal('k', absent))
+        scan3 = rb3.new_scan()
+        scan3.file_scanner.table.options.options.data['file-index.read.enabled'] = 'false'
+        self.assertGreater(len(scan3.plan().splits()), 0,
+                           f"{table_name}: disabled file index must not prune")
+
     @parameterized.expand([('json',), ('csv',)])
     def test_read_compressed_text_append_table(self, file_format):
         table = self.catalog.get_table(

--- a/paimon-python/pypaimon/tests/fileindex/__init__.py
+++ b/paimon-python/pypaimon/tests/fileindex/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/paimon-python/pypaimon/tests/fileindex/bloom_blob_builder.py
+++ b/paimon-python/pypaimon/tests/fileindex/bloom_blob_builder.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared test helper that builds a FileIndexFormat blob with pypaimon's own
+BloomFilter64.
+
+Used by the pure-Python unit/integration tests to exercise the scanner wiring
+and the evaluator without a checked-in fixture. Cross-language byte
+compatibility with the Java writer is covered by the e2e test
+(JavaPyE2ETest#testBloomFilterIndexWrite), not by this builder.
+
+Keeping the FileIndexFormat framing in one place means a format change touches a
+single helper rather than several hand-rolled copies.
+"""
+
+import struct
+
+from pypaimon.fileindex.bloom_filter import BloomFilter64
+from pypaimon.fileindex.fast_hash import get_hash_function
+from pypaimon.fileindex.file_index_format import MAGIC, VERSION_1
+
+
+def build_bloom_blob(column, type_str, values, items=100, fpp=0.1):
+    """Build a complete FileIndexFormat blob carrying a single bloom-filter index.
+
+    Args:
+        column: column name to register the index under.
+        type_str: the column's atomic type string (e.g. "BIGINT", "VARCHAR(10)").
+        values: values to insert into the bloom filter (hashed with the same
+            routine the read path uses).
+        items, fpp: bloom sizing parameters.
+
+    Returns:
+        bytes: magic + header + serialized BloomFilter64 body, in the exact
+        layout FileIndexFormatReader expects.
+    """
+    from pypaimon.schema.data_types import AtomicType
+
+    hash_fn = get_hash_function(AtomicType(type_str))
+    bf = BloomFilter64(items, fpp)
+    for v in values:
+        bf.add_hash(hash_fn(v))
+    body = struct.pack(">I", bf.get_num_hash_functions()) + bytes(bf.get_bitset().data)
+
+    def w_utf(s):
+        b = s.encode("utf-8")
+        return struct.pack(">H", len(b)) + b
+
+    idx = "bloom-filter"
+    # head_length = magic(8) + version(4) + headLength(4) + body-info section.
+    head_length = 8 + 4 + 4 + (
+        4 + len(w_utf(column)) + 4 + len(w_utf(idx)) + 4 + 4 + 4
+    )
+    head = (
+        struct.pack(">I", 1)                  # column count
+        + w_utf(column)
+        + struct.pack(">I", 1)                # index count for the column
+        + w_utf(idx)
+        + struct.pack(">i", head_length)      # start pos (relative 0 + head_length)
+        + struct.pack(">i", len(body))        # length
+        + struct.pack(">I", 0)                # redundant length
+    )
+    return (
+        struct.pack(">Q", MAGIC)
+        + struct.pack(">I", VERSION_1)
+        + struct.pack(">I", head_length)
+        + head
+        + body
+    )

--- a/paimon-python/pypaimon/tests/fileindex/test_bloom_filter.py
+++ b/paimon-python/pypaimon/tests/fileindex/test_bloom_filter.py
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestBitSet:
+    def test_set_and_get(self):
+        from pypaimon.fileindex.bloom_filter import BitSet
+
+        data = bytearray(2)  # 16 bits
+        bitset = BitSet(data, 0)
+
+        # Set bits 0, 7, 15
+        bitset.set(0)
+        bitset.set(7)
+        bitset.set(15)
+
+        assert bitset.get(0) is True
+        assert bitset.get(1) is False
+        assert bitset.get(7) is True
+        assert bitset.get(15) is True
+        assert bitset.get(8) is False
+
+
+class TestBloomFilter64:
+    def test_add_and_test_hash(self):
+        from pypaimon.fileindex.bloom_filter import BloomFilter64
+
+        # Create filter: 100 items, 0.1 fpp
+        bf = BloomFilter64(100, 0.1)
+
+        # Add hash
+        bf.add_hash(12345678901234)
+
+        # Should find it. (A bloom filter guarantees no false negatives; it does
+        # NOT guarantee a non-inserted value tests False, so we only assert the
+        # inserted-key invariant here.)
+        assert bf.test_hash(12345678901234) is True
+
+    def test_multiple_hashes(self):
+        from pypaimon.fileindex.bloom_filter import BloomFilter64
+
+        bf = BloomFilter64(1000, 0.01)
+
+        # Add multiple hashes
+        hashes = [111, 222, 333, 444, 555]
+        for h in hashes:
+            bf.add_hash(h)
+
+        # All should be found (no false negatives). We intentionally do not
+        # assert that a non-inserted value tests False — that depends on the
+        # absence of a false positive, which a bloom filter does not guarantee
+        # and which can flip if the sizing math changes.
+        for h in hashes:
+            assert bf.test_hash(h) is True

--- a/paimon-python/pypaimon/tests/fileindex/test_java_compat.py
+++ b/paimon-python/pypaimon/tests/fileindex/test_java_compat.py
@@ -1,0 +1,335 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Cross-language compatibility tests for the bloom-filter file index.
+
+The PyPaimon read path must decode bloom-filter indexes written by the Java
+writer, so the hash arithmetic has to reproduce Java's integer-overflow
+semantics bit-for-bit. These unit tests pin each routine with vectors derived
+from the Java algorithms (Thomas Wang long overflow, XXH64 constants) and the
+on-disk format rules, to localize any drift to a specific routine.
+
+End-to-end byte compatibility against the real Java writer is covered separately
+by the e2e test ``JavaPyE2ETest#testBloomFilterIndexWrite`` ->
+``JavaPyReadWriteTest::test_read_bloom_filter_index_table``.
+"""
+
+import pytest
+
+
+class TestGetLongHashJavaCompat:
+    """get_long_hash must match Java FastHash.getLongHash for all 64-bit keys."""
+
+    # key -> Java getLongHash(key) reinterpreted as unsigned 64-bit
+    GOLDEN = {
+        0: 0,
+        1: 6614235796240398542,
+        2: 13228483051453548148,
+        42: 1098236396662648698,
+        123456789: 16581954974024456952,
+        # 2**40 - regression: the original port computed this wrong because it
+        # never truncated intermediate results to 64 bits.
+        1099511627776: 6024996419662910741,
+        # signed boundaries (passed in as unsigned 64-bit)
+        (1 << 64) - 1: 6614246905173314819,            # Java -1L
+        9223372036854775807: 9344215449356265527,       # Long.MAX_VALUE
+        9223372036854775808: 4316648529147585864,       # Long.MIN_VALUE bits
+    }
+
+    def test_known_vectors(self):
+        from pypaimon.fileindex.fast_hash import get_long_hash
+
+        for key, expected in self.GOLDEN.items():
+            assert get_long_hash(key) == expected, f"key={key}"
+
+
+class TestXxHashJavaCompat:
+    """hash64_bytes must match Java net.openhft LongHashFunction.xx() (XXH64 seed=0)."""
+
+    GOLDEN = {
+        b"": 17241709254077376921,
+        b"a": 15154266338359012955,
+        b"hello": 2794345569481354659,
+        b"paimon": 615975309333239268,
+    }
+
+    def test_known_vectors(self):
+        pytest.importorskip("xxhash")
+        from pypaimon.fileindex.fast_hash import hash64_bytes
+
+        for data, expected in self.GOLDEN.items():
+            assert hash64_bytes(data) == expected, f"data={data!r}"
+
+
+class TestTypeRouting:
+    """Type dispatch must not misroute TIMESTAMP/TIME and must reach numeric/string branches."""
+
+    def _atomic(self, type_str):
+        from pypaimon.schema.data_types import AtomicType
+
+        return AtomicType(type_str)
+
+    def test_timestamp_not_routed_to_integer(self):
+        # TIMESTAMP must use the millisecond/micros logic, NOT int(value).
+        # A bare int() on a timestamp-like object would raise; the dedicated
+        # branch handles get_millisecond()/to_micros() (as the real pypaimon
+        # Timestamp does).
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        class FakeTs:
+            def get_millisecond(self):
+                return 1700000000000
+
+            def to_micros(self):
+                return 1700000000000000
+
+        hash_fn = get_hash_function(self._atomic("TIMESTAMP(3)"))
+        assert hash_fn(FakeTs()) == get_long_hash(1700000000000)
+
+    def test_int_routes_to_long_hash(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        hash_fn = get_hash_function(self._atomic("INT"))
+        assert hash_fn(42) == get_long_hash(42)
+
+    def test_tinyint_in_range_matches_plain_hash(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        # In-range values (the only ones pyarrow produces) are unchanged.
+        hash_fn = get_hash_function(self._atomic("TINYINT"))
+        for v in (0, 1, -1, 127, -128):
+            assert hash_fn(v) == get_long_hash(v), f"value={v}"
+
+    def test_tinyint_out_of_range_sign_truncates_like_java(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        # Java casts to (byte): 200 -> -56, 256 -> 0.
+        hash_fn = get_hash_function(self._atomic("TINYINT"))
+        assert hash_fn(200) == get_long_hash(-56)
+        assert hash_fn(256) == get_long_hash(0)
+
+    def test_smallint_out_of_range_sign_truncates_like_java(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        # Java casts to (short): 40000 -> 40000 - 65536 = -25536.
+        hash_fn = get_hash_function(self._atomic("SMALLINT"))
+        assert hash_fn(40000) == get_long_hash(-25536)
+
+    def test_varchar_routes_to_bytes_hash(self):
+        pytest.importorskip("xxhash")
+        from pypaimon.fileindex.fast_hash import get_hash_function, hash64_bytes
+
+        hash_fn = get_hash_function(self._atomic("VARCHAR(10)"))
+        assert hash_fn("hello") == hash64_bytes(b"hello")
+
+
+class TestEvaluatorFailOpen:
+    """The predicate evaluator must fail open (REMAIN) on a literal it cannot
+    hash in a Java-compatible way, rather than raise. This is pure-Python
+    evaluator behavior, so it builds its own bloom blob locally."""
+
+    def _bigint_predicate(self):
+        from pypaimon.fileindex.file_index_predicate import FileIndexPredicate
+        from pypaimon.schema.data_types import AtomicType
+        from pypaimon.tests.fileindex.bloom_blob_builder import build_bloom_blob
+
+        blob = build_bloom_blob("a", "BIGINT", (10, 20, 30))
+        return FileIndexPredicate(blob, {"a": AtomicType("BIGINT")})
+
+    @staticmethod
+    def _equal(value):
+        from pypaimon.common.predicate import Predicate
+
+        return Predicate(method="equal", index=0, field="a", literals=[value])
+
+    @staticmethod
+    def _in(values):
+        from pypaimon.common.predicate import Predicate
+
+        return Predicate(method="in", index=0, field="a", literals=values)
+
+    def test_present_value_remains(self):
+        fip = self._bigint_predicate()
+        assert fip.evaluate(self._equal(20)).remain() is True
+
+    def test_absent_value_skips(self):
+        fip = self._bigint_predicate()
+        assert fip.evaluate(self._equal(99)).remain() is False
+
+    def test_unhashable_literal_fails_open(self):
+        # A non-numeric string against a BIGINT column (as a CLI WHERE parser
+        # might produce) cannot be hashed, so the evaluator must fail open to
+        # REMAIN rather than raise.
+        fip = self._bigint_predicate()
+        assert fip.evaluate(self._equal("not-a-number")).remain() is True
+        assert fip.evaluate(self._in(["nope", "also-nope"])).remain() is True
+
+    def test_empty_in_fails_open(self):
+        from pypaimon.common.predicate import Predicate
+
+        # An empty IN has no value to probe; it must fail open (REMAIN) rather
+        # than SKIP, which would silently drop the file.
+        fip = self._bigint_predicate()
+        empty_in = Predicate(method="in", index=0, field="a", literals=[])
+        assert fip.evaluate(empty_in).remain() is True
+
+    def test_empty_or_fails_open(self):
+        from pypaimon.common.predicate import Predicate
+
+        # An empty OR likewise must fail open rather than SKIP.
+        fip = self._bigint_predicate()
+        empty_or = Predicate(method="or", index=None, field=None, literals=[])
+        assert fip.evaluate(empty_or).remain() is True
+
+
+class TestTemporalHashing:
+    """DATE/TIME/TIMESTAMP literals must hash their Java internal representation.
+
+    Java's FastHash hashes DATE as epoch-day (int), TIME as millis-of-day (int),
+    and TIMESTAMP as millis (precision<=3) or micros (precision>3). The Python
+    read path receives native ``date``/``time``/``datetime`` literals, so it must
+    convert them before hashing — otherwise the bloom probe lands on the wrong
+    bits and a present value can be wrongly skipped.
+    """
+
+    def _atomic(self, type_str):
+        from pypaimon.schema.data_types import AtomicType
+
+        return AtomicType(type_str)
+
+    def test_date_hashes_epoch_day(self):
+        from datetime import date
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        d = date(2021, 1, 1)
+        epoch_day = (d - date(1970, 1, 1)).days
+        assert get_hash_function(self._atomic("DATE"))(d) == get_long_hash(epoch_day)
+
+    def test_time_hashes_millis_of_day(self):
+        from datetime import time
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        t = time(1, 2, 3, 456000)
+        millis = (1 * 3600 + 2 * 60 + 3) * 1000 + 456000 // 1000
+        assert get_hash_function(self._atomic("TIME(3)"))(t) == get_long_hash(millis)
+
+    def test_timestamp_precision3_hashes_millis(self):
+        import calendar
+        from datetime import datetime
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        ts = datetime(2021, 1, 1, 0, 0, 0)
+        millis = calendar.timegm(ts.timetuple()) * 1000
+        assert get_hash_function(self._atomic("TIMESTAMP(3)"))(ts) == get_long_hash(millis)
+
+    def test_timestamp_precision6_hashes_micros(self):
+        import calendar
+        from datetime import datetime
+        from pypaimon.fileindex.fast_hash import get_hash_function, get_long_hash
+
+        ts = datetime(2021, 1, 1, 0, 0, 0)
+        micros = calendar.timegm(ts.timetuple()) * 1_000_000
+        assert get_hash_function(self._atomic("TIMESTAMP(6)"))(ts) == get_long_hash(micros)
+
+    def test_timestamp_rejects_ambiguous_int(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function
+
+        # A bare int cannot be hashed unambiguously (millis vs micros), so it
+        # must raise rather than silently guess the wrong unit.
+        with pytest.raises(TypeError):
+            get_hash_function(self._atomic("TIMESTAMP(3)"))(12345)
+
+    def test_temporal_none_hashes_zero(self):
+        from pypaimon.fileindex.fast_hash import get_hash_function
+
+        for type_str in ("DATE", "TIME(3)", "TIMESTAMP(3)", "TIMESTAMP(6)"):
+            assert get_hash_function(self._atomic(type_str))(None) == 0
+
+    def test_timezone_aware_datetime_raises(self):
+        from datetime import datetime, timezone, timedelta
+        from pypaimon.fileindex.fast_hash import get_hash_function
+
+        # An aware datetime carries an instant the wall-clock hash would get
+        # wrong, so it must raise (the evaluator then fails open) rather than
+        # silently probe the wrong bloom bit.
+        aware = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+        for type_str in ("TIMESTAMP(3)", "TIMESTAMP(6)"):
+            with pytest.raises(TypeError):
+                get_hash_function(self._atomic(type_str))(aware)
+
+
+class TestFileIndexFormatHardening:
+    """The format reader must mirror Java's signed-int / EOF semantics so a
+    corrupt or empty index degrades safely (REMAIN) instead of silently
+    producing a short bitset that could cause false SKIPs."""
+
+    def _make_reader(self, blob):
+        from pypaimon.fileindex.file_index_format import FileIndexFormatReader
+
+        return FileIndexFormatReader(blob)
+
+    def _header_blob(self, start_pos, length, body=b""):
+        """Build a one-column ('a') / one-index ('bloom-filter') blob with an
+        arbitrary (start_pos, length) so the reader's bounds handling can be
+        exercised. ``start_pos`` is written signed, matching Java."""
+        import struct
+
+        from pypaimon.fileindex.file_index_format import MAGIC, VERSION_1
+
+        def w_utf(s):
+            b = s.encode("utf-8")
+            return struct.pack(">H", len(b)) + b
+
+        col, idx = "a", "bloom-filter"
+        head_len = 8 + 4 + 4 + (4 + len(w_utf(col)) + 4 + len(w_utf(idx)) + 4 + 4 + 4)
+        head = (
+            struct.pack(">I", 1)
+            + w_utf(col)
+            + struct.pack(">I", 1)
+            + w_utf(idx)
+            + struct.pack(">i", start_pos)   # signed, like Java writeInt
+            + struct.pack(">i", length)
+            + struct.pack(">I", 0)            # redundant length
+        )
+        return (
+            struct.pack(">Q", MAGIC)
+            + struct.pack(">I", VERSION_1)
+            + struct.pack(">I", head_len)
+            + head
+            + body
+        )
+
+    def test_empty_index_flag_returns_none(self):
+        # Java writes EMPTY_INDEX_FLAG (-1) for columns with no index body.
+        blob = self._header_blob(start_pos=-1, length=0)
+        reader = self._make_reader(blob)
+        assert reader.get_columns() == ["a"]
+        assert reader.read_column_index("a", "bloom-filter") is None
+
+    def test_out_of_range_slice_returns_none(self):
+        # A truncated/corrupt blob whose declared (start,length) exceeds the data
+        # must NOT return a silently-shortened slice.
+        blob = self._header_blob(start_pos=10_000, length=64)
+        reader = self._make_reader(blob)
+        assert reader.read_column_index("a", "bloom-filter") is None
+
+    def test_length_overrun_returns_none(self):
+        blob = self._header_blob(start_pos=0, length=1)  # start 0 is inside header, but
+        # extend length far past the end to force the overrun branch
+        blob = self._header_blob(start_pos=len(blob) - 4, length=1024)
+        reader = self._make_reader(blob)
+        assert reader.read_column_index("a", "bloom-filter") is None

--- a/paimon-python/pypaimon/tests/fileindex/test_scanner_integration.py
+++ b/paimon-python/pypaimon/tests/fileindex/test_scanner_integration.py
@@ -1,0 +1,160 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Scanner-level integration tests for bloom-filter file index pushdown.
+
+These tests build a bloom blob with pypaimon's own BloomFilter64 (over keys
+10/20/30), attach it to a real manifest entry, and drive the actual scan path,
+verifying that:
+
+* a value absent from the bloom prunes the file (fewer/zero splits),
+* a value present in the bloom keeps the file,
+* ``file-index.read.enabled=false`` disables pruning,
+* the explain counters / "File index pruning" funnel reflect what happened.
+
+This covers the scanner *wiring* (pure Python); cross-language byte
+compatibility with the Java writer is covered separately by the e2e test
+(JavaPyE2ETest#testBloomFilterIndexWrite) and the hash unit tests in
+test_java_compat.py.
+
+The value stats on the entry are deliberately widened to span the queried
+values, so the stats stage never prunes and the bloom filter is the sole
+decider — otherwise these would not actually exercise the file-index stage.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.read.scanner.file_scanner import FileScanner
+from pypaimon.table.row.generic_row import GenericRow
+
+from pypaimon.tests.fileindex.bloom_blob_builder import build_bloom_blob
+
+
+class BloomScannerIntegrationTest(unittest.TestCase):
+
+    BLOOM_KEYS = [10, 20, 30]   # keys baked into the bloom blob
+    ABSENT_KEY = 99             # not in the bloom
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.warehouse = os.path.join(self.tempdir, "warehouse")
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("default", False)
+        self.pa_schema = pa.schema([("a", pa.int64())])
+        self.blob = build_bloom_blob("a", "BIGINT", self.BLOOM_KEYS)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def _create_table(self, name, options=None):
+        schema = Schema.from_pyarrow_schema(self.pa_schema, options=options or {})
+        self.catalog.create_table(f"default.{name}", schema, False)
+        table = self.catalog.get_table(f"default.{name}")
+        # Write the keys that are actually in the bloom so the data file is real.
+        data = pa.Table.from_pydict({"a": list(self.BLOOM_KEYS)}, schema=self.pa_schema)
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_arrow(data)
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+        return table
+
+    def _attach_bloom(self, table):
+        """Attach the locally-built bloom blob to the single data file's manifest
+        entry, and widen value stats so the stats stage never prunes."""
+        fs = FileScanner(table, lambda: ([], None))
+        snapshot = fs.snapshot_manager.get_latest_snapshot()
+        manifest_files = fs.manifest_list_manager.read_all(snapshot)
+        entries = fs.manifest_file_manager.read(manifest_files[0].file_name)
+        self.assertEqual(len(entries), 1)
+        for entry in entries:
+            entry.file.embedded_index = self.blob
+            # Span [0, 1000] so any queried value passes the stats stage and the
+            # bloom filter is the only thing that can prune.
+            entry.file.value_stats_cols = ["a"]
+            entry.file.value_stats = SimpleStats(
+                GenericRow([0], [table.fields[0]]),
+                GenericRow([1000], [table.fields[0]]),
+                [0],
+            )
+        fs.manifest_file_manager.write(manifest_files[0].file_name, entries)
+
+    def _scan_splits(self, table, value):
+        rb = table.new_read_builder()
+        pred = rb.new_predicate_builder().equal("a", value)
+        return rb.with_filter(pred).new_scan().plan().splits()
+
+    def test_absent_value_prunes_file(self):
+        table = self._create_table("t_absent")
+        self._attach_bloom(table)
+        # 99 is not in the bloom -> the only file is pruned -> no splits.
+        splits = self._scan_splits(table, self.ABSENT_KEY)
+        self.assertEqual(len(splits), 0)
+
+    def test_present_value_keeps_file(self):
+        table = self._create_table("t_present")
+        self._attach_bloom(table)
+        # 10 is in the bloom -> file is kept.
+        splits = self._scan_splits(table, self.BLOOM_KEYS[0])
+        self.assertGreater(len(splits), 0)
+
+    def test_disabled_does_not_prune(self):
+        table = self._create_table("t_disabled", options={"file-index.read.enabled": "false"})
+        self._attach_bloom(table)
+        # With the feature off, even an absent value must not prune via bloom.
+        splits = self._scan_splits(table, self.ABSENT_KEY)
+        self.assertGreater(len(splits), 0)
+
+    def test_explain_counters_reflect_pruning(self):
+        table = self._create_table("t_explain")
+        self._attach_bloom(table)
+        rb = table.new_read_builder()
+        pred = rb.new_predicate_builder().equal("a", self.ABSENT_KEY)
+        rb = rb.with_filter(pred)
+        scan = rb.new_scan()
+        _, stats = scan.file_scanner.scan_with_stats()
+        # One entry survived stats, the bloom was applied to it, and it did not
+        # survive the file-index stage.
+        self.assertEqual(stats.entries_after_stats, 1)
+        self.assertEqual(stats.entries_file_index_applied, 1)
+        self.assertEqual(stats.entries_after_file_index, 0)
+        self.assertEqual(stats.file_index_fail_open_count, 0)
+
+    def test_explain_counters_present_value(self):
+        table = self._create_table("t_explain_present")
+        self._attach_bloom(table)
+        rb = table.new_read_builder()
+        pred = rb.new_predicate_builder().equal("a", self.BLOOM_KEYS[0])
+        rb = rb.with_filter(pred)
+        scan = rb.new_scan()
+        _, stats = scan.file_scanner.scan_with_stats()
+        self.assertEqual(stats.entries_after_stats, 1)
+        self.assertEqual(stats.entries_file_index_applied, 1)
+        self.assertEqual(stats.entries_after_file_index, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Purpose

Implements the embedded bloom-filter file index read path from #8090 (PR 1 of the umbrella). On the PyPaimon read path, a data file whose embedded bloom index proves a queried value is absent is skipped before being read.

This is a Python reimplementation of Java's file-index wire format and hashing, so it is byte/bit exact against the Java writer.

**Changes**
- New `fileindex` module: `BloomFilter64`/`BitSet`, `FastHash`, `FileIndexFormat` reader, `FileIndexPredicate` evaluator, `FileIndexResult`.
- New option `file-index.read.enabled` (default `true`).
- Pushdown integrated into `FileScanner._filter_manifest_entry`; explain gains a "File index pruning" funnel line.

**Java compatibility**
- `get_long_hash` reproduces Java's signed 64-bit long overflow; the bloom combined-hash reproduces signed 32-bit int overflow.
- Strings/binary hash via XXH64 (matches `net.openhft LongHashFunction.xx`); FLOAT/DOUBLE via IEEE-754 bits; TINYINT/SMALLINT sign-truncate like Java's `(byte)`/`(short)`.
- DATE/TIME/TIMESTAMP normalized to Java's internal repr (epoch-day / millis-of-day / millis-or-micros by precision).
- `FileIndexFormat` reads start positions as signed ints, honors the `EMPTY_INDEX_FLAG` sentinel, and bounds-checks slices (a corrupt/truncated blob fails open instead of producing a short bitset).

**Correctness gates**
- **PK tables**: only applied in deletion-vector mode (files within a bucket don't overlap there), mirroring the existing value-stats gate, to avoid keeping a stale older value while skipping a newer overwrite.
- **Data evolution**: skipped (Java devolves the filter by field id; out of scope here).
- **Fail-open throughout**: unhashable literals and empty OR/IN degrade to REMAIN; any unexpected error keeps the file and is counted (`file_index_fail_open_count`, surfaced in explain).

**Out of scope (tracked in #8090)**
- External `.index` files (PR 4 in #8090) — only embedded indexes are read here.
- CLI temporal literals (WHERE parser yields strings; safely fall back to REMAIN).
- TIMESTAMP_LTZ / timezone-aware datetimes (rejected → fail open).
- Modified-UTF-8 column names (decoded as standard UTF-8; ASCII in practice).

### Tests

- **Cross-language e2e (authoritative, runs in CI `mixed_check`)**: `JavaPyE2ETest#testBloomFilterIndexWrite` writes embedded bloom indexes (BIGINT/INT/STRING) with the real Java writer and asserts an existing key is kept and an **in-range-but-absent** key is pruned; `JavaPyReadWriteTest::test_read_bloom_filter_index_table` reads them via PyPaimon and asserts the same. Absent keys are chosen inside each file's value-stats min/max so the prune decision falls on the bloom blob, not on value stats. Wired into `dev/run_mixed_tests.sh`.
- **Unit** (plain `pytest`): `test_java_compat.py` pins each hash routine and the format-reader rules with Java-derived vectors, plus evaluator fail-open behavior (unhashable literal, empty OR/IN).
- **Scanner integration**: `test_scanner_integration.py` builds a bloom blob with PyPaimon's own `BloomFilter64` and drives the scan path (prune / keep / disabled / explain counters).
