### PR TITLE
[spark] Correct MigrateTableProcedureTest with set target table iterations

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/MigrateTableProcedureTest.scala
@@ -108,23 +108,24 @@ class MigrateTableProcedureTest extends PaimonHiveTestBase {
     format => {
       test(
         s"Paimon migrate table procedure: migrate $format non-partitioned table with set target table") {
-        withTable(s"hive_tbl_$random", s"target_$random") {
+        withTable(s"hive_tbl_${random}_$format", s"target_${random}_$format") {
           // create hive table
           spark.sql(s"""
-                       |CREATE TABLE hive_tbl_$random (id STRING, name STRING, pt STRING)
+                       |CREATE TABLE hive_tbl_${random}_$format (id STRING, name STRING, pt STRING)
                        |USING $format
                        |""".stripMargin)
 
-          spark.sql(s"INSERT INTO hive_tbl_$random VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
+          spark.sql(
+            s"INSERT INTO hive_tbl_${random}_$format VALUES ('1', 'a', 'p1'), ('2', 'b', 'p2')")
 
           spark.sql(
-            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_$random', options => 'file.format=$format', target_table => '$hiveDbName.target_$random', delete_origin => false)")
+            s"CALL sys.migrate_table(source_type => 'hive', table => '$hiveDbName.hive_tbl_${random}_$format', options => 'file.format=$format', target_table => '$hiveDbName.target_${random}_$format', delete_origin => false)")
 
           checkAnswer(
-            spark.sql(s"SELECT * FROM target_$random ORDER BY id"),
+            spark.sql(s"SELECT * FROM target_${random}_$format ORDER BY id"),
             Row("1", "a", "p1") :: Row("2", "b", "p2") :: Nil)
 
-          checkAnswer(spark.sql(s"SELECT * FROM hive_tbl_$random ORDER BY id"), Nil)
+          checkAnswer(spark.sql(s"SELECT * FROM hive_tbl_${random}_$format ORDER BY id"), Nil)
 
         }
       }


### PR DESCRIPTION
### Purpose
 - MigrateTable UT is flaky and causes CI failures. 
 - The UT runs 3 `migrate $format` for (parquet/orc/avro) with the same `hive_tbl_$random` and `target_$random` (same `random` shared at class level).
 - Run 2 re-uses cached HMS values from `SessionCatalog.tableRelationCache` from run 1, which is a parquet file, and appends .orc to it. (making it an invalid <filename>.parquet.orc when the entries are cached). 
 - This causes the UT to fail, ensure we can use different names to avoid cache collision

### Tests
 - UT now passes