### PR TITLE
[core] FormatTable supports Blob Format

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -291,6 +291,7 @@ public class CoreOptions implements Serializable {
     public static final String FILE_FORMAT_TEXT = "text";
     public static final String FILE_FORMAT_JSON = "json";
     public static final String FILE_FORMAT_MOSAIC = "mosaic";
+    public static final String FILE_FORMAT_BLOB = "blob";
 
     public static final ConfigOption<String> FILE_FORMAT =
             key("file.format")
@@ -2908,6 +2909,7 @@ public class CoreOptions implements Serializable {
                 case FILE_FORMAT_CSV:
                 case FILE_FORMAT_TEXT:
                 case FILE_FORMAT_JSON:
+                case FILE_FORMAT_BLOB:
                     return "none";
                 default:
                     throw new UnsupportedOperationException(

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -46,6 +46,7 @@ import org.apache.paimon.table.system.AllTablesTable;
 import org.apache.paimon.table.system.CatalogOptionsTable;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Preconditions;
@@ -61,8 +62,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.AUTO_CREATE;
+import static org.apache.paimon.CoreOptions.FILE_FORMAT;
+import static org.apache.paimon.CoreOptions.FILE_FORMAT_BLOB;
 import static org.apache.paimon.CoreOptions.FORMAT_TABLE_IMPLEMENTATION;
 import static org.apache.paimon.CoreOptions.PARTITION_DEFAULT_NAME;
 import static org.apache.paimon.CoreOptions.PARTITION_GENERATE_LEGACY_NAME;
@@ -169,10 +173,28 @@ public class CatalogUtils {
                         FORMAT_TABLE_IMPLEMENTATION.key(),
                         PATH.key());
             }
+            validateBlobFormatTable(schema, options);
         }
         for (DataField field : schema.fields()) {
             validateDefaultValue(field.type(), field.defaultValue());
         }
+    }
+
+    private static void validateBlobFormatTable(Schema schema, Options options) {
+        if (!FILE_FORMAT_BLOB.equalsIgnoreCase(options.get(FILE_FORMAT))) {
+            return;
+        }
+
+        List<DataField> nonPartitionFields =
+                schema.fields().stream()
+                        .filter(field -> !schema.partitionKeys().contains(field.name()))
+                        .collect(Collectors.toList());
+        checkArgument(
+                nonPartitionFields.size() == 1,
+                "BLOB format table only supports one non-partition field.");
+        checkArgument(
+                nonPartitionFields.get(0).type().getTypeRoot() == DataTypeRoot.BLOB,
+                "BLOB format table only supports BLOB type as non-partition field.");
     }
 
     public static void validateNamePattern(Catalog catalog, String namePattern) {

--- a/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/io/FormatTableSingleFileWriter.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.io;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FileAwareFormatWriter;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.FormatWriterFactory;
 import org.apache.paimon.format.SupportsDirectWrite;
@@ -63,6 +64,10 @@ public class FormatTableSingleFileWriter {
             } else {
                 out = fileIO.newTwoPhaseOutputStream(path, false);
                 writer = factory.create(out, compression);
+            }
+            if (writer instanceof FileAwareFormatWriter) {
+                FileAwareFormatWriter fileAwareFormatWriter = (FileAwareFormatWriter) writer;
+                fileAwareFormatWriter.setFile(path);
             }
         } catch (IOException e) {
             LOG.warn(

--- a/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FormatTable.java
@@ -77,6 +77,7 @@ public interface FormatTable extends Table {
     enum Format {
         ORC,
         PARQUET,
+        BLOB,
         CSV,
         TEXT,
         JSON,

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableFileWriter.java
@@ -20,8 +20,10 @@ package org.apache.paimon.table.format;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BlobConsumer;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
+import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
@@ -76,6 +78,14 @@ public class FormatTableFileWriter {
 
     public void withWriteType(RowType writeType) {
         this.writeRowType = writeType;
+    }
+
+    public void withBlobConsumer(BlobConsumer blobConsumer) {
+        if (!(fileFormat instanceof BlobFileFormat)) {
+            throw new UnsupportedOperationException(
+                    "BlobConsumer is only supported for BLOB format table.");
+        }
+        ((BlobFileFormat) fileFormat).setWriteConsumer(blobConsumer);
     }
 
     public void write(BinaryRow partition, InternalRow data) throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/format/FormatTableWrite.java
@@ -119,7 +119,8 @@ public class FormatTableWrite implements BatchTableWrite {
 
     @Override
     public TableWrite withBlobConsumer(BlobConsumer blobConsumer) {
-        throw new UnsupportedOperationException();
+        write.withBlobConsumer(blobConsumer);
+        return this;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogUtilsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link CatalogUtils}. */
+public class CatalogUtilsTest {
+
+    @Test
+    public void testValidateBlobFormatTable() {
+        assertThatNoException()
+                .isThrownBy(
+                        () ->
+                                CatalogUtils.validateCreateTable(
+                                        Schema.newBuilder()
+                                                .column("payload", DataTypes.BLOB())
+                                                .column("ds", DataTypes.INT())
+                                                .partitionKeys("ds")
+                                                .options(blobFormatTableOptions())
+                                                .build(),
+                                        false));
+
+        assertThatThrownBy(
+                        () ->
+                                CatalogUtils.validateCreateTable(
+                                        Schema.newBuilder()
+                                                .column("payload", DataTypes.BLOB())
+                                                .column("id", DataTypes.INT())
+                                                .column("ds", DataTypes.INT())
+                                                .partitionKeys("ds")
+                                                .options(blobFormatTableOptions())
+                                                .build(),
+                                        false))
+                .hasMessageContaining("only supports one non-partition field");
+
+        assertThatThrownBy(
+                        () ->
+                                CatalogUtils.validateCreateTable(
+                                        Schema.newBuilder()
+                                                .column("payload", DataTypes.BYTES())
+                                                .column("ds", DataTypes.INT())
+                                                .partitionKeys("ds")
+                                                .options(blobFormatTableOptions())
+                                                .build(),
+                                        false))
+                .hasMessageContaining("only supports BLOB type as non-partition field");
+
+        assertThatThrownBy(
+                        () ->
+                                CatalogUtils.validateCreateTable(
+                                        Schema.newBuilder()
+                                                .column("payload", DataTypes.BLOB())
+                                                .partitionKeys("payload")
+                                                .options(blobFormatTableOptions())
+                                                .build(),
+                                        false))
+                .hasMessageContaining("only supports one non-partition field");
+    }
+
+    private Map<String, String> blobFormatTableOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("type", "format-table");
+        options.put("file.format", "blob");
+        return options;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableBlobTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/format/FormatTableBlobTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.format;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FormatTable;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.UriReader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for BLOB {@link FormatTable}. */
+public class FormatTableBlobTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    public void testReadAndWriteBlobDataAndDescriptor() throws Exception {
+        FormatTable table = createBlobFormatTable();
+        byte[] first = "hello".getBytes(StandardCharsets.UTF_8);
+        byte[] second = "world".getBytes(StandardCharsets.UTF_8);
+        Blob descriptorBlob = createDescriptorBlob(table, second);
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(GenericRow.of(new BlobData(first), 1));
+            write.write(GenericRow.of(descriptorBlob, 1));
+            write.write(GenericRow.of(null, 1));
+            commit.commit(write.prepareCommit());
+        }
+
+        assertReadRows(table, first, second);
+    }
+
+    @Test
+    public void testBlobConsumerProducesDescriptors() throws Exception {
+        FormatTable table = createBlobFormatTable();
+        byte[] bytes = "hello".getBytes(StandardCharsets.UTF_8);
+        List<BlobDescriptor> descriptors = new ArrayList<>();
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.withBlobConsumer(
+                    (blobFieldName, blobDescriptor) -> {
+                        assertThat(blobFieldName).isEqualTo("payload");
+                        descriptors.add(blobDescriptor);
+                        return true;
+                    });
+            write.write(GenericRow.of(new BlobData(bytes), 1));
+            write.write(GenericRow.of(null, 1));
+            commit.commit(write.prepareCommit());
+        }
+
+        assertThat(descriptors).hasSize(2);
+        assertDescriptor(table, descriptors.get(0), bytes);
+        assertThat(descriptors.get(1)).isNull();
+    }
+
+    private FormatTable createBlobFormatTable() throws Exception {
+        RowType rowType =
+                RowType.builder()
+                        .field("payload", DataTypes.BLOB())
+                        .field("ds", DataTypes.INT())
+                        .build();
+        java.nio.file.Path tableDir = tempPath.resolve("table");
+        Files.createDirectories(tableDir);
+        Path tablePath = new Path(tableDir.toUri());
+        Map<String, String> options = new HashMap<>();
+        options.put("path", tablePath.toString());
+        options.put("file.format", "blob");
+
+        return FormatTable.builder()
+                .fileIO(LocalFileIO.create())
+                .identifier(Identifier.create("test_db", "blob_table"))
+                .rowType(rowType)
+                .partitionKeys(Collections.singletonList("ds"))
+                .location(tablePath.toString())
+                .format(FormatTable.Format.BLOB)
+                .options(options)
+                .build();
+    }
+
+    private Blob createDescriptorBlob(FormatTable table, byte[] bytes) throws Exception {
+        java.nio.file.Path externalFile = tempPath.resolve("external-blob");
+        Files.write(externalFile, bytes);
+        BlobDescriptor descriptor =
+                new BlobDescriptor(new Path(externalFile.toUri()).toString(), 0, bytes.length);
+        return Blob.fromDescriptor(UriReader.fromFile(table.fileIO()), descriptor);
+    }
+
+    private void assertDescriptor(FormatTable table, BlobDescriptor descriptor, byte[] bytes)
+            throws Exception {
+        assertThat(descriptor).isNotNull();
+        assertThat(descriptor.uri()).isNotEmpty();
+        assertThat(descriptor.uri()).contains("ds=1");
+        assertThat(descriptor.offset()).isGreaterThanOrEqualTo(0L);
+        assertThat(descriptor.length()).isEqualTo(bytes.length);
+        assertThat(Blob.fromDescriptor(UriReader.fromFile(table.fileIO()), descriptor).toData())
+                .isEqualTo(bytes);
+    }
+
+    private void assertReadRows(FormatTable table, byte[] first, byte[] second) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder();
+        List<InternalRow> rows = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan())) {
+            InternalRowSerializer serializer = new InternalRowSerializer(readBuilder.readType());
+            reader.forEachRemaining(row -> rows.add(serializer.copy(row)));
+        }
+
+        assertThat(rows).hasSize(3);
+        assertThat(rows.get(0).getBlob(0).toData()).isEqualTo(first);
+        assertThat(rows.get(0).getInt(1)).isEqualTo(1);
+        assertThat(rows.get(1).getBlob(0).toData()).isEqualTo(second);
+        assertThat(rows.get(1).getInt(1)).isEqualTo(1);
+        assertThat(rows.get(2).isNullAt(0)).isTrue();
+        assertThat(rows.get(2).getInt(1)).isEqualTo(1);
+    }
+}

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveTableCloneExtractor.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/clone/HiveTableCloneExtractor.java
@@ -135,7 +135,8 @@ public class HiveTableCloneExtractor implements HiveCloneExtractor {
     @Override
     public boolean supportCloneSplits(String format) {
         for (FormatTable.Format supportFormat : FormatTable.Format.values()) {
-            if (supportFormat.name().equalsIgnoreCase(format)) {
+            if (supportFormat != FormatTable.Format.BLOB
+                    && supportFormat.name().equalsIgnoreCase(format)) {
                 return true;
             }
         }

--- a/paimon-python/pypaimon/catalog/catalog.py
+++ b/paimon-python/pypaimon/catalog/catalog.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 
 from pypaimon.common.identifier import Identifier
+from pypaimon.catalog.catalog_utils import validate_create_table
 from pypaimon.schema.schema import Schema
 from pypaimon.schema.schema_change import SchemaChange
 from pypaimon.snapshot.snapshot import Snapshot
@@ -89,9 +90,14 @@ class Catalog(ABC):
     def get_table(self, identifier: Union[str, Identifier]) -> 'Table':
         """Get paimon table identified by the given Identifier."""
 
-    @abstractmethod
     def create_table(self, identifier: Union[str, Identifier], schema: Schema, ignore_if_exists: bool):
         """Create table with schema."""
+        validate_create_table(schema)
+        return self._create_table(identifier, schema, ignore_if_exists)
+
+    @abstractmethod
+    def _create_table(self, identifier: Union[str, Identifier], schema: Schema, ignore_if_exists: bool):
+        """Create table with schema after common validation."""
 
     @abstractmethod
     def drop_table(self, identifier: Union[str, Identifier], ignore_if_not_exists: bool = False):

--- a/paimon-python/pypaimon/catalog/catalog_utils.py
+++ b/paimon-python/pypaimon/catalog/catalog_utils.py
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pypaimon.common.options.core_options import CoreOptions
+from pypaimon.schema.schema import Schema
+
+
+FORMAT_TABLE_TYPE = "format-table"
+
+
+def validate_create_table(schema: Schema) -> None:
+    _validate_blob_format_table(schema)
+
+
+def _validate_blob_format_table(schema: Schema) -> None:
+    options = schema.options or {}
+    table_type = str(options.get(CoreOptions.TYPE.key(), "")).lower()
+    file_format = str(options.get(CoreOptions.FILE_FORMAT.key(), "")).lower()
+    if (
+        table_type != FORMAT_TABLE_TYPE
+        or file_format != CoreOptions.FILE_FORMAT_BLOB
+    ):
+        return
+
+    partition_keys = set(schema.partition_keys or [])
+    data_fields = [
+        field for field in schema.fields if field.name not in partition_keys
+    ]
+    if len(data_fields) != 1:
+        raise ValueError(
+            "BLOB format table only supports one non-partition field."
+        )
+    if getattr(data_fields[0].type, "type", "").upper() != "BLOB":
+        raise ValueError(
+            "BLOB format table only supports BLOB type as non-partition field."
+        )

--- a/paimon-python/pypaimon/catalog/filesystem_catalog.py
+++ b/paimon-python/pypaimon/catalog/filesystem_catalog.py
@@ -168,7 +168,7 @@ class FileSystemCatalog(Catalog):
             raise TableNotExistException(identifier)
         return sys_table
 
-    def create_table(self, identifier: Union[str, Identifier], schema: 'Schema', ignore_if_exists: bool):
+    def _create_table(self, identifier: Union[str, Identifier], schema: 'Schema', ignore_if_exists: bool):
         if schema.options and schema.options.get(CoreOptions.AUTO_CREATE.key()):
             raise ValueError(f"The value of {CoreOptions.AUTO_CREATE.key()} property should be False.")
 

--- a/paimon-python/pypaimon/catalog/jdbc_catalog.py
+++ b/paimon-python/pypaimon/catalog/jdbc_catalog.py
@@ -407,7 +407,7 @@ class JdbcCatalog(Catalog):
         )
         return FileStoreTable(self.file_io, identifier, table_path, table_schema, catalog_environment)
 
-    def create_table(self, identifier: Union[str, Identifier], schema: 'Schema', ignore_if_exists: bool):
+    def _create_table(self, identifier: Union[str, Identifier], schema: 'Schema', ignore_if_exists: bool):
         if schema.options and schema.options.get(CoreOptions.AUTO_CREATE.key()):
             raise ValueError(f"The value of {CoreOptions.AUTO_CREATE.key()} property should be False.")
         if not isinstance(identifier, Identifier):

--- a/paimon-python/pypaimon/catalog/rest/rest_catalog.py
+++ b/paimon-python/pypaimon/catalog/rest/rest_catalog.py
@@ -249,7 +249,7 @@ class RESTCatalog(Catalog):
             raise TableNotExistException(identifier)
         return sys_table
 
-    def create_table(self, identifier: Union[str, Identifier], schema: Schema, ignore_if_exists: bool):
+    def _create_table(self, identifier: Union[str, Identifier], schema: Schema, ignore_if_exists: bool):
         if not isinstance(identifier, Identifier):
             identifier = Identifier.from_string(identifier)
         try:

--- a/paimon-python/pypaimon/table/format/format_table.py
+++ b/paimon-python/pypaimon/table/format/format_table.py
@@ -30,6 +30,7 @@ class Format(str, Enum):
     CSV = "csv"
     TEXT = "text"
     JSON = "json"
+    BLOB = "blob"
 
     @classmethod
     def parse(cls, file_format: str) -> "Format":

--- a/paimon-python/pypaimon/table/format/format_table_read.py
+++ b/paimon-python/pypaimon/table/format/format_table_read.py
@@ -21,6 +21,7 @@ import pandas
 import pyarrow
 
 from pypaimon.schema.data_types import PyarrowFieldParser
+from pypaimon.read.reader.format_blob_reader import FormatBlobReader
 from pypaimon.table.format.format_data_split import FormatDataSplit
 from pypaimon.table.format.format_table import FormatTable, Format
 
@@ -39,6 +40,99 @@ def _text_format_schema_column(table: FormatTable) -> Optional[str]:
     )
 
 
+def _append_partition_columns(
+    tbl: pyarrow.Table,
+    partition_spec: Optional[Dict[str, str]],
+    partition_key_types: Optional[Dict[str, pyarrow.DataType]],
+) -> pyarrow.Table:
+    if not partition_spec:
+        return tbl
+    for k, v in partition_spec.items():
+        if k in tbl.column_names:
+            continue
+        pa_type = (
+            partition_key_types.get(k, pyarrow.string())
+            if partition_key_types
+            else pyarrow.string()
+        )
+        arr = pyarrow.array([v] * tbl.num_rows, type=pyarrow.string())
+        if pa_type != pyarrow.string():
+            arr = arr.cast(pa_type)
+        tbl = tbl.append_column(k, arr)
+    return tbl
+
+
+def _project_table(
+    tbl: pyarrow.Table, read_fields: Optional[List[str]]
+) -> pyarrow.Table:
+    if read_fields and tbl.num_columns > 0:
+        existing = [c for c in read_fields if c in tbl.column_names]
+        if existing:
+            tbl = tbl.select(existing)
+    return tbl
+
+
+def _blob_data_fields(
+    full_fields: List[Any],
+    partition_spec: Optional[Dict[str, str]],
+) -> List[Any]:
+    partition_keys = set(partition_spec.keys()) if partition_spec else set()
+    data_fields = [
+        field for field in full_fields if field.name not in partition_keys
+    ]
+    if len(data_fields) != 1:
+        raise ValueError(
+            "BLOB format table only supports one non-partition field."
+        )
+    if getattr(data_fields[0].type, "type", "").upper() != "BLOB":
+        raise ValueError(
+            "BLOB format table only supports BLOB type as non-partition field."
+        )
+    return data_fields
+
+
+def _read_blob_file_to_arrow(
+    file_io: Any,
+    path: str,
+    partition_spec: Optional[Dict[str, str]],
+    read_fields: Optional[List[str]],
+    partition_key_types: Optional[Dict[str, pyarrow.DataType]],
+    full_fields: List[Any],
+    blob_as_descriptor: bool,
+) -> pyarrow.Table:
+    data_fields = _blob_data_fields(full_fields, partition_spec)
+    blob_field_name = data_fields[0].name
+    reader = FormatBlobReader(
+        file_io,
+        path,
+        [blob_field_name],
+        full_fields,
+        None,
+        blob_as_descriptor,
+    )
+    batches = []
+    try:
+        while True:
+            batch = reader.read_arrow_batch()
+            if batch is None:
+                break
+            batches.append(batch)
+    finally:
+        reader.close()
+
+    if batches:
+        tbl = pyarrow.Table.from_batches(batches)
+    else:
+        schema = PyarrowFieldParser.from_paimon_schema(data_fields)
+        tbl = pyarrow.Table.from_pydict(
+            {blob_field_name: []}, schema=schema
+        )
+    tbl = _append_partition_columns(
+        tbl, partition_spec, partition_key_types
+    )
+    return _project_table(tbl, read_fields)
+
+
 def _read_file_to_arrow(
     file_io: Any,
     split: FormatDataSplit,
@@ -48,8 +142,21 @@ def _read_file_to_arrow(
     partition_key_types: Optional[Dict[str, pyarrow.DataType]] = None,
     text_column_name: Optional[str] = None,
     text_line_delimiter: str = "\n",
+    full_fields: Optional[List[Any]] = None,
+    blob_as_descriptor: bool = False,
 ) -> pyarrow.Table:
     path = split.data_path()
+    if fmt == Format.BLOB:
+        return _read_blob_file_to_arrow(
+            file_io,
+            path,
+            partition_spec,
+            read_fields,
+            partition_key_types,
+            full_fields or [],
+            blob_as_descriptor,
+        )
+
     csv_read_options = None
     if fmt == Format.CSV:
         import pyarrow.csv as csv
@@ -131,25 +238,10 @@ def _read_file_to_arrow(
     else:
         raise ValueError(f"Format {fmt} read not implemented in Python")
 
-    if partition_spec:
-        for k, v in partition_spec.items():
-            if k in tbl.column_names:
-                continue
-            pa_type = (
-                partition_key_types.get(k, pyarrow.string())
-                if partition_key_types
-                else pyarrow.string()
-            )
-            arr = pyarrow.array([v] * tbl.num_rows, type=pyarrow.string())
-            if pa_type != pyarrow.string():
-                arr = arr.cast(pa_type)
-            tbl = tbl.append_column(k, arr)
-
-    if read_fields and tbl.num_columns > 0:
-        existing = [c for c in read_fields if c in tbl.column_names]
-        if existing:
-            tbl = tbl.select(existing)
-    return tbl
+    tbl = _append_partition_columns(
+        tbl, partition_spec, partition_key_types
+    )
+    return _project_table(tbl, read_fields)
 
 
 def _partition_key_types(
@@ -195,6 +287,9 @@ class FormatTableRead:
             if fmt == Format.TEXT
             else "\n"
         )
+        blob_as_descriptor = str(
+            self.table.options().get("blob-as-descriptor", "false")
+        ).lower() == "true"
         tables = []
         nrows = 0
         for split in splits:
@@ -207,6 +302,8 @@ class FormatTableRead:
                 partition_key_types,
                 text_column_name=text_col,
                 text_line_delimiter=text_delim,
+                full_fields=self.table.fields,
+                blob_as_descriptor=blob_as_descriptor,
             )
             if t.num_rows > 0:
                 tables.append(t)
@@ -252,6 +349,9 @@ class FormatTableRead:
             if fmt == Format.TEXT
             else "\n"
         )
+        blob_as_descriptor = str(
+            self.table.options().get("blob-as-descriptor", "false")
+        ).lower() == "true"
         n_yielded = 0
         for split in splits:
             if self.limit is not None and n_yielded >= self.limit:
@@ -265,6 +365,8 @@ class FormatTableRead:
                 partition_key_types,
                 text_column_name=text_col,
                 text_line_delimiter=text_delim,
+                full_fields=self.table.fields,
+                blob_as_descriptor=blob_as_descriptor,
             )
             for batch in t.to_batches():
                 for i in range(batch.num_rows):

--- a/paimon-python/pypaimon/table/format/format_table_write.py
+++ b/paimon-python/pypaimon/table/format/format_table_write.py
@@ -30,6 +30,8 @@ from pypaimon.table.format.format_table import (
     Format,
     FormatTable,
 )
+from pypaimon.table.row.blob import BlobConsumer
+from pypaimon.write.blob_format_writer import BlobFormatWriter
 
 
 def _partition_path(
@@ -78,6 +80,24 @@ def _partition_from_row(
     return tuple(out)
 
 
+def _data_fields(table: FormatTable):
+    partition_keys = set(table.partition_keys)
+    return [field for field in table.fields if field.name not in partition_keys]
+
+
+def _validate_blob_format_table(table: FormatTable):
+    data_fields = _data_fields(table)
+    if len(data_fields) != 1:
+        raise ValueError(
+            "BLOB format table only supports one non-partition field."
+        )
+    if getattr(data_fields[0].type, "type", "").upper() != "BLOB":
+        raise ValueError(
+            "BLOB format table only supports BLOB type as non-partition field."
+        )
+    return data_fields
+
+
 class FormatTableWrite:
     """Batch write for format table: Arrow/Pandas to partition dirs."""
 
@@ -99,6 +119,7 @@ class FormatTableWrite:
         )
         self._partition_only_value = opt.lower() == "true"
         self._file_format = table.format()
+        self._blob_consumer: Optional[BlobConsumer] = None
         self._data_file_prefix = "data-"
         self._suffix = {
             "parquet": ".parquet",
@@ -106,7 +127,22 @@ class FormatTableWrite:
             "json": ".json",
             "orc": ".orc",
             "text": ".txt",
+            "blob": ".blob",
         }.get(self._file_format.value, ".parquet")
+
+    def with_blob_consumer(
+        self, blob_consumer: BlobConsumer
+    ) -> "FormatTableWrite":
+        if self._file_format != Format.BLOB:
+            raise RuntimeError(
+                "BlobConsumer is only supported for BLOB format table."
+            )
+        if self._written_paths:
+            raise RuntimeError(
+                "with_blob_consumer must be called before any write operation."
+            )
+        self._blob_consumer = blob_consumer
+        return self
 
     def write_arrow(self, data: pyarrow.Table) -> None:
         for batch in data.to_batches():
@@ -227,6 +263,36 @@ class FormatTableWrite:
                 line = "" if py_val is None else str(py_val)
                 lines.append(line + line_delimiter)
             raw = "".join(lines).encode("utf-8")
+        elif fmt == Format.BLOB:
+            data_fields = _validate_blob_format_table(self.table)
+            blob_field_name = data_fields[0].name
+            if blob_field_name not in tbl.column_names:
+                raise ValueError(
+                    f"BLOB column missing from input data: {blob_field_name}"
+                )
+            uri_reader_factory = getattr(
+                self.table.file_io, "uri_reader_factory", None
+            )
+            try:
+                with self.table.file_io.new_output_stream(path) as out:
+                    writer = BlobFormatWriter(
+                        out,
+                        blob_consumer=self._blob_consumer,
+                        file_path=path,
+                    )
+                    blob_values = tbl.column(blob_field_name)
+                    for i in range(tbl.num_rows):
+                        writer.write_value(
+                            blob_values[i], data_fields, uri_reader_factory
+                        )
+                    writer.close()
+            except Exception as e:
+                self.table.file_io.delete_quietly(path)
+                raise RuntimeError(
+                    f"Failed to write blob format table file {path}: {e}"
+                ) from e
+            self._written_paths.append(path)
+            return
         else:
             raise ValueError(f"Format table write not implemented for {fmt}")
 

--- a/paimon-python/pypaimon/tests/catalog_utils_test.py
+++ b/paimon-python/pypaimon/tests/catalog_utils_test.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import pyarrow as pa
+
+from pypaimon import Schema
+from pypaimon.catalog.catalog_utils import validate_create_table
+
+
+class CatalogUtilsTest(unittest.TestCase):
+
+    def test_blob_format_table_requires_single_blob_data_field(self):
+        options = {'type': 'format-table', 'file.format': 'blob'}
+
+        valid = Schema.from_pyarrow_schema(
+            pa.schema([
+                ('payload', pa.large_binary()),
+                ('dt', pa.int32()),
+            ]),
+            partition_keys=['dt'],
+            options=options,
+        )
+        validate_create_table(valid)
+
+        too_many_data_fields = Schema.from_pyarrow_schema(
+            pa.schema([
+                ('payload', pa.large_binary()),
+                ('id', pa.int32()),
+                ('dt', pa.int32()),
+            ]),
+            partition_keys=['dt'],
+            options=options,
+        )
+        with self.assertRaisesRegex(
+            ValueError, 'only supports one non-partition field'
+        ):
+            validate_create_table(too_many_data_fields)
+
+        non_blob_data_field = Schema.from_pyarrow_schema(
+            pa.schema([
+                ('payload', pa.binary()),
+                ('dt', pa.int32()),
+            ]),
+            partition_keys=['dt'],
+            options=options,
+        )
+        with self.assertRaisesRegex(
+            ValueError, 'only supports BLOB type as non-partition field'
+        ):
+            validate_create_table(non_blob_data_field)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_format_table_test.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest
+from pathlib import Path
 
 import pandas as pd
 import pyarrow as pa
@@ -23,7 +24,9 @@ from parameterized import parameterized
 
 from pypaimon import Schema
 from pypaimon.catalog.catalog_exception import TableNotExistException
+from pypaimon.common.uri_reader import FileUriReader
 from pypaimon.table.format import FormatTable
+from pypaimon.table.row.blob import Blob, BlobDescriptor
 from pypaimon.tests.rest.rest_base_test import RESTBaseTest
 
 
@@ -187,6 +190,97 @@ class RESTFormatTableTest(RESTBaseTest):
         self.assertEqual(actual.shape[0], 3)
         self.assertEqual(actual["value"].tolist(), ["a", "b", "c"])
         self.assertEqual(actual["dt"].tolist(), [1, 1, 2])
+
+    def test_format_table_blob_read_write(self):
+        pa_schema = pa.schema([
+            ("payload", pa.large_binary()),
+            ("dt", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=["dt"],
+            options={"type": "format-table", "file.format": "blob"},
+        )
+        table_name = "default.format_table_rw_blob"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+        self.assertIsInstance(table, FormatTable)
+        self.assertEqual(table.format().value, "blob")
+
+        raw_blob = b"blob-data"
+        descriptor_blob = b"descriptor-backed-blob"
+        external_file = Path(self.temp_dir) / "format-table-source-blob.bin"
+        external_file.write_bytes(descriptor_blob)
+        descriptor = BlobDescriptor(
+            external_file.as_uri(), 0, len(descriptor_blob)
+        )
+
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.write_arrow(pa.Table.from_pydict({
+            "payload": [raw_blob, descriptor.serialize(), None],
+            "dt": [1, 1, 1],
+        }, schema=pa_schema))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        rb = table.new_read_builder()
+        splits = rb.new_scan().plan().splits()
+        actual = rb.new_read().to_pandas(splits)
+        self.assertEqual(actual["payload"].tolist(), [
+            raw_blob,
+            descriptor_blob,
+            None,
+        ])
+        self.assertEqual(actual["dt"].tolist(), [1, 1, 1])
+
+    def test_format_table_blob_consumer(self):
+        pa_schema = pa.schema([
+            ("payload", pa.large_binary()),
+            ("dt", pa.int32()),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=["dt"],
+            options={"type": "format-table", "file.format": "blob"},
+        )
+        table_name = "default.format_table_blob_consumer"
+        self.rest_catalog.drop_table(table_name, True)
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+
+        received = []
+
+        def consumer(field_name, descriptor):
+            received.append((field_name, descriptor))
+            return False
+
+        blob_bytes = b"blob-consumer-data"
+        wb = table.new_batch_write_builder()
+        tw = wb.new_write()
+        tc = wb.new_commit()
+        tw.with_blob_consumer(consumer)
+        tw.write_arrow(pa.Table.from_pydict({
+            "payload": [blob_bytes, None],
+            "dt": [2, 2],
+        }, schema=pa_schema))
+        tc.commit(tw.prepare_commit())
+        tw.close()
+        tc.close()
+
+        self.assertEqual(len(received), 2)
+        self.assertEqual(received[0][0], "payload")
+        self.assertIsInstance(received[0][1], BlobDescriptor)
+        self.assertIn("dt=2", received[0][1].uri)
+        blob = Blob.from_descriptor(
+            FileUriReader(table.file_io), received[0][1]
+        )
+        self.assertEqual(blob.to_data(), blob_bytes)
+        self.assertEqual(received[1][0], "payload")
+        self.assertIsNone(received[1][1])
 
     def test_format_table_read_with_limit_to_iterator(self):
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -61,6 +61,7 @@ from pypaimon.catalog.catalog_exception import (BranchAlreadyExistException,
                                                 DefinitionNotExistException,
                                                 TagNotExistException,
                                                 TagAlreadyExistException)
+from pypaimon.catalog.catalog_utils import validate_create_table
 from pypaimon.catalog.rest.table_metadata import TableMetadata
 from pypaimon.common.identifier import Identifier
 from pypaimon.api.typedef import RESTAuthParameter
@@ -975,6 +976,7 @@ class RESTCatalogServer:
                 create_table = JSON.from_json(data, CreateTableRequest)
                 if create_table.identifier.get_full_name() in self.table_metadata_store:
                     raise TableAlreadyExistException(create_table.identifier)
+                validate_create_table(create_table.schema)
                 table_metadata = self._create_table_metadata(
                     create_table.identifier, 0, create_table.schema, str(uuid.uuid4()), False
                 )

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -117,22 +117,27 @@ class BlobFormatWriter:
 
         is_blob = hasattr(fields[0].type, 'type') and fields[0].type.type == "BLOB"
 
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if isinstance(col_data, str):
+            col_data = col_data.encode('utf-8')
+        if isinstance(col_data, bytearray):
+            col_data = bytes(col_data)
+
         if col_data is None:
             if not is_blob:
                 raise RuntimeError("Null values are only supported for BLOB type fields")
-            self.lengths.append(self.NULL_LENGTH)
+            row = GenericRow([None], fields, RowKind.INSERT)
+            self.add_element(row)
             return
 
         if is_blob:
-            if hasattr(col_data, 'as_py'):
-                col_data = col_data.as_py()
-            if isinstance(col_data, str):
-                col_data = col_data.encode('utf-8')
-            if isinstance(col_data, bytearray):
-                col_data = bytes(col_data)
-
             if isinstance(col_data, bytes):
                 if BlobDescriptor.is_blob_descriptor(col_data):
+                    if uri_reader_factory is None:
+                        raise RuntimeError(
+                            "uri_reader_factory is required to resolve BlobDescriptor bytes."
+                        )
                     descriptor = BlobDescriptor.deserialize(col_data)
                     uri_reader = uri_reader_factory.create(descriptor.uri)
                     blob_value = Blob.from_descriptor(uri_reader, descriptor)


### PR DESCRIPTION
### Purpose
Supports Blob Format in FormatTable.
The situation is to replace ObjectStore by Paimon on DFS, unifying storage engines. Consider this situation:
1. Users are trying to parse big videos, splitting into hundreds of images.
2. This is always done by UDF, input is a video, output is a Json Map, contains <ImageIdentifier, ImageURL>, the results will be exported to structural storage e.g. ODPS
3. Image splitting and upload is done within the UDF. Previously those images are uploaded to OSS. Now we can use paimon FormatTable to store them, we could get the BlobDescriptor easily by BlobConsumers.

The key advantages are:
1. Partition-level management: drop/overwrite partitions to manage blob lifecycle natively
2. Drastically fewer files: N blobs packed into one file instead of N separate objects.
3. BlobDescriptor output: each written blob returns a descriptor (path + offset + length) that downstream structured tables (e.g., ODPS) can consume via UDF for random access.

#### Restriction
Now we only permit one non-partition column Blob Format Table.
 
### Tests
See `org.apache.paimon.table.format.FormatTableBlobTest` 