### PR TITLE
[core] Validate file index data type compatibility at table creation time

### DIFF
--- a/docs/docs/concepts/spec/fileindex.mdx
+++ b/docs/docs/concepts/spec/fileindex.mdx
@@ -98,6 +98,9 @@ Content of bloom filter index is simple:
 This class use (64-bits) long hash. Store the num hash function (one integer) and bit set bytes only. Hash bytes type 
 (like varchar, binary, etc.) using xx hash, hash numeric type by [specified number hash](http://web.archive.org/web/20071223173210/http://www.concentric.net/~Ttwang/tech/inthash.htm).
 
+BloomFilter only support the following data type: TinyIntType, SmallIntType, IntType, BigIntType, FloatType, DoubleType,
+DateType, TimeType, TimestampType, LocalZonedTimestampType, CharType, VarCharType, BinaryType, VarBinaryType.
+
 ## Index: Bitmap
 
 * `file-index.bitmap.columns`: specify the columns that need bitmap index.

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexerFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexerFactory.java
@@ -27,4 +27,10 @@ public interface FileIndexerFactory {
     String identifier();
 
     FileIndexer create(DataType type, Options options);
+
+    /**
+     * Validate whether the given data type is supported by this index. Throws {@link
+     * UnsupportedOperationException} if not supported.
+     */
+    default void validate(DataType dataType) {}
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexerFactoryUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexerFactoryUtils.java
@@ -46,7 +46,7 @@ public class FileIndexerFactoryUtils {
         }
     }
 
-    static FileIndexerFactory load(String type) {
+    public static FileIndexerFactory load(String type) {
         FileIndexerFactory fileIndexerFactory = factories.get(type);
         if (fileIndexerFactory == null) {
             throw new RuntimeException("Can't find file index for type: " + type);

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bitmap/BitmapFileIndexFactory.java
@@ -37,4 +37,9 @@ public class BitmapFileIndexFactory implements FileIndexerFactory {
     public FileIndexer create(DataType dataType, Options options) {
         return new BitmapFileIndex(dataType, options);
     }
+
+    @Override
+    public void validate(DataType dataType) {
+        BitmapFileIndex.getValueMapper(dataType);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bloomfilter/BloomFilterFileIndexFactory.java
@@ -37,4 +37,9 @@ public class BloomFilterFileIndexFactory implements FileIndexerFactory {
     public FileIndexer create(DataType type, Options options) {
         return new BloomFilterFileIndex(type, options);
     }
+
+    @Override
+    public void validate(DataType dataType) {
+        FastHash.getHashFunction(dataType);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndexFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/bsi/BitSliceIndexBitmapFileIndexFactory.java
@@ -37,4 +37,9 @@ public class BitSliceIndexBitmapFileIndexFactory implements FileIndexerFactory {
     public FileIndexer create(DataType dataType, Options options) {
         return new BitSliceIndexBitmapFileIndex(dataType);
     }
+
+    @Override
+    public void validate(DataType dataType) {
+        BitSliceIndexBitmapFileIndex.getValueMapper(dataType);
+    }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexFactory.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/rangebitmap/RangeBitmapFileIndexFactory.java
@@ -20,6 +20,7 @@ package org.apache.paimon.fileindex.rangebitmap;
 
 import org.apache.paimon.fileindex.FileIndexer;
 import org.apache.paimon.fileindex.FileIndexerFactory;
+import org.apache.paimon.fileindex.rangebitmap.dictionary.chunked.KeyFactory;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.types.DataType;
 
@@ -36,5 +37,10 @@ public class RangeBitmapFileIndexFactory implements FileIndexerFactory {
     @Override
     public FileIndexer create(DataType dataType, Options options) {
         return new RangeBitmapFileIndex(dataType, options);
+    }
+
+    @Override
+    public void validate(DataType dataType) {
+        KeyFactory.create(dataType);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -24,6 +24,8 @@ import org.apache.paimon.CoreOptions.MergeEngine;
 import org.apache.paimon.TableType;
 import org.apache.paimon.factories.FactoryUtil;
 import org.apache.paimon.fileindex.FileIndexOptions;
+import org.apache.paimon.fileindex.FileIndexerFactory;
+import org.apache.paimon.fileindex.FileIndexerFactoryUtils;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.mergetree.compact.aggregate.FieldAggregator;
 import org.apache.paimon.mergetree.compact.aggregate.factory.FieldAggregatorFactory;
@@ -642,6 +644,22 @@ public class SchemaValidation {
                                 + "Only CHAR/VARCHAR/STRING is supported.",
                         columnName,
                         keyType);
+            }
+
+            for (String indexType : entry.getValue().keySet()) {
+                FileIndexerFactory factory = FileIndexerFactoryUtils.load(indexType);
+                DataType dataType =
+                        column.isNestedColumn()
+                                ? ((MapType) field.type()).getValueType()
+                                : field.type();
+                try {
+                    factory.validate(dataType);
+                } catch (UnsupportedOperationException e) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Column '%s' with type '%s' is not supported by '%s' index. %s",
+                                    columnName, dataType.asSQLString(), indexType, e.getMessage()));
+                }
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -405,9 +405,9 @@ class SchemaValidationTest {
                         "file-index.range-bitmap.columns");
 
         for (String key : keys) {
-            // valid: all referenced columns exist
+            // valid: all referenced columns exist and types are supported
             Map<String, String> okOptions = new HashMap<>();
-            okOptions.put(key, "f0,f3");
+            okOptions.put(key, "f0");
             assertThatCode(() -> validateTableSchemaExec(okOptions))
                     .as("valid key=%s", key)
                     .doesNotThrowAnyException();
@@ -468,6 +468,87 @@ class SchemaValidationTest {
         options.put(BUCKET.key(), String.valueOf(-1));
         validateTableSchema(
                 new TableSchema(1, fields, 10, emptyList(), singletonList("f1"), options, ""));
+    }
+
+    @Test
+    public void testFileIndexUnsupportedDataType() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "f0", DataTypes.INT()),
+                        new DataField(1, "f1", DataTypes.INT()),
+                        new DataField(2, "arr", DataTypes.ARRAY(DataTypes.STRING())),
+                        new DataField(3, "f3", DataTypes.STRING()));
+
+        // bloom-filter on ARRAY should fail
+        Map<String, String> bloomOptions = new HashMap<>();
+        bloomOptions.put("file-index.bloom-filter.columns", "arr");
+        bloomOptions.put(BUCKET.key(), String.valueOf(-1));
+        assertThatThrownBy(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                singletonList("f1"),
+                                                bloomOptions,
+                                                "")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported by 'bloom-filter' index");
+
+        // bitmap on ARRAY should fail
+        Map<String, String> bitmapOptions = new HashMap<>();
+        bitmapOptions.put("file-index.bitmap.columns", "arr");
+        bitmapOptions.put(BUCKET.key(), String.valueOf(-1));
+        assertThatThrownBy(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                singletonList("f1"),
+                                                bitmapOptions,
+                                                "")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported by 'bitmap' index");
+
+        // bsi on STRING should fail
+        Map<String, String> bsiOptions = new HashMap<>();
+        bsiOptions.put("file-index.bsi.columns", "f3");
+        bsiOptions.put(BUCKET.key(), String.valueOf(-1));
+        assertThatThrownBy(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                singletonList("f1"),
+                                                bsiOptions,
+                                                "")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not supported by 'bsi' index");
+
+        // bloom-filter on INT should pass
+        Map<String, String> okOptions = new HashMap<>();
+        okOptions.put("file-index.bloom-filter.columns", "f0");
+        okOptions.put(BUCKET.key(), String.valueOf(-1));
+        assertThatCode(
+                        () ->
+                                validateTableSchema(
+                                        new TableSchema(
+                                                1,
+                                                fields,
+                                                10,
+                                                emptyList(),
+                                                singletonList("f1"),
+                                                okOptions,
+                                                "")))
+                .doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Add data type validation for file indexes (bloom-filter, bitmap, bsi, range-bitmap) at table creation time. Previously, unsupported types (e.g., Array on bloom-filter) were only caught at data insertion time, causing a confusing user experience.

Changes:
- Add `validate(DataType)` method to `FileIndexerFactory` interface
- Implement validation in all four index factories, reusing existing visitor logic
- Call validation in `SchemaValidation.validateFileIndex()`
- Add supported data types documentation for BloomFilter in fileindex.mdx

### Tests

Add `testFileIndexUnsupportedDataType` in `SchemaValidationTest` covering:
- bloom-filter on Array → fails at creation
- bitmap on Array → fails at creation
- bsi on String → fails at creation
- bloom-filter on Int → passes (sanity check)