### PR TITLE
[python] Support query auth (row filter & column masking) for REST catalog

### DIFF
--- a/paimon-python/pypaimon/api/api_response.py
+++ b/paimon-python/pypaimon/api/api_response.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, Generic, List, Optional
 
+from pypaimon.api.api_request import RESTRequest
 from pypaimon.common.identifier import Identifier
 from pypaimon.common.json_util import T, json_field
 from pypaimon.common.options import Options
@@ -600,3 +601,14 @@ class ListFunctionsGloballyResponse(PagedResponse[Identifier]):
             result["functions"] = None
         result["nextPageToken"] = self.next_page_token
         return result
+
+
+@dataclass
+class AuthTableQueryRequest(RESTRequest):
+    select: Optional[List[str]] = json_field("select", default=None)
+
+
+@dataclass
+class AuthTableQueryResponse(RESTResponse):
+    filter: Optional[List[str]] = json_field("filter", default=None)
+    column_masking: Optional[Dict[str, str]] = json_field("columnMasking", default=None)

--- a/paimon-python/pypaimon/api/resource_paths.py
+++ b/paimon-python/pypaimon/api/resource_paths.py
@@ -133,3 +133,9 @@ class ResourcePaths:
     def forward_branch(self, database_name: str, table_name: str, branch_name: str) -> str:
         return "{}/{}".format(
             self.branch(database_name, table_name, branch_name), self.FORWARD)
+
+    def auth_table(self, database_name: str, table_name: str) -> str:
+        return "{}/{}/{}/{}/{}/auth".format(
+            self.base_path, self.DATABASES, RESTUtil.encode_string(database_name),
+            self.TABLES, RESTUtil.encode_string(table_name)
+        )

--- a/paimon-python/pypaimon/api/rest_api.py
+++ b/paimon-python/pypaimon/api/rest_api.py
@@ -40,7 +40,9 @@ from pypaimon.api.api_response import (CommitTableResponse, ConfigResponse,
                                        ListTablesResponse, ListTagsResponse,
                                        PagedList,
                                        PagedResponse, GetTableSnapshotResponse,
-                                       Partition)
+                                       Partition,
+                                       AuthTableQueryRequest,
+                                       AuthTableQueryResponse)
 from pypaimon.api.auth import AuthProviderFactory, RESTAuthFunction
 from pypaimon.api.client import HttpClient
 from pypaimon.api.resource_paths import ResourcePaths
@@ -685,6 +687,16 @@ class RESTApi:
             self.resource_paths.function(
                 identifier.get_database_name(), identifier.get_object_name()),
             request,
+            self.rest_auth_function,
+        )
+
+    def auth_table_query(self, identifier: Identifier, select: Optional[List[str]]) -> AuthTableQueryResponse:
+        database_name, table_name = self.__validate_identifier(identifier)
+        request = AuthTableQueryRequest(select=select)
+        return self.client.post_with_response_type(
+            self.resource_paths.auth_table(database_name, table_name),
+            request,
+            AuthTableQueryResponse,
             self.rest_auth_function,
         )
 

--- a/paimon-python/pypaimon/catalog/catalog.py
+++ b/paimon-python/pypaimon/catalog/catalog.py
@@ -401,3 +401,6 @@ class Catalog(ABC):
         raise NotImplementedError(
             "list_tags_paged is not supported by this catalog."
         )
+
+    def auth_table_query(self, identifier: Identifier, select: Optional[List[str]]) -> 'TableQueryAuthResult':
+        raise NotImplementedError("auth_table_query not supported by this catalog")

--- a/paimon-python/pypaimon/catalog/catalog_environment.py
+++ b/paimon-python/pypaimon/catalog/catalog_environment.py
@@ -117,3 +117,19 @@ class CatalogEnvironment:
             catalog_loader=None,
             supports_version_management=False
         )
+
+    def table_query_auth(self, options, identifier):
+        if not options.query_auth_enabled or self.catalog_loader is None:
+            return None
+        return _TableQueryAuthFn(self.catalog_loader, identifier)
+
+
+class _TableQueryAuthFn:
+
+    def __init__(self, catalog_loader, identifier):
+        self._catalog_loader = catalog_loader
+        self._identifier = identifier
+
+    def __call__(self, select):
+        catalog = self._catalog_loader.load()
+        return catalog.auth_table_query(self._identifier, select)

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -21,7 +21,8 @@ from pypaimon.api.api_response import GetTableResponse, PagedList, ErrorResponse
 from pypaimon.api.rest_api import RESTApi
 from pypaimon.catalog.catalog_exception import IllegalArgumentError
 from pypaimon.api.rest_exception import (NoSuchResourceException, AlreadyExistsException,
-                                         ForbiddenException, BadRequestException)
+                                         ForbiddenException, BadRequestException,
+                                         ServiceFailureException, NotImplementedException)
 from pypaimon.catalog.catalog import Catalog
 from pypaimon.catalog.catalog_context import CatalogContext
 from pypaimon.catalog.catalog_environment import CatalogEnvironment
@@ -756,3 +757,19 @@ class RESTCatalog(Catalog):
                ) -> FileStoreTable:
         """Create FileStoreTable with dynamic options and catalog environment"""
         return FileStoreTable(file_io, catalog_environment.identifier, table_path, table_schema, catalog_environment)
+
+    def auth_table_query(self, identifier, select=None):
+        from pypaimon.catalog.table_query_auth import TableQueryAuthResult
+        try:
+            response = self.rest_api.auth_table_query(identifier, select)
+            return TableQueryAuthResult(response.filter, response.column_masking)
+        except NoSuchResourceException as e:
+            raise TableNotExistException(identifier) from e
+        except ForbiddenException as e:
+            raise TableNoPermissionException(identifier) from e
+        except ServiceFailureException as e:
+            raise RuntimeError(e.args[0] if e.args else str(e)) from e
+        except NotImplementedException as e:
+            raise NotImplementedError(e.args[0] if e.args else str(e)) from e
+        except BadRequestException as e:
+            raise RuntimeError(str(e)) from e

--- a/paimon-python/pypaimon/catalog/table_query_auth.py
+++ b/paimon-python/pypaimon/catalog/table_query_auth.py
@@ -1,0 +1,80 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from typing import Callable, Dict, List, Optional
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from pypaimon.common.predicate_json_parser import (
+    extract_referenced_fields,
+    parse_predicate_to_batch_filter,
+)
+from pypaimon.schema.data_types import DataField
+
+
+class TableQueryAuthResult:
+
+    def __init__(self, filter: Optional[List[str]], column_masking: Optional[Dict[str, str]]):
+        self.filter = [f for f in filter if f] if filter else filter
+        self.column_masking = (
+            {k: v for k, v in column_masking.items() if k and v}
+            if column_masking else column_masking
+        )
+
+    def convert_plan(self, plan):
+        from pypaimon.read.query_auth_split import QueryAuthSplit
+        from pypaimon.read.plan import Plan
+
+        if not self.filter and not self.column_masking:
+            return plan
+        auth_splits = [QueryAuthSplit(split, self) for split in plan.splits()]
+        return Plan(auth_splits, snapshot_id=plan.snapshot_id)
+
+    def extract_row_filter(self) -> Optional[Callable[[pa.RecordBatch], pa.Array]]:
+        if not self.filter:
+            return None
+        filters = [parse_predicate_to_batch_filter(json_str) for json_str in self.filter]
+        if len(filters) == 1:
+            return filters[0]
+
+        def combined(batch: pa.RecordBatch) -> pa.Array:
+            result = filters[0](batch)
+            for f in filters[1:]:
+                result = pc.and_(result, f(batch))
+            return result
+        return combined
+
+    def get_extra_fields_for_filter(
+            self,
+            read_fields: List[DataField],
+            table_fields: List[DataField],
+    ) -> List[DataField]:
+        if not self.filter:
+            return []
+        read_field_names = {f.name for f in read_fields}
+        extra = []
+        for json_str in self.filter:
+            referenced = extract_referenced_fields(json_str)
+            for name in referenced:
+                if name not in read_field_names:
+                    field = next((f for f in table_fields if f.name == name), None)
+                    if field:
+                        extra.append(field)
+                        read_field_names.add(name)
+        return extra

--- a/paimon-python/pypaimon/catalog/table_query_auth.py
+++ b/paimon-python/pypaimon/catalog/table_query_auth.py
@@ -25,6 +25,8 @@ from pypaimon.common.predicate_json_parser import (
     extract_referenced_fields,
     parse_predicate_to_batch_filter,
 )
+from pypaimon.read.plan import Plan
+from pypaimon.read.query_auth_split import QueryAuthSplit
 from pypaimon.schema.data_types import DataField
 
 
@@ -37,11 +39,12 @@ class TableQueryAuthResult:
             if column_masking else column_masking
         )
 
-    def convert_plan(self, plan):
-        from pypaimon.read.query_auth_split import QueryAuthSplit
-        from pypaimon.read.plan import Plan
+    @property
+    def has_restrictions(self):
+        return bool(self.filter) or bool(self.column_masking)
 
-        if not self.filter and not self.column_masking:
+    def convert_plan(self, plan):
+        if not self.has_restrictions:
             return plan
         auth_splits = [QueryAuthSplit(split, self) for split in plan.splits()]
         return Plan(auth_splits, snapshot_id=plan.snapshot_id)

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -900,6 +900,13 @@ class CoreOptions:
         )
     )
 
+    QUERY_AUTH_ENABLED: ConfigOption[bool] = (
+        ConfigOptions.key("query-auth.enabled")
+        .boolean_type()
+        .default_value(False)
+        .with_description("Whether to enable query auth.")
+    )
+
     PARTITION_DEFAULT_NAME: ConfigOption[str] = (
         ConfigOptions.key("partition.default-name")
         .string_type()
@@ -1368,3 +1375,7 @@ class CoreOptions:
             .boolean_type()
             .default_value(False)
         )
+
+    @property
+    def query_auth_enabled(self) -> bool:
+        return self.options.get(CoreOptions.QUERY_AUTH_ENABLED)

--- a/paimon-python/pypaimon/common/predicate_json_parser.py
+++ b/paimon-python/pypaimon/common/predicate_json_parser.py
@@ -244,7 +244,7 @@ def _convert_literal(literal, target_type: pa.DataType):
                 dt = dt.replace(microsecond=literal[6] // 1000)
             return pa.scalar(dt, type=target_type)
         elif isinstance(literal, (int, float)):
-            dt = datetime.datetime.fromtimestamp(literal / 1000.0, tz=datetime.timezone.utc)
+            dt = datetime.datetime.fromtimestamp(literal, tz=datetime.timezone.utc)
             return pa.scalar(dt, type=target_type)
     elif pa.types.is_date(target_type):
         import datetime
@@ -259,6 +259,8 @@ def _convert_literal(literal, target_type: pa.DataType):
             return pa.scalar(t, type=target_type)
         elif isinstance(literal, list):
             t = datetime.time(*literal[:3])
+            if len(literal) > 3:
+                t = t.replace(microsecond=literal[3] // 1000)
             return pa.scalar(t, type=target_type)
     elif pa.types.is_decimal(target_type):
         import decimal

--- a/paimon-python/pypaimon/common/predicate_json_parser.py
+++ b/paimon-python/pypaimon/common/predicate_json_parser.py
@@ -1,0 +1,358 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import json
+import re
+from typing import Callable
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+
+def parse_predicate_to_batch_filter(json_str: str) -> Callable[[pa.RecordBatch], pa.Array]:
+    data = json.loads(json_str)
+    return _build_filter(data)
+
+
+def _build_filter(data: dict) -> Callable[[pa.RecordBatch], pa.Array]:
+    kind = data["kind"]
+    if kind == "LEAF":
+        return _build_leaf_filter(data)
+    elif kind == "COMPOUND":
+        return _build_compound_filter(data)
+    raise ValueError(f"Unknown predicate kind: {kind}")
+
+
+def _build_leaf_filter(data: dict) -> Callable:
+    transform = data["transform"]
+    function = data["function"]
+    literals = data.get("literals", [])
+
+    def filter_fn(batch: pa.RecordBatch) -> pa.Array:
+        value_array = _apply_predicate_transform(transform, batch)
+        return _apply_leaf_function(function, value_array, literals, len(batch))
+
+    return filter_fn
+
+
+def _build_compound_filter(data: dict) -> Callable:
+    function = data["function"]
+    child_filters = [_build_filter(child) for child in data["children"]]
+
+    def filter_fn(batch: pa.RecordBatch) -> pa.Array:
+        if function == "AND":
+            result = child_filters[0](batch)
+            for cf in child_filters[1:]:
+                result = pc.and_(result, cf(batch))
+            return result
+        elif function == "OR":
+            result = child_filters[0](batch)
+            for cf in child_filters[1:]:
+                result = pc.or_(result, cf(batch))
+            return result
+        raise ValueError(f"Unknown compound function: {function}")
+
+    return filter_fn
+
+
+def _apply_predicate_transform(transform: dict, batch: pa.RecordBatch,
+                               null_type: pa.DataType = pa.bool_()) -> pa.Array:
+    name = transform["name"]
+
+    if name == "FIELD_REF":
+        return batch.column(transform["fieldRef"]["name"])
+
+    elif name == "CAST":
+        col = batch.column(transform["fieldRef"]["name"])
+        target_type = _paimon_type_to_arrow(transform["type"])
+        return pc.cast(col, target_type)
+
+    elif name == "UPPER":
+        input_col = _resolve_transform_input(transform["inputs"][0], batch)
+        return pc.utf8_upper(input_col)
+
+    elif name == "LOWER":
+        input_col = _resolve_transform_input(transform["inputs"][0], batch)
+        return pc.utf8_lower(input_col)
+
+    elif name == "CONCAT":
+        resolved = [_resolve_transform_input(inp, batch) for inp in transform["inputs"]]
+        if not resolved:
+            return pa.nulls(len(batch), type=pa.string())
+        return pc.binary_join_element_wise(*resolved, "")
+
+    elif name == "CONCAT_WS":
+        sep = _resolve_transform_input(transform["inputs"][0], batch)
+        values = [_resolve_transform_input(inp, batch) for inp in transform["inputs"][1:]]
+        if not values:
+            return pa.nulls(len(batch), type=pa.string())
+        return _concat_ws(sep, values)
+
+    elif name == "NULL":
+        return pa.nulls(len(batch), type=null_type)
+
+    raise ValueError(f"Unknown transform type: {name}")
+
+
+def _resolve_transform_input(inp, batch: pa.RecordBatch) -> pa.Array:
+    if isinstance(inp, dict):
+        return batch.column(inp["name"])
+    elif isinstance(inp, str):
+        return pa.array([inp] * len(batch), type=pa.string())
+    elif inp is None:
+        return pa.nulls(len(batch), type=pa.string())
+    return pa.array([str(inp)] * len(batch), type=pa.string())
+
+
+def _concat_ws(sep: pa.Array, value_arrays: list) -> pa.Array:
+    sep_list = sep.to_pylist()
+    val_lists = [v.to_pylist() for v in value_arrays]
+    results = []
+    for i in range(len(sep)):
+        s = sep_list[i]
+        if s is None:
+            results.append(None)
+            continue
+        parts = [vl[i] for vl in val_lists if vl[i] is not None]
+        results.append(s.join(parts))
+    return pa.array(results, type=pa.string())
+
+
+def _null_as_false(arr: pa.Array) -> pa.Array:
+    """Replace nulls with False to match Java two-valued predicate semantics."""
+    if arr.null_count == 0:
+        return arr
+    return pc.if_else(pc.is_valid(arr), arr, False)
+
+
+def _apply_leaf_function(function: str, value_array: pa.Array, literals: list, batch_len: int) -> pa.Array:
+    """Null literal yields False to match Java LeafBinaryFunction/LeafTernaryFunction semantics.
+
+    All comparison results are coerced from three-valued (PyArrow null) to
+    two-valued logic (null → False) so that compound AND/OR behaves
+    identically to Java.
+    """
+    converted = [_convert_literal(lit, value_array.type) for lit in literals]
+
+    if function == "EQUAL":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.equal(value_array, converted[0]))
+    elif function == "NOT_EQUAL":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.not_equal(value_array, converted[0]))
+    elif function == "LESS_THAN":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.less(value_array, converted[0]))
+    elif function == "LESS_OR_EQUAL":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.less_equal(value_array, converted[0]))
+    elif function == "GREATER_THAN":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.greater(value_array, converted[0]))
+    elif function == "GREATER_OR_EQUAL":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.greater_equal(value_array, converted[0]))
+    elif function == "IS_NULL":
+        return pc.is_null(value_array)
+    elif function == "IS_NOT_NULL":
+        return pc.is_valid(value_array)
+    elif function == "IN":
+        non_null = [v for v in converted if v is not None]
+        if not non_null:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        in_mask = pc.is_in(value_array, pa.array(non_null, type=value_array.type))
+        return pc.if_else(pc.is_valid(value_array), in_mask, False)
+    elif function == "NOT_IN":
+        if any(lit is None for lit in literals):
+            return pa.array([False] * batch_len, type=pa.bool_())
+        not_in_mask = pc.invert(
+            pc.is_in(value_array, pa.array(converted, type=value_array.type)))
+        return pc.if_else(pc.is_valid(value_array), not_in_mask, False)
+    elif function == "BETWEEN":
+        if converted[0] is None or converted[1] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.and_(
+            pc.greater_equal(value_array, converted[0]),
+            pc.less_equal(value_array, converted[1])))
+    elif function == "NOT_BETWEEN":
+        if converted[0] is None or converted[1] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.or_(
+            pc.less(value_array, converted[0]),
+            pc.greater(value_array, converted[1])))
+    elif function == "STARTS_WITH":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.starts_with(value_array, converted[0]))
+    elif function == "ENDS_WITH":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.ends_with(value_array, converted[0]))
+    elif function == "CONTAINS":
+        if converted[0] is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        return _null_as_false(pc.match_substring(value_array, converted[0]))
+    elif function == "LIKE":
+        raw = literals[0]
+        if raw is None:
+            return pa.array([False] * batch_len, type=pa.bool_())
+        from pypaimon.common.predicate import Like
+        pattern = Like._sql_like_to_regex(raw)
+        return _null_as_false(
+            pc.match_substring_regex(value_array, f"^{pattern}$"))
+    elif function == "TRUE":
+        return pa.array([True] * batch_len, type=pa.bool_())
+    elif function == "FALSE":
+        return pa.array([False] * batch_len, type=pa.bool_())
+    elif function == "IS_NAN":
+        return _null_as_false(pc.is_nan(value_array))
+    raise ValueError(f"Unknown leaf function: {function}")
+
+
+def _convert_literal(literal, target_type: pa.DataType):
+    if literal is None:
+        return None
+    if pa.types.is_timestamp(target_type):
+        import datetime
+        if isinstance(literal, str):
+            dt = datetime.datetime.fromisoformat(literal.replace("Z", "+00:00"))
+            return pa.scalar(dt, type=target_type)
+    elif pa.types.is_date(target_type):
+        import datetime
+        if isinstance(literal, str):
+            return pa.scalar(datetime.date.fromisoformat(literal), type=target_type)
+    elif pa.types.is_time(target_type):
+        import datetime
+        if isinstance(literal, str):
+            t = datetime.time.fromisoformat(literal)
+            return pa.scalar(t, type=target_type)
+    elif pa.types.is_decimal(target_type):
+        import decimal
+        return pa.scalar(decimal.Decimal(str(literal)), type=target_type)
+    return literal
+
+
+def _paimon_type_to_arrow(paimon_type: str) -> pa.DataType:
+    type_str = paimon_type.strip().upper()
+
+    m = re.match(r"^([A-Z_ ]+?)(?:\((.+)\))?(?:\s+NOT\s+NULL)?$", type_str)
+    if not m:
+        raise ValueError(f"Cannot parse Paimon type: '{paimon_type}'")
+    base_type = m.group(1).strip()
+    params = m.group(2)
+
+    simple_mapping = {
+        "INT": pa.int32(),
+        "BIGINT": pa.int64(),
+        "SMALLINT": pa.int16(),
+        "TINYINT": pa.int8(),
+        "FLOAT": pa.float32(),
+        "DOUBLE": pa.float64(),
+        "STRING": pa.string(),
+        "BOOLEAN": pa.bool_(),
+        "BYTES": pa.binary(),
+        "DATE": pa.date32(),
+    }
+    if base_type in simple_mapping:
+        return simple_mapping[base_type]
+
+    if base_type in ("VARCHAR", "CHAR"):
+        return pa.string()
+
+    if base_type in ("VARBINARY", "BINARY"):
+        return pa.binary()
+
+    if base_type == "TIMESTAMP":
+        precision = int(params) if params else 6
+        unit = _timestamp_precision_to_unit(precision)
+        return pa.timestamp(unit)
+
+    if base_type in ("TIMESTAMP WITH LOCAL TIME ZONE", "TIMESTAMP_WITH_LOCAL_TIME_ZONE", "TIMESTAMP_LTZ"):
+        precision = int(params) if params else 6
+        unit = _timestamp_precision_to_unit(precision)
+        return pa.timestamp(unit, tz="UTC")
+
+    if base_type == "TIME":
+        precision = int(params) if params else 6
+        unit = _timestamp_precision_to_unit(precision)
+        return pa.time64(unit) if unit in ("us", "ns") else pa.time32(unit)
+
+    if base_type == "DECIMAL":
+        if params:
+            parts = [x.strip() for x in params.split(",")]
+            if len(parts) == 2:
+                return pa.decimal128(int(parts[0]), int(parts[1]))
+        raise ValueError(f"DECIMAL type requires (precision, scale): '{paimon_type}'")
+
+    raise ValueError(
+        f"Unsupported Paimon type for PyArrow conversion: '{paimon_type}'. "
+        f"Supported: INT, BIGINT, SMALLINT, TINYINT, FLOAT, DOUBLE, STRING, VARCHAR, CHAR, "
+        f"BOOLEAN, BYTES, VARBINARY, DATE, TIME(p), TIMESTAMP(p), "
+        f"TIMESTAMP WITH LOCAL TIME ZONE(p), DECIMAL(p,s)."
+    )
+
+
+def _timestamp_precision_to_unit(precision: int) -> str:
+    if precision == 0:
+        return "s"
+    elif precision <= 3:
+        return "ms"
+    elif precision <= 6:
+        return "us"
+    else:
+        return "ns"
+
+
+def extract_referenced_fields(json_str: str) -> set:
+    data = json.loads(json_str)
+    fields = set()
+    _collect_fields(data, fields)
+    return fields
+
+
+def _collect_fields(data: dict, fields: set):
+    kind = data.get("kind")
+    if kind == "LEAF":
+        _collect_all_field_refs_from_transform(data["transform"], fields)
+    elif kind == "COMPOUND":
+        for child in data["children"]:
+            _collect_fields(child, fields)
+
+
+def _collect_all_field_refs_from_transform(transform: dict, fields: set = None) -> set:
+    if fields is None:
+        fields = set()
+    name = transform.get("name")
+    if name == "FIELD_REF" and "fieldRef" in transform:
+        fields.add(transform["fieldRef"]["name"])
+    elif name == "CAST" and "fieldRef" in transform:
+        fields.add(transform["fieldRef"]["name"])
+    else:
+        for inp in transform.get("inputs", []):
+            if isinstance(inp, dict):
+                if "name" in inp and "index" in inp:
+                    fields.add(inp["name"])
+                elif "name" in inp:
+                    _collect_all_field_refs_from_transform(inp, fields)
+    return fields

--- a/paimon-python/pypaimon/common/predicate_json_parser.py
+++ b/paimon-python/pypaimon/common/predicate_json_parser.py
@@ -80,7 +80,7 @@ def _apply_predicate_transform(transform: dict, batch: pa.RecordBatch,
     elif name == "CAST":
         col = batch.column(transform["fieldRef"]["name"])
         target_type = _paimon_type_to_arrow(transform["type"])
-        return pc.cast(col, target_type)
+        return pc.cast(col, target_type, safe=False)
 
     elif name == "UPPER":
         input_col = _resolve_transform_input(transform["inputs"][0], batch)
@@ -238,14 +238,27 @@ def _convert_literal(literal, target_type: pa.DataType):
         if isinstance(literal, str):
             dt = datetime.datetime.fromisoformat(literal.replace("Z", "+00:00"))
             return pa.scalar(dt, type=target_type)
+        elif isinstance(literal, list):
+            dt = datetime.datetime(*literal[:6])
+            if len(literal) > 6:
+                dt = dt.replace(microsecond=literal[6] // 1000)
+            return pa.scalar(dt, type=target_type)
+        elif isinstance(literal, (int, float)):
+            dt = datetime.datetime.fromtimestamp(literal / 1000.0, tz=datetime.timezone.utc)
+            return pa.scalar(dt, type=target_type)
     elif pa.types.is_date(target_type):
         import datetime
         if isinstance(literal, str):
             return pa.scalar(datetime.date.fromisoformat(literal), type=target_type)
+        elif isinstance(literal, list):
+            return pa.scalar(datetime.date(*literal[:3]), type=target_type)
     elif pa.types.is_time(target_type):
         import datetime
         if isinstance(literal, str):
             t = datetime.time.fromisoformat(literal)
+            return pa.scalar(t, type=target_type)
+        elif isinstance(literal, list):
+            t = datetime.time(*literal[:3])
             return pa.scalar(t, type=target_type)
     elif pa.types.is_decimal(target_type):
         import decimal
@@ -255,6 +268,12 @@ def _convert_literal(literal, target_type: pa.DataType):
 
 def _paimon_type_to_arrow(paimon_type: str) -> pa.DataType:
     type_str = paimon_type.strip().upper()
+
+    ltz_match = re.match(
+        r"^TIMESTAMP\s*\((\d+)\)\s+WITH\s+LOCAL\s+TIME\s+ZONE", type_str)
+    if ltz_match:
+        precision = int(ltz_match.group(1))
+        return pa.timestamp(_timestamp_precision_to_unit(precision), tz="UTC")
 
     m = re.match(r"^([A-Z_ ]+?)(?:\((.+)\))?(?:\s+NOT\s+NULL)?$", type_str)
     if not m:

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -39,6 +39,7 @@ from pypaimon.daft.daft_explain import (
     READER_MODE_PYPAIMON_FALLBACK,
 )
 from pypaimon.daft.daft_predicate_visitor import convert_filters_to_paimon
+from pypaimon.read.query_auth_split import QueryAuthSplit
 from pypaimon.schema.data_types import is_array_blob_type, is_blob_type
 
 if TYPE_CHECKING:
@@ -594,7 +595,7 @@ class PaimonDataSource(DataSource):
             routing = self._reader_routing(
                 raw_convertible=split.raw_convertible,
                 has_deletion_vectors=split.has_deletion_vectors,
-                has_auth=self._split_has_auth(split),
+                has_auth=paimon_scan.has_auth,
             )
             if routing.use_native_reader:
                 native_split_count += 1
@@ -677,7 +678,6 @@ class PaimonDataSource(DataSource):
 
     @staticmethod
     def _split_has_auth(split) -> bool:
-        from pypaimon.read.query_auth_split import QueryAuthSplit
         return isinstance(split, QueryAuthSplit)
 
     def _partition_filter_skips_split(

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -530,6 +530,7 @@ class PaimonDataSource(DataSource):
             routing = self._reader_routing(
                 raw_convertible=split.raw_convertible,
                 has_deletion_vectors=self._split_has_deletion_vectors(split),
+                has_auth=self._split_has_auth(split),
             )
 
             if routing.use_native_reader:
@@ -593,6 +594,7 @@ class PaimonDataSource(DataSource):
             routing = self._reader_routing(
                 raw_convertible=split.raw_convertible,
                 has_deletion_vectors=split.has_deletion_vectors,
+                has_auth=self._split_has_auth(split),
             )
             if routing.use_native_reader:
                 native_split_count += 1
@@ -644,12 +646,14 @@ class PaimonDataSource(DataSource):
         self,
         raw_convertible: bool,
         has_deletion_vectors: bool,
+        has_auth: bool = False,
     ) -> _ReaderRouting:
         can_use_native_reader = (
             self._is_parquet
             and not self._has_blob_columns
             and (not self._table.is_primary_key_table or raw_convertible)
             and not has_deletion_vectors
+            and not has_auth
         )
         if can_use_native_reader:
             return _ReaderRouting(READER_MODE_NATIVE_PARQUET, None)
@@ -658,6 +662,8 @@ class PaimonDataSource(DataSource):
             reason = "non-parquet format"
         elif self._has_blob_columns:
             reason = "blob columns present"
+        elif has_auth:
+            reason = "query auth active"
         elif has_deletion_vectors:
             reason = "deletion vectors present"
         else:
@@ -668,6 +674,11 @@ class PaimonDataSource(DataSource):
     def _split_has_deletion_vectors(split: Split) -> bool:
         deletion_files = getattr(split, "data_deletion_files", None)
         return deletion_files is not None and any(df is not None for df in deletion_files)
+
+    @staticmethod
+    def _split_has_auth(split) -> bool:
+        from pypaimon.read.query_auth_split import QueryAuthSplit
+        return isinstance(split, QueryAuthSplit)
 
     def _partition_filter_skips_split(
         self,

--- a/paimon-python/pypaimon/globalindex/create_global_index.py
+++ b/paimon-python/pypaimon/globalindex/create_global_index.py
@@ -160,7 +160,7 @@ class GlobalIndexBuilder:
             read_builder = read_builder.with_partition_filter(partition_filter)
 
         scan = read_builder.new_scan()
-        plan = scan.plan()
+        plan = scan.plan_for_write()
         splits = plan.splits()
         if not splits:
             return []

--- a/paimon-python/pypaimon/multimodal/blob_store.py
+++ b/paimon-python/pypaimon/multimodal/blob_store.py
@@ -321,7 +321,8 @@ class BlobStore:
         projection.extend(columns)
         read_builder = read_builder.with_projection(projection)
         read_builder = read_builder.with_filter(self._keys_predicate(keys))
-        plan = read_builder.new_scan().plan()
+        scan = read_builder.new_scan()
+        plan = scan.plan_for_write()
         table = read_builder.new_read().to_arrow(plan.splits())
 
         targets = {}

--- a/paimon-python/pypaimon/read/explain.py
+++ b/paimon-python/pypaimon/read/explain.py
@@ -121,6 +121,8 @@ class ExplainResult:
     split_size_p50: int = 0
     split_size_p95: int = 0
 
+    has_auth: bool = False
+
     # Verbose-only
     splits: Optional[List[ExplainSplitInfo]] = None
 

--- a/paimon-python/pypaimon/read/query_auth_split.py
+++ b/paimon-python/pypaimon/read/query_auth_split.py
@@ -68,7 +68,10 @@ def resolve_auth_result(query_auth_fn, read_type):
     if query_auth_fn is None:
         return None
     select = [f.name for f in read_type] if read_type else None
-    return query_auth_fn(select)
+    result = query_auth_fn(select)
+    if result is None or not result.has_restrictions:
+        return None
+    return result
 
 
 def wrap_plan_with_auth(auth_result, plan):

--- a/paimon-python/pypaimon/read/query_auth_split.py
+++ b/paimon-python/pypaimon/read/query_auth_split.py
@@ -1,0 +1,64 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pypaimon.read.split import Split
+
+
+class QueryAuthSplit(Split):
+
+    def __init__(self, split: Split, auth_result):
+        self._split = split
+        self._auth_result = auth_result
+
+    @property
+    def split(self) -> Split:
+        return self._split
+
+    @property
+    def auth_result(self):
+        return self._auth_result
+
+    @property
+    def row_count(self) -> int:
+        return self._split.row_count
+
+    @property
+    def files(self):
+        return self._split.files
+
+    @property
+    def partition(self):
+        return self._split.partition
+
+    @property
+    def bucket(self) -> int:
+        return self._split.bucket
+
+    @property
+    def raw_convertible(self) -> bool:
+        return self._split.raw_convertible
+
+    def merged_row_count(self):
+        if self._auth_result.filter:
+            return None
+        return self._split.merged_row_count()
+
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            raise AttributeError(name)
+        return getattr(self._split, name)

--- a/paimon-python/pypaimon/read/query_auth_split.py
+++ b/paimon-python/pypaimon/read/query_auth_split.py
@@ -62,3 +62,16 @@ class QueryAuthSplit(Split):
         if name.startswith('_'):
             raise AttributeError(name)
         return getattr(self._split, name)
+
+
+def resolve_auth_result(query_auth_fn, read_type):
+    if query_auth_fn is None:
+        return None
+    select = [f.name for f in read_type] if read_type else None
+    return query_auth_fn(select)
+
+
+def wrap_plan_with_auth(auth_result, plan):
+    if auth_result is not None:
+        return auth_result.convert_plan(plan)
+    return plan

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -21,6 +21,7 @@ from pypaimon.common.predicate import Predicate
 from pypaimon.common.predicate_builder import PredicateBuilder
 from pypaimon.read.explain import ExplainResult, ExplainSplitInfo, PruningStat
 from pypaimon.read.explain_render import render_predicate
+from pypaimon.read.query_auth_split import QueryAuthSplit
 from pypaimon.read.scan_stats import ScanStats
 from pypaimon.read.split import Split
 from pypaimon.read.table_read import TableRead
@@ -238,6 +239,8 @@ def _build_explain_result(table, scan: TableScan, plan, stats: ScanStats,
     splits_all_above_l0 = 0
     split_infos: List[ExplainSplitInfo] = []
 
+    plan_has_auth = any(isinstance(s, QueryAuthSplit) for s in splits)
+
     for split in splits:
         files = getattr(split, 'files', []) or []
         per_split_levels: dict = {}
@@ -309,6 +312,7 @@ def _build_explain_result(table, scan: TableScan, plan, stats: ScanStats,
         split_size_avg=sz_avg,
         split_size_p50=sz_p50,
         split_size_p95=sz_p95,
+        has_auth=plan_has_auth,
         splits=split_infos if verbose else None,
     )
 

--- a/paimon-python/pypaimon/read/read_builder.py
+++ b/paimon-python/pypaimon/read/read_builder.py
@@ -79,12 +79,14 @@ class ReadBuilder:
         return self
 
     def new_scan(self) -> TableScan:
-        return TableScan(
+        scan = TableScan(
             table=self.table,
             predicate=self._predicate,
             limit=self._limit,
             partition_predicate=self._partition_filter,
         )
+        scan._read_type = self.read_type()
+        return scan
 
     def new_read(self) -> TableRead:
         return TableRead(

--- a/paimon-python/pypaimon/read/reader/auth_masking_reader.py
+++ b/paimon-python/pypaimon/read/reader/auth_masking_reader.py
@@ -100,16 +100,12 @@ class BatchToRecordReaderAdapter(RecordReader):
 
     def __init__(self, inner: RecordBatchReader):
         self._inner = inner
-        self._file_io = getattr(inner, 'file_io', None)
-        self._blob_field_indices = getattr(inner, 'blob_field_indices', None)
-        self._vector_field_indices = getattr(inner, 'vector_field_indices', None)
 
     def read_batch(self):
         batch = self._inner.read_arrow_batch()
         if batch is None:
             return None
-        return _ArrowBatchIterator(
-            batch, self._file_io, self._blob_field_indices, self._vector_field_indices)
+        return _ArrowBatchIterator(batch)
 
     def close(self):
         self._inner.close()

--- a/paimon-python/pypaimon/read/reader/auth_masking_reader.py
+++ b/paimon-python/pypaimon/read/reader/auth_masking_reader.py
@@ -1,0 +1,189 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import json
+from typing import Callable, Dict, List, Optional
+
+import pyarrow as pa
+
+from pypaimon.common.predicate_json_parser import (
+    _apply_predicate_transform,
+    _collect_all_field_refs_from_transform,
+)
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+
+
+class RecordReaderToBatchAdapter(RecordBatchReader):
+
+    def __init__(self, inner, schema: pa.Schema, chunk_size: int = 65536, include_row_kind: bool = False):
+        self._inner = inner
+        self._schema = schema
+        self._chunk_size = chunk_size
+        self._exhausted = False
+        self._pending_iterator = None
+        self._include_row_kind = include_row_kind
+        self.blob_field_indices = getattr(inner, 'blob_field_indices', None)
+        self.vector_field_indices = getattr(inner, 'vector_field_indices', None)
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        if self._exhausted:
+            return None
+        row_tuples = []
+        row_kinds = []
+        while len(row_tuples) < self._chunk_size:
+            if self._pending_iterator is not None:
+                row = self._pending_iterator.next()
+                while row is not None:
+                    row_tuples.append(
+                        row.row_tuple[row.offset:row.offset + row.arity])
+                    if self._include_row_kind:
+                        row_kinds.append(row.get_row_kind().to_string())
+                    if len(row_tuples) >= self._chunk_size:
+                        return self._flush(row_tuples, row_kinds)
+                    row = self._pending_iterator.next()
+                self._pending_iterator = None
+
+            row_iterator = self._inner.read_batch()
+            if row_iterator is None:
+                self._exhausted = True
+                break
+            self._pending_iterator = row_iterator
+
+        if not row_tuples:
+            return None
+        return self._flush(row_tuples, row_kinds)
+
+    def _flush(self, row_tuples, row_kinds=None):
+        columns_data = list(zip(*row_tuples))
+        pydict = {
+            name: list(col)
+            for name, col in zip(self._schema.names, columns_data)
+        }
+        batch = pa.RecordBatch.from_pydict(pydict, schema=self._schema)
+        if row_kinds:
+            row_kind_array = pa.array(row_kinds, type=pa.string())
+            row_kind_field = pa.field("_row_kind", pa.string())
+            new_schema = pa.schema([row_kind_field] + list(batch.schema))
+            columns = [row_kind_array] + [batch.column(i) for i in range(batch.num_columns)]
+            batch = pa.RecordBatch.from_arrays(columns, schema=new_schema)
+        return batch
+
+    def close(self):
+        self._inner.close()
+
+
+class AuthFilterReader(RecordBatchReader):
+
+    def __init__(self, inner_reader: RecordBatchReader, filter_fn: Callable[[pa.RecordBatch], pa.Array]):
+        self._inner = inner_reader
+        self._filter_fn = filter_fn
+        self.blob_field_indices = inner_reader.blob_field_indices
+        self.vector_field_indices = inner_reader.vector_field_indices
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        mask = self._filter_fn(batch)
+        return batch.filter(mask)
+
+    def close(self):
+        self._inner.close()
+
+
+class AuthMaskingReader(RecordBatchReader):
+
+    def __init__(self, inner_reader: RecordBatchReader, masking_rules: Dict[str, str], read_fields: List):
+        self._inner = inner_reader
+        self._masking_rules = masking_rules
+        self._read_fields = read_fields
+        self.blob_field_indices = inner_reader.blob_field_indices
+        self.vector_field_indices = inner_reader.vector_field_indices
+        read_field_names = {f.name for f in read_fields}
+        # Filter to projected columns only; skip empty JSON values (matches Java
+        # extractColumnMasking StringUtils.isEmpty guard and null-transform skip).
+        parsed = {}
+        for col, tj in masking_rules.items():
+            if col not in read_field_names:
+                continue
+            if not tj:
+                continue
+            transform = json.loads(tj)
+            if transform is None:
+                continue
+            parsed[col] = transform
+        self._parsed_rules = parsed
+        for col_name, transform in self._parsed_rules.items():
+            for ref_name in _collect_all_field_refs_from_transform(transform):
+                if ref_name not in read_field_names:
+                    raise RuntimeError(
+                        f"Column masking refers to field '{ref_name}' which is not present "
+                        f"in output row type. Available fields: {read_field_names}"
+                    )
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        original_batch = batch
+        masked_columns = {}
+        for col_name, transform in self._parsed_rules.items():
+            if col_name in original_batch.schema.names:
+                col_idx = original_batch.schema.get_field_index(col_name)
+                target_col_type = original_batch.schema.field(col_idx).type
+                masked_columns[col_idx] = self._apply_masking_transform(transform, original_batch, target_col_type)
+        for col_idx, masked_array in masked_columns.items():
+            original_field = original_batch.schema.field(col_idx)
+            batch = batch.set_column(
+                col_idx,
+                pa.field(original_field.name, masked_array.type, nullable=True),
+                masked_array)
+        return batch
+
+    def close(self):
+        self._inner.close()
+
+    def _apply_masking_transform(
+            self,
+            transform: dict,
+            original_batch: pa.RecordBatch,
+            target_col_type: pa.DataType,
+    ) -> pa.Array:
+        return _apply_predicate_transform(
+            transform, original_batch, null_type=target_col_type)
+
+
+class ColumnProjectReader(RecordBatchReader):
+
+    def __init__(self, inner_reader: RecordBatchReader, columns: List[str]):
+        self._inner = inner_reader
+        self._columns = columns
+        self.blob_field_indices = inner_reader.blob_field_indices
+        self.vector_field_indices = inner_reader.vector_field_indices
+
+    def read_arrow_batch(self) -> Optional[pa.RecordBatch]:
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        columns = self._columns
+        if "_row_kind" in batch.schema.names and "_row_kind" not in columns:
+            columns = ["_row_kind"] + list(columns)
+        return batch.select(columns)
+
+    def close(self):
+        self._inner.close()

--- a/paimon-python/pypaimon/read/reader/auth_masking_reader.py
+++ b/paimon-python/pypaimon/read/reader/auth_masking_reader.py
@@ -31,12 +31,7 @@ from pypaimon.read.reader.iface.record_reader import RecordReader
 from pypaimon.table.row.offset_row import OffsetRow
 
 
-# ---------------------------------------------------------------------------
-#  Adapters: row ↔ batch conversion
-# ---------------------------------------------------------------------------
-
 class RecordReaderToBatchAdapter(RecordBatchReader):
-    """Convert a row-level RecordReader to a batch-level RecordBatchReader."""
 
     def __init__(self, inner, schema: pa.Schema, chunk_size: int = 65536, include_row_kind: bool = False):
         self._inner = inner
@@ -139,10 +134,6 @@ class _ArrowBatchIterator(RecordIterator):
         self._idx += 1
         return row
 
-
-# ---------------------------------------------------------------------------
-#  Batch-level auth readers
-# ---------------------------------------------------------------------------
 
 class AuthFilterReader(RecordBatchReader):
 

--- a/paimon-python/pypaimon/read/reader/auth_masking_reader.py
+++ b/paimon-python/pypaimon/read/reader/auth_masking_reader.py
@@ -26,9 +26,17 @@ from pypaimon.common.predicate_json_parser import (
     _collect_all_field_refs_from_transform,
 )
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.read.reader.iface.record_iterator import RecordIterator
+from pypaimon.read.reader.iface.record_reader import RecordReader
+from pypaimon.table.row.offset_row import OffsetRow
 
+
+# ---------------------------------------------------------------------------
+#  Adapters: row ↔ batch conversion
+# ---------------------------------------------------------------------------
 
 class RecordReaderToBatchAdapter(RecordBatchReader):
+    """Convert a row-level RecordReader to a batch-level RecordBatchReader."""
 
     def __init__(self, inner, schema: pa.Schema, chunk_size: int = 65536, include_row_kind: bool = False):
         self._inner = inner
@@ -87,6 +95,59 @@ class RecordReaderToBatchAdapter(RecordBatchReader):
         self._inner.close()
 
 
+class BatchToRecordReaderAdapter(RecordReader):
+    """Convert a batch-level RecordBatchReader back to a row-level RecordReader."""
+
+    def __init__(self, inner: RecordBatchReader):
+        self._inner = inner
+        self._file_io = getattr(inner, 'file_io', None)
+        self._blob_field_indices = getattr(inner, 'blob_field_indices', None)
+        self._vector_field_indices = getattr(inner, 'vector_field_indices', None)
+
+    def read_batch(self):
+        batch = self._inner.read_arrow_batch()
+        if batch is None:
+            return None
+        return _ArrowBatchIterator(
+            batch, self._file_io, self._blob_field_indices, self._vector_field_indices)
+
+    def close(self):
+        self._inner.close()
+
+
+class _ArrowBatchIterator(RecordIterator):
+
+    def __init__(self, batch: pa.RecordBatch):
+        self._batch = batch
+        self._idx = 0
+        self._has_rk = "_row_kind" in batch.schema.names
+        if self._has_rk:
+            self._rk_idx = batch.schema.get_field_index("_row_kind")
+            self._data_cols = [j for j in range(batch.num_columns) if j != self._rk_idx]
+        else:
+            self._rk_idx = -1
+            self._data_cols = list(range(batch.num_columns))
+
+    def next(self):
+        if self._idx >= self._batch.num_rows:
+            return None
+        row_tuple = tuple(
+            self._batch.column(j)[self._idx].as_py()
+            for j in self._data_cols
+        )
+        row = OffsetRow(row_tuple, 0, len(self._data_cols))
+        if self._has_rk:
+            from pypaimon.table.row.row_kind import RowKind
+            kind_str = self._batch.column(self._rk_idx)[self._idx].as_py()
+            row.set_row_kind_byte(RowKind.from_string(kind_str).value)
+        self._idx += 1
+        return row
+
+
+# ---------------------------------------------------------------------------
+#  Batch-level auth readers
+# ---------------------------------------------------------------------------
+
 class AuthFilterReader(RecordBatchReader):
 
     def __init__(self, inner_reader: RecordBatchReader, filter_fn: Callable[[pa.RecordBatch], pa.Array]):
@@ -115,8 +176,6 @@ class AuthMaskingReader(RecordBatchReader):
         self.blob_field_indices = inner_reader.blob_field_indices
         self.vector_field_indices = inner_reader.vector_field_indices
         read_field_names = {f.name for f in read_fields}
-        # Filter to projected columns only; skip empty JSON values (matches Java
-        # extractColumnMasking StringUtils.isEmpty guard and null-transform skip).
         parsed = {}
         for col, tj in masking_rules.items():
             if col not in read_field_names:

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -276,6 +276,8 @@ class FileScanner:
         # ``scan_with_stats()`` flips it on for a single explain pass and
         # the filter callbacks below increment counters when present.
         self.scan_stats: Optional[ScanStats] = None
+        self.auth_partition_predicate = None
+        self.auth_has_non_partition_filter = False
 
         # Predicate-driven bucket pruning (HASH_FIXED only). Mirrors Java
         # BucketSelectConverter. Set on demand and reused across all
@@ -589,7 +591,7 @@ class FileScanner:
             return splits
         if self.data_evolution and self.deletion_vectors_enabled:
             return splits
-        if self._has_non_partition_filter():
+        if self._has_non_partition_filter() or self.auth_has_non_partition_filter:
             return splits
 
         scanned_row_count = 0
@@ -688,6 +690,8 @@ class FileScanner:
         # partition predicates, so this check is the sole partition gate
         # at the entry level — not a "redundant safety net".
         if self.partition_key_predicate and not self.partition_key_predicate.test(entry.partition):
+            return False
+        if self.auth_partition_predicate and not self.auth_partition_predicate.test(entry.partition):
             return False
         if stats is not None:
             stats.entries_after_partition += 1

--- a/paimon-python/pypaimon/read/stream_read_builder.py
+++ b/paimon-python/pypaimon/read/stream_read_builder.py
@@ -115,13 +115,15 @@ class StreamReadBuilder:
 
     def new_streaming_scan(self) -> AsyncStreamingTableScan:
         """Create a new AsyncStreamingTableScan with this builder's settings."""
-        return AsyncStreamingTableScan(
+        scan = AsyncStreamingTableScan(
             table=self.table,
             predicate=self._predicate,
             poll_interval_ms=self._poll_interval_ms,
             bucket_filter=self._bucket_filter,
             consumer_id=self._consumer_id
         )
+        scan._read_type = self.read_type()
+        return scan
 
     def new_read(self) -> TableRead:
         """Create a new TableRead with this builder's settings."""

--- a/paimon-python/pypaimon/read/streaming_table_scan.py
+++ b/paimon-python/pypaimon/read/streaming_table_scan.py
@@ -109,6 +109,8 @@ class AsyncStreamingTableScan:
         # Consumer management for persisting streaming progress
         self._consumer_id = consumer_id
         self._read_type = None
+        self._query_auth_fn = self.table.catalog_environment.table_query_auth(
+            self.table.options, self.table.identifier)
         self._consumer_manager = (
             ConsumerManager(table.file_io, table.table_path)
             if consumer_id else None
@@ -269,8 +271,7 @@ class AsyncStreamingTableScan:
             self._pending_consumer_snapshot = None
 
     def _apply_auth(self, plan) -> Plan:
-        fn = self.table.catalog_environment.table_query_auth(
-            self.table.options, self.table.identifier)
+        fn = self._query_auth_fn
         if fn is None:
             return plan
         select = [f.name for f in self._read_type] if self._read_type else None

--- a/paimon-python/pypaimon/read/streaming_table_scan.py
+++ b/paimon-python/pypaimon/read/streaming_table_scan.py
@@ -36,6 +36,7 @@ from pypaimon.consumer.consumer_manager import ConsumerManager
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.read.plan import Plan
+from pypaimon.read.query_auth_split import resolve_auth_result, wrap_plan_with_auth
 from pypaimon.read.scanner.append_table_split_generator import \
     AppendTableSplitGenerator
 from pypaimon.read.scanner.changelog_follow_up_scanner import \
@@ -270,15 +271,11 @@ class AsyncStreamingTableScan:
             )
             self._pending_consumer_snapshot = None
 
-    def _apply_auth(self, plan) -> Plan:
-        fn = self._query_auth_fn
-        if fn is None:
-            return plan
-        select = [f.name for f in self._read_type] if self._read_type else None
-        auth_result = fn(select)
-        if auth_result is not None:
-            return auth_result.convert_plan(plan)
-        return plan
+    def __apply_auth(self, plan) -> Plan:
+        return wrap_plan_with_auth(self.__auth_query(), plan)
+
+    def __auth_query(self):
+        return resolve_auth_result(self._query_auth_fn, self._read_type)
 
     def _start_prefetch(self, snapshot_id: int) -> None:
         """Start prefetching the next scannable snapshot in a background thread."""
@@ -316,7 +313,7 @@ class AsyncStreamingTableScan:
             plan = self._create_changelog_plan(snapshot)
         else:
             plan = self._create_delta_plan(snapshot)
-        return self._apply_auth(plan)
+        return self.__apply_auth(plan)
 
     def _create_follow_up_scanner(self) -> FollowUpScanner:
         """Create the appropriate follow-up scanner based on changelog-producer option."""
@@ -333,8 +330,7 @@ class AsyncStreamingTableScan:
             return [e for e in entries if self._bucket_filter(e.bucket)]
         return entries
 
-    def _create_initial_plan_raw(self, snapshot: Snapshot) -> Plan:
-        """Create initial plan without auth (used by catch-up to avoid double auth)."""
+    def __create_initial_plan_raw(self, snapshot, auth_result=None):
         def all_manifests():
             return self._manifest_list_manager.read_all(snapshot), snapshot
 
@@ -344,11 +340,16 @@ class AsyncStreamingTableScan:
             predicate=self.predicate,
             limit=None
         )
+        if auth_result is not None:
+            from pypaimon.read.table_scan import prune_scanner_by_auth
+            prune_scanner_by_auth(self.table, starting_scanner, auth_result)
         return starting_scanner.scan()
 
     def _create_initial_plan(self, snapshot: Snapshot) -> Plan:
         """Create a Plan for the initial full scan of the latest snapshot."""
-        return self._apply_auth(self._create_initial_plan_raw(snapshot))
+        auth_result = self.__auth_query()
+        plan = self.__create_initial_plan_raw(snapshot, auth_result)
+        return wrap_plan_with_auth(auth_result, plan)
 
     def _create_delta_plan(self, snapshot: Snapshot) -> Plan:
         """Read new files from delta_manifest_list (changelog-producer=none)."""
@@ -425,7 +426,9 @@ class AsyncStreamingTableScan:
         if start_id > 1:
             start_snapshot = self._snapshot_manager.get_snapshot_by_id(start_id - 1)
 
+        auth_result = self.__auth_query()
         if start_snapshot is None:
-            return self._apply_auth(self._create_initial_plan_raw(end_snapshot))
-
-        return self._apply_auth(IncrementalDiffScanner(self.table).scan(start_snapshot, end_snapshot))
+            plan = self.__create_initial_plan_raw(end_snapshot, auth_result)
+        else:
+            plan = IncrementalDiffScanner(self.table).scan(start_snapshot, end_snapshot)
+        return wrap_plan_with_auth(auth_result, plan)

--- a/paimon-python/pypaimon/read/streaming_table_scan.py
+++ b/paimon-python/pypaimon/read/streaming_table_scan.py
@@ -108,6 +108,7 @@ class AsyncStreamingTableScan:
 
         # Consumer management for persisting streaming progress
         self._consumer_id = consumer_id
+        self._read_type = None
         self._consumer_manager = (
             ConsumerManager(table.file_io, table.table_path)
             if consumer_id else None
@@ -267,6 +268,17 @@ class AsyncStreamingTableScan:
             )
             self._pending_consumer_snapshot = None
 
+    def _apply_auth(self, plan) -> Plan:
+        fn = self.table.catalog_environment.table_query_auth(
+            self.table.options, self.table.identifier)
+        if fn is None:
+            return plan
+        select = [f.name for f in self._read_type] if self._read_type else None
+        auth_result = fn(select)
+        if auth_result is not None:
+            return auth_result.convert_plan(plan)
+        return plan
+
     def _start_prefetch(self, snapshot_id: int) -> None:
         """Start prefetching the next scannable snapshot in a background thread."""
         if self._prefetch_future is not None or self._prefetch_executor is None:
@@ -300,9 +312,10 @@ class AsyncStreamingTableScan:
     def _create_follow_up_plan(self, snapshot: Snapshot) -> Plan:
         """Route to changelog or delta plan based on scanner type."""
         if isinstance(self.follow_up_scanner, ChangelogFollowUpScanner):
-            return self._create_changelog_plan(snapshot)
+            plan = self._create_changelog_plan(snapshot)
         else:
-            return self._create_delta_plan(snapshot)
+            plan = self._create_delta_plan(snapshot)
+        return self._apply_auth(plan)
 
     def _create_follow_up_scanner(self) -> FollowUpScanner:
         """Create the appropriate follow-up scanner based on changelog-producer option."""
@@ -319,8 +332,8 @@ class AsyncStreamingTableScan:
             return [e for e in entries if self._bucket_filter(e.bucket)]
         return entries
 
-    def _create_initial_plan(self, snapshot: Snapshot) -> Plan:
-        """Create a Plan for the initial full scan of the latest snapshot."""
+    def _create_initial_plan_raw(self, snapshot: Snapshot) -> Plan:
+        """Create initial plan without auth (used by catch-up to avoid double auth)."""
         def all_manifests():
             return self._manifest_list_manager.read_all(snapshot), snapshot
 
@@ -331,6 +344,10 @@ class AsyncStreamingTableScan:
             limit=None
         )
         return starting_scanner.scan()
+
+    def _create_initial_plan(self, snapshot: Snapshot) -> Plan:
+        """Create a Plan for the initial full scan of the latest snapshot."""
+        return self._apply_auth(self._create_initial_plan_raw(snapshot))
 
     def _create_delta_plan(self, snapshot: Snapshot) -> Plan:
         """Read new files from delta_manifest_list (changelog-producer=none)."""
@@ -403,13 +420,11 @@ class AsyncStreamingTableScan:
 
     def _create_catch_up_plan(self, start_id: int, end_snapshot: Snapshot) -> Plan:
         """Create a catch-up plan using diff-based scanning between start and end snapshots."""
-        # Get start snapshot (one before where we want to start reading).
-        # If start_id is 0 or 1, fall back to a full scan of end_snapshot.
         start_snapshot = None
         if start_id > 1:
             start_snapshot = self._snapshot_manager.get_snapshot_by_id(start_id - 1)
 
         if start_snapshot is None:
-            return self._create_initial_plan(end_snapshot)
+            return self._apply_auth(self._create_initial_plan_raw(end_snapshot))
 
-        return IncrementalDiffScanner(self.table).scan(start_snapshot, end_snapshot)
+        return self._apply_auth(IncrementalDiffScanner(self.table).scan(start_snapshot, end_snapshot))

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -31,6 +31,7 @@ from pypaimon.read.split_read import (DataEvolutionSplitRead,
                                       SplitRead)
 from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.row.offset_row import OffsetRow
+from pypaimon.table.row.row_kind import RowKind
 
 ROW_KIND_COLUMN = "_row_kind"
 
@@ -119,14 +120,43 @@ class TableRead:
             for split in splits:
                 if limit is not None and count >= limit:
                     return
-                reader = self._create_split_read(split).create_reader()
+                reader = self._create_reader_for_split(split)
                 try:
-                    for batch in iter(reader.read_batch, None):
-                        for row in iter(batch.next, None):
-                            yield row
-                            count += 1
-                            if limit is not None and count >= limit:
-                                return
+                    if isinstance(reader, RecordBatchReader):
+                        blob_indices = getattr(reader, 'blob_field_indices', None)
+                        vector_indices = getattr(reader, 'vector_field_indices', None)
+                        file_io = self.table.file_io
+                        for arrow_batch in iter(reader.read_arrow_batch, None):
+                            has_rk = ROW_KIND_COLUMN in arrow_batch.schema.names
+                            if has_rk:
+                                rk_idx = arrow_batch.schema.get_field_index(ROW_KIND_COLUMN)
+                                data_cols = [j for j in range(arrow_batch.num_columns) if j != rk_idx]
+                            else:
+                                data_cols = list(range(arrow_batch.num_columns))
+                            for row_idx in range(arrow_batch.num_rows):
+                                row_tuple = tuple(
+                                    arrow_batch.column(j)[row_idx].as_py()
+                                    for j in data_cols
+                                )
+                                row = OffsetRow(
+                                    row_tuple, 0, len(data_cols),
+                                    file_io=file_io,
+                                    blob_field_indices=blob_indices,
+                                    vector_field_indices=vector_indices)
+                                if has_rk:
+                                    kind_str = arrow_batch.column(rk_idx)[row_idx].as_py()
+                                    row.set_row_kind_byte(RowKind.from_string(kind_str).value)
+                                yield row
+                                count += 1
+                                if limit is not None and count >= limit:
+                                    return
+                    else:
+                        for batch in iter(reader.read_batch, None):
+                            for row in iter(batch.next, None):
+                                yield row
+                                count += 1
+                                if limit is not None and count >= limit:
+                                    return
                 finally:
                     reader.close()
 
@@ -223,7 +253,7 @@ class TableRead:
         for split in splits:
             if remaining is not None and remaining <= 0:
                 break
-            reader = self._create_split_read(split, blob_parallelism).create_reader()
+            reader = self._create_reader_for_split(split, blob_parallelism)
             try:
                 if isinstance(reader, RecordBatchReader):
                     for batch in iter(reader.read_arrow_batch, None):
@@ -231,7 +261,8 @@ class TableRead:
                             batch = batch.slice(0, remaining)
                         batch = self._project_batch_to_output(batch)
                         if self.include_row_kind:
-                            batch = self._add_row_kind_column_to_batch(batch, "+I")
+                            if "_row_kind" not in batch.schema.names:
+                                batch = self._add_row_kind_column_to_batch(batch, "+I")
                         yield batch
                         if remaining is not None:
                             remaining -= batch.num_rows
@@ -387,10 +418,12 @@ class TableRead:
         """
         chunk_size = 65536
         out: List[pyarrow.RecordBatch] = []
-        reader = self._create_split_read(split, blob_parallelism).create_reader()
+        reader = self._create_reader_for_split(split, blob_parallelism)
         try:
             if isinstance(reader, RecordBatchReader):
                 for batch in iter(reader.read_arrow_batch, None):
+                    if batch.num_rows == 0:
+                        continue
                     allowed = remaining_state.try_consume(batch.num_rows)
                     if allowed == 0:
                         break
@@ -398,7 +431,8 @@ class TableRead:
                         batch = batch.slice(0, allowed)
                     batch = self._project_batch_to_output(batch)
                     if self.include_row_kind:
-                        batch = self._add_row_kind_column_to_batch(batch, "+I")
+                        if "_row_kind" not in batch.schema.names:
+                            batch = self._add_row_kind_column_to_batch(batch, "+I")
                     out.append(batch)
                     if remaining_state.exhausted():
                         break
@@ -629,14 +663,16 @@ class TableRead:
             dataset = TorchDataset(self, splits)
             return dataset
 
-    def _create_split_read(self, split: Split, blob_parallelism: int = 1) -> SplitRead:
-        sr = self._build_split_read(split)
+    def _create_split_read(self, split: Split, read_type=None, blob_parallelism: int = 1) -> SplitRead:
+        sr = self._build_split_read(split, read_type)
         sr._blob_parallelism = blob_parallelism
         return sr
 
-    def _build_split_read(self, split: Split) -> SplitRead:
+    def _build_split_read(self, split: Split, read_type=None) -> SplitRead:
+        effective_read_type = read_type if read_type is not None else self.read_type
+        scan_read_type = read_type if read_type is not None else self._scan_read_type
         if self.table.is_primary_key_table and not split.raw_convertible:
-            inner_read_type = self._scan_read_type
+            inner_read_type = scan_read_type
             outer_extract_name_paths: Optional[List[List[str]]] = None
             if self.nested_name_paths and any(
                     len(p) > 1 for p in self.nested_name_paths):
@@ -670,10 +706,8 @@ class TableRead:
                         # Drop the injected seq columns: project back to the
                         # user's requested (flat) columns in order.
                         outer_extract_name_paths = [
-                            [f.name] for f in self.read_type]
+                            [f.name] for f in effective_read_type]
             if outer_extract_name_paths is None and self._needs_output_projection():
-                # Split readers own the output projection for iterator reads;
-                # the TableRead Arrow projection below is a final guard.
                 outer_extract_name_paths = self._output_extract_name_paths()
             return MergeFileSplitRead(
                 table=self.table,
@@ -683,7 +717,7 @@ class TableRead:
                 row_tracking_enabled=False,
                 outer_extract_name_paths=outer_extract_name_paths,
                 outer_flat_read_type=(
-                    self.read_type if outer_extract_name_paths else None),
+                    effective_read_type if outer_extract_name_paths else None),
                 limit=self.limit,
             )
         elif self.table.options.data_evolution_enabled():
@@ -699,7 +733,7 @@ class TableRead:
             return DataEvolutionSplitRead(
                 table=self.table,
                 predicate=self.predicate,
-                read_type=self._scan_read_type,
+                read_type=scan_read_type,
                 split=split,
                 row_tracking_enabled=True,
                 nested_name_paths=self.nested_name_paths,
@@ -709,7 +743,7 @@ class TableRead:
                 limit=self.limit,
             )
         else:
-            inner_read_type = self._scan_read_type
+            inner_read_type = scan_read_type
             outer_extract_name_paths: Optional[List[List[str]]] = None
             if self.nested_name_paths and any(
                     len(p) > 1 for p in self.nested_name_paths):
@@ -733,7 +767,7 @@ class TableRead:
                 row_tracking_enabled=self.table.options.row_tracking_enabled(),
                 outer_extract_name_paths=outer_extract_name_paths,
                 outer_flat_read_type=(
-                    self.read_type if outer_extract_name_paths else None),
+                    effective_read_type if outer_extract_name_paths else None),
                 limit=self.limit,
             )
 
@@ -793,6 +827,53 @@ class TableRead:
                     "table schema" % (top_name,))
             widened.append(field)
         return widened
+
+    def _create_reader_for_split(self, split, blob_parallelism=1):
+        from pypaimon.read.query_auth_split import QueryAuthSplit
+
+        auth_result = None
+        if isinstance(split, QueryAuthSplit):
+            auth_result = split.auth_result
+            split = split.split
+
+        if auth_result is not None:
+            return self._authed_reader(split, auth_result, blob_parallelism)
+        else:
+            return self._create_split_read(split, blob_parallelism=blob_parallelism).create_reader()
+
+    def _authed_reader(self, split, auth_result, blob_parallelism=1):
+        from pypaimon.read.reader.auth_masking_reader import (
+            AuthFilterReader, AuthMaskingReader, ColumnProjectReader)
+
+        table_fields = self.table.fields
+        read_fields = self.read_type
+
+        extra_fields = auth_result.get_extra_fields_for_filter(read_fields, table_fields)
+        effective_read_type = read_fields
+        if extra_fields:
+            effective_read_type = read_fields + extra_fields
+
+        reader = self._create_split_read(
+            split, read_type=effective_read_type,
+            blob_parallelism=blob_parallelism).create_reader()
+
+        if not isinstance(reader, RecordBatchReader):
+            from pypaimon.read.reader.auth_masking_reader import RecordReaderToBatchAdapter
+            schema = PyarrowFieldParser.from_paimon_schema(effective_read_type)
+            reader = RecordReaderToBatchAdapter(reader, schema, include_row_kind=self.include_row_kind)
+
+        filter_fn = auth_result.extract_row_filter()
+        if filter_fn:
+            reader = AuthFilterReader(reader, filter_fn)
+
+        if auth_result.column_masking:
+            reader = AuthMaskingReader(reader, auth_result.column_masking, effective_read_type)
+
+        if extra_fields:
+            original_columns = [f.name for f in read_fields]
+            reader = ColumnProjectReader(reader, original_columns)
+
+        return reader
 
     @staticmethod
     def convert_rows_to_arrow_batch(row_tuples: List[tuple], schema: pyarrow.Schema) -> pyarrow.RecordBatch:

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -227,6 +227,8 @@ class TableRead:
             try:
                 if isinstance(reader, RecordBatchReader):
                     for batch in iter(reader.read_arrow_batch, None):
+                        if batch.num_rows == 0:
+                            continue
                         if remaining is not None and batch.num_rows > remaining:
                             batch = batch.slice(0, remaining)
                         batch = self._project_batch_to_output(batch)
@@ -639,7 +641,7 @@ class TableRead:
 
     def _build_split_read(self, split: Split, read_type=None) -> SplitRead:
         effective_read_type = read_type if read_type is not None else self.read_type
-        scan_read_type = read_type if read_type is not None else self._scan_read_type
+        scan_read_type = self._with_predicate_extra_fields(read_type) if read_type is not None else self._scan_read_type
         if self.table.is_primary_key_table and not split.raw_convertible:
             inner_read_type = scan_read_type
             outer_extract_name_paths: Optional[List[List[str]]] = None
@@ -676,7 +678,7 @@ class TableRead:
                         # user's requested (flat) columns in order.
                         outer_extract_name_paths = [
                             [f.name] for f in effective_read_type]
-            if outer_extract_name_paths is None and self._needs_output_projection():
+            if read_type is None and outer_extract_name_paths is None and self._needs_output_projection():
                 outer_extract_name_paths = self._output_extract_name_paths()
             return MergeFileSplitRead(
                 table=self.table,
@@ -696,8 +698,7 @@ class TableRead:
                     "Nested-field projection on data-evolution tables is "
                     "not yet supported")
             outer_extract_name_paths = None
-            if self._needs_output_projection():
-                # Keep iterator output narrow inside DataEvolutionSplitRead.
+            if read_type is None and self._needs_output_projection():
                 outer_extract_name_paths = self._output_extract_name_paths()
             return DataEvolutionSplitRead(
                 table=self.table,
@@ -724,9 +725,7 @@ class TableRead:
                 inner_read_type = self._with_predicate_extra_fields(
                     self._widen_to_top_level_for_merge())
                 outer_extract_name_paths = self.nested_name_paths
-            if outer_extract_name_paths is None and self._needs_output_projection():
-                # Split readers own the output projection for iterator reads;
-                # the TableRead Arrow projection below is a final guard.
+            if read_type is None and outer_extract_name_paths is None and self._needs_output_projection():
                 outer_extract_name_paths = self._output_extract_name_paths()
             return RawFileSplitRead(
                 table=self.table,

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -24,6 +24,10 @@ import pyarrow
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.read.push_down_utils import predicate_field_names
+from pypaimon.read.query_auth_split import QueryAuthSplit
+from pypaimon.read.reader.auth_masking_reader import (
+    AuthFilterReader, AuthMaskingReader, ColumnProjectReader,
+    RecordReaderToBatchAdapter, BatchToRecordReaderAdapter)
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.read.split import Split
 from pypaimon.read.split_read import (DataEvolutionSplitRead,
@@ -119,7 +123,7 @@ class TableRead:
             for split in splits:
                 if limit is not None and count >= limit:
                     return
-                reader = self._create_reader_for_split(split)
+                reader = self.__create_reader_for_split(split)
                 try:
                     for batch in iter(reader.read_batch, None):
                         for row in iter(batch.next, None):
@@ -223,7 +227,7 @@ class TableRead:
         for split in splits:
             if remaining is not None and remaining <= 0:
                 break
-            reader = self._create_reader_for_split(split, blob_parallelism)
+            reader = self.__create_reader_for_split(split, blob_parallelism)
             try:
                 if isinstance(reader, RecordBatchReader):
                     for batch in iter(reader.read_arrow_batch, None):
@@ -233,7 +237,8 @@ class TableRead:
                             batch = batch.slice(0, remaining)
                         batch = self._project_batch_to_output(batch)
                         if self.include_row_kind:
-                            batch = self._add_row_kind_column_to_batch(batch, "+I")
+                            if "_row_kind" not in batch.schema.names:
+                                batch = self._add_row_kind_column_to_batch(batch, "+I")
                         yield batch
                         if remaining is not None:
                             remaining -= batch.num_rows
@@ -389,7 +394,7 @@ class TableRead:
         """
         chunk_size = 65536
         out: List[pyarrow.RecordBatch] = []
-        reader = self._create_reader_for_split(split, blob_parallelism)
+        reader = self.__create_reader_for_split(split, blob_parallelism)
         try:
             if isinstance(reader, RecordBatchReader):
                 for batch in iter(reader.read_arrow_batch, None):
@@ -796,24 +801,18 @@ class TableRead:
             widened.append(field)
         return widened
 
-    def _create_reader_for_split(self, split, blob_parallelism=1):
-        from pypaimon.read.query_auth_split import QueryAuthSplit
-
+    def __create_reader_for_split(self, split, blob_parallelism=1):
         auth_result = None
         if isinstance(split, QueryAuthSplit):
             auth_result = split.auth_result
             split = split.split
 
         if auth_result is not None:
-            return self._authed_reader(split, auth_result, blob_parallelism)
+            return self.__authed_reader(split, auth_result, blob_parallelism)
         else:
             return self._create_split_read(split, blob_parallelism=blob_parallelism).create_reader()
 
-    def _authed_reader(self, split, auth_result, blob_parallelism=1):
-        from pypaimon.read.reader.auth_masking_reader import (
-            AuthFilterReader, AuthMaskingReader, ColumnProjectReader,
-            RecordReaderToBatchAdapter, BatchToRecordReaderAdapter)
-
+    def __authed_reader(self, split, auth_result, blob_parallelism=1):
         table_fields = self.table.fields
         read_fields = self.read_type
 

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -634,7 +634,7 @@ class TableRead:
             dataset = TorchDataset(self, splits)
             return dataset
 
-    def _create_split_read(self, split: Split, read_type=None, blob_parallelism: int = 1) -> SplitRead:
+    def _create_split_read(self, split: Split, blob_parallelism: int = 1, read_type=None) -> SplitRead:
         sr = self._build_split_read(split, read_type)
         sr._blob_parallelism = blob_parallelism
         return sr
@@ -823,8 +823,8 @@ class TableRead:
             effective_read_type = read_fields + extra_fields
 
         reader = self._create_split_read(
-            split, read_type=effective_read_type,
-            blob_parallelism=blob_parallelism).create_reader()
+            split, blob_parallelism=blob_parallelism,
+            read_type=effective_read_type).create_reader()
 
         needs_convert_back = False
         if not isinstance(reader, RecordBatchReader):

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -31,7 +31,6 @@ from pypaimon.read.split_read import (DataEvolutionSplitRead,
                                       SplitRead)
 from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.row.offset_row import OffsetRow
-from pypaimon.table.row.row_kind import RowKind
 
 ROW_KIND_COLUMN = "_row_kind"
 
@@ -122,41 +121,12 @@ class TableRead:
                     return
                 reader = self._create_reader_for_split(split)
                 try:
-                    if isinstance(reader, RecordBatchReader):
-                        blob_indices = getattr(reader, 'blob_field_indices', None)
-                        vector_indices = getattr(reader, 'vector_field_indices', None)
-                        file_io = self.table.file_io
-                        for arrow_batch in iter(reader.read_arrow_batch, None):
-                            has_rk = ROW_KIND_COLUMN in arrow_batch.schema.names
-                            if has_rk:
-                                rk_idx = arrow_batch.schema.get_field_index(ROW_KIND_COLUMN)
-                                data_cols = [j for j in range(arrow_batch.num_columns) if j != rk_idx]
-                            else:
-                                data_cols = list(range(arrow_batch.num_columns))
-                            for row_idx in range(arrow_batch.num_rows):
-                                row_tuple = tuple(
-                                    arrow_batch.column(j)[row_idx].as_py()
-                                    for j in data_cols
-                                )
-                                row = OffsetRow(
-                                    row_tuple, 0, len(data_cols),
-                                    file_io=file_io,
-                                    blob_field_indices=blob_indices,
-                                    vector_field_indices=vector_indices)
-                                if has_rk:
-                                    kind_str = arrow_batch.column(rk_idx)[row_idx].as_py()
-                                    row.set_row_kind_byte(RowKind.from_string(kind_str).value)
-                                yield row
-                                count += 1
-                                if limit is not None and count >= limit:
-                                    return
-                    else:
-                        for batch in iter(reader.read_batch, None):
-                            for row in iter(batch.next, None):
-                                yield row
-                                count += 1
-                                if limit is not None and count >= limit:
-                                    return
+                    for batch in iter(reader.read_batch, None):
+                        for row in iter(batch.next, None):
+                            yield row
+                            count += 1
+                            if limit is not None and count >= limit:
+                                return
                 finally:
                     reader.close()
 
@@ -261,8 +231,7 @@ class TableRead:
                             batch = batch.slice(0, remaining)
                         batch = self._project_batch_to_output(batch)
                         if self.include_row_kind:
-                            if "_row_kind" not in batch.schema.names:
-                                batch = self._add_row_kind_column_to_batch(batch, "+I")
+                            batch = self._add_row_kind_column_to_batch(batch, "+I")
                         yield batch
                         if remaining is not None:
                             remaining -= batch.num_rows
@@ -843,7 +812,8 @@ class TableRead:
 
     def _authed_reader(self, split, auth_result, blob_parallelism=1):
         from pypaimon.read.reader.auth_masking_reader import (
-            AuthFilterReader, AuthMaskingReader, ColumnProjectReader)
+            AuthFilterReader, AuthMaskingReader, ColumnProjectReader,
+            RecordReaderToBatchAdapter, BatchToRecordReaderAdapter)
 
         table_fields = self.table.fields
         read_fields = self.read_type
@@ -857,10 +827,11 @@ class TableRead:
             split, read_type=effective_read_type,
             blob_parallelism=blob_parallelism).create_reader()
 
+        needs_convert_back = False
         if not isinstance(reader, RecordBatchReader):
-            from pypaimon.read.reader.auth_masking_reader import RecordReaderToBatchAdapter
             schema = PyarrowFieldParser.from_paimon_schema(effective_read_type)
             reader = RecordReaderToBatchAdapter(reader, schema, include_row_kind=self.include_row_kind)
+            needs_convert_back = True
 
         filter_fn = auth_result.extract_row_filter()
         if filter_fn:
@@ -872,6 +843,9 @@ class TableRead:
         if extra_fields:
             original_columns = [f.name for f in read_fields]
             reader = ColumnProjectReader(reader, original_columns)
+
+        if needs_convert_back:
+            reader = BatchToRecordReaderAdapter(reader)
 
         return reader
 

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -15,15 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json as _json
 from typing import Optional, Tuple
 
+from pypaimon.catalog.catalog_exception import TableNoPermissionException
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.common.predicate import Predicate
-
+from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.read.plan import Plan
+from pypaimon.read.query_auth_split import QueryAuthSplit, resolve_auth_result, wrap_plan_with_auth
 from pypaimon.read.scan_stats import ScanStats
 from pypaimon.read.scanner.file_scanner import FileScanner
-from pypaimon.manifest.manifest_list_manager import ManifestListManager
 
 
 class TableScan:
@@ -48,78 +51,20 @@ class TableScan:
         self.file_scanner = self._create_file_scanner()
 
     def plan(self) -> Plan:
-        auth_result = self._auth_query()
+        auth_result = self.__auth_query()
         if auth_result is not None:
-            self._apply_auth_to_scanner(auth_result)
+            prune_scanner_by_auth(self.table, self.file_scanner, auth_result)
         plan = self.file_scanner.scan()
-        if auth_result is not None:
-            plan = auth_result.convert_plan(plan)
+        return wrap_plan_with_auth(auth_result, plan)
+
+    def plan_for_write(self) -> Plan:
+        plan = self.plan()
+        if any(isinstance(s, QueryAuthSplit) for s in plan.splits()):
+            raise TableNoPermissionException(self.table.identifier)
         return plan
 
-    def _apply_auth_to_scanner(self, auth_result):
-        if not auth_result.filter:
-            return
-        partition_preds, has_non_partition = self._split_auth_filter(auth_result)
-        if partition_preds:
-            from pypaimon.common.predicate_builder import PredicateBuilder
-            combined = PredicateBuilder.and_predicates(partition_preds)
-            self.file_scanner.auth_partition_predicate = combined
-        if has_non_partition:
-            self.file_scanner.auth_has_non_partition_filter = True
-
-    def _split_auth_filter(self, auth_result):
-        partition_keys = set(self.table.partition_keys or [])
-        if not partition_keys:
-            return [], bool(auth_result.filter)
-
-        partition_preds = []
-        has_non_partition = False
-        field_index_map = {f.name: i for i, f in enumerate(self.table.fields)}
-
-        for json_str in (auth_result.filter or []):
-            pred = self._try_parse_partition_predicate(json_str, partition_keys, field_index_map)
-            if pred is not None:
-                partition_preds.append(pred)
-            else:
-                has_non_partition = True
-        return partition_preds, has_non_partition
-
-    def _try_parse_partition_predicate(self, json_str, partition_keys, field_index_map):
-        import json as _json
-        data = _json.loads(json_str)
-        if data is None or data.get("kind") != "LEAF":
-            return None
-        transform = data.get("transform", {})
-        if transform.get("name") != "FIELD_REF":
-            return None
-        field_name = transform.get("fieldRef", {}).get("name")
-        if field_name is None or field_name not in partition_keys:
-            return None
-        field_index = field_index_map.get(field_name)
-        if field_index is None:
-            return None
-
-        from pypaimon.common.predicate import Predicate
-        function = data.get("function", "")
-        literals = data.get("literals", [])
-        method_map = {
-            "EQUAL": "equal", "NOT_EQUAL": "not_equal",
-            "LESS_THAN": "less_than", "LESS_OR_EQUAL": "less_or_equal",
-            "GREATER_THAN": "greater_than", "GREATER_OR_EQUAL": "greater_or_equal",
-            "IS_NULL": "is_null", "IS_NOT_NULL": "is_not_null",
-            "IN": "in", "NOT_IN": "not_in",
-        }
-        method = method_map.get(function)
-        if method is None:
-            return None
-        return Predicate(method=method, index=field_index, field=field_name, literals=literals)
-
-    def _auth_query(self):
-        fn = self._query_auth_fn
-        if fn is None:
-            return None
-        select = [f.name for f in self._read_type] if self._read_type else None
-        return fn(select)
+    def __auth_query(self):
+        return resolve_auth_result(self._query_auth_fn, self._read_type)
 
     def scan_with_stats(self) -> Tuple[Plan, ScanStats]:
         """Run :meth:`plan` while recording manifest / pruning counters.
@@ -127,10 +72,11 @@ class TableScan:
         Only used by :meth:`ReadBuilder.explain`; the regular read path
         keeps going through :meth:`plan`.
         """
-        auth_result = self._auth_query()
+        auth_result = self.__auth_query()
         if auth_result is not None:
-            self._apply_auth_to_scanner(auth_result)
-        return self.file_scanner.scan_with_stats()
+            prune_scanner_by_auth(self.table, self.file_scanner, auth_result)
+        plan, stats = self.file_scanner.scan_with_stats()
+        return wrap_plan_with_auth(auth_result, plan), stats
 
     def _create_file_scanner(self) -> FileScanner:
         options = self.table.options.options
@@ -360,3 +306,72 @@ class TableScan:
                 f"Only {sorted(allowed) if allowed else 'no scan keys'} "
                 f"are allowed for this mode."
             )
+
+
+def prune_scanner_by_auth(table, scanner, auth_result):
+    if not auth_result.filter:
+        return
+    partition_preds, has_non_partition = __split_auth_filter(table, auth_result)
+    if partition_preds:
+        combined = PredicateBuilder.and_predicates(partition_preds)
+        scanner.auth_partition_predicate = combined
+    if has_non_partition:
+        scanner.auth_has_non_partition_filter = True
+
+
+def __split_auth_filter(table, auth_result):
+    partition_keys = list(table.partition_keys or [])
+    if not partition_keys:
+        return [], bool(auth_result.filter)
+
+    partition_preds = []
+    has_non_partition = False
+    partition_key_set = set(partition_keys)
+    partition_index_map = {name: i for i, name in enumerate(partition_keys)}
+
+    for json_str in (auth_result.filter or []):
+        pred = __try_parse_partition_predicate(table, json_str, partition_key_set, partition_index_map)
+        if pred is not None:
+            partition_preds.append(pred)
+        else:
+            has_non_partition = True
+    return partition_preds, has_non_partition
+
+
+def __try_parse_partition_predicate(table, json_str, partition_keys, partition_index_map):
+    data = _json.loads(json_str)
+    if data is None or data.get("kind") != "LEAF":
+        return None
+    transform = data.get("transform", {})
+    if transform.get("name") != "FIELD_REF":
+        return None
+    field_name = transform.get("fieldRef", {}).get("name")
+    if field_name is None or field_name not in partition_keys:
+        return None
+    field_index = partition_index_map.get(field_name)
+    if field_index is None:
+        return None
+
+    partition_field_type = None
+    for f in table.fields:
+        if f.name == field_name:
+            partition_field_type = getattr(f.type, 'type', '')
+            break
+    base_type = partition_field_type.split('(')[0] if partition_field_type else ''
+    safe_types = {'INT', 'BIGINT', 'SMALLINT', 'TINYINT', 'STRING', 'VARCHAR', 'CHAR'}
+    if base_type not in safe_types:
+        return None
+
+    function = data.get("function", "")
+    literals = data.get("literals", [])
+    method_map = {
+        "EQUAL": "equal", "NOT_EQUAL": "notEqual",
+        "LESS_THAN": "lessThan", "LESS_OR_EQUAL": "lessOrEqual",
+        "GREATER_THAN": "greaterThan", "GREATER_OR_EQUAL": "greaterOrEqual",
+        "IS_NULL": "isNull", "IS_NOT_NULL": "isNotNull",
+        "IN": "in", "NOT_IN": "notIn",
+    }
+    method = method_map.get(function)
+    if method is None:
+        return None
+    return Predicate(method=method, index=field_index, field=field_name, literals=literals)

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -42,10 +42,23 @@ class TableScan:
         self.predicate = predicate
         self.limit = limit
         self.partition_predicate = partition_predicate
+        self._read_type = None
         self.file_scanner = self._create_file_scanner()
 
     def plan(self) -> Plan:
-        return self.file_scanner.scan()
+        auth_result = self._auth_query()
+        plan = self.file_scanner.scan()
+        if auth_result is not None:
+            plan = auth_result.convert_plan(plan)
+        return plan
+
+    def _auth_query(self):
+        fn = self.table.catalog_environment.table_query_auth(
+            self.table.options, self.table.identifier)
+        if fn is None:
+            return None
+        select = [f.name for f in self._read_type] if self._read_type else None
+        return fn(select)
 
     def scan_with_stats(self) -> Tuple[Plan, ScanStats]:
         """Run :meth:`plan` while recording manifest / pruning counters.

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -24,7 +24,7 @@ from pypaimon.common.predicate import Predicate
 from pypaimon.common.predicate_builder import PredicateBuilder
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.read.plan import Plan
-from pypaimon.read.query_auth_split import QueryAuthSplit, resolve_auth_result, wrap_plan_with_auth
+from pypaimon.read.query_auth_split import resolve_auth_result, wrap_plan_with_auth
 from pypaimon.read.scan_stats import ScanStats
 from pypaimon.read.scanner.file_scanner import FileScanner
 
@@ -58,10 +58,9 @@ class TableScan:
         return wrap_plan_with_auth(auth_result, plan)
 
     def plan_for_write(self) -> Plan:
-        plan = self.plan()
-        if any(isinstance(s, QueryAuthSplit) for s in plan.splits()):
+        if self.__auth_query() is not None:
             raise TableNoPermissionException(self.table.identifier)
-        return plan
+        return self.file_scanner.scan()
 
     def __auth_query(self):
         return resolve_auth_result(self._query_auth_fn, self._read_type)

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -47,10 +47,70 @@ class TableScan:
 
     def plan(self) -> Plan:
         auth_result = self._auth_query()
+        if auth_result is not None:
+            self._apply_auth_to_scanner(auth_result)
         plan = self.file_scanner.scan()
         if auth_result is not None:
             plan = auth_result.convert_plan(plan)
         return plan
+
+    def _apply_auth_to_scanner(self, auth_result):
+        if not auth_result.filter:
+            return
+        partition_preds, has_non_partition = self._split_auth_filter(auth_result)
+        if partition_preds:
+            from pypaimon.common.predicate_builder import PredicateBuilder
+            combined = PredicateBuilder.and_predicates(partition_preds)
+            self.file_scanner.auth_partition_predicate = combined
+        if has_non_partition:
+            self.file_scanner.auth_has_non_partition_filter = True
+
+    def _split_auth_filter(self, auth_result):
+        partition_keys = set(self.table.partition_keys or [])
+        if not partition_keys:
+            return [], bool(auth_result.filter)
+
+        partition_preds = []
+        has_non_partition = False
+        field_index_map = {f.name: i for i, f in enumerate(self.table.fields)}
+
+        for json_str in (auth_result.filter or []):
+            pred = self._try_parse_partition_predicate(json_str, partition_keys, field_index_map)
+            if pred is not None:
+                partition_preds.append(pred)
+            else:
+                has_non_partition = True
+        return partition_preds, has_non_partition
+
+    def _try_parse_partition_predicate(self, json_str, partition_keys, field_index_map):
+        import json as _json
+        data = _json.loads(json_str)
+        if data is None or data.get("kind") != "LEAF":
+            return None
+        transform = data.get("transform", {})
+        if transform.get("name") != "FIELD_REF":
+            return None
+        field_name = transform.get("fieldRef", {}).get("name")
+        if field_name is None or field_name not in partition_keys:
+            return None
+        field_index = field_index_map.get(field_name)
+        if field_index is None:
+            return None
+
+        from pypaimon.common.predicate import Predicate
+        function = data.get("function", "")
+        literals = data.get("literals", [])
+        method_map = {
+            "EQUAL": "equal", "NOT_EQUAL": "not_equal",
+            "LESS_THAN": "less_than", "LESS_OR_EQUAL": "less_or_equal",
+            "GREATER_THAN": "greater_than", "GREATER_OR_EQUAL": "greater_or_equal",
+            "IS_NULL": "is_null", "IS_NOT_NULL": "is_not_null",
+            "IN": "in", "NOT_IN": "not_in",
+        }
+        method = method_map.get(function)
+        if method is None:
+            return None
+        return Predicate(method=method, index=field_index, field=field_name, literals=literals)
 
     def _auth_query(self):
         fn = self.table.catalog_environment.table_query_auth(
@@ -176,7 +236,7 @@ class TableScan:
             self.table,
             all_manifests,
             self.predicate,
-            self.limit,
+            effective_limit,
             partition_predicate=self.partition_predicate,
         )
 

--- a/paimon-python/pypaimon/read/table_scan.py
+++ b/paimon-python/pypaimon/read/table_scan.py
@@ -43,6 +43,8 @@ class TableScan:
         self.limit = limit
         self.partition_predicate = partition_predicate
         self._read_type = None
+        self._query_auth_fn = self.table.catalog_environment.table_query_auth(
+            self.table.options, self.table.identifier)
         self.file_scanner = self._create_file_scanner()
 
     def plan(self) -> Plan:
@@ -113,8 +115,7 @@ class TableScan:
         return Predicate(method=method, index=field_index, field=field_name, literals=literals)
 
     def _auth_query(self):
-        fn = self.table.catalog_environment.table_query_auth(
-            self.table.options, self.table.identifier)
+        fn = self._query_auth_fn
         if fn is None:
             return None
         select = [f.name for f in self._read_type] if self._read_type else None
@@ -126,6 +127,9 @@ class TableScan:
         Only used by :meth:`ReadBuilder.explain`; the regular read path
         keeps going through :meth:`plan`.
         """
+        auth_result = self._auth_query()
+        if auth_result is not None:
+            self._apply_auth_to_scanner(auth_result)
         return self.file_scanner.scan_with_stats()
 
     def _create_file_scanner(self) -> FileScanner:
@@ -236,7 +240,7 @@ class TableScan:
             self.table,
             all_manifests,
             self.predicate,
-            effective_limit,
+            self.limit,
             partition_predicate=self.partition_predicate,
         )
 

--- a/paimon-python/pypaimon/table/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/table/data_evolution_merge_into.py
@@ -723,7 +723,7 @@ def _read_table(table, projection: Optional[List[str]] = None,
     if projection is not None:
         read_builder.with_projection(projection)
     scan = read_builder.new_scan()
-    return read_builder.new_read().to_arrow(scan.plan().splits())
+    return read_builder.new_read().to_arrow(scan.plan_for_write().splits())
 
 
 def _copy_at_snapshot(table, snapshot_id: Optional[int]):

--- a/paimon-python/pypaimon/table/source/global_index_live_row_filter.py
+++ b/paimon-python/pypaimon/table/source/global_index_live_row_filter.py
@@ -43,7 +43,9 @@ def live_rows(table, partition_filter=None) -> Optional[RoaringBitmap64]:
         read_builder = read_builder.with_partition_filter(partition_filter)
 
     rows = RoaringBitmap64()
-    for split in read_builder.new_scan().plan().splits():
+    scan = read_builder.new_scan()
+    scan._query_auth_fn = None
+    for split in scan.plan().splits():
         if isinstance(split, DataSplit):
             rows = _add_live_rows(table, rows, split)
     return rows

--- a/paimon-python/pypaimon/table/source/global_index_live_row_filter.py
+++ b/paimon-python/pypaimon/table/source/global_index_live_row_filter.py
@@ -20,6 +20,7 @@
 from typing import Optional
 
 from pypaimon.deletionvectors.deletion_vector import DeletionVector
+from pypaimon.read.query_auth_split import QueryAuthSplit
 from pypaimon.read.split import DataSplit
 from pypaimon.utils.range import Range
 from pypaimon.utils.roaring_bitmap import RoaringBitmap64
@@ -44,10 +45,10 @@ def live_rows(table, partition_filter=None) -> Optional[RoaringBitmap64]:
 
     rows = RoaringBitmap64()
     scan = read_builder.new_scan()
-    scan._query_auth_fn = None
     for split in scan.plan().splits():
-        if isinstance(split, DataSplit):
-            rows = _add_live_rows(table, rows, split)
+        inner = split.split if isinstance(split, QueryAuthSplit) else split
+        if isinstance(inner, DataSplit):
+            rows = _add_live_rows(table, rows, inner)
     return rows
 
 

--- a/paimon-python/pypaimon/tests/auth_masking_reader_test.py
+++ b/paimon-python/pypaimon/tests/auth_masking_reader_test.py
@@ -25,7 +25,6 @@ from pypaimon.read.reader.auth_masking_reader import (
     AuthFilterReader,
     AuthMaskingReader,
     ColumnProjectReader,
-    RecordReaderToBatchAdapter,
 )
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 
@@ -45,103 +44,6 @@ class _FakeBatchReader(RecordBatchReader):
     def close(self):
         pass
 
-
-class _FakeRecordIterator:
-    """Simulates RecordIterator[InternalRow] from a RecordReader."""
-    def __init__(self, rows):
-        self._rows = iter(rows)
-
-    def next(self):
-        return next(self._rows, None)
-
-
-class _FakeOffsetRow:
-    """Simulates OffsetRow returned by RecordReader.read_batch()."""
-    def __init__(self, row_tuple, arity):
-        self.row_tuple = row_tuple
-        self.offset = 0
-        self.arity = arity
-
-
-class _FakeRecordReader:
-    """Simulates a RecordReader (non-batch) like MergeFileSplitRead returns."""
-    def __init__(self, batches_of_rows):
-        self._batches = iter(batches_of_rows)
-        self.closed = False
-
-    def read_batch(self):
-        batch = next(self._batches, None)
-        if batch is None:
-            return None
-        return _FakeRecordIterator(batch)
-
-    def close(self):
-        self.closed = True
-
-
-class TestRecordReaderToBatchAdapter(unittest.TestCase):
-
-    def test_converts_rows_to_record_batch(self):
-        rows = [
-            _FakeOffsetRow((1, "alice"), 2),
-            _FakeOffsetRow((2, "bob"), 2),
-        ]
-        inner = _FakeRecordReader([[rows[0], rows[1]]])
-        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-
-        batch = adapter.read_arrow_batch()
-        self.assertIsNotNone(batch)
-        self.assertEqual(batch.num_rows, 2)
-        self.assertEqual(batch.column("id").to_pylist(), [1, 2])
-        self.assertEqual(batch.column("name").to_pylist(), ["alice", "bob"])
-
-        # Second call returns None (exhausted)
-        self.assertIsNone(adapter.read_arrow_batch())
-
-    def test_multiple_inner_batches(self):
-        batch1 = [_FakeOffsetRow((10,), 1)]
-        batch2 = [_FakeOffsetRow((20,), 1), _FakeOffsetRow((30,), 1)]
-        inner = _FakeRecordReader([batch1, batch2])
-        schema = pa.schema([("val", pa.int64())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-
-        batch = adapter.read_arrow_batch()
-        self.assertIsNotNone(batch)
-        self.assertEqual(batch.column("val").to_pylist(), [10, 20, 30])
-
-    def test_empty_reader(self):
-        inner = _FakeRecordReader([])
-        schema = pa.schema([("x", pa.int64())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-        self.assertIsNone(adapter.read_arrow_batch())
-
-    def test_close_delegates(self):
-        inner = _FakeRecordReader([])
-        schema = pa.schema([("x", pa.int64())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-        adapter.close()
-        self.assertTrue(inner.closed)
-
-    def test_works_with_auth_filter_reader(self):
-        """Integration: adapter output can be wrapped by AuthFilterReader."""
-        rows = [
-            _FakeOffsetRow((1, "eng"), 2),
-            _FakeOffsetRow((2, "sales"), 2),
-            _FakeOffsetRow((3, "eng"), 2),
-        ]
-        inner = _FakeRecordReader([[rows[0], rows[1], rows[2]]])
-        schema = pa.schema([("id", pa.int64()), ("dept", pa.string())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-
-        def filter_fn(batch):
-            import pyarrow.compute as pc
-            return pc.equal(batch.column("dept"), "eng")
-
-        filtered = AuthFilterReader(adapter, filter_fn)
-        batch = filtered.read_arrow_batch()
-        self.assertEqual(batch.num_rows, 2)
-        self.assertEqual(batch.column("id").to_pylist(), [1, 3])
 
 
 class TestAuthMaskingReaderTransforms(unittest.TestCase):
@@ -433,90 +335,6 @@ class TestColumnProjectReader(unittest.TestCase):
     def test_returns_none_at_end(self):
         reader = ColumnProjectReader(_FakeBatchReader([]), ["a"])
         self.assertIsNone(reader.read_arrow_batch())
-
-
-class TestRecordReaderToBatchAdapterDataLoss(unittest.TestCase):
-
-    def test_no_data_loss_when_batch_exceeds_chunk_size(self):
-        total_rows = 100
-        chunk_size = 30
-
-        all_rows = [_FakeOffsetRow((i, f"name_{i}"), 2) for i in range(total_rows)]
-        row_iter = iter(all_rows)
-
-        class MockBatchIterator:
-            def next(self_inner):
-                return next(row_iter, None)
-
-        call_count = [0]
-
-        class MockRecordReader:
-            closed = False
-
-            def read_batch(self):
-                if call_count[0] == 0:
-                    call_count[0] = 1
-                    return MockBatchIterator()
-                return None
-
-            def close(self):
-                self.closed = True
-
-        inner = MockRecordReader()
-        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
-        adapter = RecordReaderToBatchAdapter(inner, schema, chunk_size=chunk_size)
-
-        collected_rows = 0
-        while True:
-            batch = adapter.read_arrow_batch()
-            if batch is None:
-                break
-            collected_rows += batch.num_rows
-
-        self.assertEqual(
-            collected_rows, total_rows,
-            f"Expected {total_rows} rows, got {collected_rows} (data loss!)")
-
-
-class TestRecordReaderToBatchAdapterRowKind(unittest.TestCase):
-
-    def test_include_row_kind_captures_kind(self):
-        row1 = _FakeOffsetRow((1, "alice"), 2)
-        row1.row_kind_byte = 0  # +I
-        row2 = _FakeOffsetRow((2, "bob"), 2)
-        row2.row_kind_byte = 3  # -D
-
-        class FakeRowKindRow:
-            def __init__(self, row):
-                self.row_tuple = row.row_tuple
-                self.offset = row.offset
-                self.arity = row.arity
-                self._row_kind_byte = row.row_kind_byte
-
-            def get_row_kind(self):
-                from pypaimon.table.row.row_kind import RowKind
-                return RowKind(self._row_kind_byte)
-
-        rows = [FakeRowKindRow(row1), FakeRowKindRow(row2)]
-        inner = _FakeRecordReader([rows])
-        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
-        adapter = RecordReaderToBatchAdapter(inner, schema, include_row_kind=True)
-
-        batch = adapter.read_arrow_batch()
-        self.assertIsNotNone(batch)
-        self.assertIn("_row_kind", batch.schema.names)
-        self.assertEqual(batch.column("_row_kind").to_pylist(), ["+I", "-D"])
-        self.assertEqual(batch.column("id").to_pylist(), [1, 2])
-        self.assertEqual(batch.column("name").to_pylist(), ["alice", "bob"])
-
-    def test_no_row_kind_by_default(self):
-        rows = [_FakeOffsetRow((1,), 1)]
-        inner = _FakeRecordReader([[rows[0]]])
-        schema = pa.schema([("id", pa.int64())])
-        adapter = RecordReaderToBatchAdapter(inner, schema)
-
-        batch = adapter.read_arrow_batch()
-        self.assertNotIn("_row_kind", batch.schema.names)
 
 
 class TestColumnProjectReaderRowKind(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/auth_masking_reader_test.py
+++ b/paimon-python/pypaimon/tests/auth_masking_reader_test.py
@@ -1,0 +1,706 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import json
+import unittest
+
+import pyarrow as pa
+
+from pypaimon.read.reader.auth_masking_reader import (
+    AuthFilterReader,
+    AuthMaskingReader,
+    ColumnProjectReader,
+    RecordReaderToBatchAdapter,
+)
+from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+
+
+class _FakeField:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeBatchReader(RecordBatchReader):
+    def __init__(self, batches):
+        self._batches = iter(batches)
+
+    def read_arrow_batch(self):
+        return next(self._batches, None)
+
+    def close(self):
+        pass
+
+
+class _FakeRecordIterator:
+    """Simulates RecordIterator[InternalRow] from a RecordReader."""
+    def __init__(self, rows):
+        self._rows = iter(rows)
+
+    def next(self):
+        return next(self._rows, None)
+
+
+class _FakeOffsetRow:
+    """Simulates OffsetRow returned by RecordReader.read_batch()."""
+    def __init__(self, row_tuple, arity):
+        self.row_tuple = row_tuple
+        self.offset = 0
+        self.arity = arity
+
+
+class _FakeRecordReader:
+    """Simulates a RecordReader (non-batch) like MergeFileSplitRead returns."""
+    def __init__(self, batches_of_rows):
+        self._batches = iter(batches_of_rows)
+        self.closed = False
+
+    def read_batch(self):
+        batch = next(self._batches, None)
+        if batch is None:
+            return None
+        return _FakeRecordIterator(batch)
+
+    def close(self):
+        self.closed = True
+
+
+class TestRecordReaderToBatchAdapter(unittest.TestCase):
+
+    def test_converts_rows_to_record_batch(self):
+        rows = [
+            _FakeOffsetRow((1, "alice"), 2),
+            _FakeOffsetRow((2, "bob"), 2),
+        ]
+        inner = _FakeRecordReader([[rows[0], rows[1]]])
+        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+
+        batch = adapter.read_arrow_batch()
+        self.assertIsNotNone(batch)
+        self.assertEqual(batch.num_rows, 2)
+        self.assertEqual(batch.column("id").to_pylist(), [1, 2])
+        self.assertEqual(batch.column("name").to_pylist(), ["alice", "bob"])
+
+        # Second call returns None (exhausted)
+        self.assertIsNone(adapter.read_arrow_batch())
+
+    def test_multiple_inner_batches(self):
+        batch1 = [_FakeOffsetRow((10,), 1)]
+        batch2 = [_FakeOffsetRow((20,), 1), _FakeOffsetRow((30,), 1)]
+        inner = _FakeRecordReader([batch1, batch2])
+        schema = pa.schema([("val", pa.int64())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+
+        batch = adapter.read_arrow_batch()
+        self.assertIsNotNone(batch)
+        self.assertEqual(batch.column("val").to_pylist(), [10, 20, 30])
+
+    def test_empty_reader(self):
+        inner = _FakeRecordReader([])
+        schema = pa.schema([("x", pa.int64())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+        self.assertIsNone(adapter.read_arrow_batch())
+
+    def test_close_delegates(self):
+        inner = _FakeRecordReader([])
+        schema = pa.schema([("x", pa.int64())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+        adapter.close()
+        self.assertTrue(inner.closed)
+
+    def test_works_with_auth_filter_reader(self):
+        """Integration: adapter output can be wrapped by AuthFilterReader."""
+        rows = [
+            _FakeOffsetRow((1, "eng"), 2),
+            _FakeOffsetRow((2, "sales"), 2),
+            _FakeOffsetRow((3, "eng"), 2),
+        ]
+        inner = _FakeRecordReader([[rows[0], rows[1], rows[2]]])
+        schema = pa.schema([("id", pa.int64()), ("dept", pa.string())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+
+        def filter_fn(batch):
+            import pyarrow.compute as pc
+            return pc.equal(batch.column("dept"), "eng")
+
+        filtered = AuthFilterReader(adapter, filter_fn)
+        batch = filtered.read_arrow_batch()
+        self.assertEqual(batch.num_rows, 2)
+        self.assertEqual(batch.column("id").to_pylist(), [1, 3])
+
+
+class TestAuthMaskingReaderTransforms(unittest.TestCase):
+
+    def setUp(self):
+        self.batch = pa.RecordBatch.from_pydict({
+            "name": ["alice", "bob", "charlie"],
+            "email": ["A@x.com", "B@y.com", "C@z.com"],
+            "age": [25, 30, 35],
+            "dept": ["eng", "sales", "eng"],
+        })
+        self.fields = [
+            _FakeField("name"),
+            _FakeField("email"),
+            _FakeField("age"),
+            _FakeField("dept"),
+        ]
+
+    def _apply_masking(self, masking_rules, batch=None, fields=None):
+        batch = batch or self.batch
+        fields = fields or self.fields
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]), masking_rules, fields
+        )
+        return reader.read_arrow_batch()
+
+    def test_null_transform(self):
+        result = self._apply_masking(
+            {"name": json.dumps({"name": "NULL"})}
+        )
+        self.assertEqual(result.column("name").to_pylist(), [None, None, None])
+        self.assertEqual(result.schema.field("name").type, pa.string())
+
+    def test_upper_transform(self):
+        result = self._apply_masking({
+            "email": json.dumps({
+                "name": "UPPER",
+                "inputs": [{"index": 1, "name": "email", "type": "STRING"}],
+            })
+        })
+        self.assertEqual(
+            result.column("email").to_pylist(),
+            ["A@X.COM", "B@Y.COM", "C@Z.COM"],
+        )
+
+    def test_lower_transform(self):
+        result = self._apply_masking({
+            "email": json.dumps({
+                "name": "LOWER",
+                "inputs": [{"index": 1, "name": "email", "type": "STRING"}],
+            })
+        })
+        self.assertEqual(
+            result.column("email").to_pylist(),
+            ["a@x.com", "b@y.com", "c@z.com"],
+        )
+
+    def test_field_ref_transform(self):
+        result = self._apply_masking({
+            "name": json.dumps({
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 3, "name": "dept", "type": "STRING"},
+            })
+        })
+        self.assertEqual(
+            result.column("name").to_pylist(), ["eng", "sales", "eng"]
+        )
+
+    def test_cast_transform(self):
+        result = self._apply_masking({
+            "age": json.dumps({
+                "name": "CAST",
+                "fieldRef": {"index": 2, "name": "age", "type": "INT"},
+                "type": "BIGINT",
+            })
+        })
+        self.assertEqual(result.column("age").type, pa.int64())
+        self.assertEqual(result.column("age").to_pylist(), [25, 30, 35])
+
+    def test_cast_transform_changes_column_type(self):
+        """CAST transform changes the output column type (matching Java behavior)."""
+        batch = pa.RecordBatch.from_pydict(
+            {"id": pa.array([1, 2, 3], type=pa.int32())},
+            schema=pa.schema([("id", pa.int32())]),
+        )
+        fields = [_FakeField("id")]
+        result = self._apply_masking(
+            {"id": json.dumps({
+                "name": "CAST",
+                "fieldRef": {"index": 0, "name": "id", "type": "INT"},
+                "type": "BIGINT",
+            })},
+            batch=batch,
+            fields=fields,
+        )
+        self.assertEqual(result.column("id").type, pa.int64())
+        self.assertEqual(result.column("id").to_pylist(), [1, 2, 3])
+
+    def test_cast_transform_int_to_string(self):
+        """CAST INT to STRING changes column type to string (matching Java)."""
+        batch = pa.RecordBatch.from_pydict(
+            {"id": pa.array([100, 200], type=pa.int32())},
+            schema=pa.schema([("id", pa.int32())]),
+        )
+        fields = [_FakeField("id")]
+        result = self._apply_masking(
+            {"id": json.dumps({
+                "name": "CAST",
+                "fieldRef": {"index": 0, "name": "id", "type": "INT"},
+                "type": "STRING",
+            })},
+            batch=batch,
+            fields=fields,
+        )
+        self.assertEqual(result.column("id").type, pa.string())
+        self.assertEqual(result.column("id").to_pylist(), ["100", "200"])
+
+    def test_concat_transform(self):
+        result = self._apply_masking({
+            "name": json.dumps({
+                "name": "CONCAT",
+                "inputs": [
+                    "***",
+                    {"index": 1, "name": "email", "type": "STRING"},
+                ],
+            })
+        })
+        self.assertEqual(
+            result.column("name").to_pylist(),
+            ["***A@x.com", "***B@y.com", "***C@z.com"],
+        )
+
+    def test_concat_null_emits_null(self):
+        batch = pa.RecordBatch.from_pydict({
+            "name": ["alice", None, "charlie"],
+            "tag": ["x", "y", "z"],
+        })
+        fields = [_FakeField("name"), _FakeField("tag")]
+        result = self._apply_masking(
+            {
+                "tag": json.dumps({
+                    "name": "CONCAT",
+                    "inputs": [
+                        {"index": 0, "name": "name", "type": "STRING"},
+                        "@masked",
+                    ],
+                })
+            },
+            batch=batch,
+            fields=fields,
+        )
+        self.assertEqual(
+            result.column("tag").to_pylist(),
+            ["alice@masked", None, "charlie@masked"],
+        )
+
+    def test_concat_ws_transform(self):
+        batch = pa.RecordBatch.from_pydict({
+            "name": ["alice", None, "charlie"],
+            "dept": ["eng", "sales", "eng"],
+        })
+        fields = [_FakeField("name"), _FakeField("dept")]
+        result = self._apply_masking(
+            {
+                "name": json.dumps({
+                    "name": "CONCAT_WS",
+                    "inputs": [
+                        "-",
+                        {"index": 0, "name": "name", "type": "STRING"},
+                        {"index": 1, "name": "dept", "type": "STRING"},
+                    ],
+                })
+            },
+            batch=batch,
+            fields=fields,
+        )
+        self.assertEqual(
+            result.column("name").to_pylist(),
+            ["alice-eng", "sales", "charlie-eng"],
+        )
+
+    def test_concat_ws_field_ref_separator(self):
+        batch = pa.RecordBatch.from_pydict({
+            "sep": ["-", "|", ":"],
+            "a": ["x", "y", "z"],
+            "b": ["1", "2", "3"],
+        })
+        fields = [_FakeField("sep"), _FakeField("a"), _FakeField("b")]
+        result = self._apply_masking(
+            {
+                "a": json.dumps({
+                    "name": "CONCAT_WS",
+                    "inputs": [
+                        {"index": 0, "name": "sep", "type": "STRING"},
+                        {"index": 1, "name": "a", "type": "STRING"},
+                        {"index": 2, "name": "b", "type": "STRING"},
+                    ],
+                })
+            },
+            batch=batch,
+            fields=fields,
+        )
+        self.assertEqual(
+            result.column("a").to_pylist(), ["x-1", "y|2", "z:3"]
+        )
+
+
+class TestMaskingOrderIndependence(unittest.TestCase):
+
+    def test_cross_reference_uses_original_batch(self):
+        batch = pa.RecordBatch.from_pydict({"a": ["x", "y"], "b": ["p", "q"]})
+        fields = [_FakeField("a"), _FakeField("b")]
+        masking = {
+            "a": json.dumps({
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 1, "name": "b", "type": "STRING"},
+            }),
+            "b": json.dumps({
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 0, "name": "a", "type": "STRING"},
+            }),
+        }
+        reader = AuthMaskingReader(_FakeBatchReader([batch]), masking, fields)
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.column("a").to_pylist(), ["p", "q"])
+        self.assertEqual(result.column("b").to_pylist(), ["x", "y"])
+
+
+class TestMaskingFieldValidation(unittest.TestCase):
+
+    def test_missing_field_raises(self):
+        batch = pa.RecordBatch.from_pydict({"name": ["alice"]})
+        fields = [_FakeField("name")]
+        with self.assertRaises(RuntimeError) as ctx:
+            AuthMaskingReader(
+                _FakeBatchReader([batch]),
+                {
+                    "name": json.dumps({
+                        "name": "FIELD_REF",
+                        "fieldRef": {"index": 0, "name": "nonexistent", "type": "STRING"},
+                    })
+                },
+                fields,
+            )
+        self.assertIn("nonexistent", str(ctx.exception))
+
+
+class TestAuthFilterReader(unittest.TestCase):
+
+    def test_filters_rows(self):
+        import pyarrow.compute as pc
+
+        batch = pa.RecordBatch.from_pydict({
+            "dept": ["eng", "sales", "eng", "hr"],
+        })
+
+        def filter_fn(b):
+            return pc.equal(b.column("dept"), "eng")
+
+        reader = AuthFilterReader(_FakeBatchReader([batch]), filter_fn)
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.num_rows, 2)
+        self.assertEqual(result.column("dept").to_pylist(), ["eng", "eng"])
+
+    def test_returns_none_at_end(self):
+        import pyarrow.compute as pc
+
+        reader = AuthFilterReader(
+            _FakeBatchReader([]),
+            lambda b: pc.equal(b.column("x"), 1),
+        )
+        self.assertIsNone(reader.read_arrow_batch())
+
+
+class TestColumnProjectReader(unittest.TestCase):
+
+    def test_selects_columns(self):
+        batch = pa.RecordBatch.from_pydict({
+            "a": [1, 2],
+            "b": ["x", "y"],
+            "c": [3.0, 4.0],
+        })
+        reader = ColumnProjectReader(_FakeBatchReader([batch]), ["a", "c"])
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.schema.names, ["a", "c"])
+        self.assertEqual(result.column("a").to_pylist(), [1, 2])
+        self.assertEqual(result.column("c").to_pylist(), [3.0, 4.0])
+
+    def test_returns_none_at_end(self):
+        reader = ColumnProjectReader(_FakeBatchReader([]), ["a"])
+        self.assertIsNone(reader.read_arrow_batch())
+
+
+class TestRecordReaderToBatchAdapterDataLoss(unittest.TestCase):
+
+    def test_no_data_loss_when_batch_exceeds_chunk_size(self):
+        total_rows = 100
+        chunk_size = 30
+
+        all_rows = [_FakeOffsetRow((i, f"name_{i}"), 2) for i in range(total_rows)]
+        row_iter = iter(all_rows)
+
+        class MockBatchIterator:
+            def next(self_inner):
+                return next(row_iter, None)
+
+        call_count = [0]
+
+        class MockRecordReader:
+            closed = False
+
+            def read_batch(self):
+                if call_count[0] == 0:
+                    call_count[0] = 1
+                    return MockBatchIterator()
+                return None
+
+            def close(self):
+                self.closed = True
+
+        inner = MockRecordReader()
+        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+        adapter = RecordReaderToBatchAdapter(inner, schema, chunk_size=chunk_size)
+
+        collected_rows = 0
+        while True:
+            batch = adapter.read_arrow_batch()
+            if batch is None:
+                break
+            collected_rows += batch.num_rows
+
+        self.assertEqual(
+            collected_rows, total_rows,
+            f"Expected {total_rows} rows, got {collected_rows} (data loss!)")
+
+
+class TestRecordReaderToBatchAdapterRowKind(unittest.TestCase):
+
+    def test_include_row_kind_captures_kind(self):
+        row1 = _FakeOffsetRow((1, "alice"), 2)
+        row1.row_kind_byte = 0  # +I
+        row2 = _FakeOffsetRow((2, "bob"), 2)
+        row2.row_kind_byte = 3  # -D
+
+        class FakeRowKindRow:
+            def __init__(self, row):
+                self.row_tuple = row.row_tuple
+                self.offset = row.offset
+                self.arity = row.arity
+                self._row_kind_byte = row.row_kind_byte
+
+            def get_row_kind(self):
+                from pypaimon.table.row.row_kind import RowKind
+                return RowKind(self._row_kind_byte)
+
+        rows = [FakeRowKindRow(row1), FakeRowKindRow(row2)]
+        inner = _FakeRecordReader([rows])
+        schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+        adapter = RecordReaderToBatchAdapter(inner, schema, include_row_kind=True)
+
+        batch = adapter.read_arrow_batch()
+        self.assertIsNotNone(batch)
+        self.assertIn("_row_kind", batch.schema.names)
+        self.assertEqual(batch.column("_row_kind").to_pylist(), ["+I", "-D"])
+        self.assertEqual(batch.column("id").to_pylist(), [1, 2])
+        self.assertEqual(batch.column("name").to_pylist(), ["alice", "bob"])
+
+    def test_no_row_kind_by_default(self):
+        rows = [_FakeOffsetRow((1,), 1)]
+        inner = _FakeRecordReader([[rows[0]]])
+        schema = pa.schema([("id", pa.int64())])
+        adapter = RecordReaderToBatchAdapter(inner, schema)
+
+        batch = adapter.read_arrow_batch()
+        self.assertNotIn("_row_kind", batch.schema.names)
+
+
+class TestColumnProjectReaderRowKind(unittest.TestCase):
+
+    def test_preserves_row_kind_column(self):
+        batch = pa.RecordBatch.from_pydict({
+            "_row_kind": ["+I", "-D"],
+            "a": [1, 2],
+            "b": ["x", "y"],
+            "c": [3.0, 4.0],
+        })
+        reader = ColumnProjectReader(_FakeBatchReader([batch]), ["a", "c"])
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.schema.names, ["_row_kind", "a", "c"])
+        self.assertEqual(result.column("_row_kind").to_pylist(), ["+I", "-D"])
+
+    def test_no_row_kind_no_change(self):
+        batch = pa.RecordBatch.from_pydict({"a": [1], "b": [2]})
+        reader = ColumnProjectReader(_FakeBatchReader([batch]), ["a"])
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.schema.names, ["a"])
+
+
+class TestMaskingSkipsNonProjectedColumns(unittest.TestCase):
+    """Java skips masking rules whose target column is absent from the output row type."""
+
+    def test_non_projected_masking_target_does_not_raise(self):
+        """If REST returns secret=FIELD_REF(email) but user reads only id,
+        the rule should be silently skipped, not raise for missing email."""
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        fields = [_FakeField("id")]
+        # Masking rule targets 'secret', which is NOT in the user's projection
+        masking_rules = {
+            "secret": json.dumps({
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 0, "name": "email", "type": "STRING"},
+            })
+        }
+        # Should not raise even though 'email' is not in read_fields
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]), masking_rules, fields)
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.column("id").to_pylist(), [1, 2, 3])
+
+    def test_projected_masking_target_still_validates(self):
+        """If target IS projected, referenced fields must still exist."""
+        batch = pa.RecordBatch.from_pydict({"name": ["alice"]})
+        fields = [_FakeField("name")]
+        masking_rules = {
+            "name": json.dumps({
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 0, "name": "nonexistent", "type": "STRING"},
+            })
+        }
+        with self.assertRaises(RuntimeError) as ctx:
+            AuthMaskingReader(
+                _FakeBatchReader([batch]), masking_rules, fields)
+        self.assertIn("nonexistent", str(ctx.exception))
+
+
+class TestMaskingSkipsBlankJsonValues(unittest.TestCase):
+    """Java extractColumnMasking skips entries with empty column name or empty JSON value."""
+
+    def test_blank_json_value_skipped(self):
+        batch = pa.RecordBatch.from_pydict({"name": ["alice", "bob"]})
+        fields = [_FakeField("name")]
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]),
+            {"name": ""},
+            fields
+        )
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.column("name").to_pylist(), ["alice", "bob"])
+
+    def test_valid_and_blank_rules_mixed(self):
+        batch = pa.RecordBatch.from_pydict({"name": ["alice"], "email": ["a@b.com"]})
+        fields = [_FakeField("name"), _FakeField("email")]
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]),
+            {"name": "", "email": json.dumps({"name": "NULL"})},
+            fields
+        )
+        result = reader.read_arrow_batch()
+        self.assertEqual(result.column("name").to_pylist(), ["alice"])
+        self.assertEqual(result.column("email").to_pylist(), [None])
+
+
+class TestConcatWsAllNullMasking(unittest.TestCase):
+
+    def test_concat_ws_all_null_values_returns_empty_string(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": [None, None, None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fields = [_FakeField("name")]
+        masking_rules = {
+            "name": json.dumps({
+                "name": "CONCAT_WS",
+                "inputs": [",", None, None],
+            })
+        }
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]), masking_rules, fields)
+        result = reader.read_arrow_batch()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result.column("name").to_pylist(), ["", "", ""])
+
+    def test_concat_ws_null_separator_returns_null(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["hello", "world", "test"]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fields = [_FakeField("name")]
+        masking_rules = {
+            "name": json.dumps({
+                "name": "CONCAT_WS",
+                "inputs": [None, "a", "b"],
+            })
+        }
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]), masking_rules, fields)
+        result = reader.read_arrow_batch()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result.column("name").to_pylist(), [None, None, None])
+
+    def test_concat_ws_mixed_null_preserves_row_positions(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"a": [None, "x", None, "p"], "b": [None, "y", "z", None]},
+            schema=pa.schema([("a", pa.string()), ("b", pa.string())]),
+        )
+        fields = [_FakeField("a"), _FakeField("b")]
+        masking_rules = {
+            "a": json.dumps({
+                "name": "CONCAT_WS",
+                "inputs": ["-", {"index": 0, "name": "a", "type": "STRING"},
+                           {"index": 1, "name": "b", "type": "STRING"}],
+            })
+        }
+        reader = AuthMaskingReader(
+            _FakeBatchReader([batch]), masking_rules, fields)
+        result = reader.read_arrow_batch()
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result.column("a").to_pylist(), ["", "x-y", "z", "p"])
+
+
+class TestPickleTableQueryAuthFn(unittest.TestCase):
+
+    def test_auth_fn_is_pickleable(self):
+        import pickle
+        from pypaimon.catalog.catalog_environment import _TableQueryAuthFn
+
+        fn = _TableQueryAuthFn(None, "db.table")
+        restored = pickle.loads(pickle.dumps(fn))
+        self.assertEqual(restored._identifier, "db.table")
+        self.assertIsNone(restored._catalog_loader)
+
+
+class TestTableNoPermissionExceptionUnified(unittest.TestCase):
+
+    def test_catalog_exception_is_base(self):
+        from pypaimon.catalog.catalog_exception import (
+            CatalogException,
+            TableNoPermissionException,
+        )
+        from pypaimon.common.identifier import Identifier
+        exc = TableNoPermissionException(Identifier("db", "table"))
+        self.assertIsInstance(exc, CatalogException)
+
+    def test_message_contains_table_name(self):
+        from pypaimon.catalog.catalog_exception import TableNoPermissionException
+        from pypaimon.common.identifier import Identifier
+        exc = TableNoPermissionException(Identifier("db", "table"))
+        self.assertIn("db.table", str(exc))
+        self.assertIn("No permission", str(exc))
+
+    def test_catches_as_catalog_exception(self):
+        from pypaimon.catalog.catalog_exception import (
+            CatalogException,
+            TableNoPermissionException,
+        )
+        from pypaimon.common.identifier import Identifier
+        with self.assertRaises(CatalogException):
+            raise TableNoPermissionException(Identifier("db", "table"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/auth_masking_reader_test.py
+++ b/paimon-python/pypaimon/tests/auth_masking_reader_test.py
@@ -45,7 +45,6 @@ class _FakeBatchReader(RecordBatchReader):
         pass
 
 
-
 class TestAuthMaskingReaderTransforms(unittest.TestCase):
 
     def setUp(self):

--- a/paimon-python/pypaimon/tests/daft/daft_explain_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_explain_test.py
@@ -89,6 +89,7 @@ def _single_split_explain(
     table_identifier: str,
     raw_convertible: bool,
     has_deletion_vectors: bool,
+    has_auth: bool = False,
 ) -> ExplainResult:
     split = ExplainSplitInfo(
         partition={},
@@ -127,6 +128,7 @@ def _single_split_explain(
         split_size_avg=float(split.file_size),
         split_size_p50=split.file_size,
         split_size_p95=split.file_size,
+        has_auth=has_auth,
         splits=[split],
     )
 
@@ -453,3 +455,41 @@ def test_explain_scan_reports_deletion_vector_fallback(catalog_options, monkeypa
     assert len(result.splits) == 1
     assert result.splits[0].reader_mode == READER_MODE_PYPAIMON_FALLBACK
     assert result.splits[0].fallback_reason == "deletion vectors present"
+
+
+def test_explain_scan_reports_auth_fallback(catalog_options, monkeypatch):
+    pa_schema = pa.schema([
+        ("id", pa.int64()),
+        ("name", pa.string()),
+    ])
+    _, table = _create_table(
+        catalog_options,
+        "explain_auth_fallback",
+        pa_schema,
+        options={"bucket": "-1", "file.format": "parquet"},
+    )
+
+    class FakeReadBuilder:
+        def explain(self, verbose: bool = False) -> ExplainResult:
+            assert verbose is True
+            return _single_split_explain(
+                table_identifier="test_db.explain_auth_fallback",
+                raw_convertible=True,
+                has_deletion_vectors=False,
+                has_auth=True,
+            )
+
+    def fake_scan_read_builder(self, table, read_pushdowns):
+        return FakeReadBuilder()
+
+    monkeypatch.setattr(PaimonDataSource, "_scan_read_builder", fake_scan_read_builder)
+
+    result = _explain_table(table, catalog_options=catalog_options, verbose=True)
+
+    assert result.pypaimon_fallback_split_count == 1
+    assert result.native_parquet_split_count == 0
+    assert result.fallback_reasons == {"query auth active": 1}
+    assert result.splits is not None
+    assert len(result.splits) == 1
+    assert result.splits[0].reader_mode == READER_MODE_PYPAIMON_FALLBACK
+    assert result.splits[0].fallback_reason == "query auth active"

--- a/paimon-python/pypaimon/tests/predicate_json_parser_test.py
+++ b/paimon-python/pypaimon/tests/predicate_json_parser_test.py
@@ -16,6 +16,7 @@
 #  limitations under the License.
 ################################################################################
 
+import datetime
 import json
 import unittest
 
@@ -369,6 +370,34 @@ class TestConvertLiteral(unittest.TestCase):
     def test_decimal_literal(self):
         result = _convert_literal(123.45, pa.decimal128(10, 2))
         self.assertIsInstance(result, pa.Scalar)
+
+    def test_timestamp_ltz_literal_uses_epoch_seconds(self):
+        # Jackson serializes java.time.Instant as epoch seconds (with an
+        # optional fractional part for nanos), not epoch milliseconds.
+        target_type = pa.timestamp("us", tz="UTC")
+        result = _convert_literal(1720612345.123456, target_type)
+        self.assertIsInstance(result, pa.Scalar)
+        expected = pa.scalar(
+            datetime.datetime.fromtimestamp(1720612345.123456, tz=datetime.timezone.utc),
+            type=target_type,
+        )
+        self.assertEqual(result.value, expected.value)
+
+    def test_time_literal_with_nanos(self):
+        # Jackson serializes java.time.LocalTime as [hour, minute, second,
+        # nanoOfSecond]; the nanosecond component must survive as
+        # sub-second precision on the resulting time scalar.
+        result = _convert_literal([12, 30, 45, 123456000], pa.time64("us"))
+        self.assertIsInstance(result, pa.Scalar)
+        expected = pa.scalar(
+            datetime.time(12, 30, 45, microsecond=123456), type=pa.time64("us"))
+        self.assertEqual(result.value, expected.value)
+
+    def test_time_literal_without_nanos(self):
+        result = _convert_literal([12, 30, 45], pa.time64("us"))
+        self.assertIsInstance(result, pa.Scalar)
+        expected = pa.scalar(datetime.time(12, 30, 45), type=pa.time64("us"))
+        self.assertEqual(result.value, expected.value)
 
 
 class TestExtractReferencedFields(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/predicate_json_parser_test.py
+++ b/paimon-python/pypaimon/tests/predicate_json_parser_test.py
@@ -1,0 +1,775 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import json
+import unittest
+
+import pyarrow as pa
+
+from pypaimon.common.predicate_json_parser import (
+    _convert_literal,
+    _paimon_type_to_arrow,
+    extract_referenced_fields,
+    parse_predicate_to_batch_filter,
+)
+
+
+def _make_leaf(field_name, function, literals=None, field_type="INT"):
+    d = {
+        "kind": "LEAF",
+        "transform": {
+            "name": "FIELD_REF",
+            "fieldRef": {"index": 0, "name": field_name, "type": field_type},
+        },
+        "function": function,
+    }
+    if literals is not None:
+        d["literals"] = literals
+    return json.dumps(d)
+
+
+class TestLeafFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self.batch = pa.RecordBatch.from_pydict({
+            "id": [1, 2, 3, 4, 5],
+            "name": ["alice", "bob", "charlie", "alice", "eve"],
+            "score": [85.5, 92.0, 78.3, 95.1, 60.0],
+        })
+
+    def _filter(self, json_str):
+        return parse_predicate_to_batch_filter(json_str)(self.batch).to_pylist()
+
+    def test_equal(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "EQUAL", [3])),
+            [False, False, True, False, False],
+        )
+
+    def test_not_equal(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "NOT_EQUAL", [3])),
+            [True, True, False, True, True],
+        )
+
+    def test_less_than(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "LESS_THAN", [3])),
+            [True, True, False, False, False],
+        )
+
+    def test_less_or_equal(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "LESS_OR_EQUAL", [3])),
+            [True, True, True, False, False],
+        )
+
+    def test_greater_than(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "GREATER_THAN", [3])),
+            [False, False, False, True, True],
+        )
+
+    def test_greater_or_equal(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "GREATER_OR_EQUAL", [3])),
+            [False, False, True, True, True],
+        )
+
+    def test_is_null(self):
+        batch = pa.RecordBatch.from_pydict({"val": [1, None, 3, None, 5]})
+        f = parse_predicate_to_batch_filter(_make_leaf("val", "IS_NULL"))
+        self.assertEqual(f(batch).to_pylist(), [False, True, False, True, False])
+
+    def test_is_not_null(self):
+        batch = pa.RecordBatch.from_pydict({"val": [1, None, 3, None, 5]})
+        f = parse_predicate_to_batch_filter(_make_leaf("val", "IS_NOT_NULL"))
+        self.assertEqual(f(batch).to_pylist(), [True, False, True, False, True])
+
+    def test_in(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "IN", [1, 3, 5])),
+            [True, False, True, False, True],
+        )
+
+    def test_not_in(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "NOT_IN", [1, 3, 5])),
+            [False, True, False, True, False],
+        )
+
+    def test_between(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "BETWEEN", [2, 4])),
+            [False, True, True, True, False],
+        )
+
+    def test_not_between(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "NOT_BETWEEN", [2, 4])),
+            [True, False, False, False, True],
+        )
+
+    def test_starts_with(self):
+        self.assertEqual(
+            self._filter(_make_leaf("name", "STARTS_WITH", ["al"], "STRING")),
+            [True, False, False, True, False],
+        )
+
+    def test_ends_with(self):
+        self.assertEqual(
+            self._filter(_make_leaf("name", "ENDS_WITH", ["e"], "STRING")),
+            [True, False, True, True, True],
+        )
+
+    def test_contains(self):
+        self.assertEqual(
+            self._filter(_make_leaf("name", "CONTAINS", ["li"], "STRING")),
+            [True, False, True, True, False],
+        )
+
+    def test_like(self):
+        like_json = json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"index": 0, "name": "name", "type": "STRING"}},
+            "function": "LIKE",
+            "literals": ["%li%"],
+        })
+        self.assertEqual(
+            parse_predicate_to_batch_filter(like_json)(self.batch).to_pylist(),
+            [True, False, True, True, False],
+        )
+
+    def test_true(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "TRUE")),
+            [True, True, True, True, True],
+        )
+
+    def test_false(self):
+        self.assertEqual(
+            self._filter(_make_leaf("id", "FALSE")),
+            [False, False, False, False, False],
+        )
+
+
+class TestCompoundPredicates(unittest.TestCase):
+
+    def setUp(self):
+        self.batch = pa.RecordBatch.from_pydict({
+            "id": [1, 2, 3, 4, 5],
+        })
+
+    def test_and(self):
+        pred = json.dumps({
+            "kind": "COMPOUND",
+            "function": "AND",
+            "children": [
+                {"kind": "LEAF",
+                 "transform": {"name": "FIELD_REF",
+                               "fieldRef": {"index": 0, "name": "id", "type": "INT"}},
+                 "function": "GREATER_THAN", "literals": [2]},
+                {"kind": "LEAF",
+                 "transform": {"name": "FIELD_REF",
+                               "fieldRef": {"index": 0, "name": "id", "type": "INT"}},
+                 "function": "LESS_THAN", "literals": [5]},
+            ],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [False, False, True, True, False])
+
+    def test_or(self):
+        pred = json.dumps({
+            "kind": "COMPOUND",
+            "function": "OR",
+            "children": [
+                {"kind": "LEAF",
+                 "transform": {"name": "FIELD_REF",
+                               "fieldRef": {"index": 0, "name": "id", "type": "INT"}},
+                 "function": "EQUAL", "literals": [1]},
+                {"kind": "LEAF",
+                 "transform": {"name": "FIELD_REF",
+                               "fieldRef": {"index": 0, "name": "id", "type": "INT"}},
+                 "function": "EQUAL", "literals": [5]},
+            ],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [True, False, False, False, True])
+
+
+class TestPredicateTransforms(unittest.TestCase):
+
+    def setUp(self):
+        self.batch = pa.RecordBatch.from_pydict({
+            "id": [1, 2, 3, 4, 5],
+            "name": ["alice", "bob", "charlie", "alice", "eve"],
+        })
+
+    def test_upper_transform(self):
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "UPPER", "inputs": [{"index": 1, "name": "name", "type": "STRING"}]},
+            "function": "EQUAL",
+            "literals": ["ALICE"],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [True, False, False, True, False])
+
+    def test_lower_transform(self):
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "LOWER", "inputs": [{"index": 1, "name": "name", "type": "STRING"}]},
+            "function": "EQUAL",
+            "literals": ["bob"],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [False, True, False, False, False])
+
+    def test_cast_transform(self):
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "CAST", "fieldRef": {"index": 0, "name": "id", "type": "INT"}, "type": "BIGINT"},
+            "function": "GREATER_THAN",
+            "literals": [3],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [False, False, False, True, True])
+
+    def test_null_transform(self):
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "NULL"},
+            "function": "IS_NULL",
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(self.batch).to_pylist(), [True, True, True, True, True])
+
+    def test_concat_transform_in_predicate(self):
+        batch = pa.RecordBatch.from_pydict({
+            "first": ["john", "jane"],
+            "last": ["doe", "smith"],
+        })
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "CONCAT",
+                "inputs": [
+                    {"index": 0, "name": "first", "type": "STRING"},
+                    {"index": 1, "name": "last", "type": "STRING"},
+                ],
+            },
+            "function": "EQUAL",
+            "literals": ["johndoe"],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(batch).to_pylist(), [True, False])
+
+    def test_concat_ws_transform_in_predicate(self):
+        batch = pa.RecordBatch.from_pydict({
+            "first": ["john", "jane"],
+            "last": ["doe", "smith"],
+        })
+        pred = json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "CONCAT_WS",
+                "inputs": [
+                    " ",
+                    {"index": 0, "name": "first", "type": "STRING"},
+                    {"index": 1, "name": "last", "type": "STRING"},
+                ],
+            },
+            "function": "EQUAL",
+            "literals": ["john doe"],
+        })
+        f = parse_predicate_to_batch_filter(pred)
+        self.assertEqual(f(batch).to_pylist(), [True, False])
+
+
+class TestPaimonTypeToArrow(unittest.TestCase):
+
+    def test_simple_types(self):
+        self.assertEqual(_paimon_type_to_arrow("INT"), pa.int32())
+        self.assertEqual(_paimon_type_to_arrow("BIGINT"), pa.int64())
+        self.assertEqual(_paimon_type_to_arrow("SMALLINT"), pa.int16())
+        self.assertEqual(_paimon_type_to_arrow("TINYINT"), pa.int8())
+        self.assertEqual(_paimon_type_to_arrow("FLOAT"), pa.float32())
+        self.assertEqual(_paimon_type_to_arrow("DOUBLE"), pa.float64())
+        self.assertEqual(_paimon_type_to_arrow("STRING"), pa.string())
+        self.assertEqual(_paimon_type_to_arrow("BOOLEAN"), pa.bool_())
+        self.assertEqual(_paimon_type_to_arrow("BYTES"), pa.binary())
+        self.assertEqual(_paimon_type_to_arrow("DATE"), pa.date32())
+
+    def test_varchar_char(self):
+        self.assertEqual(_paimon_type_to_arrow("VARCHAR"), pa.string())
+        self.assertEqual(_paimon_type_to_arrow("VARCHAR(100)"), pa.string())
+        self.assertEqual(_paimon_type_to_arrow("CHAR(10)"), pa.string())
+
+    def test_timestamp(self):
+        self.assertEqual(_paimon_type_to_arrow("TIMESTAMP(3)"), pa.timestamp("ms"))
+        self.assertEqual(_paimon_type_to_arrow("TIMESTAMP(6)"), pa.timestamp("us"))
+        self.assertEqual(_paimon_type_to_arrow("TIMESTAMP(9)"), pa.timestamp("ns"))
+        self.assertEqual(_paimon_type_to_arrow("TIMESTAMP(0)"), pa.timestamp("s"))
+
+    def test_timestamp_ltz(self):
+        self.assertEqual(
+            _paimon_type_to_arrow("TIMESTAMP WITH LOCAL TIME ZONE(6)"),
+            pa.timestamp("us", tz="UTC"),
+        )
+
+    def test_decimal(self):
+        self.assertEqual(
+            _paimon_type_to_arrow("DECIMAL(10, 2)"),
+            pa.decimal128(10, 2),
+        )
+
+    def test_unsupported_type_raises(self):
+        with self.assertRaises(ValueError):
+            _paimon_type_to_arrow("ARRAY<INT>")
+
+
+class TestConvertLiteral(unittest.TestCase):
+
+    def test_none_literal(self):
+        self.assertIsNone(_convert_literal(None, pa.int32()))
+
+    def test_int_passthrough(self):
+        self.assertEqual(_convert_literal(42, pa.int32()), 42)
+
+    def test_string_passthrough(self):
+        self.assertEqual(_convert_literal("hello", pa.string()), "hello")
+
+    def test_timestamp_literal(self):
+        result = _convert_literal("2024-01-15T10:30:00", pa.timestamp("us"))
+        self.assertIsInstance(result, pa.Scalar)
+
+    def test_timestamp_z_suffix(self):
+        result = _convert_literal("2024-01-15T10:30:00Z", pa.timestamp("us", tz="UTC"))
+        self.assertIsInstance(result, pa.Scalar)
+
+    def test_date_literal(self):
+        result = _convert_literal("2024-01-15", pa.date32())
+        self.assertIsInstance(result, pa.Scalar)
+
+    def test_decimal_literal(self):
+        result = _convert_literal(123.45, pa.decimal128(10, 2))
+        self.assertIsInstance(result, pa.Scalar)
+
+
+class TestExtractReferencedFields(unittest.TestCase):
+
+    def test_leaf_field_ref(self):
+        refs = extract_referenced_fields(json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"index": 0, "name": "col1", "type": "INT"}},
+            "function": "EQUAL",
+            "literals": [1],
+        }))
+        self.assertEqual(refs, {"col1"})
+
+    def test_leaf_cast(self):
+        refs = extract_referenced_fields(json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "CAST", "fieldRef": {"index": 0, "name": "col1", "type": "INT"}, "type": "BIGINT"},
+            "function": "EQUAL",
+            "literals": [1],
+        }))
+        self.assertEqual(refs, {"col1"})
+
+    def test_compound_collects_all(self):
+        refs = extract_referenced_fields(json.dumps({
+            "kind": "COMPOUND",
+            "function": "AND",
+            "children": [
+                {"kind": "LEAF",
+                 "transform": {"name": "FIELD_REF",
+                               "fieldRef": {"index": 0, "name": "a", "type": "INT"}},
+                 "function": "EQUAL", "literals": [1]},
+                {"kind": "LEAF",
+                 "transform": {"name": "UPPER",
+                               "inputs": [{"index": 1, "name": "b", "type": "STRING"}]},
+                 "function": "EQUAL", "literals": ["X"]},
+            ],
+        }))
+        self.assertEqual(refs, {"a", "b"})
+
+    def test_concat_inputs(self):
+        refs = extract_referenced_fields(json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "CONCAT",
+                "inputs": [
+                    {"index": 0, "name": "first", "type": "STRING"},
+                    "literal",
+                    {"index": 1, "name": "last", "type": "STRING"},
+                ],
+            },
+            "function": "EQUAL",
+            "literals": ["x"],
+        }))
+        self.assertEqual(refs, {"first", "last"})
+
+
+class TestLikeEdgeCases(unittest.TestCase):
+
+    def test_dot_is_literal(self):
+        batch = pa.RecordBatch.from_pydict({"v": ["a.b", "axb", "a.bc"]})
+        f = parse_predicate_to_batch_filter(json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"index": 0, "name": "v", "type": "STRING"}},
+            "function": "LIKE",
+            "literals": ["a.b"],
+        }))
+        self.assertEqual(f(batch).to_pylist(), [True, False, False])
+
+    def test_underscore_matches_single_char(self):
+        batch = pa.RecordBatch.from_pydict({"v": ["abc", "axc", "ac", "abbc"]})
+        f = parse_predicate_to_batch_filter(json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"index": 0, "name": "v", "type": "STRING"}},
+            "function": "LIKE",
+            "literals": ["a_c"],
+        }))
+        self.assertEqual(f(batch).to_pylist(), [True, True, False, False])
+
+    def test_percent_matches_any(self):
+        batch = pa.RecordBatch.from_pydict({"v": ["abc", "ac", "axyzc", "def"]})
+        f = parse_predicate_to_batch_filter(json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"index": 0, "name": "v", "type": "STRING"}},
+            "function": "LIKE",
+            "literals": ["a%c"],
+        }))
+        self.assertEqual(f(batch).to_pylist(), [True, True, True, False])
+
+
+class TestLikeEscapeSemantics(unittest.TestCase):
+
+    def _make_like_batch(self, values):
+        return pa.RecordBatch.from_pydict(
+            {"name": values}, schema=pa.schema([("name", pa.string())]))
+
+    def _make_like_predicate(self, pattern):
+        return json.dumps({
+            "kind": "LEAF",
+            "transform": {"name": "FIELD_REF", "fieldRef": {"name": "name"}},
+            "function": "LIKE",
+            "literals": [pattern]
+        })
+
+    def test_like_simple_percent(self):
+        batch = self._make_like_batch(["admin", "admin_foo", "user"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("admin%"))
+        self.assertEqual(fn(batch).to_pylist(), [True, True, False])
+
+    def test_like_simple_underscore(self):
+        batch = self._make_like_batch(["ab", "abc", "a"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("a_"))
+        self.assertEqual(fn(batch).to_pylist(), [True, False, False])
+
+    def test_like_escaped_underscore(self):
+        batch = self._make_like_batch(["admin_foo", "adminXfoo", "admin"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("admin\\_%"))
+        self.assertEqual(fn(batch).to_pylist(), [True, False, False])
+
+    def test_like_escaped_percent(self):
+        batch = self._make_like_batch(["100%", "100X", "100"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("100\\%"))
+        self.assertEqual(fn(batch).to_pylist(), [True, False, False])
+
+    def test_like_escaped_backslash(self):
+        batch = self._make_like_batch(["a\\b", "a/b", "ab"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("a\\\\b"))
+        self.assertEqual(fn(batch).to_pylist(), [True, False, False])
+
+    def test_like_regex_special_chars(self):
+        batch = self._make_like_batch(["a.b", "axb", "a..b"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("a.b"))
+        self.assertEqual(fn(batch).to_pylist(), [True, False, False])
+
+    def test_like_percent_matches_newline(self):
+        batch = self._make_like_batch(["hello\nworld", "hello"])
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("hello%"))
+        self.assertEqual(fn(batch).to_pylist(), [True, True])
+
+    def test_like_invalid_escape_sequence(self):
+        import pytest
+        fn = parse_predicate_to_batch_filter(self._make_like_predicate("admin\\x"))
+        batch = self._make_like_batch(["admin"])
+        with pytest.raises((RuntimeError, ValueError), match="Invalid escape sequence"):
+            fn(batch)
+
+
+class TestNotInNullSemantics(unittest.TestCase):
+    """Java NOT_IN: null field -> false; any null literal -> false for all."""
+
+    def test_not_in_null_field_returns_false(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"dept": ["eng", None, "sales"]},
+            schema=pa.schema([("dept", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("dept", "NOT_IN", ["blocked"], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        # null dept must return false, not true
+        self.assertEqual(result, [True, False, True])
+
+    def test_not_in_null_literal_returns_false_for_all(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"dept": ["eng", None, "sales"]},
+            schema=pa.schema([("dept", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("dept", "NOT_IN", ["blocked", None],
+                       field_type="STRING"))
+        result = fn(batch).to_pylist()
+        # any null literal makes NOT_IN false for all rows
+        self.assertEqual(result, [False, False, False])
+
+    def test_not_in_normal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"id": [1, 2, 3]},
+            schema=pa.schema([("id", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("id", "NOT_IN", [2, 3]))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [True, False, False])
+
+
+class TestIsNaN(unittest.TestCase):
+
+    def test_is_nan_float(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1.0, float("nan"), 3.0, None]},
+            schema=pa.schema([("val", pa.float64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "IS_NAN", field_type="DOUBLE"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, True, False, False])
+
+    def test_is_nan_no_nans(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1.0, 2.0]},
+            schema=pa.schema([("val", pa.float64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "IS_NAN", field_type="DOUBLE"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False])
+
+
+class TestNullLiteralDefense(unittest.TestCase):
+    """Java LeafBinaryFunction/LeafTernaryFunction: null literal -> false."""
+
+    def test_starts_with_null_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["alice", "bob", None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("name", "STARTS_WITH", [None], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_ends_with_null_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["alice", "bob", None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("name", "ENDS_WITH", [None], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_contains_null_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["alice", "bob", None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("name", "CONTAINS", [None], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_like_null_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["alice", "bob", None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("name", "LIKE", [None], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_between_null_lower_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1, 5, 10, None]},
+            schema=pa.schema([("val", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "BETWEEN", [None, 10]))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False, False])
+
+    def test_between_null_upper_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1, 5, 10, None]},
+            schema=pa.schema([("val", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "BETWEEN", [1, None]))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False, False])
+
+    def test_not_between_null_literal(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1, 5, 10, None]},
+            schema=pa.schema([("val", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "NOT_BETWEEN", [None, 10]))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, False, False, False])
+
+    def test_starts_with_normal(self):
+        """Verify normal case still works after adding null guard."""
+        batch = pa.RecordBatch.from_pydict(
+            {"name": ["alice", "anna", "bob", None]},
+            schema=pa.schema([("name", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("name", "STARTS_WITH", ["a"], field_type="STRING"))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [True, True, False, False])
+
+    def test_between_normal(self):
+        """Verify normal BETWEEN still works."""
+        batch = pa.RecordBatch.from_pydict(
+            {"val": [1, 5, 10, None]},
+            schema=pa.schema([("val", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(
+            _make_leaf("val", "BETWEEN", [3, 8]))
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, True, False, False])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestInNullHandling(unittest.TestCase):
+
+    def test_in_with_null_literal_drops_null(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"dept": ["eng", "sales", None]},
+            schema=pa.schema([("dept", pa.string())]),
+        )
+        pred = _make_leaf("dept", "IN", ["eng", None], field_type="STRING")
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [True, False, False])
+
+    def test_in_all_null_literals(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"dept": ["eng", "sales"]},
+            schema=pa.schema([("dept", pa.string())]),
+        )
+        pred = _make_leaf("dept", "IN", [None, None], field_type="STRING")
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, False])
+
+    def test_in_null_field_value_returns_false(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"dept": [None, "eng"]},
+            schema=pa.schema([("dept", pa.string())]),
+        )
+        pred = _make_leaf("dept", "IN", ["eng", "sales"], field_type="STRING")
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, True])
+
+
+class TestComparisonNullLiteral(unittest.TestCase):
+
+    def test_equal_null_literal_returns_false(self):
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        pred = _make_leaf("id", "EQUAL", [None])
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_not_equal_null_literal_returns_false(self):
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        pred = _make_leaf("id", "NOT_EQUAL", [None])
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_less_than_null_literal_returns_false(self):
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        pred = _make_leaf("id", "LESS_THAN", [None])
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+    def test_greater_than_null_literal_returns_false(self):
+        batch = pa.RecordBatch.from_pydict({"id": [1, 2, 3]})
+        pred = _make_leaf("id", "GREATER_THAN", [None])
+        result = parse_predicate_to_batch_filter(pred)(batch).to_pylist()
+        self.assertEqual(result, [False, False, False])
+
+
+class TestConcatWsAllNull(unittest.TestCase):
+
+    def test_concat_ws_all_null_values_returns_empty(self):
+        pred_json = json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "CONCAT_WS",
+                "inputs": [",", None, None],
+            },
+            "function": "EQUAL",
+            "literals": [""],
+        })
+        batch = pa.RecordBatch.from_pydict(
+            {"x": [1, 2, 3]},
+            schema=pa.schema([("x", pa.int64())]),
+        )
+        fn = parse_predicate_to_batch_filter(pred_json)
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [True, True, True])
+
+    def test_concat_ws_mixed_null_preserves_row_positions(self):
+        pred_json = json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "CONCAT_WS",
+                "inputs": [
+                    "-",
+                    {"index": 0, "name": "a", "type": "STRING"},
+                    {"index": 1, "name": "b", "type": "STRING"},
+                ],
+            },
+            "function": "EQUAL",
+            "literals": ["x-y"],
+        })
+        batch = pa.RecordBatch.from_pydict(
+            {"a": [None, "x", None, "p"], "b": [None, "y", "z", None]},
+            schema=pa.schema([("a", pa.string()), ("b", pa.string())]),
+        )
+        fn = parse_predicate_to_batch_filter(pred_json)
+        result = fn(batch).to_pylist()
+        self.assertEqual(result, [False, True, False, False])

--- a/paimon-python/pypaimon/tests/read_builder_explain_test.py
+++ b/paimon-python/pypaimon/tests/read_builder_explain_test.py
@@ -245,7 +245,29 @@ class ReadBuilderExplainTest(unittest.TestCase):
         self.assertEqual(dv_result.split_count, 0)
         self.assertEqual(dv_result.splits_all_above_l0, 0)
 
-    # ---- 7. pretty-print smoke -----------------------------------------
+    # ---- 8. query auth wraps splits and is surfaced in explain ---------
+
+    def test_explain_reports_query_auth_split(self):
+        from pypaimon.catalog.table_query_auth import TableQueryAuthResult
+
+        table, pa_schema = self._append_table('explain_query_auth')
+        _write(table, [{'id': i, 'val': i} for i in range(20)], pa_schema)
+
+        auth_result = TableQueryAuthResult(filter=None, column_masking={'val': 'CAST(NULL AS BIGINT)'})
+        table.catalog_environment.table_query_auth = lambda options, identifier: (lambda select: auth_result)
+
+        rb = table.new_read_builder()
+        result = rb.explain(verbose=True)
+
+        self.assertIsNotNone(result.splits)
+        self.assertGreater(len(result.splits), 0)
+        self.assertTrue(result.has_auth)
+
+        plan_splits = rb.new_scan().plan().splits()
+        from pypaimon.read.query_auth_split import QueryAuthSplit
+        self.assertTrue(all(isinstance(s, QueryAuthSplit) for s in plan_splits))
+
+    # ---- 9. pretty-print smoke -----------------------------------------
 
     def test_pretty_print_smoke(self):
         table, pa_schema = self._append_table('explain_print_smoke')

--- a/paimon-python/pypaimon/tests/reader_split_generator_test.py
+++ b/paimon-python/pypaimon/tests/reader_split_generator_test.py
@@ -348,6 +348,7 @@ class ApplyPushDownLimitUnitTest(unittest.TestCase):
         scanner.limit = limit
         scanner.data_evolution = data_evolution
         scanner.deletion_vectors_enabled = deletion_vectors_enabled
+        scanner.auth_has_non_partition_filter = False
         scanner._has_non_partition_filter = lambda: has_non_partition_filter
         return FileScanner._apply_push_down_limit(scanner, splits)
 

--- a/paimon-python/pypaimon/tests/streaming_table_scan_test.py
+++ b/paimon-python/pypaimon/tests/streaming_table_scan_test.py
@@ -60,6 +60,8 @@ def _create_mock_table(latest_snapshot_id: int = 5):
     table.table_schema.fields = []
     table.schema_manager = Mock()
     table.schema_manager.get_schema.return_value = table.table_schema
+    table.catalog_environment = Mock()
+    table.catalog_environment.table_query_auth.return_value = None
 
     return table, latest_snapshot_id
 

--- a/paimon-python/pypaimon/tests/table_query_auth_test.py
+++ b/paimon-python/pypaimon/tests/table_query_auth_test.py
@@ -1,0 +1,370 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+
+import json
+import unittest
+
+import pyarrow as pa
+
+from pypaimon.catalog.catalog_exception import TableNoPermissionException
+from pypaimon.catalog.table_query_auth import (
+    TableQueryAuthResult,
+)
+from pypaimon.common.identifier import Identifier
+from pypaimon.common.options import Options
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.read.query_auth_split import QueryAuthSplit
+
+
+class _FakeField:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeSplit:
+    def __init__(self, name="s1"):
+        self.name = name
+
+    @property
+    def row_count(self):
+        return 100
+
+    @property
+    def files(self):
+        return []
+
+    @property
+    def partition(self):
+        return {}
+
+    @property
+    def bucket(self):
+        return 0
+
+    def merged_row_count(self):
+        return 100
+
+
+class _FakePlan:
+    def __init__(self, splits, snapshot_id=None):
+        self._splits = splits
+        self.snapshot_id = snapshot_id
+
+    def splits(self):
+        return self._splits
+
+
+def _simple_filter_json(field_name="dept", value="eng"):
+    return json.dumps({
+        "kind": "LEAF",
+        "transform": {
+            "name": "FIELD_REF",
+            "fieldRef": {"index": 0, "name": field_name, "type": "STRING"},
+        },
+        "function": "EQUAL",
+        "literals": [value],
+    })
+
+
+class TestTableNoPermissionException(unittest.TestCase):
+
+    def test_message_format(self):
+        identifier = Identifier("db", "table")
+        exc = TableNoPermissionException(identifier)
+        self.assertIn("db.table", str(exc))
+        self.assertIn("No permission", str(exc))
+        self.assertEqual(exc.identifier, identifier)
+
+
+class TestTableQueryAuthResultConvertPlan(unittest.TestCase):
+
+    def test_no_auth_returns_original_plan(self):
+        result = TableQueryAuthResult(None, None)
+        plan = _FakePlan([_FakeSplit()])
+        converted = result.convert_plan(plan)
+        self.assertIs(converted, plan)
+
+    def test_empty_filter_and_masking_returns_original(self):
+        result = TableQueryAuthResult([], {})
+        plan = _FakePlan([_FakeSplit()])
+        converted = result.convert_plan(plan)
+        self.assertIs(converted, plan)
+
+    def test_blank_filter_entries_are_skipped(self):
+        result = TableQueryAuthResult(["", None], None)
+        self.assertFalse(result.filter)
+
+    def test_mixed_blank_and_valid_filter_entries(self):
+        valid = _simple_filter_json()
+        result = TableQueryAuthResult(["", valid], None)
+        self.assertEqual(len(result.filter), 1)
+        self.assertEqual(result.filter[0], valid)
+
+    def test_blank_filter_no_extra_fields(self):
+        result = TableQueryAuthResult([""], None)
+        extra = result.get_extra_fields_for_filter(
+            [_FakeField("a")], [_FakeField("a"), _FakeField("b")])
+        self.assertEqual(extra, [])
+
+    def test_blank_filter_no_row_filter(self):
+        result = TableQueryAuthResult(["", None], None)
+        self.assertIsNone(result.extract_row_filter())
+
+    def test_blank_column_masking_values_stripped(self):
+        result = TableQueryAuthResult(None, {"col": "", "col3": '{"name":"NULL"}'})
+        self.assertEqual(list(result.column_masking.keys()), ["col3"])
+
+    def test_blank_column_masking_keys_stripped(self):
+        result = TableQueryAuthResult(None, {"": '{"name":"NULL"}'})
+        self.assertEqual(result.column_masking, {})
+
+    def test_blank_masking_returns_original_plan(self):
+        result = TableQueryAuthResult(None, {"col": ""})
+        plan = _FakePlan([_FakeSplit()])
+        converted = result.convert_plan(plan)
+        self.assertIs(converted, plan)
+
+    def test_wraps_splits_with_filter(self):
+        result = TableQueryAuthResult([_simple_filter_json()], None)
+        plan = _FakePlan([_FakeSplit("s1"), _FakeSplit("s2")])
+        converted = result.convert_plan(plan)
+        self.assertEqual(len(converted.splits()), 2)
+        for qs in converted.splits():
+            self.assertIsInstance(qs, QueryAuthSplit)
+
+    def test_wraps_splits_with_masking(self):
+        result = TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
+        plan = _FakePlan([_FakeSplit()])
+        converted = result.convert_plan(plan)
+        self.assertEqual(len(converted.splits()), 1)
+        self.assertIsInstance(converted.splits()[0], QueryAuthSplit)
+
+    def test_inner_split_preserved(self):
+        result = TableQueryAuthResult([_simple_filter_json()], None)
+        plan = _FakePlan([_FakeSplit("original")])
+        converted = result.convert_plan(plan)
+        self.assertEqual(converted.splits()[0].split.name, "original")
+
+
+class TestTableQueryAuthResultExtractRowFilter(unittest.TestCase):
+
+    def test_no_filter_returns_none(self):
+        result = TableQueryAuthResult(None, None)
+        self.assertIsNone(result.extract_row_filter())
+
+    def test_single_filter(self):
+        result = TableQueryAuthResult([_simple_filter_json("dept", "eng")], None)
+        fn = result.extract_row_filter()
+        self.assertIsNotNone(fn)
+        batch = pa.RecordBatch.from_pydict({"dept": ["eng", "sales", "eng"]})
+        mask = fn(batch)
+        self.assertEqual(mask.to_pylist(), [True, False, True])
+
+    def test_multiple_filters_combined_with_and(self):
+        f1 = _simple_filter_json("dept", "eng")
+        f2 = json.dumps({
+            "kind": "LEAF",
+            "transform": {
+                "name": "FIELD_REF",
+                "fieldRef": {"index": 0, "name": "dept", "type": "STRING"},
+            },
+            "function": "NOT_EQUAL",
+            "literals": ["eng"],
+        })
+        result = TableQueryAuthResult([f1, f2], None)
+        fn = result.extract_row_filter()
+        batch = pa.RecordBatch.from_pydict({"dept": ["eng", "sales", "eng"]})
+        mask = fn(batch)
+        self.assertEqual(mask.to_pylist(), [False, False, False])
+
+
+class TestTableQueryAuthResultExtraFields(unittest.TestCase):
+
+    def test_detects_unprojected_field(self):
+        read_fields = [_FakeField("name"), _FakeField("age")]
+        table_fields = [
+            _FakeField("name"),
+            _FakeField("age"),
+            _FakeField("dept"),
+        ]
+        result = TableQueryAuthResult([_simple_filter_json("dept")], None)
+        extra = result.get_extra_fields_for_filter(read_fields, table_fields)
+        self.assertEqual(len(extra), 1)
+        self.assertEqual(extra[0].name, "dept")
+
+    def test_no_extra_when_already_projected(self):
+        read_fields = [_FakeField("name"), _FakeField("dept")]
+        table_fields = read_fields + [_FakeField("age")]
+        result = TableQueryAuthResult([_simple_filter_json("dept")], None)
+        extra = result.get_extra_fields_for_filter(read_fields, table_fields)
+        self.assertEqual(len(extra), 0)
+
+    def test_no_extra_when_no_filter(self):
+        result = TableQueryAuthResult(None, None)
+        extra = result.get_extra_fields_for_filter(
+            [_FakeField("a")], [_FakeField("a"), _FakeField("b")]
+        )
+        self.assertEqual(len(extra), 0)
+
+    def test_deduplicates_extra_fields(self):
+        f1 = _simple_filter_json("dept", "eng")
+        f2 = _simple_filter_json("dept", "sales")
+        read_fields = [_FakeField("name")]
+        table_fields = [_FakeField("name"), _FakeField("dept")]
+        result = TableQueryAuthResult([f1, f2], None)
+        extra = result.get_extra_fields_for_filter(read_fields, table_fields)
+        self.assertEqual(len(extra), 1)
+
+
+class TestQueryAuthSplit(unittest.TestCase):
+
+    def test_delegates_properties(self):
+        auth = TableQueryAuthResult([_simple_filter_json()], None)
+        split = _FakeSplit()
+        qs = QueryAuthSplit(split, auth)
+        self.assertEqual(qs.row_count, 100)
+        self.assertEqual(qs.bucket, 0)
+        self.assertEqual(qs.files, [])
+        self.assertEqual(qs.partition, {})
+
+    def test_merged_row_count_none_with_filter(self):
+        auth = TableQueryAuthResult([_simple_filter_json()], None)
+        qs = QueryAuthSplit(_FakeSplit(), auth)
+        self.assertIsNone(qs.merged_row_count())
+
+    def test_merged_row_count_delegates_without_filter(self):
+        auth = TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
+        qs = QueryAuthSplit(_FakeSplit(), auth)
+        self.assertEqual(qs.merged_row_count(), 100)
+
+    def test_exposes_inner_split(self):
+        split = _FakeSplit("inner")
+        qs = QueryAuthSplit(split, TableQueryAuthResult(None, None))
+        self.assertIs(qs.split, split)
+
+    def test_exposes_auth_result(self):
+        auth = TableQueryAuthResult(None, None)
+        qs = QueryAuthSplit(_FakeSplit(), auth)
+        self.assertIs(qs.auth_result, auth)
+
+
+class TestQueryAuthSplitRawConvertible(unittest.TestCase):
+
+    def test_raw_convertible_proxy_true(self):
+        inner = _FakeSplit()
+        inner.raw_convertible = True
+        auth_split = QueryAuthSplit(inner, None)
+        self.assertTrue(auth_split.raw_convertible)
+
+    def test_raw_convertible_proxy_false(self):
+        inner = _FakeSplit()
+        inner.raw_convertible = False
+        auth_split = QueryAuthSplit(inner, None)
+        self.assertFalse(auth_split.raw_convertible)
+
+
+class TestQueryAuthSplitAttributeDelegation(unittest.TestCase):
+
+    def test_file_size_delegated(self):
+        inner = _FakeSplit()
+        inner.file_size = 12345
+        auth_split = QueryAuthSplit(inner, TableQueryAuthResult(None, None))
+        self.assertEqual(auth_split.file_size, 12345)
+
+    def test_file_paths_delegated(self):
+        inner = _FakeSplit()
+        inner.file_paths = ["/data/file1.parquet", "/data/file2.parquet"]
+        auth_split = QueryAuthSplit(inner, TableQueryAuthResult(None, None))
+        self.assertEqual(auth_split.file_paths, ["/data/file1.parquet", "/data/file2.parquet"])
+
+    def test_data_deletion_files_delegated(self):
+        inner = _FakeSplit()
+        inner.data_deletion_files = [None, "dv-1"]
+        auth_split = QueryAuthSplit(inner, TableQueryAuthResult(None, None))
+        self.assertEqual(auth_split.data_deletion_files, [None, "dv-1"])
+
+    def test_unknown_attr_raises(self):
+        inner = _FakeSplit()
+        auth_split = QueryAuthSplit(inner, TableQueryAuthResult(None, None))
+        with self.assertRaises(AttributeError):
+            _ = auth_split.completely_nonexistent_attr
+
+    def test_pickle_roundtrip(self):
+        import pickle
+        inner = _FakeSplit()
+        inner.file_size = 999
+        auth_split = QueryAuthSplit(inner, TableQueryAuthResult(None, None))
+        restored = pickle.loads(pickle.dumps(auth_split))
+        self.assertEqual(restored.file_size, 999)
+        self.assertEqual(restored.row_count, 100)
+
+
+class TestCoreOptionsQueryAuth(unittest.TestCase):
+
+    def test_disabled_by_default(self):
+        opts = CoreOptions(Options({}))
+        self.assertFalse(opts.query_auth_enabled)
+
+    def test_enabled_when_set(self):
+        opts = CoreOptions(Options({"query-auth.enabled": True}))
+        self.assertTrue(opts.query_auth_enabled)
+
+    def test_disabled_when_false(self):
+        opts = CoreOptions(Options({"query-auth.enabled": False}))
+        self.assertFalse(opts.query_auth_enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestConvertPlanPreservesSnapshotId(unittest.TestCase):
+
+    def test_convert_plan_preserves_snapshot_id(self):
+        from pypaimon.catalog.table_query_auth import TableQueryAuthResult
+        from pypaimon.read.plan import Plan
+        from unittest.mock import MagicMock
+
+        split = MagicMock()
+        original_plan = Plan([split], snapshot_id=42)
+        predicate_json = (
+            '{"kind":"LEAF","transform":{"name":"FIELD_REF",'
+            '"fieldRef":{"name":"id"}},"function":"EQUAL","literals":[1]}'
+        )
+        auth_result = TableQueryAuthResult(
+            filter=[predicate_json],
+            column_masking=None)
+        converted = auth_result.convert_plan(original_plan)
+        assert converted.snapshot_id == 42
+
+    def test_convert_plan_preserves_none_snapshot_id(self):
+        from pypaimon.catalog.table_query_auth import TableQueryAuthResult
+        from pypaimon.read.plan import Plan
+        from unittest.mock import MagicMock
+
+        split = MagicMock()
+        original_plan = Plan([split], snapshot_id=None)
+        predicate_json = (
+            '{"kind":"LEAF","transform":{"name":"FIELD_REF",'
+            '"fieldRef":{"name":"id"}},"function":"EQUAL","literals":[1]}'
+        )
+        auth_result = TableQueryAuthResult(
+            filter=[predicate_json],
+            column_masking=None)
+        converted = auth_result.convert_plan(original_plan)
+        assert converted.snapshot_id is None

--- a/paimon-python/pypaimon/tests/table_query_auth_test.py
+++ b/paimon-python/pypaimon/tests/table_query_auth_test.py
@@ -69,6 +69,20 @@ class _FakePlan:
         return self._splits
 
 
+class _FakeTable:
+    def __init__(self, identifier=None):
+        self.identifier = identifier or Identifier("db", "table")
+
+
+class _FakeScan:
+    def __init__(self, plan, identifier=None):
+        self._plan = plan
+        self.table = _FakeTable(identifier)
+
+    def plan(self):
+        return self._plan
+
+
 def _simple_filter_json(field_name="dept", value="eng"):
     return json.dumps({
         "kind": "LEAF",
@@ -312,6 +326,45 @@ class TestQueryAuthSplitAttributeDelegation(unittest.TestCase):
         restored = pickle.loads(pickle.dumps(auth_split))
         self.assertEqual(restored.file_size, 999)
         self.assertEqual(restored.row_count, 100)
+
+
+class TestPlanForWrite(unittest.TestCase):
+
+    def test_no_restriction_returns_plan_unchanged(self):
+        from pypaimon.read.table_scan import TableScan
+
+        plain_plan = _FakePlan([_FakeSplit()], snapshot_id=5)
+        scan = _FakeScan(plain_plan)
+        result = TableScan.plan_for_write(scan)
+        self.assertIs(result, plain_plan)
+
+    def test_row_filter_restriction_raises(self):
+        from pypaimon.read.table_scan import TableScan
+
+        auth = TableQueryAuthResult([_simple_filter_json()], None)
+        wrapped_plan = _FakePlan([QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
+        scan = _FakeScan(wrapped_plan)
+        with self.assertRaises(TableNoPermissionException):
+            TableScan.plan_for_write(scan)
+
+    def test_column_masking_restriction_raises(self):
+        from pypaimon.read.table_scan import TableScan
+
+        auth = TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
+        wrapped_plan = _FakePlan([QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
+        scan = _FakeScan(wrapped_plan)
+        with self.assertRaises(TableNoPermissionException):
+            TableScan.plan_for_write(scan)
+
+    def test_mixed_splits_any_restricted_raises(self):
+        from pypaimon.read.table_scan import TableScan
+
+        auth = TableQueryAuthResult([_simple_filter_json()], None)
+        wrapped_plan = _FakePlan(
+            [_FakeSplit(), QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
+        scan = _FakeScan(wrapped_plan)
+        with self.assertRaises(TableNoPermissionException):
+            TableScan.plan_for_write(scan)
 
 
 class TestCoreOptionsQueryAuth(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/table_query_auth_test.py
+++ b/paimon-python/pypaimon/tests/table_query_auth_test.py
@@ -75,11 +75,24 @@ class _FakeTable:
 
 
 class _FakeScan:
-    def __init__(self, plan, identifier=None):
+    def __init__(self, plan, identifier=None, auth_result=None):
         self._plan = plan
         self.table = _FakeTable(identifier)
+        self.file_scanner = _FakeFileScanner(plan)
+        self._auth_result = auth_result
 
     def plan(self):
+        return self._plan
+
+    def _TableScan__auth_query(self):
+        return self._auth_result
+
+
+class _FakeFileScanner:
+    def __init__(self, plan):
+        self._plan = plan
+
+    def scan(self):
         return self._plan
 
 
@@ -113,11 +126,27 @@ class TestTableQueryAuthResultConvertPlan(unittest.TestCase):
         converted = result.convert_plan(plan)
         self.assertIs(converted, plan)
 
+    def test_no_auth_has_no_restrictions(self):
+        result = TableQueryAuthResult(None, None)
+        self.assertFalse(result.has_restrictions)
+
     def test_empty_filter_and_masking_returns_original(self):
         result = TableQueryAuthResult([], {})
         plan = _FakePlan([_FakeSplit()])
         converted = result.convert_plan(plan)
         self.assertIs(converted, plan)
+
+    def test_empty_filter_and_masking_has_no_restrictions(self):
+        result = TableQueryAuthResult([], {})
+        self.assertFalse(result.has_restrictions)
+
+    def test_filter_has_restrictions(self):
+        result = TableQueryAuthResult([_simple_filter_json()], None)
+        self.assertTrue(result.has_restrictions)
+
+    def test_masking_has_restrictions(self):
+        result = TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
+        self.assertTrue(result.has_restrictions)
 
     def test_blank_filter_entries_are_skipped(self):
         result = TableQueryAuthResult(["", None], None)
@@ -334,7 +363,7 @@ class TestPlanForWrite(unittest.TestCase):
         from pypaimon.read.table_scan import TableScan
 
         plain_plan = _FakePlan([_FakeSplit()], snapshot_id=5)
-        scan = _FakeScan(plain_plan)
+        scan = _FakeScan(plain_plan, auth_result=None)
         result = TableScan.plan_for_write(scan)
         self.assertIs(result, plain_plan)
 
@@ -342,8 +371,8 @@ class TestPlanForWrite(unittest.TestCase):
         from pypaimon.read.table_scan import TableScan
 
         auth = TableQueryAuthResult([_simple_filter_json()], None)
-        wrapped_plan = _FakePlan([QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
-        scan = _FakeScan(wrapped_plan)
+        plan = _FakePlan([_FakeSplit()], snapshot_id=5)
+        scan = _FakeScan(plan, auth_result=auth)
         with self.assertRaises(TableNoPermissionException):
             TableScan.plan_for_write(scan)
 
@@ -351,20 +380,63 @@ class TestPlanForWrite(unittest.TestCase):
         from pypaimon.read.table_scan import TableScan
 
         auth = TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
-        wrapped_plan = _FakePlan([QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
-        scan = _FakeScan(wrapped_plan)
+        plan = _FakePlan([_FakeSplit()], snapshot_id=5)
+        scan = _FakeScan(plan, auth_result=auth)
         with self.assertRaises(TableNoPermissionException):
             TableScan.plan_for_write(scan)
 
-    def test_mixed_splits_any_restricted_raises(self):
+    def test_empty_table_with_auth_still_raises(self):
         from pypaimon.read.table_scan import TableScan
 
         auth = TableQueryAuthResult([_simple_filter_json()], None)
-        wrapped_plan = _FakePlan(
-            [_FakeSplit(), QueryAuthSplit(_FakeSplit(), auth)], snapshot_id=5)
-        scan = _FakeScan(wrapped_plan)
+        empty_plan = _FakePlan([], snapshot_id=5)
+        scan = _FakeScan(empty_plan, auth_result=auth)
         with self.assertRaises(TableNoPermissionException):
             TableScan.plan_for_write(scan)
+
+    def test_no_restrictions_allows_write(self):
+        from pypaimon.read.table_scan import TableScan
+
+        plan = _FakePlan([_FakeSplit()], snapshot_id=5)
+        scan = _FakeScan(plan, auth_result=None)
+        result = TableScan.plan_for_write(scan)
+        self.assertIs(result, plan)
+
+
+class TestResolveAuthResult(unittest.TestCase):
+
+    def test_none_fn_returns_none(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        self.assertIsNone(resolve_auth_result(None, None))
+
+    def test_no_restrictions_returns_none(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        fn = lambda select: TableQueryAuthResult(None, None)
+        self.assertIsNone(resolve_auth_result(fn, None))
+
+    def test_empty_filter_returns_none(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        fn = lambda select: TableQueryAuthResult([], {})
+        self.assertIsNone(resolve_auth_result(fn, None))
+
+    def test_blank_filter_stripped_returns_none(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        fn = lambda select: TableQueryAuthResult(["", None], None)
+        self.assertIsNone(resolve_auth_result(fn, None))
+
+    def test_with_filter_returns_result(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        fn = lambda select: TableQueryAuthResult([_simple_filter_json()], None)
+        result = resolve_auth_result(fn, None)
+        self.assertIsNotNone(result)
+        self.assertTrue(result.has_restrictions)
+
+    def test_with_masking_returns_result(self):
+        from pypaimon.read.query_auth_split import resolve_auth_result
+        fn = lambda select: TableQueryAuthResult(None, {"col": '{"name":"NULL"}'})
+        result = resolve_auth_result(fn, None)
+        self.assertIsNotNone(result)
+        self.assertTrue(result.has_restrictions)
 
 
 class TestCoreOptionsQueryAuth(unittest.TestCase):

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -294,8 +294,7 @@ class FileStoreWrite:
         partition_filter = predicate_builder.and_predicates(sub_predicates)
 
         scan = read_builder.with_filter(partition_filter).new_scan()
-        scan._query_auth_fn = None
-        splits = scan.plan().splits()
+        splits = scan.plan_for_write().splits()
 
         max_seq_numbers = {}
         for split in splits:

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -294,6 +294,7 @@ class FileStoreWrite:
         partition_filter = predicate_builder.and_predicates(sub_predicates)
 
         scan = read_builder.with_filter(partition_filter).new_scan()
+        scan._query_auth_fn = None
         splits = scan.plan().splits()
 
         max_seq_numbers = {}

--- a/paimon-python/pypaimon/write/table_delete.py
+++ b/paimon-python/pypaimon/write/table_delete.py
@@ -133,7 +133,8 @@ class TableDeleteByRowId:
         return self._scan_anchor_ranges()
 
     def _scan_anchor_ranges(self) -> Tuple[int, List[_AnchorRange]]:
-        plan = self.table.new_read_builder().new_scan().plan()
+        scan = self.table.new_read_builder().new_scan()
+        plan = scan.plan_for_write()
         snapshot_id = plan.snapshot_id if plan.snapshot_id is not None else -1
         anchors = []
 

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -246,8 +246,7 @@ class TableUpdate:
             read_builder.with_projection([SpecialFields.ROW_ID.name])
 
         scan = read_builder.new_scan()
-        scan._query_auth_fn = None
-        splits = scan.plan().splits()
+        splits = scan.plan_for_write().splits()
         matched = read_builder.new_read().to_arrow(splits)
         if matched.num_rows == 0:
             return []
@@ -489,8 +488,7 @@ class TableUpdate:
             read_builder.with_projection([SpecialFields.ROW_ID.name])
 
         scan = read_builder.new_scan()
-        scan._query_auth_fn = None
-        splits = scan.plan().splits()
+        splits = scan.plan_for_write().splits()
         matched = read_builder.new_read().to_arrow(splits)
         if matched.num_rows == 0:
             return []
@@ -668,8 +666,7 @@ class ShardTableUpdator:
         self.dict = defaultdict(list)
 
         scanner = self.table.new_read_builder().new_scan()
-        scanner._query_auth_fn = None
-        plan = scanner.plan()
+        plan = scanner.plan_for_write()
         self.snapshot_id = plan.snapshot_id if plan.snapshot_id is not None else -1
         splits = plan.splits()
         splits = _filter_by_whole_file_shard(splits, shard_num, total_shard_count)

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -245,7 +245,9 @@ class TableUpdate:
         else:
             read_builder.with_projection([SpecialFields.ROW_ID.name])
 
-        splits = read_builder.new_scan().plan().splits()
+        scan = read_builder.new_scan()
+        scan._query_auth_fn = None
+        splits = scan.plan().splits()
         matched = read_builder.new_read().to_arrow(splits)
         if matched.num_rows == 0:
             return []
@@ -486,7 +488,9 @@ class TableUpdate:
         else:
             read_builder.with_projection([SpecialFields.ROW_ID.name])
 
-        splits = read_builder.new_scan().plan().splits()
+        scan = read_builder.new_scan()
+        scan._query_auth_fn = None
+        splits = scan.plan().splits()
         matched = read_builder.new_read().to_arrow(splits)
         if matched.num_rows == 0:
             return []
@@ -664,6 +668,7 @@ class ShardTableUpdator:
         self.dict = defaultdict(list)
 
         scanner = self.table.new_read_builder().new_scan()
+        scanner._query_auth_fn = None
         plan = scanner.plan()
         self.snapshot_id = plan.snapshot_id if plan.snapshot_id is not None else -1
         splits = plan.splits()

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -113,8 +113,7 @@ class TableUpdateByRowId:
         split a logical row range).
         """
         scan = self.table.new_read_builder().new_scan()
-        scan._query_auth_fn = None
-        plan = scan.plan()
+        plan = scan.plan_for_write()
         splits = plan.splits()
 
         index: Dict[int, Tuple[DataSplit, List[DataFileMeta]]] = {}

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -112,7 +112,9 @@ class TableUpdateByRowId:
         id (a single id may belong to multiple files when data evolution has
         split a logical row range).
         """
-        plan = self.table.new_read_builder().new_scan().plan()
+        scan = self.table.new_read_builder().new_scan()
+        scan._query_auth_fn = None
+        plan = scan.plan()
         splits = plan.splits()
 
         index: Dict[int, Tuple[DataSplit, List[DataFileMeta]]] = {}

--- a/paimon-python/pypaimon/write/table_upsert_by_key.py
+++ b/paimon-python/pypaimon/write/table_upsert_by_key.py
@@ -505,6 +505,7 @@ class TableUpsertByKey:
             read_builder = read_builder.with_filter(partition_predicate)
 
         scan = read_builder.new_scan()
+        scan._query_auth_fn = None
         splits = scan.plan().splits()
         if not splits:
             return {}

--- a/paimon-python/pypaimon/write/table_upsert_by_key.py
+++ b/paimon-python/pypaimon/write/table_upsert_by_key.py
@@ -505,8 +505,7 @@ class TableUpsertByKey:
             read_builder = read_builder.with_filter(partition_predicate)
 
         scan = read_builder.new_scan()
-        scan._query_auth_fn = None
-        splits = scan.plan().splits()
+        splits = scan.plan_for_write().splits()
         if not splits:
             return {}
 


### PR DESCRIPTION
### Purpose
 
Adds query-auth support to the Python client so it honors the row-level filter and column masking rules returned by a REST catalog, matching the existing JVM client behavior.
 
When the new option `query-auth.enabled` is set to `true`, before producing a `Plan` the client calls `POST /v1/.../databases/{db}/tables/{tb}/auth` with the projected fields, receives `{ filter, columnMasking }`, and applies them on the read path:
 
- `RESTApi.auth_table_query` issues the call (new request/response models `AuthTableQueryRequest` / `AuthTableQueryResponse`, new path in `ResourcePaths.auth_table`).
- `TableQueryAuth` / `TableQueryAuthResult` (`catalog/table_query_auth.py`) wrap the result and convert each split to a `QueryAuthSplit`.
- `predicate_json_parser` (`common/predicate_json_parser.py`) parses Paimon predicate JSON into a PyArrow compute filter (EQ/NEQ/LT/LTEQ/GT/GTEQ/IS_NULL/IS_NOT_NULL/IN/NOT_IN/STARTS_WITH/ENDS_WITH/CONTAINS/AND/OR/NOT).
- `AuthFilterReader` / `AuthMaskingReader` / `ColumnProjectReader` (`read/reader/auth_masking_reader.py`) implement row filtering, column masking transforms (`NULL`, `FIELD_REF`, `CAST`, `UPPER`, `LOWER`, `CONCAT`, `CONCAT_WS`) and final projection back to the user's requested columns.
- `read_builder` / `stream_read_builder` / `table_read` / `table_scan` / `file_store_table` / `catalog_environment` / `rest_catalog` are wired to invoke the auth call and pull extra fields required only by the auth filter.
 
Behavior is gated by the new `CoreOptions.QUERY_AUTH_ENABLED` (`query-auth.enabled`, default `false`), so existing users see no change.
 
### Tests
 
Three new test files (994+ lines, all passing locally under `pytest`):
 
- `paimon-python/pypaimon/tests/predicate_json_parser_test.py` — covers each predicate kind, nested AND/OR/NOT, type coercion, null handling, and `extract_referenced_fields`.
- `paimon-python/pypaimon/tests/auth_masking_reader_test.py` — covers each masking transform, missing-field validation, and projection back to the user-requested columns.
- `paimon-python/pypaimon/tests/table_query_auth_test.py` — end-to-end coverage: REST catalog calls `auth_table_query`, the result is plumbed into the plan, splits become `QueryAuthSplit`, and reads return filtered + masked rows.
 
Local check:
 
```
cd paimon-python
python -m pytest pypaimon/tests/predicate_json_parser_test.py \
                  pypaimon/tests/auth_masking_reader_test.py \
                  pypaimon/tests/table_query_auth_test.py -q
flake8 --config dev/cfg.ini pypaimon/  # 已在改动范围内通过
```
 
### API and Format
 
- New catalog option: `query-auth.enabled` (boolean, default `false`).
- New REST endpoint consumed by the client: `POST /v1/{prefix}/databases/{db}/tables/{tb}/auth`. Request `{ "select": [...] }`, response `{ "filter": [<predicate-json>...], "columnMasking": { <col>: <transform-json>, ... } }`. The contract follows the existing Java client; no server-side change is required for catalogs that already implement query auth.
- No change to existing user-facing Python APIs. New types (`AuthTableQueryRequest`, `AuthTableQueryResponse`, `TableQueryAuth`, `TableQueryAuthResult`, `QueryAuthSplit`, `AuthFilterReader`, `AuthMaskingReader`, `ColumnProjectReader`) are additive and live under existing modules.
- File format / on-disk layout: unchanged.
 
### Documentation
 
The new option `query-auth.enabled` should be reflected in the Python configuration reference. Happy to add the docs entry in this PR or in a follow-up — please advise.
 

This closes #8135 