### PR TITLE
[common] Fix wrong binary ordering due to signed subtraction

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/CompareUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/CompareUtils.java
@@ -38,7 +38,7 @@ public class CompareUtils {
 
     private static int compare(byte[] first, byte[] second) {
         for (int x = 0; x < min(first.length, second.length); x++) {
-            int cmp = first[x] - second[x];
+            int cmp = Byte.toUnsignedInt(first[x]) - Byte.toUnsignedInt(second[x]);
             if (cmp != 0) {
                 return cmp;
             }

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/PredicateTest.java
@@ -65,6 +65,26 @@ public class PredicateTest {
     }
 
     @Test
+    public void testBinaryUnsignedComparison() {
+        PredicateBuilder builder = new PredicateBuilder(RowType.of(DataTypes.BYTES()));
+
+        Predicate greaterThan = builder.greaterThan(0, new byte[] {(byte) 0x7F});
+        assertThat(greaterThan.test(GenericRow.of((Object) new byte[] {(byte) 0x80}))).isTrue();
+        assertThat(greaterThan.test(GenericRow.of((Object) new byte[] {(byte) 0x7E}))).isFalse();
+
+        Predicate greaterThanLow = builder.greaterThan(0, new byte[] {(byte) 0x01});
+        assertThat(greaterThanLow.test(GenericRow.of((Object) new byte[] {(byte) 0xFF}))).isTrue();
+
+        Predicate lessThan = builder.lessThan(0, new byte[] {(byte) 0x80});
+        assertThat(lessThan.test(GenericRow.of((Object) new byte[] {(byte) 0x01}))).isTrue();
+        assertThat(lessThan.test(GenericRow.of((Object) new byte[] {(byte) 0xFF}))).isFalse();
+
+        Predicate between = builder.between(0, new byte[] {(byte) 0x70}, new byte[] {(byte) 0x90});
+        assertThat(between.test(GenericRow.of((Object) new byte[] {(byte) 0x80}))).isTrue();
+        assertThat(between.test(GenericRow.of((Object) new byte[] {(byte) 0x60}))).isFalse();
+    }
+
+    @Test
     public void testEqualNull() {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         Predicate predicate = builder.equal(0, null);


### PR DESCRIPTION
### Purpose
 - CompareUtils compares binary values with signed byte subtraction, this can cause range predicates on BINARY and
VARBINARY to silently return wrong rows.
 - Ensure we use Byte.toUnsignedInt on the comparison to represent the range as 0 - 255 instead of -128 to +127.
 
### Tests
 - UT