### PR TITLE
[python] Fix manifest read failure when _WRITE_COLS contains system fields

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -190,7 +190,8 @@ class ManifestFileManager:
                     fields = schema_fields
                 else:
                     read_fields = file_dict['_WRITE_COLS']
-                    fields = [self.table.field_dict[col] for col in read_fields]
+                    fields = [self.table.field_dict[col] for col in read_fields
+                              if col in self.table.field_dict]
             else:
                 fields = schema_fields
         elif not file_dict['_VALUE_STATS_COLS']:

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -190,6 +190,7 @@ class ManifestFileManager:
                     fields = schema_fields
                 else:
                     read_fields = file_dict['_WRITE_COLS']
+                    # writeCols may contain metadata fields (e.g. _ROW_ID, _SEQUENCE_NUMBER)
                     fields = [self.table.field_dict[col] for col in read_fields
                               if col in self.table.field_dict]
             else:

--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -191,8 +191,9 @@ class ManifestFileManager:
                 else:
                     read_fields = file_dict['_WRITE_COLS']
                     # writeCols may contain metadata fields (e.g. _ROW_ID, _SEQUENCE_NUMBER)
-                    fields = [self.table.field_dict[col] for col in read_fields
-                              if col in self.table.field_dict]
+                    data_field_dict = {f.name: f for f in schema_fields}
+                    fields = [data_field_dict[col] for col in read_fields
+                              if col in data_field_dict]
             else:
                 fields = schema_fields
         elif not file_dict['_VALUE_STATS_COLS']:

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -36,8 +36,9 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
+from pypaimon.schema.data_types import AtomicType, DataField
 from pypaimon.schema.schema import Schema
-from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
 
 _EMPTY_ROW = GenericRow([], [])
 _EMPTY_STATS = SimpleStats(min_values=_EMPTY_ROW, max_values=_EMPTY_ROW, null_counts=[])
@@ -285,6 +286,12 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
     def test_read_write_cols_with_system_field(self):
         manager = self._make_manager()
 
+        id_field = DataField(0, 'id', AtomicType('INT', nullable=True))
+        min_row = GenericRow([1], [id_field])
+        max_row = GenericRow([10], [id_field])
+        value_stats = SimpleStats(
+            min_values=min_row, max_values=max_row, null_counts=[2])
+
         entry = ManifestEntry(
             kind=0,
             partition=_EMPTY_ROW,
@@ -293,7 +300,7 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             file=DataFileMeta(
                 file_name="data-dirty.parquet", file_size=1024, row_count=50,
                 min_key=_EMPTY_ROW, max_key=_EMPTY_ROW,
-                key_stats=_EMPTY_STATS, value_stats=_EMPTY_STATS,
+                key_stats=_EMPTY_STATS, value_stats=value_stats,
                 min_sequence_number=1, max_sequence_number=50,
                 schema_id=0, level=0, extra_files=[],
                 creation_time=Timestamp.from_epoch_millis(0),
@@ -307,9 +314,15 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         entries = manager.read("dirty-manifest.avro", drop_stats=False)
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].file.write_cols, ["id", "_ROW_ID"])
-        stats_field_names = [f.name for f in entries[0].file.value_stats.min_values.fields]
+
+        read_stats = entries[0].file.value_stats
+        stats_field_names = [f.name for f in read_stats.min_values.fields]
         self.assertIn("id", stats_field_names)
         self.assertNotIn("_ROW_ID", stats_field_names)
+
+        self.assertEqual(read_stats.min_values.get_field(0), 1)
+        self.assertEqual(read_stats.max_values.get_field(0), 10)
+        self.assertEqual(read_stats.null_counts, [2])
 
 
 class ManifestListManagerTest(_ManifestManagerSetup):

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -304,8 +304,9 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         )
         manager.write("dirty-manifest.avro", [entry])
 
-        with self.assertRaises(KeyError):
-            manager.read("dirty-manifest.avro", drop_stats=False)
+        entries = manager.read("dirty-manifest.avro", drop_stats=False)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].file.write_cols, ["id", "_ROW_ID"])
 
 
 class ManifestListManagerTest(_ManifestManagerSetup):

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -306,14 +306,16 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
                 creation_time=Timestamp.from_epoch_millis(0),
                 delete_row_count=0, embedded_index=None, file_source=None,
                 value_stats_cols=None, external_path=None,
-                first_row_id=0, write_cols=["id", "_ROW_ID"],
+                first_row_id=0,
+                write_cols=["id", "_ROW_ID", "_SEQUENCE_NUMBER"],
             ),
         )
         manager.write("dirty-manifest.avro", [entry])
 
         entries = manager.read("dirty-manifest.avro", drop_stats=False)
         self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0].file.write_cols, ["id", "_ROW_ID"])
+        self.assertEqual(
+            entries[0].file.write_cols, ["id", "_ROW_ID", "_SEQUENCE_NUMBER"])
 
         read_stats = entries[0].file.value_stats
         stats_field_names = [f.name for f in read_stats.min_values.fields]

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -38,7 +38,7 @@ from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
 from pypaimon.schema.data_types import AtomicType, DataField
 from pypaimon.schema.schema import Schema
-from pypaimon.table.row.generic_row import GenericRow, GenericRowSerializer
+from pypaimon.table.row.generic_row import GenericRow
 
 _EMPTY_ROW = GenericRow([], [])
 _EMPTY_STATS = SimpleStats(min_values=_EMPTY_ROW, max_values=_EMPTY_ROW, null_counts=[])

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -307,6 +307,9 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
         entries = manager.read("dirty-manifest.avro", drop_stats=False)
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].file.write_cols, ["id", "_ROW_ID"])
+        stats_field_names = [f.name for f in entries[0].file.value_stats.min_values.fields]
+        self.assertIn("id", stats_field_names)
+        self.assertNotIn("_ROW_ID", stats_field_names)
 
 
 class ManifestListManagerTest(_ManifestManagerSetup):

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -282,7 +282,7 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             "test-manifest.avro", manifest_entry_filter=lambda e: e.bucket == 0)
         self.assertEqual(len(result_filtered), 2)
 
-    def test_read_write_cols_with_system_field_raises_key_error(self):
+    def test_read_write_cols_with_system_field(self):
         manager = self._make_manager()
 
         entry = ManifestEntry(

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -317,8 +317,7 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
 
         read_stats = entries[0].file.value_stats
         stats_field_names = [f.name for f in read_stats.min_values.fields]
-        self.assertIn("id", stats_field_names)
-        self.assertNotIn("_ROW_ID", stats_field_names)
+        self.assertEqual(stats_field_names, ["id"])
 
         self.assertEqual(read_stats.min_values.get_field(0), 1)
         self.assertEqual(read_stats.max_values.get_field(0), 10)

--- a/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
+++ b/paimon-python/pypaimon/tests/manifest/manifest_manager_test.py
@@ -282,6 +282,31 @@ class ManifestFileManagerTest(_ManifestManagerSetup):
             "test-manifest.avro", manifest_entry_filter=lambda e: e.bucket == 0)
         self.assertEqual(len(result_filtered), 2)
 
+    def test_read_write_cols_with_system_field_raises_key_error(self):
+        manager = self._make_manager()
+
+        entry = ManifestEntry(
+            kind=0,
+            partition=_EMPTY_ROW,
+            bucket=0,
+            total_buckets=1,
+            file=DataFileMeta(
+                file_name="data-dirty.parquet", file_size=1024, row_count=50,
+                min_key=_EMPTY_ROW, max_key=_EMPTY_ROW,
+                key_stats=_EMPTY_STATS, value_stats=_EMPTY_STATS,
+                min_sequence_number=1, max_sequence_number=50,
+                schema_id=0, level=0, extra_files=[],
+                creation_time=Timestamp.from_epoch_millis(0),
+                delete_row_count=0, embedded_index=None, file_source=None,
+                value_stats_cols=None, external_path=None,
+                first_row_id=0, write_cols=["id", "_ROW_ID"],
+            ),
+        )
+        manager.write("dirty-manifest.avro", [entry])
+
+        with self.assertRaises(KeyError):
+            manager.read("dirty-manifest.avro", drop_stats=False)
+
 
 class ManifestListManagerTest(_ManifestManagerSetup):
     """Tests for ManifestListManager."""


### PR DESCRIPTION
### Purpose
When reading a table whose data files have `_WRITE_COLS` containing system fields (e.g. `_ROW_ID`, `_SEQUENCE_NUMBER`), the read
  fails with:
  KeyError: '_ROW_ID'

  Aligns with the Java-side fix in #7797 — skip metadata fields that are not in the table schema when resolving value stats fields from `_WRITE_COLS`.

  ## Test

  - `test_read_write_cols_with_system_field`
