### PR TITLE
[core] Fix BSI reader predicate pruning for Long.MIN_VALUE boundary

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndex.java
@@ -320,8 +320,7 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
                         Long value = valueMapper.apply(literal);
                         if (value == Long.MIN_VALUE) {
                             // Everything is greater than Long.MIN_VALUE (writer cannot store it)
-                            return RoaringBitmap32.or(
-                                    positive.isNotNull(), negative.isNotNull());
+                            return RoaringBitmap32.or(positive.isNotNull(), negative.isNotNull());
                         } else if (value < 0) {
                             return RoaringBitmap32.or(
                                     positive.isNotNull(), negative.lt(Math.abs(value)));
@@ -338,8 +337,7 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
                         Long value = valueMapper.apply(literal);
                         if (value == Long.MIN_VALUE) {
                             // All non-null rows satisfy x >= Long.MIN_VALUE
-                            return RoaringBitmap32.or(
-                                    positive.isNotNull(), negative.isNotNull());
+                            return RoaringBitmap32.or(positive.isNotNull(), negative.isNotNull());
                         } else if (value < 0) {
                             return RoaringBitmap32.or(
                                     positive.isNotNull(), negative.lte(Math.abs(value)));

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndex.java
@@ -240,7 +240,11 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
                                     .map(valueMapper)
                                     .map(
                                             value -> {
-                                                if (value < 0) {
+                                                if (value == Long.MIN_VALUE) {
+                                                    // Writer cannot store Long.MIN_VALUE, so no
+                                                    // row can match it
+                                                    return new RoaringBitmap32();
+                                                } else if (value < 0) {
                                                     return negative.eq(Math.abs(value));
                                                 } else {
                                                     return positive.eq(value);
@@ -262,7 +266,9 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
                                         .map(valueMapper)
                                         .map(
                                                 value -> {
-                                                    if (value < 0) {
+                                                    if (value == Long.MIN_VALUE) {
+                                                        return new RoaringBitmap32();
+                                                    } else if (value < 0) {
                                                         return negative.eq(Math.abs(value));
                                                     } else {
                                                         return positive.eq(value);
@@ -280,7 +286,10 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
             return new BitmapIndexResult(
                     () -> {
                         Long value = valueMapper.apply(literal);
-                        if (value < 0) {
+                        if (value == Long.MIN_VALUE) {
+                            // Nothing is less than Long.MIN_VALUE
+                            return new RoaringBitmap32();
+                        } else if (value < 0) {
                             return negative.gt(Math.abs(value));
                         } else {
                             return RoaringBitmap32.or(positive.lt(value), negative.isNotNull());
@@ -293,7 +302,10 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
             return new BitmapIndexResult(
                     () -> {
                         Long value = valueMapper.apply(literal);
-                        if (value < 0) {
+                        if (value == Long.MIN_VALUE) {
+                            // Writer cannot store Long.MIN_VALUE, so no row can match
+                            return new RoaringBitmap32();
+                        } else if (value < 0) {
                             return negative.gte(Math.abs(value));
                         } else {
                             return RoaringBitmap32.or(positive.lte(value), negative.isNotNull());
@@ -306,7 +318,11 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
             return new BitmapIndexResult(
                     () -> {
                         Long value = valueMapper.apply(literal);
-                        if (value < 0) {
+                        if (value == Long.MIN_VALUE) {
+                            // Everything is greater than Long.MIN_VALUE (writer cannot store it)
+                            return RoaringBitmap32.or(
+                                    positive.isNotNull(), negative.isNotNull());
+                        } else if (value < 0) {
                             return RoaringBitmap32.or(
                                     positive.isNotNull(), negative.lt(Math.abs(value)));
                         } else {
@@ -320,7 +336,11 @@ public class BitSliceIndexBitmapFileIndex implements FileIndexer {
             return new BitmapIndexResult(
                     () -> {
                         Long value = valueMapper.apply(literal);
-                        if (value < 0) {
+                        if (value == Long.MIN_VALUE) {
+                            // All non-null rows satisfy x >= Long.MIN_VALUE
+                            return RoaringBitmap32.or(
+                                    positive.isNotNull(), negative.isNotNull());
+                        } else if (value < 0) {
                             return RoaringBitmap32.or(
                                     positive.isNotNull(), negative.lte(Math.abs(value)));
                         } else {

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndexTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fileindex.FileIndexWriter;
 import org.apache.paimon.fileindex.bitmap.BitmapIndexResult;
 import org.apache.paimon.fs.ByteArraySeekableStream;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.utils.RoaringBitmap32;
 
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** test for {@link BitSliceIndexBitmapFileIndex}. */
 public class BitSliceIndexBitmapFileIndexTest {
@@ -249,5 +251,84 @@ public class BitSliceIndexBitmapFileIndexTest {
                 .isEqualTo(RoaringBitmap32.bitmapOf());
         assertThat(((BitmapIndexResult) reader.visitGreaterOrEqual(fieldRef, 1)).get())
                 .isEqualTo(RoaringBitmap32.bitmapOf());
+    }
+
+    @Test
+    public void testReaderPredicatePruningWithLongMinValue() {
+        BigIntType bigIntType = new BigIntType();
+        FieldRef fieldRef = new FieldRef(0, "", bigIntType);
+        BitSliceIndexBitmapFileIndex bsiFileIndex = new BitSliceIndexBitmapFileIndex(bigIntType);
+        FileIndexWriter writer = bsiFileIndex.createWriter();
+
+        // Use values that include negative numbers but NOT Long.MIN_VALUE itself
+        // (since the writer cannot handle it). This isolates the reader-side bug.
+        // Data: [-100, -1, null, 0, 1, 50]
+        Object[] arr = {-100L, -1L, null, 0L, 1L, 50L};
+
+        for (Object o : arr) {
+            writer.write(o);
+        }
+        byte[] bytes = writer.serializedBytes();
+        ByteArraySeekableStream stream = new ByteArraySeekableStream(bytes);
+        FileIndexReader reader = bsiFileIndex.createReader(stream, 0, bytes.length);
+
+        // All non-null row ids: {0, 1, 3, 4, 5}
+
+        // x > Long.MIN_VALUE: every int64 value > Long.MIN_VALUE (since no row IS Long.MIN_VALUE),
+        // so result should be ALL non-null rows = {0, 1, 3, 4, 5}
+        RoaringBitmap32 gtResult =
+                ((BitmapIndexResult) reader.visitGreaterThan(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(gtResult)
+                .as("x > Long.MIN_VALUE should return all non-null rows")
+                .isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 3, 4, 5));
+
+        // x >= Long.MIN_VALUE: same — all non-null rows satisfy this
+        RoaringBitmap32 gteResult =
+                ((BitmapIndexResult) reader.visitGreaterOrEqual(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(gteResult)
+                .as("x >= Long.MIN_VALUE should return all non-null rows")
+                .isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 3, 4, 5));
+
+        // x < Long.MIN_VALUE: no int64 value is less than Long.MIN_VALUE, so result should be
+        // empty
+        RoaringBitmap32 ltResult =
+                ((BitmapIndexResult) reader.visitLessThan(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(ltResult)
+                .as("x < Long.MIN_VALUE should return empty")
+                .isEqualTo(RoaringBitmap32.bitmapOf());
+
+        // x <= Long.MIN_VALUE: no row has Long.MIN_VALUE, so result should be empty
+        RoaringBitmap32 lteResult =
+                ((BitmapIndexResult) reader.visitLessOrEqual(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(lteResult)
+                .as("x <= Long.MIN_VALUE should return empty (no row has that value)")
+                .isEqualTo(RoaringBitmap32.bitmapOf());
+
+        // x == Long.MIN_VALUE: no row has Long.MIN_VALUE, so result should be empty
+        RoaringBitmap32 eqResult =
+                ((BitmapIndexResult) reader.visitEqual(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(eqResult)
+                .as("x == Long.MIN_VALUE should return empty")
+                .isEqualTo(RoaringBitmap32.bitmapOf());
+
+        // x != Long.MIN_VALUE: all non-null rows (no row has Long.MIN_VALUE)
+        RoaringBitmap32 neqResult =
+                ((BitmapIndexResult) reader.visitNotEqual(fieldRef, Long.MIN_VALUE)).get();
+        assertThat(neqResult)
+                .as("x != Long.MIN_VALUE should return all non-null rows")
+                .isEqualTo(RoaringBitmap32.bitmapOf(0, 1, 3, 4, 5));
+    }
+
+    @Test
+    public void testWriterCannotHandleLongMinValue() {
+        BigIntType bigIntType = new BigIntType();
+        BitSliceIndexBitmapFileIndex bsiFileIndex = new BitSliceIndexBitmapFileIndex(bigIntType);
+        FileIndexWriter writer = bsiFileIndex.createWriter();
+        writer.write(Long.MIN_VALUE);
+
+        assertThatThrownBy(writer::serializedBytes)
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage("values should be non-negative");
     }
 }


### PR DESCRIPTION
**Purpose**

Fix incorrect predicate pruning in `BitSliceIndexBitmapFileIndex.Reader` when the query literal is `Long.MIN_VALUE`.

**Problem**

The BSI reader uses `Math.abs(value)` to convert negative literals before querying the negative BSI. However, `Math.abs(Long.MIN_VALUE)` overflows and returns `Long.MIN_VALUE` itself (still negative) due to Java's two-complement arithmetic. This causes incorrect results for all comparison predicates:

| Predicate | Expected | Actual (before fix) |
|---|---|---|
| `x > Long.MIN_VALUE` | all non-null rows | only positive rows (negative rows dropped) |
| `x >= Long.MIN_VALUE` | all non-null rows | only positive rows (negative rows dropped) |
| `x < Long.MIN_VALUE` | empty | negative rows incorrectly kept |
| `x <= Long.MIN_VALUE` | empty | negative rows incorrectly kept |
| `x == Long.MIN_VALUE` | empty | incorrect result |
| `x != Long.MIN_VALUE` | all non-null rows | incorrect result |

**Root Cause**

`Math.abs(Long.MIN_VALUE) == Long.MIN_VALUE` — the only `long` value for which `Math.abs` overflows.

**Fix**

Add an early check for `value == Long.MIN_VALUE` in `visitIn`, `visitNotIn`, `visitLessThan`, `visitLessOrEqual`, `visitGreaterThan`, and `visitGreaterOrEqual`. Since the BSI writer cannot store `Long.MIN_VALUE` (the `Appender` rejects negative min), the index can never contain this value. Therefore:
- `GT` / `GTE` with `Long.MIN_VALUE` → return all non-null rows
- `LT` / `LTE` with `Long.MIN_VALUE` → return empty
- `EQ` / `IN` with `Long.MIN_VALUE` → return empty
- `NEQ` / `NOT IN` with `Long.MIN_VALUE` → return all non-null rows

**Note:** The writer-side issue (`Math.abs(Long.MIN_VALUE)` in `StatsCollectList.collect()` and `serializedBytes()`) is a known limitation — the writer rejects `Long.MIN_VALUE` with an `IllegalArgumentException`. A separate writer test is added to document this behavior.

**Testing**

- `testReaderPredicatePruningWithLongMinValue` — verifies all 6 predicates (`>`, `>=`, `<`, `<=`, `==`, `!=`) with `Long.MIN_VALUE` as the query literal against data containing negative values.
- `testWriterCannotHandleLongMinValue` — documents that the writer throws `IllegalArgumentException("values should be non-negative")` when attempting to write `Long.MIN_VALUE`.