### PR TITLE
[python] Add early partition filter in manifest entry reading

### DIFF
--- a/paimon-python/pypaimon/manifest/manifest_file_manager.py
+++ b/paimon-python/pypaimon/manifest/manifest_file_manager.py
@@ -49,12 +49,14 @@ class ManifestFileManager:
 
     def read_entries_parallel(self, manifest_files: List[ManifestFileMeta], manifest_entry_filter=None,
                               drop_stats=True, max_workers=8,
-                              early_entry_filter: Optional[Callable[[int, int], bool]] = None
+                              early_entry_filter: Optional[Callable[[int, int], bool]] = None,
+                              partition_filter=None,
                               ) -> List[ManifestEntry]:
 
         def _process_single_manifest(manifest_file: ManifestFileMeta) -> List[ManifestEntry]:
             return self.read(manifest_file.file_name, manifest_entry_filter, drop_stats,
-                             early_entry_filter=early_entry_filter)
+                             early_entry_filter=early_entry_filter,
+                             partition_filter=partition_filter)
 
         def _entry_identifier(e: ManifestEntry) -> tuple:
             return (
@@ -85,7 +87,8 @@ class ManifestFileManager:
         return final_entries
 
     def read(self, manifest_file_name: str, manifest_entry_filter=None, drop_stats=True,
-             early_entry_filter: Optional[Callable[[int, int], bool]] = None
+             early_entry_filter: Optional[Callable[[int, int], bool]] = None,
+             partition_filter=None,
              ) -> List[ManifestEntry]:
         """
         early_entry_filter: optional ``(bucket, total_buckets) -> bool``
@@ -115,6 +118,12 @@ class ManifestFileManager:
                 else:
                     if not early_entry_filter(bucket, total_buckets):
                         continue
+            partition = None
+            if partition_filter is not None:
+                partition = GenericRowDeserializer.from_bytes(
+                    record['_PARTITION'], self.partition_keys_fields)
+                if not partition_filter.test(partition):
+                    continue
             file_dict = dict(record['_FILE'])
             key_dict = dict(file_dict['_KEY_STATS'])
             key_stats = SimpleStats(
@@ -169,9 +178,12 @@ class ManifestFileManager:
                 first_row_id=file_dict['_FIRST_ROW_ID'] if '_FIRST_ROW_ID' in file_dict else None,
                 write_cols=file_dict['_WRITE_COLS'] if '_WRITE_COLS' in file_dict else None,
             )
+            if partition is None:
+                partition = GenericRowDeserializer.from_bytes(
+                    record['_PARTITION'], self.partition_keys_fields)
             entry = ManifestEntry(
                 kind=record['_KIND'],
-                partition=GenericRowDeserializer.from_bytes(record['_PARTITION'], self.partition_keys_fields),
+                partition=partition,
                 bucket=record['_BUCKET'],
                 total_buckets=record['_TOTAL_BUCKETS'],
                 file=file_meta

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -367,11 +367,15 @@ class FileScanner:
             self.scan_stats.manifest_files_after_partition += len(manifest_files)
             # Force single-threaded so we can mutate stats without locking.
             max_workers = 1
+        partition_filter = None
+        if self.scan_stats is None:
+            partition_filter = self.partition_key_predicate
         return self.manifest_file_manager.read_entries_parallel(
             manifest_files,
             self._filter_manifest_entry,
             max_workers=max_workers,
             early_entry_filter=self._build_early_bucket_filter(),
+            partition_filter=partition_filter,
         )
 
     def _build_early_bucket_filter(self):

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -986,7 +986,7 @@ class AoReaderTest(unittest.TestCase):
 
             print(f"✓ Iteration {test_iteration + 1}/{iter_num} completed successfully")
 
-    def test_is_in_partition_deserializes_all_entries(self):
+    def test_is_in_with_partitions(self):
         from pypaimon.manifest.manifest_file_manager import ManifestFileManager
         from io import BytesIO
         import fastavro

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -1023,3 +1023,96 @@ class AoReaderTest(unittest.TestCase):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
         return table_read.to_arrow(splits)
+
+
+class IsInPartitionScanPlanTest(unittest.TestCase):
+    """Reproduces slow scan plan when using is_in() on partition key with many
+    values. All manifest entries are fully deserialized before partition
+    filtering — the early_entry_filter only checks bucket, not partition.
+    Java's createEntryRowFilter() tests partition on raw InternalRow before
+    full deserialization; Python lacks this optimization."""
+
+    NUM_PARTITIONS = 5000
+    IN_SIZE = 2000
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
+        cls.catalog = CatalogFactory.create({'warehouse': cls.warehouse})
+        cls.catalog.create_database('default', True)
+
+        cls.pa_schema = pa.schema([
+            ('pk', pa.int32()),
+            ('val', pa.string()),
+            ('pt', pa.string()),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            cls.pa_schema, partition_keys=['pt'])
+        cls.catalog.create_table('default.is_in_bench', schema, False)
+        table = cls.catalog.get_table('default.is_in_bench')
+
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        for i in range(cls.NUM_PARTITIONS):
+            w.write_arrow(pa.Table.from_pydict(
+                {'pk': [i], 'val': [f'v_{i}'], 'pt': [f'pt_{i}']},
+                schema=cls.pa_schema,
+            ))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    def test_is_in_scans_all_entries_before_filtering(self):
+        table = self.catalog.get_table('default.is_in_bench')
+        rb = table.new_read_builder()
+        builder = rb.new_predicate_builder()
+
+        in_values = [f'pt_{i}' for i in range(self.IN_SIZE)]
+        pred = builder.is_in('pt', in_values)
+
+        rb_filtered = table.new_read_builder().with_filter(pred)
+        splits = rb_filtered.new_scan().plan().splits()
+        self.assertEqual(len(splits), self.IN_SIZE)
+
+        from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+        from io import BytesIO
+        import fastavro
+
+        entry_counts = {'total': 0, 'constructed': 0}
+        original_read = ManifestFileManager.read
+
+        def counting_read(self_mgr, manifest_file_name,
+                          manifest_entry_filter=None,
+                          drop_stats=True, early_entry_filter=None):
+            manifest_path = (
+                f"{self_mgr.manifest_path}/{manifest_file_name}")
+            with self_mgr.file_io.new_input_stream(
+                    manifest_path) as stream:
+                buf = BytesIO(stream.read())
+                reader = fastavro.reader(buf)
+                for _ in reader:
+                    entry_counts['total'] += 1
+            entry_counts['constructed'] = entry_counts['total']
+            return original_read(
+                self_mgr, manifest_file_name,
+                manifest_entry_filter, drop_stats, early_entry_filter)
+
+        ManifestFileManager.read = counting_read
+        try:
+            rb2 = table.new_read_builder().with_filter(pred)
+            rb2.new_scan().plan()
+        finally:
+            ManifestFileManager.read = original_read
+
+        self.assertEqual(entry_counts['total'], self.NUM_PARTITIONS)
+        self.assertEqual(entry_counts['constructed'], self.NUM_PARTITIONS)
+        wasted = entry_counts['constructed'] - self.IN_SIZE
+        self.assertGreater(wasted, 0,
+                           f"Expected wasted construction: all "
+                           f"{self.NUM_PARTITIONS} entries are fully "
+                           f"deserialized but only {self.IN_SIZE} match")

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -996,7 +996,7 @@ class AoReaderTest(unittest.TestCase):
 
         schema = Schema.from_pyarrow_schema(
             pa.schema([('pk', pa.int32()), ('val', pa.string()),
-                        ('pt', pa.string())]),
+                       ('pt', pa.string())]),
             partition_keys=['pt'])
         self.catalog.create_table(
             'default.test_is_in_partition_bench', schema, False)
@@ -1023,19 +1023,23 @@ class AoReaderTest(unittest.TestCase):
             pred).new_scan().plan().splits()
         self.assertEqual(len(splits), in_size)
 
-        entry_counts = {'total': 0}
+        entry_counts = {'avro_total': 0, 'constructed': 0}
         original_read = ManifestFileManager.read
 
         def counting_read(self_mgr, manifest_file_name,
                           manifest_entry_filter=None,
-                          drop_stats=True, early_entry_filter=None):
+                          drop_stats=True, early_entry_filter=None,
+                          partition_filter=None):
             path = f"{self_mgr.manifest_path}/{manifest_file_name}"
             with self_mgr.file_io.new_input_stream(path) as s:
                 for _ in fastavro.reader(BytesIO(s.read())):
-                    entry_counts['total'] += 1
-            return original_read(
+                    entry_counts['avro_total'] += 1
+            result = original_read(
                 self_mgr, manifest_file_name,
-                manifest_entry_filter, drop_stats, early_entry_filter)
+                manifest_entry_filter, drop_stats,
+                early_entry_filter, partition_filter)
+            entry_counts['constructed'] += len(result)
+            return result
 
         ManifestFileManager.read = counting_read
         try:
@@ -1044,7 +1048,8 @@ class AoReaderTest(unittest.TestCase):
         finally:
             ManifestFileManager.read = original_read
 
-        self.assertEqual(entry_counts['total'], num_partitions)
+        self.assertEqual(entry_counts['avro_total'], num_partitions)
+        self.assertEqual(entry_counts['constructed'], in_size)
 
     def _write_test_table(self, table):
         write_builder = table.new_batch_write_builder()

--- a/paimon-python/pypaimon/tests/reader_append_only_test.py
+++ b/paimon-python/pypaimon/tests/reader_append_only_test.py
@@ -986,6 +986,66 @@ class AoReaderTest(unittest.TestCase):
 
             print(f"✓ Iteration {test_iteration + 1}/{iter_num} completed successfully")
 
+    def test_is_in_partition_deserializes_all_entries(self):
+        from pypaimon.manifest.manifest_file_manager import ManifestFileManager
+        from io import BytesIO
+        import fastavro
+
+        num_partitions = 5000
+        in_size = 2000
+
+        schema = Schema.from_pyarrow_schema(
+            pa.schema([('pk', pa.int32()), ('val', pa.string()),
+                        ('pt', pa.string())]),
+            partition_keys=['pt'])
+        self.catalog.create_table(
+            'default.test_is_in_partition_bench', schema, False)
+        table = self.catalog.get_table(
+            'default.test_is_in_partition_bench')
+
+        wb = table.new_batch_write_builder()
+        w = wb.new_write()
+        bench_schema = pa.schema(
+            [('pk', pa.int32()), ('val', pa.string()),
+             ('pt', pa.string())])
+        for i in range(num_partitions):
+            w.write_arrow(pa.Table.from_pydict(
+                {'pk': [i], 'val': [f'v_{i}'], 'pt': [f'pt_{i}']},
+                schema=bench_schema))
+        wb.new_commit().commit(w.prepare_commit())
+        w.close()
+
+        builder = table.new_read_builder().new_predicate_builder()
+        in_values = [f'pt_{i}' for i in range(in_size)]
+        pred = builder.is_in('pt', in_values)
+
+        splits = table.new_read_builder().with_filter(
+            pred).new_scan().plan().splits()
+        self.assertEqual(len(splits), in_size)
+
+        entry_counts = {'total': 0}
+        original_read = ManifestFileManager.read
+
+        def counting_read(self_mgr, manifest_file_name,
+                          manifest_entry_filter=None,
+                          drop_stats=True, early_entry_filter=None):
+            path = f"{self_mgr.manifest_path}/{manifest_file_name}"
+            with self_mgr.file_io.new_input_stream(path) as s:
+                for _ in fastavro.reader(BytesIO(s.read())):
+                    entry_counts['total'] += 1
+            return original_read(
+                self_mgr, manifest_file_name,
+                manifest_entry_filter, drop_stats, early_entry_filter)
+
+        ManifestFileManager.read = counting_read
+        try:
+            table.new_read_builder().with_filter(
+                pred).new_scan().plan()
+        finally:
+            ManifestFileManager.read = original_read
+
+        self.assertEqual(entry_counts['total'], num_partitions)
+
     def _write_test_table(self, table):
         write_builder = table.new_batch_write_builder()
 
@@ -1023,96 +1083,3 @@ class AoReaderTest(unittest.TestCase):
         table_read = read_builder.new_read()
         splits = read_builder.new_scan().plan().splits()
         return table_read.to_arrow(splits)
-
-
-class IsInPartitionScanPlanTest(unittest.TestCase):
-    """Reproduces slow scan plan when using is_in() on partition key with many
-    values. All manifest entries are fully deserialized before partition
-    filtering — the early_entry_filter only checks bucket, not partition.
-    Java's createEntryRowFilter() tests partition on raw InternalRow before
-    full deserialization; Python lacks this optimization."""
-
-    NUM_PARTITIONS = 5000
-    IN_SIZE = 2000
-
-    @classmethod
-    def setUpClass(cls):
-        cls.tempdir = tempfile.mkdtemp()
-        cls.warehouse = os.path.join(cls.tempdir, 'warehouse')
-        cls.catalog = CatalogFactory.create({'warehouse': cls.warehouse})
-        cls.catalog.create_database('default', True)
-
-        cls.pa_schema = pa.schema([
-            ('pk', pa.int32()),
-            ('val', pa.string()),
-            ('pt', pa.string()),
-        ])
-
-        schema = Schema.from_pyarrow_schema(
-            cls.pa_schema, partition_keys=['pt'])
-        cls.catalog.create_table('default.is_in_bench', schema, False)
-        table = cls.catalog.get_table('default.is_in_bench')
-
-        wb = table.new_batch_write_builder()
-        w = wb.new_write()
-        for i in range(cls.NUM_PARTITIONS):
-            w.write_arrow(pa.Table.from_pydict(
-                {'pk': [i], 'val': [f'v_{i}'], 'pt': [f'pt_{i}']},
-                schema=cls.pa_schema,
-            ))
-        wb.new_commit().commit(w.prepare_commit())
-        w.close()
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tempdir, ignore_errors=True)
-
-    def test_is_in_scans_all_entries_before_filtering(self):
-        table = self.catalog.get_table('default.is_in_bench')
-        rb = table.new_read_builder()
-        builder = rb.new_predicate_builder()
-
-        in_values = [f'pt_{i}' for i in range(self.IN_SIZE)]
-        pred = builder.is_in('pt', in_values)
-
-        rb_filtered = table.new_read_builder().with_filter(pred)
-        splits = rb_filtered.new_scan().plan().splits()
-        self.assertEqual(len(splits), self.IN_SIZE)
-
-        from pypaimon.manifest.manifest_file_manager import ManifestFileManager
-        from io import BytesIO
-        import fastavro
-
-        entry_counts = {'total': 0, 'constructed': 0}
-        original_read = ManifestFileManager.read
-
-        def counting_read(self_mgr, manifest_file_name,
-                          manifest_entry_filter=None,
-                          drop_stats=True, early_entry_filter=None):
-            manifest_path = (
-                f"{self_mgr.manifest_path}/{manifest_file_name}")
-            with self_mgr.file_io.new_input_stream(
-                    manifest_path) as stream:
-                buf = BytesIO(stream.read())
-                reader = fastavro.reader(buf)
-                for _ in reader:
-                    entry_counts['total'] += 1
-            entry_counts['constructed'] = entry_counts['total']
-            return original_read(
-                self_mgr, manifest_file_name,
-                manifest_entry_filter, drop_stats, early_entry_filter)
-
-        ManifestFileManager.read = counting_read
-        try:
-            rb2 = table.new_read_builder().with_filter(pred)
-            rb2.new_scan().plan()
-        finally:
-            ManifestFileManager.read = original_read
-
-        self.assertEqual(entry_counts['total'], self.NUM_PARTITIONS)
-        self.assertEqual(entry_counts['constructed'], self.NUM_PARTITIONS)
-        wasted = entry_counts['constructed'] - self.IN_SIZE
-        self.assertGreater(wasted, 0,
-                           f"Expected wasted construction: all "
-                           f"{self.NUM_PARTITIONS} entries are fully "
-                           f"deserialized but only {self.IN_SIZE} match")


### PR DESCRIPTION
### Purpose
 Partition predicate was tested after full `_FILE` deserialization. This PR moves the
  test before `_FILE` construction, skipping non-matching entries early. Aligns with
  Java's `createEntryRowFilter()`.

  ## Test plan

  `test_is_in_with_partitions`