### PR TITLE
[core] Add totalFileSize and totalDataFiles to snapshot metadata

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
+++ b/paimon-api/src/main/java/org/apache/paimon/Snapshot.java
@@ -69,6 +69,8 @@ public class Snapshot implements Serializable {
     protected static final String FIELD_STATISTICS = "statistics";
     protected static final String FIELD_PROPERTIES = "properties";
     protected static final String FIELD_NEXT_ROW_ID = "nextRowId";
+    protected static final String FIELD_TOTAL_FILE_SIZE = "totalFileSize";
+    protected static final String FIELD_TOTAL_DATA_FILES = "totalDataFiles";
 
     // version of snapshot
     @JsonProperty(FIELD_VERSION)
@@ -181,6 +183,16 @@ public class Snapshot implements Serializable {
     @Nullable
     protected final Long nextRowId;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_TOTAL_FILE_SIZE)
+    @Nullable
+    protected final Long totalFileSize;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_TOTAL_DATA_FILES)
+    @Nullable
+    protected final Long totalDataFiles;
+
     public Snapshot(
             long id,
             long schemaId,
@@ -201,7 +213,9 @@ public class Snapshot implements Serializable {
             @Nullable Long watermark,
             @Nullable String statistics,
             @Nullable Map<String, String> properties,
-            @Nullable Long nextRowId) {
+            @Nullable Long nextRowId,
+            @Nullable Long totalFileSize,
+            @Nullable Long totalDataFiles) {
         this(
                 CURRENT_VERSION,
                 id,
@@ -223,7 +237,9 @@ public class Snapshot implements Serializable {
                 watermark,
                 statistics,
                 properties,
-                nextRowId);
+                nextRowId,
+                totalFileSize,
+                totalDataFiles);
     }
 
     @JsonCreator
@@ -249,7 +265,9 @@ public class Snapshot implements Serializable {
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties,
-            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId) {
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE) @Nullable Long totalFileSize,
+            @JsonProperty(FIELD_TOTAL_DATA_FILES) @Nullable Long totalDataFiles) {
         this.version = version;
         this.id = id;
         this.schemaId = schemaId;
@@ -271,6 +289,8 @@ public class Snapshot implements Serializable {
         this.statistics = statistics;
         this.properties = properties;
         this.nextRowId = nextRowId;
+        this.totalFileSize = totalFileSize;
+        this.totalDataFiles = totalDataFiles;
     }
 
     @JsonGetter(FIELD_VERSION)
@@ -388,6 +408,18 @@ public class Snapshot implements Serializable {
         return nextRowId;
     }
 
+    @JsonGetter(FIELD_TOTAL_FILE_SIZE)
+    @Nullable
+    public Long totalFileSize() {
+        return totalFileSize;
+    }
+
+    @JsonGetter(FIELD_TOTAL_DATA_FILES)
+    @Nullable
+    public Long totalDataFiles() {
+        return totalDataFiles;
+    }
+
     public String toJson() {
         return JsonSerdeUtil.toJson(this);
     }
@@ -415,7 +447,9 @@ public class Snapshot implements Serializable {
                 watermark,
                 statistics,
                 properties,
-                nextRowId);
+                nextRowId,
+                totalFileSize,
+                totalDataFiles);
     }
 
     @Override
@@ -447,7 +481,9 @@ public class Snapshot implements Serializable {
                 && Objects.equals(watermark, that.watermark)
                 && Objects.equals(statistics, that.statistics)
                 && Objects.equals(properties, that.properties)
-                && Objects.equals(nextRowId, that.nextRowId);
+                && Objects.equals(nextRowId, that.nextRowId)
+                && Objects.equals(totalFileSize, that.totalFileSize)
+                && Objects.equals(totalDataFiles, that.totalDataFiles);
     }
 
     /** Type of changes in this snapshot. */

--- a/paimon-core/src/main/java/org/apache/paimon/Changelog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/Changelog.java
@@ -63,7 +63,9 @@ public class Changelog extends Snapshot {
                 snapshot.watermark(),
                 snapshot.statistics(),
                 snapshot.properties,
-                snapshot.nextRowId);
+                snapshot.nextRowId,
+                snapshot.totalFileSize(),
+                snapshot.totalDataFiles());
     }
 
     @JsonCreator
@@ -89,7 +91,9 @@ public class Changelog extends Snapshot {
             @JsonProperty(FIELD_WATERMARK) @Nullable Long watermark,
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
-            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId) {
+            @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE) @Nullable Long totalFileSize,
+            @JsonProperty(FIELD_TOTAL_DATA_FILES) @Nullable Long totalDataFiles) {
         super(
                 version,
                 id,
@@ -111,7 +115,9 @@ public class Changelog extends Snapshot {
                 watermark,
                 statistics,
                 properties,
-                nextRowId);
+                nextRowId,
+                totalFileSize,
+                totalDataFiles);
     }
 
     public static Changelog fromJson(String json) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -948,9 +948,15 @@ public class FileStoreCommitImpl implements FileStoreCommit {
         long nextRowIdStart = firstRowIdStart;
         try {
             long previousTotalRecordCount = 0L;
+            long previousTotalFileSize = 0L;
+            long previousTotalDataFiles = 0L;
             Long currentWatermark = watermark;
             if (latestSnapshot != null) {
                 previousTotalRecordCount = latestSnapshot.totalRecordCount();
+                Long previousFileSize = latestSnapshot.totalFileSize();
+                previousTotalFileSize = previousFileSize == null ? 0L : previousFileSize;
+                Long previousDataFiles = latestSnapshot.totalDataFiles();
+                previousTotalDataFiles = previousDataFiles == null ? 0L : previousDataFiles;
                 // read all previous manifest files
                 mergeBeforeManifests = manifestList.readDataManifests(latestSnapshot);
                 Long latestWatermark = latestSnapshot.watermark();
@@ -988,6 +994,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             // the added records subtract the deleted records from
             long deltaRecordCount = recordCountAdd(deltaFiles) - recordCountDelete(deltaFiles);
             long totalRecordCount = previousTotalRecordCount + deltaRecordCount;
+
+            long deltaFileSize = 0L;
+            long deltaDataFiles = 0L;
+            for (ManifestEntry entry : deltaFiles) {
+                int sign = FileKind.ADD.equals(entry.kind()) ? 1 : -1;
+                deltaFileSize += sign * entry.file().fileSize();
+                deltaDataFiles += sign;
+            }
+            long totalFileSize = previousTotalFileSize + deltaFileSize;
+            long totalDataFiles = previousTotalDataFiles + deltaDataFiles;
 
             // write new delta files into manifest files
             deltaStatistics = new ArrayList<>(PartitionEntry.merge(deltaFiles));
@@ -1044,7 +1060,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                             statsFileName,
                             // if empty properties, just set to null
                             properties.isEmpty() ? null : properties,
-                            nextRowIdStart);
+                            nextRowIdStart,
+                            totalFileSize,
+                            totalDataFiles);
         } catch (Throwable e) {
             // fails when preparing for commit, we should clean up
             commitCleaner.cleanUpReuseTmpManifests(
@@ -1148,7 +1166,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latest.statistics(),
                         // if empty properties, just set to null
                         latest.properties(),
-                        nextRowId);
+                        nextRowId,
+                        latest.totalFileSize(),
+                        latest.totalDataFiles());
 
         return commitSnapshotImpl(newSnapshot, emptyList());
     }
@@ -1227,7 +1247,9 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         latestSnapshot.watermark(),
                         latestSnapshot.statistics(),
                         latestSnapshot.properties(),
-                        latestSnapshot.nextRowId());
+                        latestSnapshot.nextRowId(),
+                        latestSnapshot.totalFileSize(),
+                        latestSnapshot.totalDataFiles());
 
         return commitSnapshotImpl(newSnapshot, emptyList());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SnapshotsTable.java
@@ -108,7 +108,9 @@ public class SnapshotsTable implements ReadonlyTable {
                             new DataField(10, "delta_record_count", new BigIntType(true)),
                             new DataField(11, "changelog_record_count", new BigIntType(true)),
                             new DataField(12, "watermark", new BigIntType(true)),
-                            new DataField(13, "next_row_id", new BigIntType(true))));
+                            new DataField(13, "next_row_id", new BigIntType(true)),
+                            new DataField(14, "total_file_size", new BigIntType(true)),
+                            new DataField(15, "total_data_files", new BigIntType(true))));
 
     private final FileIO fileIO;
     private final Path location;
@@ -339,7 +341,9 @@ public class SnapshotsTable implements ReadonlyTable {
                     snapshot.deltaRecordCount(),
                     snapshot.changelogRecordCount(),
                     snapshot.watermark(),
-                    snapshot.nextRowId());
+                    snapshot.nextRowId(),
+                    snapshot.totalFileSize(),
+                    snapshot.totalDataFiles());
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/Tag.java
@@ -80,6 +80,8 @@ public class Tag extends Snapshot {
             @JsonProperty(FIELD_STATISTICS) @Nullable String statistics,
             @JsonProperty(FIELD_PROPERTIES) Map<String, String> properties,
             @JsonProperty(FIELD_NEXT_ROW_ID) @Nullable Long nextRowId,
+            @JsonProperty(FIELD_TOTAL_FILE_SIZE) @Nullable Long totalFileSize,
+            @JsonProperty(FIELD_TOTAL_DATA_FILES) @Nullable Long totalDataFiles,
             @JsonProperty(FIELD_TAG_CREATE_TIME) @Nullable LocalDateTime tagCreateTime,
             @JsonProperty(FIELD_TAG_TIME_RETAINED) @Nullable Duration tagTimeRetained) {
         super(
@@ -103,7 +105,9 @@ public class Tag extends Snapshot {
                 watermark,
                 statistics,
                 properties,
-                nextRowId);
+                nextRowId,
+                totalFileSize,
+                totalDataFiles);
         this.tagCreateTime = tagCreateTime;
         this.tagTimeRetained = tagTimeRetained;
     }
@@ -142,6 +146,8 @@ public class Tag extends Snapshot {
                 snapshot.statistics(),
                 snapshot.properties(),
                 snapshot.nextRowId(),
+                snapshot.totalFileSize(),
+                snapshot.totalDataFiles(),
                 tagCreateTime,
                 tagTimeRetained);
     }
@@ -168,7 +174,9 @@ public class Tag extends Snapshot {
                 watermark,
                 statistics,
                 properties,
-                nextRowId);
+                nextRowId,
+                totalFileSize,
+                totalDataFiles);
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/RenamingSnapshotCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/RenamingSnapshotCommitTest.java
@@ -137,6 +137,8 @@ public class RenamingSnapshotCommitTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/SnapshotsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/SnapshotsTableTest.java
@@ -118,7 +118,9 @@ public class SnapshotsTableTest extends TableTestBase {
                             snapshot.deltaRecordCount(),
                             snapshot.changelogRecordCount(),
                             snapshot.watermark(),
-                            snapshot.nextRowId()));
+                            snapshot.nextRowId(),
+                            snapshot.totalFileSize(),
+                            snapshot.totalDataFiles()));
         }
 
         return expectedRow;

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagAutoManagerTest.java
@@ -410,6 +410,8 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
                         null,
                         null,
                         null,
+                        null,
+                        null,
                         null);
         tagManager.createTag(
                 snapshot1,
@@ -435,6 +437,8 @@ public class TagAutoManagerTest extends PrimaryKeyTableTestBase {
                         1000,
                         0L,
                         0L,
+                        null,
+                        null,
                         null,
                         null,
                         null,

--- a/paimon-core/src/test/java/org/apache/paimon/tag/TagTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/TagTest.java
@@ -51,6 +51,8 @@ public class TagTest {
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     null);
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SnapshotManagerTest.java
@@ -276,6 +276,8 @@ public class SnapshotManagerTest {
                 null,
                 null,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -300,6 +302,8 @@ public class SnapshotManagerTest {
                 watermark,
                 null,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -321,6 +325,8 @@ public class SnapshotManagerTest {
                         millis,
                         0L,
                         0L,
+                        null,
+                        null,
                         null,
                         null,
                         null,
@@ -352,6 +358,8 @@ public class SnapshotManagerTest {
                             i * 1000,
                             0L,
                             0L,
+                            null,
+                            null,
                             null,
                             null,
                             null,
@@ -405,6 +413,8 @@ public class SnapshotManagerTest {
                             i * 1000,
                             0L,
                             0L,
+                            null,
+                            null,
                             null,
                             null,
                             null,


### PR DESCRIPTION
### Purpose
 - Add support for total file size and total data file count in snapshot metadata.
 - Allows visibility into data files at any snapshot for monitoring table growth and analytics.
 - Track at commit time as a running total off the previous snapshot, so reading them later via the snapshots table has no extra overhead.
 - Fixes user reported issue #4997
### Tests
 - UT