### PR TITLE
[python][ray] Fix overly strict rejection of matched updates on partitioned tables

### DIFF
--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -123,11 +123,6 @@ def _prepare(target, source, catalog_options, when_matched, when_not_matched, on
         c for c in full_target_field_names if c not in blob_cols
     ]
     on_map = dict(zip(target_on_cols, source_on_cols))
-    if when_matched and table.partition_keys:
-        raise ValueError(
-            "merge_into does not support matched clauses on partitioned "
-            "tables; cross-partition row movement is not implemented."
-        )
     matched_specs = [
         _NormalizedClause(
             spec=_normalize_set_spec(
@@ -137,6 +132,16 @@ def _prepare(target, source, catalog_options, when_matched, when_not_matched, on
         )
         for c in when_matched
     ]
+    if matched_specs and table.partition_keys:
+        partition_set = set(table.partition_keys)
+        for clause in matched_specs:
+            modified_partition_cols = partition_set & set(clause.spec.keys())
+            if modified_partition_cols:
+                raise ValueError(
+                    f"merge_into does not support updating partition columns "
+                    f"{sorted(modified_partition_cols)}; cross-partition row "
+                    f"movement is not implemented."
+                )
     has_condition = any(
         c.condition is not None
         for c in list(when_matched) + list(when_not_matched)

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -543,7 +543,6 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
 
         self.assertEqual(self._snapshot_id(target), before)
 
-    @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
     def test_matched_on_partitioned_table(self):
         pt_schema = pa.schema([
             ('pt', pa.string()),

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -543,40 +543,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
 
         self.assertEqual(self._snapshot_id(target), before)
 
-    def test_partitioned_matched_update_rejected(self):
-        pt_schema = pa.schema([
-            ('pt', pa.string()),
-            ('id', pa.int32()),
-            ('name', pa.string()),
-        ])
-        name = f'default.tbl_{uuid.uuid4().hex[:8]}'
-        s = Schema.from_pyarrow_schema(
-            pt_schema, partition_keys=['pt'], options=self.de_options,
-        )
-        self.catalog.create_table(name, s, False)
-
-        source = pa.Table.from_pydict(
-            {
-                'pt': ['a'],
-                'id': pa.array([1], type=pa.int32()),
-                'name': ['x'],
-            },
-            schema=pt_schema,
-        )
-
-        with self.assertRaises(ValueError) as ctx:
-            merge_into(
-                target=name,
-                source=source,
-                catalog_options=self.catalog_options,
-                on=['id'],
-                when_matched=[WhenMatched(update='*')],
-                num_partitions=_TEST_NUM_PARTITIONS,
-            )
-        self.assertIn('partitioned', str(ctx.exception))
-
     @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
-    def test_partitioned_table_allows_non_partition_col_update(self):
+    def test_matched_on_partitioned_table(self):
         pt_schema = pa.schema([
             ('pt', pa.string()),
             ('id', pa.int32()),
@@ -625,6 +593,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         splits = rb.new_scan().plan().splits()
         out = rb.new_read().to_arrow(splits).sort_by('id').to_pydict()
         self.assertEqual(out['name'], ['new_1', 'old_2'])
+        self.assertEqual(out['pt'], ['a', 'a'])
 
         # Partition column update should be rejected
         with self.assertRaises(ValueError) as ctx:
@@ -633,7 +602,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=source,
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched(update={'pt': source_col('pt')})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('partition', str(ctx.exception))

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -575,6 +575,69 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             )
         self.assertIn('partitioned', str(ctx.exception))
 
+    @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
+    def test_partitioned_table_allows_non_partition_col_update(self):
+        pt_schema = pa.schema([
+            ('pt', pa.string()),
+            ('id', pa.int32()),
+            ('name', pa.string()),
+        ])
+        name = f'default.tbl_{uuid.uuid4().hex[:8]}'
+        s = Schema.from_pyarrow_schema(
+            pt_schema, partition_keys=['pt'], options=self.de_options,
+        )
+        self.catalog.create_table(name, s, False)
+
+        table = self.catalog.get_table(name)
+        wb = table.new_batch_write_builder()
+        writer = wb.new_write()
+        writer.write_arrow(pa.Table.from_pydict(
+            {
+                'pt': ['a', 'a'],
+                'id': pa.array([1, 2], type=pa.int32()),
+                'name': ['old_1', 'old_2'],
+            },
+            schema=pt_schema,
+        ))
+        wb.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        source = pa.Table.from_pydict(
+            {
+                'pt': ['a'],
+                'id': pa.array([1], type=pa.int32()),
+                'name': ['new_1'],
+            },
+            schema=pt_schema,
+        )
+
+        # Non-partition column update should succeed
+        merge_into(
+            target=name,
+            source=source,
+            catalog_options=self.catalog_options,
+            on=['id'],
+            when_matched=[WhenMatched(update={'name': source_col('name')})],
+            num_partitions=_TEST_NUM_PARTITIONS,
+        )
+
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        out = rb.new_read().to_arrow(splits).sort_by('id').to_pydict()
+        self.assertEqual(out['name'], ['new_1', 'old_2'])
+
+        # Partition column update should be rejected
+        with self.assertRaises(ValueError) as ctx:
+            merge_into(
+                target=name,
+                source=source,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[WhenMatched(update='*')],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+        self.assertIn('partition', str(ctx.exception))
+
     def test_partitioned_insert_allowed(self):
         pt_schema = pa.schema([
             ('pt', pa.string()),


### PR DESCRIPTION
### Purpose

  Fix #8078 which rejected all matched updates on partitioned
  data-evolution tables. Spark allows matched updates when only
  non-partition columns are modified (see RowTrackingTestBase.scala).

  Now only reject when the SET spec explicitly modifies a partition
  column.

  ### Tests

  - `test_matched_on_partitioned_table`