### PR TITLE
[spark] Skip empty global index builds

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -116,6 +116,10 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             }
         }
 
+        if (taskList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         List<byte[]> commitMessageBytes =
                 javaSparkContext
                         .parallelize(taskList, taskList.size())

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
@@ -117,6 +117,15 @@ public class SparkMultimodalITCase {
                 "\n"
                         + "CALL sys.create_global_index(\n"
                         + "    `table` => 'my_db1.vector_test',\n"
+                        + "    `partitions` => \"date='20260421'\",\n"
+                        + "    `index_column` => 'embs',\n"
+                        + "    `index_type` => 'lumina-vector-ann',\n"
+                        + "    `options` => 'lumina.index.dimension=4'\n"
+                        + ");");
+        spark.sql(
+                "\n"
+                        + "CALL sys.create_global_index(\n"
+                        + "    `table` => 'my_db1.vector_test',\n"
                         + "    `partitions` => \"date='20260420'\",\n"
                         + "    `index_column` => 'embs',\n"
                         + "    `index_type` => 'lumina-vector-ann',\n"


### PR DESCRIPTION
Purpose
Purpose: fix build global index in the scenario of an empty dataset
Linked issue: https://github.com/apache/paimon/issues/8201

Tests
add test on org.apache.paimon.spark.SparkMultimodalITCase#testVector
