### PR TITLE
[flink][spark] Apply orphan files clean empty-used guard from #7715

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/orphan/FlinkOrphanFilesClean.java
@@ -364,6 +364,7 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                         String, Tuple2<String, Long>, CleanOrphanFilesResult>() {
 
                                     private boolean buildEnd;
+                                    private boolean abortDeletion;
                                     private long emittedFilesCount;
                                     private long emittedFilesLen;
 
@@ -383,6 +384,12 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                                 checkState(!buildEnd, "Should not build ended.");
                                                 LOG.info("Finish build phase.");
                                                 buildEnd = true;
+                                                if (used.isEmpty()) {
+                                                    abortDeletion = true;
+                                                    LOG.warn(
+                                                            "Collected used files is empty, "
+                                                                    + "aborting orphan files clean to prevent data loss.");
+                                                }
                                                 break;
                                             case 2:
                                                 checkState(buildEnd, "Should build ended.");
@@ -409,6 +416,9 @@ public class FlinkOrphanFilesClean extends OrphanFilesClean {
                                     public void processElement2(
                                             StreamRecord<Tuple2<String, Long>> element) {
                                         checkState(buildEnd, "Should build ended.");
+                                        if (abortDeletion) {
+                                            return;
+                                        }
                                         Tuple2<String, Long> fileInfo = element.getValue();
                                         String value = fileInfo.f0;
                                         Path path = new Path(value);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkOrphanFilesClean.scala
@@ -88,6 +88,18 @@ case class SparkOrphanFilesClean(
       .toDS()
       .cache()
 
+    if (usedManifestFiles.isEmpty) {
+      logWarning("Collected used files is empty, aborting orphan files clean to prevent data loss.")
+      val abortedDataset =
+        if (deletedFilesCountInLocal.get() != 0 || deletedFilesLenInBytesInLocal.get() != 0) {
+          spark.createDataset(
+            Seq((deletedFilesCountInLocal.get(), deletedFilesLenInBytesInLocal.get())))
+        } else {
+          spark.emptyDataset[(Long, Long)]
+        }
+      return (abortedDataset, usedManifestFiles)
+    }
+
     // find all data files
     val dataFiles = usedManifestFiles
       .filter(_.isManifestFile)


### PR DESCRIPTION
Follow-up of #7715: apply the same empty-`usedFiles` guard to FlinkOrphanFilesClean and SparkOrphanFilesClean. Related: #7710.
