### PR TITLE
[core] Improve file index option validation message

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/fileindex/FileIndexOptions.java
@@ -22,6 +22,8 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.utils.StringUtils;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -97,21 +99,27 @@ public class FileIndexOptions {
             String opkey = kv[2];
 
             // if reaches here, must be an option.
-            if (get(cname, indexType) != null) {
-                get(cname, indexType).set(opkey, optionEntry.getValue());
-            } else if (getMapTopLevelOptions(cname, indexType) != null) {
-                getMapTopLevelOptions(cname, indexType).set(opkey, optionEntry.getValue());
+            Options indexOptions = get(cname, indexType);
+            if (indexOptions == null) {
+                indexOptions = getMapTopLevelOptionsOrNull(cname, indexType);
+            }
+            if (indexOptions != null) {
+                indexOptions.set(opkey, optionEntry.getValue());
             } else {
                 throw new IllegalArgumentException(
-                        "Wrong option in \""
-                                + key
-                                + "\", can't found column \""
-                                + cname
-                                + "\" in \""
-                                + fileIndexPrefix
-                                + indexType
-                                + fileIndexColumnSuffix
-                                + "\"");
+                        String.format(
+                                "Wrong file index option '%s': column '%s' is not declared in '%s%s%s'. "
+                                        + "Please add '%s%s%s' = '%s' before setting column options. "
+                                        + "For map nested index, declare it like '<map-column>[<map-key>]'.",
+                                key,
+                                cname,
+                                fileIndexPrefix,
+                                indexType,
+                                fileIndexColumnSuffix,
+                                fileIndexPrefix,
+                                indexType,
+                                fileIndexColumnSuffix,
+                                cname));
             }
         }
     }
@@ -151,6 +159,13 @@ public class FileIndexOptions {
         }
 
         return Optional.ofNullable(indexTypeOptions.getOrDefault(columnKey, null))
+                .map(x -> x.get(indexType))
+                .orElse(null);
+    }
+
+    @Nullable
+    private Options getMapTopLevelOptionsOrNull(String column, String indexType) {
+        return Optional.ofNullable(topLevelMapColumnOptions.getOrDefault(new Column(column), null))
                 .map(x -> x.get(indexType))
                 .orElse(null);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -423,6 +423,22 @@ class SchemaValidationTest {
     }
 
     @Test
+    public void testFileIndexColumnOptionWithoutColumnsDeclaration() {
+        Map<String, String> options = new HashMap<>();
+        options.put("file-index.bloom-filter.vin.items", "2000");
+        options.put("file-index.bloom-filter.vin.fpp", "0.0001");
+
+        assertThatThrownBy(() -> validateTableSchemaExec(options))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Wrong file index option 'file-index.bloom-filter.vin.")
+                .hasMessageContaining(
+                        "column 'vin' is not declared in 'file-index.bloom-filter.columns'")
+                .hasMessageContaining("Please add 'file-index.bloom-filter.columns' = 'vin'")
+                .hasMessageContaining(
+                        "For map nested index, declare it like '<map-column>[<map-key>]'");
+    }
+
+    @Test
     public void testFileIndexNestedColumn() {
         List<String> keys =
                 Arrays.asList(


### PR DESCRIPTION
### Purpose
Improve the error message when a file index column option is set without declaring the column in `file-index.<type>.columns`.

### Case
A table had `file-index.bloom-filter.vin.items` and `file-index.bloom-filter.vin.fpp`, but missed `file-index.bloom-filter.columns = vin`. The old path reported a confusing map top-level option error.

### Changes
- Keep the same lookup order for normal columns and map nested columns.
- Avoid throwing the map-specific error during optional fallback lookup.
- Add a validation test for the missing columns declaration case.

### Tests
- `SchemaValidationTest#testFileIndexColumnOptionWithoutColumnsDeclaration`