### PR TITLE
[hive] Truncate Iceberg Hive column comments for Glue compatibility

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.iceberg;
 
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.client.ClientPool;
 import org.apache.paimon.fs.Path;
@@ -61,6 +62,8 @@ import static org.apache.paimon.iceberg.IcebergCommitCallback.catalogDatabasePat
 public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
 
     private static final Logger LOG = LoggerFactory.getLogger(IcebergHiveMetadataCommitter.class);
+    private static final int HIVE_COLUMN_COMMENT_MAX_LENGTH = 255;
+    private static final String TRUNCATION_MARKER = "...";
 
     private final FileStoreTable table;
     private final ClientPool<IMetaStoreClient, TException> clients;
@@ -263,6 +266,16 @@ public class IcebergHiveMetadataCommitter implements IcebergMetadataCommitter {
         return new FieldSchema(
                 dataField.name(),
                 HiveTypeUtils.toTypeInfo(dataField.type()).getTypeName(),
-                dataField.description());
+                normalizeColumnComment(dataField.description()));
+    }
+
+    @VisibleForTesting
+    static String normalizeColumnComment(@Nullable String comment) {
+        if (comment == null || comment.length() <= HIVE_COLUMN_COMMENT_MAX_LENGTH) {
+            return comment;
+        }
+
+        return comment.substring(0, HIVE_COLUMN_COMMENT_MAX_LENGTH - TRUNCATION_MARKER.length())
+                + TRUNCATION_MARKER;
     }
 }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/iceberg/IcebergHiveMetadataCommitterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.iceberg;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link IcebergHiveMetadataCommitter}. */
+class IcebergHiveMetadataCommitterTest {
+
+    @Test
+    void testNormalizeColumnComment() {
+        assertThat(IcebergHiveMetadataCommitter.normalizeColumnComment(null)).isNull();
+
+        String maxLengthComment = repeat('a', 255);
+        assertThat(IcebergHiveMetadataCommitter.normalizeColumnComment(maxLengthComment))
+                .isEqualTo(maxLengthComment);
+
+        String longComment = repeat('b', 256);
+        assertThat(IcebergHiveMetadataCommitter.normalizeColumnComment(longComment))
+                .hasSize(255)
+                .isEqualTo(repeat('b', 252) + "...");
+    }
+
+    private static String repeat(char c, int count) {
+        char[] chars = new char[count];
+        Arrays.fill(chars, c);
+        return new String(chars);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR truncates column comments written by IcebergHiveMetadataCommitter to 255 characters before syncing them to Hive/Glue metadata. ErrorTrace:
```
'table.storageDescriptor.columns.29.member.comment' failed to satisfy constraint: Member must have length less than or equal to 255 (Service: AWSGlue; Status Code: 400; Error Code: ValidationException; Request ID: f75bb3cb-36e2-4979-b38a-c4bec5aeb930; Proxy: null))
```
AWS Glue rejects FieldSchema.comment values longer than 255 characters, which can cause Paimon commits to fail when Iceberg Hive metadata sync is enabled and an upstream schema field description is too long. The committer now preserves short/null comments unchanged and truncates longer comments with a `...` marker while staying within the Glue limit.

### Tests
- Added unit tests and tested the change manually as well.