### PR TITLE
[common] Fix RowHelper internal buffer never shrinking for large records

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -37,12 +37,18 @@ public class RowHelper implements Serializable {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Threshold in bytes for releasing the internal reuse buffer. When big records are written, the
-     * BinaryRowWriter's internal segment can grow very large via grow(). The {@link
-     * #resetIfTooLarge(BinaryRow)} method checks this threshold and releases the bloated
-     * reuseRow/reuseWriter to avoid holding onto oversized buffers indefinitely.
+     * Maximum retained reuse buffer size in bytes. Buffers exceeding this cap are eligible for
+     * release when the shrink ratio condition is also met.
      */
-    private static final int REUSE_RELEASE_THRESHOLD = 4 * 1024 * 1024; // 4MB
+    private static final int MAX_RETAINED_REUSE_BUFFER_SIZE = 4 * 1024 * 1024; // 4MB
+
+    /**
+     * Shrink ratio for hysteresis. The buffer is released only when its capacity exceeds {@link
+     * #MAX_RETAINED_REUSE_BUFFER_SIZE} AND is more than {@code SHRINK_RATIO} times the current
+     * row's size. This avoids thrashing for sustained medium-to-large records while still releasing
+     * after a spike (e.g. 100MB buffer with 5MB rows → 20x > 4x → release).
+     */
+    private static final int SHRINK_RATIO = 4;
 
     private final FieldGetter[] fieldGetters;
     private final ValueSetter[] valueSetters;
@@ -91,23 +97,27 @@ public class RowHelper implements Serializable {
 
     /**
      * Release the internal reuse buffer if the given row is the reuse row produced by this helper,
-     * the backing segment exceeds the threshold, and the current record is small. The identity
-     * check ({@code currentRow == reuseRow}) ensures we only act when the caller actually used this
-     * helper's buffer — if the input was already a {@link BinaryRow}, {@code toBinaryRow()} returns
-     * it directly and the helper state is stale, so we must skip cleanup.
+     * the backing segment exceeds the maximum retained size, and the buffer is clearly oversized
+     * relative to the current record. The identity check ({@code currentRow == reuseRow}) ensures
+     * we only act when the caller actually used this helper's buffer.
      *
-     * <p>The hysteresis ({@code currentRow.getSizeInBytes() < threshold}) avoids thrashing when
-     * records are consistently large, while still reclaiming memory when the workload transitions
-     * back to small records.
+     * <p>The release condition combines a fixed cap with a relative ratio check:
+     *
+     * <ul>
+     *   <li>bufferCapacity > {@link #MAX_RETAINED_REUSE_BUFFER_SIZE} — the buffer was inflated
+     *       beyond the baseline
+     *   <li>bufferCapacity > currentRow.getSizeInBytes() * {@link #SHRINK_RATIO} — the buffer is
+     *       significantly larger than the current workload needs
+     * </ul>
      */
     public void resetIfTooLarge(BinaryRow currentRow) {
-        if (currentRow == reuseRow
-                && reuseWriter != null
-                && reuseWriter.getSegments() != null
-                && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD
-                && currentRow.getSizeInBytes() < REUSE_RELEASE_THRESHOLD) {
-            reuseRow = null;
-            reuseWriter = null;
+        if (currentRow == reuseRow && reuseWriter != null && reuseWriter.getSegments() != null) {
+            int bufferCapacity = reuseWriter.getSegments().size();
+            if (bufferCapacity > MAX_RETAINED_REUSE_BUFFER_SIZE
+                    && bufferCapacity > (long) currentRow.getSizeInBytes() * SHRINK_RATIO) {
+                reuseRow = null;
+                reuseWriter = null;
+            }
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -36,6 +36,14 @@ public class RowHelper implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Threshold in bytes for releasing the internal reuse buffer. When big records are written, the
+     * BinaryRowWriter's internal segment can grow very large via grow(). The {@link
+     * #resetIfTooLarge()} method checks this threshold and releases the bloated
+     * reuseRow/reuseWriter to avoid holding onto oversized buffers indefinitely.
+     */
+    private static final int REUSE_RELEASE_THRESHOLD = 4 * 1024 * 1024; // 4MB
+
     private final FieldGetter[] fieldGetters;
     private final ValueSetter[] valueSetters;
     private final boolean[] writeNulls;
@@ -79,6 +87,21 @@ public class RowHelper implements Serializable {
             }
         }
         reuseWriter.complete();
+    }
+
+    /**
+     * Release the internal reuse buffer if the segment exceeds the threshold AND the last written
+     * record is small. This hysteresis avoids thrashing when records are consistently large, while
+     * still reclaiming memory when the workload transitions back to small records.
+     */
+    public void resetIfTooLarge() {
+        if (reuseWriter != null
+                && reuseWriter.getSegments() != null
+                && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD
+                && reuseRow.getSizeInBytes() < REUSE_RELEASE_THRESHOLD) {
+            reuseRow = null;
+            reuseWriter = null;
+        }
     }
 
     public BinaryRow reuseRow() {

--- a/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/RowHelper.java
@@ -39,7 +39,7 @@ public class RowHelper implements Serializable {
     /**
      * Threshold in bytes for releasing the internal reuse buffer. When big records are written, the
      * BinaryRowWriter's internal segment can grow very large via grow(). The {@link
-     * #resetIfTooLarge()} method checks this threshold and releases the bloated
+     * #resetIfTooLarge(BinaryRow)} method checks this threshold and releases the bloated
      * reuseRow/reuseWriter to avoid holding onto oversized buffers indefinitely.
      */
     private static final int REUSE_RELEASE_THRESHOLD = 4 * 1024 * 1024; // 4MB
@@ -90,15 +90,22 @@ public class RowHelper implements Serializable {
     }
 
     /**
-     * Release the internal reuse buffer if the segment exceeds the threshold AND the last written
-     * record is small. This hysteresis avoids thrashing when records are consistently large, while
-     * still reclaiming memory when the workload transitions back to small records.
+     * Release the internal reuse buffer if the given row is the reuse row produced by this helper,
+     * the backing segment exceeds the threshold, and the current record is small. The identity
+     * check ({@code currentRow == reuseRow}) ensures we only act when the caller actually used this
+     * helper's buffer — if the input was already a {@link BinaryRow}, {@code toBinaryRow()} returns
+     * it directly and the helper state is stale, so we must skip cleanup.
+     *
+     * <p>The hysteresis ({@code currentRow.getSizeInBytes() < threshold}) avoids thrashing when
+     * records are consistently large, while still reclaiming memory when the workload transitions
+     * back to small records.
      */
-    public void resetIfTooLarge() {
-        if (reuseWriter != null
+    public void resetIfTooLarge(BinaryRow currentRow) {
+        if (currentRow == reuseRow
+                && reuseWriter != null
                 && reuseWriter.getSegments() != null
                 && reuseWriter.getSegments().size() > REUSE_RELEASE_THRESHOLD
-                && reuseRow.getSizeInBytes() < REUSE_RELEASE_THRESHOLD) {
+                && currentRow.getSizeInBytes() < REUSE_RELEASE_THRESHOLD) {
             reuseRow = null;
             reuseWriter = null;
         }

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
@@ -59,7 +59,16 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
 
     @Override
     public void serialize(InternalRow row, DataOutputView target) throws IOException {
-        binarySerializer.serialize(toBinaryRow(row), target);
+        try {
+            binarySerializer.serialize(toBinaryRow(row), target);
+        } finally {
+            // Must use finally here: toBinaryRow() may inflate RowHelper's internal buffer
+            // for large records (e.g. 100MB+). The serialization can exit via EOFException
+            // thrown by SimpleCollectingOutputView.nextSegment() when the sort buffer is
+            // full, which is caught by BinaryInMemorySortBuffer.write() as a normal signal.
+            // Without finally, the bloated buffer would never be released on that path.
+            rowHelper.resetIfTooLarge();
+        }
     }
 
     @Override
@@ -132,7 +141,13 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
     @Override
     public int serializeToPages(InternalRow row, AbstractPagedOutputView target)
             throws IOException {
-        return binarySerializer.serializeToPages(toBinaryRow(row), target);
+        try {
+            return binarySerializer.serializeToPages(toBinaryRow(row), target);
+        } finally {
+            // Same as serialize(): must use finally because EOFException may bypass normal
+            // return when the sort buffer is full.
+            rowHelper.resetIfTooLarge();
+        }
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalRowSerializer.java
@@ -59,15 +59,11 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
 
     @Override
     public void serialize(InternalRow row, DataOutputView target) throws IOException {
+        BinaryRow binaryRow = toBinaryRow(row);
         try {
-            binarySerializer.serialize(toBinaryRow(row), target);
+            binarySerializer.serialize(binaryRow, target);
         } finally {
-            // Must use finally here: toBinaryRow() may inflate RowHelper's internal buffer
-            // for large records (e.g. 100MB+). The serialization can exit via EOFException
-            // thrown by SimpleCollectingOutputView.nextSegment() when the sort buffer is
-            // full, which is caught by BinaryInMemorySortBuffer.write() as a normal signal.
-            // Without finally, the bloated buffer would never be released on that path.
-            rowHelper.resetIfTooLarge();
+            rowHelper.resetIfTooLarge(binaryRow);
         }
     }
 
@@ -141,12 +137,11 @@ public class InternalRowSerializer extends AbstractRowDataSerializer<InternalRow
     @Override
     public int serializeToPages(InternalRow row, AbstractPagedOutputView target)
             throws IOException {
+        BinaryRow binaryRow = toBinaryRow(row);
         try {
-            return binarySerializer.serializeToPages(toBinaryRow(row), target);
+            return binarySerializer.serializeToPages(binaryRow, target);
         } finally {
-            // Same as serialize(): must use finally because EOFException may bypass normal
-            // return when the sort buffer is full.
-            rowHelper.resetIfTooLarge();
+            rowHelper.resetIfTooLarge(binaryRow);
         }
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 
@@ -27,69 +28,89 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link RowHelper}, focusing on the resetIfTooLarge() behavior. */
+/** Tests for {@link RowHelper}, focusing on the resetIfTooLarge(BinaryRow) behavior. */
 class RowHelperTest {
 
     @Test
-    void testResetIfTooLargeReleasesAfterTransitionToSmallRecord() {
+    void testReleasesWhenTransitionFromLargeToSmallRecord() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
 
         // Write a large record (> 4MB) to inflate the internal buffer
-        byte[] largePayload = new byte[5 * 1024 * 1024]; // 5MB
-        Arrays.fill(largePayload, (byte) 'x');
+        byte[] largePayload = new byte[5 * 1024 * 1024];
         GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
         largeRow.setRowKind(RowKind.INSERT);
         helper.copyInto(largeRow);
+        BinaryRow reuseAfterLarge = helper.reuseRow();
+        assertThat(reuseAfterLarge).isNotNull();
 
+        // Hysteresis: should NOT release when current record is large
+        helper.resetIfTooLarge(reuseAfterLarge);
         assertThat(helper.reuseRow()).isNotNull();
 
-        // Hysteresis: resetIfTooLarge() should NOT release when last record is large
-        helper.resetIfTooLarge();
-        assertThat(helper.reuseRow()).isNotNull();
-
-        // Now write a small record — buffer is still oversized from the large record
+        // Write a small record — buffer is still oversized from the large record
         GenericRow smallRow = GenericRow.of(BinaryString.fromString("s"), new byte[10]);
         smallRow.setRowKind(RowKind.INSERT);
         helper.copyInto(smallRow);
+        BinaryRow reuseAfterSmall = helper.reuseRow();
 
-        // resetIfTooLarge() should release now: buffer > 4MB but last record < 4MB
-        helper.resetIfTooLarge();
+        // Should release now: buffer > 4MB but current record < 4MB
+        helper.resetIfTooLarge(reuseAfterSmall);
         assertThat(helper.reuseRow()).isNull();
     }
 
     @Test
-    void testResetIfTooLargeKeepsSmallBuffer() {
+    void testKeepsSmallBuffer() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.INT()));
 
-        // Write a small record (< 4MB)
         GenericRow smallRow = GenericRow.of(BinaryString.fromString("hello"), 42);
         smallRow.setRowKind(RowKind.INSERT);
         helper.copyInto(smallRow);
+        BinaryRow reuse = helper.reuseRow();
+        assertThat(reuse).isNotNull();
 
-        assertThat(helper.reuseRow()).isNotNull();
-
-        // resetIfTooLarge() should NOT release the small buffer
-        helper.resetIfTooLarge();
+        // Small buffer should NOT be released
+        helper.resetIfTooLarge(reuse);
         assertThat(helper.reuseRow()).isNotNull();
     }
 
     @Test
-    void testResetIfTooLargeBeforeCopyInto() {
-        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING()));
-
-        // reuseRow is null before any copyInto
-        assertThat(helper.reuseRow()).isNull();
-
-        // resetIfTooLarge() should be safe to call when reuseRow is null
-        helper.resetIfTooLarge();
-        assertThat(helper.reuseRow()).isNull();
-    }
-
-    @Test
-    void testReuseIsRecreatedAfterRelease() {
+    void testSkipsWhenCurrentRowIsNotReuseRow() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
 
-        // Write a large record to inflate the buffer, then a small record to trigger release
+        // Write a large record to inflate the buffer
+        byte[] largePayload = new byte[5 * 1024 * 1024];
+        GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
+        largeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(largeRow);
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Simulate the BinaryRow input path: toBinaryRow() returns the input directly,
+        // not the helper's reuseRow. Pass a different BinaryRow instance.
+        BinaryRow externalRow = new BinaryRow(2);
+        externalRow.pointTo(MemorySegment.wrap(new byte[32]), 0, 32);
+
+        // Should NOT release because externalRow != reuseRow
+        helper.resetIfTooLarge(externalRow);
+        assertThat(helper.reuseRow()).isNotNull();
+    }
+
+    @Test
+    void testSafeToCallWithNullReuseRow() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING()));
+        assertThat(helper.reuseRow()).isNull();
+
+        // Should be safe — reuseRow is null, no NPE
+        BinaryRow someRow = new BinaryRow(1);
+        someRow.pointTo(MemorySegment.wrap(new byte[16]), 0, 16);
+        helper.resetIfTooLarge(someRow);
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testReuseRecreatedAfterRelease() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Inflate buffer, then transition to small
         byte[] largePayload = new byte[5 * 1024 * 1024];
         GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
         largeRow.setRowKind(RowKind.INSERT);
@@ -99,16 +120,15 @@ class RowHelperTest {
         smallRow.setRowKind(RowKind.INSERT);
         helper.copyInto(smallRow);
 
-        // Buffer is oversized + last record is small → release
-        helper.resetIfTooLarge();
+        helper.resetIfTooLarge(helper.reuseRow());
         assertThat(helper.reuseRow()).isNull();
 
         // Write another small record — reuseRow should be recreated
         helper.copyInto(smallRow);
         assertThat(helper.reuseRow()).isNotNull();
 
-        // Small buffer should survive resetIfTooLarge()
-        helper.resetIfTooLarge();
+        // Small buffer should survive
+        helper.resetIfTooLarge(helper.reuseRow());
         assertThat(helper.reuseRow()).isNotNull();
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RowHelperTest {
 
     @Test
-    void testReleasesWhenTransitionFromLargeToSmallRecord() {
+    void testReleasesWhenSpikeFollowedBySmallRecords() {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
 
         // Write a large record (> 4MB) to inflate the internal buffer
@@ -43,19 +43,56 @@ class RowHelperTest {
         BinaryRow reuseAfterLarge = helper.reuseRow();
         assertThat(reuseAfterLarge).isNotNull();
 
-        // Hysteresis: should NOT release when current record is large
+        // buffer ~8MB, row ~5MB → ratio ~1.6x < 4x → should NOT release
         helper.resetIfTooLarge(reuseAfterLarge);
         assertThat(helper.reuseRow()).isNotNull();
 
-        // Write a small record — buffer is still oversized from the large record
+        // Write a small record — buffer still oversized
         GenericRow smallRow = GenericRow.of(BinaryString.fromString("s"), new byte[10]);
         smallRow.setRowKind(RowKind.INSERT);
         helper.copyInto(smallRow);
-        BinaryRow reuseAfterSmall = helper.reuseRow();
 
-        // Should release now: buffer > 4MB but current record < 4MB
-        helper.resetIfTooLarge(reuseAfterSmall);
+        // buffer ~8MB, row ~50B → ratio huge > 4x, buffer > 4MB → release
+        helper.resetIfTooLarge(helper.reuseRow());
         assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testReleasesWhenSpikeFollowedByMediumRecords() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a very large record (100MB) to inflate the buffer significantly
+        byte[] hugePayload = new byte[100 * 1024 * 1024];
+        GenericRow hugeRow = GenericRow.of(BinaryString.fromString("key"), hugePayload);
+        hugeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(hugeRow);
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Write a medium record (5MB) — buffer is ~150MB (from grow), row is ~5MB
+        // ratio ~30x > 4x, buffer > 4MB → should release
+        byte[] mediumPayload = new byte[5 * 1024 * 1024];
+        GenericRow mediumRow = GenericRow.of(BinaryString.fromString("m"), mediumPayload);
+        mediumRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(mediumRow);
+
+        helper.resetIfTooLarge(helper.reuseRow());
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testRetainsWhenBufferProportionalToRecordSize() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a 5MB record — buffer grows to ~8MB via grow() (1.5x strategy)
+        byte[] payload = new byte[5 * 1024 * 1024];
+        GenericRow row = GenericRow.of(BinaryString.fromString("key"), payload);
+        row.setRowKind(RowKind.INSERT);
+        helper.copyInto(row);
+
+        // buffer ~8MB, row ~5MB → ratio ~1.6x < 4x → should NOT release
+        // even though buffer > 4MB
+        helper.resetIfTooLarge(helper.reuseRow());
+        assertThat(helper.reuseRow()).isNotNull();
     }
 
     @Test
@@ -68,7 +105,7 @@ class RowHelperTest {
         BinaryRow reuse = helper.reuseRow();
         assertThat(reuse).isNotNull();
 
-        // Small buffer should NOT be released
+        // Small buffer (< 4MB) — should NOT be released regardless of ratio
         helper.resetIfTooLarge(reuse);
         assertThat(helper.reuseRow()).isNotNull();
     }
@@ -84,8 +121,7 @@ class RowHelperTest {
         helper.copyInto(largeRow);
         assertThat(helper.reuseRow()).isNotNull();
 
-        // Simulate the BinaryRow input path: toBinaryRow() returns the input directly,
-        // not the helper's reuseRow. Pass a different BinaryRow instance.
+        // Pass a different BinaryRow — simulates toBinaryRow() returning input directly
         BinaryRow externalRow = new BinaryRow(2);
         externalRow.pointTo(MemorySegment.wrap(new byte[32]), 0, 32);
 
@@ -99,7 +135,6 @@ class RowHelperTest {
         RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING()));
         assertThat(helper.reuseRow()).isNull();
 
-        // Should be safe — reuseRow is null, no NPE
         BinaryRow someRow = new BinaryRow(1);
         someRow.pointTo(MemorySegment.wrap(new byte[16]), 0, 16);
         helper.resetIfTooLarge(someRow);

--- a/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/RowHelperTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link RowHelper}, focusing on the resetIfTooLarge() behavior. */
+class RowHelperTest {
+
+    @Test
+    void testResetIfTooLargeReleasesAfterTransitionToSmallRecord() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a large record (> 4MB) to inflate the internal buffer
+        byte[] largePayload = new byte[5 * 1024 * 1024]; // 5MB
+        Arrays.fill(largePayload, (byte) 'x');
+        GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
+        largeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(largeRow);
+
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Hysteresis: resetIfTooLarge() should NOT release when last record is large
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Now write a small record — buffer is still oversized from the large record
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("s"), new byte[10]);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        // resetIfTooLarge() should release now: buffer > 4MB but last record < 4MB
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testResetIfTooLargeKeepsSmallBuffer() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.INT()));
+
+        // Write a small record (< 4MB)
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("hello"), 42);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // resetIfTooLarge() should NOT release the small buffer
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+    }
+
+    @Test
+    void testResetIfTooLargeBeforeCopyInto() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING()));
+
+        // reuseRow is null before any copyInto
+        assertThat(helper.reuseRow()).isNull();
+
+        // resetIfTooLarge() should be safe to call when reuseRow is null
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+    }
+
+    @Test
+    void testReuseIsRecreatedAfterRelease() {
+        RowHelper helper = new RowHelper(Arrays.asList(DataTypes.STRING(), DataTypes.BYTES()));
+
+        // Write a large record to inflate the buffer, then a small record to trigger release
+        byte[] largePayload = new byte[5 * 1024 * 1024];
+        GenericRow largeRow = GenericRow.of(BinaryString.fromString("key"), largePayload);
+        largeRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(largeRow);
+
+        GenericRow smallRow = GenericRow.of(BinaryString.fromString("small"), new byte[10]);
+        smallRow.setRowKind(RowKind.INSERT);
+        helper.copyInto(smallRow);
+
+        // Buffer is oversized + last record is small → release
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNull();
+
+        // Write another small record — reuseRow should be recreated
+        helper.copyInto(smallRow);
+        assertThat(helper.reuseRow()).isNotNull();
+
+        // Small buffer should survive resetIfTooLarge()
+        helper.resetIfTooLarge();
+        assertThat(helper.reuseRow()).isNotNull();
+    }
+}


### PR DESCRIPTION
### Purpose

Linked issue: #7620

`RowHelper.reuseWriter` grows its internal `MemorySegment` for large records (e.g. 100MB+), but `BinaryRowWriter.reset()` only resets the cursor without releasing the oversized segment. Additionally, `InternalRowSerializer.serialize()` can exit via `EOFException` — a normal signal when the sort buffer is full (`SimpleCollectingOutputView.nextSegment()` throws it, caught by `BinaryInMemorySortBuffer.write()`) — skipping any cleanup of the bloated buffer.

With many buckets (e.g. 256), each bucket's writer independently retains an inflated buffer: 256 × 100MB+ = tens of GB, causing OOM.

#### Changes

- **`RowHelper`**: add `resetIfTooLarge()` with hysteresis — release internal buffer only when the segment exceeds 4MB **and** the last written record (`reuseRow.getSizeInBytes()`) is smaller than 4MB
  - Sustained large records (5–10MB): buffer retained, no thrashing
  - Occasional large record → back to small records: buffer released, OOM protection
  - Normal small records (< 4MB): buffer never exceeds threshold, the check is a no-op
- **`InternalRowSerializer`**: call `resetIfTooLarge()` in `finally` blocks of `serialize()` and `serializeToPages()` to handle the `EOFException` exit path

#### Why 4MB and why not configurable

The threshold is derived from the production scenario: 256 buckets × 4MB = 1GB baseline, leaving reasonable headroom in a typical 4–8GB TaskManager heap. Making it configurable would require plumbing config through the entire serializer chain — `RowHelper` and `InternalRowSerializer` live in paimon-common which is config-free by design (all 27 serializer classes are parameterized solely by schema types). The full chain from `CoreOptions` → `KeyValueFileStoreWrite` → `MergeTreeWriter` → `SortBufferWriteBuffer` → `BinaryInMemorySortBuffer` → `InternalRowSerializer` → `RowHelper` would need changes across modules. A fixed value with hysteresis is sufficient for the initial fix.

### Tests

`RowHelperTest` — 4 test cases covering:
- Hysteresis: buffer retained when last record is large
- Buffer released when workload transitions to small records
- Safe to call before any `copyInto`
- Reuse recreated after release, small buffer survives `resetIfTooLarge()`

### API and Format

N/A

### Documentation

N/A
