### PR TITLE
[core] Prevent integer overflow in sort buffer size with isEmpty check

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/cluster/Sorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/cluster/Sorter.java
@@ -104,7 +104,7 @@ public abstract class Sorter {
             buffer.write(rowWithKey);
         }
 
-        if (buffer.size() > 0) {
+        if (!buffer.isEmpty()) {
             return buffer.sortedIterator();
         } else {
             throw new IllegalStateException("numRecords after sorting is 0.");

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/GlobalIndexAssigner.java
@@ -207,7 +207,7 @@ public class GlobalIndexAssigner implements Serializable, Closeable {
             throws Exception {
         bootstrap = false;
         boolean isEmpty = true;
-        if (bootstrapKeys.size() > 0) {
+        if (!bootstrapKeys.isEmpty()) {
             RocksDBBulkLoader bulkLoader = keyIndex.createBulkLoader();
             MutableObjectIterator<BinaryRow> keyIterator = bootstrapKeys.sortedIterator();
             BinaryRow row = new BinaryRow(2);

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/MergeTreeWriter.java
@@ -208,7 +208,7 @@ public class MergeTreeWriter implements RecordWriter<KeyValue>, MemoryOwner {
 
     private void flushWriteBuffer(boolean waitForLatestCompaction, boolean forcedFullCompaction)
             throws Exception {
-        if (writeBuffer.size() > 0) {
+        if (!writeBuffer.isEmpty()) {
             if (compactManager.shouldWaitForLatestCompaction()) {
                 waitForLatestCompaction = true;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/SortBufferWriteBuffer.java
@@ -151,6 +151,11 @@ public class SortBufferWriteBuffer implements WriteBuffer {
     }
 
     @Override
+    public boolean isEmpty() {
+        return buffer.isEmpty();
+    }
+
+    @Override
     public long memoryOccupancy() {
         return buffer.getOccupancy();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/WriteBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/WriteBuffer.java
@@ -45,6 +45,8 @@ public interface WriteBuffer {
     /** Record size of this table. */
     int size();
 
+    boolean isEmpty();
+
     /** Memory occupancy size of this table. */
     long memoryOccupancy();
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/HashMapLocalMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/HashMapLocalMerger.java
@@ -119,6 +119,11 @@ public class HashMapLocalMerger implements LocalMerger {
     }
 
     @Override
+    public boolean isEmpty() {
+        return buffer.getNumElements() == 0;
+    }
+
+    @Override
     public void forEach(Consumer<InternalRow> consumer) throws IOException {
         KeyValueIterator<BinaryRow, BinaryRow> iterator = buffer.getEntryIterator(false);
         while (iterator.advanceNext()) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/LocalMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/LocalMerger.java
@@ -32,6 +32,8 @@ public interface LocalMerger {
 
     int size();
 
+    boolean isEmpty();
+
     void forEach(Consumer<InternalRow> consumer) throws IOException;
 
     void clear();

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/SortBufferLocalMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/localmerge/SortBufferLocalMerger.java
@@ -59,6 +59,11 @@ public class SortBufferLocalMerger implements LocalMerger {
     }
 
     @Override
+    public boolean isEmpty() {
+        return sortBuffer.isEmpty();
+    }
+
+    @Override
     public void forEach(Consumer<InternalRow> consumer) throws IOException {
         sortBuffer.forEach(
                 keyComparator,

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -59,7 +59,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
     private final List<ChannelWithMeta> spillChannelIDs;
     private final MemorySize maxDiskSize;
 
-    private int numRecords = 0;
+    private long numRecords = 0;
 
     public BinaryExternalSortBuffer(
             BinaryRowSerializer serializer,
@@ -122,7 +122,18 @@ public class BinaryExternalSortBuffer implements SortBuffer {
 
     @Override
     public int size() {
-        return numRecords;
+        if (numRecords >= Integer.MAX_VALUE) {
+            throw new RuntimeException(
+                    "numRecords "
+                            + numRecords
+                            + " exceeds Integer.MAX_VALUE, use isEmpty() instead of size().");
+        }
+        return (int) numRecords;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return numRecords == 0;
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryExternalSortBuffer.java
@@ -122,7 +122,7 @@ public class BinaryExternalSortBuffer implements SortBuffer {
 
     @Override
     public int size() {
-        if (numRecords >= Integer.MAX_VALUE) {
+        if (numRecords > Integer.MAX_VALUE) {
             throw new RuntimeException(
                     "numRecords "
                             + numRecords

--- a/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/BinaryInMemorySortBuffer.java
@@ -148,7 +148,8 @@ public class BinaryInMemorySortBuffer extends BinaryIndexedSortable implements S
         return false;
     }
 
-    boolean isEmpty() {
+    @Override
+    public boolean isEmpty() {
         return this.numRecords == 0;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/sort/SortBuffer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/sort/SortBuffer.java
@@ -29,6 +29,8 @@ public interface SortBuffer {
 
     int size();
 
+    boolean isEmpty();
+
     void clear();
 
     long getOccupancy();

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferOverflowTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferOverflowTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.mergetree;
+
+import org.apache.paimon.compression.CompressOptions;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.memory.HeapMemorySegmentPool;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.sort.BinaryExternalSortBuffer;
+import org.apache.paimon.sort.SortBuffer;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test that {@link SortBufferWriteBuffer} (used by {@link MergeTreeWriter}) handles int overflow in
+ * numRecords correctly by using isEmpty() instead of size().
+ */
+public class SortBufferWriteBufferOverflowTest {
+
+    @TempDir Path tempDir;
+
+    private IOManager ioManager;
+
+    @BeforeEach
+    public void setUp() {
+        ioManager = IOManager.create(tempDir.toString());
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        ioManager.close();
+    }
+
+    private SortBufferWriteBuffer createSpillableWriteBuffer() {
+        RowType keyType = RowType.builder().field("k", DataTypes.INT()).build();
+        RowType valueType = RowType.builder().field("v", DataTypes.INT()).build();
+        return new SortBufferWriteBuffer(
+                keyType,
+                valueType,
+                null,
+                new HeapMemorySegmentPool(32 * 1024 * 3L, 32 * 1024),
+                true,
+                MemorySize.MAX_VALUE,
+                128,
+                CompressOptions.defaultOptions(),
+                ioManager);
+    }
+
+    private static void setNumRecords(SortBufferWriteBuffer writeBuffer, long numRecords)
+            throws Exception {
+        Field bufferField = SortBufferWriteBuffer.class.getDeclaredField("buffer");
+        bufferField.setAccessible(true);
+        SortBuffer buffer = (SortBuffer) bufferField.get(writeBuffer);
+        assertThat(buffer).isInstanceOf(BinaryExternalSortBuffer.class);
+
+        Field numRecordsField = BinaryExternalSortBuffer.class.getDeclaredField("numRecords");
+        numRecordsField.setAccessible(true);
+        numRecordsField.setLong(buffer, numRecords);
+    }
+
+    @Test
+    public void testIsEmptyWorksWhenNumRecordsExceedsIntMax() throws Exception {
+        SortBufferWriteBuffer writeBuffer = createSpillableWriteBuffer();
+        writeBuffer.put(1L, RowKind.INSERT, GenericRow.of(1), GenericRow.of(100));
+
+        assertThat(writeBuffer.size()).isEqualTo(1);
+        assertThat(writeBuffer.isEmpty()).isFalse();
+
+        setNumRecords(writeBuffer, (long) Integer.MAX_VALUE + 1);
+
+        // isEmpty() should still work without throwing — this is the key behavior
+        // that MergeTreeWriter.flushWriteBuffer relies on
+        assertThat(writeBuffer.isEmpty()).isFalse();
+
+        // size() should throw
+        assertThatThrownBy(writeBuffer::size)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("exceeds Integer.MAX_VALUE");
+
+        writeBuffer.clear();
+        assertThat(writeBuffer.isEmpty()).isTrue();
+        assertThat(writeBuffer.size()).isEqualTo(0);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferOverflowTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/SortBufferWriteBufferOverflowTest.java
@@ -19,20 +19,22 @@
 package org.apache.paimon.mergetree;
 
 import org.apache.paimon.compression.CompressOptions;
-import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.serializer.AbstractRowDataSerializer;
+import org.apache.paimon.data.serializer.BinaryRowSerializer;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.memory.HeapMemorySegmentPool;
+import org.apache.paimon.memory.MemorySegmentPool;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.sort.BinaryExternalSortBuffer;
-import org.apache.paimon.sort.SortBuffer;
-import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.types.RowKind;
-import org.apache.paimon.types.RowType;
+import org.apache.paimon.sort.BinaryInMemorySortBuffer;
+import org.apache.paimon.sort.IntNormalizedKeyComputer;
+import org.apache.paimon.sort.IntRecordComparator;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
@@ -49,10 +51,12 @@ public class SortBufferWriteBufferOverflowTest {
     @TempDir Path tempDir;
 
     private IOManager ioManager;
+    private MemorySegmentPool memorySegmentPool;
 
     @BeforeEach
     public void setUp() {
         ioManager = IOManager.create(tempDir.toString());
+        memorySegmentPool = new HeapMemorySegmentPool(32 * 1024 * 3L, 32 * 1024);
     }
 
     @AfterEach
@@ -60,28 +64,42 @@ public class SortBufferWriteBufferOverflowTest {
         ioManager.close();
     }
 
-    private SortBufferWriteBuffer createSpillableWriteBuffer() {
-        RowType keyType = RowType.builder().field("k", DataTypes.INT()).build();
-        RowType valueType = RowType.builder().field("v", DataTypes.INT()).build();
-        return new SortBufferWriteBuffer(
-                keyType,
-                valueType,
-                null,
-                new HeapMemorySegmentPool(32 * 1024 * 3L, 32 * 1024),
-                true,
-                MemorySize.MAX_VALUE,
+    private BinaryExternalSortBuffer createSortBuffer() {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(1);
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        BinaryInMemorySortBuffer inMemorySortBuffer =
+                BinaryInMemorySortBuffer.createBuffer(
+                        IntNormalizedKeyComputer.INSTANCE,
+                        (AbstractRowDataSerializer) serializer,
+                        IntRecordComparator.INSTANCE,
+                        memorySegmentPool);
+        return new BinaryExternalSortBuffer(
+                serializer,
+                IntRecordComparator.INSTANCE,
+                memorySegmentPool.pageSize(),
+                inMemorySortBuffer,
+                ioManager,
                 128,
                 CompressOptions.defaultOptions(),
-                ioManager);
+                MemorySize.MAX_VALUE);
     }
 
-    private static void setNumRecords(SortBufferWriteBuffer writeBuffer, long numRecords)
+    private static SortBufferWriteBuffer createWriteBuffer(BinaryExternalSortBuffer buffer)
             throws Exception {
+        Field theUnsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+        theUnsafeField.setAccessible(true);
+        Unsafe unsafe = (Unsafe) theUnsafeField.get(null);
+        SortBufferWriteBuffer writeBuffer =
+                (SortBufferWriteBuffer) unsafe.allocateInstance(SortBufferWriteBuffer.class);
+
         Field bufferField = SortBufferWriteBuffer.class.getDeclaredField("buffer");
         bufferField.setAccessible(true);
-        SortBuffer buffer = (SortBuffer) bufferField.get(writeBuffer);
-        assertThat(buffer).isInstanceOf(BinaryExternalSortBuffer.class);
+        bufferField.set(writeBuffer, buffer);
+        return writeBuffer;
+    }
 
+    private static void setNumRecords(BinaryExternalSortBuffer buffer, long numRecords)
+            throws Exception {
         Field numRecordsField = BinaryExternalSortBuffer.class.getDeclaredField("numRecords");
         numRecordsField.setAccessible(true);
         numRecordsField.setLong(buffer, numRecords);
@@ -89,19 +107,19 @@ public class SortBufferWriteBufferOverflowTest {
 
     @Test
     public void testIsEmptyWorksWhenNumRecordsExceedsIntMax() throws Exception {
-        SortBufferWriteBuffer writeBuffer = createSpillableWriteBuffer();
-        writeBuffer.put(1L, RowKind.INSERT, GenericRow.of(1), GenericRow.of(100));
+        BinaryExternalSortBuffer buffer = createSortBuffer();
+        SortBufferWriteBuffer writeBuffer = createWriteBuffer(buffer);
 
-        assertThat(writeBuffer.size()).isEqualTo(1);
+        assertThat(writeBuffer.size()).isEqualTo(0);
+        assertThat(writeBuffer.isEmpty()).isTrue();
+
+        setNumRecords(buffer, Integer.MAX_VALUE);
+        assertThat(writeBuffer.size()).isEqualTo(Integer.MAX_VALUE);
         assertThat(writeBuffer.isEmpty()).isFalse();
 
-        setNumRecords(writeBuffer, (long) Integer.MAX_VALUE + 1);
+        setNumRecords(buffer, (long) Integer.MAX_VALUE + 1);
 
-        // isEmpty() should still work without throwing — this is the key behavior
-        // that MergeTreeWriter.flushWriteBuffer relies on
         assertThat(writeBuffer.isEmpty()).isFalse();
-
-        // size() should throw
         assertThatThrownBy(writeBuffer::size)
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("exceeds Integer.MAX_VALUE");

--- a/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/sort/BinaryExternalSortBufferTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link BinaryExternalSortBuffer}. */
 public class BinaryExternalSortBufferTest {
@@ -94,6 +96,33 @@ public class BinaryExternalSortBufferTest {
                         .filter(f -> !f.isDirectory())
                         .collect(Collectors.toList());
         assertThat(files).isEmpty();
+    }
+
+    private static void setNumRecords(BinaryExternalSortBuffer sorter, long numRecords)
+            throws Exception {
+        Field numRecordsField = BinaryExternalSortBuffer.class.getDeclaredField("numRecords");
+        numRecordsField.setAccessible(true);
+        numRecordsField.setLong(sorter, numRecords);
+    }
+
+    @Test
+    public void testSizeBoundary() throws Exception {
+        BinaryExternalSortBuffer sorter = createBuffer();
+
+        assertThat(sorter.size()).isEqualTo(0);
+        assertThat(sorter.isEmpty()).isTrue();
+
+        setNumRecords(sorter, Integer.MAX_VALUE);
+        assertThat(sorter.size()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(sorter.isEmpty()).isFalse();
+
+        setNumRecords(sorter, (long) Integer.MAX_VALUE + 1);
+        assertThat(sorter.isEmpty()).isFalse();
+        assertThatThrownBy(sorter::size)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("exceeds Integer.MAX_VALUE");
+
+        sorter.clear();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/LocalMergeOperator.java
@@ -201,7 +201,7 @@ public class LocalMergeOperator extends AbstractStreamOperator<InternalRow>
     }
 
     private void flushBuffer() throws Exception {
-        if (merger.size() == 0) {
+        if (merger.isEmpty()) {
             return;
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sorter/SortOperator.java
@@ -107,7 +107,7 @@ public class SortOperator extends TableStreamOperator<InternalRow>
 
     @Override
     public void endInput() throws Exception {
-        if (buffer.size() > 0) {
+        if (!buffer.isEmpty()) {
             MutableObjectIterator<BinaryRow> iterator = buffer.sortedIterator();
             BinaryRow binaryRow = new BinaryRow(arity);
             while ((binaryRow = iterator.next(binaryRow)) != null) {


### PR DESCRIPTION
### Purpose

`BinaryExternalSortBuffer#numRecords` was an `int`, so once the number of buffered records exceeds `Integer.MAX_VALUE` it silently overflows and can wrap to a negative value.

When `numRecords` overflows to a negative value, `WriteBuffer#size()` returns a value `< 0`, so the guard `if (writeBuffer.size() > 0)` in `MergeTreeWriter#flushWriteBuffer` evaluates to `false`. The buffered records are silently discarded — resulting in data loss.

This PR:
- Widens `BinaryExternalSortBuffer#numRecords` to `long` to avoid overflow.
- Adds `isEmpty()` to the `SortBuffer` and `WriteBuffer` interfaces and their implementations (`BinaryExternalSortBuffer`, `BinaryInMemorySortBuffer`, `SortBufferWriteBuffer`), and replaces emptiness checks of the form `size() > 0` with `!isEmpty()` in `Sorter`, `MergeTreeWriter`, and `SortOperator`.
- Keeps `size()` returning `int` (it now throws when the count exceeds `Integer.MAX_VALUE` instead of silently truncating). It is **not** widened to `long` because `size()` is part of the `IndexedSortable` contract and is still consumed as an `int` by the in-memory sorting algorithms — e.g. `org.apache.paimon.sort.HeapSort`, which calls `sort(s, 0, s.size())`.

### Tests

- Added `SortBufferWriteBufferOverflowTest`.