### PR TITLE
[feature] Support per-field vector index options

### DIFF
--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -127,6 +127,35 @@ Supported vector index options:
 | `<index-type>.hnsw.ef-construction` | `150` | HNSW construction search width for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
 | `<index-type>.hnsw.max-level` | `7` | Maximum HNSW level for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
 
+**Per-Column Options**
+
+The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
+by every vector column of the same index type. When a table has multiple vector columns, you can
+scope an option to a single column with `<index-type>.fields.<field-name>.<option>`. The field-level
+form takes precedence over the column-agnostic `<index-type>.<option>` for that column:
+
+```sql
+CREATE TABLE my_table (
+    id INT,
+    title_embedding ARRAY<FLOAT>,
+    image_embedding ARRAY<FLOAT>
+) TBLPROPERTIES (
+    'bucket' = '-1',
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'global-index.enabled' = 'true',
+    -- per-column dimensions
+    'ivf-pq.fields.title_embedding.dimension' = '768',
+    'ivf-pq.fields.image_embedding.dimension' = '512',
+    -- shared by every ivf-pq column, overridden only for 'image_embedding'
+    'ivf-pq.nlist' = '256',
+    'ivf-pq.fields.image_embedding.nlist' = '512'
+);
+```
+
+With the properties above, `title_embedding` is indexed with `nlist=256` while `image_embedding`
+uses `nlist=512`.
+
 **Vector Search**
 
 Search-time options are passed with each vector search request:

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -127,12 +127,13 @@ Supported vector index options:
 | `<index-type>.hnsw.ef-construction` | `150` | HNSW construction search width for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
 | `<index-type>.hnsw.max-level` | `7` | Maximum HNSW level for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
 
-**Per-Column Options**
+**Per-Field Options**
 
 The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
 by every vector column of the same index type. When a table has multiple vector columns, you can
 scope an option to a single column with `<index-type>.fields.<field-name>.<option>`. The field-level
-form takes precedence over the column-agnostic `<index-type>.<option>` for that column:
+form takes precedence over the column-agnostic `<index-type>.<option>` for that column. Use the
+stored table column name exactly as `<field-name>`:
 
 ```sql
 CREATE TABLE my_table (

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -133,7 +133,9 @@ The options above can also be set at the table level (in `TBLPROPERTIES`), where
 by every vector column of the same index type. When a table has multiple vector columns, you can
 scope an option to a single column with `fields.<field-name>.<option>`. The field-level
 form takes precedence over the column-agnostic `<index-type>.<option>` for that column. Use the
-stored table column name exactly as `<field-name>`:
+stored table column name exactly as `<field-name>`. Field-level vector options do not include the
+index-type prefix; for example, use `fields.image_embedding.nlist` to override the shared
+`ivf-pq.nlist` option for `image_embedding`:
 
 ```sql
 CREATE TABLE my_table (

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -131,7 +131,7 @@ Supported vector index options:
 
 The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
 by every vector column of the same index type. When a table has multiple vector columns, you can
-scope an option to a single column with `<index-type>.fields.<field-name>.<option>`. The field-level
+scope an option to a single column with `fields.<field-name>.<option>`. The field-level
 form takes precedence over the column-agnostic `<index-type>.<option>` for that column. Use the
 stored table column name exactly as `<field-name>`:
 
@@ -146,11 +146,11 @@ CREATE TABLE my_table (
     'data-evolution.enabled' = 'true',
     'global-index.enabled' = 'true',
     -- per-column dimensions
-    'ivf-pq.fields.title_embedding.dimension' = '768',
-    'ivf-pq.fields.image_embedding.dimension' = '512',
+    'fields.title_embedding.dimension' = '768',
+    'fields.image_embedding.dimension' = '512',
     -- shared by every ivf-pq column, overridden only for 'image_embedding'
     'ivf-pq.nlist' = '256',
-    'ivf-pq.fields.image_embedding.nlist' = '512'
+    'fields.image_embedding.nlist' = '512'
 );
 ```
 

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
@@ -46,14 +46,13 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
             DataType fieldType, Options tableOptions, String identifier, String fieldName) {
         Map<String, String> nativeOptions = new LinkedHashMap<>();
         String optionPrefix = identifier + ".";
-        String indexFieldsPrefix = optionPrefix + "fields.";
         String fieldPrefix = "fields." + fieldName + ".";
         Map<String, String> tableOptionsMap = tableOptions.toMap();
 
         // First collect index-type level options, e.g. <index-type>.xxx.
         for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
             String optionKey = entry.getKey();
-            if (optionKey.startsWith(optionPrefix) && !optionKey.startsWith(indexFieldsPrefix)) {
+            if (optionKey.startsWith(optionPrefix)) {
                 String nativeKey = nativeOptionKey(optionKey.substring(optionPrefix.length()));
                 if (nativeKey != null) {
                     nativeOptions.put(nativeKey, entry.getValue());

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
@@ -46,13 +46,14 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
             DataType fieldType, Options tableOptions, String identifier, String fieldName) {
         Map<String, String> nativeOptions = new LinkedHashMap<>();
         String optionPrefix = identifier + ".";
-        String fieldPrefix = optionPrefix + "fields." + fieldName + ".";
+        String fieldsPrefix = optionPrefix + "fields.";
+        String fieldPrefix = fieldsPrefix + fieldName + ".";
         Map<String, String> tableOptionsMap = tableOptions.toMap();
 
         // First collect index-type level options, e.g. <index-type>.xxx.
         for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
             String optionKey = entry.getKey();
-            if (optionKey.startsWith(optionPrefix)) {
+            if (optionKey.startsWith(optionPrefix) && !optionKey.startsWith(fieldsPrefix)) {
                 String nativeKey = nativeOptionKey(optionKey.substring(optionPrefix.length()));
                 if (nativeKey != null) {
                     nativeOptions.put(nativeKey, entry.getValue());

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
@@ -46,14 +46,14 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
             DataType fieldType, Options tableOptions, String identifier, String fieldName) {
         Map<String, String> nativeOptions = new LinkedHashMap<>();
         String optionPrefix = identifier + ".";
-        String fieldsPrefix = optionPrefix + "fields.";
-        String fieldPrefix = fieldsPrefix + fieldName + ".";
+        String indexFieldsPrefix = optionPrefix + "fields.";
+        String fieldPrefix = "fields." + fieldName + ".";
         Map<String, String> tableOptionsMap = tableOptions.toMap();
 
         // First collect index-type level options, e.g. <index-type>.xxx.
         for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
             String optionKey = entry.getKey();
-            if (optionKey.startsWith(optionPrefix) && !optionKey.startsWith(fieldsPrefix)) {
+            if (optionKey.startsWith(optionPrefix) && !optionKey.startsWith(indexFieldsPrefix)) {
                 String nativeKey = nativeOptionKey(optionKey.substring(optionPrefix.length()));
                 if (nativeKey != null) {
                     nativeOptions.put(nativeKey, entry.getValue());
@@ -61,8 +61,8 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
             }
         }
 
-        // Then collect field level options, e.g. <index-type>.fields.<field-name>.xxx, which take
-        // precedence over the index-type level options for this field.
+        // Then collect field level options, e.g. fields.<field-name>.xxx, which take precedence
+        // over the index-type level options for this field.
         for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
             String optionKey = entry.getKey();
             if (optionKey.startsWith(fieldPrefix)) {

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactory.java
@@ -37,14 +37,20 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
     public GlobalIndexer create(DataField field, Options options) {
         String identifier = identifier();
         return new VectorGlobalIndexer(
-                field.type(), nativeOptions(field.type(), options, identifier), identifier);
+                field.type(),
+                nativeOptions(field.type(), options, identifier, field.name()),
+                identifier);
     }
 
     static Map<String, String> nativeOptions(
-            DataType fieldType, Options tableOptions, String identifier) {
+            DataType fieldType, Options tableOptions, String identifier, String fieldName) {
         Map<String, String> nativeOptions = new LinkedHashMap<>();
         String optionPrefix = identifier + ".";
-        for (Map.Entry<String, String> entry : tableOptions.toMap().entrySet()) {
+        String fieldPrefix = optionPrefix + "fields." + fieldName + ".";
+        Map<String, String> tableOptionsMap = tableOptions.toMap();
+
+        // First collect index-type level options, e.g. <index-type>.xxx.
+        for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
             String optionKey = entry.getKey();
             if (optionKey.startsWith(optionPrefix)) {
                 String nativeKey = nativeOptionKey(optionKey.substring(optionPrefix.length()));
@@ -53,6 +59,19 @@ public abstract class VectorGlobalIndexerFactory implements GlobalIndexerFactory
                 }
             }
         }
+
+        // Then collect field level options, e.g. <index-type>.fields.<field-name>.xxx, which take
+        // precedence over the index-type level options for this field.
+        for (Map.Entry<String, String> entry : tableOptionsMap.entrySet()) {
+            String optionKey = entry.getKey();
+            if (optionKey.startsWith(fieldPrefix)) {
+                String nativeKey = nativeOptionKey(optionKey.substring(fieldPrefix.length()));
+                if (nativeKey != null) {
+                    nativeOptions.put(nativeKey, entry.getValue());
+                }
+            }
+        }
+
         nativeOptions.put("index.type", identifier.replace('-', '_'));
         nativeOptions.put(
                 "dimension", String.valueOf(dimension(fieldType, nativeOptions, identifier)));

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexTest.java
@@ -347,7 +347,7 @@ public class VectorGlobalIndexTest {
                 new VectorGlobalIndexer(
                         vectorType,
                         VectorGlobalIndexerFactory.nativeOptions(
-                                vectorType, options, IVF_PQ_IDENTIFIER),
+                                vectorType, options, IVF_PQ_IDENTIFIER, fieldName),
                         IVF_PQ_IDENTIFIER);
 
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
@@ -373,7 +373,8 @@ public class VectorGlobalIndexTest {
         return new VectorGlobalIndexWriter(
                 fileWriter,
                 fieldType,
-                VectorGlobalIndexerFactory.nativeOptions(fieldType, options, IVF_PQ_IDENTIFIER),
+                VectorGlobalIndexerFactory.nativeOptions(
+                        fieldType, options, IVF_PQ_IDENTIFIER, fieldName),
                 IVF_PQ_IDENTIFIER);
     }
 

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -137,6 +137,22 @@ public class VectorGlobalIndexerFactoryTest {
     }
 
     @Test
+    public void testFieldLevelDimensionOverridesIndexTypeDimension() {
+        Options options = new Options();
+        options.setString("ivf-flat.dimension", "32");
+        options.setString("ivf-flat.fields.vec.dimension", "64");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
+
+        assertThat(nativeOptions).containsEntry("dimension", "64");
+    }
+
+    @Test
     public void testFieldLevelOptionsOnlyApplyToMatchingField() {
         Options options = new Options();
         options.setString("ivf-flat.nlist", "128");

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -198,4 +198,23 @@ public class VectorGlobalIndexerFactoryTest {
 
         assertThat(nativeOptions).containsEntry("metric", "cosine");
     }
+
+    @Test
+    public void testFieldLevelVectorOptionsCoexistWithCoreFieldOptions() {
+        Options options = new Options();
+        options.setString("ivf-flat.nlist", "128");
+        options.setString("fields.vec.nlist", "256");
+        options.setString("fields.vec.aggregate-function", "sum");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
+
+        assertThat(nativeOptions)
+                .containsEntry("nlist", "256")
+                .doesNotContainKey("aggregate-function");
+    }
 }

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -70,7 +70,8 @@ public class VectorGlobalIndexerFactoryTest {
                 VectorGlobalIndexerFactory.nativeOptions(
                         new ArrayType(new FloatType()),
                         options,
-                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER);
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
 
         assertThat(nativeOptions)
                 .containsEntry("index.type", "ivf_flat")
@@ -92,7 +93,8 @@ public class VectorGlobalIndexerFactoryTest {
                 VectorGlobalIndexerFactory.nativeOptions(
                         new VectorType(8, new FloatType()),
                         options,
-                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER);
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
 
         assertThat(nativeOptions).containsEntry("dimension", "8");
     }
@@ -107,9 +109,61 @@ public class VectorGlobalIndexerFactoryTest {
                                 VectorGlobalIndexerFactory.nativeOptions(
                                         new ArrayType(new FloatType()),
                                         options,
-                                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER))
+                                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                                        "vec"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("ivf-flat.dimension")
                 .hasMessageContaining("positive integer");
+    }
+
+    @Test
+    public void testFieldLevelOptionsOverrideIndexTypeOptions() {
+        Options options = new Options();
+        options.setString("ivf-flat.dimension", "32");
+        options.setString("ivf-flat.nlist", "128");
+        options.setString("ivf-flat.fields.vec.nlist", "256");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
+
+        assertThat(nativeOptions)
+                .containsEntry("dimension", "32")
+                .containsEntry("nlist", "256")
+                .doesNotContainEntry("nlist", "128");
+    }
+
+    @Test
+    public void testFieldLevelOptionsOnlyApplyToMatchingField() {
+        Options options = new Options();
+        options.setString("ivf-flat.nlist", "128");
+        options.setString("ivf-flat.fields.vec.nlist", "256");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "other");
+
+        assertThat(nativeOptions).containsEntry("nlist", "128");
+    }
+
+    @Test
+    public void testFieldLevelOptionsWithoutIndexTypeOption() {
+        Options options = new Options();
+        options.setString("ivf-flat.fields.vec.distance.metric", "cosine");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
+
+        assertThat(nativeOptions).containsEntry("metric", "cosine");
     }
 }

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -153,6 +153,22 @@ public class VectorGlobalIndexerFactoryTest {
     }
 
     @Test
+    public void testFieldLevelOptionsRequireExactFieldName() {
+        Options options = new Options();
+        options.setString("ivf-flat.nlist", "128");
+        options.setString("ivf-flat.fields.vec_extra.nlist", "512");
+
+        Map<String, String> nativeOptions =
+                VectorGlobalIndexerFactory.nativeOptions(
+                        new ArrayType(new FloatType()),
+                        options,
+                        IvfFlatVectorGlobalIndexerFactory.IDENTIFIER,
+                        "vec");
+
+        assertThat(nativeOptions).containsEntry("nlist", "128");
+    }
+
+    @Test
     public void testFieldLevelOptionsWithoutIndexTypeOption() {
         Options options = new Options();
         options.setString("ivf-flat.fields.vec.distance.metric", "cosine");

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -121,7 +121,7 @@ public class VectorGlobalIndexerFactoryTest {
         Options options = new Options();
         options.setString("ivf-flat.dimension", "32");
         options.setString("ivf-flat.nlist", "128");
-        options.setString("ivf-flat.fields.vec.nlist", "256");
+        options.setString("fields.vec.nlist", "256");
 
         Map<String, String> nativeOptions =
                 VectorGlobalIndexerFactory.nativeOptions(
@@ -140,7 +140,7 @@ public class VectorGlobalIndexerFactoryTest {
     public void testFieldLevelDimensionOverridesIndexTypeDimension() {
         Options options = new Options();
         options.setString("ivf-flat.dimension", "32");
-        options.setString("ivf-flat.fields.vec.dimension", "64");
+        options.setString("fields.vec.dimension", "64");
 
         Map<String, String> nativeOptions =
                 VectorGlobalIndexerFactory.nativeOptions(
@@ -156,7 +156,7 @@ public class VectorGlobalIndexerFactoryTest {
     public void testFieldLevelOptionsOnlyApplyToMatchingField() {
         Options options = new Options();
         options.setString("ivf-flat.nlist", "128");
-        options.setString("ivf-flat.fields.vec.nlist", "256");
+        options.setString("fields.vec.nlist", "256");
 
         Map<String, String> nativeOptions =
                 VectorGlobalIndexerFactory.nativeOptions(
@@ -172,7 +172,7 @@ public class VectorGlobalIndexerFactoryTest {
     public void testFieldLevelOptionsRequireExactFieldName() {
         Options options = new Options();
         options.setString("ivf-flat.nlist", "128");
-        options.setString("ivf-flat.fields.vec_extra.nlist", "512");
+        options.setString("fields.vec_extra.nlist", "512");
 
         Map<String, String> nativeOptions =
                 VectorGlobalIndexerFactory.nativeOptions(
@@ -187,7 +187,7 @@ public class VectorGlobalIndexerFactoryTest {
     @Test
     public void testFieldLevelOptionsWithoutIndexTypeOption() {
         Options options = new Options();
-        options.setString("ivf-flat.fields.vec.distance.metric", "cosine");
+        options.setString("fields.vec.distance.metric", "cosine");
 
         Map<String, String> nativeOptions =
                 VectorGlobalIndexerFactory.nativeOptions(


### PR DESCRIPTION
### Purpose
Support per-field vector index options with `fields.<field-name>.<option>`.

This allows tables with multiple vector columns using the same index type to configure different dimensions or index parameters for each column. Field-level options do not include the index-type prefix, and they override index-type-level defaults such as `<index-type>.<option>` for the matching stored table column name.

### Tests
Added unit tests in `VectorGlobalIndexerFactoryTest`:
- field-level options override index-type-level options
- field-level dimension overrides index-type-level dimension
- field-level options only apply to the exact matching field name
- field-level options work without an index-type-level counterpart
- field-level vector options coexist with core `fields.<field-name>.*` options

Also ran:
- `git diff --check`
- `mvn -o -pl paimon-vector/paimon-vector-index -Pfast-build -Dtest=VectorGlobalIndexerFactoryTest test` failed locally because `org.apache.paimon:paimon-core:jar:tests:1.5-SNAPSHOT` was not available in the local Maven cache.