### PR TITLE
[common] Fix npe on null value map(k, v) cast

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/StringToMapCastRule.java
@@ -37,8 +37,6 @@ import java.util.Map;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /** {@link DataTypeFamily#CHARACTER_STRING} to {@link DataTypeRoot#MAP} cast rule. */
 class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
@@ -141,15 +139,13 @@ class StringToMapCastRule extends AbstractCastRule<BinaryString, InternalMap> {
             throw new RuntimeException("Invalid Function map format: odd number of elements");
         }
 
-        return IntStream.range(0, elements.size() / 2)
-                .boxed()
-                .collect(
-                        Collectors.toMap(
-                                i -> parseValue(elements.get(i * 2).trim(), keyCastExecutor),
-                                i ->
-                                        parseValue(
-                                                elements.get(i * 2 + 1).trim(),
-                                                valueCastExecutor)));
+        Map<Object, Object> mapContent = Maps.newHashMap();
+        for (int i = 0; i < elements.size(); i += 2) {
+            mapContent.put(
+                    parseValue(elements.get(i).trim(), keyCastExecutor),
+                    parseValue(elements.get(i + 1).trim(), valueCastExecutor));
+        }
+        return mapContent;
     }
 
     private Map<Object, Object> parseMapEntry(

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -643,6 +643,15 @@ public class CastExecutorTest {
         assertThat(valueArray.getInt(0)).isEqualTo(42);
         assertThat(keyArray.getString(1).toString()).isEqualTo("key1");
         assertThat(valueArray.isNullAt(1)).isTrue();
+
+        result = stringToMap.cast(BinaryString.fromString("MAP(key1, null, key2, 42)"));
+        assertThat(result.size()).isEqualTo(2);
+        keyArray = result.keyArray();
+        valueArray = result.valueArray();
+        assertThat(keyArray.getString(0).toString()).isEqualTo("key2");
+        assertThat(valueArray.getInt(0)).isEqualTo(42);
+        assertThat(keyArray.getString(1).toString()).isEqualTo("key1");
+        assertThat(valueArray.isNullAt(1)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 -  cast('map(k, null)' as map<string, int>) fails with npe, but the equivalent bracket form cast('{k -> null}' as map<string, int>) succeeds.
 - Bracket parser uses HashMap.put permits null. Function parser uses Collectors.toMap which rejects null.
 - The shared parseValue already returns null for the literal "null", so null is part of the intended input contract.
 - Switch the function parser to a HashMap.put loop matching the bracket parser. Both forms now behave the same.

### Tests
 - UT