### PR TITLE
[core] Fix drop table when table directory is missing on disk

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -364,15 +364,21 @@ public abstract class AbstractCatalog implements Catalog {
         checkNotBranch(identifier, "dropTable");
         checkNotSystemTable(identifier, "dropTable");
 
+        if (!tableExists(identifier)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotExistException(identifier);
+        }
+
         Set<Path> externalPaths = new HashSet<>();
-        try {
+        if (tableExistsInFileSystem(getTableLocation(identifier), DEFAULT_MAIN_BRANCH)) {
             Table table = getTable(identifier);
             if (table instanceof FileStoreTable) {
                 FileStoreTable fileStoreTable = (FileStoreTable) table;
                 List<Path> schemaExternalPaths =
                         getSchemaExternalPaths(fileStoreTable.schemaManager().listAll());
                 externalPaths.addAll(schemaExternalPaths);
-                // get table branch external path
                 List<String> branches = fileStoreTable.branchManager().branches();
                 for (String branch : branches) {
                     SchemaManager schemaManager =
@@ -380,14 +386,13 @@ public abstract class AbstractCatalog implements Catalog {
                     externalPaths.addAll(getSchemaExternalPaths(schemaManager.listAll()));
                 }
             }
-        } catch (TableNotExistException e) {
-            if (ignoreIfNotExists) {
-                return;
-            }
-            throw new TableNotExistException(identifier);
         }
 
         dropTableImpl(identifier, new ArrayList<>(externalPaths));
+    }
+
+    protected boolean tableExists(Identifier identifier) {
+        return tableExistsInFileSystem(getTableLocation(identifier), DEFAULT_MAIN_BRANCH);
     }
 
     private List<Path> getSchemaExternalPaths(List<TableSchema> schemas) {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -452,6 +452,16 @@ public class JdbcCatalog extends AbstractCatalog {
     }
 
     @Override
+    protected boolean tableExists(Identifier identifier) {
+        return JdbcUtils.tableExists(
+                        connections,
+                        catalogKey,
+                        identifier.getDatabaseName(),
+                        identifier.getTableName())
+                || super.tableExists(identifier);
+    }
+
+    @Override
     public boolean caseSensitive() {
         return false;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
@@ -85,6 +86,27 @@ public class JdbcCatalogTest extends CatalogTestBase {
     @Override // ignore for lock error
     @Test
     public void testGetTable() throws Exception {}
+
+    @Test
+    public void testDropTableWhenTablePathMissing() throws Exception {
+        String databaseName = "test_db";
+        String tableName = "new_table";
+        catalog.createDatabase(databaseName, false);
+        Identifier identifier = Identifier.create(databaseName, tableName);
+        catalog.createTable(identifier, DEFAULT_TABLE_SCHEMA, false);
+
+        JdbcCatalog jdbcCatalog = (JdbcCatalog) catalog;
+        Path path = jdbcCatalog.getTableLocation(identifier);
+        jdbcCatalog.fileIO().deleteDirectoryQuietly(path);
+
+        assertThatThrownBy(() -> catalog.getTable(identifier))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("There is no paimon table in " + path);
+        assertThat(jdbcCatalog.listTables(databaseName)).contains(tableName);
+
+        jdbcCatalog.dropTable(identifier, false);
+        assertThat(jdbcCatalog.listTables(databaseName)).doesNotContain(tableName);
+    }
 
     @Test
     public void testAcquireLockFail() throws SQLException, InterruptedException {

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -304,6 +304,27 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
+    protected boolean tableExists(Identifier identifier) {
+        try {
+            boolean inHms =
+                    clients()
+                            .run(
+                                    client ->
+                                            client.tableExists(
+                                                    identifier.getDatabaseName(),
+                                                    identifier.getTableName()));
+            return inHms || super.tableExists(identifier);
+        } catch (TException e) {
+            throw new RuntimeException(
+                    "Cannot determine if table " + identifier.getFullName() + " exists.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(
+                    "Interrupted in call to tableExists " + identifier.getFullName(), e);
+        }
+    }
+
+    @Override
     protected void createDatabaseImpl(String name, Map<String, String> properties) {
         try {
             Database database = convertToHiveDatabase(name, properties);

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.client.ClientPool;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
@@ -279,6 +280,37 @@ public class HiveCatalogTest extends CatalogTestBase {
         } catch (Exception e) {
             fail("Test failed due to exception: " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testDropTableWhenTablePathMissing() throws Exception {
+        String databaseName = "test_db";
+        String tableName = "new_table";
+        catalog.createDatabase(databaseName, false);
+        Identifier identifier = Identifier.create(databaseName, tableName);
+
+        Schema schema =
+                new Schema(
+                        Lists.newArrayList(
+                                new DataField(0, "pk", DataTypes.INT()),
+                                new DataField(1, "col1", DataTypes.STRING()),
+                                new DataField(2, "col2", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<>(),
+                        "");
+        catalog.createTable(identifier, schema, false);
+
+        HiveCatalog hiveCatalog = (HiveCatalog) catalog;
+        Path path = hiveCatalog.getTableLocation(identifier);
+        hiveCatalog.fileIO().deleteDirectoryQuietly(path);
+
+        assertThatThrownBy(() -> hiveCatalog.getTable(identifier))
+                .isInstanceOf(Catalog.TableNotExistException.class);
+        assertThat(hiveCatalog.listTables(databaseName)).contains(tableName);
+
+        hiveCatalog.dropTable(identifier, false);
+        assertThat(hiveCatalog.listTables(databaseName)).doesNotContain(tableName);
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 - Drop fails when table exists in metastore but not available on disk
 - Ensure we can can check with the hms/jdbc catalog for the entry during deletion
 - Also delete the metadata when the table drop is requested but the table does not exist on disk.
 - This avoids leaking metadata, and manual risky operations on the metastore to do cleanup.
 - Fixes user reported issue #4853 

### Tests
 - UT