### PR TITLE
[spark] Fix restarted streaming query re-scanning full snapshot instead of resuming from checkpoint

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonMicroBatchStream.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonMicroBatchStream.scala
@@ -116,7 +116,17 @@ class PaimonMicroBatchStream(
   override def planInputPartitions(start: Offset, end: Offset): Array[InputPartition] = {
     val startOffset = {
       val startOffset0 = PaimonSourceOffset(start)
-      if (startOffset0.compareTo(initOffset) < 0) {
+      // Fall back to initOffset only when the checkpointed snapshot has expired.
+      // initOffset is recomputed from the current table state on every (re)start,
+      // so with scan modes like latest-full it points at the current snapshot with
+      // scanSnapshot=true. Clamping a still-valid checkpointed offset up to it made
+      // a restarted query silently skip the changelog gap and re-scan the whole
+      // snapshot, re-emitting every row as +I.
+      if (startOffset0.snapshotId < table.snapshotManager().earliestSnapshotId()) {
+        logWarning(
+          s"Checkpointed start offset $startOffset0 is no longer available " +
+            s"(earliest snapshot: ${table.snapshotManager().earliestSnapshotId()}), " +
+            s"falling back to $initOffset.")
         initOffset
       } else {
         startOffset0


### PR DESCRIPTION
### Purpose

Linked issue: close #8205

`PaimonMicroBatchStream#planInputPartitions` clamped the checkpointed start offset up to `initOffset` whenever it compared lower. `initOffset` is recomputed from the current table state on every restart, so with scan modes like `latest-full` it always points at the current snapshot with `scanSnapshot=true`. Any restarted query therefore dropped its valid checkpointed position, silently skipped the changelog gap, and re-emitted the entire snapshot as `+I` rows.

This PR falls back to `initOffset` only when the checkpointed snapshot has actually expired (older than `earliestSnapshotId`); otherwise the query resumes from the checkpointed offset as-is. A warning is logged when the fallback is taken.

### Tests

Verified against a production 5-minute-trigger streaming query (~300k-row source): with the fix the first batch after a restart resumes from the checkpointed offset and reads only the downtime changelog; without it, restarts produced one empty batch followed by a full-snapshot re-emission (offset WAL evidence in #8205).

I did not find an existing harness for restart simulation of `PaimonMicroBatchStream` unit-side; happy to add one if maintainers can point at a preferred pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)