### PR TITLE
[mosaic] Support ARRAY and MAP type validation

### DIFF
--- a/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
+++ b/paimon-mosaic/src/main/java/org/apache/paimon/format/mosaic/MosaicFileFormat.java
@@ -209,8 +209,8 @@ public class MosaicFileFormat extends FileFormat {
 
         @Override
         public Void visit(ArrayType arrayType) {
-            throw new UnsupportedOperationException(
-                    "Mosaic file format does not support type ARRAY");
+            arrayType.getElementType().accept(this);
+            return null;
         }
 
         @Override
@@ -227,7 +227,9 @@ public class MosaicFileFormat extends FileFormat {
 
         @Override
         public Void visit(MapType mapType) {
-            throw new UnsupportedOperationException("Mosaic file format does not support type MAP");
+            mapType.getKeyType().accept(this);
+            mapType.getValueType().accept(this);
+            return null;
         }
 
         @Override

--- a/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicFileFormatTest.java
+++ b/paimon-mosaic/src/test/java/org/apache/paimon/format/mosaic/MosaicFileFormatTest.java
@@ -85,12 +85,17 @@ class MosaicFileFormatTest {
     }
 
     @Test
-    void testValidateDataFieldsMapUnsupported() {
+    void testValidateDataFieldsArraySupported() {
+        MosaicFileFormat format = createFormat();
+        RowType rowType = DataTypes.ROW(DataTypes.ARRAY(DataTypes.INT()));
+        format.validateDataFields(rowType);
+    }
+
+    @Test
+    void testValidateDataFieldsMapSupported() {
         MosaicFileFormat format = createFormat();
         RowType rowType = DataTypes.ROW(DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()));
-        assertThatThrownBy(() -> format.validateDataFields(rowType))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessageContaining("MAP");
+        format.validateDataFields(rowType);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove `UnsupportedOperationException` for ARRAY and MAP types in `MosaicRowTypeVisitor`, allowing these types to pass schema validation
- Recursively validate child types (element type for ARRAY, key/value types for MAP)
- Once paimon-mosaic upstream releases 0.2.0 (which includes ARRAY/MAP support in the native library), we only need to bump the mosaic dependency version

## Test plan

- [x] `MosaicFileFormatTest` passes — added `testValidateDataFieldsArraySupported` and `testValidateDataFieldsMapSupported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)