### PR TITLE
[core][flink][spark] Support ARRAY<BLOB> blob files

### DIFF
--- a/docs/docs/concepts/spec/fileformat.md
+++ b/docs/docs/concepts/spec/fileformat.md
@@ -849,13 +849,33 @@ BLOB files use the `.blob` extension and have the following structure:
 +------------------+
 ```
 
+Each physical BLOB file stores one logical field. The field can be either `BLOB` or
+`ARRAY<BLOB>`. For `ARRAY<BLOB>`, the variable-length data area in an entry uses the
+following nested payload:
+
+```
++----------------------+-----------------------------------------------+
+| Array Magic Number   | 4 bytes (1094861634, Little Endian)           |
+| Array Version        | 1 byte                                        |
+| Element Count        | 4 bytes (Little Endian)                       |
+| Element Data         | Concatenated bytes of all non-null elements   |
+| Element Length Index | Delta-Varint compressed element lengths       |
+| Index Length         | 4 bytes (Little Endian)                       |
++----------------------+-----------------------------------------------+
+```
+
+An element length of `-1` represents a null array element. At the outer file index
+level, `-1` represents a null field and `-2` represents a field placeholder used by
+data evolution. An empty array is encoded with an element count of zero and an empty
+element index; it is distinct from a null array.
+
 Key features:
 - **CRC32 Checksums**: Each blob entry has a CRC32 checksum for data integrity verification
 - **Indexed Access**: The index at the end enables efficient random access to any blob in the file
 - **Delta-Varint Compression**: The index uses delta-varint compression for space efficiency
 
 Limitations:
-1. BLOB format only supports a single BLOB type column per file.
+1. BLOB format only supports a single `BLOB` or `ARRAY<BLOB>` field per physical file.
 2. BLOB format does not support predicate pushdown.
 3. Statistics collection is not supported for BLOB columns.
 

--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -29,7 +29,7 @@ under the License.
 
 ## Overview
 
-The `BLOB` (Binary Large Object) type is a data type designed for storing multimodal data such as images, videos, audio files, and other large binary objects in Paimon tables. Unlike traditional `BYTES` type which stores binary data inline with other columns, `BLOB` type stores large binary data in separate files and maintains references to them, providing better performance for large objects.
+The `BLOB` (Binary Large Object) type is a data type designed for storing multimodal data such as images, videos, audio files, and other large binary objects in Paimon tables. Unlike traditional `BYTES` type which stores binary data inline with other columns, `BLOB` type stores large binary data in separate files and maintains references to them, providing better performance for large objects. A field can also use `ARRAY<BLOB>` to store an ordered collection of blobs, including null arrays and null elements.
 
 The Blob Storage is based on Data Evolution mode.
 
@@ -76,6 +76,7 @@ Paimon supports three storage modes for BLOB fields, selected via **comment dire
 
 1. **Default blob storage** (`__BLOB_FIELD`)
    Blob bytes are written to Paimon-managed `.blob` files under the table path.
+   This mode supports both `BLOB` and `ARRAY<BLOB>` fields.
 
 2. **Descriptor-only storage** (`__BLOB_DESCRIPTOR_FIELD`)
    Only serialized `BlobDescriptor` bytes are stored inline in data files. Paimon does not write `.blob` files for these fields, and writes must provide descriptor-based input.
@@ -84,6 +85,8 @@ Paimon supports three storage modes for BLOB fields, selected via **comment dire
    Serialized `BlobViewStruct` bytes are stored inline. The struct points to a BLOB value in an upstream table by table identifier, BLOB field, and row id. The actual blob bytes are resolved from the upstream table at read time.
 
 This allows one table to mix different storage modes for different BLOB columns.
+`ARRAY<BLOB>` is supported only by `__BLOB_FIELD`; descriptor-only and blob-view
+comment directives accept scalar BLOB fields only.
 
 ## Table Options
 
@@ -180,7 +183,8 @@ The recommended way to create a blob table in SQL is to use the **comment direct
 CREATE TABLE image_table (
     id INT,
     name STRING,
-    image BYTES COMMENT '__BLOB_FIELD; product image'
+    image BYTES COMMENT '__BLOB_FIELD; product image',
+    gallery ARRAY<BYTES> COMMENT '__BLOB_FIELD; product gallery'
 ) WITH (
     'row-tracking.enabled' = 'true',
     'data-evolution.enabled' = 'true'
@@ -206,7 +210,8 @@ CREATE TABLE media_table (
 CREATE TABLE image_table (
     id INT,
     name STRING,
-    image BINARY COMMENT '__BLOB_FIELD; product image'
+    image BINARY COMMENT '__BLOB_FIELD; product image',
+    gallery ARRAY<BINARY> COMMENT '__BLOB_FIELD; product gallery'
 ) TBLPROPERTIES (
     'row-tracking.enabled' = 'true',
     'data-evolution.enabled' = 'true'
@@ -218,11 +223,13 @@ CREATE TABLE image_table (
 <TabItem value="java" label="Java API">
 
 ```java
-// Java API uses BlobType directly, with comment directive for auto option registration
+// Comment directives convert binary source types and register the blob fields.
 Schema schema = Schema.newBuilder()
         .column("id", DataTypes.INT())
         .column("name", DataTypes.STRING())
         .column("image", DataTypes.BYTES(), "__BLOB_FIELD; product image")
+        .column("gallery", DataTypes.ARRAY(DataTypes.BYTES()),
+                "__BLOB_FIELD; product gallery")
         .option("row-tracking.enabled", "true")
         .option("data-evolution.enabled", "true")
         .build();
@@ -236,11 +243,12 @@ Schema schema = Schema.newBuilder()
 import pyarrow as pa
 from pypaimon import Schema
 
-# pa.large_binary() is automatically recognized as BLOB type
+# pa.large_binary() and list_(large_binary()) are recognized as blob types.
 pa_schema = pa.schema([
     ('id', pa.int32()),
     ('name', pa.string()),
     ('image', pa.large_binary()),
+    ('gallery', pa.list_(pa.large_binary())),
 ])
 
 schema = Schema.from_pyarrow_schema(
@@ -256,13 +264,13 @@ schema = Schema.from_pyarrow_schema(
 
 </Tabs>
 
-The comment directive format is `__DIRECTIVE; optional user comment`. Paimon converts the `BYTES`/`BINARY` type to `BLOB`, registers the field in the corresponding option, and stores the text after `;` as the column's real comment.
+The comment directive format is `__DIRECTIVE; optional user comment`. Paimon converts `BYTES`/`BINARY` to `BLOB` and `ARRAY<BYTES>`/`ARRAY<BINARY>` to `ARRAY<BLOB>`, registers the field in the corresponding option, and stores the text after `;` as the column's real comment.
 
 Supported directives:
 
 | Directive | Storage mode | Option |
 |-----------|-------------|--------|
-| `__BLOB_FIELD` | Raw bytes in `.blob` files | `blob-field` |
+| `__BLOB_FIELD` | Raw scalar or array elements in `.blob` files | `blob-field` |
 | `__BLOB_DESCRIPTOR_FIELD` | Descriptor bytes inline | `blob-descriptor-field` |
 | `__BLOB_VIEW_FIELD` | View reference inline | `blob-view-field` |
 
@@ -330,10 +338,10 @@ catalog.alter_table(
 <TabItem value="flink-sql" label="Flink SQL">
 
 ```sql
-INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A');
+INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
 
 INSERT INTO image_table
-SELECT id, name, content FROM source_table;
+SELECT id, name, content, CAST(NULL AS ARRAY<BYTES>) FROM source_table;
 ```
 
 </TabItem>
@@ -341,7 +349,7 @@ SELECT id, name, content FROM source_table;
 <TabItem value="spark-sql" label="Spark SQL">
 
 ```sql
-INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A');
+INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A', NULL);
 ```
 
 </TabItem>
@@ -352,7 +360,8 @@ INSERT INTO image_table VALUES (1, 'sample', X'89504E470D0A1A0A');
 GenericRow row = GenericRow.of(
         1,
         BinaryString.fromString("sample"),
-        new BlobData(imageBytes)
+        new BlobData(imageBytes),
+        null
 );
 write.write(row);
 ```
@@ -366,8 +375,54 @@ data = pa.table({
     'id': pa.array([1], type=pa.int32()),
     'name': pa.array(['sample']),
     'image': pa.array([b'\x89PNG\r\n\x1a\n'], type=pa.large_binary()),
+    'gallery': pa.array([None], type=pa.list_(pa.large_binary())),
 })
 writer.write_arrow(data)
+```
+
+</TabItem>
+
+</Tabs>
+
+For an `ARRAY<BLOB>` field, write an array of binary values. The array itself and
+individual elements may be null when the corresponding array and element types are
+nullable:
+
+<Tabs groupId="array-blob-insert">
+
+<TabItem value="flink-sql" label="Flink SQL">
+
+```sql
+INSERT INTO image_table
+VALUES (1, 'sample', X'89504E470D0A1A0A', ARRAY[X'01', NULL, X'02']);
+```
+
+</TabItem>
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+INSERT INTO image_table
+VALUES (1, 'sample', X'89504E470D0A1A0A', array(X'01', NULL, X'02'));
+```
+
+</TabItem>
+
+<TabItem value="java" label="Java API">
+
+```java
+GenericArray gallery = new GenericArray(new Object[] {
+        new BlobData(firstImageBytes), null, new BlobData(secondImageBytes)
+});
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python API">
+
+```python
+gallery_type = pa.list_(pa.large_binary())
+gallery = pa.array([[first_image, None, second_image]], type=gallery_type)
 ```
 
 </TabItem>
@@ -550,6 +605,7 @@ For the Python equivalent, see [Blob Storage in pypaimon](../pypaimon/blob).
 3. **No Statistics**: Statistics collection is not supported for blob columns.
 4. **Required Options**: `row-tracking.enabled` and `data-evolution.enabled` must be set to `true`.
 5. **Blob View Dependency**: Blob view fields depend on the referenced upstream table and row. If the upstream data is removed or no longer readable, the view cannot be resolved.
+6. **Array Storage Mode**: `ARRAY<BLOB>` is supported only for raw managed blob storage (`__BLOB_FIELD`), not for `__BLOB_DESCRIPTOR_FIELD` or `__BLOB_VIEW_FIELD`.
 
 ## Best Practices
 

--- a/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
@@ -103,12 +103,21 @@ public final class BlobType extends DataType {
         rowType.getFields()
                 .forEach(
                         field -> {
-                            DataTypeRoot type = field.type().getTypeRoot();
-                            if (type == DataTypeRoot.BLOB
+                            if (isBlobFileField(field.type())
                                     && !descriptorFields.contains(field.name())) {
                                 result.add(field);
                             }
                         });
         return result;
+    }
+
+    public static boolean isBlobFileField(DataType type) {
+        if (type.getTypeRoot() == DataTypeRoot.BLOB) {
+            return true;
+        }
+        if (type.getTypeRoot() == DataTypeRoot.ARRAY) {
+            return ((ArrayType) type).getElementType().getTypeRoot() == DataTypeRoot.BLOB;
+        }
+        return false;
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobArrayPlaceholder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobArrayPlaceholder.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import org.apache.paimon.data.variant.Variant;
+
+import java.io.Serializable;
+
+/**
+ * Placeholder for an array blob field in data-evolution blob files. It should never be exposed to
+ * users.
+ */
+public final class BlobArrayPlaceholder implements InternalArray, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final BlobArrayPlaceholder INSTANCE = new BlobArrayPlaceholder();
+
+    private BlobArrayPlaceholder() {}
+
+    private Object readResolve() {
+        return INSTANCE;
+    }
+
+    private static UnsupportedOperationException unsupported() {
+        return new UnsupportedOperationException(
+                "Should never call this method for placeholder blob array.");
+    }
+
+    @Override
+    public int size() {
+        throw unsupported();
+    }
+
+    @Override
+    public boolean isNullAt(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public boolean getBoolean(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public byte getByte(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public short getShort(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public int getInt(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public long getLong(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public float getFloat(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public double getDouble(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public BinaryString getString(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public Decimal getDecimal(int pos, int precision, int scale) {
+        throw unsupported();
+    }
+
+    @Override
+    public Timestamp getTimestamp(int pos, int precision) {
+        throw unsupported();
+    }
+
+    @Override
+    public byte[] getBinary(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public Blob getBlob(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalArray getArray(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalVector getVector(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalMap getMap(int pos) {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalRow getRow(int pos, int numFields) {
+        throw unsupported();
+    }
+
+    @Override
+    public boolean[] toBooleanArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public short[] toShortArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public int[] toIntArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public long[] toLongArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public float[] toFloatArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public double[] toDoubleArray() {
+        throw unsupported();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/InternalRow.java
@@ -153,6 +153,8 @@ public interface InternalRow extends DataGetters {
                 return InternalMap.class;
             case ROW:
                 return InternalRow.class;
+            case BLOB:
+                return Blob.class;
             default:
                 throw new IllegalArgumentException("Illegal type: " + type);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -59,7 +59,7 @@ import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETIO
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
 import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
-import static org.apache.paimon.types.DataTypeRoot.BLOB;
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -114,7 +114,7 @@ public class DataEvolutionCompactCoordinator {
                                 ? table.rowType().getFields().stream()
                                         .filter(
                                                 field ->
-                                                        field.type().is(BLOB)
+                                                        isBlobFileField(field.type())
                                                                 && !blobInlineFields.contains(
                                                                         field.name()))
                                         .map(DataField::id)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AllPlaceholdersRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AllPlaceholdersRecordReader.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -25,6 +26,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 
@@ -41,6 +43,7 @@ class AllPlaceholdersRecordReader implements FileRecordReader<InternalRow> {
     private final long firstRowId;
     private final int fieldCount;
     private final int blobIndex;
+    private final Object blobPlaceholder;
     private final int rowIdIndex;
     private final int seqNumIndex;
     private final long sequenceNumber;
@@ -57,6 +60,10 @@ class AllPlaceholdersRecordReader implements FileRecordReader<InternalRow> {
         this.firstRowId = firstRowId;
         this.fieldCount = readRowType.getFieldCount();
         this.blobIndex = blobIndex;
+        this.blobPlaceholder =
+                readRowType.getTypeAt(blobIndex).getTypeRoot() == DataTypeRoot.ARRAY
+                        ? BlobArrayPlaceholder.INSTANCE
+                        : BlobPlaceholder.INSTANCE;
         this.rowIdIndex = readRowType.getFieldIndex(SpecialFields.ROW_ID.name());
         this.seqNumIndex = readRowType.getFieldIndex(SpecialFields.SEQUENCE_NUMBER.name());
         this.sequenceNumber = sequenceNumber;
@@ -95,7 +102,7 @@ class AllPlaceholdersRecordReader implements FileRecordReader<InternalRow> {
 
     private InternalRow placeholderRow(long rowId) {
         GenericRow row = new GenericRow(fieldCount);
-        row.setField(blobIndex, BlobPlaceholder.INSTANCE);
+        row.setField(blobIndex, blobPlaceholder);
         if (rowIdIndex >= 0) {
             row.setField(rowIdIndex, rowId);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.append.ForceSingleBatchReader;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -28,6 +29,7 @@ import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.ReaderSupplier;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.Range;
@@ -63,6 +65,8 @@ public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
     private final int fieldCount;
     private final int rowIdIndex;
     private final int seqNumIndex;
+    private final Object blobPlaceholder;
+    private final InternalRow.FieldGetter blobGetter;
     private boolean returned;
 
     BlobFallbackRecordReader(
@@ -77,6 +81,9 @@ public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
         this.fieldCount = readRowType.getFieldCount();
         this.rowIdIndex = readRowType.getFieldIndex(SpecialFields.ROW_ID.name());
         this.seqNumIndex = readRowType.getFieldIndex(SpecialFields.SEQUENCE_NUMBER.name());
+        this.blobPlaceholder = blobPlaceholder(readRowType, blobIndex);
+        this.blobGetter =
+                InternalRow.createFieldGetter(readRowType.getTypeAt(blobIndex), blobIndex);
 
         checkArgument(!files.isEmpty(), "Blob bunch should not be empty.");
         long firstRowId = Long.MAX_VALUE;
@@ -217,7 +224,13 @@ public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
     }
 
     private boolean isPlaceHolder(InternalRow row) {
-        return !row.isNullAt(blobIndex) && row.getBlob(blobIndex) == BlobPlaceholder.INSTANCE;
+        return blobGetter.getFieldOrNull(row) == blobPlaceholder;
+    }
+
+    private static Object blobPlaceholder(RowType rowType, int blobIndex) {
+        return rowType.getTypeAt(blobIndex).getTypeRoot() == DataTypeRoot.ARRAY
+                ? BlobArrayPlaceholder.INSTANCE
+                : BlobPlaceholder.INSTANCE;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
@@ -61,7 +61,6 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
 
     private final List<RecordReader<InternalRow>> groupReaders = new ArrayList<>();
-    private final int blobIndex;
     private final int fieldCount;
     private final int rowIdIndex;
     private final int seqNumIndex;
@@ -77,7 +76,6 @@ public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
             RowType readRowType,
             int blobIndex)
             throws IOException {
-        this.blobIndex = blobIndex;
         this.fieldCount = readRowType.getFieldCount();
         this.rowIdIndex = readRowType.getFieldIndex(SpecialFields.ROW_ID.name());
         this.seqNumIndex = readRowType.getFieldIndex(SpecialFields.SEQUENCE_NUMBER.name());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
@@ -20,16 +20,13 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BlobConsumer;
-import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 
 import javax.annotation.Nullable;
 
 import java.util.Set;
-
-import static org.apache.paimon.types.DataTypeRoot.BLOB;
 
 /** Context for blob file. */
 public class BlobFileContext {
@@ -40,7 +37,6 @@ public class BlobFileContext {
     private final boolean writeNullOnFetchFailure;
 
     private @Nullable BlobConsumer blobConsumer;
-    private BlobFetchMetricReporter blobFetchMetricReporter = BlobFetchMetricReporter.NOOP;
 
     private BlobFileContext(
             Set<String> blobDescriptorFields,
@@ -55,15 +51,14 @@ public class BlobFileContext {
 
     @Nullable
     public static BlobFileContext create(RowType rowType, CoreOptions options) {
-        if (rowType.getFieldTypes().stream().noneMatch(t -> t.is(BLOB))) {
+        if (rowType.getFieldTypes().stream().noneMatch(BlobType::isBlobFileField)) {
             return null;
         }
         Set<String> descriptorFields = options.blobDescriptorField();
         Set<String> inlineFields = options.blobInlineField();
         boolean requireBlobFile = false;
         for (DataField field : rowType.getFields()) {
-            DataTypeRoot type = field.type().getTypeRoot();
-            if (type == DataTypeRoot.BLOB && !inlineFields.contains(field.name())) {
+            if (BlobType.isBlobFileField(field.type()) && !inlineFields.contains(field.name())) {
                 requireBlobFile = true;
                 break;
             }
@@ -83,14 +78,8 @@ public class BlobFileContext {
         return this;
     }
 
-    public BlobFileContext withBlobFetchMetricReporter(
-            BlobFetchMetricReporter blobFetchMetricReporter) {
-        this.blobFetchMetricReporter = blobFetchMetricReporter;
-        return this;
-    }
-
     public BlobFileContext withWriteType(RowType writeType) {
-        if (writeType.getFieldTypes().stream().noneMatch(t -> t.is(BLOB))) {
+        if (writeType.getFieldTypes().stream().noneMatch(BlobType::isBlobFileField)) {
             return null;
         }
         return this;
@@ -115,9 +104,5 @@ public class BlobFileContext {
 
     public boolean writeNullOnFetchFailure() {
         return writeNullOnFetchFailure;
-    }
-
-    public BlobFetchMetricReporter blobFetchMetricReporter() {
-        return blobFetchMetricReporter;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFileContext.java
@@ -20,6 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
@@ -37,6 +38,7 @@ public class BlobFileContext {
     private final boolean writeNullOnFetchFailure;
 
     private @Nullable BlobConsumer blobConsumer;
+    private BlobFetchMetricReporter blobFetchMetricReporter = BlobFetchMetricReporter.NOOP;
 
     private BlobFileContext(
             Set<String> blobDescriptorFields,
@@ -78,6 +80,12 @@ public class BlobFileContext {
         return this;
     }
 
+    public BlobFileContext withBlobFetchMetricReporter(
+            BlobFetchMetricReporter blobFetchMetricReporter) {
+        this.blobFetchMetricReporter = blobFetchMetricReporter;
+        return this;
+    }
+
     public BlobFileContext withWriteType(RowType writeType) {
         if (writeType.getFieldTypes().stream().noneMatch(BlobType::isBlobFileField)) {
             return null;
@@ -104,5 +112,9 @@ public class BlobFileContext {
 
     public boolean writeNullOnFetchFailure() {
         return writeNullOnFetchFailure;
+    }
+
+    public BlobFetchMetricReporter blobFetchMetricReporter() {
+        return blobFetchMetricReporter;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -50,7 +50,6 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.FormatReaderMapping;
@@ -80,6 +79,7 @@ import static java.util.Collections.reverseOrder;
 import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.table.SpecialFields.rowTypeWithRowTracking;
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -448,7 +448,7 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
     private static int findBlobFieldIndex(RowType rowType) {
         for (int i = 0; i < rowType.getFieldCount(); i++) {
-            if (rowType.getTypeAt(i).getTypeRoot() == DataTypeRoot.BLOB) {
+            if (isBlobFileField(rowType.getTypeAt(i))) {
                 return i;
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
@@ -221,16 +221,39 @@ public final class ColumnDirectiveUtils {
             return new VectorType(sourceType.isNullable(), directive.vectorDim(), elementType);
         } else {
             DataTypeRoot root = sourceType.getTypeRoot();
+            if (root == DataTypeRoot.ARRAY) {
+                Preconditions.checkArgument(
+                        CoreOptions.BLOB_FIELD.key().equals(directive.optionKey()),
+                        "Column %s declared with '%s' must be of BYTES, BINARY or BLOB type, but was %s. "
+                                + "ARRAY<BLOB> is only supported by '%s'.",
+                        fieldName,
+                        directive.optionKey(),
+                        sourceType,
+                        CoreOptions.BLOB_FIELD.key());
+                DataType elementType = ((ArrayType) sourceType).getElementType();
+                Preconditions.checkArgument(
+                        isBlobSourceRoot(elementType.getTypeRoot()),
+                        "Column %s declared with a BLOB directive must be of BYTES, BINARY, "
+                                + "BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type, but was %s.",
+                        fieldName,
+                        sourceType);
+                return new ArrayType(
+                        sourceType.isNullable(), new BlobType(elementType.isNullable()));
+            }
             Preconditions.checkArgument(
-                    root == DataTypeRoot.VARBINARY
-                            || root == DataTypeRoot.BINARY
-                            || root == DataTypeRoot.BLOB,
-                    "Column %s declared with a BLOB directive must be of BYTES, "
-                            + "BINARY or BLOB type, but was %s.",
+                    isBlobSourceRoot(root),
+                    "Column %s declared with a BLOB directive must be of BYTES, BINARY, "
+                            + "BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type, but was %s.",
                     fieldName,
                     sourceType);
             return new BlobType(sourceType.isNullable());
         }
+    }
+
+    private static boolean isBlobSourceRoot(DataTypeRoot root) {
+        return root == DataTypeRoot.VARBINARY
+                || root == DataTypeRoot.BINARY
+                || root == DataTypeRoot.BLOB;
     }
 
     /**
@@ -279,19 +302,19 @@ public final class ColumnDirectiveUtils {
             new ConfigOption[] {CoreOptions.VECTOR_FIELD};
 
     /**
-     * Remove directive-managed options when a BLOB or VECTOR column is dropped. Only acts on BLOB
-     * or VECTOR type columns; other types are ignored.
+     * Remove directive-managed options when a BLOB or VECTOR column is dropped. Only acts on BLOB,
+     * {@code ARRAY<BLOB>} or VECTOR type columns; other types are ignored.
      */
     public static void removeDroppedDirectiveOptions(
-            String fieldName, DataTypeRoot typeRoot, Map<String, String> options) {
-        if (typeRoot == DataTypeRoot.BLOB) {
+            String fieldName, DataType type, Map<String, String> options) {
+        if (BlobType.isBlobFileField(type)) {
             for (ConfigOption<String> option : BLOB_OPTIONS) {
                 removeFromCsvOption(option.key(), fieldName, options);
                 for (FallbackKey fk : option.fallbackKeys()) {
                     removeFromCsvOption(fk.getKey(), fieldName, options);
                 }
             }
-        } else if (typeRoot == DataTypeRoot.VECTOR) {
+        } else if (type.getTypeRoot() == DataTypeRoot.VECTOR) {
             for (ConfigOption<String> option : VECTOR_OPTIONS) {
                 removeFromCsvOption(option.key(), fieldName, options);
                 for (FallbackKey fk : option.fallbackKeys()) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -43,7 +43,6 @@ import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeCasts;
-import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.ReassignFieldId;
 import org.apache.paimon.types.RowType;
@@ -104,6 +103,7 @@ import static org.apache.paimon.catalog.Identifier.UNKNOWN_DATABASE;
 import static org.apache.paimon.mergetree.compact.PartialUpdateMergeFunction.SEQUENCE_GROUP;
 import static org.apache.paimon.schema.ColumnDirectiveUtils.applyAddColumnDirective;
 import static org.apache.paimon.schema.ColumnDirectiveUtils.applyDirectives;
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.utils.DefaultValueUtils.validateDefaultValue;
 import static org.apache.paimon.utils.FileUtils.listVersionedFiles;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
@@ -478,7 +478,7 @@ public class SchemaManager implements Serializable {
                             .ifPresent(
                                     f ->
                                             ColumnDirectiveUtils.removeDroppedDirectiveOptions(
-                                                    dropName, f.type().getTypeRoot(), newOptions));
+                                                    dropName, f.type(), newOptions));
                 }
                 new NestedColumnModifier(drop.fieldNames(), lazyIdentifier) {
                     @Override
@@ -977,7 +977,7 @@ public class SchemaManager implements Serializable {
         }
         String fieldName = fieldNames[0];
         for (DataField field : fields) {
-            if (field.name().equals(fieldName) && field.type().is(DataTypeRoot.BLOB)) {
+            if (field.name().equals(fieldName) && isBlobFileField(field.type())) {
                 throw new UnsupportedOperationException(
                         String.format("Cannot rename BLOB column: [%s]", fieldName));
             }
@@ -1007,8 +1007,8 @@ public class SchemaManager implements Serializable {
             if (!field.name().equals(fieldName)) {
                 continue;
             }
-            boolean wasBlob = field.type().is(DataTypeRoot.BLOB);
-            boolean willBeBlob = newType.is(DataTypeRoot.BLOB);
+            boolean wasBlob = isBlobFileField(field.type());
+            boolean willBeBlob = isBlobFileField(newType);
             if (wasBlob || willBeBlob) {
                 throw new UnsupportedOperationException(
                         String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -92,6 +92,7 @@ import static org.apache.paimon.table.PrimaryKeyTableUtils.createMergeFunctionFa
 import static org.apache.paimon.table.SpecialFields.KEY_FIELD_PREFIX;
 import static org.apache.paimon.table.SpecialFields.SYSTEM_FIELD_NAMES;
 import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.types.DataTypeRoot.ARRAY;
 import static org.apache.paimon.types.DataTypeRoot.MAP;
 import static org.apache.paimon.types.DataTypeRoot.MULTISET;
@@ -1100,19 +1101,19 @@ public class SchemaValidation {
         List<DataField> fields = schema.fields();
         List<String> blobNames =
                 fields.stream()
-                        .filter(field -> field.type().is(DataTypeRoot.BLOB))
+                        .filter(field -> isBlobFileField(field.type()))
                         .map(DataField::name)
                         .collect(Collectors.toList());
         if (!blobNames.isEmpty()) {
             checkArgument(
                     options.dataEvolutionEnabled(),
-                    "Data evolution config must enabled for table with BLOB type column.");
+                    "Data evolution config must enabled for table with BLOB or ARRAY<BLOB> type column.");
             checkArgument(
                     fields.size() > blobNames.size(),
-                    "Table with BLOB type column must have other normal columns.");
+                    "Table with BLOB or ARRAY<BLOB> type column must have other normal columns.");
             checkArgument(
                     blobNames.stream().noneMatch(schema.partitionKeys()::contains),
-                    "The BLOB type column can not be part of partition keys.");
+                    "The BLOB or ARRAY<BLOB> type column can not be part of partition keys.");
         }
 
         FileFormat vectorFileFormat = vectorFileFormat(options);
@@ -1136,7 +1137,7 @@ public class SchemaValidation {
     private static void validateBlobFields(RowType rowType, CoreOptions options) {
         Set<String> blobFieldNames =
                 rowType.getFields().stream()
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.BLOB)
+                        .filter(field -> isBlobFileField(field.type()))
                         .map(DataField::name)
                         .collect(Collectors.toCollection(HashSet::new));
         Set<String> configured =
@@ -1145,7 +1146,7 @@ public class SchemaValidation {
         for (String field : configured) {
             checkArgument(
                     blobFieldNames.contains(field),
-                    "Field '%s' in '%s' must be a BLOB field in table schema.",
+                    "Field '%s' in '%s' must be a BLOB field or ARRAY<BLOB> field in table schema.",
                     field,
                     CoreOptions.BLOB_FIELD.key());
         }
@@ -1161,9 +1162,11 @@ public class SchemaValidation {
         for (String field : configured) {
             checkArgument(
                     blobFieldNames.contains(field),
-                    "Field '%s' in '%s' must be a BLOB field in table schema.",
+                    "Field '%s' in '%s' must be a BLOB field in table schema. "
+                            + "ARRAY<BLOB> is only supported by '%s'.",
                     field,
-                    CoreOptions.BLOB_DESCRIPTOR_FIELD.key());
+                    CoreOptions.BLOB_DESCRIPTOR_FIELD.key(),
+                    CoreOptions.BLOB_FIELD.key());
         }
         return configured;
     }
@@ -1179,9 +1182,11 @@ public class SchemaValidation {
         for (String field : configured) {
             checkArgument(
                     blobFieldNames.contains(field),
-                    "Field '%s' in '%s' must be a BLOB field in table schema.",
+                    "Field '%s' in '%s' must be a BLOB field in table schema. "
+                            + "ARRAY<BLOB> is only supported by '%s'.",
                     field,
-                    CoreOptions.BLOB_VIEW_FIELD.key());
+                    CoreOptions.BLOB_VIEW_FIELD.key(),
+                    CoreOptions.BLOB_FIELD.key());
             checkArgument(
                     !blobDescriptorFields.contains(field),
                     "Field '%s' in '%s' can not also be in '%s'.",

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -29,7 +29,9 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BinaryVector;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.DataFormatTestUtil;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.variant.GenericVariant;
 import org.apache.paimon.deletionvectors.BitmapDeletionVector;
@@ -86,6 +88,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -1326,6 +1329,96 @@ public class JavaPyE2ETest {
         LOG.info(
                 "testReadRowAppendTable: Java read {} ROW-format rows written by Python",
                 res.size());
+    }
+
+    /** Java writes an ARRAY&lt;BLOB&gt; table for Python to read. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaWriteArrayBlobTable() throws Exception {
+        Identifier identifier = identifier("array_blob_java_test");
+        catalog.dropTable(identifier, true);
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("payloads", DataTypes.ARRAY(DataTypes.BLOB()))
+                        .option(ROW_TRACKING_ENABLED.key(), "true")
+                        .option(DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(BUCKET.key(), "-1")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(
+                    GenericRow.of(
+                            1,
+                            new GenericArray(
+                                    new Object[] {
+                                        new BlobData("java-alpha".getBytes(StandardCharsets.UTF_8)),
+                                        null,
+                                        new BlobData(new byte[0])
+                                    })));
+            write.write(GenericRow.of(2, new GenericArray(new Object[0])));
+            write.write(GenericRow.of(3, null));
+            write.write(
+                    GenericRow.of(
+                            4,
+                            new GenericArray(
+                                    new Object[] {
+                                        new BlobData("java-omega".getBytes(StandardCharsets.UTF_8))
+                                    })));
+            commit.commit(write.prepareCommit());
+        }
+
+        assertArrayBlobRows(readArrayBlobRows(table), "java-alpha", "java-omega");
+    }
+
+    /** Java reads an ARRAY&lt;BLOB&gt; table written by Python. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaReadArrayBlobTable() throws Exception {
+        FileStoreTable table =
+                (FileStoreTable) catalog.getTable(identifier("array_blob_python_test"));
+        assertArrayBlobRows(readArrayBlobRows(table), "python-alpha", "python-omega");
+    }
+
+    private Map<Integer, List<byte[]>> readArrayBlobRows(FileStoreTable table) throws Exception {
+        Map<Integer, List<byte[]>> rows = new HashMap<>();
+        List<Split> splits = new ArrayList<>(table.newSnapshotReader().read().dataSplits());
+        try (org.apache.paimon.reader.RecordReader<InternalRow> reader =
+                table.newRead().createReader(splits)) {
+            reader.forEachRemaining(
+                    row -> {
+                        int id = row.getInt(0);
+                        if (row.isNullAt(1)) {
+                            rows.put(id, null);
+                            return;
+                        }
+
+                        InternalArray array = row.getArray(1);
+                        List<byte[]> values = new ArrayList<>(array.size());
+                        for (int i = 0; i < array.size(); i++) {
+                            values.add(array.isNullAt(i) ? null : array.getBlob(i).toData());
+                        }
+                        rows.put(id, values);
+                    });
+        }
+        return rows;
+    }
+
+    private void assertArrayBlobRows(
+            Map<Integer, List<byte[]>> rows, String firstValue, String lastValue) {
+        assertThat(rows).containsOnlyKeys(1, 2, 3, 4);
+        assertThat(rows.get(1)).hasSize(3);
+        assertThat(rows.get(1).get(0)).isEqualTo(firstValue.getBytes(StandardCharsets.UTF_8));
+        assertThat(rows.get(1).get(1)).isNull();
+        assertThat(rows.get(1).get(2)).isEmpty();
+        assertThat(rows.get(2)).isEmpty();
+        assertThat(rows.get(3)).isNull();
+        assertThat(rows.get(4)).hasSize(1);
+        assertThat(rows.get(4).get(0)).isEqualTo(lastValue.getBytes(StandardCharsets.UTF_8));
     }
 
     /** Java writes a VARIANT-column table for Python to read (Java→Python E2E). */

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -210,9 +210,10 @@ public class BlobTableTest extends TableTestBase {
         assertArrayBlobRows(blob0, blob1, updatedBlob1, blob2);
 
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
         List<CommitMessage> compactMessages = new ArrayList<>();
         for (DataEvolutionCompactTask task : tasks) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -24,12 +24,15 @@ import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.BlobViewStruct;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIO;
@@ -151,6 +154,98 @@ public class BlobTableTest extends TableTestBase {
                 });
 
         assertThat(integer.get()).isEqualTo(1000);
+    }
+
+    @Test
+    public void testArrayBlobField() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.ARRAY(DataTypes.BLOB()));
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "25 MB");
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        byte[] blob0 = "blob-0".getBytes();
+        byte[] blob1 = "blob-1".getBytes();
+        byte[] blob2 = "blob-2".getBytes();
+        writeDataDefault(
+                Arrays.asList(
+                        GenericRow.of(
+                                0,
+                                new GenericArray(
+                                        new Object[] {
+                                            new BlobData(blob0), null, new BlobData(blob1)
+                                        })),
+                        GenericRow.of(1, null),
+                        GenericRow.of(2, new GenericArray(new Object[] {new BlobData(blob2)}))));
+
+        FileStoreTable table = getTableDefault();
+        List<DataFileMeta> filesMetas =
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList());
+        List<DataEvolutionSplitRead.FieldBunch> fieldGroups =
+                DataEvolutionSplitRead.splitFieldBunches(filesMetas, file -> table.rowType());
+        assertThat(fieldGroups.size()).isEqualTo(2);
+        assertThat(countFilesWithSuffix(table.fileIO(), table.location(), ".blob")).isEqualTo(1);
+
+        assertArrayBlobRows(blob0, blob1, null, blob2);
+
+        byte[] updatedBlob1 = "updated-blob-1".getBytes();
+        RowType blobWriteType = table.schema().logicalRowType().project("f1");
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite().withWriteType(blobWriteType);
+                BatchTableCommit commit = builder.newCommit()) {
+            write.write(GenericRow.of(BlobArrayPlaceholder.INSTANCE));
+            write.write(GenericRow.of(new GenericArray(new Object[] {new BlobData(updatedBlob1)})));
+            write.write(GenericRow.of(BlobArrayPlaceholder.INSTANCE));
+
+            List<CommitMessage> commitMessages = write.prepareCommit();
+            assignFirstRowId(commitMessages, 0L);
+            commit.commit(commitMessages);
+        }
+
+        assertArrayBlobRows(blob0, blob1, updatedBlob1, blob2);
+
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(table, true, false);
+        List<DataEvolutionCompactTask> tasks = coordinator.plan();
+        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+
+        List<CommitMessage> compactMessages = new ArrayList<>();
+        for (DataEvolutionCompactTask task : tasks) {
+            compactMessages.add(task.doCompact(table, commitUser));
+        }
+        commitDefault(compactMessages);
+
+        assertArrayBlobRows(blob0, blob1, updatedBlob1, blob2);
+    }
+
+    private void assertArrayBlobRows(byte[] blob0, byte[] blob1, byte[] updatedBlob1, byte[] blob2)
+            throws Exception {
+        Map<Integer, InternalArray> actual = new HashMap<>();
+        readDefault(row -> actual.put(row.getInt(0), row.getArray(1)));
+
+        assertThat(actual.size()).isEqualTo(3);
+        InternalArray first = actual.get(0);
+        assertThat(first.size()).isEqualTo(3);
+        assertThat(first.getBlob(0).toData()).isEqualTo(blob0);
+        assertThat(first.isNullAt(1)).isTrue();
+        assertThat(first.getBlob(2).toData()).isEqualTo(blob1);
+
+        if (updatedBlob1 == null) {
+            assertThat(actual.get(1)).isNull();
+        } else {
+            InternalArray second = actual.get(1);
+            assertThat(second.size()).isEqualTo(1);
+            assertThat(second.getBlob(0).toData()).isEqualTo(updatedBlob1);
+        }
+
+        InternalArray third = actual.get(2);
+        assertThat(third.size()).isEqualTo(1);
+        assertThat(third.getBlob(0).toData()).isEqualTo(blob2);
     }
 
     @Test
@@ -490,6 +585,41 @@ public class BlobTableTest extends TableTestBase {
                 "blob_descriptor_without_blob_field", CoreOptions.BLOB_DESCRIPTOR_FIELD.key());
         assertCreateBlobInlineFieldWithoutBlobField(
                 "blob_view_without_blob_field", CoreOptions.BLOB_VIEW_FIELD.key());
+    }
+
+    @Test
+    public void testBlobInlineFieldRejectsArrayBlob() {
+        assertArrayBlobInlineOptionRejected(CoreOptions.BLOB_DESCRIPTOR_FIELD.key());
+        assertArrayBlobInlineOptionRejected(CoreOptions.BLOB_VIEW_FIELD.key());
+    }
+
+    private void assertArrayBlobInlineOptionRejected(String optionKey) {
+        assertThatThrownBy(
+                        () -> {
+                            Schema.Builder schemaBuilder = Schema.newBuilder();
+                            schemaBuilder.column("f0", DataTypes.INT());
+                            schemaBuilder.column("f1", DataTypes.ARRAY(DataTypes.BLOB()));
+                            schemaBuilder.column("f2", DataTypes.BLOB());
+                            schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "25 MB");
+                            schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+                            schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+                            schemaBuilder.option(optionKey, "f1");
+                            catalog.createTable(
+                                    identifier(
+                                            "array_blob_inline_reject_"
+                                                    + optionKey
+                                                            .replace('-', '_')
+                                                            .replace('.', '_')),
+                                    schemaBuilder.build(),
+                                    true);
+                        })
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasRootCauseMessage(
+                        "Field 'f1' in '"
+                                + optionKey
+                                + "' must be a BLOB field in table schema. ARRAY<BLOB> is only supported by '"
+                                + CoreOptions.BLOB_FIELD.key()
+                                + "'.");
     }
 
     private void assertCreateBlobInlineFieldWithoutBlobField(String tableName, String optionKey)

--- a/paimon-core/src/test/java/org/apache/paimon/operation/BlobFallbackRecordReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/BlobFallbackRecordReaderTest.java
@@ -18,9 +18,12 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.BlobPlaceholder;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.deletionvectors.ApplyDeletionVectorReader;
@@ -74,6 +77,14 @@ public class BlobFallbackRecordReaderTest {
                             new DataField(BLOB_INDEX, BLOB_FIELD, DataTypes.BLOB()),
                             new DataField(
                                     1, SpecialFields.SEQUENCE_NUMBER.name(), DataTypes.BIGINT())));
+    private static final RowType READ_ARRAY_ROW_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new DataField(
+                                    BLOB_INDEX, BLOB_FIELD, DataTypes.ARRAY(DataTypes.BLOB())),
+                            new DataField(1, SpecialFields.ROW_ID.name(), DataTypes.BIGINT()),
+                            new DataField(
+                                    2, SpecialFields.SEQUENCE_NUMBER.name(), DataTypes.BIGINT())));
 
     @Test
     public void testBlobSequenceGroupReaderWithRowRanges() throws Exception {
@@ -259,6 +270,40 @@ public class BlobFallbackRecordReaderTest {
         assertThat(rows.sequenceNumbers).containsExactly(2L, 1L, 2L, 1L, 1L);
     }
 
+    @Test
+    public void testArrayBlobFallbackRecordReader() throws Exception {
+        DataFileMeta newFile = blobFile("new-array-file", 0, 3, 2);
+        DataFileMeta oldFile = blobFile("old-array-file", 0, 5, 1);
+        Set<String> placeholderRows = placeholderRows(newFile, 1);
+
+        try (RecordReader<InternalRow> reader =
+                new BlobFallbackRecordReader(
+                        Arrays.asList(newFile, oldFile),
+                        file -> oneRowPerBatchReader(file, arrayFileRows(file, placeholderRows)),
+                        (placeholderReader, range) -> placeholderReader,
+                        null,
+                        READ_ARRAY_ROW_TYPE,
+                        BLOB_INDEX)) {
+            List<Long> rowIds = new ArrayList<>();
+            List<Long> sequenceNumbers = new ArrayList<>();
+
+            RecordIterator<InternalRow> batch;
+            while ((batch = reader.readBatch()) != null) {
+                InternalRow row;
+                while ((row = batch.next()) != null) {
+                    InternalArray array = row.getArray(BLOB_INDEX);
+                    assertThat(array).isNotSameAs(BlobArrayPlaceholder.INSTANCE);
+                    rowIds.add(row.getLong(1));
+                    sequenceNumbers.add(row.getLong(2));
+                }
+                batch.releaseBatch();
+            }
+
+            assertThat(rowIds).containsExactly(0L, 1L, 2L, 3L, 4L);
+            assertThat(sequenceNumbers).containsExactly(2L, 1L, 2L, 1L, 1L);
+        }
+    }
+
     private static ReadResult readFallback(
             List<DataFileMeta> files, List<Range> rowRanges, Set<String> placeholderRows)
             throws Exception {
@@ -362,6 +407,19 @@ public class BlobFallbackRecordReaderTest {
         return rows;
     }
 
+    private static List<InternalRow> arrayFileRows(DataFileMeta file, Set<String> placeholderRows) {
+        List<InternalRow> rows = new ArrayList<>();
+        long lastRowId = file.nonNullFirstRowId() + file.rowCount() - 1;
+        for (long rowId = file.nonNullFirstRowId(); rowId <= lastRowId; rowId++) {
+            rows.add(
+                    arrayBlobRow(
+                            rowId,
+                            file.maxSequenceNumber(),
+                            placeholderRows.contains(rowKey(file, rowId))));
+        }
+        return rows;
+    }
+
     private static boolean selected(long rowId, List<Range> rowRanges) {
         if (rowRanges == null) {
             return true;
@@ -426,6 +484,18 @@ public class BlobFallbackRecordReaderTest {
         row.setField(
                 BLOB_INDEX,
                 placeholder ? BlobPlaceholder.INSTANCE : new BlobData(new byte[] {(byte) rowId}));
+        row.setField(1, rowId);
+        row.setField(2, sequenceNumber);
+        return row;
+    }
+
+    private static InternalRow arrayBlobRow(long rowId, long sequenceNumber, boolean placeholder) {
+        GenericRow row = new GenericRow(3);
+        row.setField(
+                BLOB_INDEX,
+                placeholder
+                        ? BlobArrayPlaceholder.INSTANCE
+                        : new GenericArray(new Object[] {new BlobData(new byte[] {(byte) rowId})}));
         row.setField(1, rowId);
         row.setField(2, sequenceNumber);
         return row;

--- a/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.schema;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
@@ -160,6 +162,24 @@ public class ColumnDirectiveUtilsTest {
         assertThat(result.type().getTypeRoot()).isEqualTo(DataTypeRoot.BLOB);
     }
 
+    @Test
+    public void testBlobDirectiveWithArraySourceType() {
+        Map<String, String> opts = new HashMap<>();
+        ColumnDirectiveUtils.ConvertedColumn result =
+                ColumnDirectiveUtils.applyAddColumnDirective(
+                        "__BLOB_FIELD",
+                        "images",
+                        new ArrayType(false, DataTypes.BYTES().copy(false)),
+                        opts);
+
+        assertThat(result).isNotNull();
+        assertThat(result.type().getTypeRoot()).isEqualTo(DataTypeRoot.ARRAY);
+        assertThat(result.type().isNullable()).isFalse();
+        BlobType elementType = (BlobType) ((ArrayType) result.type()).getElementType();
+        assertThat(elementType.isNullable()).isFalse();
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "images");
+    }
+
     // -- applyAddColumnDirective error cases --
 
     @Test
@@ -169,7 +189,30 @@ public class ColumnDirectiveUtilsTest {
                                 ColumnDirectiveUtils.applyAddColumnDirective(
                                         "__BLOB_FIELD", "col", DataTypes.INT(), new HashMap<>()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("must be of BYTES, BINARY or BLOB type");
+                .hasMessageContaining(
+                        "must be of BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type");
+    }
+
+    @Test
+    public void testInlineBlobDirectivesRejectArraySourceType() {
+        assertThatThrownBy(
+                        () ->
+                                ColumnDirectiveUtils.applyAddColumnDirective(
+                                        "__BLOB_DESCRIPTOR_FIELD",
+                                        "images",
+                                        DataTypes.ARRAY(DataTypes.BYTES()),
+                                        new HashMap<>()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ARRAY<BLOB> is only supported by 'blob-field'");
+        assertThatThrownBy(
+                        () ->
+                                ColumnDirectiveUtils.applyAddColumnDirective(
+                                        "__BLOB_VIEW_FIELD",
+                                        "images",
+                                        DataTypes.ARRAY(DataTypes.BYTES()),
+                                        new HashMap<>()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ARRAY<BLOB> is only supported by 'blob-field'");
     }
 
     @Test
@@ -317,7 +360,7 @@ public class ColumnDirectiveUtilsTest {
         opts.put("blob.stored-descriptor-fields", "b,legacy");
         opts.put(CoreOptions.VECTOR_FIELD.key(), "v");
 
-        ColumnDirectiveUtils.removeDroppedDirectiveOptions("b", DataTypeRoot.BLOB, opts);
+        ColumnDirectiveUtils.removeDroppedDirectiveOptions("b", DataTypes.BLOB(), opts);
 
         assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "a");
         assertThat(opts).containsEntry(CoreOptions.BLOB_DESCRIPTOR_FIELD.key(), "c");
@@ -327,13 +370,25 @@ public class ColumnDirectiveUtilsTest {
     }
 
     @Test
+    public void testRemoveDroppedArrayBlobOptions() {
+        Map<String, String> opts = new HashMap<>();
+        opts.put(CoreOptions.BLOB_FIELD.key(), "images,other");
+
+        ColumnDirectiveUtils.removeDroppedDirectiveOptions(
+                "images", DataTypes.ARRAY(DataTypes.BLOB()), opts);
+
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "other");
+    }
+
+    @Test
     public void testRemoveDroppedVectorOptions() {
         Map<String, String> opts = new HashMap<>();
         opts.put(CoreOptions.BLOB_FIELD.key(), "a");
         opts.put(CoreOptions.VECTOR_FIELD.key(), "emb,emb2");
         opts.put("field.emb.vector-dim", "128");
 
-        ColumnDirectiveUtils.removeDroppedDirectiveOptions("emb", DataTypeRoot.VECTOR, opts);
+        ColumnDirectiveUtils.removeDroppedDirectiveOptions(
+                "emb", DataTypes.VECTOR(128, DataTypes.FLOAT()), opts);
 
         assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "a");
         assertThat(opts).containsEntry(CoreOptions.VECTOR_FIELD.key(), "emb2");
@@ -346,7 +401,7 @@ public class ColumnDirectiveUtilsTest {
         opts.put(CoreOptions.BLOB_FIELD.key(), "a");
         opts.put(CoreOptions.VECTOR_FIELD.key(), "v");
 
-        ColumnDirectiveUtils.removeDroppedDirectiveOptions("x", DataTypeRoot.INTEGER, opts);
+        ColumnDirectiveUtils.removeDroppedDirectiveOptions("x", DataTypes.INT(), opts);
 
         assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "a");
         assertThat(opts).containsEntry(CoreOptions.VECTOR_FIELD.key(), "v");

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -147,13 +147,15 @@ class SchemaValidationTest {
 
         options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         assertThatThrownBy(() -> validateBlobSchema(options, emptyList()))
-                .hasMessage("Data evolution config must enabled for table with BLOB type column.");
+                .hasMessage(
+                        "Data evolution config must enabled for table with BLOB or ARRAY<BLOB> type column.");
 
         options.clear();
         options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
         assertThatThrownBy(() -> validateBlobSchema(options, singletonList("f2")))
-                .hasMessage("The BLOB type column can not be part of partition keys.");
+                .hasMessage(
+                        "The BLOB or ARRAY<BLOB> type column can not be part of partition keys.");
 
         assertThatThrownBy(
                         () -> {
@@ -167,7 +169,8 @@ class SchemaValidationTest {
                                             options,
                                             ""));
                         })
-                .hasMessage("Table with BLOB type column must have other normal columns.");
+                .hasMessage(
+                        "Table with BLOB or ARRAY<BLOB> type column must have other normal columns.");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SchemaEvolutionTest.java
@@ -318,7 +318,8 @@ public class SchemaEvolutionTest {
                                                         "__BLOB_FIELD",
                                                         null))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("must be of BYTES, BINARY or BLOB type");
+                .hasMessageContaining(
+                        "must be of BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type");
 
         // nested column rejected.
         assertThatThrownBy(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -1096,7 +1096,8 @@ public class FlinkCatalog extends AbstractCatalog {
 
         Map<String, String> options = new HashMap<>(catalogTable.getOptions());
         List<String> blobFields = CoreOptions.blobField(options);
-        Set<String> blobTypeFields = blobTypeFields(options);
+        Set<String> blobFileFields = new HashSet<>(CoreOptions.blobField(options));
+        Set<String> blobInlineFields = blobInlineFields(options);
         if (!blobFields.isEmpty()) {
             checkArgument(
                     options.containsKey(CoreOptions.DATA_EVOLUTION_ENABLED.key()),
@@ -1129,26 +1130,31 @@ public class FlinkCatalog extends AbstractCatalog {
                                                 field.getName(),
                                                 field.getType(),
                                                 options,
-                                                blobTypeFields),
+                                                blobFileFields,
+                                                blobInlineFields),
                                         columnComments.get(field.getName())));
 
         return schemaBuilder.build();
     }
 
-    private static Set<String> blobTypeFields(Map<String, String> options) {
-        Set<String> blobTypeFields = new HashSet<>(CoreOptions.blobField(options));
-        blobTypeFields.addAll(new CoreOptions(options).blobDescriptorField());
-        blobTypeFields.addAll(CoreOptions.blobViewField(options));
-        return blobTypeFields;
+    private static Set<String> blobInlineFields(Map<String, String> options) {
+        Set<String> blobInlineFields =
+                new HashSet<>(new CoreOptions(options).blobDescriptorField());
+        blobInlineFields.addAll(CoreOptions.blobViewField(options));
+        return blobInlineFields;
     }
 
     private static org.apache.paimon.types.DataType resolveDataType(
             String fieldName,
             org.apache.flink.table.types.logical.LogicalType logicalType,
             Map<String, String> options,
-            Set<String> blobTypeFields) {
-        if (blobTypeFields.contains(fieldName)) {
-            return toBlobType(logicalType);
+            Set<String> blobFileFields,
+            Set<String> blobInlineFields) {
+        if (blobInlineFields.contains(fieldName)) {
+            return toBlobType(logicalType, false);
+        }
+        if (blobFileFields.contains(fieldName)) {
+            return toBlobType(logicalType, true);
         }
         Set<String> vectorFields = CoreOptions.vectorField(options);
         if (vectorFields.contains(fieldName)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
@@ -19,11 +19,16 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.RowType;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -36,15 +41,23 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.types.variant.BinaryVariant;
 import org.apache.flink.types.variant.Variant;
 
+import javax.annotation.Nullable;
+
 import static org.apache.paimon.flink.FlinkRowWrapper.fromFlinkRowKind;
 
 /** Convert to Flink row data. */
 public class FlinkRowData implements RowData {
 
     protected InternalRow row;
+    @Nullable protected final RowType rowType;
 
     public FlinkRowData(InternalRow row) {
+        this(row, null);
+    }
+
+    public FlinkRowData(InternalRow row, @Nullable RowType rowType) {
         this.row = row;
+        this.rowType = rowType;
     }
 
     public FlinkRowData replace(InternalRow row) {
@@ -134,7 +147,7 @@ public class FlinkRowData implements RowData {
 
     @Override
     public ArrayData getArray(int pos) {
-        return new FlinkArrayData(row.getArray(pos));
+        return new FlinkArrayData(row.getArray(pos), arrayElementType(typeAt(pos)));
     }
 
     @Override
@@ -144,7 +157,10 @@ public class FlinkRowData implements RowData {
 
     @Override
     public RowData getRow(int pos, int numFields) {
-        return new FlinkRowData(row.getRow(pos, numFields));
+        DataType type = typeAt(pos);
+        return new FlinkRowData(
+                row.getRow(pos, numFields),
+                type != null && type.getTypeRoot() == DataTypeRoot.ROW ? (RowType) type : null);
     }
 
     public Variant getVariant(int pos) {
@@ -152,12 +168,30 @@ public class FlinkRowData implements RowData {
         return new BinaryVariant(variant.value(), variant.metadata());
     }
 
+    @Nullable
+    private DataType typeAt(int pos) {
+        return rowType == null ? null : rowType.getTypeAt(pos);
+    }
+
+    @Nullable
+    private static DataType arrayElementType(@Nullable DataType type) {
+        return type != null && type.getTypeRoot() == DataTypeRoot.ARRAY
+                ? ((ArrayType) type).getElementType()
+                : null;
+    }
+
     private static class FlinkArrayData implements ArrayData {
 
         private final InternalArray array;
+        @Nullable private final DataType elementType;
 
         private FlinkArrayData(InternalArray array) {
+            this(array, null);
+        }
+
+        private FlinkArrayData(InternalArray array, @Nullable DataType elementType) {
             this.array = array;
+            this.elementType = elementType;
         }
 
         @Override
@@ -232,12 +266,19 @@ public class FlinkRowData implements RowData {
 
         @Override
         public byte[] getBinary(int pos) {
+            if (elementType != null && elementType.getTypeRoot() == DataTypeRoot.BLOB) {
+                if (array.isNullAt(pos)) {
+                    return null;
+                }
+                Blob blob = array.getBlob(pos);
+                return blob == null ? null : blob.toData();
+            }
             return array.getBinary(pos);
         }
 
         @Override
         public ArrayData getArray(int pos) {
-            return new FlinkArrayData(array.getArray(pos));
+            return new FlinkArrayData(array.getArray(pos), arrayElementType(elementType));
         }
 
         @Override
@@ -247,7 +288,11 @@ public class FlinkRowData implements RowData {
 
         @Override
         public RowData getRow(int pos, int numFields) {
-            return new FlinkRowData(array.getRow(pos, numFields));
+            return new FlinkRowData(
+                    array.getRow(pos, numFields),
+                    elementType != null && elementType.getTypeRoot() == DataTypeRoot.ROW
+                            ? (RowType) elementType
+                            : null);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
@@ -50,14 +51,20 @@ public class FlinkRowData implements RowData {
 
     protected InternalRow row;
     @Nullable protected final RowType rowType;
+    protected final boolean blobAsDescriptor;
 
     public FlinkRowData(InternalRow row) {
         this(row, null);
     }
 
     public FlinkRowData(InternalRow row, @Nullable RowType rowType) {
+        this(row, rowType, false);
+    }
+
+    public FlinkRowData(InternalRow row, @Nullable RowType rowType, boolean blobAsDescriptor) {
         this.row = row;
         this.rowType = rowType;
+        this.blobAsDescriptor = blobAsDescriptor;
     }
 
     public FlinkRowData replace(InternalRow row) {
@@ -147,7 +154,8 @@ public class FlinkRowData implements RowData {
 
     @Override
     public ArrayData getArray(int pos) {
-        return new FlinkArrayData(row.getArray(pos), arrayElementType(typeAt(pos)));
+        return new FlinkArrayData(
+                row.getArray(pos), arrayElementType(typeAt(pos)), blobAsDescriptor);
     }
 
     @Override
@@ -160,7 +168,8 @@ public class FlinkRowData implements RowData {
         DataType type = typeAt(pos);
         return new FlinkRowData(
                 row.getRow(pos, numFields),
-                type != null && type.getTypeRoot() == DataTypeRoot.ROW ? (RowType) type : null);
+                type != null && type.getTypeRoot() == DataTypeRoot.ROW ? (RowType) type : null,
+                blobAsDescriptor);
     }
 
     public Variant getVariant(int pos) {
@@ -184,14 +193,21 @@ public class FlinkRowData implements RowData {
 
         private final InternalArray array;
         @Nullable private final DataType elementType;
+        private final boolean blobAsDescriptor;
 
         private FlinkArrayData(InternalArray array) {
-            this(array, null);
+            this(array, null, false);
         }
 
         private FlinkArrayData(InternalArray array, @Nullable DataType elementType) {
+            this(array, elementType, false);
+        }
+
+        private FlinkArrayData(
+                InternalArray array, @Nullable DataType elementType, boolean blobAsDescriptor) {
             this.array = array;
             this.elementType = elementType;
+            this.blobAsDescriptor = blobAsDescriptor;
         }
 
         @Override
@@ -271,14 +287,25 @@ public class FlinkRowData implements RowData {
                     return null;
                 }
                 Blob blob = array.getBlob(pos);
-                return blob == null ? null : blob.toData();
+                return fromBlob(blob);
             }
             return array.getBinary(pos);
         }
 
+        private byte[] fromBlob(Blob blob) {
+            if (blob == null) {
+                return null;
+            }
+            if (blob instanceof BlobView && !((BlobView) blob).isResolved()) {
+                return Blob.serializeBlob(blob);
+            }
+            return blobAsDescriptor ? blob.toDescriptor().serialize() : blob.toData();
+        }
+
         @Override
         public ArrayData getArray(int pos) {
-            return new FlinkArrayData(array.getArray(pos), arrayElementType(elementType));
+            return new FlinkArrayData(
+                    array.getArray(pos), arrayElementType(elementType), blobAsDescriptor);
         }
 
         @Override
@@ -292,7 +319,8 @@ public class FlinkRowData implements RowData {
                     array.getRow(pos, numFields),
                     elementType != null && elementType.getTypeRoot() == DataTypeRoot.ROW
                             ? (RowType) elementType
-                            : null);
+                            : null,
+                    blobAsDescriptor);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
@@ -19,17 +19,11 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.data.BinaryString;
-import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.types.ArrayType;
-import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeRoot;
-import org.apache.paimon.types.RowType;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
@@ -42,29 +36,15 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.types.variant.BinaryVariant;
 import org.apache.flink.types.variant.Variant;
 
-import javax.annotation.Nullable;
-
 import static org.apache.paimon.flink.FlinkRowWrapper.fromFlinkRowKind;
 
 /** Convert to Flink row data. */
 public class FlinkRowData implements RowData {
 
     protected InternalRow row;
-    @Nullable protected final RowType rowType;
-    protected final boolean blobAsDescriptor;
 
     public FlinkRowData(InternalRow row) {
-        this(row, null);
-    }
-
-    public FlinkRowData(InternalRow row, @Nullable RowType rowType) {
-        this(row, rowType, false);
-    }
-
-    public FlinkRowData(InternalRow row, @Nullable RowType rowType, boolean blobAsDescriptor) {
         this.row = row;
-        this.rowType = rowType;
-        this.blobAsDescriptor = blobAsDescriptor;
     }
 
     public FlinkRowData replace(InternalRow row) {
@@ -154,8 +134,7 @@ public class FlinkRowData implements RowData {
 
     @Override
     public ArrayData getArray(int pos) {
-        return new FlinkArrayData(
-                row.getArray(pos), arrayElementType(typeAt(pos)), blobAsDescriptor);
+        return new FlinkArrayData(row.getArray(pos));
     }
 
     @Override
@@ -165,11 +144,7 @@ public class FlinkRowData implements RowData {
 
     @Override
     public RowData getRow(int pos, int numFields) {
-        DataType type = typeAt(pos);
-        return new FlinkRowData(
-                row.getRow(pos, numFields),
-                type != null && type.getTypeRoot() == DataTypeRoot.ROW ? (RowType) type : null,
-                blobAsDescriptor);
+        return new FlinkRowData(row.getRow(pos, numFields));
     }
 
     public Variant getVariant(int pos) {
@@ -177,37 +152,12 @@ public class FlinkRowData implements RowData {
         return new BinaryVariant(variant.value(), variant.metadata());
     }
 
-    @Nullable
-    private DataType typeAt(int pos) {
-        return rowType == null ? null : rowType.getTypeAt(pos);
-    }
-
-    @Nullable
-    private static DataType arrayElementType(@Nullable DataType type) {
-        return type != null && type.getTypeRoot() == DataTypeRoot.ARRAY
-                ? ((ArrayType) type).getElementType()
-                : null;
-    }
-
     private static class FlinkArrayData implements ArrayData {
 
         private final InternalArray array;
-        @Nullable private final DataType elementType;
-        private final boolean blobAsDescriptor;
 
         private FlinkArrayData(InternalArray array) {
-            this(array, null, false);
-        }
-
-        private FlinkArrayData(InternalArray array, @Nullable DataType elementType) {
-            this(array, elementType, false);
-        }
-
-        private FlinkArrayData(
-                InternalArray array, @Nullable DataType elementType, boolean blobAsDescriptor) {
             this.array = array;
-            this.elementType = elementType;
-            this.blobAsDescriptor = blobAsDescriptor;
         }
 
         @Override
@@ -282,30 +232,12 @@ public class FlinkRowData implements RowData {
 
         @Override
         public byte[] getBinary(int pos) {
-            if (elementType != null && elementType.getTypeRoot() == DataTypeRoot.BLOB) {
-                if (array.isNullAt(pos)) {
-                    return null;
-                }
-                Blob blob = array.getBlob(pos);
-                return fromBlob(blob);
-            }
             return array.getBinary(pos);
-        }
-
-        private byte[] fromBlob(Blob blob) {
-            if (blob == null) {
-                return null;
-            }
-            if (blob instanceof BlobView && !((BlobView) blob).isResolved()) {
-                return Blob.serializeBlob(blob);
-            }
-            return blobAsDescriptor ? blob.toDescriptor().serialize() : blob.toData();
         }
 
         @Override
         public ArrayData getArray(int pos) {
-            return new FlinkArrayData(
-                    array.getArray(pos), arrayElementType(elementType), blobAsDescriptor);
+            return new FlinkArrayData(array.getArray(pos));
         }
 
         @Override
@@ -315,12 +247,7 @@ public class FlinkRowData implements RowData {
 
         @Override
         public RowData getRow(int pos, int numFields) {
-            return new FlinkRowData(
-                    array.getRow(pos, numFields),
-                    elementType != null && elementType.getTypeRoot() == DataTypeRoot.ROW
-                            ? (RowType) elementType
-                            : null,
-                    blobAsDescriptor);
+            return new FlinkRowData(array.getRow(pos, numFields));
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
@@ -21,6 +21,9 @@ package org.apache.paimon.flink;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
 
 import java.util.Set;
 
@@ -32,7 +35,15 @@ public class FlinkRowDataWithBlob extends FlinkRowData {
 
     public FlinkRowDataWithBlob(
             InternalRow row, Set<Integer> blobFields, boolean blobAsDescriptor) {
-        super(row);
+        this(row, null, blobFields, blobAsDescriptor);
+    }
+
+    public FlinkRowDataWithBlob(
+            InternalRow row,
+            @Nullable RowType rowType,
+            Set<Integer> blobFields,
+            boolean blobAsDescriptor) {
+        super(row, rowType);
         this.blobFields = blobFields;
         this.blobAsDescriptor = blobAsDescriptor;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
@@ -20,10 +20,11 @@ package org.apache.paimon.flink;
 
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.types.RowType;
 
-import javax.annotation.Nullable;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
 
 import java.util.Set;
 
@@ -31,31 +32,45 @@ import java.util.Set;
 public class FlinkRowDataWithBlob extends FlinkRowData {
 
     private final Set<Integer> blobFields;
+    private final boolean blobAsDescriptor;
 
     public FlinkRowDataWithBlob(
             InternalRow row, Set<Integer> blobFields, boolean blobAsDescriptor) {
-        this(row, null, blobFields, blobAsDescriptor);
-    }
-
-    public FlinkRowDataWithBlob(
-            InternalRow row,
-            @Nullable RowType rowType,
-            Set<Integer> blobFields,
-            boolean blobAsDescriptor) {
-        super(row, rowType, blobAsDescriptor);
+        super(row);
         this.blobFields = blobFields;
+        this.blobAsDescriptor = blobAsDescriptor;
     }
 
     @Override
     public byte[] getBinary(int pos) {
         if (blobFields.contains(pos)) {
-            Blob blob = row.getBlob(pos);
-            if (blob instanceof BlobView && !((BlobView) blob).isResolved()) {
-                return Blob.serializeBlob(blob);
-            }
-            return blobAsDescriptor ? blob.toDescriptor().serialize() : blob.toData();
+            return blobToBytes(row.getBlob(pos));
         } else {
             return row.getBinary(pos);
         }
+    }
+
+    @Override
+    public ArrayData getArray(int pos) {
+        if (blobFields.contains(pos)) {
+            InternalArray array = row.getArray(pos);
+            Object[] elements = new Object[array.size()];
+            for (int i = 0; i < array.size(); i++) {
+                elements[i] = array.isNullAt(i) ? null : blobToBytes(array.getBlob(i));
+            }
+            return new GenericArrayData(elements);
+        } else {
+            return super.getArray(pos);
+        }
+    }
+
+    private byte[] blobToBytes(Blob blob) {
+        if (blob == null) {
+            return null;
+        }
+        if (blob instanceof BlobView && !((BlobView) blob).isResolved()) {
+            return Blob.serializeBlob(blob);
+        }
+        return blobAsDescriptor ? blob.toDescriptor().serialize() : blob.toData();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
@@ -31,7 +31,6 @@ import java.util.Set;
 public class FlinkRowDataWithBlob extends FlinkRowData {
 
     private final Set<Integer> blobFields;
-    private final boolean blobAsDescriptor;
 
     public FlinkRowDataWithBlob(
             InternalRow row, Set<Integer> blobFields, boolean blobAsDescriptor) {
@@ -43,9 +42,8 @@ public class FlinkRowDataWithBlob extends FlinkRowData {
             @Nullable RowType rowType,
             Set<Integer> blobFields,
             boolean blobAsDescriptor) {
-        super(row, rowType);
+        super(row, rowType, blobAsDescriptor);
         this.blobFields = blobFields;
-        this.blobAsDescriptor = blobAsDescriptor;
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowWrapper.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
@@ -283,17 +285,17 @@ public class FlinkRowWrapper implements InternalRow {
 
     @Override
     public InternalArray getArray(int pos) {
-        return new FlinkArrayWrapper(row.getArray(pos));
+        return new FlinkArrayWrapper(row.getArray(pos), uriReaderFactory);
     }
 
     @Override
     public InternalVector getVector(int pos) {
-        return new FlinkVectorWrapper(row.getArray(pos));
+        return new FlinkVectorWrapper(row.getArray(pos), uriReaderFactory);
     }
 
     @Override
     public InternalMap getMap(int pos) {
-        return new FlinkMapWrapper(row.getMap(pos));
+        return new FlinkMapWrapper(row.getMap(pos), uriReaderFactory);
     }
 
     @Override
@@ -304,9 +306,17 @@ public class FlinkRowWrapper implements InternalRow {
     private static class FlinkArrayWrapper implements InternalArray {
 
         private final org.apache.flink.table.data.ArrayData array;
+        @Nullable private final UriReaderFactory uriReaderFactory;
 
         private FlinkArrayWrapper(org.apache.flink.table.data.ArrayData array) {
+            this(array, null);
+        }
+
+        private FlinkArrayWrapper(
+                org.apache.flink.table.data.ArrayData array,
+                @Nullable UriReaderFactory uriReaderFactory) {
             this.array = array;
+            this.uriReaderFactory = uriReaderFactory;
         }
 
         @Override
@@ -383,22 +393,22 @@ public class FlinkRowWrapper implements InternalRow {
 
         @Override
         public Blob getBlob(int pos) {
-            return Blob.fromBytes(array.getBinary(pos), null, null);
+            return Blob.fromBytes(array.getBinary(pos), uriReaderFactory, null);
         }
 
         @Override
         public InternalArray getArray(int pos) {
-            return new FlinkArrayWrapper(array.getArray(pos));
+            return new FlinkArrayWrapper(array.getArray(pos), uriReaderFactory);
         }
 
         @Override
         public InternalVector getVector(int pos) {
-            return new FlinkVectorWrapper(array.getArray(pos));
+            return new FlinkVectorWrapper(array.getArray(pos), uriReaderFactory);
         }
 
         @Override
         public InternalMap getMap(int pos) {
-            return new FlinkMapWrapper(array.getMap(pos));
+            return new FlinkMapWrapper(array.getMap(pos), uriReaderFactory);
         }
 
         @Override
@@ -446,14 +456,28 @@ public class FlinkRowWrapper implements InternalRow {
         private FlinkVectorWrapper(org.apache.flink.table.data.ArrayData array) {
             super(array);
         }
+
+        private FlinkVectorWrapper(
+                org.apache.flink.table.data.ArrayData array,
+                @Nullable UriReaderFactory uriReaderFactory) {
+            super(array, uriReaderFactory);
+        }
     }
 
     private static class FlinkMapWrapper implements InternalMap {
 
         private final org.apache.flink.table.data.MapData map;
+        @Nullable private final UriReaderFactory uriReaderFactory;
 
         private FlinkMapWrapper(org.apache.flink.table.data.MapData map) {
+            this(map, null);
+        }
+
+        private FlinkMapWrapper(
+                org.apache.flink.table.data.MapData map,
+                @Nullable UriReaderFactory uriReaderFactory) {
             this.map = map;
+            this.uriReaderFactory = uriReaderFactory;
         }
 
         @Override
@@ -463,12 +487,12 @@ public class FlinkRowWrapper implements InternalRow {
 
         @Override
         public InternalArray keyArray() {
-            return new FlinkArrayWrapper(map.keyArray());
+            return new FlinkArrayWrapper(map.keyArray(), uriReaderFactory);
         }
 
         @Override
         public InternalArray valueArray() {
-            return new FlinkArrayWrapper(map.valueArray());
+            return new FlinkArrayWrapper(map.valueArray(), uriReaderFactory);
         }
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
@@ -46,11 +46,35 @@ public class LogicalTypeConversion {
         return dataType.accept(DataTypeToLogicalType.INSTANCE);
     }
 
-    public static BlobType toBlobType(LogicalType logicalType) {
+    public static DataType toBlobType(LogicalType logicalType) {
+        return toBlobType(logicalType, true);
+    }
+
+    public static DataType toBlobType(LogicalType logicalType, boolean allowArray) {
+        if (logicalType instanceof org.apache.flink.table.types.logical.ArrayType) {
+            checkArgument(
+                    allowArray,
+                    "ARRAY<BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
+            LogicalType elementType =
+                    ((org.apache.flink.table.types.logical.ArrayType) logicalType).getElementType();
+            checkArgument(
+                    isBinaryType(elementType),
+                    "Expected BinaryType, VarBinaryType or ArrayType with BinaryType or "
+                            + "VarBinaryType element, but got: "
+                            + logicalType);
+            return new org.apache.paimon.types.ArrayType(
+                    logicalType.isNullable(), new BlobType(elementType.isNullable()));
+        }
         checkArgument(
-                logicalType instanceof BinaryType || logicalType instanceof VarBinaryType,
-                "Expected BinaryType or VarBinaryType, but got: " + logicalType);
-        return new BlobType();
+                isBinaryType(logicalType),
+                "Expected BinaryType, VarBinaryType or ArrayType with BinaryType or "
+                        + "VarBinaryType element, but got: "
+                        + logicalType);
+        return new BlobType(logicalType.isNullable());
+    }
+
+    private static boolean isBinaryType(LogicalType logicalType) {
+        return logicalType instanceof BinaryType || logicalType instanceof VarBinaryType;
     }
 
     public static VectorType toVectorType(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -37,6 +37,7 @@ import org.apache.paimon.flink.utils.InternalTypeInfo;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeCasts;
@@ -499,10 +500,10 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                     throw new IllegalStateException(
                             "Column not found in target table: " + flinkColumn.getName());
                 }
-                if (targetField.type().getTypeRoot() == DataTypeRoot.BLOB
+                if (BlobType.isBlobFileField(targetField.type())
                         && !updatableBlobFields.contains(flinkColumn.getName())) {
                     throw new IllegalStateException(
-                            "Should not append/update raw-data BLOB column '"
+                            "Should not append/update raw-data BLOB or ARRAY<BLOB> column '"
                                     + flinkColumn.getName()
                                     + "' through MERGE INTO. "
                                     + "Only descriptor-based BLOB columns (configured via '"

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.lookup;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
@@ -93,6 +94,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     @Nullable private final RefreshBlacklist refreshBlacklist;
     @Nullable private final ShuffleStrategy strategy;
     private final RowType projectedType;
+    private final boolean blobAsDescriptor;
 
     private final List<InternalRow.FieldGetter> projectFieldsGetters;
 
@@ -158,6 +160,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
             partitionLoader.addPartitionKeysTo(joinKeys, projectFields);
         }
         this.projectedType = rowType.project(projectFields);
+        Options options = table.coreOptions().toConfiguration();
+        this.blobAsDescriptor =
+                options.get(CoreOptions.BLOB_AS_DESCRIPTOR)
+                        || options.get(CoreOptions.LOOKUP_CACHE_BLOB_DESCRIPTOR);
 
         this.predicate = predicate;
 
@@ -320,7 +326,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         List<RowData> rows = new ArrayList<>();
         List<InternalRow> lookupResults = lookupTable.get(key);
         for (InternalRow matchedRow : lookupResults) {
-            rows.add(new FlinkRowData(matchedRow, projectedType));
+            rows.add(new FlinkRowData(matchedRow, projectedType, blobAsDescriptor));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.flink.FlinkConnectorOptions.LookupCacheMode;
 import org.apache.paimon.flink.FlinkRowData;
+import org.apache.paimon.flink.FlinkRowDataWithBlob;
 import org.apache.paimon.flink.FlinkRowWrapper;
 import org.apache.paimon.flink.lookup.partitioner.ShuffleStrategy;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
@@ -35,6 +36,7 @@ import org.apache.paimon.table.ChainGroupReadTable;
 import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.OutOfRangeException;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.FileIOUtils;
 import org.apache.paimon.utils.Filter;
@@ -93,7 +95,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     @Nullable private final Predicate predicate;
     @Nullable private final RefreshBlacklist refreshBlacklist;
     @Nullable private final ShuffleStrategy strategy;
-    private final RowType projectedType;
+    private final Set<Integer> blobFields;
     private final boolean blobAsDescriptor;
 
     private final List<InternalRow.FieldGetter> projectFieldsGetters;
@@ -159,7 +161,12 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         if (partitionLoader != null) {
             partitionLoader.addPartitionKeysTo(joinKeys, projectFields);
         }
-        this.projectedType = rowType.project(projectFields);
+        RowType projectedType = rowType.project(projectFields);
+        this.blobFields =
+                IntStream.range(0, projectedType.getFieldCount())
+                        .filter(i -> BlobType.isBlobFileField(projectedType.getTypeAt(i)))
+                        .boxed()
+                        .collect(Collectors.toSet());
         Options options = table.coreOptions().toConfiguration();
         this.blobAsDescriptor =
                 options.get(CoreOptions.BLOB_AS_DESCRIPTOR)
@@ -326,7 +333,10 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         List<RowData> rows = new ArrayList<>();
         List<InternalRow> lookupResults = lookupTable.get(key);
         for (InternalRow matchedRow : lookupResults) {
-            rows.add(new FlinkRowData(matchedRow, projectedType, blobAsDescriptor));
+            rows.add(
+                    blobFields.isEmpty()
+                            ? new FlinkRowData(matchedRow)
+                            : new FlinkRowDataWithBlob(matchedRow, blobFields, blobAsDescriptor));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -92,6 +92,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
     @Nullable private final Predicate predicate;
     @Nullable private final RefreshBlacklist refreshBlacklist;
     @Nullable private final ShuffleStrategy strategy;
+    private final RowType projectedType;
 
     private final List<InternalRow.FieldGetter> projectFieldsGetters;
 
@@ -156,6 +157,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         if (partitionLoader != null) {
             partitionLoader.addPartitionKeysTo(joinKeys, projectFields);
         }
+        this.projectedType = rowType.project(projectFields);
 
         this.predicate = predicate;
 
@@ -318,7 +320,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
         List<RowData> rows = new ArrayList<>();
         List<InternalRow> lookupResults = lookupTable.get(key);
         for (InternalRow matchedRow : lookupResults) {
-            rows.add(new FlinkRowData(matchedRow));
+            rows.add(new FlinkRowData(matchedRow, projectedType));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FullCacheLookupTable.java
@@ -38,6 +38,7 @@ import org.apache.paimon.table.ChainGroupReadTable;
 import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ExecutorThreadFactory;
 import org.apache.paimon.utils.ExecutorUtils;
@@ -86,6 +87,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
     protected final boolean refreshAsync;
     protected final boolean blobAsDescriptor;
     protected final Set<Integer> blobFieldPositions;
+    private final boolean hasBlobFileFields;
 
     @Nullable protected final FieldsComparator userDefinedSeqComparator;
     protected final int appendUdsFieldNumber;
@@ -142,6 +144,8 @@ public abstract class FullCacheLookupTable implements LookupTable {
         this.refreshAsync = options.get(LOOKUP_REFRESH_ASYNC);
         this.blobAsDescriptor = options.get(CoreOptions.LOOKUP_CACHE_BLOB_DESCRIPTOR);
         this.blobFieldPositions = BlobAsDescriptorRow.blobFieldPositions(projectedType);
+        this.hasBlobFileFields =
+                projectedType.getFieldTypes().stream().anyMatch(BlobType::isBlobFileField);
         this.cachedException = new AtomicReference<>();
         this.maxPendingSnapshotCount = options.get(LOOKUP_REFRESH_ASYNC_PENDING_SNAPSHOT_COUNT);
     }
@@ -194,7 +198,7 @@ public abstract class FullCacheLookupTable implements LookupTable {
         // blob.toDescriptor() succeeds during cache serialization, even when the table
         // was not originally written with blob-as-descriptor=true.
         LookupFileStoreTable readerTable = context.table;
-        if (blobAsDescriptor && !blobFieldPositions.isEmpty()) {
+        if (blobAsDescriptor && hasBlobFileFields) {
             readerTable =
                     (LookupFileStoreTable)
                             context.table.copy(
@@ -215,9 +219,9 @@ public abstract class FullCacheLookupTable implements LookupTable {
             return;
         }
 
-        // Parallel bootstrap read serializes rows with BlobSerializer, which materializes
-        // BlobRef into BlobData. Disable parallelism when caching blob descriptors.
-        boolean useParallelBootstrapRead = !(blobAsDescriptor && !blobFieldPositions.isEmpty());
+        // Parallel bootstrap serialization drops runtime readers from descriptor-backed blobs.
+        // Disable it when caching blob descriptors so cache conversion sees the original blobs.
+        boolean useParallelBootstrapRead = !(blobAsDescriptor && hasBlobFileFields);
 
         BinaryExternalSortBuffer bulkLoadSorter =
                 RocksDBState.createBulkLoadSorter(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -278,9 +278,11 @@ public class FileStoreSourceSplitReader
 
         private final MutableRecordAndPosition<RowData> recordAndPosition =
                 new MutableRecordAndPosition<>();
+        @Nullable private final RowType rowType;
         private final Set<Integer> blobFields;
 
         private FileStoreRecordIterator(@Nullable RowType rowType) {
+            this.rowType = rowType;
             this.blobFields = rowType == null ? Collections.emptySet() : blobFieldIndex(rowType);
         }
 
@@ -318,8 +320,8 @@ public class FileStoreSourceSplitReader
 
             recordAndPosition.setNext(
                     blobFields.isEmpty()
-                            ? new FlinkRowData(row)
-                            : new FlinkRowDataWithBlob(row, blobFields, blobAsDescriptor));
+                            ? new FlinkRowData(row, rowType)
+                            : new FlinkRowDataWithBlob(row, rowType, blobFields, blobAsDescriptor));
             currentNumRead++;
             if (limiter != null) {
                 limiter.increment();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -320,7 +320,7 @@ public class FileStoreSourceSplitReader
 
             recordAndPosition.setNext(
                     blobFields.isEmpty()
-                            ? new FlinkRowData(row, rowType)
+                            ? new FlinkRowData(row, rowType, blobAsDescriptor)
                             : new FlinkRowDataWithBlob(row, rowType, blobFields, blobAsDescriptor));
             currentNumRead++;
             if (limiter != null) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -27,7 +27,7 @@ import org.apache.paimon.reader.RecordReader.RecordIterator;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
-import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pool;
 
@@ -278,18 +278,16 @@ public class FileStoreSourceSplitReader
 
         private final MutableRecordAndPosition<RowData> recordAndPosition =
                 new MutableRecordAndPosition<>();
-        @Nullable private final RowType rowType;
         private final Set<Integer> blobFields;
 
         private FileStoreRecordIterator(@Nullable RowType rowType) {
-            this.rowType = rowType;
-            this.blobFields = rowType == null ? Collections.emptySet() : blobFieldIndex(rowType);
+            this.blobFields = rowType == null ? Collections.emptySet() : blobFieldIndexes(rowType);
         }
 
-        private Set<Integer> blobFieldIndex(RowType rowType) {
+        private Set<Integer> blobFieldIndexes(RowType rowType) {
             Set<Integer> result = new HashSet<>();
             for (int i = 0; i < rowType.getFieldCount(); i++) {
-                if (rowType.getTypeAt(i).getTypeRoot() == DataTypeRoot.BLOB) {
+                if (BlobType.isBlobFileField(rowType.getTypeAt(i))) {
                     result.add(i);
                 }
             }
@@ -320,8 +318,8 @@ public class FileStoreSourceSplitReader
 
             recordAndPosition.setNext(
                     blobFields.isEmpty()
-                            ? new FlinkRowData(row, rowType, blobAsDescriptor)
-                            : new FlinkRowDataWithBlob(row, rowType, blobFields, blobAsDescriptor));
+                            ? new FlinkRowData(row)
+                            : new FlinkRowDataWithBlob(row, blobFields, blobAsDescriptor));
             currentNumRead++;
             if (limiter != null) {
                 limiter.increment();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -148,6 +148,59 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testArrayBlobFieldWithDescriptorElements() throws Exception {
+        byte[] blobData = new byte[1024];
+        RANDOM.nextBytes(blobData);
+        FileIO fileIO = new LocalFileIO();
+        String uri = "file://" + warehouse + "/external_array_blob";
+        try (OutputStream outputStream =
+                fileIO.newOutputStream(new org.apache.paimon.fs.Path(uri), true)) {
+            outputStream.write(blobData);
+        }
+
+        tEnv.executeSql(
+                        "CREATE TABLE array_blob_descriptor_table "
+                                + "(id INT, data STRING, pictures ARRAY<BYTES>) "
+                                + "WITH ('row-tracking.enabled'='true', "
+                                + "'data-evolution.enabled'='true', "
+                                + "'blob-field'='pictures', "
+                                + "'blob-as-descriptor'='true')")
+                .await();
+        batchSql(
+                "INSERT INTO array_blob_descriptor_table VALUES "
+                        + "(1, 'paimon', ARRAY[sys.path_to_descriptor('"
+                        + uri
+                        + "'), X'5945'])");
+
+        Row descriptorRow =
+                batchSql("SELECT pictures[1], pictures[2] " + "FROM array_blob_descriptor_table")
+                        .get(0);
+        BlobDescriptor firstDescriptor =
+                BlobDescriptor.deserialize((byte[]) descriptorRow.getField(0));
+        BlobDescriptor secondDescriptor =
+                BlobDescriptor.deserialize((byte[]) descriptorRow.getField(1));
+        Options options = new Options();
+        options.set("warehouse", warehouse.toString());
+        CatalogContext catalogContext = CatalogContext.create(options);
+        UriReaderFactory uriReaderFactory = new UriReaderFactory(catalogContext);
+        Blob firstBlob =
+                Blob.fromDescriptor(
+                        uriReaderFactory.create(firstDescriptor.uri()), firstDescriptor);
+        Blob secondBlob =
+                Blob.fromDescriptor(
+                        uriReaderFactory.create(secondDescriptor.uri()), secondDescriptor);
+        assertThat(firstBlob.toData()).isEqualTo(blobData);
+        assertThat(secondBlob.toData()).isEqualTo(new byte[] {89, 69});
+
+        batchSql("ALTER TABLE array_blob_descriptor_table SET ('blob-as-descriptor'='false')");
+        assertThat(
+                        batchSql(
+                                "SELECT pictures[1], pictures[2] "
+                                        + "FROM array_blob_descriptor_table"))
+                .containsExactly(Row.of(blobData, new byte[] {89, 69}));
+    }
+
+    @Test
     public void testBlobCompaction() throws Exception {
         for (int i = 1; i <= 10; i++) {
             batchSql("INSERT INTO blob_table VALUES (%s, 'paimon', X'48656C6C6F')", i);

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -33,6 +33,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.UriReader;
 import org.apache.paimon.utils.UriReaderFactory;
 
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -60,6 +61,7 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 "CREATE TABLE IF NOT EXISTS blob_table (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='picture')",
                 "CREATE TABLE IF NOT EXISTS blob_table_descriptor (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture', 'blob-as-descriptor'='true')",
                 "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pic1,pic2')",
+                "CREATE TABLE IF NOT EXISTS array_blob_table (id INT, data STRING, pictures ARRAY<BYTES>) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pictures')",
                 "CREATE TABLE IF NOT EXISTS mixed_blob_table"
                         + " (id INT, data STRING, raw_pic BYTES, desc_pic BYTES)"
                         + " WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true',"
@@ -95,6 +97,54 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 .containsExactlyInAnyOrder(Row.of(new byte[] {89, 69}));
         assertThat(batchSql("SELECT file_path FROM `multiple_blob_table$files`").size())
                 .isEqualTo(3);
+    }
+
+    @Test
+    public void testArrayBlobField() throws Exception {
+        org.apache.paimon.types.ArrayType arrayType =
+                (org.apache.paimon.types.ArrayType)
+                        paimonTable("array_blob_table").rowType().getTypeAt(2);
+        assertThat(arrayType.getElementType().getTypeRoot()).isEqualTo(DataTypeRoot.BLOB);
+
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(
+                                        1,
+                                        "paimon",
+                                        new byte[][] {
+                                            new byte[] {72, 101, 108, 108, 111},
+                                            null,
+                                            new byte[] {89, 69}
+                                        }),
+                                Row.of(2, "one", new byte[][] {new byte[] {65, 66, 67}}),
+                                Row.of(3, "null-array", null)));
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE array_blob_source "
+                                        + "(id INT, data STRING, pictures ARRAY<BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+        batchSql("INSERT INTO array_blob_table SELECT * FROM array_blob_source");
+
+        assertThat(
+                        batchSql(
+                                "SELECT id, CARDINALITY(pictures), pictures[1], pictures[2], pictures[3] "
+                                        + "FROM array_blob_table ORDER BY id"))
+                .containsExactly(
+                        Row.of(
+                                1,
+                                3,
+                                new byte[] {72, 101, 108, 108, 111},
+                                null,
+                                new byte[] {89, 69}),
+                        Row.of(2, 1, new byte[] {65, 66, 67}, null, null),
+                        Row.of(3, null, null, null, null));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) > 0 FROM `array_blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(true));
     }
 
     @Test
@@ -419,6 +469,27 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 "blob_descriptor_without_blob_field", "blob-descriptor-field");
         assertSecondaryBlobFieldCanDeclareBlobWithoutBlobField(
                 "blob_view_without_blob_field", "blob-view-field");
+    }
+
+    @Test
+    public void testBlobInlineFieldRejectsArrayBlob() {
+        assertArrayBlobInlineFieldRejected(
+                "array_blob_descriptor_reject", "'blob-descriptor-field'='pictures'");
+        assertArrayBlobInlineFieldRejected(
+                "array_blob_view_reject", "'blob-view-field'='pictures'");
+    }
+
+    private void assertArrayBlobInlineFieldRejected(String tableName, String blobOptions) {
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                                String.format(
+                                                        "CREATE TABLE %s (id INT, pictures ARRAY<BYTES>)"
+                                                                + " WITH ('row-tracking.enabled'='true',"
+                                                                + " 'data-evolution.enabled'='true', %s)",
+                                                        tableName, blobOptions))
+                                        .await())
+                .hasRootCauseMessage("ARRAY<BLOB> is only supported by 'blob-field'.");
     }
 
     private void assertSecondaryBlobFieldCanDeclareBlobWithoutBlobField(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowDataWithBlobTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowDataWithBlobTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobViewStruct;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.utils.UriReader;
+
+import org.apache.flink.table.data.ArrayData;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FlinkRowDataWithBlob}. */
+public class FlinkRowDataWithBlobTest {
+
+    @Test
+    public void testRawAndArrayBlobAsData() {
+        byte[] raw = new byte[] {1, 2};
+        byte[] first = new byte[] {3, 4};
+        byte[] second = new byte[] {5, 6};
+        byte[] normal = new byte[] {7, 8};
+        GenericRow row =
+                GenericRow.of(
+                        Blob.fromData(raw),
+                        new GenericArray(
+                                new Object[] {Blob.fromData(first), null, Blob.fromData(second)}),
+                        new GenericArray(new Object[] {normal}));
+
+        FlinkRowDataWithBlob rowData =
+                new FlinkRowDataWithBlob(row, new HashSet<>(Arrays.asList(0, 1)), false);
+
+        assertThat(rowData.getBinary(0)).isEqualTo(raw);
+        ArrayData blobArray = rowData.getArray(1);
+        assertThat(blobArray.size()).isEqualTo(3);
+        assertThat(blobArray.getBinary(0)).isEqualTo(first);
+        assertThat(blobArray.isNullAt(1)).isTrue();
+        assertThat(blobArray.getBinary(1)).isNull();
+        assertThat(blobArray.getBinary(2)).isEqualTo(second);
+        assertThat(rowData.getArray(2).getBinary(0)).isEqualTo(normal);
+    }
+
+    @Test
+    public void testRawAndArrayBlobAsDescriptor() {
+        BlobDescriptor rawDescriptor = new BlobDescriptor("file:///raw", 1, 2);
+        BlobDescriptor arrayDescriptor = new BlobDescriptor("file:///array", 3, 4);
+        UriReader uriReader = UriReader.fromHttp();
+        GenericRow row =
+                GenericRow.of(
+                        Blob.fromDescriptor(uriReader, rawDescriptor),
+                        new GenericArray(
+                                new Object[] {Blob.fromDescriptor(uriReader, arrayDescriptor)}));
+
+        FlinkRowDataWithBlob rowData =
+                new FlinkRowDataWithBlob(row, new HashSet<>(Arrays.asList(0, 1)), true);
+
+        assertThat(rowData.getBinary(0)).isEqualTo(rawDescriptor.serialize());
+        assertThat(rowData.getArray(1).getBinary(0)).isEqualTo(arrayDescriptor.serialize());
+    }
+
+    @Test
+    public void testUnresolvedBlobViewInArray() {
+        BlobViewStruct viewStruct =
+                new BlobViewStruct(Identifier.create("database", "table"), 1, 2L);
+        GenericRow row =
+                GenericRow.of(new GenericArray(new Object[] {Blob.fromView(viewStruct), null}));
+
+        FlinkRowDataWithBlob rowData =
+                new FlinkRowDataWithBlob(row, new HashSet<>(Arrays.asList(0)), false);
+
+        ArrayData blobArray = rowData.getArray(0);
+        assertThat(blobArray.getBinary(0)).isEqualTo(viewStruct.serialize());
+        assertThat(blobArray.getBinary(1)).isNull();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -22,12 +22,14 @@ import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.flink.FlinkConnectorOptions.LookupCacheMode;
 import org.apache.paimon.utils.BlockingIterator;
 
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -1618,6 +1620,71 @@ public class LookupJoinITCase extends CatalogITCaseBase {
                 assertThat(descriptor.length()).isGreaterThan(0);
             }
         }
+
+        iterator.close();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = LookupCacheMode.class,
+            names = {"FULL", "MEMORY"})
+    public void testLookupArrayBlobAsDescriptorOnNormalBlobTable(LookupCacheMode mode)
+            throws Exception {
+        sql(
+                "CREATE TABLE ARRAY_BLOB_DIM (id INT, name STRING, pictures ARRAY<BYTES>) WITH ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true', "
+                        + "'blob-field'='pictures', "
+                        + "'lookup.blob-as-descriptor'='true', "
+                        + "'lookup.cache'='%s', "
+                        + "'continuous.discovery-interval'='1 ms')",
+                mode);
+
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(
+                                        1,
+                                        "cat",
+                                        new byte[][] {
+                                            new byte[] {72, 101, 108, 108, 111},
+                                            new byte[] {89, 69}
+                                        }),
+                                Row.of(
+                                        2,
+                                        "dog",
+                                        new byte[][] {new byte[] {87, 111, 114, 108, 100}})));
+        sql(
+                "CREATE TEMPORARY TABLE ARRAY_BLOB_SOURCE "
+                        + "(id INT, name STRING, pictures ARRAY<BYTES>) WITH ("
+                        + "'connector'='values', 'bounded'='true', 'data-id'='%s')",
+                dataId);
+        sql("INSERT INTO ARRAY_BLOB_DIM SELECT * FROM ARRAY_BLOB_SOURCE");
+
+        String query =
+                "SELECT T.i, D.name, D.pictures[1], D.pictures[2] FROM T "
+                        + "LEFT JOIN ARRAY_BLOB_DIM for system_time as of T.proctime AS D "
+                        + "ON T.i = D.id";
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        sql("INSERT INTO T VALUES (1), (2), (3)");
+        List<Row> result = iterator.collect(3);
+        assertThat(result).hasSize(3);
+
+        Row first = result.stream().filter(row -> row.getField(0).equals(1)).findFirst().get();
+        assertThat(first.getField(1)).isEqualTo("cat");
+        assertThat(BlobDescriptor.deserialize((byte[]) first.getField(2)).length()).isEqualTo(5);
+        assertThat(BlobDescriptor.deserialize((byte[]) first.getField(3)).length()).isEqualTo(2);
+
+        Row second = result.stream().filter(row -> row.getField(0).equals(2)).findFirst().get();
+        assertThat(second.getField(1)).isEqualTo("dog");
+        assertThat(BlobDescriptor.deserialize((byte[]) second.getField(2)).length()).isEqualTo(5);
+        assertThat(second.getField(3)).isNull();
+
+        Row missing = result.stream().filter(row -> row.getField(0).equals(3)).findFirst().get();
+        assertThat(missing.getField(1)).isNull();
+        assertThat(missing.getField(2)).isNull();
+        assertThat(missing.getField(3)).isNull();
 
         iterator.close();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
@@ -24,6 +24,7 @@ import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -717,8 +718,9 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
 
         Throwable t = Assertions.assertThrows(IllegalStateException.class, () -> action.run());
         Assertions.assertTrue(
-                t.getMessage().contains("raw-data BLOB column"),
-                "Expected error about raw-data BLOB column but got: " + t.getMessage());
+                t.getMessage().contains("raw-data BLOB or ARRAY<BLOB> column"),
+                "Expected error about raw-data BLOB or ARRAY<BLOB> column but got: "
+                        + t.getMessage());
     }
 
     @Test
@@ -771,6 +773,84 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
                         changelogRow("+I", 2, "name2"),
                         changelogRow("+I", 3, "name3"));
         testBatchRead("SELECT id, name FROM RAW_BLOB_SPLIT_T ORDER BY id", expected);
+    }
+
+    @Test
+    public void testUpdateNonBlobColumnOnRawArrayBlobTableWithSplitFiles() throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_ARRAY_BLOB_SPLIT_T",
+                        Arrays.asList("id INT", "name STRING", "pictures ARRAY<BYTES>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put("blob-field", "pictures");
+                                put(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "1 b");
+                                put("sink.parallelism", "1");
+                            }
+                        }));
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(
+                                        1,
+                                        "name1",
+                                        new byte[][] {
+                                            new byte[] {72, 101, 108, 108, 111},
+                                            new byte[] {89, 69}
+                                        }),
+                                Row.of(2, "name2", new byte[][] {new byte[] {65, 66, 67}}),
+                                Row.of(3, "name3", null)));
+        sEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE RAW_ARRAY_BLOB_SPLIT_SOURCE "
+                                        + "(id INT, name STRING, pictures ARRAY<BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+        sEnv.executeSql(
+                        "INSERT INTO RAW_ARRAY_BLOB_SPLIT_T "
+                                + "SELECT * FROM RAW_ARRAY_BLOB_SPLIT_SOURCE")
+                .await();
+        testBatchRead(
+                "SELECT COUNT(*) > 1 FROM `RAW_ARRAY_BLOB_SPLIT_T$files` "
+                        + "WHERE file_path LIKE '%.blob'",
+                Collections.singletonList(changelogRow("+I", true)));
+
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_ARRAY_BLOB_SPLIT_S",
+                        Arrays.asList("id INT", "name STRING"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyMap()));
+        insertInto("RAW_ARRAY_BLOB_SPLIT_S", "(1, 'updated_name1')");
+
+        builder(warehouse, database, "RAW_ARRAY_BLOB_SPLIT_T")
+                .withMergeCondition("RAW_ARRAY_BLOB_SPLIT_T.id=RAW_ARRAY_BLOB_SPLIT_S.id")
+                .withMatchedUpdateSet("RAW_ARRAY_BLOB_SPLIT_T.name=RAW_ARRAY_BLOB_SPLIT_S.name")
+                .withSourceTable("RAW_ARRAY_BLOB_SPLIT_S")
+                .withSinkParallelism(1)
+                .build()
+                .run();
+
+        List<Row> expected =
+                Arrays.asList(
+                        changelogRow(
+                                "+I",
+                                1,
+                                "updated_name1",
+                                new byte[] {72, 101, 108, 108, 111},
+                                new byte[] {89, 69}),
+                        changelogRow("+I", 2, "name2", new byte[] {65, 66, 67}, null),
+                        changelogRow("+I", 3, "name3", null, null));
+        testBatchRead(
+                "SELECT id, name, pictures[1], pictures[2] "
+                        + "FROM RAW_ARRAY_BLOB_SPLIT_T ORDER BY id",
+                expected);
     }
 
     @Test

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -34,6 +34,7 @@ import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
@@ -45,6 +46,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** {@link FileFormat} for blob file. */
@@ -103,8 +105,8 @@ public class BlobFileFormat extends FileFormat {
     public void validateDataFields(RowType rowType) {
         checkArgument(rowType.getFieldCount() == 1, "BlobFileFormat only support one field.");
         checkArgument(
-                rowType.getField(0).type().getTypeRoot() == DataTypeRoot.BLOB,
-                "BlobFileFormat only support blob type.");
+                isBlobFileField(rowType.getField(0).type()),
+                "BlobFileFormat only support blob type or array of blob type.");
     }
 
     @Override
@@ -139,6 +141,7 @@ public class BlobFileFormat extends FileFormat {
         private final boolean blobAsDescriptor;
         private final int fieldCount;
         private final int blobIndex;
+        private final DataType blobFieldType;
 
         public BlobFormatReaderFactory(boolean blobAsDescriptor, RowType projectedRowType) {
             this.blobAsDescriptor = blobAsDescriptor;
@@ -147,6 +150,7 @@ public class BlobFileFormat extends FileFormat {
             Preconditions.checkState(
                     this.blobIndex >= 0,
                     "Read type of a blob format does not contain any blob field.");
+            this.blobFieldType = projectedRowType.getTypeAt(this.blobIndex);
         }
 
         @Override
@@ -159,18 +163,26 @@ public class BlobFileFormat extends FileFormat {
                 in = fileIO.newInputStream(filePath);
                 fileMeta = new BlobFileMeta(in, context.fileSize(), context.selection());
             } finally {
-                if (blobAsDescriptor) {
+                if (blobAsDescriptor && blobFieldType.getTypeRoot() != DataTypeRoot.ARRAY) {
                     IOUtils.closeQuietly(in);
                     in = null;
                 }
             }
 
-            return new BlobFormatReader(fileIO, filePath, fileMeta, in, fieldCount, blobIndex);
+            return new BlobFormatReader(
+                    fileIO,
+                    filePath,
+                    fileMeta,
+                    in,
+                    fieldCount,
+                    blobIndex,
+                    blobFieldType,
+                    blobAsDescriptor);
         }
 
         private static int findBlobFieldIndex(RowType rowType) {
             for (int i = 0; i < rowType.getFieldCount(); i++) {
-                if (rowType.getTypeAt(i).getTypeRoot() == DataTypeRoot.BLOB) {
+                if (isBlobFileField(rowType.getTypeAt(i))) {
                     return i;
                 }
             }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -19,7 +19,9 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
@@ -27,11 +29,16 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.FileRecordReader;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.utils.DeltaVarintCompressor;
 import org.apache.paimon.utils.IOUtils;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /** {@link FileRecordReader} for blob file. */
 public class BlobFormatReader implements FileRecordReader<InternalRow> {
@@ -43,6 +50,9 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
     private final @Nullable SeekableInputStream in;
     private final int fieldCount;
     private final int blobIndex;
+    private final DataType blobFieldType;
+    private final Object blobPlaceholder;
+    private final boolean blobAsDescriptor;
 
     private boolean returned;
 
@@ -52,7 +62,9 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
             BlobFileMeta fileMeta,
             @Nullable SeekableInputStream in,
             int fieldCount,
-            int blobIndex) {
+            int blobIndex,
+            DataType blobFieldType,
+            boolean blobAsDescriptor) {
         this.fileIO = fileIO;
         this.filePath = filePath;
         this.filePathString = filePath.toString();
@@ -60,6 +72,12 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
         this.in = in;
         this.fieldCount = fieldCount;
         this.blobIndex = blobIndex;
+        this.blobFieldType = blobFieldType;
+        this.blobPlaceholder =
+                blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY
+                        ? BlobArrayPlaceholder.INSTANCE
+                        : BlobPlaceholder.INSTANCE;
+        this.blobAsDescriptor = blobAsDescriptor;
         this.returned = false;
     }
 
@@ -92,29 +110,36 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                     return null;
                 }
 
-                Blob blob;
+                Object field;
                 if (fileMeta.isNull(currentPosition)) {
-                    blob = null;
+                    field = null;
                 } else if (fileMeta.isPlaceHolder(currentPosition)) {
-                    blob = BlobPlaceholder.INSTANCE;
+                    field = blobPlaceholder;
                 } else {
                     long offset = fileMeta.blobOffset(currentPosition) + 4;
                     long length = fileMeta.blobLength(currentPosition) - 16;
-                    if (in != null) {
-                        blob = Blob.fromData(readInlineBlob(in, offset, length));
+                    if (blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY) {
+                        field = readBlobArray(in, offset, length);
                     } else {
-                        blob = Blob.fromFile(fileIO, filePathString, offset, length);
+                        field = readBlob(in, offset, length);
                     }
                 }
                 currentPosition++;
                 GenericRow row = new GenericRow(fieldCount);
-                row.setField(blobIndex, blob);
+                row.setField(blobIndex, field);
                 return row;
             }
 
             @Override
             public void releaseBatch() {}
         };
+    }
+
+    private Blob readBlob(@Nullable SeekableInputStream in, long position, long length) {
+        if (in != null && !blobAsDescriptor) {
+            return Blob.fromData(readInlineBlob(in, position, length));
+        }
+        return Blob.fromFile(fileIO, filePathString, position, length);
     }
 
     @Override
@@ -131,5 +156,67 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
             throw new RuntimeException(e);
         }
         return blobData;
+    }
+
+    private GenericArray readBlobArray(SeekableInputStream in, long position, long length) {
+        if (in == null) {
+            throw new IllegalStateException("Input stream must be available for ARRAY<BLOB>.");
+        }
+
+        try {
+            byte[] header = new byte[9];
+            in.seek(position);
+            IOUtils.readFully(in, header);
+            ByteBuffer headerBuffer = littleEndianBuffer(header);
+            int magic = headerBuffer.getInt();
+            if (magic != BlobFormatWriter.ARRAY_MAGIC_NUMBER) {
+                throw new IllegalArgumentException(
+                        "Invalid ARRAY<BLOB> payload magic number: " + magic);
+            }
+            byte version = headerBuffer.get();
+            if (version > BlobFormatWriter.ARRAY_VERSION) {
+                throw new UnsupportedOperationException(
+                        "Unsupported ARRAY<BLOB> payload version: " + version);
+            }
+            int elementCount = headerBuffer.getInt();
+
+            long elementIndexLengthPosition = position + length - Integer.BYTES;
+            byte[] indexLengthBytes = new byte[Integer.BYTES];
+            in.seek(elementIndexLengthPosition);
+            IOUtils.readFully(in, indexLengthBytes);
+            int elementIndexLength = littleEndianBuffer(indexLengthBytes).getInt();
+
+            byte[] elementIndexBytes = new byte[elementIndexLength];
+            in.seek(elementIndexLengthPosition - elementIndexLength);
+            IOUtils.readFully(in, elementIndexBytes);
+            long[] elementLengths = DeltaVarintCompressor.decompress(elementIndexBytes);
+            if (elementLengths.length != elementCount) {
+                throw new IllegalArgumentException(
+                        "ARRAY<BLOB> element count does not match element index length.");
+            }
+
+            Object[] blobs = new Object[elementCount];
+            long elementOffset = position + header.length;
+            for (int i = 0; i < elementCount; i++) {
+                long elementLength = elementLengths[i];
+                if (elementLength == BlobFormatWriter.ARRAY_NULL_ELEMENT_LENGTH) {
+                    blobs[i] = null;
+                } else if (blobAsDescriptor) {
+                    blobs[i] = Blob.fromFile(fileIO, filePathString, elementOffset, elementLength);
+                    elementOffset += elementLength;
+                } else {
+                    blobs[i] = Blob.fromData(readInlineBlob(in, elementOffset, elementLength));
+                    elementOffset += elementLength;
+                }
+            }
+
+            return new GenericArray(blobs);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ByteBuffer littleEndianBuffer(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -43,6 +43,11 @@ import java.nio.ByteOrder;
 /** {@link FileRecordReader} for blob file. */
 public class BlobFormatReader implements FileRecordReader<InternalRow> {
 
+    private static final int ARRAY_HEADER_LENGTH = 9;
+    private static final int ARRAY_INDEX_LENGTH_SIZE = Integer.BYTES;
+    private static final int MIN_ARRAY_PAYLOAD_LENGTH =
+            ARRAY_HEADER_LENGTH + ARRAY_INDEX_LENGTH_SIZE;
+
     private final FileIO fileIO;
     private final Path filePath;
     private final String filePathString;
@@ -162,9 +167,15 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
         if (in == null) {
             throw new IllegalStateException("Input stream must be available for ARRAY<BLOB>.");
         }
+        if (position < 0
+                || length < MIN_ARRAY_PAYLOAD_LENGTH
+                || position > Long.MAX_VALUE - length) {
+            throw new IllegalArgumentException(
+                    "Invalid ARRAY<BLOB> payload position or length: " + position + ", " + length);
+        }
 
         try {
-            byte[] header = new byte[9];
+            byte[] header = new byte[ARRAY_HEADER_LENGTH];
             in.seek(position);
             IOUtils.readFully(in, header);
             ByteBuffer headerBuffer = littleEndianBuffer(header);
@@ -174,29 +185,75 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                         "Invalid ARRAY<BLOB> payload magic number: " + magic);
             }
             byte version = headerBuffer.get();
-            if (version > BlobFormatWriter.ARRAY_VERSION) {
+            if (version != BlobFormatWriter.ARRAY_VERSION) {
                 throw new UnsupportedOperationException(
                         "Unsupported ARRAY<BLOB> payload version: " + version);
             }
             int elementCount = headerBuffer.getInt();
+            if (elementCount < 0) {
+                throw new IllegalArgumentException(
+                        "Invalid ARRAY<BLOB> element count: " + elementCount);
+            }
 
-            long elementIndexLengthPosition = position + length - Integer.BYTES;
-            byte[] indexLengthBytes = new byte[Integer.BYTES];
+            long payloadEnd = position + length;
+            long elementDataStart = position + ARRAY_HEADER_LENGTH;
+            long elementIndexLengthPosition = payloadEnd - ARRAY_INDEX_LENGTH_SIZE;
+            byte[] indexLengthBytes = new byte[ARRAY_INDEX_LENGTH_SIZE];
             in.seek(elementIndexLengthPosition);
             IOUtils.readFully(in, indexLengthBytes);
             int elementIndexLength = littleEndianBuffer(indexLengthBytes).getInt();
+            long maximumIndexLength = length - MIN_ARRAY_PAYLOAD_LENGTH;
+            if (elementIndexLength < 0 || elementIndexLength > maximumIndexLength) {
+                throw new IllegalArgumentException(
+                        "Invalid ARRAY<BLOB> element index length: " + elementIndexLength);
+            }
+            if (elementCount > elementIndexLength) {
+                throw new IllegalArgumentException(
+                        "ARRAY<BLOB> element count exceeds element index length.");
+            }
 
             byte[] elementIndexBytes = new byte[elementIndexLength];
-            in.seek(elementIndexLengthPosition - elementIndexLength);
+            long elementIndexStart = elementIndexLengthPosition - elementIndexLength;
+            in.seek(elementIndexStart);
             IOUtils.readFully(in, elementIndexBytes);
-            long[] elementLengths = DeltaVarintCompressor.decompress(elementIndexBytes);
+            long[] elementLengths;
+            try {
+                elementLengths = DeltaVarintCompressor.decompress(elementIndexBytes);
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException("Invalid ARRAY<BLOB> element index.", e);
+            }
             if (elementLengths.length != elementCount) {
                 throw new IllegalArgumentException(
                         "ARRAY<BLOB> element count does not match element index length.");
             }
 
+            long elementDataLength = elementIndexStart - elementDataStart;
+            long totalElementLength = 0;
+            for (long elementLength : elementLengths) {
+                if (elementLength == BlobFormatWriter.ARRAY_NULL_ELEMENT_LENGTH) {
+                    continue;
+                }
+                if (elementLength < 0) {
+                    throw new IllegalArgumentException(
+                            "Invalid ARRAY<BLOB> element length: " + elementLength);
+                }
+                if (!blobAsDescriptor && elementLength > Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException(
+                            "ARRAY<BLOB> inline element is too large: " + elementLength);
+                }
+                if (elementLength > elementDataLength - totalElementLength) {
+                    throw new IllegalArgumentException(
+                            "ARRAY<BLOB> element lengths exceed the payload data length.");
+                }
+                totalElementLength += elementLength;
+            }
+            if (totalElementLength != elementDataLength) {
+                throw new IllegalArgumentException(
+                        "ARRAY<BLOB> element lengths do not match the payload data length.");
+            }
+
             Object[] blobs = new Object[elementCount];
-            long elementOffset = position + header.length;
+            long elementOffset = elementDataStart;
             for (int i = 0; i < elementCount; i++) {
                 long elementLength = elementLengths[i];
                 if (elementLength == BlobFormatWriter.ARRAY_NULL_ELEMENT_LENGTH) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -85,14 +85,6 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             PositionOutputStream out,
             @Nullable BlobConsumer writeConsumer,
             RowType type,
-            boolean writeNullOnMissingFile) {
-        this(out, writeConsumer, type, writeNullOnMissingFile, false);
-    }
-
-    public BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            RowType type,
             boolean writeNullOnMissingFile,
             boolean writeNullOnFetchFailure) {
         this.out = out;

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -32,7 +32,6 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.rest.HttpClientUtils;
-import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DeltaVarintCompressor;
@@ -70,7 +69,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     private final String blobFieldName;
     private final boolean writeNullOnMissingFile;
     private final boolean writeNullOnFetchFailure;
-    private final DataType blobFieldType;
+    private final BlobElementWriter elementWriter;
     private final CRC32 crc32;
     private final byte[] tmpBuffer;
     private final LongArrayList lengths;
@@ -102,7 +101,10 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
         this.writeNullOnFetchFailure = writeNullOnFetchFailure;
         checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
         this.blobFieldName = type.getFieldNames().get(0);
-        this.blobFieldType = type.getTypeAt(0);
+        this.elementWriter =
+                type.getTypeAt(0).getTypeRoot() == DataTypeRoot.ARRAY
+                        ? new ArrayBlobElementWriter()
+                        : new RawBlobElementWriter();
         this.crc32 = new CRC32();
         this.tmpBuffer = new byte[4096];
         this.lengths = new LongArrayList(16);
@@ -126,33 +128,49 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             return;
         }
 
-        if (blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY) {
+        elementWriter.addElement(element);
+    }
+
+    private interface BlobElementWriter {
+        void addElement(InternalRow element) throws IOException;
+    }
+
+    private class RawBlobElementWriter implements BlobElementWriter {
+
+        @Override
+        public void addElement(InternalRow element) throws IOException {
+            Blob blob;
+            try {
+                blob = element.getBlob(0);
+            } catch (RuntimeException e) {
+                if (shouldWriteNullOnFetchFailure(e)) {
+                    logWriteNullOnFetchFailure(e, null);
+                    writeNullElement();
+                    return;
+                }
+                throw e;
+            }
+            if (blob == BlobPlaceholder.INSTANCE) {
+                lengths.add(PLACE_HOLDER_LENGTH);
+                return;
+            }
+
+            addBlob(blob);
+        }
+    }
+
+    private class ArrayBlobElementWriter implements BlobElementWriter {
+
+        @Override
+        public void addElement(InternalRow element) throws IOException {
             InternalArray array = element.getArray(0);
             if (array == BlobArrayPlaceholder.INSTANCE) {
                 lengths.add(PLACE_HOLDER_LENGTH);
-            } else {
-                addBlobArray(array);
-            }
-            return;
-        }
-
-        Blob blob;
-        try {
-            blob = element.getBlob(0);
-        } catch (RuntimeException e) {
-            if (shouldWriteNullOnFetchFailure(e)) {
-                logWriteNullOnFetchFailure(e, null);
-                writeNullElement();
                 return;
             }
-            throw e;
-        }
-        if (blob == BlobPlaceholder.INSTANCE) {
-            lengths.add(PLACE_HOLDER_LENGTH);
-            return;
-        }
 
-        addBlob(blob);
+            addBlobArray(array);
+        }
     }
 
     private void addBlob(Blob blob) throws IOException {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -19,11 +19,12 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobConsumer;
 import org.apache.paimon.data.BlobDescriptor;
-import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileAwareFormatWriter;
 import org.apache.paimon.format.FormatWriter;
@@ -31,6 +32,8 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.rest.HttpClientUtils;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DeltaVarintCompressor;
 import org.apache.paimon.utils.LongArrayList;
@@ -55,15 +58,19 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     public static final byte VERSION = 1;
     public static final int MAGIC_NUMBER = 1481511375;
     public static final byte[] MAGIC_NUMBER_BYTES = intToLittleEndian(MAGIC_NUMBER);
+    public static final byte ARRAY_VERSION = 1;
+    public static final int ARRAY_MAGIC_NUMBER = 1094861634;
+    public static final byte[] ARRAY_MAGIC_NUMBER_BYTES = intToLittleEndian(ARRAY_MAGIC_NUMBER);
     public static final long NULL_LENGTH = -1L;
     public static final long PLACE_HOLDER_LENGTH = -2L;
+    public static final long ARRAY_NULL_ELEMENT_LENGTH = -1L;
 
     private final PositionOutputStream out;
     @Nullable private final BlobConsumer writeConsumer;
-    private final BlobFetchMetricReporter blobFetchMetricReporter;
     private final String blobFieldName;
     private final boolean writeNullOnMissingFile;
     private final boolean writeNullOnFetchFailure;
+    private final DataType blobFieldType;
     private final CRC32 crc32;
     private final byte[] tmpBuffer;
     private final LongArrayList lengths;
@@ -89,29 +96,13 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             RowType type,
             boolean writeNullOnMissingFile,
             boolean writeNullOnFetchFailure) {
-        this(
-                out,
-                writeConsumer,
-                type,
-                writeNullOnMissingFile,
-                writeNullOnFetchFailure,
-                BlobFetchMetricReporter.NOOP);
-    }
-
-    public BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            RowType type,
-            boolean writeNullOnMissingFile,
-            boolean writeNullOnFetchFailure,
-            BlobFetchMetricReporter blobFetchMetricReporter) {
         this.out = out;
         this.writeConsumer = writeConsumer;
-        this.blobFetchMetricReporter = blobFetchMetricReporter;
         this.writeNullOnMissingFile = writeNullOnMissingFile;
         this.writeNullOnFetchFailure = writeNullOnFetchFailure;
         checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
         this.blobFieldName = type.getFieldNames().get(0);
+        this.blobFieldType = type.getTypeAt(0);
         this.crc32 = new CRC32();
         this.tmpBuffer = new byte[4096];
         this.lengths = new LongArrayList(16);
@@ -131,18 +122,29 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     public void addElement(InternalRow element) throws IOException {
         checkArgument(element.getFieldCount() == 1, "BlobFormatWriter only support one field.");
         if (element.isNullAt(0)) {
-            recordPreCheckedMissingFileNull(element);
             writeNullElement();
             return;
         }
+
+        if (blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY) {
+            InternalArray array = element.getArray(0);
+            if (array == BlobArrayPlaceholder.INSTANCE) {
+                lengths.add(PLACE_HOLDER_LENGTH);
+            } else {
+                addBlobArray(array);
+            }
+            return;
+        }
+
         Blob blob;
         try {
             blob = element.getBlob(0);
         } catch (RuntimeException e) {
-            if (tryWriteNullOnFetchFailure(e, null)) {
+            if (shouldWriteNullOnFetchFailure(e)) {
+                logWriteNullOnFetchFailure(e, null);
+                writeNullElement();
                 return;
             }
-            blobFetchMetricReporter.recordFetchFailure(e);
             throw e;
         }
         if (blob == BlobPlaceholder.INSTANCE) {
@@ -150,44 +152,21 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             return;
         }
 
-        SeekableInputStream in;
-        try {
-            in = blob.newInputStream();
-        } catch (IOException | RuntimeException e) {
-            if (writeNullOnMissingFile && HttpClientUtils.isNotFoundError(e)) {
-                LOG.warn(
-                        "Failed to open blob from {} (HTTP 404), writing NULL for BLOB field {}.",
-                        blobUri(blob),
-                        blobFieldName,
-                        e);
-                blobFetchMetricReporter.recordMissingFileNullWritten(true);
-                writeNullElement();
-                return;
-            }
-            if (tryWriteNullOnFetchFailure(e, blob)) {
-                return;
-            }
-            blobFetchMetricReporter.recordFetchFailure(e);
-            throw e;
-        }
+        addBlob(blob);
+    }
 
+    private void addBlob(Blob blob) throws IOException {
+        SeekableInputStream in = openBlobInputStream(blob, true);
+        if (in == null) {
+            return;
+        }
+        long previousPos = out.getPos();
         crc32.reset();
         write(MAGIC_NUMBER_BYTES);
-        long blobPos = out.getPos();
-        long blobLength = 0;
-        try (SeekableInputStream stream = in) {
-            int bytesRead = stream.read(tmpBuffer);
-            while (bytesRead >= 0) {
-                write(tmpBuffer, bytesRead);
-                blobLength += bytesRead;
-                bytesRead = stream.read(tmpBuffer);
-            }
-        } catch (IOException | RuntimeException e) {
-            blobFetchMetricReporter.recordFetchFailure(e);
-            throw e;
-        }
 
-        long binLength = blobLength + MAGIC_NUMBER_BYTES.length + 12;
+        BlobDescriptor descriptor = writeBlobData(in);
+
+        long binLength = out.getPos() - previousPos + 12;
         lengths.add(binLength);
         byte[] lenBytes = longToLittleEndian(binLength);
         write(lenBytes);
@@ -195,20 +174,105 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
         out.write(intToLittleEndian(crcValue));
 
         if (writeConsumer != null) {
-            BlobDescriptor descriptor = new BlobDescriptor(pathString, blobPos, blobLength);
             boolean flush = writeConsumer.accept(blobFieldName, descriptor);
             if (flush) {
                 out.flush();
             }
         }
-        blobFetchMetricReporter.recordSuccess(blobLength);
     }
 
-    private boolean tryWriteNullOnFetchFailure(Throwable e, @Nullable Blob blob)
-            throws IOException {
-        if (!writeNullOnFetchFailure || HttpClientUtils.isNotFoundError(e)) {
-            return false;
+    private void addBlobArray(InternalArray array) throws IOException {
+        long previousPos = out.getPos();
+        crc32.reset();
+
+        write(MAGIC_NUMBER_BYTES);
+
+        write(ARRAY_MAGIC_NUMBER_BYTES);
+        write(new byte[] {ARRAY_VERSION});
+        write(intToLittleEndian(array.size()));
+
+        long[] elementLengths = new long[array.size()];
+        boolean flush = false;
+        for (int i = 0; i < array.size(); i++) {
+            if (array.isNullAt(i)) {
+                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
+                continue;
+            }
+
+            Blob blob = array.getBlob(i);
+            SeekableInputStream in = openBlobInputStream(blob, false);
+            if (in == null) {
+                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
+                continue;
+            }
+            BlobDescriptor descriptor = writeBlobData(in);
+            elementLengths[i] = descriptor.length();
+            if (writeConsumer != null) {
+                flush |= writeConsumer.accept(blobFieldName, descriptor);
+            }
         }
+
+        byte[] elementIndexBytes = DeltaVarintCompressor.compress(elementLengths);
+        write(elementIndexBytes);
+        write(intToLittleEndian(elementIndexBytes.length));
+
+        long binLength = out.getPos() - previousPos + 12;
+        lengths.add(binLength);
+        write(longToLittleEndian(binLength));
+        int crcValue = (int) crc32.getValue();
+        out.write(intToLittleEndian(crcValue));
+
+        if (flush) {
+            out.flush();
+        }
+    }
+
+    @Nullable
+    private SeekableInputStream openBlobInputStream(Blob blob, boolean writeNullElement)
+            throws IOException {
+        try {
+            return blob.newInputStream();
+        } catch (IOException | RuntimeException e) {
+            if (writeNullOnMissingFile && HttpClientUtils.isNotFoundError(e)) {
+                LOG.warn(
+                        "Failed to open blob from {} (HTTP 404), writing NULL for BLOB field {}.",
+                        blobUri(blob),
+                        blobFieldName,
+                        e);
+                if (writeNullElement) {
+                    writeNullElement();
+                }
+                return null;
+            }
+            if (shouldWriteNullOnFetchFailure(e)) {
+                logWriteNullOnFetchFailure(e, blob);
+                if (writeNullElement) {
+                    writeNullElement();
+                }
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private BlobDescriptor writeBlobData(SeekableInputStream in) throws IOException {
+        long blobPos = out.getPos();
+        try (SeekableInputStream stream = in) {
+            int bytesRead = stream.read(tmpBuffer);
+            while (bytesRead >= 0) {
+                write(tmpBuffer, bytesRead);
+                bytesRead = stream.read(tmpBuffer);
+            }
+        }
+
+        return new BlobDescriptor(pathString, blobPos, out.getPos() - blobPos);
+    }
+
+    private boolean shouldWriteNullOnFetchFailure(Throwable e) {
+        return writeNullOnFetchFailure && !HttpClientUtils.isNotFoundError(e);
+    }
+
+    private void logWriteNullOnFetchFailure(Throwable e, @Nullable Blob blob) {
         Integer statusCode = HttpClientUtils.getHttpStatusCode(e);
         if (statusCode != null) {
             LOG.warn(
@@ -230,20 +294,6 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                     blobFieldName,
                     e);
         }
-        blobFetchMetricReporter.recordFetchFailureNullWritten(e);
-        writeNullElement();
-        return true;
-    }
-
-    private void recordPreCheckedMissingFileNull(InternalRow element) {
-        if (!writeNullOnMissingFile) {
-            return;
-        }
-        Blob blob = element.getBlob(0);
-        if (blob instanceof BlobRef) {
-            BlobDescriptor descriptor = ((BlobRef) blob).toDescriptor();
-            blobFetchMetricReporter.recordMissingFileNullWritten(isHttpUri(descriptor.uri()));
-        }
     }
 
     private void writeNullElement() throws IOException {
@@ -258,11 +308,6 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             return ((BlobRef) blob).toDescriptor().uri();
         }
         return "unknown";
-    }
-
-    private static boolean isHttpUri(String uri) {
-        return uri.regionMatches(true, 0, "http://", 0, "http://".length())
-                || uri.regionMatches(true, 0, "https://", 0, "https://".length());
     }
 
     private void write(byte[] bytes) throws IOException {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -22,6 +22,7 @@ import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobConsumer;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.InternalArray;
@@ -66,6 +67,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
 
     private final PositionOutputStream out;
     @Nullable private final BlobConsumer writeConsumer;
+    private final BlobFetchMetricReporter blobFetchMetricReporter;
     private final String blobFieldName;
     private final boolean writeNullOnMissingFile;
     private final boolean writeNullOnFetchFailure;
@@ -85,10 +87,35 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             PositionOutputStream out,
             @Nullable BlobConsumer writeConsumer,
             RowType type,
+            boolean writeNullOnMissingFile) {
+        this(out, writeConsumer, type, writeNullOnMissingFile, false);
+    }
+
+    public BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
             boolean writeNullOnMissingFile,
             boolean writeNullOnFetchFailure) {
+        this(
+                out,
+                writeConsumer,
+                type,
+                writeNullOnMissingFile,
+                writeNullOnFetchFailure,
+                BlobFetchMetricReporter.NOOP);
+    }
+
+    public BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter) {
         this.out = out;
         this.writeConsumer = writeConsumer;
+        this.blobFetchMetricReporter = blobFetchMetricReporter;
         this.writeNullOnMissingFile = writeNullOnMissingFile;
         this.writeNullOnFetchFailure = writeNullOnFetchFailure;
         checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
@@ -115,11 +142,6 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     @Override
     public void addElement(InternalRow element) throws IOException {
         checkArgument(element.getFieldCount() == 1, "BlobFormatWriter only support one field.");
-        if (element.isNullAt(0)) {
-            writeNullElement();
-            return;
-        }
-
         elementWriter.addElement(element);
     }
 
@@ -131,15 +153,23 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
 
         @Override
         public void addElement(InternalRow element) throws IOException {
+            if (element.isNullAt(0)) {
+                recordPreCheckedMissingFileNull(element);
+                writeNullElement();
+                return;
+            }
+
             Blob blob;
             try {
                 blob = element.getBlob(0);
             } catch (RuntimeException e) {
                 if (shouldWriteNullOnFetchFailure(e)) {
                     logWriteNullOnFetchFailure(e, null);
+                    blobFetchMetricReporter.recordFetchFailureNullWritten(e);
                     writeNullElement();
                     return;
                 }
+                blobFetchMetricReporter.recordFetchFailure(e);
                 throw e;
             }
             if (blob == BlobPlaceholder.INSTANCE) {
@@ -155,6 +185,11 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
 
         @Override
         public void addElement(InternalRow element) throws IOException {
+            if (element.isNullAt(0)) {
+                writeNullElement();
+                return;
+            }
+
             InternalArray array = element.getArray(0);
             if (array == BlobArrayPlaceholder.INSTANCE) {
                 lengths.add(PLACE_HOLDER_LENGTH);
@@ -189,6 +224,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                 out.flush();
             }
         }
+        blobFetchMetricReporter.recordSuccess(descriptor.length());
     }
 
     private void addBlobArray(InternalArray array) throws IOException {
@@ -224,6 +260,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             if (writeConsumer != null) {
                 flush |= writeConsumer.accept(blobFieldName, descriptor);
             }
+            blobFetchMetricReporter.recordSuccess(descriptor.length());
         }
 
         byte[] elementIndexBytes = DeltaVarintCompressor.compress(elementLengths);
@@ -248,8 +285,10 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
         } catch (RuntimeException e) {
             if (shouldWriteNullOnFetchFailure(e)) {
                 logWriteNullOnFetchFailure(e, null);
+                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
                 return null;
             }
+            blobFetchMetricReporter.recordFetchFailure(e);
             throw e;
         }
     }
@@ -266,6 +305,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                         blobUri(blob),
                         blobFieldName,
                         e);
+                blobFetchMetricReporter.recordMissingFileNullWritten(true);
                 if (writeNullElement) {
                     writeNullElement();
                 }
@@ -273,11 +313,13 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             }
             if (shouldWriteNullOnFetchFailure(e)) {
                 logWriteNullOnFetchFailure(e, blob);
+                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
                 if (writeNullElement) {
                     writeNullElement();
                 }
                 return null;
             }
+            blobFetchMetricReporter.recordFetchFailure(e);
             throw e;
         }
     }
@@ -290,6 +332,9 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                 write(tmpBuffer, bytesRead);
                 bytesRead = stream.read(tmpBuffer);
             }
+        } catch (IOException | RuntimeException e) {
+            blobFetchMetricReporter.recordFetchFailure(e);
+            throw e;
         }
 
         return new BlobDescriptor(pathString, blobPos, out.getPos() - blobPos);
@@ -323,6 +368,17 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
         }
     }
 
+    private void recordPreCheckedMissingFileNull(InternalRow element) {
+        if (!writeNullOnMissingFile) {
+            return;
+        }
+        Blob blob = element.getBlob(0);
+        if (blob instanceof BlobRef) {
+            BlobDescriptor descriptor = ((BlobRef) blob).toDescriptor();
+            blobFetchMetricReporter.recordMissingFileNullWritten(isHttpUri(descriptor.uri()));
+        }
+    }
+
     private void writeNullElement() throws IOException {
         lengths.add(NULL_LENGTH);
         if (writeConsumer != null) {
@@ -335,6 +391,11 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             return ((BlobRef) blob).toDescriptor().uri();
         }
         return "unknown";
+    }
+
+    private static boolean isHttpUri(String uri) {
+        return uri.regionMatches(true, 0, "http://", 0, "http://".length())
+                || uri.regionMatches(true, 0, "https://", 0, "https://".length());
     }
 
     private void write(byte[] bytes) throws IOException {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -201,8 +201,9 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     }
 
     private void addBlob(Blob blob) throws IOException {
-        SeekableInputStream in = openBlobInputStream(blob, true);
+        SeekableInputStream in = openBlobInputStream(blob);
         if (in == null) {
+            writeNullElement();
             return;
         }
         long previousPos = out.getPos();
@@ -250,7 +251,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                 elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
                 continue;
             }
-            SeekableInputStream in = openBlobInputStream(blob, false);
+            SeekableInputStream in = openBlobInputStream(blob);
             if (in == null) {
                 elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
                 continue;
@@ -294,8 +295,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     }
 
     @Nullable
-    private SeekableInputStream openBlobInputStream(Blob blob, boolean writeNullElement)
-            throws IOException {
+    private SeekableInputStream openBlobInputStream(Blob blob) throws IOException {
         try {
             return blob.newInputStream();
         } catch (IOException | RuntimeException e) {
@@ -306,17 +306,11 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                         blobFieldName,
                         e);
                 blobFetchMetricReporter.recordMissingFileNullWritten(true);
-                if (writeNullElement) {
-                    writeNullElement();
-                }
                 return null;
             }
             if (shouldWriteNullOnFetchFailure(e)) {
                 logWriteNullOnFetchFailure(e, blob);
                 blobFetchMetricReporter.recordFetchFailureNullWritten(e);
-                if (writeNullElement) {
-                    writeNullElement();
-                }
                 return null;
             }
             blobFetchMetricReporter.recordFetchFailure(e);

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -209,7 +209,11 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                 continue;
             }
 
-            Blob blob = array.getBlob(i);
+            Blob blob = getArrayBlob(array, i);
+            if (blob == null) {
+                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
+                continue;
+            }
             SeekableInputStream in = openBlobInputStream(blob, false);
             if (in == null) {
                 elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
@@ -234,6 +238,19 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
 
         if (flush) {
             out.flush();
+        }
+    }
+
+    @Nullable
+    private Blob getArrayBlob(InternalArray array, int pos) {
+        try {
+            return array.getBlob(pos);
+        } catch (RuntimeException e) {
+            if (shouldWriteNullOnFetchFailure(e)) {
+                logWriteNullOnFetchFailure(e, null);
+                return null;
+            }
+            throw e;
         }
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -34,7 +34,9 @@ import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ProjectedRow;
@@ -45,12 +47,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link BlobFileFormat}. */
 public class BlobFileFormatTest {
@@ -109,6 +114,51 @@ public class BlobFileFormatTest {
 
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getArray(0)).isSameAs(BlobArrayPlaceholder.INSTANCE);
+    }
+
+    @Test
+    public void testRejectUnsupportedArrayBlobPayloadVersion() throws IOException {
+        assertMalformedArrayPayload(
+                (bytes, position, length) -> bytes[position + Integer.BYTES] = 0,
+                "Unsupported ARRAY<BLOB> payload version");
+    }
+
+    @Test
+    public void testRejectInvalidArrayBlobElementCount() throws IOException {
+        assertMalformedArrayPayload(
+                (bytes, position, length) -> {
+                    int countPosition = position + Integer.BYTES + 1;
+                    Arrays.fill(bytes, countPosition, countPosition + Integer.BYTES, (byte) 0xff);
+                },
+                "Invalid ARRAY<BLOB> element count");
+    }
+
+    @Test
+    public void testRejectInvalidArrayBlobIndexLength() throws IOException {
+        assertMalformedArrayPayload(
+                (bytes, position, length) -> {
+                    int indexLengthPosition = position + length - Integer.BYTES;
+                    Arrays.fill(
+                            bytes,
+                            indexLengthPosition,
+                            indexLengthPosition + Integer.BYTES,
+                            (byte) 0xff);
+                },
+                "Invalid ARRAY<BLOB> element index length");
+    }
+
+    @Test
+    public void testRejectInvalidArrayBlobElementLength() throws IOException {
+        assertMalformedArrayPayload(
+                (bytes, position, length) -> bytes[position + length - Integer.BYTES - 1] = 3,
+                "Invalid ARRAY<BLOB> element length");
+    }
+
+    @Test
+    public void testRejectArrayBlobElementLengthMismatch() throws IOException {
+        assertMalformedArrayPayload(
+                (bytes, position, length) -> bytes[position + length - Integer.BYTES - 1] = 4,
+                "element lengths exceed the payload data length");
     }
 
     private void innerTest(boolean blobAsDescriptor) throws IOException {
@@ -181,6 +231,43 @@ public class BlobFileFormatTest {
         // assert
         assertThat(result).hasSize(1);
         assertThat(result.get(0)).isSameAs(BlobPlaceholder.INSTANCE);
+    }
+
+    private void assertMalformedArrayPayload(
+            ArrayPayloadCorruptor corruptor, String expectedMessage) throws IOException {
+        BlobFileFormat format = new BlobFileFormat();
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(
+                    GenericRow.of(new GenericArray(new Object[] {new BlobData("a".getBytes())})));
+            writer.close();
+        }
+
+        int payloadPosition;
+        int payloadLength;
+        try (SeekableInputStream input = fileIO.newInputStream(file)) {
+            BlobFileMeta fileMeta = new BlobFileMeta(input, fileIO.getFileSize(file), null);
+            payloadPosition = Math.toIntExact(fileMeta.blobOffset(0) + Integer.BYTES);
+            payloadLength = Math.toIntExact(fileMeta.blobLength(0) - 16);
+        }
+
+        java.nio.file.Path localFile = Paths.get(file.toUri());
+        byte[] bytes = Files.readAllBytes(localFile);
+        corruptor.corrupt(bytes, payloadPosition, payloadLength);
+        Files.write(localFile, bytes);
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        assertThatThrownBy(
+                        () -> {
+                            try (FileRecordReader<InternalRow> reader =
+                                    readerFactory.createReader(context)) {
+                                reader.forEachRemaining(ignored -> {});
+                            }
+                        })
+                .hasMessageContaining(expectedMessage);
     }
 
     @Test
@@ -298,5 +385,9 @@ public class BlobFileFormatTest {
             }
         }
         result.add(bytes);
+    }
+
+    private interface ArrayPayloadCorruptor {
+        void corrupt(byte[] bytes, int position, int length);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -19,10 +19,13 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatReaderFactory;
@@ -34,6 +37,7 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ProjectedRow;
 import org.apache.paimon.utils.RoaringBitmap32;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -72,6 +76,39 @@ public class BlobFileFormatTest {
     @Test
     public void testReadBlobInlineBytes() throws IOException {
         innerTest(false);
+    }
+
+    @Test
+    public void testArrayBlobAsDescriptor() throws IOException {
+        innerTestArray(true);
+    }
+
+    @Test
+    public void testReadArrayBlobInlineBytes() throws IOException {
+        innerTestArray(false);
+    }
+
+    @Test
+    public void testWriteArrayBlobPlaceholderWithProjectedRow() throws IOException {
+        BlobFileFormat format = new BlobFileFormat();
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter formatWriter = format.createWriterFactory(rowType).create(out, null);
+            ProjectedRow projectedRow = ProjectedRow.from(new int[] {1});
+            formatWriter.addElement(
+                    projectedRow.replaceRow(GenericRow.of(0, BlobArrayPlaceholder.INSTANCE)));
+            formatWriter.close();
+        }
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        List<InternalRow> rows = new ArrayList<>();
+        readerFactory.createReader(context).forEachRemaining(rows::add);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getArray(0)).isSameAs(BlobArrayPlaceholder.INSTANCE);
     }
 
     private void innerTest(boolean blobAsDescriptor) throws IOException {
@@ -183,5 +220,83 @@ public class BlobFileFormatTest {
         }
         assertThat(rows.get(0).getBlob(1).toData()).isEqualTo("hello".getBytes());
         assertThat(rows.get(1).getBlob(1).toData()).isEqualTo("world".getBytes());
+    }
+
+    private void innerTestArray(boolean blobAsDescriptor) throws IOException {
+        BlobFileFormat format = new BlobFileFormat(blobAsDescriptor);
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+
+        GenericArray first =
+                new GenericArray(
+                        new Object[] {
+                            new BlobData("hello".getBytes()), null, new BlobData("world".getBytes())
+                        });
+        GenericArray empty = new GenericArray(new Object[0]);
+        List<Object> arrays = Arrays.asList(first, null, BlobArrayPlaceholder.INSTANCE, empty);
+
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter formatWriter = format.createWriterFactory(rowType).create(out, null);
+            for (Object array : arrays) {
+                formatWriter.addElement(GenericRow.of(array));
+            }
+            formatWriter.close();
+        }
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        List<Object> result = new ArrayList<>();
+        readerFactory
+                .createReader(context)
+                .forEachRemaining(
+                        row -> {
+                            if (row.isNullAt(0)) {
+                                result.add(null);
+                            } else {
+                                addArrayBlobResult(row, blobAsDescriptor, result);
+                            }
+                        });
+
+        assertThat(result).hasSize(4);
+        assertThat((byte[]) ((Object[]) result.get(0))[0]).isEqualTo("hello".getBytes());
+        assertThat(((Object[]) result.get(0))[1]).isNull();
+        assertThat((byte[]) ((Object[]) result.get(0))[2]).isEqualTo("world".getBytes());
+        assertThat(result.get(1)).isNull();
+        assertThat(result.get(2)).isSameAs(BlobArrayPlaceholder.INSTANCE);
+        assertThat((Object[]) result.get(3)).isEmpty();
+
+        RoaringBitmap32 selection = new RoaringBitmap32();
+        selection.add(0);
+        context = new FormatReaderContext(fileIO, file, fileIO.getFileSize(file), selection);
+        result.clear();
+        readerFactory
+                .createReader(context)
+                .forEachRemaining(row -> result.add(row.getArray(0).getBlob(0).toData()));
+        assertThat(result).hasSize(1);
+        assertThat((byte[]) result.get(0)).isEqualTo("hello".getBytes());
+    }
+
+    private static void addArrayBlobResult(
+            InternalRow row, boolean blobAsDescriptor, List<Object> result) {
+        InternalArray array = row.getArray(0);
+        if (array == BlobArrayPlaceholder.INSTANCE) {
+            result.add(BlobArrayPlaceholder.INSTANCE);
+            return;
+        }
+        Object[] bytes = new Object[array.size()];
+        for (int i = 0; i < array.size(); i++) {
+            if (array.isNullAt(i)) {
+                bytes[i] = null;
+            } else {
+                Blob blob = array.getBlob(i);
+                if (blobAsDescriptor) {
+                    assertThat(blob).isInstanceOf(BlobRef.class);
+                } else {
+                    assertThat(blob).isInstanceOf(BlobData.class);
+                }
+                bytes[i] = blob.toData();
+            }
+        }
+        result.add(bytes);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
@@ -399,6 +400,81 @@ public class BlobFormatWriterTest {
 
         assertThat(metricReporter.missingFileNullWritten).isEqualTo(0);
         assertThat(metricReporter.httpNotFound).isEqualTo(0);
+    }
+
+    @Test
+    public void testArrayBlobFetchMetricReporter(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+        TestingBlobFetchMetricReporter metricReporter = new TestingBlobFetchMetricReporter();
+        BlobFormatWriter writer =
+                new BlobFormatWriter(
+                        new LocalFileIO.LocalPositionOutputStream(
+                                tempDir.resolve("blob.out").toFile()),
+                        null,
+                        rowType,
+                        true,
+                        true,
+                        metricReporter);
+
+        writer.addElement(
+                GenericRow.of(
+                        new GenericArray(
+                                new Object[] {
+                                    Blob.fromData("image".getBytes()),
+                                    new BlobRef(
+                                            failingHttpReader(500),
+                                            new BlobDescriptor(
+                                                    "https://example.com/error.jpg", 0, -1)),
+                                    new BlobRef(
+                                            failingHttpReader(404),
+                                            new BlobDescriptor(
+                                                    "https://example.com/missing.jpg", 0, -1)),
+                                    null
+                                })));
+        writer.addElement(GenericRow.of((Object) null));
+        writer.close();
+
+        assertThat(metricReporter.success).isEqualTo(1);
+        assertThat(metricReporter.successBytes).isEqualTo(5);
+        assertThat(metricReporter.missingFileNullWritten).isEqualTo(1);
+        assertThat(metricReporter.httpNotFound).isEqualTo(1);
+        assertThat(metricReporter.fetchFailureNullWritten).isEqualTo(1);
+        assertThat(metricReporter.failure).isEqualTo(0);
+    }
+
+    @Test
+    public void testArrayBlobFetchMetricReporterForUnhandledFailure(
+            @TempDir java.nio.file.Path tempDir) throws Exception {
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+        TestingBlobFetchMetricReporter metricReporter = new TestingBlobFetchMetricReporter();
+        BlobFormatWriter writer =
+                new BlobFormatWriter(
+                        new LocalFileIO.LocalPositionOutputStream(
+                                tempDir.resolve("blob.out").toFile()),
+                        null,
+                        rowType,
+                        false,
+                        false,
+                        metricReporter);
+
+        assertThatThrownBy(
+                        () ->
+                                writer.addElement(
+                                        GenericRow.of(
+                                                new GenericArray(
+                                                        new Object[] {
+                                                            new BlobRef(
+                                                                    failingHttpReader(500),
+                                                                    new BlobDescriptor(
+                                                                            "https://example.com/error.jpg",
+                                                                            0,
+                                                                            -1))
+                                                        }))))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("HTTP error code: 500");
+        assertThat(metricReporter.failure).isEqualTo(1);
+        assertThat(metricReporter.fetchFailureNullWritten).isEqualTo(0);
     }
 
     private static void assertBlobPayload(Blob blob, byte[] expected) throws Exception {

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
@@ -33,6 +34,7 @@ import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.ProjectedArray;
 import org.apache.paimon.utils.UriReader;
 import org.apache.paimon.utils.UriReaderFactory;
 
@@ -211,6 +213,53 @@ public class BlobFormatWriterTest {
             BlobFileMeta fileMeta = new BlobFileMeta(in, fileSize, null);
             assertThat(fileMeta.recordNumber()).isEqualTo(1);
             assertThat(fileMeta.isNull(0)).isTrue();
+        }
+    }
+
+    @Test
+    public void testArrayWriteNullOnFetchFailureForInvalidUriDescriptor(
+            @TempDir java.nio.file.Path tempDir) throws Exception {
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+        java.nio.file.Path outputFile = tempDir.resolve("blob.out");
+        UriReaderFactory uriReaderFactory =
+                new UriReaderFactory(CatalogContext.create(new Options()));
+        byte[] descriptorBytes =
+                new BlobDescriptor("https://img.alicdn.com/imgextra/##1304008055350781673", 0, -1)
+                        .serialize();
+
+        BlobFormatWriter writer =
+                new BlobFormatWriter(
+                        new LocalFileIO.LocalPositionOutputStream(outputFile.toFile()),
+                        null,
+                        rowType,
+                        false,
+                        true);
+
+        writer.addElement(
+                GenericRow.of(new DescriptorBytesArray(descriptorBytes, uriReaderFactory)));
+        writer.close();
+
+        LocalFileIO fileIO = new LocalFileIO();
+        Path filePath = new Path(outputFile.toUri());
+        long fileSize = Files.size(outputFile);
+        try (SeekableInputStream in = fileIO.newInputStream(filePath)) {
+            BlobFileMeta fileMeta = new BlobFileMeta(in, fileSize, null);
+            assertThat(fileMeta.recordNumber()).isEqualTo(1);
+            assertThat(fileMeta.isNull(0)).isFalse();
+
+            BlobFormatReader reader =
+                    new BlobFormatReader(
+                            fileIO,
+                            filePath,
+                            fileMeta,
+                            in,
+                            1,
+                            0,
+                            DataTypes.ARRAY(DataTypes.BLOB()),
+                            false);
+            InternalArray array = reader.readBatch().next().getArray(0);
+            assertThat(array.size()).isEqualTo(1);
+            assertThat(array.isNullAt(0)).isTrue();
         }
     }
 
@@ -524,6 +573,27 @@ public class BlobFormatWriterTest {
         @Override
         public void recordFetchFailure(Throwable throwable) {
             failure++;
+        }
+    }
+
+    private static final class DescriptorBytesArray extends ProjectedArray {
+        private final byte[] descriptorBytes;
+        private final UriReaderFactory uriReaderFactory;
+
+        private DescriptorBytesArray(byte[] descriptorBytes, UriReaderFactory uriReaderFactory) {
+            super(new int[] {0});
+            this.descriptorBytes = descriptorBytes;
+            this.uriReaderFactory = uriReaderFactory;
+        }
+
+        @Override
+        public boolean isNullAt(int pos) {
+            return false;
+        }
+
+        @Override
+        public Blob getBlob(int pos) {
+            return Blob.fromBytes(descriptorBytes, uriReaderFactory, null);
         }
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
@@ -71,7 +71,9 @@ public class BlobFormatWriterTest {
             BlobFileMeta fileMeta = new BlobFileMeta(in, fileSize, null);
             assertThat(fileMeta.recordNumber()).isEqualTo(2);
 
-            BlobFormatReader reader = new BlobFormatReader(fileIO, filePath, fileMeta, in, 1, 0);
+            BlobFormatReader reader =
+                    new BlobFormatReader(
+                            fileIO, filePath, fileMeta, in, 1, 0, DataTypes.BLOB(), false);
             FileRecordIterator<InternalRow> iterator = reader.readBatch();
             assertBlobPayload(iterator.next().getBlob(0), firstPayload);
             assertBlobPayload(iterator.next().getBlob(0), secondPayload);

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -108,6 +108,7 @@ run_batched_java_write_tests() {
     core_tests="${core_tests}+testCompactConflictWriteBase"
     core_tests="${core_tests}+testBlobCompactConflictWriteBase"
     core_tests="${core_tests}+testBlobWriteAlterCompact"
+    core_tests="${core_tests}+testJavaWriteArrayBlobTable"
     core_tests="${core_tests}+testDataEvolutionWrite"
     core_tests="${core_tests}+testJavaWriteRowAppendTable"
     if [[ "$PYTHON_MINOR" -ge 7 ]]; then
@@ -916,6 +917,43 @@ run_blob_alter_compact_test() {
     fi
 }
 
+run_array_blob_interop_test() {
+    echo -e "${YELLOW}=== Running ARRAY<BLOB> Test (Java Write → Python Read, Python Write → Java Read) ===${NC}"
+
+    if ! skip_batched_java_write; then
+        cd "$PROJECT_ROOT"
+        echo "Running Maven test for JavaPyE2ETest.testJavaWriteArrayBlobTable..."
+        if ! mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteArrayBlobTable -pl paimon-core -q -Drun.e2e.tests=true; then
+            echo -e "${RED}✗ Java ARRAY<BLOB> write test failed${NC}"
+            return 1
+        fi
+        echo -e "${GREEN}✓ Java ARRAY<BLOB> write test completed successfully${NC}"
+    fi
+
+    cd "$PAIMON_PYTHON_DIR"
+    echo "Running Python ARRAY<BLOB> read test..."
+    if ! python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_read_array_blob_written_by_java -v; then
+        echo -e "${RED}✗ Python ARRAY<BLOB> read test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Python ARRAY<BLOB> read test completed successfully${NC}"
+
+    echo "Running Python ARRAY<BLOB> write test..."
+    if ! python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_write_array_blob_for_java -v; then
+        echo -e "${RED}✗ Python ARRAY<BLOB> write test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Python ARRAY<BLOB> write test completed successfully${NC}"
+
+    cd "$PROJECT_ROOT"
+    echo "Running Maven test for JavaPyE2ETest.testJavaReadArrayBlobTable..."
+    if ! mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaReadArrayBlobTable -pl paimon-core -q -Drun.e2e.tests=true; then
+        echo -e "${RED}✗ Java ARRAY<BLOB> read test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Java ARRAY<BLOB> read test completed successfully${NC}"
+}
+
 # Function to run VARIANT test (Java write, Python read)
 run_java_variant_write_py_read_test() {
     echo -e "${YELLOW}=== Running VARIANT Test (Java Write, Python Read) ===${NC}"
@@ -1032,6 +1070,7 @@ main() {
     local compact_conflict_result=0
     local blob_compact_conflict_result=0
     local blob_alter_compact_result=0
+    local array_blob_interop_result=0
     local data_evolution_result=0
     local data_evolution_deletion_vector_result=0
     local data_evolution_py_write_result=0
@@ -1248,6 +1287,12 @@ main() {
 
     echo ""
 
+    if ! run_array_blob_interop_test; then
+        array_blob_interop_result=1
+    fi
+
+    echo ""
+
     # Run data evolution test (Java write, Python read)
     if ! run_data_evolution_test; then
         data_evolution_result=1
@@ -1435,6 +1480,12 @@ main() {
         echo -e "${RED}✗ Blob Alter+Compact Test (Java Write+Alter+Compact, Python Read): FAILED${NC}"
     fi
 
+    if [[ $array_blob_interop_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ ARRAY<BLOB> Interoperability Test (Java ↔ Python): PASSED${NC}"
+    else
+        echo -e "${RED}✗ ARRAY<BLOB> Interoperability Test (Java ↔ Python): FAILED${NC}"
+    fi
+
     if [[ $data_evolution_result -eq 0 ]]; then
         echo -e "${GREEN}✓ Data Evolution Test (Java Write, Python Read): PASSED${NC}"
     else
@@ -1476,7 +1527,7 @@ main() {
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $btree_raw_fallback_result -eq 0 && $bitmap_index_result -eq 0 && $compressed_global_index_result -eq 0 && $compressed_text_result -eq 0 && $native_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $vindex_vector_result -eq 0 && $vindex_vector_raw_fallback_result -eq 0 && $compact_conflict_result -eq 0 && $blob_compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_deletion_vector_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $btree_raw_fallback_result -eq 0 && $bitmap_index_result -eq 0 && $compressed_global_index_result -eq 0 && $compressed_text_result -eq 0 && $native_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $vindex_vector_result -eq 0 && $vindex_vector_raw_fallback_result -eq 0 && $compact_conflict_result -eq 0 && $blob_compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $array_blob_interop_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_deletion_vector_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/pypaimon/daft/daft_blob.py
+++ b/paimon-python/pypaimon/daft/daft_blob.py
@@ -87,3 +87,45 @@ def blob_column_to_file_array(column: pa.Array, io_config_bytes: bytes | None = 
         ],
         names=["url", "io_config", file_range_position_field(), file_range_size_field()],
     )
+
+
+def blob_array_column_to_file_array(
+    column: pa.Array,
+    io_config_bytes: bytes | None = None,
+) -> pa.Array:
+    """Convert a list of serialized BlobDescriptors to a list of File structs."""
+    if not (pa.types.is_list(column.type) or pa.types.is_large_list(column.type)):
+        raise TypeError(f"Expected a list column, but got {column.type}.")
+
+    rows = []
+    for row in column:
+        if row is None or not row.is_valid:
+            rows.append(None)
+            continue
+
+        files = []
+        for raw in row.as_py():
+            if raw is None:
+                files.append(None)
+                continue
+            uri, offset, length = _deserialize_one(raw)
+            files.append({
+                "url": uri,
+                "io_config": io_config_bytes,
+                file_range_position_field(): offset,
+                file_range_size_field(): length,
+            })
+        rows.append(files)
+
+    value_field = pa.field(
+        column.type.value_field.name,
+        FILE_PHYSICAL_TYPE,
+        nullable=column.type.value_field.nullable,
+        metadata=column.type.value_field.metadata,
+    )
+    target_type = (
+        pa.large_list(value_field)
+        if pa.types.is_large_list(column.type)
+        else pa.list_(value_field)
+    )
+    return pa.array(rows, type=target_type)

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -39,6 +39,7 @@ from pypaimon.daft.daft_explain import (
     READER_MODE_PYPAIMON_FALLBACK,
 )
 from pypaimon.daft.daft_predicate_visitor import convert_filters_to_paimon
+from pypaimon.schema.data_types import is_array_blob_type, is_blob_type
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -181,6 +182,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         output_columns: list[str] | None = None,
         blob_column_names: set[str] | None = None,
         explicit_io_config_bytes: bytes | None = None,
+        array_blob_column_names: set[str] | None = None,
     ) -> None:
         self._table_catalog_options = table_catalog_options
         self._table_identifier = table_identifier
@@ -193,6 +195,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         self._predicate = predicate
         self._output_columns = output_columns
         self._blob_column_names = blob_column_names or set()
+        self._array_blob_column_names = array_blob_column_names or set()
         self._explicit_io_config_bytes = explicit_io_config_bytes
 
     @property
@@ -214,16 +217,30 @@ class _PaimonPKSplitTask(DataSourceTask):
         if self._predicate is not None:
             read_builder = read_builder.with_filter(self._predicate)
 
-        blob_io_config_bytes = self._blob_io_config_bytes(table) if self._blob_column_names else None
+        has_blob_columns = bool(
+            self._blob_column_names or self._array_blob_column_names
+        )
+        blob_io_config_bytes = (
+            self._blob_io_config_bytes(table) if has_blob_columns else None
+        )
         reader = read_builder.new_read().to_arrow_batch_reader([self._split])
         for batch in iter(reader.read_next_batch, None):
             if self._output_columns is not None:
                 batch = batch.select(self._output_columns)
-            if self._blob_column_names:
-                batch = _convert_blob_columns(batch, self._blob_column_names, blob_io_config_bytes)
+            if has_blob_columns:
+                batch = _convert_blob_columns(
+                    batch,
+                    self._blob_column_names,
+                    blob_io_config_bytes,
+                    self._array_blob_column_names,
+                )
             rb = RecordBatch.from_arrow_record_batches([batch], batch.schema)
-            if self._blob_column_names:
-                rb = _cast_blob_columns_to_file(rb, self._blob_column_names)
+            if has_blob_columns:
+                rb = _cast_blob_columns_to_file(
+                    rb,
+                    self._blob_column_names,
+                    self._array_blob_column_names,
+                )
             yield rb
 
     def _blob_io_config_bytes(self, table: FileStoreTable) -> bytes | None:
@@ -255,9 +272,16 @@ def _convert_blob_columns(
     batch: pa.RecordBatch,
     blob_column_names: set[str],
     io_config_bytes: bytes | None = None,
+    array_blob_column_names: set[str] | None = None,
 ) -> pa.RecordBatch:
     """Replace serialized BlobDescriptor columns with the File physical struct layout."""
-    from pypaimon.daft.daft_blob import FILE_PHYSICAL_TYPE, blob_column_to_file_array
+    from pypaimon.daft.daft_blob import (
+        FILE_PHYSICAL_TYPE,
+        blob_array_column_to_file_array,
+        blob_column_to_file_array,
+    )
+
+    array_blob_column_names = array_blob_column_names or set()
 
     arrays = []
     fields = []
@@ -266,22 +290,35 @@ def _convert_blob_columns(
         if field.name in blob_column_names and (pa.types.is_large_binary(field.type) or pa.types.is_binary(field.type)):
             arrays.append(blob_column_to_file_array(col, io_config_bytes))
             fields.append(pa.field(field.name, FILE_PHYSICAL_TYPE, nullable=field.nullable))
+        elif field.name in array_blob_column_names and (
+            pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+        ):
+            converted = blob_array_column_to_file_array(col, io_config_bytes)
+            arrays.append(converted)
+            fields.append(pa.field(field.name, converted.type, nullable=field.nullable))
         else:
             arrays.append(col)
             fields.append(field)
     return pa.RecordBatch.from_arrays(arrays, schema=pa.schema(fields))
 
 
-def _cast_blob_columns_to_file(rb: RecordBatch, blob_column_names: set[str]) -> RecordBatch:
+def _cast_blob_columns_to_file(
+    rb: RecordBatch,
+    blob_column_names: set[str],
+    array_blob_column_names: set[str] | None = None,
+) -> RecordBatch:
     """Cast struct-typed blob columns in a RecordBatch to DataType.file()."""
     from daft.datatype import DataType
 
     file_dtype = DataType.file()
+    array_blob_column_names = array_blob_column_names or set()
     columns = {}
     for i, field in enumerate(rb.schema()):
         col = rb.get_column(i)
         if field.name in blob_column_names:
             col = col.cast(file_dtype)
+        elif field.name in array_blob_column_names:
+            col = col.cast(DataType.list(file_dtype))
         columns[field.name] = col
     return RecordBatch.from_pydict(columns)
 
@@ -365,8 +402,15 @@ class PaimonDataSource(DataSource):
 
         pa_schema = PyarrowFieldParser.from_paimon_schema(table.fields)
 
-        self._blob_column_names: set[str] = {field.name for field in pa_schema if pa.types.is_large_binary(field.type)}
-        self._has_blob_columns = bool(self._blob_column_names)
+        self._scalar_blob_column_names = {
+            field.name for field in table.fields if is_blob_type(field.type)
+        }
+        self._array_blob_column_names = {
+            field.name for field in table.fields if is_array_blob_type(field.type)
+        }
+        self._has_blob_columns = bool(
+            self._scalar_blob_column_names or self._array_blob_column_names
+        )
 
         if self._has_blob_columns:
             require_file_range_reads()
@@ -375,8 +419,10 @@ class PaimonDataSource(DataSource):
             base_schema = Schema.from_pyarrow_schema(pa_schema)
             fields = []
             for f in base_schema:
-                if f.name in self._blob_column_names:
+                if f.name in self._scalar_blob_column_names:
                     fields.append((f.name, DataType.file()))
+                elif f.name in self._array_blob_column_names:
+                    fields.append((f.name, DataType.list(DataType.file())))
                 else:
                     fields.append((f.name, f.dtype))
             self._schema = Schema.from_field_name_and_types(fields)
@@ -519,8 +565,9 @@ class PaimonDataSource(DataSource):
                     read_pushdowns.source_limit,
                     read_pushdowns.reader_predicate,
                     read_pushdowns.task_columns,
-                    self._blob_column_names,
+                    self._scalar_blob_column_names,
                     self._explicit_io_config_bytes,
+                    self._array_blob_column_names,
                 )
 
     def explain_scan(self, pushdowns: Pushdowns, verbose: bool = False) -> PaimonScanExplain:

--- a/paimon-python/pypaimon/multimodal/blob_store.py
+++ b/paimon-python/pypaimon/multimodal/blob_store.py
@@ -22,6 +22,7 @@ from typing import BinaryIO, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.schema.data_types import is_blob_type
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor
 from pypaimon.table.row.generic_row import GenericRow
@@ -643,4 +644,4 @@ def _bytes_value(value) -> bytes:
 
 
 def _is_blob_field(field) -> bool:
-    return getattr(field.type, "type", None) == "BLOB"
+    return is_blob_type(field.type)

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -21,6 +21,7 @@ import pyarrow as pa
 
 from pypaimon.common.where_parser import parse_where_clause
 from pypaimon.multimodal.blob_read import fetch_blob_bodies
+from pypaimon.schema.data_types import is_blob_type
 from pypaimon.table.special_fields import SpecialFields
 
 
@@ -244,7 +245,7 @@ class ScanQuery:
     def _all_blob_columns(self) -> List[str]:
         return [
             field.name for field in self._table.fields
-            if getattr(field.type, "type", None) == "BLOB"
+            if is_blob_type(field.type)
         ]
 
     def _resolve_blob_columns(self, columns) -> List[str]:

--- a/paimon-python/pypaimon/multimodal/table.py
+++ b/paimon-python/pypaimon/multimodal/table.py
@@ -30,7 +30,7 @@ from pypaimon.multimodal.query import (
     TextQuery,
     VectorQuery,
 )
-from pypaimon.schema.data_types import PyarrowFieldParser
+from pypaimon.schema.data_types import PyarrowFieldParser, is_blob_type
 from pypaimon.table.data_evolution_merge_into import (
     WhenMatched,
     WhenNotMatched,
@@ -375,7 +375,7 @@ class _MergeBuilder:
 def _blob_columns(table):
     return tuple(
         field.name for field in table.fields
-        if getattr(field.type, "type", None) == "BLOB"
+        if is_blob_type(field.type)
     )
 
 

--- a/paimon-python/pypaimon/ray/update_by_row_id.py
+++ b/paimon-python/pypaimon/ray/update_by_row_id.py
@@ -36,6 +36,7 @@ from pypaimon.ray.data_evolution_merge_into import (
 )
 from pypaimon.ray.data_evolution_merge_join import distributed_update_apply
 from pypaimon.ray.data_evolution_merge_transform import build_update_schema
+from pypaimon.schema.data_types import is_blob_file_field
 
 __all__ = ["update_by_row_id"]
 
@@ -44,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 def _blob_col_names(table: "FileStoreTable") -> set:
     return {f.name for f in table.table_schema.fields
-            if getattr(f.type, "type", None) == "BLOB"}
+            if is_blob_file_field(f)}
 
 
 def update_by_row_id(

--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -25,6 +25,7 @@ from pyarrow import RecordBatch
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.reader.format_blob_reader import BlobRecordIterator
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
+from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.row.blob import Blob
 from pypaimon.utils.range import Range
 
@@ -265,6 +266,12 @@ class BlobFallbackBatchReader(RecordBatchReader):
         self._output_type = output_type
         self._row_ranges = Range.sort_and_merge_overlap(row_ranges) if row_ranges else None
         self._blob_as_descriptor = blob_as_descriptor
+        self._is_array_blob = pa.types.is_list(output_type) or pa.types.is_large_list(output_type)
+        self._data_field = DataField(
+            0,
+            field_name,
+            PyarrowFieldParser.to_paimon_type(output_type, True),
+        )
         if deletion_vector is None:
             self._deletion_vector_range = None
             self._deletion_vector = None
@@ -308,8 +315,10 @@ class BlobFallbackBatchReader(RecordBatchReader):
                     )
                 if blob is None:
                     group[row_id] = (None, False)
-                elif blob is Blob.PLACE_HOLDER:
+                elif blob is Blob.PLACE_HOLDER or blob is Blob.ARRAY_PLACE_HOLDER:
                     group[row_id] = (None, True)
+                elif self._is_array_blob:
+                    group[row_id] = (self._array_value_for_arrow(blob), False)
                 else:
                     if self._blob_as_descriptor:
                         group[row_id] = (blob.to_descriptor().serialize(), False)
@@ -338,6 +347,17 @@ class BlobFallbackBatchReader(RecordBatchReader):
             [pa.array(result, type=self._output_type)],
             names=[self._field_name],
         )
+
+    def _array_value_for_arrow(self, blob_array):
+        result = []
+        for blob in blob_array:
+            if blob is None:
+                result.append(None)
+            elif self._blob_as_descriptor:
+                result.append(blob.to_descriptor().serialize())
+            else:
+                result.append(blob.to_data())
+        return result
 
     def _compute_target_ranges(self) -> List[Range]:
         ranges = Range.sort_and_merge_overlap([
@@ -434,8 +454,9 @@ class BlobFallbackBatchReader(RecordBatchReader):
                 reader.file_path,
                 blob_lengths,
                 blob_offsets,
-                self._field_name,
+                self._data_field,
                 reader._input_stream,
+                blob_as_descriptor=self._blob_as_descriptor,
             )
 
             blobs = []

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -263,6 +263,8 @@ class BlobRecordIterator:
     ARRAY_VERSION = 1
     ARRAY_MAGIC_NUMBER = 1094861634
     ARRAY_NULL_ELEMENT_LENGTH = -1
+    ARRAY_INDEX_LENGTH_SIZE = 4
+    MIN_ARRAY_PAYLOAD_LENGTH = ARRAY_HEADER_SIZE + ARRAY_INDEX_LENGTH_SIZE
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
 
@@ -323,6 +325,11 @@ class BlobRecordIterator:
         return data
 
     def _read_blob_array(self, position: int, length: int):
+        if position < 0 or length < self.MIN_ARRAY_PAYLOAD_LENGTH:
+            raise ValueError(
+                f"Invalid ARRAY<BLOB> payload position or length: {position}, {length}"
+            )
+
         stream = self.input_stream
         close_stream = False
         if stream is None:
@@ -336,28 +343,62 @@ class BlobRecordIterator:
             magic, version, element_count = struct.unpack('<IBI', header)
             if magic != self.ARRAY_MAGIC_NUMBER:
                 raise ValueError(f"Invalid ARRAY<BLOB> payload magic number: {magic}")
-            if version > self.ARRAY_VERSION:
+            if version != self.ARRAY_VERSION:
                 raise ValueError(f"Unsupported ARRAY<BLOB> payload version: {version}")
+            if element_count > 0x7fffffff:
+                raise ValueError(f"Invalid ARRAY<BLOB> element count: {element_count}")
 
-            index_length_position = position + length - 4
+            payload_end = position + length
+            element_data_start = position + self.ARRAY_HEADER_SIZE
+            index_length_position = payload_end - self.ARRAY_INDEX_LENGTH_SIZE
             stream.seek(index_length_position)
-            index_length_bytes = self._read_fully_from(stream, 4)
-            if len(index_length_bytes) != 4:
+            index_length_bytes = self._read_fully_from(stream, self.ARRAY_INDEX_LENGTH_SIZE)
+            if len(index_length_bytes) != self.ARRAY_INDEX_LENGTH_SIZE:
                 raise IOError("Invalid ARRAY<BLOB> payload: cannot read index length")
             index_length = struct.unpack('<I', index_length_bytes)[0]
+            maximum_index_length = length - self.MIN_ARRAY_PAYLOAD_LENGTH
+            if index_length > 0x7fffffff or index_length > maximum_index_length:
+                raise ValueError(
+                    f"Invalid ARRAY<BLOB> element index length: {index_length}"
+                )
+            if element_count > index_length:
+                raise ValueError(
+                    "ARRAY<BLOB> element count exceeds element index length."
+                )
 
-            stream.seek(index_length_position - index_length)
+            element_index_start = index_length_position - index_length
+            stream.seek(element_index_start)
             index_bytes = self._read_fully_from(stream, index_length)
             if len(index_bytes) != index_length:
                 raise IOError("Invalid ARRAY<BLOB> payload: cannot read element index")
+            self._validate_array_element_index(index_bytes)
             element_lengths = DeltaVarintCompressor.decompress(index_bytes)
             if len(element_lengths) != element_count:
                 raise ValueError(
                     "ARRAY<BLOB> element count does not match element index length."
                 )
 
+            element_data_length = element_index_start - element_data_start
+            total_element_length = 0
+            for element_length in element_lengths:
+                if element_length == self.ARRAY_NULL_ELEMENT_LENGTH:
+                    continue
+                if element_length < 0:
+                    raise ValueError(
+                        f"Invalid ARRAY<BLOB> element length: {element_length}"
+                    )
+                if element_length > element_data_length - total_element_length:
+                    raise ValueError(
+                        "ARRAY<BLOB> element lengths exceed the payload data length."
+                    )
+                total_element_length += element_length
+            if total_element_length != element_data_length:
+                raise ValueError(
+                    "ARRAY<BLOB> element lengths do not match the payload data length."
+                )
+
             blobs = []
-            element_offset = position + self.ARRAY_HEADER_SIZE
+            element_offset = element_data_start
             for element_length in element_lengths:
                 if element_length == self.ARRAY_NULL_ELEMENT_LENGTH:
                     blobs.append(None)
@@ -377,6 +418,18 @@ class BlobRecordIterator:
         finally:
             if close_stream:
                 stream.close()
+
+    @staticmethod
+    def _validate_array_element_index(index_bytes: bytes) -> None:
+        varint_length = 0
+        for value in index_bytes:
+            varint_length += 1
+            if varint_length > 10:
+                raise ValueError("Invalid ARRAY<BLOB> element index.")
+            if value & 0x80 == 0:
+                varint_length = 0
+        if varint_length != 0:
+            raise ValueError("Invalid ARRAY<BLOB> element index.")
 
     def _read_fully(self, length: int) -> bytes:
         return self._read_fully_from(self.input_stream, length)

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -97,7 +97,9 @@ class FormatBlobReader(RecordBatchReader):
             batch_iterator = BlobRecordIterator(
                 self._file_io, self.file_path, self.blob_lengths,
                 self.blob_offsets, self._data_field, self._input_stream,
-                blob_as_descriptor=self._blob_as_descriptor
+                blob_as_descriptor=(
+                    self._blob_as_descriptor or self._blob_parallelism > 1
+                )
             )
             self._blob_iterator = iter(batch_iterator)
         read_size = self._batch_size
@@ -120,7 +122,15 @@ class FormatBlobReader(RecordBatchReader):
                 blob = blob_row.values[0]
                 for field_name in self._fields:
                     if self._is_array_blob:
-                        pydict_data[field_name].append(self._array_value_for_arrow(blob))
+                        row_index = len(pydict_data[field_name])
+                        pydict_data[field_name].append(
+                            self._array_value_for_arrow(
+                                blob,
+                                field_name,
+                                row_index,
+                                blobs_to_resolve,
+                            )
+                        )
                     else:
                         if blob is None:
                             pydict_data[field_name].append(None)
@@ -133,7 +143,7 @@ class FormatBlobReader(RecordBatchReader):
                         elif self._blob_parallelism > 1:
                             idx = len(pydict_data[field_name])
                             pydict_data[field_name].append(None)
-                            blobs_to_resolve.append((field_name, idx, blob))
+                            blobs_to_resolve.append((field_name, idx, None, blob))
                         else:
                             pydict_data[field_name].append(blob.to_data())
 
@@ -170,12 +180,22 @@ class FormatBlobReader(RecordBatchReader):
                 return None
 
     def _resolve_blobs_concurrent(self, pydict_data, blobs_to_resolve):
-        blobs = [item[2] for item in blobs_to_resolve]
+        blobs = [item[3] for item in blobs_to_resolve]
         results = self._file_io.read_blobs_concurrent(blobs, self._blob_parallelism)
-        for (field_name, idx, _), data in zip(blobs_to_resolve, results):
-            pydict_data[field_name][idx] = data
+        for target, data in zip(blobs_to_resolve, results):
+            field_name, row_index, element_index, _ = target
+            if element_index is None:
+                pydict_data[field_name][row_index] = data
+            else:
+                pydict_data[field_name][row_index][element_index] = data
 
-    def _array_value_for_arrow(self, blob_array):
+    def _array_value_for_arrow(
+        self,
+        blob_array,
+        field_name,
+        row_index,
+        blobs_to_resolve,
+    ):
         if blob_array is None:
             return None
         if blob_array is Blob.ARRAY_PLACE_HOLDER:
@@ -183,11 +203,16 @@ class FormatBlobReader(RecordBatchReader):
                 "Blob placeholder is not supported by FormatBlobReader yet."
             )
         result = []
-        for blob in blob_array:
+        for element_index, blob in enumerate(blob_array):
             if blob is None:
                 result.append(None)
             elif self._blob_as_descriptor:
                 result.append(blob.to_descriptor().serialize())
+            elif self._blob_parallelism > 1:
+                result.append(None)
+                blobs_to_resolve.append(
+                    (field_name, row_index, element_index, blob)
+                )
             else:
                 result.append(blob.to_data())
         return result
@@ -397,8 +422,16 @@ class BlobRecordIterator:
                     "ARRAY<BLOB> element lengths do not match the payload data length."
                 )
 
+            element_data = None
+            if not self.blob_as_descriptor:
+                stream.seek(element_data_start)
+                element_data = self._read_fully_from(stream, element_data_length)
+                if len(element_data) != element_data_length:
+                    raise IOError("Invalid ARRAY<BLOB> payload: cannot read element data")
+
             blobs = []
             element_offset = element_data_start
+            data_offset = 0
             for element_length in element_lengths:
                 if element_length == self.ARRAY_NULL_ELEMENT_LENGTH:
                     blobs.append(None)
@@ -408,12 +441,11 @@ class BlobRecordIterator:
                         Blob.from_file(self.file_io, self.file_path, element_offset, element_length)
                     )
                 else:
-                    stream.seek(element_offset)
-                    data = self._read_fully_from(stream, element_length)
-                    if len(data) != element_length:
-                        raise IOError("Invalid ARRAY<BLOB> payload: cannot read element data")
-                    blobs.append(Blob.from_data(data))
+                    blobs.append(Blob.from_data(
+                        element_data[data_offset:data_offset + element_length]
+                    ))
                 element_offset += element_length
+                data_offset += element_length
             return blobs
         finally:
             if close_stream:

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -25,7 +25,12 @@ from pyarrow import RecordBatch
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 from pypaimon.common.file_io import FileIO
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
-from pypaimon.schema.data_types import DataField, PyarrowFieldParser, AtomicType
+from pypaimon.schema.data_types import (
+    DataField,
+    PyarrowFieldParser,
+    AtomicType,
+    is_array_blob_type,
+)
 from pypaimon.table.row.blob import Blob
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.row.row_kind import RowKind
@@ -59,19 +64,23 @@ class FormatBlobReader(RecordBatchReader):
             self._input_stream = file_io.new_input_stream(file_path)
             self._read_index()
             self._apply_row_indices(row_indices)
-            # Drop the shared stream: descriptor/concurrent reads yield BlobRefs
-            # that each open their own stream (one stream isn't thread-safe).
-            if self._blob_as_descriptor or self._blob_parallelism > 1:
-                self._input_stream.close()
-                self._input_stream = None
 
-            # Set up fields and schema
+            # Set up fields and schema before deciding whether the stream can be dropped.
             if len(read_fields) > 1:
                 raise RuntimeError("Blob reader only supports one field.")
             self._fields = read_fields
             full_fields_map = {field.name: field for field in full_fields}
             projected_data_fields = [full_fields_map[name] for name in read_fields]
+            self._data_field = projected_data_fields[0]
+            self._is_array_blob = is_array_blob_type(self._data_field.type)
             self._schema = PyarrowFieldParser.from_paimon_schema(projected_data_fields)
+
+            # Drop the shared stream: descriptor/concurrent reads yield BlobRefs
+            # that each open their own stream (one stream isn't thread-safe).
+            # ARRAY<BLOB> needs the stream to read the nested element index.
+            if not self._is_array_blob and (self._blob_as_descriptor or self._blob_parallelism > 1):
+                self._input_stream.close()
+                self._input_stream = None
         except Exception:
             self.close()
             raise
@@ -87,7 +96,8 @@ class FormatBlobReader(RecordBatchReader):
             self.returned = True
             batch_iterator = BlobRecordIterator(
                 self._file_io, self.file_path, self.blob_lengths,
-                self.blob_offsets, self._fields[0], self._input_stream
+                self.blob_offsets, self._data_field, self._input_stream,
+                blob_as_descriptor=self._blob_as_descriptor
             )
             self._blob_iterator = iter(batch_iterator)
         read_size = self._batch_size
@@ -109,20 +119,23 @@ class FormatBlobReader(RecordBatchReader):
                     break
                 blob = blob_row.values[0]
                 for field_name in self._fields:
-                    if blob is None:
-                        pydict_data[field_name].append(None)
-                    elif blob is Blob.PLACE_HOLDER:
-                        raise RuntimeError(
-                            "Blob placeholder is not supported by FormatBlobReader yet."
-                        )
-                    elif self._blob_as_descriptor:
-                        pydict_data[field_name].append(blob.to_descriptor().serialize())
-                    elif self._blob_parallelism > 1:
-                        idx = len(pydict_data[field_name])
-                        pydict_data[field_name].append(None)
-                        blobs_to_resolve.append((field_name, idx, blob))
+                    if self._is_array_blob:
+                        pydict_data[field_name].append(self._array_value_for_arrow(blob))
                     else:
-                        pydict_data[field_name].append(blob.to_data())
+                        if blob is None:
+                            pydict_data[field_name].append(None)
+                        elif blob is Blob.PLACE_HOLDER:
+                            raise RuntimeError(
+                                "Blob placeholder is not supported by FormatBlobReader yet."
+                            )
+                        elif self._blob_as_descriptor:
+                            pydict_data[field_name].append(blob.to_descriptor().serialize())
+                        elif self._blob_parallelism > 1:
+                            idx = len(pydict_data[field_name])
+                            pydict_data[field_name].append(None)
+                            blobs_to_resolve.append((field_name, idx, blob))
+                        else:
+                            pydict_data[field_name].append(blob.to_data())
 
                 records_in_batch += 1
                 if records_in_batch >= read_size:
@@ -161,6 +174,23 @@ class FormatBlobReader(RecordBatchReader):
         results = self._file_io.read_blobs_concurrent(blobs, self._blob_parallelism)
         for (field_name, idx, _), data in zip(blobs_to_resolve, results):
             pydict_data[field_name][idx] = data
+
+    def _array_value_for_arrow(self, blob_array):
+        if blob_array is None:
+            return None
+        if blob_array is Blob.ARRAY_PLACE_HOLDER:
+            raise RuntimeError(
+                "Blob placeholder is not supported by FormatBlobReader yet."
+            )
+        result = []
+        for blob in blob_array:
+            if blob is None:
+                result.append(None)
+            elif self._blob_as_descriptor:
+                result.append(blob.to_descriptor().serialize())
+            else:
+                result.append(blob.to_data())
+        return result
 
     def close(self):
         self._blob_iterator = None
@@ -229,16 +259,27 @@ class FormatBlobReader(RecordBatchReader):
 class BlobRecordIterator:
     MAGIC_NUMBER_SIZE = 4
     METADATA_OVERHEAD = 16
+    ARRAY_HEADER_SIZE = 9
+    ARRAY_VERSION = 1
+    ARRAY_MAGIC_NUMBER = 1094861634
+    ARRAY_NULL_ELEMENT_LENGTH = -1
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
 
     def __init__(self, file_io: FileIO, file_path: str, blob_lengths: List[int],
-                 blob_offsets: List[int], field_name: str,
-                 input_stream: Optional[BinaryIO] = None):
+                 blob_offsets: List[int], field,
+                 input_stream: Optional[BinaryIO] = None,
+                 blob_as_descriptor: bool = False):
         self.file_io = file_io
         self.file_path = file_path
         self.input_stream = input_stream
-        self.field_name = field_name
+        if isinstance(field, DataField):
+            self.field = field
+        else:
+            self.field = DataField(0, field, AtomicType("BLOB"))
+        self.field_name = self.field.name
+        self.is_array_blob = is_array_blob_type(self.field.type)
+        self.blob_as_descriptor = blob_as_descriptor
         self.blob_lengths = blob_lengths
         self.blob_offsets = blob_offsets
         self.current_position = 0
@@ -249,19 +290,22 @@ class BlobRecordIterator:
     def __next__(self) -> GenericRow:
         if self.current_position >= len(self.blob_lengths):
             raise StopIteration
-        fields = [DataField(0, self.field_name, AtomicType("BLOB"))]
+        fields = [self.field]
         length = self.blob_lengths[self.current_position]
         if length == self.NULL_LENGTH:
             self.current_position += 1
             return GenericRow([None], fields, RowKind.INSERT)
         if length == self.PLACE_HOLDER_LENGTH:
             self.current_position += 1
-            return GenericRow([Blob.PLACE_HOLDER], fields, RowKind.INSERT)
+            placeholder = Blob.ARRAY_PLACE_HOLDER if self.is_array_blob else Blob.PLACE_HOLDER
+            return GenericRow([placeholder], fields, RowKind.INSERT)
         # Create blob reference for the current blob
         # Skip magic number (4 bytes) and exclude length (8 bytes) + CRC (4 bytes) = 12 bytes
         blob_offset = self.blob_offsets[self.current_position] + self.MAGIC_NUMBER_SIZE  # Skip magic number
         blob_length = length - self.METADATA_OVERHEAD
-        if self.input_stream is not None:
+        if self.is_array_blob:
+            blob = self._read_blob_array(blob_offset, blob_length)
+        elif self.input_stream is not None and not self.blob_as_descriptor:
             blob = Blob.from_data(self._read_inline_blob(blob_offset, blob_length))
         else:
             blob = Blob.from_file(self.file_io, self.file_path, blob_offset, blob_length)
@@ -278,10 +322,70 @@ class BlobRecordIterator:
             raise IOError("Invalid blob file: cannot read blob data")
         return data
 
+    def _read_blob_array(self, position: int, length: int):
+        stream = self.input_stream
+        close_stream = False
+        if stream is None:
+            stream = self.file_io.new_input_stream(self.file_path)
+            close_stream = True
+        try:
+            stream.seek(position)
+            header = self._read_fully_from(stream, self.ARRAY_HEADER_SIZE)
+            if len(header) != self.ARRAY_HEADER_SIZE:
+                raise IOError("Invalid ARRAY<BLOB> payload: cannot read header")
+            magic, version, element_count = struct.unpack('<IBI', header)
+            if magic != self.ARRAY_MAGIC_NUMBER:
+                raise ValueError(f"Invalid ARRAY<BLOB> payload magic number: {magic}")
+            if version > self.ARRAY_VERSION:
+                raise ValueError(f"Unsupported ARRAY<BLOB> payload version: {version}")
+
+            index_length_position = position + length - 4
+            stream.seek(index_length_position)
+            index_length_bytes = self._read_fully_from(stream, 4)
+            if len(index_length_bytes) != 4:
+                raise IOError("Invalid ARRAY<BLOB> payload: cannot read index length")
+            index_length = struct.unpack('<I', index_length_bytes)[0]
+
+            stream.seek(index_length_position - index_length)
+            index_bytes = self._read_fully_from(stream, index_length)
+            if len(index_bytes) != index_length:
+                raise IOError("Invalid ARRAY<BLOB> payload: cannot read element index")
+            element_lengths = DeltaVarintCompressor.decompress(index_bytes)
+            if len(element_lengths) != element_count:
+                raise ValueError(
+                    "ARRAY<BLOB> element count does not match element index length."
+                )
+
+            blobs = []
+            element_offset = position + self.ARRAY_HEADER_SIZE
+            for element_length in element_lengths:
+                if element_length == self.ARRAY_NULL_ELEMENT_LENGTH:
+                    blobs.append(None)
+                    continue
+                if self.blob_as_descriptor:
+                    blobs.append(
+                        Blob.from_file(self.file_io, self.file_path, element_offset, element_length)
+                    )
+                else:
+                    stream.seek(element_offset)
+                    data = self._read_fully_from(stream, element_length)
+                    if len(data) != element_length:
+                        raise IOError("Invalid ARRAY<BLOB> payload: cannot read element data")
+                    blobs.append(Blob.from_data(data))
+                element_offset += element_length
+            return blobs
+        finally:
+            if close_stream:
+                stream.close()
+
     def _read_fully(self, length: int) -> bytes:
+        return self._read_fully_from(self.input_stream, length)
+
+    @staticmethod
+    def _read_fully_from(stream, length: int) -> bytes:
         data = bytearray()
         while len(data) < length:
-            chunk = self.input_stream.read(length - len(data))
+            chunk = stream.read(length - len(data))
             if not chunk:
                 break
             data.extend(chunk)

--- a/paimon-python/pypaimon/schema/column_directive_utils.py
+++ b/paimon-python/pypaimon/schema/column_directive_utils.py
@@ -149,13 +149,41 @@ def _convert_type(directive: ParsedDirective, field_name: str, source_type: Data
             )
         return VectorType(source_type.nullable, source_type.element, directive.vector_dim)
     else:
+        if isinstance(source_type, ArrayType):
+            if directive.option_key != CoreOptions.BLOB_FIELD.key():
+                raise ValueError(
+                    f"ARRAY<BLOB> is only supported by '{CoreOptions.BLOB_FIELD.key()}'."
+                )
+            element_type = getattr(source_type.element, 'type', None) \
+                if isinstance(source_type.element, AtomicType) else None
+            if not _is_blob_source_type(element_type):
+                raise ValueError(
+                    f"Column {field_name} declared with a BLOB directive must be of "
+                    f"BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> "
+                    f"type, but was {source_type}."
+                )
+            return ArrayType(
+                source_type.nullable,
+                AtomicType('BLOB', source_type.element.nullable),
+            )
         type_name = getattr(source_type, 'type', None) if isinstance(source_type, AtomicType) else None
-        if type_name not in ('VARBINARY', 'BINARY', 'BYTES', 'BLOB'):
+        if not _is_blob_source_type(type_name):
             raise ValueError(
                 f"Column {field_name} declared with a BLOB directive "
-                f"must be of BYTES, BINARY or BLOB type, but was {source_type}."
+                f"must be of BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> "
+                f"or ARRAY<BLOB> type, but was {source_type}."
             )
         return AtomicType('BLOB', source_type.nullable)
+
+
+def _is_blob_source_type(type_name: Optional[str]) -> bool:
+    if type_name is None:
+        return False
+    return (
+        type_name in ('BYTES', 'BLOB')
+        or type_name.startswith('BINARY')
+        or type_name.startswith('VARBINARY')
+    )
 
 
 def _modify_field_options(option_key: str, field_name: str, options: Dict[str, str]):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -704,7 +704,14 @@ class PyarrowFieldParser:
             if type_name.startswith('TIME'):
                 return pyarrow.time32('ms')
         elif isinstance(data_type, ArrayType):
-            return pyarrow.list_(PyarrowFieldParser.from_paimon_type(data_type.element))
+            element_type = PyarrowFieldParser.from_paimon_type(data_type.element)
+            return pyarrow.list_(
+                pyarrow.field(
+                    "item",
+                    element_type,
+                    nullable=data_type.element.nullable,
+                )
+            )
         elif isinstance(data_type, VectorType):
             return pyarrow.list_(PyarrowFieldParser.from_paimon_type(data_type.element), data_type.length)
         elif isinstance(data_type, MapType):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -278,6 +278,22 @@ class MapType(DataType):
         return "MAP<{}, {}>{}".format(self.key, self.value, null_suffix)
 
 
+def is_blob_type(data_type: DataType) -> bool:
+    return isinstance(data_type, AtomicType) and data_type.type.upper() == 'BLOB'
+
+
+def is_array_blob_type(data_type: DataType) -> bool:
+    return isinstance(data_type, ArrayType) and is_blob_type(data_type.element)
+
+
+def is_blob_file_type(data_type: DataType) -> bool:
+    return is_blob_type(data_type) or is_array_blob_type(data_type)
+
+
+def is_blob_file_field(field: 'DataField') -> bool:
+    return is_blob_file_type(field.type)
+
+
 @dataclass
 class DataField:
     FIELD_ID = "id"
@@ -764,7 +780,8 @@ class PyarrowFieldParser:
             return VectorType(nullable, element_type, pa_type.list_size)
         elif types.is_list(pa_type) or types.is_large_list(pa_type):
             pa_type: pyarrow.ListType
-            element_type = PyarrowFieldParser.to_paimon_type(pa_type.value_type, nullable)
+            element_type = PyarrowFieldParser.to_paimon_type(
+                pa_type.value_type, pa_type.value_field.nullable)
             return ArrayType(nullable, element_type)
         elif types.is_map(pa_type):
             pa_type: pyarrow.MapType

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -348,7 +348,12 @@ def _assert_not_renaming_blob_column(
             )
 
 
-def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: List[str]):
+def _validate_blob_fields(
+    fields: List[DataField],
+    options: dict,
+    primary_keys: List[str],
+    partition_keys: List[str],
+):
     """Validate blob field configurations in the schema."""
     if options is None:
         options = {}
@@ -418,6 +423,11 @@ def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: 
 
         if primary_keys:
             raise ValueError("BLOB or ARRAY<BLOB> type is not supported with primary key.")
+
+        if blob_field_names.intersection(partition_keys):
+            raise ValueError(
+                "The BLOB or ARRAY<BLOB> type column can not be part of partition keys."
+            )
 
 
 def _handle_rename_column(change: RenameColumn, new_fields: List[DataField]):
@@ -583,14 +593,24 @@ class SchemaManager:
                 comment=schema.comment,
             )
 
-            _validate_blob_fields(schema.fields, schema.options, schema.primary_keys)
+            _validate_blob_fields(
+                schema.fields,
+                schema.options,
+                schema.primary_keys,
+                schema.partition_keys,
+            )
             table_schema = TableSchema.from_schema(schema_id=0, schema=schema)
             success = self.commit(table_schema)
             if success:
                 return table_schema
 
     def commit(self, new_schema: TableSchema) -> bool:
-        _validate_blob_fields(new_schema.fields, new_schema.options, new_schema.primary_keys)
+        _validate_blob_fields(
+            new_schema.fields,
+            new_schema.options,
+            new_schema.primary_keys,
+            new_schema.partition_keys,
+        )
         schema_path = self._to_schema_path(new_schema.id)
         try:
             result = self.file_io.try_to_write_atomic(schema_path, JSON.to_json(new_schema, indent=2))

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -28,7 +28,9 @@ from pypaimon.schema.column_directive_utils import (
     remove_dropped_directive_options)
 from pypaimon.casting.data_type_casts import can_execute_cast, supports_cast
 from pypaimon.schema.data_types import (ArrayType, AtomicInteger, DataField,
-                                        MapType, RowType, reassign_field_id)
+                                        MapType, RowType, is_array_blob_type,
+                                        is_blob_file_field, is_blob_file_type,
+                                        is_blob_type, reassign_field_id)
 from pypaimon.schema.schema import Schema
 from pypaimon.schema.schema_change import (AddColumn, DropColumn, RemoveOption,
                                            RenameColumn, SchemaChange,
@@ -286,10 +288,10 @@ def _handle_drop_column(change: DropColumn, new_fields: List[DataField],
 
 
 def _get_type_root(data_type) -> str:
-    from pypaimon.schema.data_types import AtomicType, VectorType
+    from pypaimon.schema.data_types import VectorType
     if isinstance(data_type, VectorType):
         return 'VECTOR'
-    if isinstance(data_type, AtomicType) and data_type.type == 'BLOB':
+    if is_blob_file_type(data_type):
         return 'BLOB'
     return getattr(data_type, 'type', '')
 
@@ -340,9 +342,9 @@ def _assert_not_renaming_blob_column(
         return
     field_name = field_names[0]
     for field in new_fields:
-        if field.name == field_name and str(field.type) == 'BLOB':
+        if field.name == field_name and is_blob_file_field(field):
             raise ValueError(
-                f"Cannot rename BLOB column: [{field_name}]"
+                f"Cannot rename BLOB or ARRAY<BLOB> column: [{field_name}]"
             )
 
 
@@ -351,14 +353,13 @@ def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: 
     if options is None:
         options = {}
 
-    blob_field_names = {
-        field.name for field in fields
-        if getattr(field.type, 'type', None) == 'BLOB'
-    }
+    blob_field_names = {field.name for field in fields if is_blob_file_field(field)}
+    scalar_blob_field_names = {field.name for field in fields if is_blob_type(field.type)}
+    array_blob_field_names = {field.name for field in fields if is_array_blob_type(field.type)}
 
     if len(fields) <= len(blob_field_names):
         raise ValueError(
-            "Table with BLOB type column must have other normal columns."
+            "Table with BLOB or ARRAY<BLOB> type column must have other normal columns."
         )
 
     core_options = CoreOptions(Options(options))
@@ -367,7 +368,7 @@ def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: 
     for field in configured_blob_fields:
         if field not in blob_field_names:
             raise ValueError(
-                "Field '{}' in '{}' must be a BLOB field in table schema.".format(
+                "Field '{}' in '{}' must be a BLOB field or ARRAY<BLOB> field in table schema.".format(
                     field, CoreOptions.BLOB_FIELD.key()
                 )
             )
@@ -376,8 +377,15 @@ def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: 
     view_fields = core_options.blob_view_fields()
 
     all_inline_fields = descriptor_fields.union(view_fields)
-    non_blob_inline_fields = all_inline_fields.difference(blob_field_names)
+    non_blob_inline_fields = all_inline_fields.difference(scalar_blob_field_names)
     if non_blob_inline_fields:
+        array_inline_fields = sorted(non_blob_inline_fields.intersection(array_blob_field_names))
+        if array_inline_fields:
+            raise ValueError(
+                "ARRAY<BLOB> is only supported by '{}'. Invalid inline blob fields: {}".format(
+                    CoreOptions.BLOB_FIELD.key(), array_inline_fields
+                )
+            )
         raise ValueError(
             "Fields in 'blob-descriptor-field' or 'blob-view-field' must be blob fields "
             "in schema. Non-BLOB fields: {}".format(sorted(non_blob_inline_fields))
@@ -403,12 +411,13 @@ def _validate_blob_fields(fields: List[DataField], options: dict, primary_keys: 
 
         if missing_options:
             raise ValueError(
-                f"Schema contains Blob type but is missing required options: {', '.join(missing_options)}. "
+                f"Schema contains BLOB or ARRAY<BLOB> type but is missing required options: "
+                f"{', '.join(missing_options)}. "
                 f"Please add these options to the schema."
             )
 
         if primary_keys:
-            raise ValueError("Blob type is not supported with primary key.")
+            raise ValueError("BLOB or ARRAY<BLOB> type is not supported with primary key.")
 
 
 def _handle_rename_column(change: RenameColumn, new_fields: List[DataField]):

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -433,6 +433,15 @@ class _PlaceholderBlob(Blob):
 Blob.PLACE_HOLDER = _PlaceholderBlob()
 
 
+class _PlaceholderBlobArray:
+
+    def __repr__(self) -> str:
+        return "Blob.ARRAY_PLACE_HOLDER"
+
+
+Blob.ARRAY_PLACE_HOLDER = _PlaceholderBlobArray()
+
+
 class BlobData(Blob):
 
     def __init__(self, data: Optional[Union[bytes, bytearray]] = None):

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -4663,7 +4663,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
                 [SchemaChange.rename_column('blob_col', 'blob_col_renamed')],
                 False
             )
-        self.assertIn('Cannot rename BLOB column', str(ctx.exception))
+        self.assertIn('Cannot rename BLOB or ARRAY<BLOB> column', str(ctx.exception))
 
     def test_nested_field_named_blob_not_treated_as_blob(self):
         """Regression: a ROW field with a nested column whose name contains

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -47,6 +47,15 @@ class _StreamingOnlyBlob(Blob):
         return io.BytesIO(self.data)
 
 
+class _RecordBatchWithoutSelect:
+    def __init__(self, batch):
+        self.schema = batch.schema
+        self._batch = batch
+
+    def column(self, index):
+        return self._batch.column(index)
+
+
 class DedicatedFormatWriterTest(unittest.TestCase):
     """Tests for DedicatedFormatWriter functionality with paimon table operations."""
 
@@ -125,6 +134,50 @@ class DedicatedFormatWriterTest(unittest.TestCase):
                 self.assertGreater(file_meta.row_count, 0)
 
         blob_writer.close()
+
+    def test_split_data_with_pyarrow_6_record_batch_api(self):
+        from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
+
+        payload_type = pa.list_(
+            pa.field('item', pa.large_binary(), nullable=False)
+        )
+        schema = pa.schema(
+            [
+                pa.field('id', pa.int32(), nullable=False),
+                pa.field('payloads', payload_type),
+                pa.field('embedding', pa.list_(pa.float32())),
+            ],
+            metadata={b'table': b'array-blob'},
+        )
+        batch = pa.RecordBatch.from_arrays(
+            [
+                pa.array([1, 2], type=pa.int32()),
+                pa.array([[b'a'], []], type=payload_type),
+                pa.array([[1.0], [2.0]], type=pa.list_(pa.float32())),
+            ],
+            schema=schema,
+        )
+
+        writer = object.__new__(DedicatedFormatWriter)
+        writer.normal_column_names = ['id']
+        writer.blob_file_column_names = ['payloads']
+        writer.vector_write_columns = ['embedding']
+
+        normal_data, blob_data_map, vector_data = writer._split_data(
+            _RecordBatchWithoutSelect(batch)
+        )
+
+        self.assertEqual(normal_data.column(0).to_pylist(), [1, 2])
+        self.assertFalse(normal_data.schema.field('id').nullable)
+        self.assertEqual(
+            blob_data_map['payloads'].column(0).to_pylist(),
+            [[b'a'], []],
+        )
+        self.assertFalse(
+            blob_data_map['payloads'].schema.field('payloads').type.value_field.nullable
+        )
+        self.assertEqual(vector_data.column(0).to_pylist(), [[1.0], [2.0]])
+        self.assertEqual(normal_data.schema.metadata, {b'table': b'array-blob'})
 
     def test_dedicated_format_writer_schema_detection(self):
         """Test that DedicatedFormatWriter correctly detects blob columns from schema."""

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1376,6 +1376,79 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             },
         )
 
+    def test_array_blob_element_not_null(self):
+        array_blob_type = pa.list_(
+            pa.field('item', pa.large_binary(), nullable=False)
+        )
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', array_blob_type),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            },
+        )
+        table_name = 'test_db.array_blob_element_not_null'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        valid_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'payloads': pa.array(
+                [[b'alpha', b''], [], None],
+                type=array_blob_type,
+            ),
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(valid_data)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        self.assertFalse(
+            result.schema.field('payloads').type.value_field.nullable
+        )
+        self.assertEqual(
+            {
+                row['id']: row['payloads']
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: [b'alpha', b''],
+                2: [],
+                3: None,
+            },
+        )
+
+        nullable_array_type = pa.list_(pa.large_binary())
+        incompatible_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', nullable_array_type),
+        ])
+        incompatible_data = pa.Table.from_pydict({
+            'id': [4],
+            'payloads': pa.array([[b'bad', None]], type=nullable_array_type),
+        }, schema=incompatible_schema)
+        incompatible_writer = table.new_batch_write_builder().new_write()
+        with self.assertRaisesRegex(ValueError, "Input schema isn't consistent"):
+            incompatible_writer.write_arrow(incompatible_data)
+        incompatible_writer.abort()
+
+        invalid_data = pa.Table.from_pydict({
+            'id': [5],
+            'payloads': pa.array([[b'bad', None]], type=array_blob_type),
+        }, schema=pa_schema)
+        invalid_writer = table.new_batch_write_builder().new_write()
+        with self.assertRaisesRegex(ValueError, "does not allow null elements"):
+            invalid_writer.write_arrow(invalid_data)
+        invalid_writer.abort()
+
     def test_blob_update_single_row_at_first_position(self):
         from pypaimon import Schema
 

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1275,6 +1275,107 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             3: b'blob-3',
         })
 
+    def test_array_blob_column_write_read_and_update(self):
+        from pypaimon import Schema
+        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        array_blob_type = pa.list_(pa.large_binary())
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', array_blob_type),
+        ])
+
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            },
+        )
+        self.catalog.create_table('test_db.array_blob_update_column', schema, False)
+        table = self.catalog.get_table('test_db.array_blob_update_column')
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'payloads': pa.array(
+                [[b'blob-1a', None, b'blob-1b'], None, [b'blob-3']],
+                type=array_blob_type,
+            ),
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        read_builder = table.new_read_builder().with_projection(['id', 'payloads'])
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        self.assertEqual(
+            {
+                row['id']: row['payloads']
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: [b'blob-1a', None, b'blob-1b'],
+                2: None,
+                3: [b'blob-3'],
+            },
+        )
+
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['payloads'])
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids_by_id[2]], type=pa.int64()),
+            'payloads': pa.array([[b'updated-2']], type=array_blob_type),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_files = [f for msg in update_messages for f in msg.new_files]
+        update_blob_files = [f for f in update_files if f.file_name.endswith('.blob')]
+        self.assertEqual(len(update_blob_files), 1)
+        self.assertEqual(update_blob_files[0].row_count, 2)
+        blob_fields = [field for field in table.fields if field.name == 'payloads']
+        blob_reader = FormatBlobReader(
+            file_io=table.file_io,
+            file_path=update_blob_files[0].file_path,
+            read_fields=['payloads'],
+            full_fields=blob_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        update_blob_lengths = list(blob_reader.blob_lengths)
+        blob_reader.close()
+        self.assertEqual(
+            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
+            1,
+        )
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder().with_projection(['id', 'payloads'])
+        result = read_builder.new_read().to_arrow(read_builder.new_scan().plan().splits())
+        self.assertEqual(
+            {
+                row['id']: row['payloads']
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: [b'blob-1a', None, b'blob-1b'],
+                2: [b'updated-2'],
+                3: [b'blob-3'],
+            },
+        )
+
     def test_blob_update_single_row_at_first_position(self):
         from pypaimon import Schema
 

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -32,7 +32,7 @@ from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.common.options import Options
 from pypaimon.read.reader.concat_batch_reader import BlobFallbackBatchReader
 from pypaimon.read.reader.format_blob_reader import BlobRecordIterator, FormatBlobReader
-from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField
 from pypaimon.table.row.blob import Blob, BlobData, BlobRef, BlobDescriptor, BlobViewStruct, BlobView
 from pypaimon.table.row.generic_row import GenericRowDeserializer, GenericRowSerializer, GenericRow
 from pypaimon.table.row.row_kind import RowKind
@@ -1698,6 +1698,177 @@ class BlobEndToEndTest(unittest.TestCase):
             blob_as_descriptor=True
         )
 
+        with self.assertRaisesRegex(RuntimeError, "Blob placeholder is not supported"):
+            reader.read_arrow_batch()
+        reader.close()
+
+    def test_array_blob_write_read(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "array_blob.blob")
+
+        fields = [
+            DataField(
+                0,
+                "blob_array",
+                ArrayType(True, AtomicType("BLOB")),
+            )
+        ]
+        with open(blob_file_path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [[BlobData(b"hello"), None, BlobData(b"world")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.add_element(GenericRow([None], fields, RowKind.INSERT))
+            writer.add_element(GenericRow([[]], fields, RowKind.INSERT))
+            writer.add_element(GenericRow(
+                [[BlobData(b"last")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.close()
+
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        batch = reader.read_arrow_batch()
+        self.assertEqual(batch.column(0).to_pylist(), [
+            [b"hello", None, b"world"],
+            None,
+            [],
+            [b"last"],
+        ])
+        reader.close()
+
+    def test_file_io_write_array_blob(self):
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = Path(self.temp_dir) / "array_blob_file_io.blob"
+        blob_file_url = _to_url(blob_file_path)
+
+        arrow_type = pa.list_(pa.large_binary())
+        table = pa.table(
+            [pa.array([[b"one", None], None, [b"two"]], type=arrow_type)],
+            schema=pa.schema([pa.field("blob_array", arrow_type)]),
+        )
+        file_io.write_blob(blob_file_url, table)
+
+        fields = [
+            DataField(
+                0,
+                "blob_array",
+                ArrayType(True, AtomicType("BLOB")),
+            )
+        ]
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=str(blob_file_path),
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        batch = reader.read_arrow_batch()
+        self.assertEqual(batch.column(0).to_pylist(), [
+            [b"one", None],
+            None,
+            [b"two"],
+        ])
+        reader.close()
+
+    def test_array_blob_read_as_descriptor(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "array_blob_desc.blob")
+
+        fields = [
+            DataField(
+                0,
+                "blob_array",
+                ArrayType(True, AtomicType("BLOB")),
+            )
+        ]
+        with open(blob_file_path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [[BlobData(b"hello"), None, BlobData(b"world")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.close()
+
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=True,
+        )
+        batch = reader.read_arrow_batch()
+        values = batch.column(0)[0].as_py()
+        self.assertEqual(len(values), 3)
+        desc0 = BlobDescriptor.deserialize(values[0])
+        self.assertEqual(desc0.uri, blob_file_path)
+        self.assertEqual(desc0.length, len(b"hello"))
+        self.assertIsNone(values[1])
+        desc2 = BlobDescriptor.deserialize(values[2])
+        self.assertEqual(desc2.uri, blob_file_path)
+        self.assertEqual(desc2.length, len(b"world"))
+        reader.close()
+
+    def test_array_blob_placeholder_write_read(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "array_placeholder.blob")
+
+        fields = [
+            DataField(
+                0,
+                "blob_array",
+                ArrayType(True, AtomicType("BLOB")),
+            )
+        ]
+        with open(blob_file_path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [[BlobData(b"hello")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.add_element(GenericRow(
+                [Blob.ARRAY_PLACE_HOLDER],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.close()
+
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        iterator = BlobRecordIterator(
+            file_io,
+            blob_file_path,
+            reader.blob_lengths,
+            reader.blob_offsets,
+            fields[0],
+        )
+        self.assertEqual(next(iterator).values[0][0].to_data(), b"hello")
+        self.assertIs(next(iterator).values[0], Blob.ARRAY_PLACE_HOLDER)
         with self.assertRaisesRegex(RuntimeError, "Blob placeholder is not supported"):
             reader.read_arrow_batch()
         reader.close()

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -26,10 +26,11 @@ from pathlib import Path
 import pyarrow as pa
 
 from pypaimon import CatalogFactory, Schema
+from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 from pypaimon.common.file_io import FileIO
+from pypaimon.common.options import Options
 from pypaimon.filesystem.local_file_io import LocalFileIO
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
-from pypaimon.common.options import Options
 from pypaimon.read.reader.concat_batch_reader import BlobFallbackBatchReader
 from pypaimon.read.reader.format_blob_reader import BlobRecordIterator, FormatBlobReader
 from pypaimon.schema.data_types import ArrayType, AtomicType, DataField
@@ -1872,6 +1873,71 @@ class BlobEndToEndTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "Blob placeholder is not supported"):
             reader.read_arrow_batch()
         reader.close()
+
+    def test_reject_malformed_array_blob_payloads(self):
+        cases = [
+            (
+                self._array_blob_payload(b"a", [1], version=0),
+                "Unsupported ARRAY<BLOB> payload version",
+            ),
+            (
+                self._array_blob_payload(b"a", [1], element_count=0x80000000),
+                "Invalid ARRAY<BLOB> element count",
+            ),
+            (
+                self._array_blob_payload(b"a", [1], index_length=100),
+                "Invalid ARRAY<BLOB> element index length",
+            ),
+            (
+                self._array_blob_payload(b"", [], index=b"\x80"),
+                "Invalid ARRAY<BLOB> element index",
+            ),
+            (
+                self._array_blob_payload(b"a", [-2]),
+                "Invalid ARRAY<BLOB> element length",
+            ),
+            (
+                self._array_blob_payload(b"a", [2]),
+                "element lengths exceed the payload data length",
+            ),
+        ]
+
+        field = DataField(0, "blob_array", ArrayType(True, AtomicType("BLOB")))
+        for payload, expected_message in cases:
+            with self.subTest(expected_message=expected_message):
+                iterator = BlobRecordIterator(
+                    None,
+                    "unused",
+                    [],
+                    [],
+                    field,
+                    input_stream=io.BytesIO(payload),
+                )
+                with self.assertRaisesRegex(ValueError, expected_message):
+                    iterator._read_blob_array(0, len(payload))
+
+    @staticmethod
+    def _array_blob_payload(
+        data, element_lengths, version=BlobRecordIterator.ARRAY_VERSION,
+        element_count=None, index_length=None, index=None,
+    ):
+        if index is None:
+            index = DeltaVarintCompressor.compress(element_lengths)
+        if element_count is None:
+            element_count = len(element_lengths)
+        if index_length is None:
+            index_length = len(index)
+        return (
+            struct.pack(
+                '<IBI',
+                BlobRecordIterator.ARRAY_MAGIC_NUMBER,
+                version,
+                element_count,
+            )
+            + data
+            + index
+            + struct.pack('<I', index_length)
+        )
 
 
 class BlobParallelismTest(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -71,6 +71,43 @@ def _to_url(path):
     return str(path) if path else path
 
 
+class RowUtilsTest(unittest.TestCase):
+
+    def test_blob_validation_only_scans_blob_fields(self):
+        from pypaimon.write.row_utils import value_for_arrow
+
+        class TrackingList(list):
+            def __init__(self, values):
+                super().__init__(values)
+                self.iterations = 0
+
+            def __iter__(self):
+                self.iterations += 1
+                return super().__iter__()
+
+        normal_values = TrackingList([1, 2, 3])
+        normal_field = DataField(
+            0,
+            "values",
+            ArrayType(True, AtomicType("INT")),
+        )
+        self.assertIs(
+            value_for_arrow(normal_values, normal_field),
+            normal_values,
+        )
+        self.assertEqual(normal_values.iterations, 0)
+
+        blob_values = TrackingList([BlobData(b"payload")])
+        blob_field = DataField(
+            1,
+            "payloads",
+            ArrayType(True, AtomicType("BLOB")),
+        )
+        with self.assertRaisesRegex(ValueError, "Blob values cannot be converted"):
+            value_for_arrow(blob_values, blob_field)
+        self.assertEqual(blob_values.iterations, 1)
+
+
 class BlobTest(unittest.TestCase):
     def setUp(self):
         """Set up test environment with temporary file."""
@@ -1748,6 +1785,129 @@ class BlobEndToEndTest(unittest.TestCase):
             [b"last"],
         ])
         reader.close()
+
+    def test_array_blob_parallelism_uses_concurrent_resolver(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "array_blob_parallel.blob")
+        fields = [DataField(
+            0,
+            "blob_array",
+            ArrayType(True, AtomicType("BLOB")),
+        )]
+        with open(blob_file_path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [[BlobData(b"a"), None, BlobData(b"bc")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.add_element(GenericRow(
+                [[BlobData(b"def")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.close()
+
+        calls = []
+        range_reads = []
+        original_read = file_io.read_blobs_concurrent
+        original_range_read = file_io.read_file_range
+
+        def read_blobs_concurrent(blobs, parallelism):
+            calls.append((list(blobs), parallelism))
+            return original_read(blobs, parallelism)
+
+        def read_file_range(path, offset, length):
+            range_reads.append((path, offset, length))
+            return original_range_read(path, offset, length)
+
+        file_io.read_blobs_concurrent = read_blobs_concurrent
+        file_io.read_file_range = read_file_range
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+            blob_parallelism=4,
+        )
+
+        batch = reader.read_arrow_batch()
+
+        self.assertEqual(
+            batch.column(0).to_pylist(),
+            [[b"a", None, b"bc"], [b"def"]],
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls[0][0]), 3)
+        self.assertEqual(calls[0][1], 4)
+        self.assertEqual(len(range_reads), 1)
+        reader.close()
+
+    def test_array_blob_serial_read_uses_single_payload_read(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "array_blob_serial.blob")
+        fields = [DataField(
+            0,
+            "blob_array",
+            ArrayType(True, AtomicType("BLOB")),
+        )]
+        with open(blob_file_path, 'wb') as output:
+            writer = BlobFormatWriter(output)
+            writer.add_element(GenericRow(
+                [[BlobData(b"a"), BlobData(b"bc"), BlobData(b"def")]],
+                fields,
+                RowKind.INSERT,
+            ))
+            writer.close()
+
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_array"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        blob_lengths = list(reader.blob_lengths)
+        blob_offsets = list(reader.blob_offsets)
+        reader.close()
+
+        class TrackingStream:
+            def __init__(self, path):
+                self.stream = open(path, 'rb')
+                self.read_sizes = []
+
+            def seek(self, position, whence=0):
+                return self.stream.seek(position, whence)
+
+            def read(self, size=-1):
+                self.read_sizes.append(size)
+                return self.stream.read(size)
+
+            def close(self):
+                self.stream.close()
+
+        stream = TrackingStream(blob_file_path)
+        iterator = BlobRecordIterator(
+            file_io,
+            blob_file_path,
+            blob_lengths,
+            blob_offsets,
+            fields[0],
+            stream,
+        )
+
+        blobs = next(iterator).values[0]
+
+        self.assertEqual([blob.to_data() for blob in blobs], [b"a", b"bc", b"def"])
+        self.assertEqual(stream.read_sizes[-1], 6)
+        stream.close()
 
     def test_file_io_write_array_blob(self):
         file_io = LocalFileIO(self.temp_dir, Options({}))

--- a/paimon-python/pypaimon/tests/column_directive_utils_test.py
+++ b/paimon-python/pypaimon/tests/column_directive_utils_test.py
@@ -99,6 +99,31 @@ class TestApplyAddColumnDirective(unittest.TestCase):
         self.assertEqual(result.comment, "pic")
         self.assertEqual(opts[CoreOptions.BLOB_FIELD.key()], "pic")
 
+    def test_blob_field_array_source_type(self):
+        opts = {}
+        result = apply_add_column_directive(
+            "__BLOB_FIELD; pictures",
+            "pictures",
+            ArrayType(True, AtomicType("BYTES", False)),
+            opts,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result.type, ArrayType)
+        self.assertEqual(result.type.element.type, "BLOB")
+        self.assertFalse(result.type.element.nullable)
+        self.assertEqual(result.comment, "pictures")
+        self.assertEqual(opts[CoreOptions.BLOB_FIELD.key()], "pictures")
+
+    def test_inline_blob_directive_rejects_array_source_type(self):
+        with self.assertRaisesRegex(ValueError, "ARRAY<BLOB> is only supported"):
+            apply_add_column_directive(
+                "__BLOB_DESCRIPTOR_FIELD",
+                "pictures",
+                ArrayType(True, AtomicType("BYTES")),
+                {},
+            )
+
     def test_vector_field(self):
         opts = {}
         result = apply_add_column_directive(

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -27,7 +27,10 @@ daft = pytest.importorskip("daft")
 from daft.datatype import DataType
 from daft.io import IOConfig, S3Config
 
-from pypaimon.daft.daft_blob import blob_column_to_file_array
+from pypaimon.daft.daft_blob import (
+    blob_array_column_to_file_array,
+    blob_column_to_file_array,
+)
 from pypaimon.daft.daft_compat import (
     file_range_position_field,
     file_range_size_field,
@@ -79,6 +82,28 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
         blob = serialize_io_config(IOConfig(s3=S3Config(key_id="AK", access_key="SK")))
         self.assertEqual(blob_column_to_file_array(col, blob).field("io_config").to_pylist(),
                          [blob, None, blob])
+
+    def test_blob_array_column_to_file_array(self):
+        descriptor_a = BlobDescriptor("oss://b/a", 1, 2).serialize()
+        descriptor_b = BlobDescriptor("oss://b/b", 3, 4).serialize()
+        column = pa.array(
+            [[descriptor_a, None, descriptor_b], None, []],
+            type=pa.list_(pa.large_binary()),
+        )
+
+        converted = blob_array_column_to_file_array(column)
+
+        files = converted[0].as_py()
+        self.assertEqual(
+            [None if value is None else value["url"] for value in files],
+            ["oss://b/a", None, "oss://b/b"],
+        )
+        self.assertEqual([
+            None if value is None else value[file_range_position_field()]
+            for value in files
+        ], [1, None, 3])
+        self.assertFalse(converted[1].is_valid)
+        self.assertEqual(converted[2].as_py(), [])
 
     def test_malformed_blob_descriptor_raises_value_error(self):
         cases = [

--- a/paimon-python/pypaimon/tests/daft/daft_explain_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_explain_test.py
@@ -385,6 +385,39 @@ def test_explain_scan_reports_blob_fallback(catalog_options):
     assert all(split.fallback_reason == "blob columns present" for split in result.splits)
 
 
+@requires_blob
+def test_explain_scan_reports_array_blob_fallback(catalog_options):
+    array_blob_type = pa.list_(pa.large_binary())
+    pa_schema = pa.schema([
+        ("id", pa.int64()),
+        ("payloads", array_blob_type),
+    ])
+    _, table = _create_table(
+        catalog_options,
+        "explain_array_blob_fallback",
+        pa_schema,
+        options={
+            "bucket": "-1",
+            "file.format": "parquet",
+            "row-tracking.enabled": "true",
+            "data-evolution.enabled": "true",
+        },
+    )
+    _write_arrow(table, pa.table({
+        "id": [1],
+        "payloads": pa.array([[b"hello"]], type=array_blob_type),
+    }, schema=pa_schema))
+
+    result = _explain_table(table, catalog_options=catalog_options, verbose=True)
+
+    assert result.pypaimon_fallback_split_count == result.paimon_scan.split_count
+    assert result.pypaimon_fallback_split_count > 0
+    assert result.native_parquet_split_count == 0
+    assert result.fallback_reasons["blob columns present"] == result.pypaimon_fallback_split_count
+    assert result.splits is not None
+    assert all(split.reader_mode == READER_MODE_PYPAIMON_FALLBACK for split in result.splits)
+
+
 def test_explain_scan_reports_deletion_vector_fallback(catalog_options, monkeypatch):
     pa_schema = pa.schema([
         ("id", pa.int64()),

--- a/paimon-python/pypaimon/tests/daft/daft_sink_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_sink_test.py
@@ -536,6 +536,60 @@ class TestBlobType:
             file_size = ref.size() if callable(getattr(ref, "size", None)) else ref.length
             assert file_size is not None
 
+    def test_read_array_blob_type(self, local_paimon_catalog):
+        """ARRAY<BLOB> columns are returned as lists of File objects."""
+        catalog, _ = local_paimon_catalog
+        array_blob_type = pa.list_(pa.large_binary())
+        pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("cover", pa.large_binary()),
+            ("payloads", array_blob_type),
+        ])
+        paimon_schema = pypaimon.Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                "bucket": "1",
+                "file.format": "parquet",
+                "row-tracking.enabled": "true",
+                "data-evolution.enabled": "true",
+            },
+        )
+        catalog.create_table(
+            "test_db.array_blob_table",
+            paimon_schema,
+            ignore_if_exists=True,
+        )
+        table = catalog.get_table("test_db.array_blob_table")
+        _write_to_paimon(table, pa.table({
+            "id": [1, 2],
+            "cover": [b"cover", None],
+            "payloads": pa.array(
+                [[b"hello", None, b"world"], None],
+                type=array_blob_type,
+            ),
+        }, schema=pa_schema))
+
+        result_df = _read_table(table).sort("id")
+        assert str(result_df.schema()["cover"].dtype) == "File[Unknown]"
+        assert str(result_df.schema()["payloads"].dtype) == "List[File[Unknown]]"
+
+        result = result_df.to_pydict()
+        payloads = result["payloads"]
+        assert isinstance(result["cover"][0], daft.File)
+        assert result["cover"][1] is None
+        with result["cover"][0].open() as stream:
+            assert stream.read() == b"cover"
+        assert payloads[1] is None
+        assert payloads[0][1] is None
+        assert all(
+            isinstance(ref, daft.File)
+            for ref in (payloads[0][0], payloads[0][2])
+        )
+        with payloads[0][0].open() as stream:
+            assert stream.read() == b"hello"
+        with payloads[0][2].open() as stream:
+            assert stream.read() == b"world"
+
 
 # ---------------------------------------------------------------------------
 # Truncate tests

--- a/paimon-python/pypaimon/tests/data_types_test.py
+++ b/paimon-python/pypaimon/tests/data_types_test.py
@@ -72,6 +72,21 @@ class DataTypesTest(unittest.TestCase):
         self.assertEqual(str(data_type_class(True, element_type)),
                          str(data_type_class.from_dict(data_type_class(True, element_type).to_dict())))
 
+    def test_array_element_nullability_roundtrip(self):
+        for element_nullable in (True, False):
+            paimon_type = ArrayType(
+                True,
+                AtomicType("BLOB", nullable=element_nullable),
+            )
+
+            arrow_type = PyarrowFieldParser.from_paimon_type(paimon_type)
+
+            self.assertEqual(arrow_type.value_field.nullable, element_nullable)
+            self.assertEqual(
+                PyarrowFieldParser.to_paimon_type(arrow_type, nullable=True),
+                paimon_type,
+            )
+
     def test_map_type(self):
         self.assertEqual(str(MapType(True, AtomicType("STRING"), AtomicType("TIMESTAMP(6)"))),
                          "MAP<STRING, TIMESTAMP(6)>")

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -1392,12 +1392,16 @@ class JavaPyReadWriteTest(unittest.TestCase):
 
         self.assertTrue(pa.types.is_list(result.schema.field('payloads').type))
         self.assertEqual(
-            result.select(['id', 'payloads']).to_pylist(),
+            result.column('id').to_pylist(),
+            [1, 2, 3, 4],
+        )
+        self.assertEqual(
+            result.column('payloads').to_pylist(),
             [
-                {'id': 1, 'payloads': [b'java-alpha', None, b'']},
-                {'id': 2, 'payloads': []},
-                {'id': 3, 'payloads': None},
-                {'id': 4, 'payloads': [b'java-omega']},
+                [b'java-alpha', None, b''],
+                [],
+                None,
+                [b'java-omega'],
             ],
         )
 
@@ -1445,8 +1449,12 @@ class JavaPyReadWriteTest(unittest.TestCase):
             read_builder.new_scan().plan().splits())
         result = table_sort_by(result, 'id')
         self.assertEqual(
-            result.select(['id', 'payloads']).to_pylist(),
-            data.select(['id', 'payloads']).to_pylist(),
+            result.column('id').to_pylist(),
+            data.column('id').to_pylist(),
+        )
+        self.assertEqual(
+            result.column('payloads').to_pylist(),
+            data.column('payloads').to_pylist(),
         )
 
     def test_compact_conflict_shard_update(self):

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -1383,6 +1383,72 @@ class JavaPyReadWriteTest(unittest.TestCase):
         result = table_read.to_arrow(splits)
         self.assertEqual(result.num_rows, 200)
 
+    def test_read_array_blob_written_by_java(self):
+        table = self.catalog.get_table('default.array_blob_java_test')
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        result = table_sort_by(result, 'id')
+
+        self.assertTrue(pa.types.is_list(result.schema.field('payloads').type))
+        self.assertEqual(
+            result.select(['id', 'payloads']).to_pylist(),
+            [
+                {'id': 1, 'payloads': [b'java-alpha', None, b'']},
+                {'id': 2, 'payloads': []},
+                {'id': 3, 'payloads': None},
+                {'id': 4, 'payloads': [b'java-omega']},
+            ],
+        )
+
+    def test_write_array_blob_for_java(self):
+        array_blob_type = pa.list_(pa.large_binary())
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', array_blob_type),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'bucket': '-1',
+            },
+        )
+        table_name = 'default.array_blob_python_test'
+        self.catalog.drop_table(table_name, True)
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4],
+            'payloads': pa.array(
+                [
+                    [b'python-alpha', None, b''],
+                    [],
+                    None,
+                    [b'python-omega'],
+                ],
+                type=array_blob_type,
+            ),
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        result = table_sort_by(result, 'id')
+        self.assertEqual(
+            result.select(['id', 'payloads']).to_pylist(),
+            data.select(['id', 'payloads']).to_pylist(),
+        )
+
     def test_compact_conflict_shard_update(self):
         """
         1. Java writes 5 base files (testCompactConflictWriteBase)

--- a/paimon-python/pypaimon/tests/schema_manager_test.py
+++ b/paimon-python/pypaimon/tests/schema_manager_test.py
@@ -23,7 +23,10 @@ from pypaimon.branch.branch_manager import BranchManager
 from pypaimon.common.identifier import DEFAULT_MAIN_BRANCH
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.options.options import Options
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField
+from pypaimon.schema.schema import Schema
 from pypaimon.schema.schema_manager import SchemaManager
+from pypaimon.schema.table_schema import TableSchema
 
 
 class TestSchemaManagerBranch(unittest.TestCase):
@@ -83,6 +86,63 @@ class TestSchemaManagerBranch(unittest.TestCase):
         schema_manager = SchemaManager(self.file_io, self.table_path, branch_name)
         expected_path = f"{self.table_path}/branch/branch-{branch_name}"
         self.assertEqual(schema_manager.branch_path, expected_path)
+
+
+class TestBlobPartitionValidation(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.file_io = FileIO.get(self.temp_dir, Options({}))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @staticmethod
+    def _schema(blob_type):
+        return Schema(
+            fields=[
+                DataField(0, "id", AtomicType("INT")),
+                DataField(1, "payload", blob_type),
+            ],
+            partition_keys=["payload"],
+            options={
+                "row-tracking.enabled": "true",
+                "data-evolution.enabled": "true",
+            },
+        )
+
+    def test_create_table_rejects_blob_partition_key(self):
+        blob_types = [
+            AtomicType("BLOB"),
+            ArrayType(True, AtomicType("BLOB")),
+        ]
+        for index, blob_type in enumerate(blob_types):
+            with self.subTest(blob_type=blob_type):
+                manager = SchemaManager(
+                    self.file_io,
+                    f"{self.temp_dir}/test_db.db/create_{index}",
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "can not be part of partition keys",
+                ):
+                    manager.create_table(self._schema(blob_type))
+
+    def test_commit_rejects_array_blob_partition_key(self):
+        manager = SchemaManager(
+            self.file_io,
+            f"{self.temp_dir}/test_db.db/commit",
+        )
+        table_schema = TableSchema.from_schema(
+            0,
+            self._schema(ArrayType(True, AtomicType("BLOB"))),
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            "can not be part of partition keys",
+        ):
+            manager.commit(table_schema)
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -19,6 +19,7 @@ import struct
 import zlib
 from typing import BinaryIO, List, Optional
 
+from pypaimon.schema.data_types import is_array_blob_type, is_blob_file_type
 from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor, BlobConsumer
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 
@@ -26,8 +27,11 @@ from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 class BlobFormatWriter:
     VERSION = 1
     MAGIC_NUMBER = 1481511375
+    ARRAY_VERSION = 1
+    ARRAY_MAGIC_NUMBER = 1094861634
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
+    ARRAY_NULL_ELEMENT_LENGTH = -1
     BUFFER_SIZE = 4096
     METADATA_SIZE = 12  # 8-byte length + 4-byte CRC
 
@@ -45,6 +49,7 @@ class BlobFormatWriter:
             raise ValueError("BlobFormatWriter only supports one field")
 
         blob_field_name = row.fields[0].name
+        blob_field_type = row.fields[0].type
         blob_value = row.values[0]
         if blob_value is None:
             self.lengths.append(self.NULL_LENGTH)
@@ -52,12 +57,22 @@ class BlobFormatWriter:
                 self._blob_consumer(blob_field_name, None)
             return
 
-        if not isinstance(blob_value, Blob):
-            raise ValueError("Field must be Blob/BlobData instance")
+        if is_array_blob_type(blob_field_type):
+            if blob_value is Blob.ARRAY_PLACE_HOLDER:
+                self.lengths.append(self.PLACE_HOLDER_LENGTH)
+                return
+            self.add_blob_array(blob_field_name, blob_value)
+            return
 
         if blob_value is Blob.PLACE_HOLDER:
             self.lengths.append(self.PLACE_HOLDER_LENGTH)
             return
+
+        self.add_blob(blob_field_name, blob_value)
+
+    def add_blob(self, blob_field_name: str, blob_value: Blob) -> None:
+        if not isinstance(blob_value, Blob):
+            raise ValueError("Field must be Blob/BlobData instance")
 
         previous_pos = self.position
         crc32 = 0  # Initialize CRC32
@@ -66,24 +81,7 @@ class BlobFormatWriter:
         magic_bytes = struct.pack('<I', self.MAGIC_NUMBER)  # Little endian
         crc32 = self._write_with_crc(magic_bytes, crc32)
 
-        blob_pos = self.position
-
-        # Write blob data
-        if isinstance(blob_value, BlobData):
-            data = blob_value.to_data()
-            crc32 = self._write_with_crc(data, crc32)
-        else:
-            # Stream from BlobRef/Blob
-            stream = blob_value.new_input_stream()
-            try:
-                chunk = stream.read(self.BUFFER_SIZE)
-                while chunk:
-                    crc32 = self._write_with_crc(chunk, crc32)
-                    chunk = stream.read(self.BUFFER_SIZE)
-            finally:
-                stream.close()
-
-        blob_length = self.position - blob_pos
+        blob_pos, blob_length, crc32 = self._write_blob_data(blob_value, crc32)
 
         # Calculate total length including magic + data + metadata (length + CRC)
         bin_length = self.position - previous_pos + self.METADATA_SIZE
@@ -105,6 +103,68 @@ class BlobFormatWriter:
             if flush:
                 self.output_stream.flush()
 
+    def add_blob_array(self, blob_field_name: str, blob_values) -> None:
+        if isinstance(blob_values, (bytes, bytearray, str)) or not hasattr(blob_values, '__iter__'):
+            raise ValueError("ARRAY<BLOB> field value must be a list or tuple of Blob values")
+
+        blob_values = list(blob_values)
+        previous_pos = self.position
+        crc32 = 0
+
+        crc32 = self._write_with_crc(struct.pack('<I', self.MAGIC_NUMBER), crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', self.ARRAY_MAGIC_NUMBER), crc32)
+        crc32 = self._write_with_crc(struct.pack('<B', self.ARRAY_VERSION), crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', len(blob_values)), crc32)
+
+        element_lengths = []
+        flush = False
+        for blob_value in blob_values:
+            if blob_value is None:
+                element_lengths.append(self.ARRAY_NULL_ELEMENT_LENGTH)
+                continue
+            if not isinstance(blob_value, Blob):
+                raise ValueError("ARRAY<BLOB> elements must be Blob/BlobData instances or None")
+            if blob_value is Blob.PLACE_HOLDER or blob_value is Blob.ARRAY_PLACE_HOLDER:
+                raise ValueError("ARRAY<BLOB> elements do not support placeholders")
+
+            blob_pos, blob_length, crc32 = self._write_blob_data(blob_value, crc32)
+            element_lengths.append(blob_length)
+            if self._blob_consumer is not None:
+                descriptor = BlobDescriptor(self._file_path, blob_pos, blob_length)
+                flush = self._blob_consumer(blob_field_name, descriptor) or flush
+
+        element_index_bytes = DeltaVarintCompressor.compress(element_lengths)
+        crc32 = self._write_with_crc(element_index_bytes, crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', len(element_index_bytes)), crc32)
+
+        bin_length = self.position - previous_pos + self.METADATA_SIZE
+        self.lengths.append(bin_length)
+        self.output_stream.write(struct.pack('<Q', bin_length))
+        self.position += 8
+        self.output_stream.write(struct.pack('<I', crc32 & 0xffffffff))
+        self.position += 4
+
+        if flush:
+            self.output_stream.flush()
+
+    def _write_blob_data(self, blob_value: Blob, crc32: int):
+        blob_pos = self.position
+
+        if isinstance(blob_value, BlobData):
+            data = blob_value.to_data()
+            crc32 = self._write_with_crc(data, crc32)
+        else:
+            stream = blob_value.new_input_stream()
+            try:
+                chunk = stream.read(self.BUFFER_SIZE)
+                while chunk:
+                    crc32 = self._write_with_crc(chunk, crc32)
+                    chunk = stream.read(self.BUFFER_SIZE)
+            finally:
+                stream.close()
+
+        return blob_pos, self.position - blob_pos, crc32
+
     def _write_with_crc(self, data: bytes, crc32: int) -> int:
         crc32 = zlib.crc32(data, crc32)
         self.output_stream.write(data)
@@ -115,7 +175,7 @@ class BlobFormatWriter:
         from pypaimon.table.row.generic_row import GenericRow
         from pypaimon.table.row.row_kind import RowKind
 
-        is_blob = hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB"
+        is_blob = is_blob_file_type(fields[0].type)
 
         if col_data is None:
             if not is_blob:
@@ -123,31 +183,59 @@ class BlobFormatWriter:
             self.lengths.append(self.NULL_LENGTH)
             return
 
-        if is_blob:
-            if hasattr(col_data, 'as_py'):
-                col_data = col_data.as_py()
-            if isinstance(col_data, str):
-                col_data = col_data.encode('utf-8')
-            if isinstance(col_data, bytearray):
-                col_data = bytes(col_data)
-
-            if isinstance(col_data, bytes):
-                if BlobDescriptor.is_blob_descriptor(col_data):
-                    descriptor = BlobDescriptor.deserialize(col_data)
-                    uri_reader = uri_reader_factory.create(descriptor.uri)
-                    blob_value = Blob.from_descriptor(uri_reader, descriptor)
-                else:
-                    blob_value = BlobData(col_data)
-            else:
-                raise RuntimeError(
-                    "Blob field value must be bytes/blob or serialized BlobDescriptor bytes."
-                )
-            row_values = [blob_value]
+        if is_array_blob_type(fields[0].type):
+            row_values = [self._to_blob_array(col_data, uri_reader_factory)]
+        elif is_blob:
+            row_values = [self._to_blob(col_data, uri_reader_factory)]
         else:
             row_values = [col_data]
 
         row = GenericRow(row_values, fields, RowKind.INSERT)
         self.add_element(row)
+
+    @staticmethod
+    def _to_blob(col_data, uri_reader_factory=None) -> Blob:
+        if col_data is Blob.PLACE_HOLDER:
+            return Blob.PLACE_HOLDER
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if isinstance(col_data, str):
+            col_data = col_data.encode('utf-8')
+        if isinstance(col_data, bytearray):
+            col_data = bytes(col_data)
+        if isinstance(col_data, Blob):
+            return col_data
+        if isinstance(col_data, bytes):
+            if BlobDescriptor.is_blob_descriptor(col_data):
+                if uri_reader_factory is None:
+                    raise RuntimeError("uri_reader_factory is required for BlobDescriptor bytes.")
+                descriptor = BlobDescriptor.deserialize(col_data)
+                uri_reader = uri_reader_factory.create(descriptor.uri)
+                return Blob.from_descriptor(uri_reader, descriptor)
+            return BlobData(col_data)
+        raise RuntimeError(
+            "Blob field value must be bytes/blob or serialized BlobDescriptor bytes."
+        )
+
+    @classmethod
+    def _to_blob_array(cls, col_data, uri_reader_factory=None):
+        if col_data is Blob.ARRAY_PLACE_HOLDER:
+            return Blob.ARRAY_PLACE_HOLDER
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if col_data is None:
+            return None
+        if isinstance(col_data, (bytes, bytearray, str)) or not hasattr(col_data, '__iter__'):
+            raise RuntimeError("ARRAY<BLOB> field value must be a list or tuple.")
+        result = []
+        for element in col_data:
+            if element is None:
+                result.append(None)
+                continue
+            if element is Blob.PLACE_HOLDER or element is Blob.ARRAY_PLACE_HOLDER:
+                raise RuntimeError("ARRAY<BLOB> elements do not support placeholders.")
+            result.append(cls._to_blob(element, uri_reader_factory))
+        return result
 
     def reach_target_size(self, target_size: int) -> bool:
         return self.position >= target_size

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -61,7 +61,11 @@ class BlobFormatWriter:
             if blob_value is Blob.ARRAY_PLACE_HOLDER:
                 self.lengths.append(self.PLACE_HOLDER_LENGTH)
                 return
-            self.add_blob_array(blob_field_name, blob_value)
+            self.add_blob_array(
+                blob_field_name,
+                blob_value,
+                element_nullable=blob_field_type.element.nullable,
+            )
             return
 
         if blob_value is Blob.PLACE_HOLDER:
@@ -103,11 +107,27 @@ class BlobFormatWriter:
             if flush:
                 self.output_stream.flush()
 
-    def add_blob_array(self, blob_field_name: str, blob_values) -> None:
+    def add_blob_array(
+            self,
+            blob_field_name: str,
+            blob_values,
+            element_nullable: bool = True) -> None:
         if isinstance(blob_values, (bytes, bytearray, str)) or not hasattr(blob_values, '__iter__'):
             raise ValueError("ARRAY<BLOB> field value must be a list or tuple of Blob values")
 
         blob_values = list(blob_values)
+        for blob_value in blob_values:
+            if blob_value is None:
+                if not element_nullable:
+                    raise ValueError(
+                        f"ARRAY<BLOB> field '{blob_field_name}' does not allow null elements"
+                    )
+                continue
+            if not isinstance(blob_value, Blob):
+                raise ValueError("ARRAY<BLOB> elements must be Blob/BlobData instances or None")
+            if blob_value is Blob.PLACE_HOLDER or blob_value is Blob.ARRAY_PLACE_HOLDER:
+                raise ValueError("ARRAY<BLOB> elements do not support placeholders")
+
         previous_pos = self.position
         crc32 = 0
 
@@ -122,10 +142,6 @@ class BlobFormatWriter:
             if blob_value is None:
                 element_lengths.append(self.ARRAY_NULL_ELEMENT_LENGTH)
                 continue
-            if not isinstance(blob_value, Blob):
-                raise ValueError("ARRAY<BLOB> elements must be Blob/BlobData instances or None")
-            if blob_value is Blob.PLACE_HOLDER or blob_value is Blob.ARRAY_PLACE_HOLDER:
-                raise ValueError("ARRAY<BLOB> elements do not support placeholders")
 
             blob_pos, blob_length, crc32 = self._write_blob_data(blob_value, crc32)
             element_lengths.append(blob_length)

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -25,6 +25,7 @@ import pyarrow as pa
 logger = logging.getLogger(__name__)
 
 from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.schema.data_types import is_blob_file_field
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.row_utils import row_values_to_arrow_table
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
@@ -240,12 +241,7 @@ class FileStoreWrite:
 
     def _has_blob_columns(self) -> bool:
         """Check if the table schema contains blob columns."""
-        for field in self.table.table_schema.fields:
-            if hasattr(field.type, 'type') and field.type.type == 'BLOB':
-                return True
-            elif hasattr(field.type, '__class__') and 'blob' in field.type.__class__.__name__.lower():
-                return True
-        return False
+        return any(is_blob_file_field(field) for field in self.table.table_schema.fields)
 
     def _has_vector_columns(self) -> bool:
         from pypaimon.schema.data_types import VectorType

--- a/paimon-python/pypaimon/write/row_utils.py
+++ b/paimon-python/pypaimon/write/row_utils.py
@@ -25,10 +25,6 @@ from pypaimon.table.row.internal_row import InternalRow
 from pypaimon.table.row.vector import Vector
 
 
-def is_blob_field(field: DataField) -> bool:
-    return is_blob_file_field(field)
-
-
 def row_to_named_values(
         row: InternalRow, table_fields: List[DataField]) -> Dict[str, Any]:
     if hasattr(row, 'fields') and getattr(row, 'fields') is not None:
@@ -65,10 +61,13 @@ def require_columns(
         )
 
 
-def value_for_arrow(value: Any) -> Any:
+def value_for_arrow(value: Any, field: DataField) -> Any:
     if isinstance(value, Vector):
         return value.to_list()
-    if _contains_blob_value(value):
+    if isinstance(value, Blob) or (
+        is_blob_file_field(field)
+        and _contains_blob_value(value)
+    ):
         raise ValueError(
             "Blob values cannot be converted to Arrow without materializing "
             "the stream. Use a Row-aware blob write path."
@@ -81,12 +80,6 @@ def _contains_blob_value(value: Any) -> bool:
         return True
     if isinstance(value, (list, tuple)):
         return any(_contains_blob_value(item) for item in value)
-    if isinstance(value, dict):
-        return any(
-            _contains_blob_value(item)
-            for pair in value.items()
-            for item in pair
-        )
     return False
 
 
@@ -98,7 +91,7 @@ def row_values_to_arrow_table(
     selected_fields = [field_by_name[name] for name in column_names]
     schema = PyarrowFieldParser.from_paimon_schema(selected_fields)
     data = {
-        name: [value_for_arrow(values_by_name[name])]
+        name: [value_for_arrow(values_by_name[name], field_by_name[name])]
         for name in column_names
     }
     return pa.Table.from_pydict(data, schema=schema)

--- a/paimon-python/pypaimon/write/row_utils.py
+++ b/paimon-python/pypaimon/write/row_utils.py
@@ -19,14 +19,14 @@ from typing import Any, Dict, Iterable, List
 
 import pyarrow as pa
 
-from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+from pypaimon.schema.data_types import DataField, PyarrowFieldParser, is_blob_file_field
 from pypaimon.table.row.blob import Blob
 from pypaimon.table.row.internal_row import InternalRow
 from pypaimon.table.row.vector import Vector
 
 
 def is_blob_field(field: DataField) -> bool:
-    return getattr(field.type, 'type', None) == 'BLOB'
+    return is_blob_file_field(field)
 
 
 def row_to_named_values(
@@ -68,12 +68,26 @@ def require_columns(
 def value_for_arrow(value: Any) -> Any:
     if isinstance(value, Vector):
         return value.to_list()
-    if isinstance(value, Blob):
+    if _contains_blob_value(value):
         raise ValueError(
             "Blob values cannot be converted to Arrow without materializing "
             "the stream. Use a Row-aware blob write path."
         )
     return value
+
+
+def _contains_blob_value(value: Any) -> bool:
+    if isinstance(value, Blob):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_contains_blob_value(item) for item in value)
+    if isinstance(value, dict):
+        return any(
+            _contains_blob_value(item)
+            for pair in value.items()
+            for item in pair
+        )
+    return False
 
 
 def row_values_to_arrow_table(

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -258,7 +258,7 @@ class TableUpdateByRowId:
             arrays.append(
                 pa.array(
                     [
-                        value_for_arrow(values_by_name[col_name])
+                        value_for_arrow(values_by_name[col_name], table_field)
                         for _, values_by_name in row_entries
                     ],
                     type=arrow_field.type,

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -26,7 +26,12 @@ import pyarrow.compute as pc
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.split import DataSplit
 from pypaimon.read.table_read import TableRead
-from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+from pypaimon.schema.data_types import (
+    DataField,
+    PyarrowFieldParser,
+    is_array_blob_type,
+    is_blob_file_field,
+)
 from pypaimon.table.row.blob import Blob
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.table.special_fields import SpecialFields
@@ -439,18 +444,20 @@ class TableUpdateByRowId:
             if self._is_blob_column(col_name):
                 if blob_object_columns and col_name in blob_object_columns:
                     update_values = blob_object_columns[col_name]
+                    placeholder = self._blob_placeholder(col_name)
                     blob_columns[col_name] = [
                         update_values[update_positions[i]]
                         if i in update_positions
-                        else Blob.PLACE_HOLDER
+                        else placeholder
                         for i in range(blob_row_count)
                     ]
                     continue
                 update_col = update_by_col[col_name]
+                placeholder = self._blob_placeholder(col_name)
                 blob_columns[col_name] = [
                     update_col[update_positions[i]].as_py()
                     if i in update_positions
-                    else Blob.PLACE_HOLDER
+                    else placeholder
                     for i in range(blob_row_count)
                 ]
                 continue
@@ -510,8 +517,18 @@ class TableUpdateByRowId:
     def _is_blob_column(self, column_name: str) -> bool:
         for table_field in self.table.fields:
             if table_field.name == column_name:
-                return getattr(table_field.type, 'type', None) == 'BLOB'
+                return is_blob_file_field(table_field)
         return False
+
+    def _blob_placeholder(self, column_name: str):
+        for table_field in self.table.fields:
+            if table_field.name == column_name:
+                return (
+                    Blob.ARRAY_PLACE_HOLDER
+                    if is_array_blob_type(table_field.type)
+                    else Blob.PLACE_HOLDER
+                )
+        return Blob.PLACE_HOLDER
 
     def _write_group(
             self,

--- a/paimon-python/pypaimon/write/writer/blob_file_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_file_writer.py
@@ -23,7 +23,11 @@ import pyarrow as pa
 from pypaimon.write.blob_format_writer import BlobFormatWriter
 from pypaimon.table.row.generic_row import GenericRow, RowKind
 from pypaimon.table.row.blob import Blob, BlobConsumer, BlobData, BlobDescriptor
-from pypaimon.schema.data_types import DataField, PyarrowFieldParser
+from pypaimon.schema.data_types import (
+    DataField,
+    PyarrowFieldParser,
+    is_array_blob_type,
+)
 
 
 class BlobFileWriter:
@@ -55,17 +59,16 @@ class BlobFileWriter:
         field_name = row_data.schema[0].name
         col_data = records_dict[field_name][0]
 
-        blob_data = self._to_blob(col_data)
-
-        self.write_blob(field_name, row_data.schema[0].type, blob_data)
+        self.write_blob(field_name, row_data.schema[0].type, col_data)
 
     def write_blob(self, field_name: str, arrow_type, blob_data):
-        blob_data = self._to_blob(blob_data)
+        field_type = PyarrowFieldParser.to_paimon_type(arrow_type, False)
+        blob_data = self._to_blob_file_value(blob_data, field_type)
         fields = [
             DataField(
                 0,
                 field_name,
-                PyarrowFieldParser.to_paimon_type(arrow_type, False),
+                field_type,
             )
         ]
         row = GenericRow([blob_data], fields, RowKind.INSERT)
@@ -73,6 +76,11 @@ class BlobFileWriter:
         # Write to blob format writer
         self.writer.add_element(row)
         self.row_count += 1
+
+    def _to_blob_file_value(self, col_data, field_type):
+        if is_array_blob_type(field_type):
+            return self._to_blob_array(col_data)
+        return self._to_blob(col_data)
 
     def _to_blob(self, col_data) -> Optional[Blob]:
         if col_data is Blob.PLACE_HOLDER:
@@ -101,6 +109,28 @@ class BlobFileWriter:
             "Blob field value must be bytes/blob or serialized BlobDescriptor bytes, "
             f"got {type(col_data)}."
         )
+
+    def _to_blob_array(self, col_data):
+        if col_data is Blob.ARRAY_PLACE_HOLDER:
+            return Blob.ARRAY_PLACE_HOLDER
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if col_data is None:
+            return None
+        if isinstance(col_data, (bytes, bytearray, str)) or not hasattr(col_data, '__iter__'):
+            raise ValueError(
+                "ARRAY<BLOB> field value must be a list or tuple, "
+                f"got {type(col_data)}."
+            )
+        result = []
+        for element in col_data:
+            if element is None:
+                result.append(None)
+                continue
+            if element is Blob.PLACE_HOLDER or element is Blob.ARRAY_PLACE_HOLDER:
+                raise ValueError("ARRAY<BLOB> elements do not support placeholders.")
+            result.append(self._to_blob(element))
+        return result
 
     @staticmethod
     def _deserialize_descriptor_or_none(raw: bytes):

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -177,7 +177,7 @@ class BlobWriter(AppendOnlyDataWriter):
         else:
             # row_count only (from BlobFileWriter)
             row_count = data_or_row_count
-            data_fields = [PyarrowFieldParser.to_paimon_schema(pa.schema([(self.blob_column, pa.large_binary())]))[0]]
+            data_fields = [self.table.field_dict[self.blob_column]]
             min_value_stats = [None]
             max_value_stats = [None]
             value_null_counts = [0]

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -346,19 +346,39 @@ class DedicatedFormatWriter(DataWriter):
         self.committed_files.clear()
 
     def _split_data(self, data: pa.RecordBatch) -> Tuple[
-            pa.RecordBatch, Dict[str, pa.RecordBatch], Optional[pa.RecordBatch]]:
+            Optional[pa.RecordBatch], Dict[str, pa.RecordBatch], Optional[pa.RecordBatch]]:
         """Split data into normal, blob, and vector parts based on column names."""
-        normal_data = data.select(self.normal_column_names) if self.normal_column_names else None
+        normal_data = (
+            self._project_columns(data, self.normal_column_names)
+            if self.normal_column_names else None
+        )
         blob_data_map = {
-            blob_column: data.select([blob_column]) for blob_column in self.blob_file_column_names
+            blob_column: self._project_columns(data, [blob_column])
+            for blob_column in self.blob_file_column_names
         }
         vector_data = (
-            pa.RecordBatch.from_arrays(
-                [data.column(name) for name in self.vector_write_columns],
-                names=self.vector_write_columns,
-            ) if self.vector_write_columns else None
+            self._project_columns(data, self.vector_write_columns)
+            if self.vector_write_columns else None
         )
         return normal_data, blob_data_map, vector_data
+
+    @staticmethod
+    def _project_columns(data: pa.RecordBatch, column_names: List[str]) -> pa.RecordBatch:
+        indices = [data.schema.get_field_index(name) for name in column_names]
+        missing_columns = [
+            name for name, index in zip(column_names, indices) if index < 0
+        ]
+        if missing_columns:
+            raise KeyError(f"Columns not found in record batch: {missing_columns}")
+
+        projected_schema = pa.schema(
+            [data.schema.field(index) for index in indices],
+            metadata=data.schema.metadata,
+        )
+        return pa.RecordBatch.from_arrays(
+            [data.column(index) for index in indices],
+            schema=projected_schema,
+        )
 
     def _validate_inline_stored_fields_input(self, data: pa.RecordBatch):
         if not self.blob_inline_fields:

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -25,7 +25,12 @@ from pypaimon.common.options.core_options import CoreOptions, ChangelogProducer
 from pypaimon.data.timestamp import Timestamp
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
-from pypaimon.schema.data_types import PyarrowFieldParser, VectorType
+from pypaimon.schema.data_types import (
+    PyarrowFieldParser,
+    VectorType,
+    is_blob_file_field,
+    is_blob_type,
+)
 from pypaimon.table.row.blob import BlobConsumer
 from pypaimon.table.row.generic_row import GenericRow
 from pypaimon.write.row_utils import (
@@ -75,6 +80,16 @@ class DedicatedFormatWriter(DataWriter):
             raise ValueError(
                 "Fields in 'blob-descriptor-field' must be blob fields in schema. "
                 f"Unknown fields: {sorted(unknown_descriptor_fields)}"
+            )
+        inline_array_blob_fields = [
+            field.name
+            for field in self.table.table_schema.fields
+            if field.name in self.blob_inline_fields and not is_blob_type(field.type)
+        ]
+        if inline_array_blob_fields:
+            raise ValueError(
+                "ARRAY<BLOB> is only supported by 'blob-field'. "
+                f"Invalid inline blob fields: {sorted(inline_array_blob_fields)}"
             )
 
         # Blob fields that should still be written to `.blob` files.
@@ -162,12 +177,11 @@ class DedicatedFormatWriter(DataWriter):
         )
 
     def _get_blob_columns_from_schema(self) -> List[str]:
-        blob_columns = []
-        for field in self.table.table_schema.fields:
-            type_str = str(field.type).lower()
-            if 'blob' in type_str:
-                blob_columns.append(field.name)
-
+        blob_columns = [
+            field.name
+            for field in self.table.table_schema.fields
+            if is_blob_file_field(field)
+        ]
         if len(blob_columns) == 0:
             raise ValueError("No blob field found in table schema.")
         return blob_columns

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -37,7 +37,6 @@ from pypaimon.write.row_utils import (
     require_columns,
     row_to_named_values,
     row_values_to_arrow_table,
-    value_for_arrow,
 )
 from pypaimon.write.writer.data_writer import DataWriter
 
@@ -308,7 +307,7 @@ class DedicatedFormatWriter(DataWriter):
                 return value.view_struct.serialize()
             return value
 
-        return value_for_arrow(value)
+        return value
 
     def prepare_commit(self) -> List[DataFileMeta]:
         # Close any remaining data

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -39,7 +39,7 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil
-import org.apache.paimon.types.{BlobType, RowType}
+import org.apache.paimon.types.{BlobType, DataTypeRoot, RowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
 import org.apache.spark.internal.Logging
@@ -419,7 +419,7 @@ case class MergeIntoPaimonDataEvolutionTable(
 
     // Find raw blob update columns and avoid reading them from target table
     val blobInlineFields = table.coreOptions().blobInlineField().asScala.toSet
-    val rawBlobFieldNames = table
+    val rawBlobFields = table
       .rowType()
       .getFields
       .asScala
@@ -427,6 +427,11 @@ case class MergeIntoPaimonDataEvolutionTable(
         field =>
           BlobType.isBlobFileField(field.`type`()) &&
             !blobInlineFields.exists(inlineField => resolver(inlineField, field.name())))
+    val rawBlobFieldNames = rawBlobFields
+      .map(_.name())
+      .toSet
+    val rawArrayBlobFieldNames = rawBlobFields
+      .filter(_.`type`().getTypeRoot == DataTypeRoot.ARRAY)
       .map(_.name())
       .toSet
 
@@ -450,14 +455,15 @@ case class MergeIntoPaimonDataEvolutionTable(
       }.toSet
     }
 
-    val modifiedRawBlobColumnNames = matchedActions
+    val modifiedRawArrayBlobColumnNames = matchedActions
       .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
       .flatten
+      .filter(name => rawArrayBlobFieldNames.exists(arrayBlobName => resolver(arrayBlobName, name)))
       .toSet
-    if (modifiedRawBlobColumnNames.nonEmpty) {
+    if (modifiedRawArrayBlobColumnNames.nonEmpty) {
       throw new UnsupportedOperationException(
-        "Should not append/update raw-data BLOB or ARRAY<BLOB> column through MERGE INTO: " +
-          modifiedRawBlobColumnNames.toSeq.sorted.mkString(", "))
+        "Should not append/update raw-data ARRAY<BLOB> column through MERGE INTO: " +
+          modifiedRawArrayBlobColumnNames.toSeq.sorted.mkString(", "))
     }
 
     val rawBlobMarkerNames =
@@ -514,17 +520,26 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
 
     // the output projection for update from source table
-    def updateOutput(action: UpdateAction): Seq[Expression] = {
+    def updateOutput(action: UpdateAction, rawBlobModified: Set[String]): Seq[Expression] = {
       val updatedColumns = updateColumnsSorted.map {
         attr =>
-          if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+          if (
+            rawBlobUpdateColumns.exists(_.sameRef(attr)) && !rawBlobModified.contains(attr.name)
+          ) {
             Literal(null, attr.dataType)
           } else {
             assignmentValue(action, attr)
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
-      val markers = rawBlobUpdateColumns.map(_ => TrueLiteral)
+      val markers = rawBlobUpdateColumns.map {
+        attr =>
+          if (rawBlobModified.contains(attr.name)) {
+            FalseLiteral
+          } else {
+            TrueLiteral
+          }
+      }
       updatedColumns ++ metadata ++ markers :+ FalseLiteral
     }
 
@@ -560,7 +575,9 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case update: UpdateAction =>
           SparkShimLoader.shim
-            .mergeRowsKeepUpdate(update.condition.getOrElse(TrueLiteral), updateOutput(update))
+            .mergeRowsKeepUpdate(
+              update.condition.getOrElse(TrueLiteral),
+              updateOutput(update, modifiedRawBlobNames(update)))
             .asInstanceOf[MergeRows.Instruction]
         case DeleteAction(condition) =>
           SparkShimLoader.shim

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -39,8 +39,7 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil
-import org.apache.paimon.types.DataTypeRoot.BLOB
-import org.apache.paimon.types.RowType
+import org.apache.paimon.types.{BlobType, RowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
 import org.apache.spark.internal.Logging
@@ -426,7 +425,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       .asScala
       .filter(
         field =>
-          field.`type`().is(BLOB) &&
+          BlobType.isBlobFileField(field.`type`()) &&
             !blobInlineFields.exists(inlineField => resolver(inlineField, field.name())))
       .map(_.name())
       .toSet
@@ -438,6 +437,29 @@ case class MergeIntoPaimonDataEvolutionTable(
     // The final output is composed by updated columns, metadata columns and blob marker columns.
     // Marker columns are used to mark whether a blob field should be written with placeholder
     val rawBlobUpdateColumns = updateColumnsSorted.filter(isRawBlobUpdateColumn)
+
+    def modifiedRawBlobNames(action: UpdateAction): Set[String] = {
+      action.assignments.flatMap {
+        assignment =>
+          if (isModifiedAssignment(assignment)) {
+            val key = assignmentKeyAttribute(assignment)
+            rawBlobUpdateColumns.find(_.sameRef(key)).map(_.name)
+          } else {
+            None
+          }
+      }.toSet
+    }
+
+    val modifiedRawBlobColumnNames = matchedActions
+      .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
+      .flatten
+      .toSet
+    if (modifiedRawBlobColumnNames.nonEmpty) {
+      throw new UnsupportedOperationException(
+        "Should not append/update raw-data BLOB or ARRAY<BLOB> column through MERGE INTO: " +
+          modifiedRawBlobColumnNames.toSeq.sorted.mkString(", "))
+    }
+
     val rawBlobMarkerNames =
       rawBlobMarkerNamesAvoiding(
         rawBlobUpdateColumns.size,
@@ -484,18 +506,6 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
     allFields ++= updateColumnsSorted.filterNot(isRawBlobUpdateColumn)
 
-    def modifiedRawBlobNames(action: UpdateAction): Set[String] = {
-      action.assignments.flatMap {
-        assignment =>
-          if (isModifiedAssignment(assignment)) {
-            val key = assignmentKeyAttribute(assignment)
-            rawBlobUpdateColumns.find(_.sameRef(key)).map(_.name)
-          } else {
-            None
-          }
-      }.toSet
-    }
-
     def assignmentValue(action: UpdateAction, attr: AttributeReference): Expression = {
       action.assignments
         .find(assignment => assignmentKeyAttribute(assignment).sameRef(attr))
@@ -504,26 +514,17 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
 
     // the output projection for update from source table
-    def updateOutput(action: UpdateAction, rawBlobModified: Set[String]): Seq[Expression] = {
+    def updateOutput(action: UpdateAction): Seq[Expression] = {
       val updatedColumns = updateColumnsSorted.map {
         attr =>
-          if (
-            rawBlobUpdateColumns.exists(_.sameRef(attr)) && !rawBlobModified.contains(attr.name)
-          ) {
+          if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
             assignmentValue(action, attr)
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
-      val markers = rawBlobUpdateColumns.map {
-        attr =>
-          if (rawBlobModified.contains(attr.name)) {
-            FalseLiteral
-          } else {
-            TrueLiteral
-          }
-      }
+      val markers = rawBlobUpdateColumns.map(_ => TrueLiteral)
       updatedColumns ++ metadata ++ markers :+ FalseLiteral
     }
 
@@ -559,9 +560,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case update: UpdateAction =>
           SparkShimLoader.shim
-            .mergeRowsKeepUpdate(
-              update.condition.getOrElse(TrueLiteral),
-              updateOutput(update, modifiedRawBlobNames(update)))
+            .mergeRowsKeepUpdate(update.condition.getOrElse(TrueLiteral), updateOutput(update))
             .asInstanceOf[MergeRows.Instruction]
         case DeleteAction(condition) =>
           SparkShimLoader.shim

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
@@ -66,13 +66,22 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
 
     protected InternalRow row;
 
+    protected boolean blobAsDescriptor;
+
     public AbstractSparkInternalRow(RowType rowType) {
         this.rowType = rowType;
+        this.blobAsDescriptor = false;
     }
 
     @Override
     public SparkInternalRow replace(InternalRow row) {
         this.row = row;
+        return this;
+    }
+
+    @Override
+    public SparkInternalRow withBlobAsDescriptor(boolean blobAsDescriptor) {
+        this.blobAsDescriptor = blobAsDescriptor;
         return this;
     }
 
@@ -93,7 +102,8 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
 
     @Override
     public org.apache.spark.sql.catalyst.InternalRow copy() {
-        return SparkInternalRow.create(rowType).replace(copyInternalRow(row, rowType));
+        return SparkInternalRow.create(rowType, blobAsDescriptor)
+                .replace(copyInternalRow(row, rowType));
     }
 
     @Override
@@ -175,7 +185,7 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
     public ArrayData getArray(int ordinal) {
         DataType type = rowType.getTypeAt(ordinal);
         if (type instanceof ArrayType) {
-            return fromPaimon(row.getArray(ordinal), (ArrayType) type);
+            return fromPaimon(row.getArray(ordinal), (ArrayType) type, blobAsDescriptor);
         } else if (type instanceof VectorType) {
             return DataConverter.fromPaimon(row.getVector(ordinal), (VectorType) type);
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
@@ -97,7 +97,12 @@ public class DataConverter {
     }
 
     public static ArrayData fromPaimon(InternalArray array, ArrayType arrayType) {
-        return fromPaimonArrayElementType(array, arrayType.getElementType());
+        return fromPaimon(array, arrayType, false);
+    }
+
+    public static ArrayData fromPaimon(
+            InternalArray array, ArrayType arrayType, boolean blobAsDescriptor) {
+        return fromPaimonArrayElementType(array, arrayType.getElementType(), blobAsDescriptor);
     }
 
     public static ArrayData fromPaimon(InternalVector vector, VectorType vectorType) {
@@ -107,11 +112,16 @@ public class DataConverter {
                             "Vector length mismatch. Expected %d but was %d.",
                             vectorType.getLength(), vector.size()));
         }
-        return fromPaimonArrayElementType(vector, vectorType.getElementType());
+        return fromPaimonArrayElementType(vector, vectorType.getElementType(), false);
     }
 
     private static ArrayData fromPaimonArrayElementType(InternalArray array, DataType elementType) {
-        return SparkArrayData.create(elementType).replace(array);
+        return fromPaimonArrayElementType(array, elementType, false);
+    }
+
+    private static ArrayData fromPaimonArrayElementType(
+            InternalArray array, DataType elementType, boolean blobAsDescriptor) {
+        return SparkArrayData.create(elementType, blobAsDescriptor).replace(array);
     }
 
     public static MapData fromPaimon(InternalMap map, DataType mapType) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
@@ -67,6 +68,8 @@ public class DataConverter {
                 return fromPaimon((InternalMap) o, type);
             case ROW:
                 return fromPaimon((InternalRow) o, (RowType) type);
+            case BLOB:
+                return ((Blob) o).toData();
             default:
                 return o;
         }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -75,6 +75,7 @@ import org.apache.spark.sql.execution.datasources.DataSource;
 import org.apache.spark.sql.execution.datasources.FileFormat;
 import org.apache.spark.sql.execution.datasources.v2.FileDataSourceV2;
 import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
@@ -606,13 +607,10 @@ public class SparkCatalog extends SparkBaseCatalog
         for (StructField field : schema.fields()) {
             String name = field.name();
             DataType type;
-            if (blobFields.contains(name)
-                    || blobDescriptorFields.contains(name)
-                    || blobViewFields.contains(name)) {
-                checkArgument(
-                        field.dataType() instanceof org.apache.spark.sql.types.BinaryType,
-                        "The type of blob field must be binary");
-                type = new BlobType();
+            if (blobDescriptorFields.contains(name) || blobViewFields.contains(name)) {
+                type = toBlobType(field, false);
+            } else if (blobFields.contains(name)) {
+                type = toBlobType(field, true);
             } else if (vectorFields.contains(field.name())) {
                 Preconditions.checkArgument(
                         field.dataType() instanceof ArrayType,
@@ -642,6 +640,26 @@ public class SparkCatalog extends SparkBaseCatalog
             }
         }
         return schemaBuilder.build();
+    }
+
+    private static DataType toBlobType(StructField field, boolean allowArray) {
+        org.apache.spark.sql.types.DataType sparkType = field.dataType();
+        if (sparkType instanceof BinaryType) {
+            return new BlobType(field.nullable());
+        }
+        if (sparkType instanceof ArrayType) {
+            checkArgument(
+                    allowArray,
+                    "ARRAY<BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
+            ArrayType arrayType = (ArrayType) sparkType;
+            checkArgument(
+                    arrayType.elementType() instanceof BinaryType,
+                    "The element type of array blob field must be binary");
+            return new org.apache.paimon.types.ArrayType(
+                    field.nullable(), new BlobType(arrayType.containsNull()));
+        }
+        throw new IllegalArgumentException(
+                "The type of blob field must be binary or array of binary");
     }
 
     private void validateAlterProperty(String alterKey) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRowWrapper.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkInternalRowWrapper.java
@@ -254,7 +254,8 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
         }
         return new SparkInternalArray(
                 internalRow.getArray(actualPos),
-                ((ArrayType) (tableSchema.fields()[pos].dataType())).elementType());
+                ((ArrayType) (tableSchema.fields()[pos].dataType())).elementType(),
+                uriReaderFactory);
     }
 
     @Override
@@ -264,15 +265,20 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
             return null;
         }
         DataType dataType = tableSchema.fields()[pos].dataType();
-        return toSparkInternalVector(dataType, internalRow.getArray(actualPos));
+        return toSparkInternalVector(dataType, internalRow.getArray(actualPos), uriReaderFactory);
     }
 
     private static InternalVector toSparkInternalVector(DataType dataType, ArrayData arrayData) {
+        return toSparkInternalVector(dataType, arrayData, null);
+    }
+
+    private static InternalVector toSparkInternalVector(
+            DataType dataType, ArrayData arrayData, @Nullable UriReaderFactory uriReaderFactory) {
         if (!(dataType instanceof ArrayType)) {
             throw new UnsupportedOperationException("Not a vector type: " + dataType);
         }
         ArrayType arrayType = (ArrayType) dataType;
-        return new SparkInternalVector(arrayData, arrayType.elementType());
+        return new SparkInternalVector(arrayData, arrayType.elementType(), uriReaderFactory);
     }
 
     @Override
@@ -283,7 +289,10 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
         }
         MapType mapType = (MapType) tableSchema.fields()[pos].dataType();
         return new SparkInternalMap(
-                internalRow.getMap(actualPos), mapType.keyType(), mapType.valueType());
+                internalRow.getMap(actualPos),
+                mapType.keyType(),
+                mapType.valueType(),
+                uriReaderFactory);
     }
 
     @Override
@@ -322,10 +331,19 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
 
         private final ArrayData arrayData;
         private final DataType elementType;
+        @Nullable private final UriReaderFactory uriReaderFactory;
 
         public SparkInternalArray(ArrayData arrayData, DataType elementType) {
+            this(arrayData, elementType, null);
+        }
+
+        public SparkInternalArray(
+                ArrayData arrayData,
+                DataType elementType,
+                @Nullable UriReaderFactory uriReaderFactory) {
             this.arrayData = arrayData;
             this.elementType = elementType;
+            this.uriReaderFactory = uriReaderFactory;
         }
 
         @Override
@@ -437,25 +455,30 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
 
         @Override
         public Blob getBlob(int pos) {
-            return Blob.fromBytes(arrayData.getBinary(pos), null, null);
+            return Blob.fromBytes(arrayData.getBinary(pos), uriReaderFactory, null);
         }
 
         @Override
         public InternalArray getArray(int pos) {
             return new SparkInternalArray(
-                    arrayData.getArray(pos), ((ArrayType) elementType).elementType());
+                    arrayData.getArray(pos),
+                    ((ArrayType) elementType).elementType(),
+                    uriReaderFactory);
         }
 
         @Override
         public InternalVector getVector(int pos) {
-            return toSparkInternalVector(elementType, arrayData.getArray(pos));
+            return toSparkInternalVector(elementType, arrayData.getArray(pos), uriReaderFactory);
         }
 
         @Override
         public InternalMap getMap(int pos) {
             MapType mapType = (MapType) elementType;
             return new SparkInternalMap(
-                    arrayData.getMap(pos), mapType.keyType(), mapType.valueType());
+                    arrayData.getMap(pos),
+                    mapType.keyType(),
+                    mapType.valueType(),
+                    uriReaderFactory);
         }
 
         @Override
@@ -470,6 +493,13 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
         public SparkInternalVector(ArrayData arrayData, DataType elementType) {
             super(arrayData, elementType);
         }
+
+        public SparkInternalVector(
+                ArrayData arrayData,
+                DataType elementType,
+                @Nullable UriReaderFactory uriReaderFactory) {
+            super(arrayData, elementType, uriReaderFactory);
+        }
     }
 
     /** adapt to spark internal map. */
@@ -478,11 +508,21 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
         private final MapData mapData;
         private final DataType keyType;
         private final DataType valueType;
+        @Nullable private final UriReaderFactory uriReaderFactory;
 
         public SparkInternalMap(MapData mapData, DataType keyType, DataType valueType) {
+            this(mapData, keyType, valueType, null);
+        }
+
+        public SparkInternalMap(
+                MapData mapData,
+                DataType keyType,
+                DataType valueType,
+                @Nullable UriReaderFactory uriReaderFactory) {
             this.mapData = mapData;
             this.keyType = keyType;
             this.valueType = valueType;
+            this.uriReaderFactory = uriReaderFactory;
         }
 
         @Override
@@ -492,12 +532,12 @@ public class SparkInternalRowWrapper implements InternalRow, Serializable {
 
         @Override
         public InternalArray keyArray() {
-            return new SparkInternalArray(mapData.keyArray(), keyType);
+            return new SparkInternalArray(mapData.keyArray(), keyType, uriReaderFactory);
         }
 
         @Override
         public InternalArray valueArray() {
-            return new SparkInternalArray(mapData.valueArray(), valueType);
+            return new SparkInternalArray(mapData.valueArray(), valueType, uriReaderFactory);
         }
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkRow.java
@@ -166,7 +166,8 @@ public class SparkRow implements InternalRow, Serializable {
 
     @Override
     public InternalArray getArray(int i) {
-        return new PaimonArray(((ArrayType) type.getTypeAt(i)).getElementType(), row.getList(i));
+        return new PaimonArray(
+                ((ArrayType) type.getTypeAt(i)).getElementType(), row.getList(i), uriReaderFactory);
     }
 
     @Override
@@ -179,7 +180,7 @@ public class SparkRow implements InternalRow, Serializable {
 
     @Override
     public InternalMap getMap(int i) {
-        return toPaimonMap((MapType) type.getTypeAt(i), row.getJavaMap(i));
+        return toPaimonMap((MapType) type.getTypeAt(i), row.getJavaMap(i), uriReaderFactory);
     }
 
     @Override
@@ -217,7 +218,8 @@ public class SparkRow implements InternalRow, Serializable {
         }
     }
 
-    private static InternalMap toPaimonMap(MapType mapType, Map<Object, Object> map) {
+    private static InternalMap toPaimonMap(
+            MapType mapType, Map<Object, Object> map, UriReaderFactory uriReaderFactory) {
         List<Object> keys = new ArrayList<>();
         List<Object> values = new ArrayList<>();
         map.forEach(
@@ -226,8 +228,8 @@ public class SparkRow implements InternalRow, Serializable {
                     values.add(v);
                 });
 
-        PaimonArray key = new PaimonArray(mapType.getKeyType(), keys);
-        PaimonArray value = new PaimonArray(mapType.getValueType(), values);
+        PaimonArray key = new PaimonArray(mapType.getKeyType(), keys, uriReaderFactory);
+        PaimonArray value = new PaimonArray(mapType.getValueType(), values, uriReaderFactory);
         return new InternalMap() {
             @Override
             public int size() {
@@ -250,10 +252,17 @@ public class SparkRow implements InternalRow, Serializable {
 
         private final DataType elementType;
         private final List<Object> list;
+        private final UriReaderFactory uriReaderFactory;
 
         private PaimonArray(DataType elementType, List<Object> list) {
+            this(elementType, list, null);
+        }
+
+        private PaimonArray(
+                DataType elementType, List<Object> list, UriReaderFactory uriReaderFactory) {
             this.list = list;
             this.elementType = elementType;
+            this.uriReaderFactory = uriReaderFactory;
         }
 
         @Override
@@ -336,7 +345,7 @@ public class SparkRow implements InternalRow, Serializable {
 
         @Override
         public Blob getBlob(int i) {
-            return Blob.fromBytes(getAs(i), null, null);
+            return Blob.fromBytes(getAs(i), uriReaderFactory, null);
         }
 
         @Override
@@ -346,7 +355,8 @@ public class SparkRow implements InternalRow, Serializable {
                     o instanceof scala.collection.Seq
                             ? JavaConverters.seqAsJavaList((scala.collection.Seq<Object>) o)
                             : (List<Object>) o;
-            return new PaimonArray(((ArrayType) elementType).getElementType(), array);
+            return new PaimonArray(
+                    ((ArrayType) elementType).getElementType(), array, uriReaderFactory);
         }
 
         @Override
@@ -361,7 +371,7 @@ public class SparkRow implements InternalRow, Serializable {
                     o instanceof scala.collection.Map
                             ? JavaConverters.mapAsJavaMap((scala.collection.Map<Object, Object>) o)
                             : (Map<Object, Object>) o;
-            return toPaimonMap((MapType) elementType, map);
+            return toPaimonMap((MapType) elementType, map, uriReaderFactory);
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
@@ -24,8 +24,7 @@ import org.apache.paimon.spark.write.{DataEvolutionTableDataWrite, WriteHelper, 
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink._
 import org.apache.paimon.table.source.DataSplit
-import org.apache.paimon.types.DataType
-import org.apache.paimon.types.DataTypeRoot.BLOB
+import org.apache.paimon.types.BlobType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 import org.apache.paimon.utils.SerializationUtils
 
@@ -59,7 +58,7 @@ case class DataEvolutionPaimonWriter(paimonTable: FileStoreTable, dataSplits: Se
     val rawBlobPlaceholderMarkerIndexes = writeType.getFields.asScala.flatMap {
       field =>
         if (
-          field.`type`().is(BLOB) &&
+          BlobType.isBlobFileField(field.`type`()) &&
           !blobInlineFields.exists(inlineField => resolver(inlineField, field.name()))
         ) {
           val markerColumn = rawBlobPlaceholderMarkerColumns.getOrElse(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -39,7 +39,7 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil
-import org.apache.paimon.types.{BlobType, RowType}
+import org.apache.paimon.types.{BlobType, DataTypeRoot, RowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
 import org.apache.spark.internal.Logging
@@ -419,7 +419,7 @@ case class MergeIntoPaimonDataEvolutionTable(
 
     // Find raw blob update columns and avoid reading them from target table
     val blobInlineFields = table.coreOptions().blobInlineField().asScala.toSet
-    val rawBlobFieldNames = table
+    val rawBlobFields = table
       .rowType()
       .getFields
       .asScala
@@ -427,6 +427,11 @@ case class MergeIntoPaimonDataEvolutionTable(
         field =>
           BlobType.isBlobFileField(field.`type`()) &&
             !blobInlineFields.exists(inlineField => resolver(inlineField, field.name())))
+    val rawBlobFieldNames = rawBlobFields
+      .map(_.name())
+      .toSet
+    val rawArrayBlobFieldNames = rawBlobFields
+      .filter(_.`type`().getTypeRoot == DataTypeRoot.ARRAY)
       .map(_.name())
       .toSet
 
@@ -450,14 +455,15 @@ case class MergeIntoPaimonDataEvolutionTable(
       }.toSet
     }
 
-    val modifiedRawBlobColumnNames = matchedActions
+    val modifiedRawArrayBlobColumnNames = matchedActions
       .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
       .flatten
+      .filter(name => rawArrayBlobFieldNames.exists(arrayBlobName => resolver(arrayBlobName, name)))
       .toSet
-    if (modifiedRawBlobColumnNames.nonEmpty) {
+    if (modifiedRawArrayBlobColumnNames.nonEmpty) {
       throw new UnsupportedOperationException(
-        "Should not append/update raw-data BLOB or ARRAY<BLOB> column through MERGE INTO: " +
-          modifiedRawBlobColumnNames.toSeq.sorted.mkString(", "))
+        "Should not append/update raw-data ARRAY<BLOB> column through MERGE INTO: " +
+          modifiedRawArrayBlobColumnNames.toSeq.sorted.mkString(", "))
     }
 
     val rawBlobMarkerNames =
@@ -514,17 +520,26 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
 
     // the output projection for update from source table
-    def updateOutput(action: UpdateAction): Seq[Expression] = {
+    def updateOutput(action: UpdateAction, rawBlobModified: Set[String]): Seq[Expression] = {
       val updatedColumns = updateColumnsSorted.map {
         attr =>
-          if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+          if (
+            rawBlobUpdateColumns.exists(_.sameRef(attr)) && !rawBlobModified.contains(attr.name)
+          ) {
             Literal(null, attr.dataType)
           } else {
             assignmentValue(action, attr)
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
-      val markers = rawBlobUpdateColumns.map(_ => TrueLiteral)
+      val markers = rawBlobUpdateColumns.map {
+        attr =>
+          if (rawBlobModified.contains(attr.name)) {
+            FalseLiteral
+          } else {
+            TrueLiteral
+          }
+      }
       updatedColumns ++ metadata ++ markers :+ FalseLiteral
     }
 
@@ -560,7 +575,9 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case update: UpdateAction =>
           SparkShimLoader.shim
-            .mergeRowsKeepUpdate(update.condition.getOrElse(TrueLiteral), updateOutput(update))
+            .mergeRowsKeepUpdate(
+              update.condition.getOrElse(TrueLiteral),
+              updateOutput(update, modifiedRawBlobNames(update)))
             .asInstanceOf[MergeRows.Instruction]
         case DeleteAction(condition) =>
           SparkShimLoader.shim

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -39,8 +39,7 @@ import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil
-import org.apache.paimon.types.DataTypeRoot.BLOB
-import org.apache.paimon.types.RowType
+import org.apache.paimon.types.{BlobType, RowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 
 import org.apache.spark.internal.Logging
@@ -426,7 +425,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       .asScala
       .filter(
         field =>
-          field.`type`().is(BLOB) &&
+          BlobType.isBlobFileField(field.`type`()) &&
             !blobInlineFields.exists(inlineField => resolver(inlineField, field.name())))
       .map(_.name())
       .toSet
@@ -438,6 +437,29 @@ case class MergeIntoPaimonDataEvolutionTable(
     // The final output is composed by updated columns, metadata columns and blob marker columns.
     // Marker columns are used to mark whether a blob field should be written with placeholder
     val rawBlobUpdateColumns = updateColumnsSorted.filter(isRawBlobUpdateColumn)
+
+    def modifiedRawBlobNames(action: UpdateAction): Set[String] = {
+      action.assignments.flatMap {
+        assignment =>
+          if (isModifiedAssignment(assignment)) {
+            val key = assignmentKeyAttribute(assignment)
+            rawBlobUpdateColumns.find(_.sameRef(key)).map(_.name)
+          } else {
+            None
+          }
+      }.toSet
+    }
+
+    val modifiedRawBlobColumnNames = matchedActions
+      .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
+      .flatten
+      .toSet
+    if (modifiedRawBlobColumnNames.nonEmpty) {
+      throw new UnsupportedOperationException(
+        "Should not append/update raw-data BLOB or ARRAY<BLOB> column through MERGE INTO: " +
+          modifiedRawBlobColumnNames.toSeq.sorted.mkString(", "))
+    }
+
     val rawBlobMarkerNames =
       rawBlobMarkerNamesAvoiding(
         rawBlobUpdateColumns.size,
@@ -484,18 +506,6 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
     allFields ++= updateColumnsSorted.filterNot(isRawBlobUpdateColumn)
 
-    def modifiedRawBlobNames(action: UpdateAction): Set[String] = {
-      action.assignments.flatMap {
-        assignment =>
-          if (isModifiedAssignment(assignment)) {
-            val key = assignmentKeyAttribute(assignment)
-            rawBlobUpdateColumns.find(_.sameRef(key)).map(_.name)
-          } else {
-            None
-          }
-      }.toSet
-    }
-
     def assignmentValue(action: UpdateAction, attr: AttributeReference): Expression = {
       action.assignments
         .find(assignment => assignmentKeyAttribute(assignment).sameRef(attr))
@@ -504,26 +514,17 @@ case class MergeIntoPaimonDataEvolutionTable(
     }
 
     // the output projection for update from source table
-    def updateOutput(action: UpdateAction, rawBlobModified: Set[String]): Seq[Expression] = {
+    def updateOutput(action: UpdateAction): Seq[Expression] = {
       val updatedColumns = updateColumnsSorted.map {
         attr =>
-          if (
-            rawBlobUpdateColumns.exists(_.sameRef(attr)) && !rawBlobModified.contains(attr.name)
-          ) {
+          if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
             assignmentValue(action, attr)
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
-      val markers = rawBlobUpdateColumns.map {
-        attr =>
-          if (rawBlobModified.contains(attr.name)) {
-            FalseLiteral
-          } else {
-            TrueLiteral
-          }
-      }
+      val markers = rawBlobUpdateColumns.map(_ => TrueLiteral)
       updatedColumns ++ metadata ++ markers :+ FalseLiteral
     }
 
@@ -559,9 +560,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       action match {
         case update: UpdateAction =>
           SparkShimLoader.shim
-            .mergeRowsKeepUpdate(
-              update.condition.getOrElse(TrueLiteral),
-              updateOutput(update, modifiedRawBlobNames(update)))
+            .mergeRowsKeepUpdate(update.condition.getOrElse(TrueLiteral), updateOutput(update))
             .asInstanceOf[MergeRows.Instruction]
         case DeleteAction(condition) =>
           SparkShimLoader.shim

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark.data
 
 import org.apache.paimon.data.InternalArray
 import org.apache.paimon.spark.DataConverter
-import org.apache.paimon.types.{ArrayType => PaimonArrayType, BigIntType, DataType => PaimonDataType, DataTypeChecks, RowType}
+import org.apache.paimon.types.{ArrayType => PaimonArrayType, BigIntType, BlobType, DataType => PaimonDataType, DataTypeChecks, RowType}
 import org.apache.paimon.utils.InternalRowUtils
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -91,7 +91,15 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
   override def getUTF8String(ordinal: Int): UTF8String =
     DataConverter.fromPaimon(paimonArray.getString(ordinal))
 
-  override def getBinary(ordinal: Int): Array[Byte] = paimonArray.getBinary(ordinal)
+  override def getBinary(ordinal: Int): Array[Byte] = elementType match {
+    case _: BlobType =>
+      if (paimonArray.isNullAt(ordinal)) {
+        null
+      } else {
+        paimonArray.getBlob(ordinal).toData
+      }
+    case _ => paimonArray.getBinary(ordinal)
+  }
 
   override def getInterval(ordinal: Int): CalendarInterval =
     throw new UnsupportedOperationException()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.spark.data
 
-import org.apache.paimon.data.InternalArray
+import org.apache.paimon.data.{Blob, BlobView, InternalArray}
 import org.apache.paimon.spark.DataConverter
 import org.apache.paimon.types.{ArrayType => PaimonArrayType, BigIntType, BlobType, DataType => PaimonDataType, DataTypeChecks, RowType}
 import org.apache.paimon.utils.InternalRowUtils
@@ -33,6 +33,8 @@ import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 abstract class SparkArrayData extends org.apache.spark.sql.catalyst.util.ArrayData {
 
   def replace(array: InternalArray): SparkArrayData
+
+  def withBlobAsDescriptor(blobAsDescriptor: Boolean): SparkArrayData
 }
 
 abstract class AbstractSparkArrayData extends SparkArrayData {
@@ -41,22 +43,39 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
 
   var paimonArray: InternalArray = _
 
+  protected var blobAsDescriptor: Boolean = false
+
   override def replace(array: InternalArray): SparkArrayData = {
     this.paimonArray = array
+    this
+  }
+
+  override def withBlobAsDescriptor(blobAsDescriptor: Boolean): SparkArrayData = {
+    this.blobAsDescriptor = blobAsDescriptor
     this
   }
 
   override def numElements(): Int = paimonArray.size()
 
   override def copy(): ArrayData = {
-    SparkArrayData.create(elementType).replace(InternalRowUtils.copyArray(paimonArray, elementType))
+    SparkArrayData
+      .create(elementType, blobAsDescriptor)
+      .replace(InternalRowUtils.copyArray(paimonArray, elementType))
   }
 
   override def array: Array[Any] = {
     Array.range(0, numElements()).map {
       i =>
-        DataConverter
-          .fromPaimon(InternalRowUtils.get(paimonArray, i, elementType), elementType)
+        if (isNullAt(i)) {
+          null
+        } else {
+          elementType match {
+            case _: BlobType => fromBlob(paimonArray.getBlob(i))
+            case _ =>
+              DataConverter
+                .fromPaimon(InternalRowUtils.get(paimonArray, i, elementType), elementType)
+          }
+        }
     }
   }
 
@@ -96,9 +115,24 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
       if (paimonArray.isNullAt(ordinal)) {
         null
       } else {
-        paimonArray.getBlob(ordinal).toData
+        fromBlob(paimonArray.getBlob(ordinal))
       }
     case _ => paimonArray.getBinary(ordinal)
+  }
+
+  private def fromBlob(blob: Blob): Array[Byte] = {
+    if (blob == null) {
+      null
+    } else {
+      blob match {
+        case blobView: BlobView if !blobView.isResolved =>
+          Blob.serializeBlob(blobView)
+        case _ if blobAsDescriptor =>
+          blob.toDescriptor.serialize()
+        case _ =>
+          blob.toData
+      }
+    }
   }
 
   override def getInterval(ordinal: Int): CalendarInterval =
@@ -109,7 +143,8 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
 
   override def getArray(ordinal: Int): ArrayData = DataConverter.fromPaimon(
     paimonArray.getArray(ordinal),
-    elementType.asInstanceOf[PaimonArrayType])
+    elementType.asInstanceOf[PaimonArrayType],
+    blobAsDescriptor)
 
   override def getMap(ordinal: Int): MapData =
     DataConverter.fromPaimon(paimonArray.getMap(ordinal), elementType)
@@ -121,6 +156,10 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
 
 object SparkArrayData {
   def create(elementType: PaimonDataType): SparkArrayData = {
-    SparkShimLoader.shim.createSparkArrayData(elementType)
+    create(elementType, blobAsDescriptor = false)
+  }
+
+  def create(elementType: PaimonDataType, blobAsDescriptor: Boolean): SparkArrayData = {
+    SparkShimLoader.shim.createSparkArrayData(elementType).withBlobAsDescriptor(blobAsDescriptor)
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkInternalRow.scala
@@ -27,6 +27,8 @@ import scala.collection.mutable
 
 abstract class SparkInternalRow extends InternalRow {
   def replace(row: org.apache.paimon.data.InternalRow): SparkInternalRow
+
+  def withBlobAsDescriptor(blobAsDescriptor: Boolean): SparkInternalRow
 }
 
 object SparkInternalRow {
@@ -40,7 +42,7 @@ object SparkInternalRow {
     if (blobs.nonEmpty) {
       SparkShimLoader.shim.createSparkInternalRowWithBlob(rowType, blobs, blobAsDescriptor)
     } else {
-      SparkShimLoader.shim.createSparkInternalRow(rowType)
+      SparkShimLoader.shim.createSparkInternalRow(rowType).withBlobAsDescriptor(blobAsDescriptor)
     }
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark.write
 
 import org.apache.paimon.casting.FallbackMappingRow
 import org.apache.paimon.catalog.CatalogContext
-import org.apache.paimon.data.{BinaryRow, BlobPlaceholder, GenericRow, InternalRow}
+import org.apache.paimon.data.{BinaryRow, BlobArrayPlaceholder, BlobPlaceholder, GenericRow, InternalRow}
 import org.apache.paimon.data.serializer.InternalSerializers
 import org.apache.paimon.disk.IOManager
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
@@ -29,7 +29,7 @@ import org.apache.paimon.operation.AbstractFileStoreWrite
 import org.apache.paimon.spark.SparkUtils
 import org.apache.paimon.spark.util.SparkRowUtils
 import org.apache.paimon.table.sink.{BatchWriteBuilder, CommitMessage, CommitMessageImpl, TableWriteImpl}
-import org.apache.paimon.types.RowType
+import org.apache.paimon.types.{DataTypeRoot, RowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 import org.apache.paimon.utils.RecordWriter
 import org.apache.paimon.utils.SerializationUtils
@@ -72,6 +72,14 @@ case class DataEvolutionTableDataWrite(
     mappings
   }
   private val rawBlobFallbackMarkerIndexes = rawBlobFallbackFields.map(_._2)
+  private val rawBlobFallbackPlaceholders: Array[AnyRef] = rawBlobFallbackFields.map {
+    case (fieldIndex, _) =>
+      if (writeType.getTypeAt(fieldIndex).getTypeRoot == DataTypeRoot.ARRAY) {
+        BlobArrayPlaceholder.INSTANCE
+      } else {
+        BlobPlaceholder.INSTANCE
+      }
+  }
   private val rawBlobFallbackRow = new GenericRow(rawBlobFallbackMarkerIndexes.length)
   private val rawBlobFallbackMappingRow = new FallbackMappingRow(rawBlobFallbackMappings)
 
@@ -98,7 +106,11 @@ case class DataEvolutionTableDataWrite(
       case (markerIndex, fallbackIndex) =>
         rawBlobFallbackRow.setField(
           fallbackIndex,
-          if (row.getBoolean(markerIndex)) BlobPlaceholder.INSTANCE else null)
+          if (row.getBoolean(markerIndex)) {
+            rawBlobFallbackPlaceholders(fallbackIndex)
+          } else {
+            null
+          })
     }
     rawBlobFallbackRow
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -77,6 +77,68 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: test array blob") {
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING, pictures ARRAY<BINARY>) TBLPROPERTIES (" +
+        "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, 'paimon', array(X'48656C6C6F', CAST(NULL AS BINARY), X'5945')), " +
+          "(2, 'one', array(X'414243')), " +
+          "(3, 'null-array', CAST(NULL AS ARRAY<BINARY>))")
+
+      val pictures = sql("SELECT pictures FROM t WHERE id = 1")
+        .collect()(0)
+        .getSeq[Array[Byte]](0)
+      assert(pictures.size == 3)
+      assert(util.Arrays.equals(pictures.head, Array[Byte](72, 101, 108, 108, 111)))
+      assert(pictures(1) == null)
+      assert(util.Arrays.equals(pictures(2), Array[Byte](89, 69)))
+
+      val first =
+        sql("SELECT id, size(pictures), pictures[0], pictures[1], pictures[2] FROM t WHERE id = 1")
+          .collect()(0)
+      assert(first.getInt(0) == 1)
+      assert(first.getInt(1) == 3)
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](2), Array[Byte](72, 101, 108, 108, 111)))
+      assert(first.isNullAt(3))
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](4), Array[Byte](89, 69)))
+
+      val second = sql("SELECT id, size(pictures), pictures[0] FROM t WHERE id = 2").collect()(0)
+      assert(second.getInt(0) == 2)
+      assert(second.getInt(1) == 1)
+      assert(util.Arrays.equals(second.getAs[Array[Byte]](2), Array[Byte](65, 66, 67)))
+
+      checkAnswer(
+        sql("SELECT id, pictures IS NULL FROM t WHERE id = 3"),
+        Seq(Row(3, true))
+      )
+      checkAnswer(
+        sql("SELECT COUNT(*) > 0 FROM `t$files` WHERE file_path LIKE '%.blob'"),
+        Seq(Row(true))
+      )
+    }
+  }
+
+  test("Blob: array blob inline fields are rejected") {
+    Seq(
+      ("array_blob_descriptor_reject", "'blob-descriptor-field'='pictures'"),
+      ("array_blob_view_reject", "'blob-view-field'='pictures'")
+    ).foreach {
+      case (tableName, blobOptions) =>
+        withTable(tableName) {
+          val error = intercept[Exception] {
+            sql(
+              s"CREATE TABLE $tableName (id INT, pictures ARRAY<BINARY>) TBLPROPERTIES (" +
+                s"'row-tracking.enabled'='true', 'data-evolution.enabled'='true', $blobOptions)")
+          }
+          assert(
+            exceptionContains(error, "ARRAY<BLOB> is only supported by 'blob-field'."),
+            exceptionMessages(error))
+        }
+    }
+  }
+
   test("Blob: test write blob descriptor") {
     withTable("t") {
       val blobData = new Array[Byte](1024 * 1024)
@@ -426,6 +488,104 @@ class BlobTestBase extends PaimonSparkTestBase {
       checkAnswer(
         sql("SELECT *, _ROW_ID, _SEQUENCE_NUMBER FROM t LIMIT 1"),
         Seq(Row(1, "paimon", Array[Byte](72, 101, 108, 108, 111), 0, 11))
+      )
+    }
+  }
+
+  test("Blob: merge-into rejects updating raw-data BLOB column") {
+    withTable("s", "t") {
+      sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
+        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
+      sql("INSERT INTO t VALUES (1, 'name1', X'48656C6C6F')")
+
+      sql("CREATE TABLE s (id INT, picture BINARY)")
+      sql("INSERT INTO s VALUES (1, X'4E4557')")
+
+      val e = intercept[UnsupportedOperationException] {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+              |""".stripMargin)
+      }
+      assert(e.getMessage.contains("raw-data BLOB"))
+    }
+  }
+
+  test("Blob: merge-into updates non-blob column on raw blob table with split blob files") {
+    withTable("s", "t") {
+      sql(
+        "CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
+          "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='picture', 'blob.target-file-size'='1 b')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, 'name1', X'48656C6C6F'), " +
+          "(2, 'name2', X'5945'), " +
+          "(3, 'name3', X'414243')")
+
+      sql("CREATE TABLE s (id INT, name STRING)")
+      sql("INSERT INTO s VALUES (1, 'updated_name1')")
+
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.name = s.name
+            |""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT id, name FROM t ORDER BY id"),
+        Seq(Row(1, "updated_name1"), Row(2, "name2"), Row(3, "name3"))
+      )
+    }
+  }
+
+  test("Blob: merge-into updates non-blob column on raw array blob table with split files") {
+    withTable("s", "t") {
+      sql(
+        "CREATE TABLE t (id INT, name STRING, pictures ARRAY<BINARY>) TBLPROPERTIES " +
+          "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='pictures', 'blob.target-file-size'='1 b')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, 'name1', array(X'48656C6C6F', X'5945')), " +
+          "(2, 'name2', array(X'414243')), " +
+          "(3, 'name3', CAST(NULL AS ARRAY<BINARY>))")
+
+      checkAnswer(
+        sql("SELECT COUNT(*) > 1 FROM `t$files` WHERE file_path LIKE '%.blob'"),
+        Seq(Row(true))
+      )
+
+      sql("CREATE TABLE s (id INT, name STRING)")
+      sql("INSERT INTO s VALUES (1, 'updated_name1')")
+
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.name = s.name
+            |""".stripMargin)
+
+      checkAnswer(
+        sql("SELECT id, name FROM t ORDER BY id"),
+        Seq(Row(1, "updated_name1"), Row(2, "name2"), Row(3, "name3"))
+      )
+
+      val first = sql("SELECT name, pictures[0], pictures[1] FROM t WHERE id = 1").collect()(0)
+      assert(first.getString(0) == "updated_name1")
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](1), Array[Byte](72, 101, 108, 108, 111)))
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](2), Array[Byte](89, 69)))
+
+      val second = sql("SELECT pictures[0], pictures[1] FROM t WHERE id = 2").collect()(0)
+      assert(util.Arrays.equals(second.getAs[Array[Byte]](0), Array[Byte](65, 66, 67)))
+      assert(second.isNullAt(1))
+
+      checkAnswer(
+        sql("SELECT pictures IS NULL FROM t WHERE id = 3"),
+        Seq(Row(true))
       )
     }
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -524,48 +524,6 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
-  test("Blob: merge-into rejects updating raw-data BLOB column") {
-    withTable("s", "t") {
-      sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
-        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
-      sql("INSERT INTO t VALUES (1, 'name1', X'48656C6C6F')")
-
-      sql("CREATE TABLE s (id INT, picture BINARY)")
-      sql("INSERT INTO s VALUES (1, X'4E4557')")
-
-      val e = intercept[UnsupportedOperationException] {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-              |""".stripMargin)
-      }
-      assert(e.getMessage.contains("raw-data BLOB"))
-    }
-  }
-
-  test("Blob: merge-into rejects updating raw-data array blob column") {
-    withTable("s", "t") {
-      sql("CREATE TABLE t (id INT, name STRING, pictures ARRAY<BINARY>) TBLPROPERTIES " +
-        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
-      sql("INSERT INTO t VALUES (1, 'name1', array(X'48656C6C6F'))")
-
-      sql("CREATE TABLE s (id INT, pictures ARRAY<BINARY>)")
-      sql("INSERT INTO s VALUES (1, array(X'4E4557'))")
-
-      val e = intercept[UnsupportedOperationException] {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.pictures = s.pictures
-              |""".stripMargin)
-      }
-      assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"))
-    }
-  }
-
   test("Blob: merge-into updates non-blob column on raw blob table with split blob files") {
     withTable("s", "t") {
       sql(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -37,6 +37,15 @@ class BlobTestBase extends PaimonSparkTestBase {
 
   private val RANDOM = new Random
 
+  private def writeFile(fileIO: LocalFileIO, uri: String, data: Array[Byte]): Unit = {
+    val outputStream = fileIO.newOutputStream(new Path(uri), true)
+    try {
+      outputStream.write(data)
+    } finally {
+      outputStream.close()
+    }
+  }
+
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
   }
@@ -120,6 +129,43 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: array blob writes descriptor elements and reads descriptors") {
+    withTable("t") {
+      val blobData = new Array[Byte](1024)
+      RANDOM.nextBytes(blobData)
+      val fileIO = new LocalFileIO
+      val uri = "file://" + tempDBDir.toString + "/external_array_blob"
+      writeFile(fileIO, uri, blobData)
+
+      sql(
+        "CREATE TABLE t (id INT, data STRING, pictures ARRAY<BINARY>) TBLPROPERTIES (" +
+          "'row-tracking.enabled'='true', " +
+          "'data-evolution.enabled'='true', " +
+          "'blob-field'='pictures', " +
+          "'blob-as-descriptor'='true')")
+      sql(s"INSERT INTO t VALUES (1, 'paimon', array(sys.path_to_descriptor('$uri'), X'5945'))")
+
+      val descriptorRow = sql("SELECT pictures[0], pictures[1] FROM t WHERE id = 1").collect()(0)
+      val firstDescriptor = BlobDescriptor.deserialize(descriptorRow.getAs[Array[Byte]](0))
+      val secondDescriptor = BlobDescriptor.deserialize(descriptorRow.getAs[Array[Byte]](1))
+      val options = new Options()
+      options.set("warehouse", tempDBDir.toString)
+      val catalogContext = CatalogContext.create(options)
+      val uriReaderFactory = new UriReaderFactory(catalogContext)
+      val firstBlob =
+        Blob.fromDescriptor(uriReaderFactory.create(firstDescriptor.uri), firstDescriptor)
+      val secondBlob =
+        Blob.fromDescriptor(uriReaderFactory.create(secondDescriptor.uri), secondDescriptor)
+      assert(util.Arrays.equals(blobData, firstBlob.toData))
+      assert(util.Arrays.equals(Array[Byte](89, 69), secondBlob.toData))
+
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='false')")
+      val dataRow = sql("SELECT pictures[0], pictures[1] FROM t WHERE id = 1").collect()(0)
+      assert(util.Arrays.equals(blobData, dataRow.getAs[Array[Byte]](0)))
+      assert(util.Arrays.equals(Array[Byte](89, 69), dataRow.getAs[Array[Byte]](1)))
+    }
+  }
+
   test("Blob: array blob inline fields are rejected") {
     Seq(
       ("array_blob_descriptor_reject", "'blob-descriptor-field'='pictures'"),
@@ -145,11 +191,7 @@ class BlobTestBase extends PaimonSparkTestBase {
       RANDOM.nextBytes(blobData)
       val fileIO = new LocalFileIO
       val uri = "file://" + tempDBDir.toString + "/external_blob"
-      try {
-        val outputStream = fileIO.newOutputStream(new Path(uri), true)
-        try outputStream.write(blobData)
-        finally if (outputStream != null) outputStream.close()
-      }
+      writeFile(fileIO, uri, blobData)
 
       val blobDescriptor = new BlobDescriptor(uri, 0, blobData.length)
 
@@ -187,11 +229,7 @@ class BlobTestBase extends PaimonSparkTestBase {
       RANDOM.nextBytes(blobData)
       val fileIO = new LocalFileIO
       val uri = "file://" + tempDBDir.toString + "/external_blob"
-      try {
-        val outputStream = fileIO.newOutputStream(new Path(uri), true)
-        try outputStream.write(blobData)
-        finally if (outputStream != null) outputStream.close()
-      }
+      writeFile(fileIO, uri, blobData)
 
       val blobDescriptor = new BlobDescriptor(uri, 0, blobData.length)
       sql(
@@ -226,11 +264,7 @@ class BlobTestBase extends PaimonSparkTestBase {
       RANDOM.nextBytes(blobData)
       val fileIO = new LocalFileIO
       val uri = "file://" + tempDBDir.toString + "/external_blob"
-      try {
-        val outputStream = fileIO.newOutputStream(new Path(uri), true)
-        try outputStream.write(blobData)
-        finally if (outputStream != null) outputStream.close()
-      }
+      writeFile(fileIO, uri, blobData)
 
       val blobDescriptor = new BlobDescriptor(uri, 0, blobData.length)
       sql(
@@ -395,9 +429,7 @@ class BlobTestBase extends PaimonSparkTestBase {
       RANDOM.nextBytes(blobData)
       val blobPath = externalRoot + "/external_blob"
       val fileIO = new LocalFileIO
-      val outputStream = fileIO.newOutputStream(new Path("file://" + blobPath), true)
-      try outputStream.write(blobData)
-      finally outputStream.close()
+      writeFile(fileIO, "file://" + blobPath, blobData)
 
       val isolatedPath = "isolated://" + blobPath
 
@@ -600,9 +632,9 @@ class BlobTestBase extends PaimonSparkTestBase {
       assert(util.Arrays.equals(first.getAs[Array[Byte]](1), Array[Byte](72, 101, 108, 108, 111)))
       assert(util.Arrays.equals(first.getAs[Array[Byte]](2), Array[Byte](89, 69)))
 
-      val second = sql("SELECT pictures[0], pictures[1] FROM t WHERE id = 2").collect()(0)
+      val second = sql("SELECT pictures[0], size(pictures) FROM t WHERE id = 2").collect()(0)
       assert(util.Arrays.equals(second.getAs[Array[Byte]](0), Array[Byte](65, 66, 67)))
-      assert(second.isNullAt(1))
+      assert(second.getInt(1) == 1)
 
       checkAnswer(
         sql("SELECT pictures IS NULL FROM t WHERE id = 3"),
@@ -649,9 +681,7 @@ class BlobTestBase extends PaimonSparkTestBase {
       RANDOM.nextBytes(blobData)
       val fileIO = new LocalFileIO()
       val uri = "file://" + tempDBDir.getCanonicalPath + "/external_desc_blob"
-      val out = fileIO.newOutputStream(new Path(uri), true)
-      try { out.write(blobData) }
-      finally { out.close() }
+      writeFile(fileIO, uri, blobData)
       val desc = new BlobDescriptor(uri, 0, blobData.length)
       sql(s"INSERT INTO t VALUES (1, 'name1', X'${bytesToHex(desc.serialize())}')")
       sql(s"INSERT INTO t VALUES (2, 'name2', X'${bytesToHex(desc.serialize())}')")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -513,6 +513,27 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: merge-into rejects updating raw-data array blob column") {
+    withTable("s", "t") {
+      sql("CREATE TABLE t (id INT, name STRING, pictures ARRAY<BINARY>) TBLPROPERTIES " +
+        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
+      sql("INSERT INTO t VALUES (1, 'name1', array(X'48656C6C6F'))")
+
+      sql("CREATE TABLE s (id INT, pictures ARRAY<BINARY>)")
+      sql("INSERT INTO s VALUES (1, array(X'4E4557'))")
+
+      val e = intercept[UnsupportedOperationException] {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.pictures = s.pictures
+              |""".stripMargin)
+      }
+      assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"))
+    }
+  }
+
   test("Blob: merge-into updates non-blob column on raw blob table with split blob files") {
     withTable("s", "t") {
       sql(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
@@ -29,14 +29,7 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
     super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
   }
 
-  private def assertRawBlobUpdateRejected(update: => Unit): Unit = {
-    val e = intercept[UnsupportedOperationException] {
-      update
-    }
-    assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"), e.getMessage)
-  }
-
-  test("Blob: merge-into rejects updating raw-data BLOB column") {
+  test("Blob: merge-into updates raw-data BLOB column") {
     withTable("s", "t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -49,26 +42,45 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (1, X'4E4557')")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
         Seq(
-          Row(1, Array[Byte](72, 101, 108, 108, 111)),
+          Row(1, Array[Byte](78, 69, 87)),
           Row(2, Array[Byte](89, 69)),
           Row(3, Array[Byte](65, 66, 67)))
       )
     }
   }
 
-  test("Blob: merge-into rejects updating raw-data BLOB column to null") {
+  test("Blob: merge-into rejects updating raw-data array blob column") {
+    withTable("s", "t") {
+      sql("CREATE TABLE t (id INT, name STRING, pictures ARRAY<BINARY>) TBLPROPERTIES " +
+        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
+      sql("INSERT INTO t VALUES (1, 'name1', array(X'48656C6C6F'))")
+
+      sql("CREATE TABLE s (id INT, pictures ARRAY<BINARY>)")
+      sql("INSERT INTO s VALUES (1, array(X'4E4557'))")
+
+      val e = intercept[UnsupportedOperationException] {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.pictures = s.pictures
+              |""".stripMargin)
+      }
+      assert(e.getMessage.contains("raw-data ARRAY<BLOB>"))
+    }
+  }
+
+  test("Blob: merge-into updates raw-data BLOB column to null") {
     withTable("s", "s2", "t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -80,39 +92,35 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (1, CAST(NULL AS BINARY))")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
-        Seq(Row(1, Array[Byte](72, 101, 108, 108, 111)), Row(2, Array[Byte](89, 69)))
+        Seq(Row(1, null), Row(2, Array[Byte](89, 69)))
       )
 
       sql("CREATE TABLE s2 (id INT, picture BINARY)")
       sql("INSERT INTO s2 VALUES (2, X'4E4557')")
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s2
-              |ON t.id = s2.id
-              |WHEN MATCHED THEN UPDATE SET t.picture = s2.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s2
+            |ON t.id = s2.id
+            |WHEN MATCHED THEN UPDATE SET t.picture = s2.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
-        Seq(Row(1, Array[Byte](72, 101, 108, 108, 111)), Row(2, Array[Byte](89, 69)))
+        Seq(Row(1, null), Row(2, Array[Byte](78, 69, 87)))
       )
     }
   }
 
-  test("Blob: merge-into rejects raw-data BLOB update when marker name collides") {
+  test("Blob: merge-into raw-data BLOB marker name does not collide with target column") {
     withTable("s", "t") {
       sql(
         "CREATE TABLE t (id INT, `__paimon_raw_blob_placeholder_0` STRING, picture BINARY) " +
@@ -123,25 +131,23 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, `__paimon_raw_blob_placeholder_0` STRING, picture BINARY)")
       sql("INSERT INTO s VALUES (1, 'new_marker_name', X'4E4557')")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET
-              |  t.`__paimon_raw_blob_placeholder_0` = s.`__paimon_raw_blob_placeholder_0`,
-              |  t.picture = s.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET
+            |  t.`__paimon_raw_blob_placeholder_0` = s.`__paimon_raw_blob_placeholder_0`,
+            |  t.picture = s.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, `__paimon_raw_blob_placeholder_0`, picture FROM t ORDER BY id"),
-        Seq(Row(1, "old_marker_name", Array[Byte](1)), Row(2, "kept", Array[Byte](2)))
+        Seq(Row(1, "new_marker_name", Array[Byte](78, 69, 87)), Row(2, "kept", Array[Byte](2)))
       )
     }
   }
 
-  test("Blob: self merge rejects updating raw-data BLOB column") {
+  test("Blob: self merge updates raw-data BLOB column") {
     withTable("t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -151,27 +157,25 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
           "(2, 'name2', X'5945'), " +
           "(3, 'name3', X'414243')")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING t AS source
-              |ON t._ROW_ID = source._ROW_ID
-              |WHEN MATCHED AND source.id = 1 THEN
-              |  UPDATE SET t.picture = unhex(concat(hex(source.picture), '01'))
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING t AS source
+            |ON t._ROW_ID = source._ROW_ID
+            |WHEN MATCHED AND source.id = 1 THEN
+            |  UPDATE SET t.picture = unhex(concat(hex(source.picture), '01'))
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
         Seq(
-          Row(1, Array[Byte](72, 101, 108, 108, 111)),
+          Row(1, Array[Byte](72, 101, 108, 108, 111, 1)),
           Row(2, Array[Byte](89, 69)),
           Row(3, Array[Byte](65, 66, 67)))
       )
     }
   }
 
-  test("Blob: merge-into rejects updating multiple raw-data BLOB columns with split blob files") {
+  test("Blob: merge-into updates multiple raw-data BLOB columns with split blob files") {
     withTable("s", "t") {
       def bytesHex(value: Int, length: Int): String = {
         Seq.fill(length)(f"$value%02X").mkString
@@ -230,26 +234,27 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
           s"(3, X'${bytesHex(13, 1)}', X'${bytesHex(43, 20)}'), " +
           s"(4, X'${bytesHex(14, 1)}', X'${bytesHex(44, 20)}')")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.pic1 = s.pic1, t.pic2 = s.pic2
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.pic1 = s.pic1, t.pic2 = s.pic2
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, pic1, pic2 FROM t ORDER BY id"),
         Seq(
-          Row(1, bytes(1, 20), bytes(31, 20)),
-          Row(2, bytes(2, 20), bytes(32, 20)),
-          Row(3, bytes(3, 20), bytes(33, 20)),
-          Row(4, bytes(4, 20), bytes(34, 20)))
+          Row(1, bytes(11, 1), bytes(41, 20)),
+          Row(2, bytes(12, 1), bytes(42, 20)),
+          Row(3, bytes(13, 1), bytes(43, 20)),
+          Row(4, bytes(14, 1), bytes(44, 20)))
       )
 
-      assert(blobFileRanges("max_sequence_number = 1") == oldRanges)
-      assert(blobFileRanges("max_sequence_number > 1").isEmpty)
+      val updatedRanges = blobFileRanges("max_sequence_number > 1")
+      assert(updatedRanges("pic1") == Seq(0L -> 2L, 2L -> 2L))
+      assert(updatedRanges("pic2") == oneBlobPerFile)
+      assert(updatedRanges("pic1") != oldRanges("pic1"))
+      assert(updatedRanges("pic1") != updatedRanges("pic2"))
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
@@ -29,7 +29,14 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
     super.sparkConf.set("spark.paimon.write.use-v2-write", "false")
   }
 
-  test("Blob: merge-into updates raw-data BLOB column") {
+  private def assertRawBlobUpdateRejected(update: => Unit): Unit = {
+    val e = intercept[UnsupportedOperationException] {
+      update
+    }
+    assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"), e.getMessage)
+  }
+
+  test("Blob: merge-into rejects updating raw-data BLOB column") {
     withTable("s", "t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -42,24 +49,26 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (1, X'4E4557')")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
         Seq(
-          Row(1, Array[Byte](78, 69, 87)),
+          Row(1, Array[Byte](72, 101, 108, 108, 111)),
           Row(2, Array[Byte](89, 69)),
           Row(3, Array[Byte](65, 66, 67)))
       )
     }
   }
 
-  test("Blob: merge-into updates raw-data BLOB column to null") {
+  test("Blob: merge-into rejects updating raw-data BLOB column to null") {
     withTable("s", "s2", "t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -71,35 +80,39 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (1, CAST(NULL AS BINARY))")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
-        Seq(Row(1, null), Row(2, Array[Byte](89, 69)))
+        Seq(Row(1, Array[Byte](72, 101, 108, 108, 111)), Row(2, Array[Byte](89, 69)))
       )
 
       sql("CREATE TABLE s2 (id INT, picture BINARY)")
       sql("INSERT INTO s2 VALUES (2, X'4E4557')")
-      sql("""
-            |MERGE INTO t
-            |USING s2
-            |ON t.id = s2.id
-            |WHEN MATCHED THEN UPDATE SET t.picture = s2.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s2
+              |ON t.id = s2.id
+              |WHEN MATCHED THEN UPDATE SET t.picture = s2.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
-        Seq(Row(1, null), Row(2, Array[Byte](78, 69, 87)))
+        Seq(Row(1, Array[Byte](72, 101, 108, 108, 111)), Row(2, Array[Byte](89, 69)))
       )
     }
   }
 
-  test("Blob: merge-into raw-data BLOB marker name does not collide with target column") {
+  test("Blob: merge-into rejects raw-data BLOB update when marker name collides") {
     withTable("s", "t") {
       sql(
         "CREATE TABLE t (id INT, `__paimon_raw_blob_placeholder_0` STRING, picture BINARY) " +
@@ -110,23 +123,25 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, `__paimon_raw_blob_placeholder_0` STRING, picture BINARY)")
       sql("INSERT INTO s VALUES (1, 'new_marker_name', X'4E4557')")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET
-            |  t.`__paimon_raw_blob_placeholder_0` = s.`__paimon_raw_blob_placeholder_0`,
-            |  t.picture = s.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET
+              |  t.`__paimon_raw_blob_placeholder_0` = s.`__paimon_raw_blob_placeholder_0`,
+              |  t.picture = s.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, `__paimon_raw_blob_placeholder_0`, picture FROM t ORDER BY id"),
-        Seq(Row(1, "new_marker_name", Array[Byte](78, 69, 87)), Row(2, "kept", Array[Byte](2)))
+        Seq(Row(1, "old_marker_name", Array[Byte](1)), Row(2, "kept", Array[Byte](2)))
       )
     }
   }
 
-  test("Blob: self merge updates raw-data BLOB column") {
+  test("Blob: self merge rejects updating raw-data BLOB column") {
     withTable("t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +
         "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture')")
@@ -136,25 +151,27 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
           "(2, 'name2', X'5945'), " +
           "(3, 'name3', X'414243')")
 
-      sql("""
-            |MERGE INTO t
-            |USING t AS source
-            |ON t._ROW_ID = source._ROW_ID
-            |WHEN MATCHED AND source.id = 1 THEN
-            |  UPDATE SET t.picture = unhex(concat(hex(source.picture), '01'))
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING t AS source
+              |ON t._ROW_ID = source._ROW_ID
+              |WHEN MATCHED AND source.id = 1 THEN
+              |  UPDATE SET t.picture = unhex(concat(hex(source.picture), '01'))
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, picture FROM t ORDER BY id"),
         Seq(
-          Row(1, Array[Byte](72, 101, 108, 108, 111, 1)),
+          Row(1, Array[Byte](72, 101, 108, 108, 111)),
           Row(2, Array[Byte](89, 69)),
           Row(3, Array[Byte](65, 66, 67)))
       )
     }
   }
 
-  test("Blob: merge-into updates multiple raw-data BLOB columns with split blob files") {
+  test("Blob: merge-into rejects updating multiple raw-data BLOB columns with split blob files") {
     withTable("s", "t") {
       def bytesHex(value: Int, length: Int): String = {
         Seq.fill(length)(f"$value%02X").mkString
@@ -213,27 +230,26 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
           s"(3, X'${bytesHex(13, 1)}', X'${bytesHex(43, 20)}'), " +
           s"(4, X'${bytesHex(14, 1)}', X'${bytesHex(44, 20)}')")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET t.pic1 = s.pic1, t.pic2 = s.pic2
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.pic1 = s.pic1, t.pic2 = s.pic2
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, pic1, pic2 FROM t ORDER BY id"),
         Seq(
-          Row(1, bytes(11, 1), bytes(41, 20)),
-          Row(2, bytes(12, 1), bytes(42, 20)),
-          Row(3, bytes(13, 1), bytes(43, 20)),
-          Row(4, bytes(14, 1), bytes(44, 20)))
+          Row(1, bytes(1, 20), bytes(31, 20)),
+          Row(2, bytes(2, 20), bytes(32, 20)),
+          Row(3, bytes(3, 20), bytes(33, 20)),
+          Row(4, bytes(4, 20), bytes(34, 20)))
       )
 
-      val updatedRanges = blobFileRanges("max_sequence_number > 1")
-      assert(updatedRanges("pic1") == Seq(0L -> 2L, 2L -> 2L))
-      assert(updatedRanges("pic2") == oneBlobPerFile)
-      assert(updatedRanges("pic1") != oldRanges("pic1"))
-      assert(updatedRanges("pic1") != updatedRanges("pic2"))
+      assert(blobFileRanges("max_sequence_number = 1") == oldRanges)
+      assert(blobFileRanges("max_sequence_number > 1").isEmpty)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -26,6 +26,13 @@ import scala.collection.JavaConverters._
 
 abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
 
+  private def assertRawBlobUpdateRejected(update: => Unit): Unit = {
+    val e = intercept[UnsupportedOperationException] {
+      update
+    }
+    assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"), e.getMessage)
+  }
+
   test("Data Evolution deletion: delete from table with deletion vectors") {
     withTable("t") {
       sql("""
@@ -160,18 +167,20 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (2, X'22'), (6, X'66'), (7, X'4D'), (9, X'79')")
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, b, picture, _ROW_ID FROM t ORDER BY id"),
         Seq(
           Row(5, 5, Array[Byte](5), 5L),
-          Row(7, 7, Array[Byte](77), 7L),
+          Row(7, 7, Array[Byte](7), 7L),
           Row(8, 8, Array[Byte](8), 8L)))
     }
   }
@@ -559,25 +568,29 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |  (9, X'79', 'delete')
             |""".stripMargin)
 
-      sql("""
-            |MERGE INTO t
-            |USING s
-            |ON t.id = s.id
-            |WHEN MATCHED AND s.op = 'delete' THEN DELETE
-            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-            |""".stripMargin)
+      assertRawBlobUpdateRejected {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED AND s.op = 'delete' THEN DELETE
+              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+              |""".stripMargin)
+      }
 
       checkAnswer(
         sql("SELECT id, b, picture, _ROW_ID FROM t ORDER BY id"),
         Seq(
           Row(0, 0, Array[Byte](0), 0L),
           Row(1, 1, Array[Byte](1), 1L),
+          Row(2, 2, Array[Byte](2), 2L),
           Row(3, 3, Array[Byte](3), 3L),
           Row(4, 4, Array[Byte](4), 4L),
           Row(5, 5, Array[Byte](5), 5L),
-          Row(6, 6, Array[Byte](102), 6L),
-          Row(7, 7, Array[Byte](77), 7L),
-          Row(8, 8, Array[Byte](8), 8L)
+          Row(6, 6, Array[Byte](6), 6L),
+          Row(7, 7, Array[Byte](7), 7L),
+          Row(8, 8, Array[Byte](8), 8L),
+          Row(9, 9, Array[Byte](9), 9L)
         )
       )
     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -26,13 +26,6 @@ import scala.collection.JavaConverters._
 
 abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
 
-  private def assertRawBlobUpdateRejected(update: => Unit): Unit = {
-    val e = intercept[UnsupportedOperationException] {
-      update
-    }
-    assert(e.getMessage.contains("raw-data BLOB or ARRAY<BLOB>"), e.getMessage)
-  }
-
   test("Data Evolution deletion: delete from table with deletion vectors") {
     withTable("t") {
       sql("""
@@ -167,20 +160,18 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
       sql("CREATE TABLE s (id INT, picture BINARY)")
       sql("INSERT INTO s VALUES (2, X'22'), (6, X'66'), (7, X'4D'), (9, X'79')")
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, b, picture, _ROW_ID FROM t ORDER BY id"),
         Seq(
           Row(5, 5, Array[Byte](5), 5L),
-          Row(7, 7, Array[Byte](7), 7L),
+          Row(7, 7, Array[Byte](77), 7L),
           Row(8, 8, Array[Byte](8), 8L)))
     }
   }
@@ -568,29 +559,25 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |  (9, X'79', 'delete')
             |""".stripMargin)
 
-      assertRawBlobUpdateRejected {
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED AND s.op = 'delete' THEN DELETE
-              |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
-              |""".stripMargin)
-      }
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED AND s.op = 'delete' THEN DELETE
+            |WHEN MATCHED THEN UPDATE SET t.picture = s.picture
+            |""".stripMargin)
 
       checkAnswer(
         sql("SELECT id, b, picture, _ROW_ID FROM t ORDER BY id"),
         Seq(
           Row(0, 0, Array[Byte](0), 0L),
           Row(1, 1, Array[Byte](1), 1L),
-          Row(2, 2, Array[Byte](2), 2L),
           Row(3, 3, Array[Byte](3), 3L),
           Row(4, 4, Array[Byte](4), 4L),
           Row(5, 5, Array[Byte](5), 5L),
-          Row(6, 6, Array[Byte](6), 6L),
-          Row(7, 7, Array[Byte](7), 7L),
-          Row(8, 8, Array[Byte](8), 8L),
-          Row(9, 9, Array[Byte](9), 9L)
+          Row(6, 6, Array[Byte](102), 6L),
+          Row(7, 7, Array[Byte](77), 7L),
+          Row(8, 8, Array[Byte](8), 8L)
         )
       )
     }

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/paimon/spark/data/Spark3InternalRowWithBlob.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/paimon/spark/data/Spark3InternalRowWithBlob.scala
@@ -27,6 +27,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 class Spark3InternalRowWithBlob(rowType: RowType, blobFields: Set[Int], blobAsDescriptor: Boolean)
   extends Spark3InternalRow(rowType) {
 
+  withBlobAsDescriptor(blobAsDescriptor)
+
   override def getBinary(ordinal: Int): Array[Byte] = {
     if (blobFields.contains(ordinal)) {
       val blob = row.getBlob(ordinal)

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/data/Spark4InternalRowWithBlob.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/data/Spark4InternalRowWithBlob.scala
@@ -29,6 +29,8 @@ import org.apache.spark.unsafe.types.VariantVal
 class Spark4InternalRowWithBlob(rowType: RowType, blobFields: Set[Int], blobAsDescriptor: Boolean)
   extends Spark4InternalRow(rowType) {
 
+  withBlobAsDescriptor(blobAsDescriptor)
+
   override def getBinary(ordinal: Int): Array[Byte] = {
     if (blobFields.contains(ordinal)) {
       val blob = row.getBlob(ordinal)


### PR DESCRIPTION
### Purpose

Support storing top-level ARRAY<BLOB> columns in dedicated blob files, so one table can use blob file storage for both BLOB and ARRAY<BLOB> fields across core, Flink, and Spark paths.

### Changes

- Treat BLOB and ARRAY<BLOB> as blob-file fields in schema validation, data-evolution planning, blob file context, and column directive cleanup.
- Extend BlobFileFormat reader/writer with an ARRAY<BLOB> payload layout that keeps one blob-file record per table row and stores per-element lengths in a compact tail index.
- Preserve support for null arrays, null elements, empty arrays, selection reads, descriptor reads, inline reads, and whole-field placeholders.
- Add Flink catalog conversion and Flink array read conversion so ARRAY<BYTES> blob fields round-trip as ARRAY<BLOB> internally.
- Add Spark catalog conversion and Spark array/data converters so ARRAY<BINARY> blob fields round-trip as ARRAY<BLOB> internally.
- Add format-level, table-level, Flink e2e, and Spark e2e coverage for ARRAY<BLOB>.
