### PR TITLE
[core] Fix readAllDeletionVectors not seeking to correct offset

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
@@ -80,6 +80,7 @@ public class DeletionVectorsIndexFile extends IndexFile {
             checkVersion(inputStream);
             DataInputStream dataInputStream = new DataInputStream(inputStream);
             for (DeletionVectorMeta deletionVectorMeta : deletionVectorMetas.values()) {
+                inputStream.seek(deletionVectorMeta.offset());
                 deletionVectors.put(
                         deletionVectorMeta.dataFileName(),
                         DeletionVector.read(dataInputStream, (long) deletionVectorMeta.length()));

--- a/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFileTest.java
@@ -34,7 +34,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -258,6 +261,59 @@ public class DeletionVectorsIndexFileTest {
         Map<String, DeletionVector> dvs2 =
                 v2DeletionVectorsIndexFile.readAllDeletionVectors(totalIndexFiles);
         assertThat(dvs2.size()).isEqualTo(100000);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testReadAllDeletionVectorsWithOutOfOrderDvRanges(boolean bitmap64) {
+        IndexPathFactory pathFactory = getPathFactory();
+        DeletionVectorsIndexFile deletionVectorsIndexFile =
+                deletionVectorsIndexFile(pathFactory, bitmap64);
+
+        // write multiple DVs so they are stored sequentially in the index file
+        HashMap<String, DeletionVector> deleteMap = new HashMap<>();
+        Map<String, Integer> expected = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            DeletionVector dv = createEmptyDV(bitmap64);
+            dv.delete(i * 100);
+            dv.delete(i * 100 + 1);
+            deleteMap.put("file" + i + ".parquet", dv);
+            expected.put("file" + i + ".parquet", i * 100);
+        }
+
+        List<IndexFileMeta> indexFiles = deletionVectorsIndexFile.writeWithRolling(deleteMap);
+        assertThat(indexFiles.size()).isEqualTo(1);
+        IndexFileMeta original = indexFiles.get(0);
+
+        // build a new IndexFileMeta with dvRanges in reverse offset order,
+        // simulating compaction merging dvRanges from multiple sources
+        LinkedHashMap<String, DeletionVectorMeta> originalRanges = original.dvRanges();
+        List<Map.Entry<String, DeletionVectorMeta>> entries =
+                new ArrayList<>(originalRanges.entrySet());
+        Collections.reverse(entries);
+        LinkedHashMap<String, DeletionVectorMeta> reversedRanges = new LinkedHashMap<>();
+        for (Map.Entry<String, DeletionVectorMeta> entry : entries) {
+            reversedRanges.put(entry.getKey(), entry.getValue());
+        }
+
+        IndexFileMeta reordered =
+                new IndexFileMeta(
+                        original.indexType(),
+                        original.fileName(),
+                        original.fileSize(),
+                        original.rowCount(),
+                        reversedRanges,
+                        original.externalPath());
+
+        // read with out-of-order dvRanges — this would fail without the seek fix
+        Map<String, DeletionVector> result =
+                deletionVectorsIndexFile.readAllDeletionVectors(reordered);
+        assertThat(result).hasSize(10);
+        for (Map.Entry<String, Integer> e : expected.entrySet()) {
+            assertThat(result.get(e.getKey()).isDeleted(e.getValue())).isTrue();
+            assertThat(result.get(e.getKey()).isDeleted(e.getValue() + 1)).isTrue();
+            assertThat(result.get(e.getKey()).isDeleted(e.getValue() + 2)).isFalse();
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
  ### Purpose

  `readAllDeletionVectors(IndexFileMeta)` reads deletion vectors sequentially without seeking to the offset recorded in each `DeletionVectorMeta`, assuming the `dvRanges` iteration order always matches the physical storage order in the index file.

This assumption is fragile — the `dvRanges` ordering can be disrupted by metadata serialization/deserialization, index file merging, or any future code path that reconstructs the `LinkedHashMap`. When iteration order diverges from physical layout, the stream reads from wrong positions and fails with:

```
  java.lang.RuntimeException: Size not match, actual size: 6690, expected size: 311612
```

  The other read methods — `readDeletionVector(Map<String, DeletionFile>)` and `readDeletionVector(DeletionFile)` — already seek to the correct offset before each read.

  #### Changes

  Fix by calling `inputStream.seek(deletionVectorMeta.offset())` before each read, consistent with the existing read paths.

  ### Tests

  - `testReadAllDeletionVectorsWithOutOfOrderDvRanges` — writes multiple DVs to an index file, then constructs an `IndexFileMeta` with reversed `dvRanges` iteration order (simulating the compaction-merged scenario), and verifies `readAllDeletionVectors` still reads each DV correctly. Parameterized for both bitmap32 and bitmap64.

  ### API and Format

  N/A — no public API or format changes.

  ### Documentation

  N/A