### PR TITLE
feat: partition archive support - initial version

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -248,7 +248,8 @@ public interface FileIO extends Serializable, Closeable {
     boolean rename(Path src, Path dst) throws IOException;
 
     default Optional<Path> archive(Path path, StorageType type) throws IOException {
-        throw new UnsupportedOperationException(getClass().getName() + " does not support archive.");
+        throw new UnsupportedOperationException(
+                getClass().getName() + " does not support archive.");
     }
 
     default void restoreArchive(Path path, Duration duration) throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -38,6 +38,7 @@ import java.io.OutputStreamWriter;
 import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -245,6 +246,20 @@ public interface FileIO extends Serializable, Closeable {
      * @return <code>true</code> if the renaming was successful, <code>false</code> otherwise
      */
     boolean rename(Path src, Path dst) throws IOException;
+
+    default Optional<Path> archive(Path path, StorageType type) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support archive.");
+    }
+
+    default void restoreArchive(Path path, Duration duration) throws IOException {
+        throw new UnsupportedOperationException(
+                getClass().getName() + " does not support restore archive.");
+    }
+
+    default Optional<Path> unarchive(Path path, StorageType type) throws IOException {
+        throw new UnsupportedOperationException(
+                getClass().getName() + " does not support unarchive.");
+    }
 
     /**
      * Override this method to empty, many FileIO implementation classes rely on static variables

--- a/paimon-common/src/main/java/org/apache/paimon/fs/StorageType.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/StorageType.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import org.apache.paimon.annotation.Public;
+
+/** Storage type for file archive operations. */
+@Public
+public enum StorageType {
+    STANDARD("Standard"),
+    ARCHIVE("Archive"),
+    COLD_ARCHIVE("ColdArchive");
+
+    private final String value;
+
+    StorageType(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/FileIOTest.java
@@ -35,6 +35,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
@@ -43,6 +44,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static org.apache.paimon.utils.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test static methods and methods with default implementations of {@link FileIO}. */
 public class FileIOTest {
@@ -166,6 +168,34 @@ public class FileIOTest {
             assertThat(statuses[0].getPath()).isEqualTo(fileA);
             assertThat(statuses[1].getPath()).isEqualTo(fileBC);
         }
+    }
+
+    @Test
+    public void testStorageTypeToString() {
+        assertThat(StorageType.STANDARD.toString()).isEqualTo("Standard");
+        assertThat(StorageType.ARCHIVE.toString()).isEqualTo("Archive");
+        assertThat(StorageType.COLD_ARCHIVE.toString()).isEqualTo("ColdArchive");
+    }
+
+    @Test
+    public void testDefaultArchiveUnsupported() {
+        FileIO fileIO = new DummyFileIO();
+        Path path = new Path(tempDir.resolve("archive-file").toUri());
+
+        assertThatThrownBy(() -> fileIO.archive(path, StorageType.ARCHIVE))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(DummyFileIO.class.getName())
+                .hasMessageContaining("archive");
+
+        assertThatThrownBy(() -> fileIO.restoreArchive(path, Duration.ofDays(1)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(DummyFileIO.class.getName())
+                .hasMessageContaining("restore archive");
+
+        assertThatThrownBy(() -> fileIO.unarchive(path, StorageType.STANDARD))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(DummyFileIO.class.getName())
+                .hasMessageContaining("unarchive");
     }
 
     /** A {@link FileIO} on local filesystem to test various default implementations. */


### PR DESCRIPTION
Ref https://github.com/apache/paimon/issues/5510

### Purpose

 Add the API contracts for partition archive support

  - Add `StorageType` for standard/archive/cold archive targets.
  - Add default `FileIO` archive, restore, and unarchive methods.


### Tests

`mvn -pl paimon-common -Pfast-build -Dtest=FileIOTest test`
