### PR TITLE
[core] Fix orphan files left behind when compaction is cancelled

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/BucketedAppendCompactManager.java
@@ -115,15 +115,15 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             LOG.debug("Submit full compaction with these files {}", toCompact);
         }
 
-        taskFuture =
-                executor.submit(
-                        new FullCompactTask(
-                                dvMaintainer,
-                                toCompact,
-                                compactionFileSize,
-                                forceRewriteAllFiles,
-                                rewriter,
-                                metricsReporter));
+        submitTask(
+                executor,
+                new FullCompactTask(
+                        dvMaintainer,
+                        toCompact,
+                        compactionFileSize,
+                        forceRewriteAllFiles,
+                        rewriter,
+                        metricsReporter));
         recordCompactionsQueuedRequest();
         compacting = new ArrayList<>(toCompact);
         toCompact.clear();
@@ -147,10 +147,9 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
                 LOG.debug("Submit normal compaction with these files {}", compacting);
             }
 
-            taskFuture =
-                    executor.submit(
-                            new AutoCompactTask(
-                                    dvMaintainer, compacting, rewriter, metricsReporter));
+            submitTask(
+                    executor,
+                    new AutoCompactTask(dvMaintainer, compacting, rewriter, metricsReporter));
             recordCompactionsQueuedRequest();
         }
     }
@@ -306,6 +305,11 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
             return dvMaintainer != null
                     && dvMaintainer.deletionVectorOf(file.fileName()).isPresent();
         }
+
+        @Override
+        public void discardInflightOutputs() {
+            rewriter.discardInflightOutputs();
+        }
     }
 
     /**
@@ -336,6 +340,11 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
         protected CompactResult doCompact() throws Exception {
             return compact(dvMaintainer, toCompact, rewriter);
         }
+
+        @Override
+        public void discardInflightOutputs() {
+            rewriter.discardInflightOutputs();
+        }
     }
 
     private static CompactResult compact(
@@ -359,5 +368,8 @@ public class BucketedAppendCompactManager extends CompactFutureManager {
     /** Compact rewriter for append-only table. */
     public interface CompactRewriter {
         List<DataFileMeta> rewrite(List<DataFileMeta> compactBefore) throws Exception;
+
+        /** Delete any files this rewriter has already written but not returned. */
+        default void discardInflightOutputs() {}
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/cluster/BucketedAppendClusterManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/cluster/BucketedAppendClusterManager.java
@@ -151,7 +151,7 @@ public class BucketedAppendClusterManager extends CompactFutureManager {
                                                     file.fileName(), file.level(), file.fileSize()))
                             .collect(Collectors.joining(", ")));
         }
-        taskFuture = executor.submit(task);
+        submitTask(executor, task);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactFutureManager.java
@@ -20,22 +20,35 @@ package org.apache.paimon.compact;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 
+import javax.annotation.Nullable;
+
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 /** Base implementation of {@link CompactManager} which runs compaction in a separate thread. */
 public abstract class CompactFutureManager implements CompactManager {
 
     protected Future<CompactResult> taskFuture;
+    @Nullable protected CompactTask currentTask;
+
+    /** Submit a task to the executor and remember it for cleanup on cancel. */
+    protected final void submitTask(ExecutorService executor, CompactTask task) {
+        this.currentTask = task;
+        this.taskFuture = executor.submit(task);
+    }
 
     @Override
     public void cancelCompaction() {
-        // TODO this method may leave behind orphan files if compaction is actually finished
-        //  but some CPU work still needs to be done
         if (taskFuture != null && !taskFuture.isCancelled()) {
             taskFuture.cancel(true);
+            CompactTask task = currentTask;
+            currentTask = null;
+            if (task != null) {
+                task.discardInflightOutputs();
+            }
         }
     }
 
@@ -52,9 +65,14 @@ public abstract class CompactFutureManager implements CompactManager {
                 try {
                     result = obtainCompactResult();
                 } catch (CancellationException e) {
+                    CompactTask task = currentTask;
+                    if (task != null) {
+                        task.discardInflightOutputs();
+                    }
                     return Optional.empty();
                 } finally {
                     taskFuture = null;
+                    currentTask = null;
                 }
                 return Optional.of(result);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/compact/CompactTask.java
@@ -115,6 +115,9 @@ public abstract class CompactTask implements Callable<CompactResult> {
      */
     protected abstract CompactResult doCompact() throws Exception;
 
+    /** Delete any files this task has already written but not returned. */
+    public void discardInflightOutputs() {}
+
     private long collectRewriteSize(List<DataFileMeta> files) {
         return files.stream().mapToLong(DataFileMeta::fileSize).sum();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/MergeTreeCompactManager.java
@@ -244,7 +244,7 @@ public class MergeTreeCompactManager extends CompactFutureManager {
                                                     file.fileName(), file.level(), file.fileSize()))
                             .collect(Collectors.joining(", ")));
         }
-        taskFuture = executor.submit(task);
+        submitTask(executor, task);
         if (metricsReporter != null) {
             metricsReporter.increaseCompactionsQueuedCount();
             metricsReporter.increaseCompactionsTotalCount();

--- a/paimon-core/src/test/java/org/apache/paimon/compact/CompactFutureManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/compact/CompactFutureManagerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.compact;
+
+import org.apache.paimon.io.DataFileMeta;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link CompactFutureManager} cancellation cleanup behaviour. */
+public class CompactFutureManagerTest {
+
+    @Test
+    public void cancelInvokesDiscardOnRunningTask() throws Exception {
+        AtomicBoolean discarded = new AtomicBoolean(false);
+        CountDownLatch started = new CountDownLatch(1);
+
+        CompactTask task =
+                new CompactTask(null) {
+                    @Override
+                    protected CompactResult doCompact() throws Exception {
+                        started.countDown();
+                        Thread.sleep(Long.MAX_VALUE);
+                        return null;
+                    }
+
+                    @Override
+                    public void discardInflightOutputs() {
+                        discarded.set(true);
+                    }
+                };
+
+        TestCompactFutureManager manager = new TestCompactFutureManager();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            manager.submit(executor, task);
+            assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+            manager.cancelCompaction();
+            assertThat(discarded.get()).isTrue();
+            assertThat(manager.getCompactionResult(true)).isEmpty();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void cancelThenDrainDoesNotDiscardTwice() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger discardCalls =
+                new java.util.concurrent.atomic.AtomicInteger();
+        CountDownLatch started = new CountDownLatch(1);
+
+        CompactTask task =
+                new CompactTask(null) {
+                    @Override
+                    protected CompactResult doCompact() throws Exception {
+                        started.countDown();
+                        Thread.sleep(Long.MAX_VALUE);
+                        return null;
+                    }
+
+                    @Override
+                    public void discardInflightOutputs() {
+                        discardCalls.incrementAndGet();
+                    }
+                };
+
+        TestCompactFutureManager manager = new TestCompactFutureManager();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            manager.submit(executor, task);
+            assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+            manager.cancelCompaction();
+            assertThat(manager.getCompactionResult(true)).isEmpty();
+            assertThat(discardCalls.get()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void cancelAfterTaskCompletesDoesNotDiscard() throws Exception {
+        AtomicBoolean discarded = new AtomicBoolean(false);
+        CountDownLatch finished = new CountDownLatch(1);
+
+        CompactTask task =
+                new CompactTask(null) {
+                    @Override
+                    protected CompactResult doCompact() throws Exception {
+                        finished.countDown();
+                        return new CompactResult(Collections.emptyList(), Collections.emptyList());
+                    }
+
+                    @Override
+                    public void discardInflightOutputs() {
+                        discarded.set(true);
+                    }
+                };
+
+        TestCompactFutureManager manager = new TestCompactFutureManager();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            manager.submit(executor, task);
+            assertThat(finished.await(5, TimeUnit.SECONDS)).isTrue();
+            Optional<CompactResult> result = manager.getCompactionResult(true);
+            assertThat(result).isPresent();
+            manager.cancelCompaction();
+            assertThat(discarded.get()).isFalse();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static class TestCompactFutureManager extends CompactFutureManager {
+
+        void submit(ExecutorService executor, CompactTask task) {
+            submitTask(executor, task);
+        }
+
+        @Override
+        public boolean shouldWaitForLatestCompaction() {
+            return false;
+        }
+
+        @Override
+        public boolean shouldWaitForPreparingCheckpoint() {
+            return false;
+        }
+
+        @Override
+        public void addNewFile(DataFileMeta file) {}
+
+        @Override
+        public Collection<DataFileMeta> allFiles() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void triggerCompaction(boolean fullCompaction) {}
+
+        @Override
+        public Optional<CompactResult> getCompactionResult(boolean blocking)
+                throws ExecutionException, InterruptedException {
+            return innerGetCompactionResult(blocking);
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
### Purpose
 - Cancelling compaction can leave new files on disk untracked.
 - Cancel can fire after the file is already written.
 - Add cleanup hook so the task deletes those files.

### Tests
 - UT