### PR TITLE
[common] Support catalog context without Hadoop configuration

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
@@ -52,15 +52,10 @@ public class CatalogContext implements Serializable {
     private CatalogContext(
             Options options,
             @Nullable Configuration hadoopConf,
-            boolean loadHadoopConf,
             @Nullable FileIOLoader preferIOLoader,
             @Nullable FileIOLoader fallbackIOLoader) {
         this.options = checkNotNull(options);
-        this.hadoopConf =
-                hadoopConf == null && !loadHadoopConf
-                        ? null
-                        : new SerializableConfiguration(
-                                hadoopConf == null ? getHadoopConfiguration(options) : hadoopConf);
+        this.hadoopConf = loadHadoopConfiguration(options, hadoopConf);
         this.preferIOLoader = preferIOLoader;
         this.fallbackIOLoader = fallbackIOLoader;
     }
@@ -72,20 +67,20 @@ public class CatalogContext implements Serializable {
     }
 
     public static CatalogContext create(Options options) {
-        return new CatalogContext(options, null, true, null, null);
+        return new CatalogContext(options, null, null, null);
     }
 
     public static CatalogContext create(Options options, Configuration hadoopConf) {
-        return new CatalogContext(options, hadoopConf, true, null, null);
+        return new CatalogContext(options, hadoopConf, null, null);
     }
 
     public static CatalogContext create(Options options, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, true, null, fallbackIOLoader);
+        return new CatalogContext(options, null, null, fallbackIOLoader);
     }
 
     public static CatalogContext create(
             Options options, FileIOLoader preferIOLoader, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, true, preferIOLoader, fallbackIOLoader);
+        return new CatalogContext(options, null, preferIOLoader, fallbackIOLoader);
     }
 
     public static CatalogContext create(
@@ -93,18 +88,7 @@ public class CatalogContext implements Serializable {
             Configuration hadoopConf,
             FileIOLoader preferIOLoader,
             FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, hadoopConf, true, preferIOLoader, fallbackIOLoader);
-    }
-
-    /**
-     * Create a catalog context without initializing Hadoop configuration.
-     *
-     * <p>This should be used only by engines that provide their own {@link FileIOLoader} and do not
-     * need Paimon's Hadoop-based FileIO path.
-     */
-    public static CatalogContext createWithoutHadoop(
-            Options options, FileIOLoader preferIOLoader, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, false, preferIOLoader, fallbackIOLoader);
+        return new CatalogContext(options, hadoopConf, preferIOLoader, fallbackIOLoader);
     }
 
     public Options options() {
@@ -118,6 +102,25 @@ public class CatalogContext implements Serializable {
                     "Hadoop configuration is not available for this CatalogContext.");
         }
         return hadoopConf.get();
+    }
+
+    @Nullable
+    private static SerializableConfiguration loadHadoopConfiguration(
+            Options options, @Nullable Configuration hadoopConf) {
+        try {
+            return new SerializableConfiguration(
+                    hadoopConf == null ? getHadoopConfiguration(options) : hadoopConf);
+        } catch (NoClassDefFoundError e) {
+            if (isHadoopClassNotFound(e)) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isHadoopClassNotFound(NoClassDefFoundError e) {
+        String message = e.getMessage();
+        return message != null && message.startsWith("org/apache/hadoop/");
     }
 
     @Nullable

--- a/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
+++ b/paimon-common/src/main/java/org/apache/paimon/catalog/CatalogContext.java
@@ -45,19 +45,22 @@ public class CatalogContext implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final Options options;
-    private final SerializableConfiguration hadoopConf;
+    @Nullable private final SerializableConfiguration hadoopConf;
     @Nullable private final FileIOLoader preferIOLoader;
     @Nullable private final FileIOLoader fallbackIOLoader;
 
     private CatalogContext(
             Options options,
             @Nullable Configuration hadoopConf,
+            boolean loadHadoopConf,
             @Nullable FileIOLoader preferIOLoader,
             @Nullable FileIOLoader fallbackIOLoader) {
         this.options = checkNotNull(options);
         this.hadoopConf =
-                new SerializableConfiguration(
-                        hadoopConf == null ? getHadoopConfiguration(options) : hadoopConf);
+                hadoopConf == null && !loadHadoopConf
+                        ? null
+                        : new SerializableConfiguration(
+                                hadoopConf == null ? getHadoopConfiguration(options) : hadoopConf);
         this.preferIOLoader = preferIOLoader;
         this.fallbackIOLoader = fallbackIOLoader;
     }
@@ -69,20 +72,20 @@ public class CatalogContext implements Serializable {
     }
 
     public static CatalogContext create(Options options) {
-        return new CatalogContext(options, null, null, null);
+        return new CatalogContext(options, null, true, null, null);
     }
 
     public static CatalogContext create(Options options, Configuration hadoopConf) {
-        return new CatalogContext(options, hadoopConf, null, null);
+        return new CatalogContext(options, hadoopConf, true, null, null);
     }
 
     public static CatalogContext create(Options options, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, null, fallbackIOLoader);
+        return new CatalogContext(options, null, true, null, fallbackIOLoader);
     }
 
     public static CatalogContext create(
             Options options, FileIOLoader preferIOLoader, FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, null, preferIOLoader, fallbackIOLoader);
+        return new CatalogContext(options, null, true, preferIOLoader, fallbackIOLoader);
     }
 
     public static CatalogContext create(
@@ -90,7 +93,18 @@ public class CatalogContext implements Serializable {
             Configuration hadoopConf,
             FileIOLoader preferIOLoader,
             FileIOLoader fallbackIOLoader) {
-        return new CatalogContext(options, hadoopConf, preferIOLoader, fallbackIOLoader);
+        return new CatalogContext(options, hadoopConf, true, preferIOLoader, fallbackIOLoader);
+    }
+
+    /**
+     * Create a catalog context without initializing Hadoop configuration.
+     *
+     * <p>This should be used only by engines that provide their own {@link FileIOLoader} and do not
+     * need Paimon's Hadoop-based FileIO path.
+     */
+    public static CatalogContext createWithoutHadoop(
+            Options options, FileIOLoader preferIOLoader, FileIOLoader fallbackIOLoader) {
+        return new CatalogContext(options, null, false, preferIOLoader, fallbackIOLoader);
     }
 
     public Options options() {
@@ -99,6 +113,10 @@ public class CatalogContext implements Serializable {
 
     /** Return hadoop {@link Configuration}. */
     public Configuration hadoopConf() {
+        if (hadoopConf == null) {
+            throw new IllegalStateException(
+                    "Hadoop configuration is not available for this CatalogContext.");
+        }
         return hadoopConf.get();
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -100,8 +100,7 @@ public class CatalogFactoryTest {
         options.set(WAREHOUSE, new Path(root, "warehouse").toString());
 
         CatalogContext context =
-                CatalogContext.createWithoutHadoop(
-                        options, new TraceableFileIO.Loader(), null);
+                CatalogContext.createWithoutHadoop(options, new TraceableFileIO.Loader(), null);
 
         assertThat(CatalogFactory.createCatalog(context).listDatabases()).isEmpty();
         assertThatThrownBy(context::hadoopConf)
@@ -114,10 +113,12 @@ public class CatalogFactoryTest {
             throws Exception {
         try (URLClassLoader classLoader = new NoHadoopClassLoader(testClasspathWithoutHadoop())) {
             Class<?> runner =
-                    Class.forName(
-                            NoHadoopCatalogContextRunner.class.getName(), true, classLoader);
+                    Class.forName(NoHadoopCatalogContextRunner.class.getName(), true, classLoader);
             runner.getMethod("run", String.class, ClassLoader.class)
-                    .invoke(null, new Path(path.toUri().toString(), "warehouse").toString(), classLoader);
+                    .invoke(
+                            null,
+                            new Path(path.toUri().toString(), "warehouse").toString(),
+                            classLoader);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
             if (cause instanceof Exception) {
@@ -180,8 +181,7 @@ public class CatalogFactoryTest {
             Options options = new Options();
             options.set("warehouse", warehouse);
             CatalogContext context =
-                    CatalogContext.createWithoutHadoop(
-                            options, new TraceableFileIO.Loader(), null);
+                    CatalogContext.createWithoutHadoop(options, new TraceableFileIO.Loader(), null);
             Catalog catalog = CatalogFactory.createCatalog(context, classLoader);
 
             assertThat(catalog.listDatabases()).isEmpty();

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -170,6 +170,7 @@ public class CatalogFactoryTest {
         }
     }
 
+    /** Runner loaded by {@link NoHadoopClassLoader} to verify no-Hadoop catalog creation. */
     public static class NoHadoopCatalogContextRunner {
 
         public static void run(String warehouse, ClassLoader classLoader) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -24,13 +24,19 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.table.CatalogTableType;
 import org.apache.paimon.utils.HadoopUtilsITCase.TestFileIOLoader;
 import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.TraceableFileIO;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
 
 import static org.apache.paimon.options.CatalogOptions.TABLE_TYPE;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
@@ -88,6 +94,40 @@ public class CatalogFactoryTest {
     }
 
     @Test
+    public void testCreateCatalogWithoutHadoop(@TempDir java.nio.file.Path path) {
+        Path root = new Path(path.toUri().toString());
+        Options options = new Options();
+        options.set(WAREHOUSE, new Path(root, "warehouse").toString());
+
+        CatalogContext context =
+                CatalogContext.createWithoutHadoop(
+                        options, new TraceableFileIO.Loader(), null);
+
+        assertThat(CatalogFactory.createCatalog(context).listDatabases()).isEmpty();
+        assertThatThrownBy(context::hadoopConf)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Hadoop configuration is not available");
+    }
+
+    @Test
+    public void testCreateCatalogWithoutHadoopClasses(@TempDir java.nio.file.Path path)
+            throws Exception {
+        try (URLClassLoader classLoader = new NoHadoopClassLoader(testClasspathWithoutHadoop())) {
+            Class<?> runner =
+                    Class.forName(
+                            NoHadoopCatalogContextRunner.class.getName(), true, classLoader);
+            runner.getMethod("run", String.class, ClassLoader.class)
+                    .invoke(null, new Path(path.toUri().toString(), "warehouse").toString(), classLoader);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw (Error) cause;
+        }
+    }
+
+    @Test
     public void testContextSerializable() throws IOException, ClassNotFoundException {
         Configuration conf = new Configuration(false);
         conf.set("my_key", "my_value");
@@ -96,5 +136,54 @@ public class CatalogFactoryTest {
                         new Options(), conf, new TestFileIOLoader(), new TestFileIOLoader());
         context = InstantiationUtil.clone(context);
         assertThat(context.hadoopConf().get("my_key")).isEqualTo(conf.get("my_key"));
+    }
+
+    private static URL[] testClasspathWithoutHadoop() {
+        return Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .filter(path -> !path.contains("/hadoop-"))
+                .filter(path -> !path.contains("/htrace-core"))
+                .filter(path -> !path.contains("/woodstox-core"))
+                .filter(path -> !path.contains("/stax2-api"))
+                .map(
+                        path -> {
+                            try {
+                                return new File(path).toURI().toURL();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .toArray(URL[]::new);
+    }
+
+    private static class NoHadoopClassLoader extends URLClassLoader {
+
+        private NoHadoopClassLoader(URL[] urls) {
+            super(urls, ClassLoader.getSystemClassLoader().getParent());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("org.apache.hadoop.")) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    public static class NoHadoopCatalogContextRunner {
+
+        public static void run(String warehouse, ClassLoader classLoader) throws Exception {
+            assertThatThrownBy(() -> classLoader.loadClass("org.apache.hadoop.conf.Configuration"))
+                    .isInstanceOf(ClassNotFoundException.class);
+
+            Options options = new Options();
+            options.set("warehouse", warehouse);
+            CatalogContext context =
+                    CatalogContext.createWithoutHadoop(
+                            options, new TraceableFileIO.Loader(), null);
+            Catalog catalog = CatalogFactory.createCatalog(context, classLoader);
+
+            assertThat(catalog.listDatabases()).isEmpty();
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -91,21 +92,6 @@ public class CatalogFactoryTest {
         assertThat(conf).isInstanceOf(HdfsConfiguration.class);
         assertThat(conf.get("fs.defaultFS")).isEqualTo(defaultFS);
         assertThat(conf.get("dfs.replication")).isEqualTo(replication);
-    }
-
-    @Test
-    public void testCreateCatalogWithoutHadoop(@TempDir java.nio.file.Path path) {
-        Path root = new Path(path.toUri().toString());
-        Options options = new Options();
-        options.set(WAREHOUSE, new Path(root, "warehouse").toString());
-
-        CatalogContext context =
-                CatalogContext.createWithoutHadoop(options, new TraceableFileIO.Loader(), null);
-
-        assertThat(CatalogFactory.createCatalog(context).listDatabases()).isEmpty();
-        assertThatThrownBy(context::hadoopConf)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Hadoop configuration is not available");
     }
 
     @Test
@@ -181,10 +167,13 @@ public class CatalogFactoryTest {
             Options options = new Options();
             options.set("warehouse", warehouse);
             CatalogContext context =
-                    CatalogContext.createWithoutHadoop(options, new TraceableFileIO.Loader(), null);
+                    CatalogContext.create(options, new TraceableFileIO.Loader(), null);
             Catalog catalog = CatalogFactory.createCatalog(context, classLoader);
 
             assertThat(catalog.listDatabases()).isEmpty();
+            Field hadoopConfField = CatalogContext.class.getDeclaredField("hadoopConf");
+            hadoopConfField.setAccessible(true);
+            assertThat(hadoopConfField.get(context)).isNull();
         }
     }
 }


### PR DESCRIPTION
### Purpose

This is a narrower follow-up to #6653 for engines such as Trino that provide their own FileIO and should not require Hadoop configuration initialization.

Instead of refactoring the FileIO/CatalogContext hierarchy, this keeps all existing `CatalogContext.create(...)` behavior unchanged and adds an explicit `CatalogContext.createWithoutHadoop(...)` factory for the no-Hadoop path.

### Changes

- Keep existing `CatalogContext.create(...)` overloads loading Hadoop configuration by default for compatibility.
- Add `CatalogContext.createWithoutHadoop(...)` for callers that provide their own `FileIOLoader`.
- Make `hadoopConf()` fail with a clear `IllegalStateException` when called on a Hadoop-free context.
- Add catalog tests, including a classloader test that filters Hadoop classes and verifies the new path can create a catalog without Hadoop on the classpath.

### Tests

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=CatalogFactoryTest test`
- `mvn -pl paimon-common -am -Pfast-build -DfailIfNoTests=false -Dtest=FileIOTest,ResolvingFileIOTest test`

### Notes

A companion Trino change is being prepared to consume this API by passing Trino's FileIO loader and disabling Hadoop default configuration loading.