### PR TITLE
[core] Parallelize snapshot expiration file IO

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
@@ -47,7 +47,7 @@ public class ChangelogDeletion extends FileDeletionBase<Changelog> {
             IndexFileHandler indexFileHandler,
             StatsFileHandler statsFileHandler,
             boolean cleanEmptyDirectories,
-            int deleteFileThreadNum) {
+            int fileOperationThreadNum) {
         super(
                 fileIO,
                 pathFactory,
@@ -56,7 +56,7 @@ public class ChangelogDeletion extends FileDeletionBase<Changelog> {
                 indexFileHandler,
                 statsFileHandler,
                 cleanEmptyDirectories,
-                deleteFileThreadNum);
+                fileOperationThreadNum);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ChangelogDeletion.java
@@ -31,7 +31,9 @@ import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -60,13 +62,11 @@ public class ChangelogDeletion extends FileDeletionBase<Changelog> {
     }
 
     @Override
-    public void cleanUnusedDataFiles(Changelog changelog, Predicate<ExpireFileEntry> skipper) {
+    public void cleanDeletedDataFiles(Changelog changelog, Predicate<ExpireFileEntry> skipper) {
         if (changelog.changelogManifestList() != null) {
-            deleteAddedDataFiles(changelog.changelogManifestList());
+            cleanDataFiles(planAddedInChangelogManifest(changelog));
         } else {
-            if (manifestList.exists(changelog.deltaManifestList())) {
-                cleanUnusedDataFiles(changelog.deltaManifestList(), skipper);
-            }
+            cleanDataFiles(planDeletedInDeltaManifest(changelog, skipper));
         }
     }
 
@@ -126,5 +126,19 @@ public class ChangelogDeletion extends FileDeletionBase<Changelog> {
         }
 
         return skippingSet;
+    }
+
+    public void cleanUnusedManifestList(String manifestName, Set<String> skippingSet) {
+        executeAll(planUnusedManifestList(manifestName, skippingSet));
+    }
+
+    public List<Runnable> planUnusedManifestList(String manifestName, Set<String> skippingSet) {
+        Set<String> manifests = new LinkedHashSet<>();
+        collectUnusedManifestList(manifestName, skippingSet, manifests);
+        List<Runnable> tasks = new ArrayList<>();
+        for (String manifest : manifests) {
+            tasks.add(() -> manifestFile.delete(manifest));
+        }
+        return tasks;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -58,8 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -199,7 +199,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     }
 
     public void cleanUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
-        deletePlannedDataFiles(Collections.singletonList(planUnusedDataFiles(manifestList, skipper)));
+        deletePlannedDataFiles(
+                Collections.singletonList(planUnusedDataFiles(manifestList, skipper)));
     }
 
     public DataFileDeletionPlan planUnusedDataFiles(
@@ -303,7 +304,9 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                                 manifest.fileName(), manifest.fileSize());
                     } catch (Exception e) {
                         // We want to delete the data file, so just ignore the unavailable files
-                        LOG.info("Failed to read manifest " + manifest.fileName() + ". Ignore it.", e);
+                        LOG.info(
+                                "Failed to read manifest " + manifest.fileName() + ". Ignore it.",
+                                e);
                         return Collections.emptyList();
                     }
                 },
@@ -682,6 +685,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         }
     }
 
+    /** Planned data files and bucket directories to clean. */
     public static class DataFileDeletionPlan {
 
         private final List<Path> dataFiles = new ArrayList<>();
@@ -715,6 +719,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         }
     }
 
+    /** Planned manifest, index, and statistics files to clean. */
     public static class ManifestDeletionPlan {
 
         private final List<String> manifests = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -68,7 +68,6 @@ import java.util.function.Predicate;
 public abstract class FileDeletionBase<T extends Snapshot> {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileDeletionBase.class);
-    private static final int DELETE_BATCH_MULTIPLIER = 4;
 
     protected final FileIO fileIO;
     protected final FileStorePathFactory pathFactory;
@@ -647,23 +646,13 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             return;
         }
 
-        int batchSize = deleteBatchSize();
-        List<CompletableFuture<Void>> deletionFutures =
-                new ArrayList<>(Math.min(files.size(), batchSize));
+        List<CompletableFuture<Void>> deletionFutures = new ArrayList<>(files.size());
         for (F file : files) {
             deletionFutures.add(
                     CompletableFuture.runAsync(() -> deletion.accept(file), fileExecutor));
-            if (deletionFutures.size() >= batchSize) {
-                waitForDeletion(deletionFutures);
-                deletionFutures.clear();
-            }
         }
 
         waitForDeletion(deletionFutures);
-    }
-
-    private int deleteBatchSize() {
-        return Math.max(1, fileOperationParallelism * DELETE_BATCH_MULTIPLIER);
     }
 
     private void waitForDeletion(List<CompletableFuture<Void>> deletionFutures) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -191,14 +191,9 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     }
 
     public List<Path> planUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
-        List<ManifestFileMeta> manifests = tryReadManifestList(manifestList);
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete = new HashMap<>();
-        try {
-            getDataFileToDelete(dataFileToDelete, readExpireFileEntries(manifests));
-        } catch (Exception e) {
-            // cancel deletion if any exception occurs
-            LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
+        if (!tryGetDataFileToDelete(dataFileToDelete, manifestList)) {
             return Collections.emptyList();
         }
 
@@ -262,6 +257,19 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
             List<ExpireFileEntry> dataFileEntries) {
         getDataFileToDelete(dataFileToDelete, (Iterable<ExpireFileEntry>) dataFileEntries);
+    }
+
+    private boolean tryGetDataFileToDelete(
+            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete, String manifestList) {
+        List<ManifestFileMeta> manifests = tryReadManifestList(manifestList);
+        try {
+            getDataFileToDelete(dataFileToDelete, readExpireFileEntries(manifests));
+            return true;
+        } catch (Exception e) {
+            // cancel deletion if any exception occurs
+            LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
+            return false;
+        }
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -37,11 +37,14 @@ import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.DataFilePathFactories;
 import org.apache.paimon.utils.FileOperationThreadPool;
 import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.ManifestReadThreadPool;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -50,11 +53,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -65,6 +70,7 @@ import java.util.function.Predicate;
 public abstract class FileDeletionBase<T extends Snapshot> {
 
     private static final Logger LOG = LoggerFactory.getLogger(FileDeletionBase.class);
+    private static final int DELETE_BATCH_MULTIPLIER = 4;
 
     protected final FileIO fileIO;
     protected final FileStorePathFactory pathFactory;
@@ -76,6 +82,8 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected final Map<BinaryRow, Set<Integer>> deletionBuckets;
 
     private final Executor fileExecutor;
+    private final int fileOperationParallelism;
+    @Nullable private final Integer manifestReadParallelism;
 
     protected boolean changelogDecoupled;
 
@@ -103,6 +111,13 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         this.cleanEmptyDirectories = cleanEmptyDirectories;
         this.deletionBuckets = new HashMap<>();
         this.fileExecutor = FileOperationThreadPool.getExecutorService(deleteFileThreadNum);
+        this.fileOperationParallelism =
+                Math.max(
+                        1,
+                        deleteFileThreadNum > 0
+                                ? deleteFileThreadNum
+                                : Runtime.getRuntime().availableProcessors());
+        this.manifestReadParallelism = deleteFileThreadNum > 0 ? deleteFileThreadNum : null;
     }
 
     public Executor fileExecutor() {
@@ -137,7 +152,6 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             return;
         }
 
-        // All directory paths are deduplicated and sorted by hierarchy level
         Map<Integer, Set<Path>> deduplicate = new HashMap<>();
         for (Map.Entry<BinaryRow, Set<Integer>> entry : deletionBuckets.entrySet()) {
             List<Path> toDeleteEmptyDirectory = new ArrayList<>();
@@ -176,32 +190,45 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                 .add(entry.bucket());
     }
 
+    private void recordDeletionBuckets(Map<BinaryRow, Set<Integer>> buckets) {
+        buckets.forEach(
+                (partition, bucketSet) ->
+                        deletionBuckets
+                                .computeIfAbsent(partition, p -> new HashSet<>())
+                                .addAll(bucketSet));
+    }
+
     public void cleanUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
-        // try read manifests
+        deletePlannedDataFiles(Collections.singletonList(planUnusedDataFiles(manifestList, skipper)));
+    }
+
+    public DataFileDeletionPlan planUnusedDataFiles(
+            String manifestList, Predicate<ExpireFileEntry> skipper) {
         List<ManifestFileMeta> manifests = tryReadManifestList(manifestList);
-        List<ExpireFileEntry> manifestEntries;
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete = new HashMap<>();
-        for (ManifestFileMeta manifest : manifests) {
-            try {
-                manifestEntries =
-                        manifestFile.readExpireFileEntries(
-                                manifest.fileName(), manifest.fileSize());
-            } catch (Exception e) {
-                // cancel deletion if any exception occurs
-                LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
-                return;
-            }
-
-            getDataFileToDelete(dataFileToDelete, manifestEntries);
+        try {
+            getDataFileToDelete(dataFileToDelete, readExpireFileEntries(manifests));
+        } catch (Exception e) {
+            // cancel deletion if any exception occurs
+            LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
+            return DataFileDeletionPlan.empty();
         }
 
-        doCleanUnusedDataFile(dataFileToDelete, skipper);
+        return planUnusedDataFile(dataFileToDelete, skipper);
     }
 
     protected void doCleanUnusedDataFile(
             Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
             Predicate<ExpireFileEntry> skipper) {
+        deletePlannedDataFiles(
+                Collections.singletonList(planUnusedDataFile(dataFileToDelete, skipper)));
+    }
+
+    protected DataFileDeletionPlan planUnusedDataFile(
+            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
+            Predicate<ExpireFileEntry> skipper) {
+        DataFileDeletionPlan plan = new DataFileDeletionPlan();
         List<Path> actualDataFileToDelete = new ArrayList<>();
         dataFileToDelete.forEach(
                 (path, pair) -> {
@@ -212,15 +239,16 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                         actualDataFileToDelete.add(path);
                         actualDataFileToDelete.addAll(pair.getRight());
 
-                        recordDeletionBuckets(entry);
+                        plan.recordDeletionBucket(entry);
                     }
                 });
-        deleteFiles(actualDataFileToDelete, fileIO::deleteQuietly);
+        plan.addDataFiles(actualDataFileToDelete);
+        return plan;
     }
 
     protected void getDataFileToDelete(
             Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
-            List<ExpireFileEntry> dataFileEntries) {
+            Iterable<ExpireFileEntry> dataFileEntries) {
         // we cannot delete a data file directly when we meet a DELETE entry, because that
         // file might be upgraded
         DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
@@ -246,48 +274,102 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         }
     }
 
+    protected void getDataFileToDelete(
+            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
+            List<ExpireFileEntry> dataFileEntries) {
+        getDataFileToDelete(dataFileToDelete, (Iterable<ExpireFileEntry>) dataFileEntries);
+    }
+
     /**
      * Delete added file in the manifest list files. Added files marked as "ADD" in manifests.
      *
      * @param manifestListName name of manifest list
      */
     public void deleteAddedDataFiles(String manifestListName) {
-        List<ManifestFileMeta> manifests = tryReadManifestList(manifestListName);
-        for (ManifestFileMeta manifest : manifests) {
-            try {
-                List<ExpireFileEntry> manifestEntries =
-                        manifestFile.readExpireFileEntries(
-                                manifest.fileName(), manifest.fileSize());
-                deleteAddedDataFiles(manifestEntries);
-            } catch (Exception e) {
-                // We want to delete the data file, so just ignore the unavailable files
-                LOG.info("Failed to read manifest " + manifest.fileName() + ". Ignore it.", e);
-            }
-        }
+        deletePlannedDataFiles(Collections.singletonList(planAddedDataFiles(manifestListName)));
     }
 
-    private void deleteAddedDataFiles(List<ExpireFileEntry> manifestEntries) {
-        List<Path> dataFileToDelete = new ArrayList<>();
+    public DataFileDeletionPlan planAddedDataFiles(String manifestListName) {
+        List<ManifestFileMeta> manifests = tryReadManifestList(manifestListName);
+        return planAddedDataFiles(readExpireFileEntriesIgnoringErrors(manifests));
+    }
+
+    private Iterable<ExpireFileEntry> readExpireFileEntriesIgnoringErrors(
+            List<ManifestFileMeta> manifests) {
+        return ManifestReadThreadPool.sequentialBatchedExecute(
+                manifest -> {
+                    try {
+                        return manifestFile.readExpireFileEntries(
+                                manifest.fileName(), manifest.fileSize());
+                    } catch (Exception e) {
+                        // We want to delete the data file, so just ignore the unavailable files
+                        LOG.info("Failed to read manifest " + manifest.fileName() + ". Ignore it.", e);
+                        return Collections.emptyList();
+                    }
+                },
+                manifests,
+                manifestReadParallelism);
+    }
+
+    private Iterable<ExpireFileEntry> readExpireFileEntries(List<ManifestFileMeta> manifests) {
+        return ManifestReadThreadPool.sequentialBatchedExecute(
+                manifest ->
+                        manifestFile.readExpireFileEntries(
+                                manifest.fileName(), manifest.fileSize()),
+                manifests,
+                manifestReadParallelism);
+    }
+
+    private DataFileDeletionPlan planAddedDataFiles(Iterable<ExpireFileEntry> manifestEntries) {
+        DataFileDeletionPlan plan = new DataFileDeletionPlan();
         DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
         for (ExpireFileEntry entry : manifestEntries) {
             DataFilePathFactory dataFilePathFactory =
                     factories.get(entry.partition(), entry.bucket());
             if (entry.kind() == FileKind.ADD) {
-                dataFileToDelete.add(dataFilePathFactory.toPath(entry));
-                recordDeletionBuckets(entry);
+                plan.addDataFile(dataFilePathFactory.toPath(entry));
+                plan.recordDeletionBucket(entry);
             }
         }
-        deleteFiles(dataFileToDelete, fileIO::deleteQuietly);
+        return plan;
+    }
+
+    private DataFileDeletionPlan planAddedDataFiles(List<ExpireFileEntry> manifestEntries) {
+        return planAddedDataFiles((Iterable<ExpireFileEntry>) manifestEntries);
+    }
+
+    public void deletePlannedDataFiles(Collection<DataFileDeletionPlan> plans) {
+        Set<Path> dataFiles = new LinkedHashSet<>();
+        for (DataFileDeletionPlan plan : plans) {
+            dataFiles.addAll(plan.dataFiles);
+            recordDeletionBuckets(plan.deletionBuckets);
+        }
+        deleteFiles(dataFiles, fileIO::deleteQuietly);
     }
 
     public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
         // clean statistics
+        deletePlannedManifests(
+                Collections.singletonList(planUnusedStatisticsManifests(snapshot, skippingSet)));
+    }
+
+    public ManifestDeletionPlan planUnusedStatisticsManifests(
+            Snapshot snapshot, Set<String> skippingSet) {
+        ManifestDeletionPlan plan = new ManifestDeletionPlan();
         if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
-            statsFileHandler.deleteStats(snapshot.statistics());
+            plan.addStatistic(snapshot.statistics());
         }
+        return plan;
     }
 
     public void cleanUnusedIndexManifests(Snapshot snapshot, Set<String> skippingSet) {
+        deletePlannedManifests(
+                Collections.singletonList(planUnusedIndexManifests(snapshot, skippingSet)));
+    }
+
+    public ManifestDeletionPlan planUnusedIndexManifests(
+            Snapshot snapshot, Set<String> skippingSet) {
+        ManifestDeletionPlan plan = new ManifestDeletionPlan();
         // clean index manifests
         String indexManifest = snapshot.indexManifest();
         // check exists, it may have been deleted by other snapshots
@@ -296,21 +378,34 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             try {
                 indexManifestEntries = indexFileHandler.readManifestWithIOException(indexManifest);
             } catch (FileNotFoundException e) {
-                return;
+                return plan;
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
             indexManifestEntries.removeIf(
                     entry -> skippingSet.contains(entry.indexFile().fileName()));
-            deleteFiles(indexManifestEntries, indexFileHandler::deleteIndexFile);
+            plan.addIndexFiles(indexManifestEntries);
 
             if (!skippingSet.contains(indexManifest)) {
-                indexFileHandler.deleteManifest(indexManifest);
+                plan.addIndexManifest(indexManifest);
             }
         }
+        return plan;
     }
 
     public void cleanUnusedManifestList(String manifestName, Set<String> skippingSet) {
+        deletePlannedManifests(
+                Collections.singletonList(planUnusedManifestList(manifestName, skippingSet)));
+    }
+
+    public ManifestDeletionPlan planUnusedManifestList(
+            String manifestName, Set<String> skippingSet) {
+        return planUnusedManifestList(manifestName, skippingSet, true);
+    }
+
+    private ManifestDeletionPlan planUnusedManifestList(
+            String manifestName, Set<String> skippingSet, boolean updateSkippingSet) {
+        ManifestDeletionPlan plan = new ManifestDeletionPlan();
         List<String> toDeleteManifests = new ArrayList<>();
         List<ManifestFileMeta> toExpireManifests = tryReadManifestList(manifestName);
         for (ManifestFileMeta manifest : toExpireManifests) {
@@ -318,14 +413,17 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             if (!skippingSet.contains(fileName)) {
                 toDeleteManifests.add(fileName);
                 // to avoid other snapshots trying to delete again
-                skippingSet.add(fileName);
+                if (updateSkippingSet) {
+                    skippingSet.add(fileName);
+                }
             }
         }
         if (!skippingSet.contains(manifestName)) {
             toDeleteManifests.add(manifestName);
         }
 
-        deleteFiles(toDeleteManifests, manifestFile::delete);
+        plan.addManifestFiles(toDeleteManifests);
+        return plan;
     }
 
     protected void cleanUnusedManifests(
@@ -333,6 +431,28 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             Set<String> skippingSet,
             boolean deleteDataManifestLists,
             boolean deleteChangelog) {
+        deletePlannedManifests(
+                Collections.singletonList(
+                        planUnusedManifests(
+                                snapshot, skippingSet, deleteDataManifestLists, deleteChangelog)));
+    }
+
+    protected ManifestDeletionPlan planUnusedManifests(
+            Snapshot snapshot,
+            Set<String> skippingSet,
+            boolean deleteDataManifestLists,
+            boolean deleteChangelog) {
+        return planUnusedManifests(
+                snapshot, skippingSet, deleteDataManifestLists, deleteChangelog, true);
+    }
+
+    protected ManifestDeletionPlan planUnusedManifests(
+            Snapshot snapshot,
+            Set<String> skippingSet,
+            boolean deleteDataManifestLists,
+            boolean deleteChangelog,
+            boolean updateSkippingSet) {
+        ManifestDeletionPlan plan = new ManifestDeletionPlan();
         if (deleteDataManifestLists) {
             // deleteDataManifestLists will be false
             // with changelog decouple + none changelog producer.
@@ -341,14 +461,39 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             // For none changelog producer, changelog files are the level 0 files.
             // Even if these files are not used by the earliest snapshot,
             // we have to keep them as changelog, and clean then in ChangelogDeletion.
-            cleanUnusedManifestList(snapshot.baseManifestList(), skippingSet);
-            cleanUnusedManifestList(snapshot.deltaManifestList(), skippingSet);
+            plan.merge(
+                    planUnusedManifestList(
+                            snapshot.baseManifestList(), skippingSet, updateSkippingSet));
+            plan.merge(
+                    planUnusedManifestList(
+                            snapshot.deltaManifestList(), skippingSet, updateSkippingSet));
         }
         if (deleteChangelog && snapshot.changelogManifestList() != null) {
-            cleanUnusedManifestList(snapshot.changelogManifestList(), skippingSet);
+            plan.merge(
+                    planUnusedManifestList(
+                            snapshot.changelogManifestList(), skippingSet, updateSkippingSet));
         }
-        cleanUnusedIndexManifests(snapshot, skippingSet);
-        cleanUnusedStatisticsManifests(snapshot, skippingSet);
+        plan.merge(planUnusedIndexManifests(snapshot, skippingSet));
+        plan.merge(planUnusedStatisticsManifests(snapshot, skippingSet));
+        return plan;
+    }
+
+    public void deletePlannedManifests(Collection<ManifestDeletionPlan> plans) {
+        Set<String> manifests = new LinkedHashSet<>();
+        Set<IndexManifestEntry> indexFiles = new LinkedHashSet<>();
+        Set<String> indexManifests = new LinkedHashSet<>();
+        Set<String> statistics = new LinkedHashSet<>();
+        for (ManifestDeletionPlan plan : plans) {
+            manifests.addAll(plan.manifests);
+            indexFiles.addAll(plan.indexFiles);
+            indexManifests.addAll(plan.indexManifests);
+            statistics.addAll(plan.statistics);
+        }
+
+        deleteFiles(manifests, manifestFile::delete);
+        deleteFiles(indexFiles, indexFileHandler::deleteIndexFile);
+        deleteFiles(indexManifests, indexFileHandler::deleteManifest);
+        deleteFiles(statistics, statsFileHandler::deleteStats);
     }
 
     public Predicate<ExpireFileEntry> createDataFileSkipperForTags(
@@ -367,6 +512,12 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             return entry -> containsDataFile(cachedTagDataFiles, entry);
         }
         return entry -> false;
+    }
+
+    public Predicate<ExpireFileEntry> createDataFileSkipperForTag(Snapshot tag) throws Exception {
+        Map<BinaryRow, Map<Integer, Set<String>>> tagDataFiles = new HashMap<>();
+        addMergedDataFiles(tagDataFiles, tag);
+        return entry -> containsDataFile(tagDataFiles, entry);
     }
 
     /**
@@ -403,12 +554,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected Collection<ExpireFileEntry> readMergedDataFiles(List<ManifestFileMeta> manifests)
             throws IOException {
         Map<Identifier, ExpireFileEntry> map = new HashMap<>();
-        for (ManifestFileMeta manifest : manifests) {
-            List<ExpireFileEntry> entries =
-                    manifestFile.readExpireFileEntries(manifest.fileName(), manifest.fileSize());
-            FileEntry.mergeEntries(entries, map);
-        }
-
+        FileEntry.mergeEntries(readExpireFileEntries(manifests), map);
         return map.values();
     }
 
@@ -425,30 +571,63 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     }
 
     public Set<String> manifestSkippingSet(List<Snapshot> skippingSnapshots) {
+        if (skippingSnapshots.size() <= 1) {
+            Set<String> skippingSet = new HashSet<>();
+            for (Snapshot skippingSnapshot : skippingSnapshots) {
+                skippingSet.addAll(manifestSkippingSet(skippingSnapshot));
+            }
+            return skippingSet;
+        }
+
+        List<CompletableFuture<Set<String>>> futures = new ArrayList<>();
+        for (Snapshot skippingSnapshot : skippingSnapshots) {
+            futures.add(
+                    CompletableFuture.supplyAsync(
+                            () -> manifestSkippingSet(skippingSnapshot),
+                            ManifestReadThreadPool.getExecutorService(manifestReadParallelism)));
+        }
+
+        Set<String> skippingSet = new HashSet<>();
+        for (CompletableFuture<Set<String>> future : futures) {
+            skippingSet.addAll(getSkippingSet(future));
+        }
+        return skippingSet;
+    }
+
+    private Set<String> getSkippingSet(CompletableFuture<Set<String>> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    private Set<String> manifestSkippingSet(Snapshot skippingSnapshot) {
         Set<String> skippingSet = new HashSet<>();
 
-        for (Snapshot skippingSnapshot : skippingSnapshots) {
-            // data manifests
-            skippingSet.add(skippingSnapshot.baseManifestList());
-            skippingSet.add(skippingSnapshot.deltaManifestList());
-            manifestList.readDataManifests(skippingSnapshot).stream()
-                    .map(ManifestFileMeta::fileName)
+        // data manifests
+        skippingSet.add(skippingSnapshot.baseManifestList());
+        skippingSet.add(skippingSnapshot.deltaManifestList());
+        manifestList.readDataManifests(skippingSnapshot).stream()
+                .map(ManifestFileMeta::fileName)
+                .forEach(skippingSet::add);
+
+        // index manifests
+        String indexManifest = skippingSnapshot.indexManifest();
+        if (indexManifest != null) {
+            skippingSet.add(indexManifest);
+            indexFileHandler.readManifest(indexManifest).stream()
+                    .map(IndexManifestEntry::indexFile)
+                    .map(IndexFileMeta::fileName)
                     .forEach(skippingSet::add);
+        }
 
-            // index manifests
-            String indexManifest = skippingSnapshot.indexManifest();
-            if (indexManifest != null) {
-                skippingSet.add(indexManifest);
-                indexFileHandler.readManifest(indexManifest).stream()
-                        .map(IndexManifestEntry::indexFile)
-                        .map(IndexFileMeta::fileName)
-                        .forEach(skippingSet::add);
-            }
-
-            // statistics
-            if (skippingSnapshot.statistics() != null) {
-                skippingSet.add(skippingSnapshot.statistics());
-            }
+        // statistics
+        if (skippingSnapshot.statistics() != null) {
+            skippingSet.add(skippingSnapshot.statistics());
         }
 
         return skippingSet;
@@ -469,16 +648,105 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             return;
         }
 
-        List<CompletableFuture<Void>> deletionFutures = new ArrayList<>(files.size());
+        int batchSize = deleteBatchSize();
+        List<CompletableFuture<Void>> deletionFutures =
+                new ArrayList<>(Math.min(files.size(), batchSize));
         for (F file : files) {
             deletionFutures.add(
                     CompletableFuture.runAsync(() -> deletion.accept(file), fileExecutor));
+            if (deletionFutures.size() >= batchSize) {
+                waitForDeletion(deletionFutures);
+                deletionFutures.clear();
+            }
+        }
+
+        waitForDeletion(deletionFutures);
+    }
+
+    private int deleteBatchSize() {
+        return Math.max(1, fileOperationParallelism * DELETE_BATCH_MULTIPLIER);
+    }
+
+    private void waitForDeletion(List<CompletableFuture<Void>> deletionFutures) {
+        if (deletionFutures.isEmpty()) {
+            return;
         }
 
         try {
             CompletableFuture.allOf(deletionFutures.toArray(new CompletableFuture[0])).get();
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    public static class DataFileDeletionPlan {
+
+        private final List<Path> dataFiles = new ArrayList<>();
+        private final Map<BinaryRow, Set<Integer>> deletionBuckets = new HashMap<>();
+
+        public static DataFileDeletionPlan empty() {
+            return new DataFileDeletionPlan();
+        }
+
+        private void addDataFile(Path path) {
+            dataFiles.add(path);
+        }
+
+        private void addDataFiles(Collection<Path> paths) {
+            dataFiles.addAll(paths);
+        }
+
+        private void recordDeletionBucket(ExpireFileEntry entry) {
+            deletionBuckets
+                    .computeIfAbsent(entry.partition(), p -> new HashSet<>())
+                    .add(entry.bucket());
+        }
+
+        private void merge(DataFileDeletionPlan plan) {
+            dataFiles.addAll(plan.dataFiles);
+            plan.deletionBuckets.forEach(
+                    (partition, bucketSet) ->
+                            deletionBuckets
+                                    .computeIfAbsent(partition, p -> new HashSet<>())
+                                    .addAll(bucketSet));
+        }
+    }
+
+    public static class ManifestDeletionPlan {
+
+        private final List<String> manifests = new ArrayList<>();
+        private final List<IndexManifestEntry> indexFiles = new ArrayList<>();
+        private final List<String> indexManifests = new ArrayList<>();
+        private final List<String> statistics = new ArrayList<>();
+
+        public static ManifestDeletionPlan empty() {
+            return new ManifestDeletionPlan();
+        }
+
+        private void addManifestFiles(Collection<String> manifestFiles) {
+            manifests.addAll(manifestFiles);
+        }
+
+        private void addIndexFiles(Collection<IndexManifestEntry> files) {
+            indexFiles.addAll(files);
+        }
+
+        private void addIndexManifest(String indexManifest) {
+            indexManifests.add(indexManifest);
+        }
+
+        private void addStatistic(String statistic) {
+            statistics.add(statistic);
+        }
+
+        private void merge(ManifestDeletionPlan plan) {
+            manifests.addAll(plan.manifests);
+            indexFiles.addAll(plan.indexFiles);
+            indexManifests.addAll(plan.indexManifests);
+            statistics.addAll(plan.statistics);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -527,13 +527,12 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     }
 
     public void executeAll(Collection<Runnable> tasks) {
-        Collection<Runnable> deduplicatedTasks = new LinkedHashSet<>(tasks);
-        if (deduplicatedTasks.isEmpty()) {
+        if (tasks.isEmpty()) {
             return;
         }
 
-        List<CompletableFuture<Void>> futures = new ArrayList<>(deduplicatedTasks.size());
-        for (Runnable runnable : deduplicatedTasks) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>(tasks.size());
+        for (Runnable runnable : tasks) {
             futures.add(CompletableFuture.runAsync(runnable, fileExecutor));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -527,12 +527,13 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     }
 
     public void executeAll(Collection<Runnable> tasks) {
-        if (tasks.isEmpty()) {
+        Collection<Runnable> deduplicatedTasks = new LinkedHashSet<>(tasks);
+        if (deduplicatedTasks.isEmpty()) {
             return;
         }
 
-        List<CompletableFuture<Void>> futures = new ArrayList<>(tasks.size());
-        for (Runnable runnable : tasks) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>(deduplicatedTasks.size());
+        for (Runnable runnable : deduplicatedTasks) {
             futures.add(CompletableFuture.runAsync(runnable, fileExecutor));
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -108,12 +108,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         this.cleanEmptyDirectories = cleanEmptyDirectories;
         this.deletionBuckets = new ConcurrentHashMap<>();
         this.fileExecutor = FileOperationThreadPool.getExecutorService(fileOperationThreadNum);
-        this.fileOperationParallelism =
-                Math.max(
-                        1,
-                        fileOperationThreadNum > 0
-                                ? fileOperationThreadNum
-                                : Runtime.getRuntime().availableProcessors());
+        this.fileOperationParallelism = fileOperationThreadNum;
     }
 
     public Executor fileExecutor() {
@@ -127,7 +122,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
      * @param skipper if the test result of a data file is true, it will be skipped when deleting;
      *     else it will be deleted
      */
-    public abstract void cleanUnusedDataFiles(T snapshot, Predicate<ExpireFileEntry> skipper);
+    public abstract void cleanDeletedDataFiles(T snapshot, Predicate<ExpireFileEntry> skipper);
 
     /**
      * Clean metadata files that will not be used anymore of a snapshot, including data manifests,
@@ -155,7 +150,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             for (Integer bucket : entry.getValue()) {
                 toDeleteEmptyDirectory.add(pathFactory.bucketPath(entry.getKey(), bucket));
             }
-            deleteFiles(toDeleteEmptyDirectory, this::tryDeleteEmptyDirectory);
+            executeAll(toDeleteEmptyDirectory, this::tryDeleteEmptyDirectory);
 
             List<Path> hierarchicalPaths = pathFactory.getHierarchicalPartitionPath(entry.getKey());
             int hierarchies = hierarchicalPaths.size();
@@ -186,29 +181,44 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                 .add(entry.bucket());
     }
 
-    public void cleanUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
-        deleteDataFiles(planUnusedDataFiles(manifestList, skipper));
-    }
-
-    public List<Path> planUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
+    /** Plan data files referenced by DELETE entries in the snapshot's delta manifest list. */
+    public List<Path> planDeletedInDeltaManifest(T snapshot, Predicate<ExpireFileEntry> skipper) {
+        String deltaManifestList = snapshot.deltaManifestList();
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete = new HashMap<>();
-        if (!tryGetDataFileToDelete(dataFileToDelete, manifestList)) {
+        try {
+            Iterable<ExpireFileEntry> dataFileEntries =
+                    readExpireFileEntries(tryReadManifestList(deltaManifestList));
+            // we cannot delete a data file directly when we meet a DELETE entry, because that
+            // file might be upgraded
+            DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
+            for (ExpireFileEntry entry : dataFileEntries) {
+                DataFilePathFactory dataFilePathFactory =
+                        factories.get(entry.partition(), entry.bucket());
+                Path dataFilePath = dataFilePathFactory.toPath(entry);
+                switch (entry.kind()) {
+                    case ADD:
+                        dataFileToDelete.remove(dataFilePath);
+                        break;
+                    case DELETE:
+                        List<Path> extraFiles = new ArrayList<>(entry.extraFiles().size());
+                        for (String file : entry.extraFiles()) {
+                            extraFiles.add(dataFilePathFactory.toAlignedPath(file, entry));
+                        }
+                        dataFileToDelete.put(dataFilePath, Pair.of(entry, extraFiles));
+                        break;
+                    default:
+                        throw new UnsupportedOperationException(
+                                "Unknown value kind " + entry.kind().name());
+                }
+            }
+        } catch (Exception e) {
+            // cancel deletion if any exception occurs
+            LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
             return Collections.emptyList();
         }
 
-        return planUnusedDataFile(dataFileToDelete, skipper);
-    }
-
-    protected void doCleanUnusedDataFile(
-            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
-            Predicate<ExpireFileEntry> skipper) {
-        deleteDataFiles(planUnusedDataFile(dataFileToDelete, skipper));
-    }
-
-    protected List<Path> planUnusedDataFile(
-            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
-            Predicate<ExpireFileEntry> skipper) {
+        // apply skipper
         List<Path> actualDataFileToDelete = new ArrayList<>();
         dataFileToDelete.forEach(
                 (path, pair) -> {
@@ -225,84 +235,39 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         return actualDataFileToDelete;
     }
 
-    protected void getDataFileToDelete(
-            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
-            Iterable<ExpireFileEntry> dataFileEntries) {
-        // we cannot delete a data file directly when we meet a DELETE entry, because that
-        // file might be upgraded
+    /** Plan data files referenced by ADD entries in the snapshot's changelog manifest list. */
+    public List<Path> planAddedInChangelogManifest(T snapshot) {
+        List<ManifestFileMeta> manifests = tryReadManifestList(snapshot.changelogManifestList());
+        Iterable<ExpireFileEntry> entries =
+                ManifestReadThreadPool.sequentialBatchedExecute(
+                        manifest -> {
+                            try {
+                                return manifestFile.readExpireFileEntries(
+                                        manifest.fileName(), manifest.fileSize());
+                            } catch (Exception e) {
+                                // We want to delete the data file, so just ignore the unavailable
+                                // files
+                                LOG.info(
+                                        "Failed to read manifest {}. Ignore it.",
+                                        manifest.fileName(),
+                                        e);
+                                return Collections.emptyList();
+                            }
+                        },
+                        manifests,
+                        fileOperationParallelism);
+
+        List<Path> dataFiles = new ArrayList<>();
         DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
-        for (ExpireFileEntry entry : dataFileEntries) {
+        for (ExpireFileEntry entry : entries) {
             DataFilePathFactory dataFilePathFactory =
                     factories.get(entry.partition(), entry.bucket());
-            Path dataFilePath = dataFilePathFactory.toPath(entry);
-            switch (entry.kind()) {
-                case ADD:
-                    dataFileToDelete.remove(dataFilePath);
-                    break;
-                case DELETE:
-                    List<Path> extraFiles = new ArrayList<>(entry.extraFiles().size());
-                    for (String file : entry.extraFiles()) {
-                        extraFiles.add(dataFilePathFactory.toAlignedPath(file, entry));
-                    }
-                    dataFileToDelete.put(dataFilePath, Pair.of(entry, extraFiles));
-                    break;
-                default:
-                    throw new UnsupportedOperationException(
-                            "Unknown value kind " + entry.kind().name());
+            if (entry.kind() == FileKind.ADD) {
+                dataFiles.add(dataFilePathFactory.toPath(entry));
+                recordDeletionBuckets(entry);
             }
         }
-    }
-
-    protected void getDataFileToDelete(
-            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
-            List<ExpireFileEntry> dataFileEntries) {
-        getDataFileToDelete(dataFileToDelete, (Iterable<ExpireFileEntry>) dataFileEntries);
-    }
-
-    private boolean tryGetDataFileToDelete(
-            Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete, String manifestList) {
-        List<ManifestFileMeta> manifests = tryReadManifestList(manifestList);
-        try {
-            getDataFileToDelete(dataFileToDelete, readExpireFileEntries(manifests));
-            return true;
-        } catch (Exception e) {
-            // cancel deletion if any exception occurs
-            LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
-            return false;
-        }
-    }
-
-    /**
-     * Delete added file in the manifest list files. Added files marked as "ADD" in manifests.
-     *
-     * @param manifestListName name of manifest list
-     */
-    public void deleteAddedDataFiles(String manifestListName) {
-        deleteDataFiles(planAddedDataFiles(manifestListName));
-    }
-
-    public List<Path> planAddedDataFiles(String manifestListName) {
-        List<ManifestFileMeta> manifests = tryReadManifestList(manifestListName);
-        return planAddedDataFiles(readExpireFileEntriesIgnoringErrors(manifests));
-    }
-
-    private Iterable<ExpireFileEntry> readExpireFileEntriesIgnoringErrors(
-            List<ManifestFileMeta> manifests) {
-        return ManifestReadThreadPool.sequentialBatchedExecute(
-                manifest -> {
-                    try {
-                        return manifestFile.readExpireFileEntries(
-                                manifest.fileName(), manifest.fileSize());
-                    } catch (Exception e) {
-                        // We want to delete the data file, so just ignore the unavailable files
-                        LOG.info(
-                                "Failed to read manifest " + manifest.fileName() + ". Ignore it.",
-                                e);
-                        return Collections.emptyList();
-                    }
-                },
-                manifests,
-                fileOperationParallelism);
+        return dataFiles;
     }
 
     private Iterable<ExpireFileEntry> readExpireFileEntries(List<ManifestFileMeta> manifests) {
@@ -314,46 +279,22 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                 fileOperationParallelism);
     }
 
-    private List<Path> planAddedDataFiles(Iterable<ExpireFileEntry> manifestEntries) {
-        List<Path> dataFiles = new ArrayList<>();
-        DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
-        for (ExpireFileEntry entry : manifestEntries) {
-            DataFilePathFactory dataFilePathFactory =
-                    factories.get(entry.partition(), entry.bucket());
-            if (entry.kind() == FileKind.ADD) {
-                dataFiles.add(dataFilePathFactory.toPath(entry));
-                recordDeletionBuckets(entry);
-            }
+    public void cleanDataFiles(Collection<Path> dataFiles) {
+        executeAll(new LinkedHashSet<>(dataFiles), fileIO::deleteQuietly);
+    }
+
+    private void collectUnusedStatisticsManifests(
+            Snapshot snapshot, Set<String> skippingSet, Set<String> statistics) {
+        if (snapshot.statistics() != null && skippingSet.add(snapshot.statistics())) {
+            statistics.add(snapshot.statistics());
         }
-        return dataFiles;
     }
 
-    public void deleteDataFiles(Collection<Path> dataFiles) {
-        deleteFiles(new LinkedHashSet<>(dataFiles), fileIO::deleteQuietly);
-    }
-
-    public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
-        deletePlannedManifests(
-                Collections.singletonList(planUnusedStatisticsManifests(snapshot, skippingSet)));
-    }
-
-    public ManifestDeletionPlan planUnusedStatisticsManifests(
-            Snapshot snapshot, Set<String> skippingSet) {
-        ManifestDeletionPlan plan = new ManifestDeletionPlan();
-        if (snapshot.statistics() != null && !skippingSet.contains(snapshot.statistics())) {
-            plan.addStatistic(snapshot.statistics());
-        }
-        return plan;
-    }
-
-    public void cleanUnusedIndexManifests(Snapshot snapshot, Set<String> skippingSet) {
-        deletePlannedManifests(
-                Collections.singletonList(planUnusedIndexManifests(snapshot, skippingSet)));
-    }
-
-    public ManifestDeletionPlan planUnusedIndexManifests(
-            Snapshot snapshot, Set<String> skippingSet) {
-        ManifestDeletionPlan plan = new ManifestDeletionPlan();
+    private void collectUnusedIndexManifests(
+            Snapshot snapshot,
+            Set<String> skippingSet,
+            Set<IndexManifestEntry> indexFiles,
+            Set<String> indexManifests) {
         // clean index manifests
         String indexManifest = snapshot.indexManifest();
         // check exists, it may have been deleted by other snapshots
@@ -362,81 +303,45 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             try {
                 indexManifestEntries = indexFileHandler.readManifestWithIOException(indexManifest);
             } catch (FileNotFoundException e) {
-                return plan;
+                return;
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            indexManifestEntries.removeIf(
-                    entry -> skippingSet.contains(entry.indexFile().fileName()));
-            plan.addIndexFiles(indexManifestEntries);
+            for (IndexManifestEntry entry : indexManifestEntries) {
+                if (skippingSet.add(entry.indexFile().fileName())) {
+                    indexFiles.add(entry);
+                }
+            }
 
-            if (!skippingSet.contains(indexManifest)) {
-                plan.addIndexManifest(indexManifest);
+            if (skippingSet.add(indexManifest)) {
+                indexManifests.add(indexManifest);
             }
         }
-        return plan;
     }
 
-    public void cleanUnusedManifestList(String manifestName, Set<String> skippingSet) {
-        deletePlannedManifests(
-                Collections.singletonList(planUnusedManifestList(manifestName, skippingSet)));
-    }
-
-    public ManifestDeletionPlan planUnusedManifestList(
-            String manifestName, Set<String> skippingSet) {
-        return planUnusedManifestList(manifestName, skippingSet, true);
-    }
-
-    private ManifestDeletionPlan planUnusedManifestList(
-            String manifestName, Set<String> skippingSet, boolean updateSkippingSet) {
-        ManifestDeletionPlan plan = new ManifestDeletionPlan();
-        List<String> toDeleteManifests = new ArrayList<>();
+    protected void collectUnusedManifestList(
+            String manifestName, Set<String> skippingSet, Set<String> manifests) {
         List<ManifestFileMeta> toExpireManifests = tryReadManifestList(manifestName);
         for (ManifestFileMeta manifest : toExpireManifests) {
             String fileName = manifest.fileName();
-            if (!skippingSet.contains(fileName)) {
-                toDeleteManifests.add(fileName);
-                // to avoid other snapshots trying to delete again
-                if (updateSkippingSet) {
-                    skippingSet.add(fileName);
-                }
+            if (skippingSet.add(fileName)) {
+                manifests.add(fileName);
             }
         }
-        if (!skippingSet.contains(manifestName)) {
-            toDeleteManifests.add(manifestName);
+        if (skippingSet.add(manifestName)) {
+            manifests.add(manifestName);
         }
-
-        plan.addManifestFiles(toDeleteManifests);
-        return plan;
     }
 
-    protected void cleanUnusedManifests(
+    protected List<Runnable> planManifestsCleaner(
             Snapshot snapshot,
             Set<String> skippingSet,
             boolean deleteDataManifestLists,
             boolean deleteChangelog) {
-        deletePlannedManifests(
-                Collections.singletonList(
-                        planUnusedManifests(
-                                snapshot, skippingSet, deleteDataManifestLists, deleteChangelog)));
-    }
-
-    protected ManifestDeletionPlan planUnusedManifests(
-            Snapshot snapshot,
-            Set<String> skippingSet,
-            boolean deleteDataManifestLists,
-            boolean deleteChangelog) {
-        return planUnusedManifests(
-                snapshot, skippingSet, deleteDataManifestLists, deleteChangelog, true);
-    }
-
-    protected ManifestDeletionPlan planUnusedManifests(
-            Snapshot snapshot,
-            Set<String> skippingSet,
-            boolean deleteDataManifestLists,
-            boolean deleteChangelog,
-            boolean updateSkippingSet) {
-        ManifestDeletionPlan plan = new ManifestDeletionPlan();
+        Set<String> manifests = new LinkedHashSet<>();
+        Set<IndexManifestEntry> indexFiles = new LinkedHashSet<>();
+        Set<String> indexManifests = new LinkedHashSet<>();
+        Set<String> statistics = new LinkedHashSet<>();
         if (deleteDataManifestLists) {
             // deleteDataManifestLists will be false
             // with changelog decouple + none changelog producer.
@@ -445,39 +350,29 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             // For none changelog producer, changelog files are the level 0 files.
             // Even if these files are not used by the earliest snapshot,
             // we have to keep them as changelog, and clean then in ChangelogDeletion.
-            plan.merge(
-                    planUnusedManifestList(
-                            snapshot.baseManifestList(), skippingSet, updateSkippingSet));
-            plan.merge(
-                    planUnusedManifestList(
-                            snapshot.deltaManifestList(), skippingSet, updateSkippingSet));
+            collectUnusedManifestList(snapshot.baseManifestList(), skippingSet, manifests);
+            collectUnusedManifestList(snapshot.deltaManifestList(), skippingSet, manifests);
         }
         if (deleteChangelog && snapshot.changelogManifestList() != null) {
-            plan.merge(
-                    planUnusedManifestList(
-                            snapshot.changelogManifestList(), skippingSet, updateSkippingSet));
+            collectUnusedManifestList(snapshot.changelogManifestList(), skippingSet, manifests);
         }
-        plan.merge(planUnusedIndexManifests(snapshot, skippingSet));
-        plan.merge(planUnusedStatisticsManifests(snapshot, skippingSet));
-        return plan;
-    }
+        collectUnusedIndexManifests(snapshot, skippingSet, indexFiles, indexManifests);
+        collectUnusedStatisticsManifests(snapshot, skippingSet, statistics);
 
-    public void deletePlannedManifests(Collection<ManifestDeletionPlan> plans) {
-        Set<String> manifests = new LinkedHashSet<>();
-        Set<IndexManifestEntry> indexFiles = new LinkedHashSet<>();
-        Set<String> indexManifests = new LinkedHashSet<>();
-        Set<String> statistics = new LinkedHashSet<>();
-        for (ManifestDeletionPlan plan : plans) {
-            manifests.addAll(plan.manifests);
-            indexFiles.addAll(plan.indexFiles);
-            indexManifests.addAll(plan.indexManifests);
-            statistics.addAll(plan.statistics);
+        List<Runnable> tasks = new ArrayList<>();
+        for (String manifest : manifests) {
+            tasks.add(() -> manifestFile.delete(manifest));
         }
-
-        deleteFiles(manifests, manifestFile::delete);
-        deleteFiles(indexFiles, indexFileHandler::deleteIndexFile);
-        deleteFiles(indexManifests, indexFileHandler::deleteManifest);
-        deleteFiles(statistics, statsFileHandler::deleteStats);
+        for (IndexManifestEntry indexFile : indexFiles) {
+            tasks.add(() -> indexFileHandler.deleteIndexFile(indexFile));
+        }
+        for (String indexManifest : indexManifests) {
+            tasks.add(() -> indexFileHandler.deleteManifest(indexManifest));
+        }
+        for (String statistic : statistics) {
+            tasks.add(() -> statsFileHandler.deleteStats(statistic));
+        }
+        return tasks;
     }
 
     public Predicate<ExpireFileEntry> createDataFileSkipperForTags(
@@ -573,20 +468,16 @@ public abstract class FileDeletionBase<T extends Snapshot> {
 
         Set<String> skippingSet = new HashSet<>();
         for (CompletableFuture<Set<String>> future : futures) {
-            skippingSet.addAll(getSkippingSet(future));
+            try {
+                skippingSet.addAll(future.get());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e.getCause());
+            }
         }
         return skippingSet;
-    }
-
-    private Set<String> getSkippingSet(CompletableFuture<Set<String>> future) {
-        try {
-            return future.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
     }
 
     private Set<String> manifestSkippingSet(Snapshot skippingSnapshot) {
@@ -627,68 +518,31 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         }
     }
 
-    protected <F> void deleteFiles(Collection<F> files, Consumer<F> deletion) {
-        if (files.isEmpty()) {
-            return;
+    protected <F> void executeAll(Collection<F> files, Consumer<F> consumer) {
+        List<Runnable> tasks = new ArrayList<>(files.size());
+        for (F f : files) {
+            tasks.add(() -> consumer.accept(f));
         }
-
-        List<CompletableFuture<Void>> deletionFutures = new ArrayList<>(files.size());
-        for (F file : files) {
-            deletionFutures.add(
-                    CompletableFuture.runAsync(() -> deletion.accept(file), fileExecutor));
-        }
-
-        waitForDeletion(deletionFutures);
+        executeAll(tasks);
     }
 
-    private void waitForDeletion(List<CompletableFuture<Void>> deletionFutures) {
-        if (deletionFutures.isEmpty()) {
+    public void executeAll(Collection<Runnable> tasks) {
+        if (tasks.isEmpty()) {
             return;
+        }
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>(tasks.size());
+        for (Runnable runnable : tasks) {
+            futures.add(CompletableFuture.runAsync(runnable, fileExecutor));
         }
 
         try {
-            CompletableFuture.allOf(deletionFutures.toArray(new CompletableFuture[0])).get();
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
             throw new RuntimeException(e.getCause());
-        }
-    }
-
-    /** Planned manifest, index, and statistics files to clean. */
-    public static class ManifestDeletionPlan {
-
-        private final List<String> manifests = new ArrayList<>();
-        private final List<IndexManifestEntry> indexFiles = new ArrayList<>();
-        private final List<String> indexManifests = new ArrayList<>();
-        private final List<String> statistics = new ArrayList<>();
-
-        public static ManifestDeletionPlan empty() {
-            return new ManifestDeletionPlan();
-        }
-
-        private void addManifestFiles(Collection<String> manifestFiles) {
-            manifests.addAll(manifestFiles);
-        }
-
-        private void addIndexFiles(Collection<IndexManifestEntry> files) {
-            indexFiles.addAll(files);
-        }
-
-        private void addIndexManifest(String indexManifest) {
-            indexManifests.add(indexManifest);
-        }
-
-        private void addStatistic(String statistic) {
-            statistics.add(statistic);
-        }
-
-        private void merge(ManifestDeletionPlan plan) {
-            manifests.addAll(plan.manifests);
-            indexFiles.addAll(plan.indexFiles);
-            indexManifests.addAll(plan.indexManifests);
-            statistics.addAll(plan.statistics);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -97,7 +98,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             IndexFileHandler indexFileHandler,
             StatsFileHandler statsFileHandler,
             boolean cleanEmptyDirectories,
-            int deleteFileThreadNum) {
+            int fileOperationThreadNum) {
         this.fileIO = fileIO;
         this.pathFactory = pathFactory;
         this.manifestFile = manifestFile;
@@ -105,13 +106,13 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         this.indexFileHandler = indexFileHandler;
         this.statsFileHandler = statsFileHandler;
         this.cleanEmptyDirectories = cleanEmptyDirectories;
-        this.deletionBuckets = new HashMap<>();
-        this.fileExecutor = FileOperationThreadPool.getExecutorService(deleteFileThreadNum);
+        this.deletionBuckets = new ConcurrentHashMap<>();
+        this.fileExecutor = FileOperationThreadPool.getExecutorService(fileOperationThreadNum);
         this.fileOperationParallelism =
                 Math.max(
                         1,
-                        deleteFileThreadNum > 0
-                                ? deleteFileThreadNum
+                        fileOperationThreadNum > 0
+                                ? fileOperationThreadNum
                                 : Runtime.getRuntime().availableProcessors());
     }
 
@@ -181,25 +182,15 @@ public abstract class FileDeletionBase<T extends Snapshot> {
 
     protected void recordDeletionBuckets(ExpireFileEntry entry) {
         deletionBuckets
-                .computeIfAbsent(entry.partition(), p -> new HashSet<>())
+                .computeIfAbsent(entry.partition(), p -> ConcurrentHashMap.newKeySet())
                 .add(entry.bucket());
     }
 
-    private void recordDeletionBuckets(Map<BinaryRow, Set<Integer>> buckets) {
-        buckets.forEach(
-                (partition, bucketSet) ->
-                        deletionBuckets
-                                .computeIfAbsent(partition, p -> new HashSet<>())
-                                .addAll(bucketSet));
-    }
-
     public void cleanUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
-        deletePlannedDataFiles(
-                Collections.singletonList(planUnusedDataFiles(manifestList, skipper)));
+        deleteDataFiles(planUnusedDataFiles(manifestList, skipper));
     }
 
-    public DataFileDeletionPlan planUnusedDataFiles(
-            String manifestList, Predicate<ExpireFileEntry> skipper) {
+    public List<Path> planUnusedDataFiles(String manifestList, Predicate<ExpireFileEntry> skipper) {
         List<ManifestFileMeta> manifests = tryReadManifestList(manifestList);
         // data file path -> (original manifest entry, extra file paths)
         Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete = new HashMap<>();
@@ -208,7 +199,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         } catch (Exception e) {
             // cancel deletion if any exception occurs
             LOG.warn("Failed to read some manifest files. Cancel deletion.", e);
-            return DataFileDeletionPlan.empty();
+            return Collections.emptyList();
         }
 
         return planUnusedDataFile(dataFileToDelete, skipper);
@@ -217,14 +208,12 @@ public abstract class FileDeletionBase<T extends Snapshot> {
     protected void doCleanUnusedDataFile(
             Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
             Predicate<ExpireFileEntry> skipper) {
-        deletePlannedDataFiles(
-                Collections.singletonList(planUnusedDataFile(dataFileToDelete, skipper)));
+        deleteDataFiles(planUnusedDataFile(dataFileToDelete, skipper));
     }
 
-    protected DataFileDeletionPlan planUnusedDataFile(
+    protected List<Path> planUnusedDataFile(
             Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete,
             Predicate<ExpireFileEntry> skipper) {
-        DataFileDeletionPlan plan = new DataFileDeletionPlan();
         List<Path> actualDataFileToDelete = new ArrayList<>();
         dataFileToDelete.forEach(
                 (path, pair) -> {
@@ -235,11 +224,10 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                         actualDataFileToDelete.add(path);
                         actualDataFileToDelete.addAll(pair.getRight());
 
-                        plan.recordDeletionBucket(entry);
+                        recordDeletionBuckets(entry);
                     }
                 });
-        plan.addDataFiles(actualDataFileToDelete);
-        return plan;
+        return actualDataFileToDelete;
     }
 
     protected void getDataFileToDelete(
@@ -282,10 +270,10 @@ public abstract class FileDeletionBase<T extends Snapshot> {
      * @param manifestListName name of manifest list
      */
     public void deleteAddedDataFiles(String manifestListName) {
-        deletePlannedDataFiles(Collections.singletonList(planAddedDataFiles(manifestListName)));
+        deleteDataFiles(planAddedDataFiles(manifestListName));
     }
 
-    public DataFileDeletionPlan planAddedDataFiles(String manifestListName) {
+    public List<Path> planAddedDataFiles(String manifestListName) {
         List<ManifestFileMeta> manifests = tryReadManifestList(manifestListName);
         return planAddedDataFiles(readExpireFileEntriesIgnoringErrors(manifests));
     }
@@ -318,35 +306,25 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                 fileOperationParallelism);
     }
 
-    private DataFileDeletionPlan planAddedDataFiles(Iterable<ExpireFileEntry> manifestEntries) {
-        DataFileDeletionPlan plan = new DataFileDeletionPlan();
+    private List<Path> planAddedDataFiles(Iterable<ExpireFileEntry> manifestEntries) {
+        List<Path> dataFiles = new ArrayList<>();
         DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
         for (ExpireFileEntry entry : manifestEntries) {
             DataFilePathFactory dataFilePathFactory =
                     factories.get(entry.partition(), entry.bucket());
             if (entry.kind() == FileKind.ADD) {
-                plan.addDataFile(dataFilePathFactory.toPath(entry));
-                plan.recordDeletionBucket(entry);
+                dataFiles.add(dataFilePathFactory.toPath(entry));
+                recordDeletionBuckets(entry);
             }
         }
-        return plan;
+        return dataFiles;
     }
 
-    private DataFileDeletionPlan planAddedDataFiles(List<ExpireFileEntry> manifestEntries) {
-        return planAddedDataFiles((Iterable<ExpireFileEntry>) manifestEntries);
-    }
-
-    public void deletePlannedDataFiles(Collection<DataFileDeletionPlan> plans) {
-        Set<Path> dataFiles = new LinkedHashSet<>();
-        for (DataFileDeletionPlan plan : plans) {
-            dataFiles.addAll(plan.dataFiles);
-            recordDeletionBuckets(plan.deletionBuckets);
-        }
-        deleteFiles(dataFiles, fileIO::deleteQuietly);
+    public void deleteDataFiles(Collection<Path> dataFiles) {
+        deleteFiles(new LinkedHashSet<>(dataFiles), fileIO::deleteQuietly);
     }
 
     public void cleanUnusedStatisticsManifests(Snapshot snapshot, Set<String> skippingSet) {
-        // clean statistics
         deletePlannedManifests(
                 Collections.singletonList(planUnusedStatisticsManifests(snapshot, skippingSet)));
     }
@@ -667,40 +645,6 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             throw new RuntimeException(e);
         } catch (ExecutionException e) {
             throw new RuntimeException(e.getCause());
-        }
-    }
-
-    /** Planned data files and bucket directories to clean. */
-    public static class DataFileDeletionPlan {
-
-        private final List<Path> dataFiles = new ArrayList<>();
-        private final Map<BinaryRow, Set<Integer>> deletionBuckets = new HashMap<>();
-
-        public static DataFileDeletionPlan empty() {
-            return new DataFileDeletionPlan();
-        }
-
-        private void addDataFile(Path path) {
-            dataFiles.add(path);
-        }
-
-        private void addDataFiles(Collection<Path> paths) {
-            dataFiles.addAll(paths);
-        }
-
-        private void recordDeletionBucket(ExpireFileEntry entry) {
-            deletionBuckets
-                    .computeIfAbsent(entry.partition(), p -> new HashSet<>())
-                    .add(entry.bucket());
-        }
-
-        private void merge(DataFileDeletionPlan plan) {
-            dataFiles.addAll(plan.dataFiles);
-            plan.deletionBuckets.forEach(
-                    (partition, bucketSet) ->
-                            deletionBuckets
-                                    .computeIfAbsent(partition, p -> new HashSet<>())
-                                    .addAll(bucketSet));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -108,7 +108,10 @@ public abstract class FileDeletionBase<T extends Snapshot> {
         this.cleanEmptyDirectories = cleanEmptyDirectories;
         this.deletionBuckets = new ConcurrentHashMap<>();
         this.fileExecutor = FileOperationThreadPool.getExecutorService(fileOperationThreadNum);
-        this.fileOperationParallelism = fileOperationThreadNum;
+        this.fileOperationParallelism =
+                fileOperationThreadNum > 0
+                        ? fileOperationThreadNum
+                        : Runtime.getRuntime().availableProcessors();
     }
 
     public Executor fileExecutor() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileDeletionBase.java
@@ -44,8 +44,6 @@ import org.apache.paimon.utils.SnapshotManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -83,7 +81,6 @@ public abstract class FileDeletionBase<T extends Snapshot> {
 
     private final Executor fileExecutor;
     private final int fileOperationParallelism;
-    @Nullable private final Integer manifestReadParallelism;
 
     protected boolean changelogDecoupled;
 
@@ -117,7 +114,6 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                         deleteFileThreadNum > 0
                                 ? deleteFileThreadNum
                                 : Runtime.getRuntime().availableProcessors());
-        this.manifestReadParallelism = deleteFileThreadNum > 0 ? deleteFileThreadNum : null;
     }
 
     public Executor fileExecutor() {
@@ -311,7 +307,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                     }
                 },
                 manifests,
-                manifestReadParallelism);
+                fileOperationParallelism);
     }
 
     private Iterable<ExpireFileEntry> readExpireFileEntries(List<ManifestFileMeta> manifests) {
@@ -320,7 +316,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
                         manifestFile.readExpireFileEntries(
                                 manifest.fileName(), manifest.fileSize()),
                 manifests,
-                manifestReadParallelism);
+                fileOperationParallelism);
     }
 
     private DataFileDeletionPlan planAddedDataFiles(Iterable<ExpireFileEntry> manifestEntries) {
@@ -587,7 +583,7 @@ public abstract class FileDeletionBase<T extends Snapshot> {
             futures.add(
                     CompletableFuture.supplyAsync(
                             () -> manifestSkippingSet(skippingSnapshot),
-                            ManifestReadThreadPool.getExecutorService(manifestReadParallelism)));
+                            ManifestReadThreadPool.getExecutorService(fileOperationParallelism)));
         }
 
         Set<String> skippingSet = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -31,6 +31,7 @@ import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Pair;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,11 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
 
     @Override
     public void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+        deletePlannedDataFiles(Collections.singletonList(planUnusedDataFiles(snapshot, skipper)));
+    }
+
+    public DataFileDeletionPlan planUnusedDataFiles(
+            Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
         if (changelogDecoupled && !produceChangelog) {
             // Skip clean the 'APPEND' data files.If we do not have the file source information
             // eg: the old version table file, we just skip clean this here, let it done by
@@ -75,9 +81,9 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
                             skipper.test(manifestEntry)
                                     || (manifestEntry.fileSource().orElse(FileSource.APPEND)
                                             == FileSource.APPEND);
-            cleanUnusedDataFiles(snapshot.deltaManifestList(), enriched);
+            return planUnusedDataFiles(snapshot.deltaManifestList(), enriched);
         } else {
-            cleanUnusedDataFiles(snapshot.deltaManifestList(), skipper);
+            return planUnusedDataFiles(snapshot.deltaManifestList(), skipper);
         }
     }
 
@@ -89,6 +95,26 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
                 skippingSet,
                 !changelogDecoupled || produceChangelog,
                 !changelogDecoupled);
+    }
+
+    public ManifestDeletionPlan planUnusedManifests(Snapshot snapshot, Set<String> skippingSet) {
+        // delay clean the base and delta manifest lists when changelog decoupled enabled
+        return planUnusedManifests(
+                snapshot,
+                skippingSet,
+                !changelogDecoupled || produceChangelog,
+                !changelogDecoupled);
+    }
+
+    public ManifestDeletionPlan planUnusedManifests(
+            Snapshot snapshot, Set<String> skippingSet, boolean updateSkippingSet) {
+        // delay clean the base and delta manifest lists when changelog decoupled enabled
+        return planUnusedManifests(
+                snapshot,
+                skippingSet,
+                !changelogDecoupled || produceChangelog,
+                !changelogDecoupled,
+                updateSkippingSet);
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
-import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexFileHandler;
@@ -29,11 +28,8 @@ import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
-import org.apache.paimon.utils.Pair;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -65,60 +61,39 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
     }
 
     @Override
-    public void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
-        deleteDataFiles(planUnusedDataFiles(snapshot, skipper));
+    public void cleanDeletedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+        cleanDataFiles(planDeletedInDeltaManifest(snapshot, skipper));
     }
 
-    public List<Path> planUnusedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+    @Override
+    public List<Path> planDeletedInDeltaManifest(
+            Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+        Predicate<ExpireFileEntry> enriched = skipper;
         if (changelogDecoupled && !produceChangelog) {
             // Skip clean the 'APPEND' data files.If we do not have the file source information
             // eg: the old version table file, we just skip clean this here, let it done by
             // ExpireChangelogImpl
-            Predicate<ExpireFileEntry> enriched =
+            enriched =
                     manifestEntry ->
                             skipper.test(manifestEntry)
                                     || (manifestEntry.fileSource().orElse(FileSource.APPEND)
                                             == FileSource.APPEND);
-            return planUnusedDataFiles(snapshot.deltaManifestList(), enriched);
-        } else {
-            return planUnusedDataFiles(snapshot.deltaManifestList(), skipper);
         }
+        return super.planDeletedInDeltaManifest(snapshot, enriched);
     }
 
     @Override
     public void cleanUnusedManifests(Snapshot snapshot, Set<String> skippingSet) {
         // delay clean the base and delta manifest lists when changelog decoupled enabled
-        cleanUnusedManifests(
+        executeAll(planManifestsCleaner(snapshot, skippingSet));
+    }
+
+    public List<Runnable> planManifestsCleaner(Snapshot snapshot, Set<String> skippingSet) {
+        // delay clean the base and delta manifest lists when changelog decoupled enabled
+        return planManifestsCleaner(
                 snapshot,
                 skippingSet,
                 !changelogDecoupled || produceChangelog,
                 !changelogDecoupled);
-    }
-
-    public ManifestDeletionPlan planUnusedManifests(Snapshot snapshot, Set<String> skippingSet) {
-        // delay clean the base and delta manifest lists when changelog decoupled enabled
-        return planUnusedManifests(
-                snapshot,
-                skippingSet,
-                !changelogDecoupled || produceChangelog,
-                !changelogDecoupled);
-    }
-
-    public ManifestDeletionPlan planUnusedManifests(
-            Snapshot snapshot, Set<String> skippingSet, boolean updateSkippingSet) {
-        // delay clean the base and delta manifest lists when changelog decoupled enabled
-        return planUnusedManifests(
-                snapshot,
-                skippingSet,
-                !changelogDecoupled || produceChangelog,
-                !changelogDecoupled,
-                updateSkippingSet);
-    }
-
-    @VisibleForTesting
-    void cleanUnusedDataFile(List<ExpireFileEntry> dataFileLog) {
-        Map<Path, Pair<ExpireFileEntry, List<Path>>> dataFileToDelete = new HashMap<>();
-        getDataFileToDelete(dataFileToDelete, dataFileLog);
-        doCleanUnusedDataFile(dataFileToDelete, f -> false);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/SnapshotDeletion.java
@@ -31,7 +31,6 @@ import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.Pair;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +51,7 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
             StatsFileHandler statsFileHandler,
             boolean produceChangelog,
             boolean cleanEmptyDirectories,
-            int deleteFileThreadNum) {
+            int fileOperationThreadNum) {
         super(
                 fileIO,
                 pathFactory,
@@ -61,17 +60,16 @@ public class SnapshotDeletion extends FileDeletionBase<Snapshot> {
                 indexFileHandler,
                 statsFileHandler,
                 cleanEmptyDirectories,
-                deleteFileThreadNum);
+                fileOperationThreadNum);
         this.produceChangelog = produceChangelog;
     }
 
     @Override
     public void cleanUnusedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
-        deletePlannedDataFiles(Collections.singletonList(planUnusedDataFiles(snapshot, skipper)));
+        deleteDataFiles(planUnusedDataFiles(snapshot, skipper));
     }
 
-    public DataFileDeletionPlan planUnusedDataFiles(
-            Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+    public List<Path> planUnusedDataFiles(Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
         if (changelogDecoupled && !produceChangelog) {
             // Skip clean the 'APPEND' data files.If we do not have the file source information
             // eg: the old version table file, we just skip clean this here, let it done by

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -57,7 +57,7 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
             IndexFileHandler indexFileHandler,
             StatsFileHandler statsFileHandler,
             boolean cleanEmptyDirectories,
-            int deleteFileThreadNum) {
+            int fileOperationThreadNum) {
         super(
                 fileIO,
                 pathFactory,
@@ -66,7 +66,7 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
                 indexFileHandler,
                 statsFileHandler,
                 cleanEmptyDirectories,
-                deleteFileThreadNum);
+                fileOperationThreadNum);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -99,6 +99,10 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
         executeAll(dataFileToDelete, fileIO::deleteQuietly);
     }
 
+    public void cleanUnusedDataFiles(Snapshot taggedSnapshot, Predicate<ExpireFileEntry> skipper) {
+        cleanDeletedDataFiles(taggedSnapshot, skipper);
+    }
+
     @Override
     public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion

--- a/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/TagDeletion.java
@@ -70,7 +70,7 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
     }
 
     @Override
-    public void cleanUnusedDataFiles(Snapshot taggedSnapshot, Predicate<ExpireFileEntry> skipper) {
+    public void cleanDeletedDataFiles(Snapshot taggedSnapshot, Predicate<ExpireFileEntry> skipper) {
         Collection<ExpireFileEntry> manifestEntries;
         try {
             List<ManifestFileMeta> manifests =
@@ -96,13 +96,13 @@ public class TagDeletion extends FileDeletionBase<Snapshot> {
                 recordDeletionBuckets(entry);
             }
         }
-        deleteFiles(dataFileToDelete, fileIO::deleteQuietly);
+        executeAll(dataFileToDelete, fileIO::deleteQuietly);
     }
 
     @Override
     public void cleanUnusedManifests(Snapshot taggedSnapshot, Set<String> skippingSet) {
         // doesn't clean changelog files because they are handled by SnapshotDeletion
-        cleanUnusedManifests(taggedSnapshot, skippingSet, true, false);
+        executeAll(planManifestsCleaner(taggedSnapshot, skippingSet, true, false));
     }
 
     public Predicate<ExpireFileEntry> dataFileSkipper(List<Snapshot> fromSnapshots)

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireChangelogImpl.java
@@ -191,7 +191,7 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
                 continue;
             }
 
-            changelogDeletion.cleanUnusedDataFiles(changelog, skipper);
+            changelogDeletion.cleanDeletedDataFiles(changelog, skipper);
             changelogDeletion.cleanUnusedManifests(changelog, manifestSkippSet);
             changelogManager.fileIO().deleteQuietly(changelogManager.longLivedChangelogPath(id));
         }
@@ -262,7 +262,7 @@ public class ExpireChangelogImpl implements ExpireSnapshots {
                 continue;
             }
 
-            changelogDeletion.cleanUnusedDataFiles(changelog, skipper);
+            changelogDeletion.cleanDeletedDataFiles(changelog, skipper);
             changelogDeletion.cleanUnusedManifests(changelog, manifestSkippSet);
             changelogManager.fileIO().deleteQuietly(changelogManager.longLivedChangelogPath(id));
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -253,8 +253,9 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
         Set<String> skippingSet = null;
         try {
-            skippingSet = ConcurrentHashMap.newKeySet();
-            skippingSet.addAll(snapshotDeletion.manifestSkippingSet(skippingSnapshots));
+            Set<String> builtSkippingSet = ConcurrentHashMap.newKeySet();
+            builtSkippingSet.addAll(snapshotDeletion.manifestSkippingSet(skippingSnapshots));
+            skippingSet = builtSkippingSet;
         } catch (Exception e) {
             LOG.info("Skip cleaning manifest files due to failed to build skipping set.", e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -22,8 +22,8 @@ import org.apache.paimon.Changelog;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ExpireFileEntry;
-import org.apache.paimon.operation.FileDeletionBase.DataFileDeletionPlan;
 import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
@@ -229,14 +229,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         // delete merge tree files
         // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
         // id should be (beginInclusiveId, endExclusiveId]
-        snapshotDeletion.deletePlannedDataFiles(
-                collectDataFileDeletionPlans(
-                        snapshotsIncludingEnd, taggedSnapshots, beginInclusiveId));
+        snapshotDeletion.deleteDataFiles(
+                collectDataFilesToDelete(snapshotsIncludingEnd, taggedSnapshots, beginInclusiveId));
 
         // delete changelog files
         if (!expireConfig.isChangelogDecoupled()) {
-            snapshotDeletion.deletePlannedDataFiles(
-                    collectChangelogDeletionPlans(snapshotsExcludingEnd));
+            snapshotDeletion.deleteDataFiles(collectChangelogFilesToDelete(snapshotsExcludingEnd));
         }
 
         // data files and changelog files in bucket directories has been deleted
@@ -279,7 +277,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return snapshotsExcludingEnd.size();
     }
 
-    private Collection<DataFileDeletionPlan> collectDataFileDeletionPlans(
+    private Collection<Path> collectDataFilesToDelete(
             List<Snapshot> snapshotsIncludingEnd,
             List<Snapshot> taggedSnapshots,
             long beginInclusiveId)
@@ -304,7 +302,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         Map<Long, Optional<Predicate<ExpireFileEntry>>> skippers =
                 collectTagSkippers(tags.values());
         Predicate<ExpireFileEntry> deleteAll = entry -> false;
-        List<CompletableFuture<DataFileDeletionPlan>> futures = new ArrayList<>();
+        List<CompletableFuture<List<Path>>> futures = new ArrayList<>();
         for (Snapshot snapshot : snapshotsIncludingEnd) {
             long id = snapshot.id();
             if (id == beginInclusiveId) {
@@ -331,7 +329,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                             () -> snapshotDeletion.planUnusedDataFiles(snapshot, skipper.get()),
                             fileExecutor));
         }
-        return getAll(futures);
+        return flatten(getAll(futures));
     }
 
     private Map<Long, Optional<Predicate<ExpireFileEntry>>> collectTagSkippers(
@@ -365,9 +363,9 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return skippers;
     }
 
-    private Collection<DataFileDeletionPlan> collectChangelogDeletionPlans(List<Snapshot> snapshots)
+    private Collection<Path> collectChangelogFilesToDelete(List<Snapshot> snapshots)
             throws ExecutionException, InterruptedException {
-        List<CompletableFuture<DataFileDeletionPlan>> futures = new ArrayList<>();
+        List<CompletableFuture<List<Path>>> futures = new ArrayList<>();
         for (Snapshot snapshot : snapshots) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ready to delete changelog files from snapshot #{}", snapshot.id());
@@ -381,7 +379,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                                 fileExecutor));
             }
         }
-        return getAll(futures);
+        return flatten(getAll(futures));
     }
 
     private Collection<ManifestDeletionPlan> collectManifestDeletionPlans(
@@ -408,6 +406,14 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         List<T> result = new ArrayList<>();
         for (CompletableFuture<T> future : futures) {
             result.add(future.get());
+        }
+        return result;
+    }
+
+    private <T> List<T> flatten(List<? extends Collection<T>> collections) {
+        List<T> result = new ArrayList<>();
+        for (Collection<T> collection : collections) {
+            result.addAll(collection);
         }
         return result;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -39,8 +39,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -188,7 +188,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         if (endExclusiveId <= earliestId) {
             return innerExpireUntil(earliestId, endExclusiveId, new ArrayList<>());
         }
-        return innerExpireUntil(earliestId, endExclusiveId, collectSnapshots(earliestId, endExclusiveId));
+        return innerExpireUntil(
+                earliestId, endExclusiveId, collectSnapshots(earliestId, endExclusiveId));
     }
 
     private int innerExpireUntil(
@@ -300,7 +301,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             }
         }
 
-        Map<Long, Optional<Predicate<ExpireFileEntry>>> skippers = collectTagSkippers(tags.values());
+        Map<Long, Optional<Predicate<ExpireFileEntry>>> skippers =
+                collectTagSkippers(tags.values());
         Predicate<ExpireFileEntry> deleteAll = entry -> false;
         List<CompletableFuture<DataFileDeletionPlan>> futures = new ArrayList<>();
         for (Snapshot snapshot : snapshotsIncludingEnd) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -26,6 +26,7 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ExpireFileEntry;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
+import org.apache.paimon.tag.Tag;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.SnapshotManager;
@@ -149,27 +150,22 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             return expireUntil(earliest, maxExclusive);
         }
 
-        try {
-            List<Snapshot> snapshots = collectSnapshots(earliest, maxExclusive);
-            Map<Long, Snapshot> snapshotById = new HashMap<>();
-            for (Snapshot snapshot : snapshots) {
-                snapshotById.put(snapshot.id(), snapshot);
-            }
-
-            for (long id = min; id < maxExclusive; id++) {
-                // Early exit the loop for 'snapshot.time-retained'
-                // A snapshot can only be expired if its next snapshot has been alive
-                // longer than snapshotTimeRetain, providing stronger protection
-                Snapshot nextSnapshot = snapshotById.get(id + 1);
-                if (nextSnapshot != null && olderThanMills <= nextSnapshot.timeMillis()) {
-                    return innerExpireUntil(earliest, id, snapshots);
+        for (long id = min; id < maxExclusive; id++) {
+            // Early exit the loop for 'snapshot.time-retained'
+            // A snapshot can only be expired if its next snapshot has been alive
+            // longer than snapshotTimeRetain, providing stronger protection
+            try {
+                Snapshot nextSnapshot = snapshotManager.tryGetSnapshot(id + 1);
+                if (olderThanMills <= nextSnapshot.timeMillis()) {
+                    return expireUntil(earliest, id);
                 }
+            } catch (FileNotFoundException e) {
+                // ignore
+                // snapshot may have been deleted by another process
             }
-
-            return innerExpireUntil(earliest, maxExclusive, snapshots);
-        } catch (ExecutionException | InterruptedException e) {
-            throw new RuntimeException(e);
         }
+
+        return expireUntil(earliest, maxExclusive);
     }
 
     @VisibleForTesting
@@ -222,7 +218,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         long beginInclusiveId = snapshotsIncludingEnd.get(0).id();
 
         // tags to create data file skipper
-        List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+        List<Snapshot> taggedSnapshots = collectTaggedSnapshots();
 
         // delete merge tree files
         // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
@@ -415,24 +411,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return result;
     }
 
-    private void deleteSnapshotFiles(List<Snapshot> snapshots)
-            throws ExecutionException, InterruptedException {
-        if (expireConfig.isChangelogDecoupled()) {
-            for (Snapshot snapshot : snapshots) {
-                commitChangelog(new Changelog(snapshot));
-                snapshotManager.deleteSnapshot(snapshot.id());
-            }
-            return;
-        }
-
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
+    private void deleteSnapshotFiles(List<Snapshot> snapshots) {
         for (Snapshot snapshot : snapshots) {
-            futures.add(
-                    CompletableFuture.runAsync(
-                            () -> snapshotManager.deleteSnapshot(snapshot.id()), fileExecutor));
-        }
-        for (CompletableFuture<Void> future : futures) {
-            future.get();
+            if (expireConfig.isChangelogDecoupled()) {
+                commitChangelog(new Changelog(snapshot));
+            }
+            snapshotManager.deleteSnapshot(snapshot.id());
         }
     }
 
@@ -457,6 +441,38 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         for (CompletableFuture<Optional<Snapshot>> future : futures) {
             future.get().ifPresent(snapshots::add);
         }
+        return snapshots;
+    }
+
+    private List<Snapshot> collectTaggedSnapshots() throws InterruptedException, ExecutionException {
+        List<Path> tagPaths;
+        try {
+            tagPaths = tagManager.tagPaths(path -> true);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<CompletableFuture<Optional<Snapshot>>> futures = new ArrayList<>();
+        for (Path path : tagPaths) {
+            futures.add(
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return Optional.of(
+                                            Tag.tryFromPath(snapshotManager.fileIO(), path)
+                                                    .trimToSnapshot());
+                                } catch (FileNotFoundException ignored) {
+                                    return Optional.empty();
+                                }
+                            },
+                            fileExecutor));
+        }
+
+        List<Snapshot> snapshots = new ArrayList<>();
+        for (CompletableFuture<Optional<Snapshot>> future : futures) {
+            future.get().ifPresent(snapshots::add);
+        }
+        snapshots.sort((left, right) -> Long.compare(left.id(), right.id()));
         return snapshots;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -261,7 +261,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         }
 
         // delete snapshot file finally
-        deleteSnapshotFiles(snapshotsExcludingEnd);
+        for (Snapshot snapshot : snapshotsExcludingEnd) {
+            if (expireConfig.isChangelogDecoupled()) {
+                commitChangelog(new Changelog(snapshot));
+            }
+            snapshotManager.deleteSnapshot(snapshot.id());
+        }
 
         writeEarliestHint(endExclusiveId);
         long duration = currentTimeMillis.get() - startTime;
@@ -411,15 +416,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return result;
     }
 
-    private void deleteSnapshotFiles(List<Snapshot> snapshots) {
-        for (Snapshot snapshot : snapshots) {
-            if (expireConfig.isChangelogDecoupled()) {
-                commitChangelog(new Changelog(snapshot));
-            }
-            snapshotManager.deleteSnapshot(snapshot.id());
-        }
-    }
-
     private List<Snapshot> collectSnapshots(long earliestId, long endExclusiveId)
             throws InterruptedException, ExecutionException {
         List<CompletableFuture<Optional<Snapshot>>> futures = new ArrayList<>();
@@ -444,7 +440,8 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         return snapshots;
     }
 
-    private List<Snapshot> collectTaggedSnapshots() throws InterruptedException, ExecutionException {
+    private List<Snapshot> collectTaggedSnapshots()
+            throws InterruptedException, ExecutionException {
         List<Path> tagPaths;
         try {
             tagPaths = tagManager.tagPaths(path -> true);

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -24,7 +24,6 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.ExpireFileEntry;
-import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.utils.ChangelogManager;
@@ -40,14 +39,13 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Predicate;
@@ -229,12 +227,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         // delete merge tree files
         // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
         // id should be (beginInclusiveId, endExclusiveId]
-        snapshotDeletion.deleteDataFiles(
+        snapshotDeletion.cleanDataFiles(
                 collectDataFilesToDelete(snapshotsIncludingEnd, taggedSnapshots, beginInclusiveId));
 
         // delete changelog files
         if (!expireConfig.isChangelogDecoupled()) {
-            snapshotDeletion.deleteDataFiles(collectChangelogFilesToDelete(snapshotsExcludingEnd));
+            snapshotDeletion.cleanDataFiles(collectChangelogFilesToDelete(snapshotsExcludingEnd));
         }
 
         // data files and changelog files in bucket directories has been deleted
@@ -255,13 +253,14 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
         Set<String> skippingSet = null;
         try {
-            skippingSet = new HashSet<>(snapshotDeletion.manifestSkippingSet(skippingSnapshots));
+            skippingSet = ConcurrentHashMap.newKeySet();
+            skippingSet.addAll(snapshotDeletion.manifestSkippingSet(skippingSnapshots));
         } catch (Exception e) {
             LOG.info("Skip cleaning manifest files due to failed to build skipping set.", e);
         }
         if (skippingSet != null) {
-            snapshotDeletion.deletePlannedManifests(
-                    collectManifestDeletionPlans(snapshotsExcludingEnd, skippingSet));
+            snapshotDeletion.executeAll(
+                    collectManifestDeletionTasks(snapshotsExcludingEnd, skippingSet));
         }
 
         // delete snapshot file finally
@@ -326,7 +325,9 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
             futures.add(
                     CompletableFuture.supplyAsync(
-                            () -> snapshotDeletion.planUnusedDataFiles(snapshot, skipper.get()),
+                            () ->
+                                    snapshotDeletion.planDeletedInDeltaManifest(
+                                            snapshot, skipper.get()),
                             fileExecutor));
         }
         return flatten(getAll(futures));
@@ -373,32 +374,27 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             if (snapshot.changelogManifestList() != null) {
                 futures.add(
                         CompletableFuture.supplyAsync(
-                                () ->
-                                        snapshotDeletion.planAddedDataFiles(
-                                                snapshot.changelogManifestList()),
+                                () -> snapshotDeletion.planAddedInChangelogManifest(snapshot),
                                 fileExecutor));
             }
         }
         return flatten(getAll(futures));
     }
 
-    private Collection<ManifestDeletionPlan> collectManifestDeletionPlans(
+    private Collection<Runnable> collectManifestDeletionTasks(
             List<Snapshot> snapshots, Set<String> skippingSet)
             throws ExecutionException, InterruptedException {
-        Set<String> readOnlySkippingSet = Collections.unmodifiableSet(skippingSet);
-        List<CompletableFuture<ManifestDeletionPlan>> futures = new ArrayList<>();
+        List<CompletableFuture<List<Runnable>>> futures = new ArrayList<>();
         for (Snapshot snapshot : snapshots) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Ready to delete manifests in snapshot #{}", snapshot.id());
             }
             futures.add(
                     CompletableFuture.supplyAsync(
-                            () ->
-                                    snapshotDeletion.planUnusedManifests(
-                                            snapshot, readOnlySkippingSet, false),
+                            () -> snapshotDeletion.planManifestsCleaner(snapshot, skippingSet),
                             fileExecutor));
         }
-        return getAll(futures);
+        return flatten(getAll(futures));
     }
 
     private <T> List<T> getAll(List<CompletableFuture<T>> futures)

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,10 +147,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         // (the maximum number of snapshots allowed to expire at a time)
         maxExclusive = Math.min(maxExclusive, earliest + maxDeletes);
 
-        if (maxExclusive <= earliest) {
-            return expireUntil(earliest, maxExclusive);
-        }
-
         for (long id = min; id < maxExclusive; id++) {
             // Early exit the loop for 'snapshot.time-retained'
             // A snapshot can only be expired if its next snapshot has been alive
@@ -179,16 +176,6 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
 
     private int innerExpireUntil(long earliestId, long endExclusiveId)
             throws ExecutionException, InterruptedException {
-        if (endExclusiveId <= earliestId) {
-            return innerExpireUntil(earliestId, endExclusiveId, new ArrayList<>());
-        }
-        return innerExpireUntil(
-                earliestId, endExclusiveId, collectSnapshots(earliestId, endExclusiveId));
-    }
-
-    private int innerExpireUntil(
-            long earliestId, long endExclusiveId, List<Snapshot> collectedSnapshots)
-            throws ExecutionException, InterruptedException {
         long startTime = currentTimeMillis.get();
 
         if (endExclusiveId <= earliestId) {
@@ -204,10 +191,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         }
 
         // collect all snapshots
-        List<Snapshot> snapshotsIncludingEnd =
-                collectedSnapshots.stream()
-                        .filter(s -> s.id() >= earliestId && s.id() <= endExclusiveId)
-                        .collect(Collectors.toList());
+        List<Snapshot> snapshotsIncludingEnd = collectSnapshots(earliestId, endExclusiveId);
         if (snapshotsIncludingEnd.isEmpty()) {
             return 0;
         }
@@ -469,7 +453,7 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         for (CompletableFuture<Optional<Snapshot>> future : futures) {
             future.get().ifPresent(snapshots::add);
         }
-        snapshots.sort((left, right) -> Long.compare(left.id(), right.id()));
+        snapshots.sort(Comparator.comparingLong(Snapshot::id));
         return snapshots;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ExpireSnapshotsImpl.java
@@ -23,6 +23,8 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.manifest.ExpireFileEntry;
+import org.apache.paimon.operation.FileDeletionBase.DataFileDeletionPlan;
+import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.operation.SnapshotDeletion;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.utils.ChangelogManager;
@@ -37,8 +39,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -141,22 +147,31 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         // (the maximum number of snapshots allowed to expire at a time)
         maxExclusive = Math.min(maxExclusive, earliest + maxDeletes);
 
-        for (long id = min; id < maxExclusive; id++) {
-            // Early exit the loop for 'snapshot.time-retained'
-            // A snapshot can only be expired if its next snapshot has been alive
-            // longer than snapshotTimeRetain, providing stronger protection
-            try {
-                Snapshot nextSnapshot = snapshotManager.tryGetSnapshot(id + 1);
-                if (olderThanMills <= nextSnapshot.timeMillis()) {
-                    return expireUntil(earliest, id);
-                }
-            } catch (FileNotFoundException e) {
-                // ignore
-                // snapshot may have been deleted by another process
-            }
+        if (maxExclusive <= earliest) {
+            return expireUntil(earliest, maxExclusive);
         }
 
-        return expireUntil(earliest, maxExclusive);
+        try {
+            List<Snapshot> snapshots = collectSnapshots(earliest, maxExclusive);
+            Map<Long, Snapshot> snapshotById = new HashMap<>();
+            for (Snapshot snapshot : snapshots) {
+                snapshotById.put(snapshot.id(), snapshot);
+            }
+
+            for (long id = min; id < maxExclusive; id++) {
+                // Early exit the loop for 'snapshot.time-retained'
+                // A snapshot can only be expired if its next snapshot has been alive
+                // longer than snapshotTimeRetain, providing stronger protection
+                Snapshot nextSnapshot = snapshotById.get(id + 1);
+                if (nextSnapshot != null && olderThanMills <= nextSnapshot.timeMillis()) {
+                    return innerExpireUntil(earliest, id, snapshots);
+                }
+            }
+
+            return innerExpireUntil(earliest, maxExclusive, snapshots);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @VisibleForTesting
@@ -169,6 +184,15 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
     }
 
     private int innerExpireUntil(long earliestId, long endExclusiveId)
+            throws ExecutionException, InterruptedException {
+        if (endExclusiveId <= earliestId) {
+            return innerExpireUntil(earliestId, endExclusiveId, new ArrayList<>());
+        }
+        return innerExpireUntil(earliestId, endExclusiveId, collectSnapshots(earliestId, endExclusiveId));
+    }
+
+    private int innerExpireUntil(
+            long earliestId, long endExclusiveId, List<Snapshot> collectedSnapshots)
             throws ExecutionException, InterruptedException {
         long startTime = currentTimeMillis.get();
 
@@ -185,7 +209,10 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         }
 
         // collect all snapshots
-        List<Snapshot> snapshotsIncludingEnd = collectSnapshots(earliestId, endExclusiveId);
+        List<Snapshot> snapshotsIncludingEnd =
+                collectedSnapshots.stream()
+                        .filter(s -> s.id() >= earliestId && s.id() <= endExclusiveId)
+                        .collect(Collectors.toList());
         if (snapshotsIncludingEnd.isEmpty()) {
             return 0;
         }
@@ -201,39 +228,14 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
         // delete merge tree files
         // deleted merge tree files in a snapshot are not used by the next snapshot, so the range of
         // id should be (beginInclusiveId, endExclusiveId]
-        for (Snapshot snapshot : snapshotsIncludingEnd) {
-            long id = snapshot.id();
-            if (id == beginInclusiveId) {
-                continue;
-            }
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Ready to delete merge tree files not used by snapshot #{}", id);
-            }
-            // expire merge tree files and collect changed buckets
-            Predicate<ExpireFileEntry> skipper;
-            try {
-                skipper = snapshotDeletion.createDataFileSkipperForTags(taggedSnapshots, id);
-            } catch (Exception e) {
-                LOG.info(
-                        "Skip cleaning data files of snapshot '{}' due to failed to build skipping set.",
-                        id,
-                        e);
-                continue;
-            }
-
-            snapshotDeletion.cleanUnusedDataFiles(snapshot, skipper);
-        }
+        snapshotDeletion.deletePlannedDataFiles(
+                collectDataFileDeletionPlans(
+                        snapshotsIncludingEnd, taggedSnapshots, beginInclusiveId));
 
         // delete changelog files
         if (!expireConfig.isChangelogDecoupled()) {
-            for (Snapshot snapshot : snapshotsExcludingEnd) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Ready to delete changelog files from snapshot #{}", snapshot.id());
-                }
-                if (snapshot.changelogManifestList() != null) {
-                    snapshotDeletion.deleteAddedDataFiles(snapshot.changelogManifestList());
-                }
-            }
+            snapshotDeletion.deletePlannedDataFiles(
+                    collectChangelogDeletionPlans(snapshotsExcludingEnd));
         }
 
         // data files and changelog files in bucket directories has been deleted
@@ -259,21 +261,12 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             LOG.info("Skip cleaning manifest files due to failed to build skipping set.", e);
         }
         if (skippingSet != null) {
-            for (Snapshot snapshot : snapshotsExcludingEnd) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Ready to delete manifests in snapshot #{}", snapshot.id());
-                }
-                snapshotDeletion.cleanUnusedManifests(snapshot, skippingSet);
-            }
+            snapshotDeletion.deletePlannedManifests(
+                    collectManifestDeletionPlans(snapshotsExcludingEnd, skippingSet));
         }
 
         // delete snapshot file finally
-        for (Snapshot snapshot : snapshotsExcludingEnd) {
-            if (expireConfig.isChangelogDecoupled()) {
-                commitChangelog(new Changelog(snapshot));
-            }
-            snapshotManager.deleteSnapshot(snapshot.id());
-        }
+        deleteSnapshotFiles(snapshotsExcludingEnd);
 
         writeEarliestHint(endExclusiveId);
         long duration = currentTimeMillis.get() - startTime;
@@ -283,6 +276,159 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
                 beginInclusiveId,
                 endExclusiveId);
         return snapshotsExcludingEnd.size();
+    }
+
+    private Collection<DataFileDeletionPlan> collectDataFileDeletionPlans(
+            List<Snapshot> snapshotsIncludingEnd,
+            List<Snapshot> taggedSnapshots,
+            long beginInclusiveId)
+            throws ExecutionException, InterruptedException {
+        Map<Long, Long> tagIdBySnapshotId = new HashMap<>();
+        Map<Long, Snapshot> tags = new HashMap<>();
+        int tagIndex = -1;
+        for (Snapshot snapshot : snapshotsIncludingEnd) {
+            long id = snapshot.id();
+            if (id == beginInclusiveId) {
+                continue;
+            }
+
+            tagIndex = advancePreviousSnapshot(taggedSnapshots, tagIndex, id);
+            if (tagIndex >= 0) {
+                Snapshot tag = taggedSnapshots.get(tagIndex);
+                tagIdBySnapshotId.put(id, tag.id());
+                tags.put(tag.id(), tag);
+            }
+        }
+
+        Map<Long, Optional<Predicate<ExpireFileEntry>>> skippers = collectTagSkippers(tags.values());
+        Predicate<ExpireFileEntry> deleteAll = entry -> false;
+        List<CompletableFuture<DataFileDeletionPlan>> futures = new ArrayList<>();
+        for (Snapshot snapshot : snapshotsIncludingEnd) {
+            long id = snapshot.id();
+            if (id == beginInclusiveId) {
+                continue;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete merge tree files not used by snapshot #{}", id);
+            }
+
+            Long tagId = tagIdBySnapshotId.get(id);
+            Optional<Predicate<ExpireFileEntry>> skipper =
+                    tagId == null
+                            ? Optional.of(deleteAll)
+                            : skippers.getOrDefault(tagId, Optional.empty());
+            if (!skipper.isPresent()) {
+                LOG.info(
+                        "Skip cleaning data files of snapshot '{}' due to failed to build skipping set.",
+                        id);
+                continue;
+            }
+
+            futures.add(
+                    CompletableFuture.supplyAsync(
+                            () -> snapshotDeletion.planUnusedDataFiles(snapshot, skipper.get()),
+                            fileExecutor));
+        }
+        return getAll(futures);
+    }
+
+    private Map<Long, Optional<Predicate<ExpireFileEntry>>> collectTagSkippers(
+            Collection<Snapshot> tags) throws ExecutionException, InterruptedException {
+        Map<Long, CompletableFuture<Optional<Predicate<ExpireFileEntry>>>> futures =
+                new HashMap<>();
+        for (Snapshot tag : tags) {
+            futures.put(
+                    tag.id(),
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return Optional.of(
+                                            snapshotDeletion.createDataFileSkipperForTag(tag));
+                                } catch (Exception e) {
+                                    LOG.info(
+                                            "Failed to build data file skipping set for tag snapshot '{}'.",
+                                            tag.id(),
+                                            e);
+                                    return Optional.empty();
+                                }
+                            },
+                            fileExecutor));
+        }
+
+        Map<Long, Optional<Predicate<ExpireFileEntry>>> skippers = new HashMap<>();
+        for (Map.Entry<Long, CompletableFuture<Optional<Predicate<ExpireFileEntry>>>> entry :
+                futures.entrySet()) {
+            skippers.put(entry.getKey(), entry.getValue().get());
+        }
+        return skippers;
+    }
+
+    private Collection<DataFileDeletionPlan> collectChangelogDeletionPlans(List<Snapshot> snapshots)
+            throws ExecutionException, InterruptedException {
+        List<CompletableFuture<DataFileDeletionPlan>> futures = new ArrayList<>();
+        for (Snapshot snapshot : snapshots) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete changelog files from snapshot #{}", snapshot.id());
+            }
+            if (snapshot.changelogManifestList() != null) {
+                futures.add(
+                        CompletableFuture.supplyAsync(
+                                () ->
+                                        snapshotDeletion.planAddedDataFiles(
+                                                snapshot.changelogManifestList()),
+                                fileExecutor));
+            }
+        }
+        return getAll(futures);
+    }
+
+    private Collection<ManifestDeletionPlan> collectManifestDeletionPlans(
+            List<Snapshot> snapshots, Set<String> skippingSet)
+            throws ExecutionException, InterruptedException {
+        Set<String> readOnlySkippingSet = Collections.unmodifiableSet(skippingSet);
+        List<CompletableFuture<ManifestDeletionPlan>> futures = new ArrayList<>();
+        for (Snapshot snapshot : snapshots) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ready to delete manifests in snapshot #{}", snapshot.id());
+            }
+            futures.add(
+                    CompletableFuture.supplyAsync(
+                            () ->
+                                    snapshotDeletion.planUnusedManifests(
+                                            snapshot, readOnlySkippingSet, false),
+                            fileExecutor));
+        }
+        return getAll(futures);
+    }
+
+    private <T> List<T> getAll(List<CompletableFuture<T>> futures)
+            throws ExecutionException, InterruptedException {
+        List<T> result = new ArrayList<>();
+        for (CompletableFuture<T> future : futures) {
+            result.add(future.get());
+        }
+        return result;
+    }
+
+    private void deleteSnapshotFiles(List<Snapshot> snapshots)
+            throws ExecutionException, InterruptedException {
+        if (expireConfig.isChangelogDecoupled()) {
+            for (Snapshot snapshot : snapshots) {
+                commitChangelog(new Changelog(snapshot));
+                snapshotManager.deleteSnapshot(snapshot.id());
+            }
+            return;
+        }
+
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (Snapshot snapshot : snapshots) {
+            futures.add(
+                    CompletableFuture.runAsync(
+                            () -> snapshotManager.deleteSnapshot(snapshot.id()), fileExecutor));
+        }
+        for (CompletableFuture<Void> future : futures) {
+            future.get();
+        }
     }
 
     private List<Snapshot> collectSnapshots(long earliestId, long endExclusiveId)
@@ -307,6 +453,15 @@ public class ExpireSnapshotsImpl implements ExpireSnapshots {
             future.get().ifPresent(snapshots::add);
         }
         return snapshots;
+    }
+
+    private static int advancePreviousSnapshot(
+            List<Snapshot> sortedSnapshots, int currentIndex, long targetSnapshotId) {
+        while (currentIndex + 1 < sortedSnapshots.size()
+                && sortedSnapshots.get(currentIndex + 1).id() < targetSnapshotId) {
+            currentIndex++;
+        }
+        return currentIndex;
     }
 
     private void commitChangelog(Changelog changelog) {

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ManifestReadThreadPool.java
@@ -37,6 +37,7 @@ public class ManifestReadThreadPool {
             createCachedThreadPool(Runtime.getRuntime().availableProcessors(), THREAD_NAME);
 
     public static synchronized ExecutorService getExecutorService(@Nullable Integer threadNum) {
+        threadNum = normalizeThreadNum(threadNum);
         if (threadNum == null || threadNum == executorService.getMaximumPoolSize()) {
             return executorService;
         }
@@ -54,6 +55,7 @@ public class ManifestReadThreadPool {
     /** This method aims to parallel process tasks with memory control and sequentially. */
     public static <T, U> Iterable<T> sequentialBatchedExecute(
             Function<U, List<T>> processor, List<U> input, @Nullable Integer threadNum) {
+        threadNum = normalizeThreadNum(threadNum);
         ExecutorService executor = getExecutorService(threadNum);
         if (threadNum == null) {
             threadNum =
@@ -62,6 +64,10 @@ public class ManifestReadThreadPool {
                             : ((SemaphoredDelegatingExecutor) executor).getPermitCount();
         }
         return ThreadPoolUtils.sequentialBatchedExecute(executor, processor, input, threadNum);
+    }
+
+    private static @Nullable Integer normalizeThreadNum(@Nullable Integer threadNum) {
+        return threadNum == null || threadNum <= 0 ? null : threadNum;
     }
 
     /** This method aims to parallel process tasks with randomly but return values sequentially. */

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -49,9 +49,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -70,8 +67,6 @@ public class TagManager {
     private final FileIO fileIO;
     private final Path tablePath;
     private final String branch;
-    @Nullable private final Integer fileOperationThreadNum;
-    private final Executor fileExecutor;
     @Nullable private final TagPeriodHandler tagPeriodHandler;
 
     public TagManager(FileIO fileIO, Path tablePath) {
@@ -84,12 +79,7 @@ public class TagManager {
 
     /** Specify the default branch for data writing. */
     public TagManager(FileIO fileIO, Path tablePath, String branch, CoreOptions options) {
-        this(
-                fileIO,
-                tablePath,
-                branch,
-                createIfNecessary(options),
-                options.fileOperationThreadNum());
+        this(fileIO, tablePath, branch, createIfNecessary(options));
     }
 
     @Nullable
@@ -104,23 +94,9 @@ public class TagManager {
             Path tablePath,
             String branch,
             @Nullable TagPeriodHandler tagPeriodHandler) {
-        this(fileIO, tablePath, branch, tagPeriodHandler, null);
-    }
-
-    private TagManager(
-            FileIO fileIO,
-            Path tablePath,
-            String branch,
-            @Nullable TagPeriodHandler tagPeriodHandler,
-            @Nullable Integer fileOperationThreadNum) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
         this.branch = BranchManager.normalizeBranch(branch);
-        this.fileOperationThreadNum = fileOperationThreadNum;
-        this.fileExecutor =
-                fileOperationThreadNum == null
-                        ? Runnable::run
-                        : FileOperationThreadPool.getExecutorService(fileOperationThreadNum);
         this.tagPeriodHandler = tagPeriodHandler;
     }
 
@@ -128,8 +104,7 @@ public class TagManager {
     // If we will use the new branch TagManager to create tag, we need to pass TagPeriodHandler
     // according to branch options.
     public TagManager copyWithBranch(String branchName) {
-        return new TagManager(
-                fileIO, tablePath, branchName, (TagPeriodHandler) null, fileOperationThreadNum);
+        return new TagManager(fileIO, tablePath, branchName, (TagPeriodHandler) null);
     }
 
     /** Return the root Directory of tags. */
@@ -335,7 +310,7 @@ public class TagManager {
             success = false;
         }
         if (success) {
-            tagDeletion.cleanDeletedDataFiles(taggedSnapshot, dataFileSkipper);
+            tagDeletion.cleanUnusedDataFiles(taggedSnapshot, dataFileSkipper);
             tagDeletion.cleanEmptyDirectories();
         }
 
@@ -422,22 +397,19 @@ public class TagManager {
         try {
             List<Path> paths = tagPaths(path -> true);
 
-            List<CompletableFuture<Optional<Pair<Snapshot, String>>>> futures = new ArrayList<>();
             for (Path path : paths) {
                 String tagName = path.getName().substring(TAG_PREFIX.length());
-                if (filter.test(tagName)) {
-                    futures.add(
-                            CompletableFuture.supplyAsync(
-                                    () -> tryReadTag(path, tagName), fileExecutor));
-                }
-            }
 
-            for (CompletableFuture<Optional<Pair<Snapshot, String>>> future : futures) {
-                Optional<Pair<Snapshot, String>> tag = getReadTagResult(future);
-                tag.ifPresent(
-                        pair ->
-                                tags.computeIfAbsent(pair.getLeft(), s -> new ArrayList<>())
-                                        .add(pair.getRight()));
+                if (!filter.test(tagName)) {
+                    continue;
+                }
+                // If the tag file is not found, it might be deleted by
+                // other processes, so just skip this tag
+                try {
+                    Snapshot snapshot = Tag.tryFromPath(fileIO, path).trimToSnapshot();
+                    tags.computeIfAbsent(snapshot, s -> new ArrayList<>()).add(tagName);
+                } catch (FileNotFoundException ignored) {
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -449,46 +421,17 @@ public class TagManager {
     public List<Pair<Tag, String>> tagObjects() {
         try {
             List<Path> paths = tagPaths(path -> true);
-            List<CompletableFuture<Optional<Pair<Tag, String>>>> futures = new ArrayList<>();
+            List<Pair<Tag, String>> tags = new ArrayList<>();
             for (Path path : paths) {
                 String tagName = path.getName().substring(TAG_PREFIX.length());
-                futures.add(
-                        CompletableFuture.supplyAsync(
-                                () -> tryReadTagObject(path, tagName), fileExecutor));
-            }
-
-            List<Pair<Tag, String>> tags = new ArrayList<>();
-            for (CompletableFuture<Optional<Pair<Tag, String>>> future : futures) {
-                getReadTagResult(future).ifPresent(tags::add);
+                try {
+                    tags.add(Pair.of(Tag.tryFromPath(fileIO, path), tagName));
+                } catch (FileNotFoundException ignored) {
+                }
             }
             return tags;
         } catch (IOException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private Optional<Pair<Snapshot, String>> tryReadTag(Path path, String tagName) {
-        return tryReadTagObject(path, tagName)
-                .map(pair -> Pair.of(pair.getLeft().trimToSnapshot(), pair.getRight()));
-    }
-
-    private Optional<Pair<Tag, String>> tryReadTagObject(Path path, String tagName) {
-        // If the tag file is not found, it might be deleted by other processes, so just skip it.
-        try {
-            return Optional.of(Pair.of(Tag.tryFromPath(fileIO, path), tagName));
-        } catch (FileNotFoundException ignored) {
-            return Optional.empty();
-        }
-    }
-
-    private <T> Optional<T> getReadTagResult(CompletableFuture<Optional<T>> future) {
-        try {
-            return future.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -49,6 +49,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -67,6 +70,8 @@ public class TagManager {
     private final FileIO fileIO;
     private final Path tablePath;
     private final String branch;
+    @Nullable private final Integer fileOperationThreadNum;
+    private final Executor fileExecutor;
     @Nullable private final TagPeriodHandler tagPeriodHandler;
 
     public TagManager(FileIO fileIO, Path tablePath) {
@@ -79,7 +84,7 @@ public class TagManager {
 
     /** Specify the default branch for data writing. */
     public TagManager(FileIO fileIO, Path tablePath, String branch, CoreOptions options) {
-        this(fileIO, tablePath, branch, createIfNecessary(options));
+        this(fileIO, tablePath, branch, createIfNecessary(options), options.fileOperationThreadNum());
     }
 
     @Nullable
@@ -94,9 +99,23 @@ public class TagManager {
             Path tablePath,
             String branch,
             @Nullable TagPeriodHandler tagPeriodHandler) {
+        this(fileIO, tablePath, branch, tagPeriodHandler, null);
+    }
+
+    private TagManager(
+            FileIO fileIO,
+            Path tablePath,
+            String branch,
+            @Nullable TagPeriodHandler tagPeriodHandler,
+            @Nullable Integer fileOperationThreadNum) {
         this.fileIO = fileIO;
         this.tablePath = tablePath;
         this.branch = BranchManager.normalizeBranch(branch);
+        this.fileOperationThreadNum = fileOperationThreadNum;
+        this.fileExecutor =
+                fileOperationThreadNum == null
+                        ? Runnable::run
+                        : FileOperationThreadPool.getExecutorService(fileOperationThreadNum);
         this.tagPeriodHandler = tagPeriodHandler;
     }
 
@@ -104,7 +123,8 @@ public class TagManager {
     // If we will use the new branch TagManager to create tag, we need to pass TagPeriodHandler
     // according to branch options.
     public TagManager copyWithBranch(String branchName) {
-        return new TagManager(fileIO, tablePath, branchName, (TagPeriodHandler) null);
+        return new TagManager(
+                fileIO, tablePath, branchName, (TagPeriodHandler) null, fileOperationThreadNum);
     }
 
     /** Return the root Directory of tags. */
@@ -397,19 +417,22 @@ public class TagManager {
         try {
             List<Path> paths = tagPaths(path -> true);
 
+            List<CompletableFuture<Optional<Pair<Snapshot, String>>>> futures = new ArrayList<>();
             for (Path path : paths) {
                 String tagName = path.getName().substring(TAG_PREFIX.length());
+                if (filter.test(tagName)) {
+                    futures.add(
+                            CompletableFuture.supplyAsync(
+                                    () -> tryReadTag(path, tagName), fileExecutor));
+                }
+            }
 
-                if (!filter.test(tagName)) {
-                    continue;
-                }
-                // If the tag file is not found, it might be deleted by
-                // other processes, so just skip this tag
-                try {
-                    Snapshot snapshot = Tag.tryFromPath(fileIO, path).trimToSnapshot();
-                    tags.computeIfAbsent(snapshot, s -> new ArrayList<>()).add(tagName);
-                } catch (FileNotFoundException ignored) {
-                }
+            for (CompletableFuture<Optional<Pair<Snapshot, String>>> future : futures) {
+                Optional<Pair<Snapshot, String>> tag = getReadTagResult(future);
+                tag.ifPresent(
+                        pair ->
+                                tags.computeIfAbsent(pair.getLeft(), s -> new ArrayList<>())
+                                        .add(pair.getRight()));
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -421,17 +444,46 @@ public class TagManager {
     public List<Pair<Tag, String>> tagObjects() {
         try {
             List<Path> paths = tagPaths(path -> true);
-            List<Pair<Tag, String>> tags = new ArrayList<>();
+            List<CompletableFuture<Optional<Pair<Tag, String>>>> futures = new ArrayList<>();
             for (Path path : paths) {
                 String tagName = path.getName().substring(TAG_PREFIX.length());
-                try {
-                    tags.add(Pair.of(Tag.tryFromPath(fileIO, path), tagName));
-                } catch (FileNotFoundException ignored) {
-                }
+                futures.add(
+                        CompletableFuture.supplyAsync(
+                                () -> tryReadTagObject(path, tagName), fileExecutor));
+            }
+
+            List<Pair<Tag, String>> tags = new ArrayList<>();
+            for (CompletableFuture<Optional<Pair<Tag, String>>> future : futures) {
+                getReadTagResult(future).ifPresent(tags::add);
             }
             return tags;
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<Pair<Snapshot, String>> tryReadTag(Path path, String tagName) {
+        return tryReadTagObject(path, tagName)
+                .map(pair -> Pair.of(pair.getLeft().trimToSnapshot(), pair.getRight()));
+    }
+
+    private Optional<Pair<Tag, String>> tryReadTagObject(Path path, String tagName) {
+        // If the tag file is not found, it might be deleted by other processes, so just skip it.
+        try {
+            return Optional.of(Pair.of(Tag.tryFromPath(fileIO, path), tagName));
+        } catch (FileNotFoundException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private <T> Optional<T> getReadTagResult(CompletableFuture<Optional<T>> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -335,7 +335,7 @@ public class TagManager {
             success = false;
         }
         if (success) {
-            tagDeletion.cleanUnusedDataFiles(taggedSnapshot, dataFileSkipper);
+            tagDeletion.cleanDeletedDataFiles(taggedSnapshot, dataFileSkipper);
             tagDeletion.cleanEmptyDirectories();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/TagManager.java
@@ -84,7 +84,12 @@ public class TagManager {
 
     /** Specify the default branch for data writing. */
     public TagManager(FileIO fileIO, Path tablePath, String branch, CoreOptions options) {
-        this(fileIO, tablePath, branch, createIfNecessary(options), options.fileOperationThreadNum());
+        this(
+                fileIO,
+                tablePath,
+                branch,
+                createIfNecessary(options),
+                options.fileOperationThreadNum());
     }
 
     @Nullable

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -38,7 +38,6 @@ import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.paimon.operation.FileDeletionBase.DataFileDeletionPlan;
 import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.schema.Schema;
@@ -780,9 +779,10 @@ public class ExpireSnapshotsTest {
 
         CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
         Snapshot snapshot = snapshotManager.snapshot(1);
-        DataFileDeletionPlan dataPlan =
-                snapshotDeletion.planAddedDataFiles(snapshot.deltaManifestList());
-        snapshotDeletion.deletePlannedDataFiles(Arrays.asList(dataPlan, dataPlan));
+        List<Path> dataFiles = snapshotDeletion.planAddedDataFiles(snapshot.deltaManifestList());
+        List<Path> duplicateDataFiles = new ArrayList<>(dataFiles);
+        duplicateDataFiles.addAll(dataFiles);
+        snapshotDeletion.deleteDataFiles(duplicateDataFiles);
         snapshotDeletion.assertDeleteBatchesDeduplicated();
 
         snapshotDeletion.reset();
@@ -1229,7 +1229,7 @@ public class ExpireSnapshotsTest {
         }
 
         @Override
-        public DataFileDeletionPlan planUnusedDataFiles(
+        public List<Path> planUnusedDataFiles(
                 Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
             if (blockDataFilePlans && shouldBlock(snapshot.id())) {
                 dataFilePlans.awaitConcurrentCall();
@@ -1238,7 +1238,7 @@ public class ExpireSnapshotsTest {
         }
 
         @Override
-        public DataFileDeletionPlan planAddedDataFiles(String manifestListName) {
+        public List<Path> planAddedDataFiles(String manifestListName) {
             if (blockedChangelogManifestLists.contains(manifestListName)) {
                 changelogPlans.awaitConcurrentCall();
             }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -616,11 +616,10 @@ public class ExpireSnapshotsTest {
     public void testExpireCollectsSnapshotsConcurrently() throws Exception {
         store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
 
-        ExpireConfig config = expireAllButLatestConfig();
-
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
         commit(5, allData, snapshotPositions);
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
         for (int i = 1; i <= 5; i++) {
             rewriteSnapshotTime(i, 0);
         }
@@ -633,13 +632,10 @@ public class ExpireSnapshotsTest {
                         changelogManager,
                         store.newSnapshotDeletion(),
                         store.newTagManager());
-        expire.config(config);
-        expire.setCurrentTimeMillis(() -> 1000L);
 
-        expire.expire();
+        expire.expireUntil(1, latestSnapshotId);
 
         assertThat(blockingSnapshotManager.maxActiveReads()).isGreaterThan(1);
-        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
         assertSnapshot(latestSnapshotId, allData, snapshotPositions);
         store.assertCleaned();
     }
@@ -779,7 +775,7 @@ public class ExpireSnapshotsTest {
     }
 
     @Test
-    public void testTagManagerReadsTagsConcurrentlyWithObjectStoreFileIO() throws Exception {
+    public void testExpireReadsTagsConcurrentlyWithObjectStoreFileIO() throws Exception {
         TestFileStore slowStore = createSlowStore();
         slowStore.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
 
@@ -798,19 +794,20 @@ public class ExpireSnapshotsTest {
                         slowStore.options().tagDefaultTimeRetained(),
                         Collections.emptyList(),
                         false);
+                rewriteSnapshotTime(slowStore.fileIO(), snapshotManager, i, 0);
             }
 
             SlowFileIO.reset();
             SlowFileIO.setDelayMillis(20);
+            ExpireSnapshotsImpl expire =
+                    (ExpireSnapshotsImpl) slowStore.newExpire(expireAllButLatestConfig());
+            expire.setCurrentTimeMillis(() -> 1000L);
 
-            List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+            expire.expire();
 
-            assertThat(taggedSnapshots).hasSize(latestSnapshotId);
-            for (int i = 1; i <= latestSnapshotId; i++) {
-                assertThat(taggedSnapshots.get(i - 1).id()).isEqualTo(i);
-            }
             assertThat(SlowFileIO.delayedOperations()).isGreaterThan(0);
             assertThat(SlowFileIO.maxActiveOperations()).isGreaterThan(1);
+            assertSnapshot(slowStore, latestSnapshotId, allData, snapshotPositions);
         } finally {
             SlowFileIO.reset();
         }
@@ -934,6 +931,45 @@ public class ExpireSnapshotsTest {
         assertSnapshot(6, allData, snapshotPositions);
 
         store.assertCleaned();
+    }
+
+    @Test
+    public void testExpireWithTimeDoesNotReadProtectedRange() throws Exception {
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ofMillis(5000))
+                        .build();
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(6, allData, snapshotPositions);
+        for (int i = 1; i <= 6; i++) {
+            rewriteSnapshotTime(i, 0);
+        }
+        rewriteSnapshotTime(4, 2000);
+
+        FailingSnapshotManager failingSnapshotManager =
+                new FailingSnapshotManager(snapshotManager, 5);
+        ExpireSnapshotsImpl expire =
+                new ExpireSnapshotsImpl(
+                        failingSnapshotManager,
+                        changelogManager,
+                        store.newSnapshotDeletion(),
+                        store.newTagManager());
+        expire.config(config);
+        expire.setCurrentTimeMillis(() -> 6000L);
+
+        expire.expire();
+
+        assertThat(failingSnapshotManager.readFailedSnapshot()).isFalse();
+        assertThat(snapshotManager.snapshotExists(1)).isFalse();
+        assertThat(snapshotManager.snapshotExists(2)).isFalse();
+        for (int i = 3; i <= 6; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isTrue();
+            assertSnapshot(i, allData, snapshotPositions);
+        }
     }
 
     @Test
@@ -1193,6 +1229,35 @@ public class ExpireSnapshotsTest {
         String newJson = JsonSerdeUtil.OBJECT_MAPPER_INSTANCE.writeValueAsString(node);
         fileIO.overwriteFileUtf8(snapshotManager.snapshotPath(snapshotId), newJson);
         snapshotManager.invalidateCache();
+    }
+
+    private static class FailingSnapshotManager extends SnapshotManager {
+
+        private final long failedSnapshotId;
+        private boolean readFailedSnapshot;
+
+        private FailingSnapshotManager(SnapshotManager snapshotManager, long failedSnapshotId) {
+            super(
+                    snapshotManager.fileIO(),
+                    snapshotManager.tablePath(),
+                    snapshotManager.branch(),
+                    null,
+                    null);
+            this.failedSnapshotId = failedSnapshotId;
+        }
+
+        @Override
+        public Snapshot tryGetSnapshot(long snapshotId) throws java.io.FileNotFoundException {
+            if (snapshotId == failedSnapshotId) {
+                readFailedSnapshot = true;
+                throw new RuntimeException("Unexpected snapshot read.");
+            }
+            return super.tryGetSnapshot(snapshotId);
+        }
+
+        private boolean readFailedSnapshot() {
+            return readFailedSnapshot;
+        }
     }
 
     private static class BlockingSnapshotManager extends SnapshotManager {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -38,6 +38,8 @@ import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
+import org.apache.paimon.operation.FileDeletionBase.DataFileDeletionPlan;
+import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -64,6 +66,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -74,6 +77,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -568,12 +572,7 @@ public class ExpireSnapshotsTest {
     public void testExpireCollectsSnapshotsConcurrently() throws Exception {
         store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
 
-        ExpireConfig config =
-                ExpireConfig.builder()
-                        .snapshotRetainMin(1)
-                        .snapshotRetainMax(Integer.MAX_VALUE)
-                        .snapshotTimeRetain(Duration.ofMillis(1))
-                        .build();
+        ExpireConfig config = expireAllButLatestConfig();
 
         List<KeyValue> allData = new ArrayList<>();
         List<Integer> snapshotPositions = new ArrayList<>();
@@ -599,6 +598,198 @@ public class ExpireSnapshotsTest {
         int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
         assertSnapshot(latestSnapshotId, allData, snapshotPositions);
         store.assertCleaned();
+    }
+
+    @Test
+    public void testExpirePlansDataFilesConcurrently() throws Exception {
+        store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(6, allData, snapshotPositions);
+        SnapshotManager snapshotManager = store.snapshotManager();
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            rewriteSnapshotTime(i, 0);
+        }
+
+        BlockingSnapshotDeletion snapshotDeletion =
+                new BlockingSnapshotDeletion(store, 2, latestSnapshotId);
+        snapshotDeletion.blockDataFilePlans();
+        ExpireSnapshotsImpl expire =
+                newExpireWithSnapshotDeletion(store, snapshotManager, snapshotDeletion);
+        expire.config(expireAllButLatestConfig());
+        expire.setCurrentTimeMillis(() -> 1000L);
+
+        expire.expire();
+
+        assertThat(snapshotDeletion.maxActiveDataFilePlans()).isGreaterThan(1);
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+        store.assertCleaned();
+    }
+
+    @Test
+    public void testExpirePlansChangelogFilesConcurrently() throws Exception {
+        TestFileStore inputStore = createStore(CoreOptions.ChangelogProducer.INPUT);
+        inputStore.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(inputStore, 6, allData, snapshotPositions);
+        SnapshotManager snapshotManager = inputStore.snapshotManager();
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            rewriteSnapshotTime(inputStore.fileIO(), snapshotManager, i, 0);
+        }
+
+        Set<String> changelogManifestLists = new HashSet<>();
+        for (int i = 1; i < latestSnapshotId; i++) {
+            String changelogManifestList = snapshotManager.snapshot(i).changelogManifestList();
+            if (changelogManifestList != null) {
+                changelogManifestLists.add(changelogManifestList);
+            }
+        }
+        assertThat(changelogManifestLists.size()).isGreaterThan(1);
+
+        BlockingSnapshotDeletion snapshotDeletion =
+                new BlockingSnapshotDeletion(inputStore, 1, latestSnapshotId - 1);
+        snapshotDeletion.blockChangelogPlans(changelogManifestLists);
+        ExpireSnapshotsImpl expire =
+                newExpireWithSnapshotDeletion(inputStore, snapshotManager, snapshotDeletion);
+        expire.config(expireAllButLatestConfig());
+        expire.setCurrentTimeMillis(() -> 1000L);
+
+        expire.expire();
+
+        assertThat(snapshotDeletion.maxActiveChangelogPlans()).isGreaterThan(1);
+        assertSnapshot(inputStore, latestSnapshotId, allData, snapshotPositions);
+        inputStore.assertCleaned();
+    }
+
+    @Test
+    public void testExpirePlansManifestsConcurrentlyWithoutMutatingSkippingSet() throws Exception {
+        store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(6, allData, snapshotPositions);
+        SnapshotManager snapshotManager = store.snapshotManager();
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            rewriteSnapshotTime(i, 0);
+        }
+
+        BlockingSnapshotDeletion snapshotDeletion =
+                new BlockingSnapshotDeletion(store, 1, latestSnapshotId - 1);
+        snapshotDeletion.blockManifestPlans();
+        ExpireSnapshotsImpl expire =
+                newExpireWithSnapshotDeletion(store, snapshotManager, snapshotDeletion);
+        expire.config(expireAllButLatestConfig());
+        expire.setCurrentTimeMillis(() -> 1000L);
+
+        expire.expire();
+
+        assertThat(snapshotDeletion.maxActiveManifestPlans()).isGreaterThan(1);
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+        store.assertCleaned();
+    }
+
+    @Test
+    public void testExpireWithTagsAndConcurrentPlanningKeepsTaggedSnapshotsReadable()
+            throws Exception {
+        store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(8, allData, snapshotPositions);
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        for (int i = 1; i <= latestSnapshotId; i++) {
+            rewriteSnapshotTime(i, 0);
+        }
+
+        TagManager tagManager = store.newTagManager();
+        tagManager.createTag(
+                snapshotManager.snapshot(3),
+                "tag3",
+                store.options().tagDefaultTimeRetained(),
+                Collections.emptyList(),
+                false);
+        tagManager.createTag(
+                snapshotManager.snapshot(6),
+                "tag6",
+                store.options().tagDefaultTimeRetained(),
+                Collections.emptyList(),
+                false);
+
+        ExpireSnapshotsImpl expire =
+                (ExpireSnapshotsImpl) store.newExpire(expireAllButLatestConfig());
+        expire.setCurrentTimeMillis(() -> 1000L);
+        expire.expire();
+
+        for (int i = 1; i < latestSnapshotId; i++) {
+            assertThat(snapshotManager.snapshotExists(i)).isFalse();
+        }
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+        assertSnapshot(tagManager.getOrThrow("tag3").trimToSnapshot(), allData, snapshotPositions);
+        assertSnapshot(tagManager.getOrThrow("tag6").trimToSnapshot(), allData, snapshotPositions);
+    }
+
+    @Test
+    public void testTagManagerReadsTagsConcurrentlyWithObjectStoreFileIO() throws Exception {
+        TestFileStore slowStore = createSlowStore();
+        slowStore.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        try {
+            List<KeyValue> allData = new ArrayList<>();
+            List<Integer> snapshotPositions = new ArrayList<>();
+            commit(slowStore, 6, allData, snapshotPositions);
+
+            SnapshotManager snapshotManager = slowStore.snapshotManager();
+            int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+            TagManager tagManager = slowStore.newTagManager();
+            for (int i = 1; i <= latestSnapshotId; i++) {
+                tagManager.createTag(
+                        snapshotManager.snapshot(i),
+                        "tag" + i,
+                        slowStore.options().tagDefaultTimeRetained(),
+                        Collections.emptyList(),
+                        false);
+            }
+
+            SlowFileIO.reset();
+            SlowFileIO.setDelayMillis(20);
+
+            List<Snapshot> taggedSnapshots = tagManager.taggedSnapshots();
+
+            assertThat(taggedSnapshots).hasSize(latestSnapshotId);
+            for (int i = 1; i <= latestSnapshotId; i++) {
+                assertThat(taggedSnapshots.get(i - 1).id()).isEqualTo(i);
+            }
+            assertThat(SlowFileIO.delayedOperations()).isGreaterThan(0);
+            assertThat(SlowFileIO.maxActiveOperations()).isGreaterThan(1);
+        } finally {
+            SlowFileIO.reset();
+        }
+    }
+
+    @Test
+    public void testPlannedDeletionDeduplicatesFilesBeforeDelete() throws Exception {
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(2, allData, snapshotPositions);
+
+        CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
+        Snapshot snapshot = snapshotManager.snapshot(1);
+        DataFileDeletionPlan dataPlan =
+                snapshotDeletion.planAddedDataFiles(snapshot.deltaManifestList());
+        snapshotDeletion.deletePlannedDataFiles(Arrays.asList(dataPlan, dataPlan));
+        snapshotDeletion.assertDeleteBatchesDeduplicated();
+
+        snapshotDeletion.reset();
+        ManifestDeletionPlan manifestPlan =
+                snapshotDeletion.planUnusedManifests(snapshot, Collections.emptySet(), false);
+        snapshotDeletion.deletePlannedManifests(Arrays.asList(manifestPlan, manifestPlan));
+        snapshotDeletion.assertDeleteBatchesDeduplicated();
     }
 
     @Test
@@ -877,6 +1068,15 @@ public class ExpireSnapshotsTest {
             changelogProducer = CoreOptions.ChangelogProducer.NONE;
         }
 
+        return createStore(root, changelogProducer);
+    }
+
+    private TestFileStore createStore(CoreOptions.ChangelogProducer changelogProducer) {
+        return createStore(tempDir.toString(), changelogProducer);
+    }
+
+    private TestFileStore createStore(
+            String root, CoreOptions.ChangelogProducer changelogProducer) {
         return new TestFileStore.Builder(
                         "avro",
                         root,
@@ -889,6 +1089,22 @@ public class ExpireSnapshotsTest {
                         null)
                 .changelogProducer(changelogProducer)
                 .build();
+    }
+
+    private ExpireConfig expireAllButLatestConfig() {
+        return ExpireConfig.builder()
+                .snapshotRetainMin(1)
+                .snapshotRetainMax(Integer.MAX_VALUE)
+                .snapshotTimeRetain(Duration.ofMillis(1))
+                .build();
+    }
+
+    private ExpireSnapshotsImpl newExpireWithSnapshotDeletion(
+            TestFileStore store,
+            SnapshotManager snapshotManager,
+            SnapshotDeletion snapshotDeletion) {
+        return new ExpireSnapshotsImpl(
+                snapshotManager, store.changelogManager(), snapshotDeletion, store.newTagManager());
     }
 
     private void rewriteSnapshotTime(long snapshotId, long newTimeMillis) throws IOException {
@@ -966,6 +1182,177 @@ public class ExpireSnapshotsTest {
 
         private int maxActiveReads() {
             return maxActiveReads.get();
+        }
+    }
+
+    private static class BlockingSnapshotDeletion extends SnapshotDeletion {
+
+        private final long minBlockedSnapshotId;
+        private final long maxBlockedSnapshotId;
+        private final ConcurrentCallTracker dataFilePlans =
+                new ConcurrentCallTracker("Data file plans were not created concurrently.");
+        private final ConcurrentCallTracker changelogPlans =
+                new ConcurrentCallTracker("Changelog plans were not created concurrently.");
+        private final ConcurrentCallTracker manifestPlans =
+                new ConcurrentCallTracker("Manifest plans were not created concurrently.");
+
+        private boolean blockDataFilePlans;
+        private boolean blockManifestPlans;
+        private Set<String> blockedChangelogManifestLists = Collections.emptySet();
+
+        private BlockingSnapshotDeletion(
+                TestFileStore store, long minBlockedSnapshotId, long maxBlockedSnapshotId) {
+            super(
+                    store.fileIO(),
+                    store.pathFactory(),
+                    store.manifestFileFactory().create(),
+                    store.manifestListFactory().create(),
+                    store.newIndexFileHandler(),
+                    store.newStatsFileHandler(),
+                    store.options().changelogProducer() != CoreOptions.ChangelogProducer.NONE,
+                    store.options().cleanEmptyDirectories(),
+                    store.options().fileOperationThreadNum());
+            this.minBlockedSnapshotId = minBlockedSnapshotId;
+            this.maxBlockedSnapshotId = maxBlockedSnapshotId;
+        }
+
+        private void blockDataFilePlans() {
+            blockDataFilePlans = true;
+        }
+
+        private void blockChangelogPlans(Set<String> changelogManifestLists) {
+            blockedChangelogManifestLists = changelogManifestLists;
+        }
+
+        private void blockManifestPlans() {
+            blockManifestPlans = true;
+        }
+
+        @Override
+        public DataFileDeletionPlan planUnusedDataFiles(
+                Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
+            if (blockDataFilePlans && shouldBlock(snapshot.id())) {
+                dataFilePlans.awaitConcurrentCall();
+            }
+            return super.planUnusedDataFiles(snapshot, skipper);
+        }
+
+        @Override
+        public DataFileDeletionPlan planAddedDataFiles(String manifestListName) {
+            if (blockedChangelogManifestLists.contains(manifestListName)) {
+                changelogPlans.awaitConcurrentCall();
+            }
+            return super.planAddedDataFiles(manifestListName);
+        }
+
+        @Override
+        public ManifestDeletionPlan planUnusedManifests(
+                Snapshot snapshot, Set<String> skippingSet, boolean updateSkippingSet) {
+            if (updateSkippingSet) {
+                throw new AssertionError(
+                        "Concurrent manifest planning must not mutate skipping set.");
+            }
+            if (blockManifestPlans && shouldBlock(snapshot.id())) {
+                manifestPlans.awaitConcurrentCall();
+            }
+            return super.planUnusedManifests(snapshot, skippingSet, updateSkippingSet);
+        }
+
+        private boolean shouldBlock(long snapshotId) {
+            return snapshotId >= minBlockedSnapshotId && snapshotId <= maxBlockedSnapshotId;
+        }
+
+        private int maxActiveDataFilePlans() {
+            return dataFilePlans.maxActiveCalls();
+        }
+
+        private int maxActiveChangelogPlans() {
+            return changelogPlans.maxActiveCalls();
+        }
+
+        private int maxActiveManifestPlans() {
+            return manifestPlans.maxActiveCalls();
+        }
+    }
+
+    private static class CapturingSnapshotDeletion extends SnapshotDeletion {
+
+        private final List<List<Object>> deleteBatches = new ArrayList<>();
+
+        private CapturingSnapshotDeletion(TestFileStore store) {
+            super(
+                    store.fileIO(),
+                    store.pathFactory(),
+                    store.manifestFileFactory().create(),
+                    store.manifestListFactory().create(),
+                    store.newIndexFileHandler(),
+                    store.newStatsFileHandler(),
+                    store.options().changelogProducer() != CoreOptions.ChangelogProducer.NONE,
+                    store.options().cleanEmptyDirectories(),
+                    store.options().fileOperationThreadNum());
+        }
+
+        @Override
+        protected <F> void deleteFiles(
+                Collection<F> files, java.util.function.Consumer<F> deletion) {
+            if (!files.isEmpty()) {
+                deleteBatches.add(new ArrayList<Object>(files));
+            }
+        }
+
+        private void assertDeleteBatchesDeduplicated() {
+            assertThat(deleteBatches).isNotEmpty();
+            for (List<Object> batch : deleteBatches) {
+                assertThat(new HashSet<>(batch)).hasSize(batch.size());
+            }
+        }
+
+        private void reset() {
+            deleteBatches.clear();
+        }
+    }
+
+    private static class ConcurrentCallTracker {
+
+        private final String timeoutMessage;
+        private final CountDownLatch releaseCalls = new CountDownLatch(1);
+        private final AtomicInteger activeCalls = new AtomicInteger();
+        private final AtomicInteger maxActiveCalls = new AtomicInteger();
+
+        private ConcurrentCallTracker(String timeoutMessage) {
+            this.timeoutMessage = timeoutMessage;
+        }
+
+        private void awaitConcurrentCall() {
+            int active = activeCalls.incrementAndGet();
+            updateMaxActiveCalls(active);
+            if (active > 1) {
+                releaseCalls.countDown();
+            }
+            try {
+                if (!releaseCalls.await(5, TimeUnit.SECONDS)) {
+                    throw new RuntimeException(timeoutMessage);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                activeCalls.decrementAndGet();
+            }
+        }
+
+        private void updateMaxActiveCalls(int active) {
+            int current;
+            do {
+                current = maxActiveCalls.get();
+                if (active <= current) {
+                    return;
+                }
+            } while (!maxActiveCalls.compareAndSet(current, active));
+        }
+
+        private int maxActiveCalls() {
+            return maxActiveCalls.get();
         }
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -285,8 +285,8 @@ public class ExpireSnapshotsTest {
                         1,
                         EMPTY_ROW,
                         EMPTY_ROW,
-                        null,
-                        null,
+                        SimpleStats.EMPTY_STATS,
+                        SimpleStats.EMPTY_STATS,
                         0,
                         1,
                         0,
@@ -346,8 +346,8 @@ public class ExpireSnapshotsTest {
                         1,
                         EMPTY_ROW,
                         EMPTY_ROW,
-                        null,
-                        null,
+                        SimpleStats.EMPTY_STATS,
+                        SimpleStats.EMPTY_STATS,
                         0,
                         1,
                         0,
@@ -835,10 +835,15 @@ public class ExpireSnapshotsTest {
         snapshotDeletion.reset();
         List<Runnable> manifestPlan =
                 snapshotDeletion.planManifestsCleaner(snapshot, new HashSet<>());
+        assertThat(manifestPlan).isNotEmpty();
         List<Runnable> duplicateManifestPlan = new ArrayList<>(manifestPlan);
         duplicateManifestPlan.addAll(manifestPlan);
+        AtomicInteger probeRuns = new AtomicInteger();
+        Runnable probe = probeRuns::incrementAndGet;
+        duplicateManifestPlan.add(probe);
+        duplicateManifestPlan.add(probe);
         snapshotDeletion.executeAll(duplicateManifestPlan);
-        snapshotDeletion.assertDeleteBatchesDeduplicated();
+        assertThat(probeRuns).hasValue(1);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -37,11 +37,13 @@ import org.apache.paimon.manifest.ExpireFileEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.table.ExpireSnapshots;
 import org.apache.paimon.table.ExpireSnapshotsImpl;
 import org.apache.paimon.utils.ChangelogManager;
@@ -790,6 +792,32 @@ public class ExpireSnapshotsTest {
                 snapshotDeletion.planUnusedManifests(snapshot, Collections.emptySet(), false);
         snapshotDeletion.deletePlannedManifests(Arrays.asList(manifestPlan, manifestPlan));
         snapshotDeletion.assertDeleteBatchesDeduplicated();
+    }
+
+    @Test
+    public void testPlanUnusedDataFilesCancelsDeletionWhenManifestFileMissing() throws Exception {
+        ManifestFileMeta missingManifest =
+                new ManifestFileMeta(
+                        "missing-manifest",
+                        1,
+                        0,
+                        1,
+                        SimpleStats.EMPTY_STATS,
+                        0,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+        String manifestList =
+                store.manifestListFactory()
+                        .create()
+                        .write(Arrays.asList(missingManifest))
+                        .getLeft();
+
+        CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
+        assertThat(snapshotDeletion.planUnusedDataFiles(manifestList, entry -> false)).isEmpty();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -817,36 +817,6 @@ public class ExpireSnapshotsTest {
     }
 
     @Test
-    public void testPlannedDeletionDeduplicatesFilesBeforeDelete() throws Exception {
-        List<KeyValue> allData = new ArrayList<>();
-        List<Integer> snapshotPositions = new ArrayList<>();
-        commit(2, allData, snapshotPositions);
-
-        CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
-        Snapshot snapshot = snapshotManager.snapshot(1);
-        List<Path> dataFiles =
-                snapshotDeletion.planAddedInChangelogManifest(
-                        snapshotWithChangelogManifestList(snapshot.deltaManifestList()));
-        List<Path> duplicateDataFiles = new ArrayList<>(dataFiles);
-        duplicateDataFiles.addAll(dataFiles);
-        snapshotDeletion.cleanDataFiles(duplicateDataFiles);
-        snapshotDeletion.assertDeleteBatchesDeduplicated();
-
-        snapshotDeletion.reset();
-        List<Runnable> manifestPlan =
-                snapshotDeletion.planManifestsCleaner(snapshot, new HashSet<>());
-        assertThat(manifestPlan).isNotEmpty();
-        List<Runnable> duplicateManifestPlan = new ArrayList<>(manifestPlan);
-        duplicateManifestPlan.addAll(manifestPlan);
-        AtomicInteger probeRuns = new AtomicInteger();
-        Runnable probe = probeRuns::incrementAndGet;
-        duplicateManifestPlan.add(probe);
-        duplicateManifestPlan.add(probe);
-        snapshotDeletion.executeAll(duplicateManifestPlan);
-        assertThat(probeRuns).hasValue(1);
-    }
-
-    @Test
     public void testPlanUnusedDataFilesCancelsDeletionWhenManifestFileMissing() throws Exception {
         ManifestFileMeta missingManifest =
                 new ManifestFileMeta(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -46,6 +46,7 @@ import org.apache.paimon.table.ExpireSnapshotsImpl;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.RecordWriter;
+import org.apache.paimon.utils.SlowFileIO;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.TagManager;
 
@@ -69,7 +70,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -561,6 +565,82 @@ public class ExpireSnapshotsTest {
     }
 
     @Test
+    public void testExpireCollectsSnapshotsConcurrently() throws Exception {
+        store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        ExpireConfig config =
+                ExpireConfig.builder()
+                        .snapshotRetainMin(1)
+                        .snapshotRetainMax(Integer.MAX_VALUE)
+                        .snapshotTimeRetain(Duration.ofMillis(1))
+                        .build();
+
+        List<KeyValue> allData = new ArrayList<>();
+        List<Integer> snapshotPositions = new ArrayList<>();
+        commit(5, allData, snapshotPositions);
+        for (int i = 1; i <= 5; i++) {
+            rewriteSnapshotTime(i, 0);
+        }
+
+        BlockingSnapshotManager blockingSnapshotManager =
+                new BlockingSnapshotManager(snapshotManager, 1, 5);
+        ExpireSnapshotsImpl expire =
+                new ExpireSnapshotsImpl(
+                        blockingSnapshotManager,
+                        changelogManager,
+                        store.newSnapshotDeletion(),
+                        store.newTagManager());
+        expire.config(config);
+        expire.setCurrentTimeMillis(() -> 1000L);
+
+        expire.expire();
+
+        assertThat(blockingSnapshotManager.maxActiveReads()).isGreaterThan(1);
+        int latestSnapshotId = requireNonNull(snapshotManager.latestSnapshotId()).intValue();
+        assertSnapshot(latestSnapshotId, allData, snapshotPositions);
+        store.assertCleaned();
+    }
+
+    @Test
+    public void testExpireWithSlowObjectStoreFileIO() throws Exception {
+        TestFileStore slowStore = createSlowStore();
+        slowStore.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
+
+        try {
+            List<KeyValue> allData = new ArrayList<>();
+            List<Integer> snapshotPositions = new ArrayList<>();
+            for (int i = 0; i < 8; i++) {
+                commit(slowStore, 3, allData, snapshotPositions);
+            }
+
+            SnapshotManager slowSnapshotManager = slowStore.snapshotManager();
+            int latestSnapshotId = requireNonNull(slowSnapshotManager.latestSnapshotId()).intValue();
+            for (int i = 1; i <= latestSnapshotId; i++) {
+                rewriteSnapshotTime(slowStore.fileIO(), slowSnapshotManager, i, 0);
+            }
+
+            SlowFileIO.reset();
+            SlowFileIO.setDelayMillis(20);
+            ExpireConfig config =
+                    ExpireConfig.builder()
+                            .snapshotRetainMin(1)
+                            .snapshotRetainMax(Integer.MAX_VALUE)
+                            .snapshotTimeRetain(Duration.ofMillis(1))
+                            .build();
+            ExpireSnapshotsImpl expire = (ExpireSnapshotsImpl) slowStore.newExpire(config);
+            expire.setCurrentTimeMillis(() -> 1000L);
+
+            expire.expire();
+
+            assertThat(SlowFileIO.delayedOperations()).isGreaterThan(0);
+            assertThat(SlowFileIO.maxActiveOperations()).isGreaterThan(1);
+            assertSnapshot(slowStore, latestSnapshotId, allData, snapshotPositions);
+        } finally {
+            SlowFileIO.reset();
+        }
+    }
+
+    @Test
     public void testExpireWithTimeProtectsEachSnapshot() throws Exception {
         // Even with a small retainMin, each snapshot should be protected by
         // snapshotTimeRetain: a snapshot can only be expired when its next
@@ -779,6 +859,14 @@ public class ExpireSnapshotsTest {
     }
 
     private TestFileStore createStore() {
+        return createStore(tempDir.toString());
+    }
+
+    private TestFileStore createSlowStore() {
+        return createStore(SlowFileIO.SCHEME + "://" + tempDir.toString());
+    }
+
+    private TestFileStore createStore(String root) {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         CoreOptions.ChangelogProducer changelogProducer;
@@ -790,7 +878,7 @@ public class ExpireSnapshotsTest {
 
         return new TestFileStore.Builder(
                         "avro",
-                        tempDir.toString(),
+                        root,
                         1,
                         TestKeyValueGenerator.DEFAULT_PART_TYPE,
                         TestKeyValueGenerator.KEY_TYPE,
@@ -803,6 +891,15 @@ public class ExpireSnapshotsTest {
     }
 
     private void rewriteSnapshotTime(long snapshotId, long newTimeMillis) throws IOException {
+        rewriteSnapshotTime(fileIO, snapshotManager, snapshotId, newTimeMillis);
+    }
+
+    private void rewriteSnapshotTime(
+            FileIO fileIO,
+            SnapshotManager snapshotManager,
+            long snapshotId,
+            long newTimeMillis)
+            throws IOException {
         String oldJson = fileIO.readFileUtf8(snapshotManager.snapshotPath(snapshotId));
         ObjectNode node = (ObjectNode) JsonSerdeUtil.OBJECT_MAPPER_INSTANCE.readTree(oldJson);
         node.put("timeMillis", newTimeMillis);
@@ -811,7 +908,77 @@ public class ExpireSnapshotsTest {
         snapshotManager.invalidateCache();
     }
 
+    private static class BlockingSnapshotManager extends SnapshotManager {
+
+        private final long minBlockedSnapshotId;
+        private final long maxBlockedSnapshotId;
+        private final CountDownLatch releaseReads = new CountDownLatch(1);
+        private final AtomicInteger activeReads = new AtomicInteger();
+        private final AtomicInteger maxActiveReads = new AtomicInteger();
+
+        private BlockingSnapshotManager(
+                SnapshotManager snapshotManager, long minBlockedSnapshotId, long maxBlockedSnapshotId) {
+            super(
+                    snapshotManager.fileIO(),
+                    snapshotManager.tablePath(),
+                    snapshotManager.branch(),
+                    null,
+                    null);
+            this.minBlockedSnapshotId = minBlockedSnapshotId;
+            this.maxBlockedSnapshotId = maxBlockedSnapshotId;
+        }
+
+        @Override
+        public Snapshot tryGetSnapshot(long snapshotId) throws java.io.FileNotFoundException {
+            if (snapshotId < minBlockedSnapshotId
+                    || snapshotId > maxBlockedSnapshotId
+                    || releaseReads.getCount() == 0) {
+                return super.tryGetSnapshot(snapshotId);
+            }
+
+            int active = activeReads.incrementAndGet();
+            updateMaxActiveReads(active);
+            if (active > 1) {
+                releaseReads.countDown();
+            }
+            try {
+                if (!releaseReads.await(5, TimeUnit.SECONDS)) {
+                    throw new RuntimeException("Snapshots were not read concurrently.");
+                }
+                return super.tryGetSnapshot(snapshotId);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            } finally {
+                activeReads.decrementAndGet();
+            }
+        }
+
+        private void updateMaxActiveReads(int active) {
+            int current;
+            do {
+                current = maxActiveReads.get();
+                if (active <= current) {
+                    return;
+                }
+            } while (!maxActiveReads.compareAndSet(current, active));
+        }
+
+        private int maxActiveReads() {
+            return maxActiveReads.get();
+        }
+    }
+
     protected void commit(int numCommits, List<KeyValue> allData, List<Integer> snapshotPositions)
+            throws Exception {
+        commit(store, numCommits, allData, snapshotPositions);
+    }
+
+    protected void commit(
+            TestFileStore store,
+            int numCommits,
+            List<KeyValue> allData,
+            List<Integer> snapshotPositions)
             throws Exception {
         for (int i = 0; i < numCommits; i++) {
             int numRecords = ThreadLocalRandom.current().nextInt(100) + 1;
@@ -830,11 +997,29 @@ public class ExpireSnapshotsTest {
     protected void assertSnapshot(
             int snapshotId, List<KeyValue> allData, List<Integer> snapshotPositions)
             throws Exception {
-        assertSnapshot(snapshotManager.snapshot(snapshotId), allData, snapshotPositions);
+        assertSnapshot(store, snapshotManager.snapshot(snapshotId), allData, snapshotPositions);
+    }
+
+    protected void assertSnapshot(
+            TestFileStore store,
+            int snapshotId,
+            List<KeyValue> allData,
+            List<Integer> snapshotPositions)
+            throws Exception {
+        assertSnapshot(store, store.snapshotManager().snapshot(snapshotId), allData, snapshotPositions);
     }
 
     protected void assertSnapshot(
             Snapshot snapshot, List<KeyValue> allData, List<Integer> snapshotPositions)
+            throws Exception {
+        assertSnapshot(store, snapshot, allData, snapshotPositions);
+    }
+
+    protected void assertSnapshot(
+            TestFileStore store,
+            Snapshot snapshot,
+            List<KeyValue> allData,
+            List<Integer> snapshotPositions)
             throws Exception {
         int snapshotId = (int) snapshot.id();
         Map<BinaryRow, BinaryRow> expected =

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -39,7 +39,6 @@ import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
-import org.apache.paimon.operation.FileDeletionBase.ManifestDeletionPlan;
 import org.apache.paimon.options.ExpireConfig;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
@@ -305,9 +304,7 @@ public class ExpireSnapshotsTest {
         ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
         // expire
-        expire.snapshotDeletion()
-                .cleanUnusedDataFile(
-                        Arrays.asList(ExpireFileEntry.from(add), ExpireFileEntry.from(delete)));
+        cleanDeletedDataFiles(expire.snapshotDeletion(), Arrays.asList(add, delete));
 
         // check
         assertThat(fileIO.exists(myDataFile)).isFalse();
@@ -368,9 +365,7 @@ public class ExpireSnapshotsTest {
         ManifestEntry delete = ManifestEntry.create(FileKind.DELETE, partition, 0, 1, dataFile);
 
         // expire
-        expire.snapshotDeletion()
-                .cleanUnusedDataFile(
-                        Arrays.asList(ExpireFileEntry.from(add), ExpireFileEntry.from(delete)));
+        cleanDeletedDataFiles(expire.snapshotDeletion(), Arrays.asList(add, delete));
 
         // check
         assertThat(fileIO.exists(myDataFile)).isFalse();
@@ -378,6 +373,54 @@ public class ExpireSnapshotsTest {
         assertThat(fileIO.exists(extra2)).isFalse();
 
         store.assertCleaned();
+    }
+
+    private void cleanDeletedDataFiles(
+            SnapshotDeletion snapshotDeletion, List<ManifestEntry> dataFileLog) {
+        List<ManifestFileMeta> manifests = store.manifestFileFactory().create().write(dataFileLog);
+        String manifestList = store.manifestListFactory().create().write(manifests).getLeft();
+        Snapshot snapshot = snapshotWithDeltaManifestList(manifestList);
+
+        snapshotDeletion.cleanDataFiles(
+                snapshotDeletion.planDeletedInDeltaManifest(snapshot, file -> false));
+
+        for (ManifestFileMeta manifest : manifests) {
+            fileIO.deleteQuietly(store.pathFactory().toManifestFilePath(manifest.fileName()));
+        }
+        fileIO.deleteQuietly(store.pathFactory().toManifestListPath(manifestList));
+    }
+
+    private Snapshot snapshotWithDeltaManifestList(String manifestList) {
+        return snapshotWithManifestLists(manifestList, null);
+    }
+
+    private Snapshot snapshotWithChangelogManifestList(String manifestList) {
+        return snapshotWithManifestLists(null, manifestList);
+    }
+
+    private Snapshot snapshotWithManifestLists(
+            String deltaManifestList, String changelogManifestList) {
+        return new Snapshot(
+                0,
+                0L,
+                null,
+                null,
+                deltaManifestList,
+                null,
+                changelogManifestList,
+                null,
+                null,
+                "test",
+                0L,
+                Snapshot.CommitKind.APPEND,
+                0L,
+                0L,
+                0L,
+                null,
+                null,
+                null,
+                null,
+                null);
     }
 
     @Test
@@ -668,7 +711,7 @@ public class ExpireSnapshotsTest {
     }
 
     @Test
-    public void testExpirePlansManifestsConcurrentlyWithoutMutatingSkippingSet() throws Exception {
+    public void testExpirePlansManifestsConcurrentlyWithSkippingSet() throws Exception {
         store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 4);
 
         List<KeyValue> allData = new ArrayList<>();
@@ -781,16 +824,20 @@ public class ExpireSnapshotsTest {
 
         CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
         Snapshot snapshot = snapshotManager.snapshot(1);
-        List<Path> dataFiles = snapshotDeletion.planAddedDataFiles(snapshot.deltaManifestList());
+        List<Path> dataFiles =
+                snapshotDeletion.planAddedInChangelogManifest(
+                        snapshotWithChangelogManifestList(snapshot.deltaManifestList()));
         List<Path> duplicateDataFiles = new ArrayList<>(dataFiles);
         duplicateDataFiles.addAll(dataFiles);
-        snapshotDeletion.deleteDataFiles(duplicateDataFiles);
+        snapshotDeletion.cleanDataFiles(duplicateDataFiles);
         snapshotDeletion.assertDeleteBatchesDeduplicated();
 
         snapshotDeletion.reset();
-        ManifestDeletionPlan manifestPlan =
-                snapshotDeletion.planUnusedManifests(snapshot, Collections.emptySet(), false);
-        snapshotDeletion.deletePlannedManifests(Arrays.asList(manifestPlan, manifestPlan));
+        List<Runnable> manifestPlan =
+                snapshotDeletion.planManifestsCleaner(snapshot, new HashSet<>());
+        List<Runnable> duplicateManifestPlan = new ArrayList<>(manifestPlan);
+        duplicateManifestPlan.addAll(manifestPlan);
+        snapshotDeletion.executeAll(duplicateManifestPlan);
         snapshotDeletion.assertDeleteBatchesDeduplicated();
     }
 
@@ -817,7 +864,10 @@ public class ExpireSnapshotsTest {
                         .getLeft();
 
         CapturingSnapshotDeletion snapshotDeletion = new CapturingSnapshotDeletion(store);
-        assertThat(snapshotDeletion.planUnusedDataFiles(manifestList, entry -> false)).isEmpty();
+        assertThat(
+                        snapshotDeletion.planDeletedInDeltaManifest(
+                                snapshotWithDeltaManifestList(manifestList), entry -> false))
+                .isEmpty();
     }
 
     @Test
@@ -1257,33 +1307,28 @@ public class ExpireSnapshotsTest {
         }
 
         @Override
-        public List<Path> planUnusedDataFiles(
+        public List<Path> planDeletedInDeltaManifest(
                 Snapshot snapshot, Predicate<ExpireFileEntry> skipper) {
             if (blockDataFilePlans && shouldBlock(snapshot.id())) {
                 dataFilePlans.awaitConcurrentCall();
             }
-            return super.planUnusedDataFiles(snapshot, skipper);
+            return super.planDeletedInDeltaManifest(snapshot, skipper);
         }
 
         @Override
-        public List<Path> planAddedDataFiles(String manifestListName) {
-            if (blockedChangelogManifestLists.contains(manifestListName)) {
+        public List<Path> planAddedInChangelogManifest(Snapshot snapshot) {
+            if (blockedChangelogManifestLists.contains(snapshot.changelogManifestList())) {
                 changelogPlans.awaitConcurrentCall();
             }
-            return super.planAddedDataFiles(manifestListName);
+            return super.planAddedInChangelogManifest(snapshot);
         }
 
         @Override
-        public ManifestDeletionPlan planUnusedManifests(
-                Snapshot snapshot, Set<String> skippingSet, boolean updateSkippingSet) {
-            if (updateSkippingSet) {
-                throw new AssertionError(
-                        "Concurrent manifest planning must not mutate skipping set.");
-            }
+        public List<Runnable> planManifestsCleaner(Snapshot snapshot, Set<String> skippingSet) {
             if (blockManifestPlans && shouldBlock(snapshot.id())) {
                 manifestPlans.awaitConcurrentCall();
             }
-            return super.planUnusedManifests(snapshot, skippingSet, updateSkippingSet);
+            return super.planManifestsCleaner(snapshot, skippingSet);
         }
 
         private boolean shouldBlock(long snapshotId) {
@@ -1321,10 +1366,10 @@ public class ExpireSnapshotsTest {
         }
 
         @Override
-        protected <F> void deleteFiles(
+        protected <F> void executeAll(
                 Collection<F> files, java.util.function.Consumer<F> deletion) {
             if (!files.isEmpty()) {
-                deleteBatches.add(new ArrayList<Object>(files));
+                deleteBatches.add(new ArrayList<>(files));
             }
         }
 

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -979,6 +979,26 @@ public class ExpireSnapshotsTest {
         store.assertCleaned();
     }
 
+    @Test
+    public void testExpireWithZeroFileOperationThreadNumCleansDataFiles() throws Exception {
+        store.options().toConfiguration().set(CoreOptions.FILE_OPERATION_THREAD_NUM, 0);
+
+        List<KeyValue> data = FileStoreTestUtils.partitionedData(5, gen, "0401", 8);
+        BinaryRow partition = gen.getPartition(data.get(0));
+        RecordWriter<KeyValue> writer = FileStoreTestUtils.writeData(store, data, partition, 0);
+        Map<BinaryRow, Map<Integer, RecordWriter<KeyValue>>> writers =
+                Collections.singletonMap(partition, Collections.singletonMap(0, writer));
+        FileStoreTestUtils.commitData(store, 0, writers);
+
+        writer.compact(true);
+        writer.sync();
+        FileStoreTestUtils.commitData(store, 1, writers);
+
+        store.newExpire(1, 1, Long.MAX_VALUE).expire();
+
+        store.assertCleaned();
+    }
+
     @RepeatedTest(5)
     public void testChangelogOutLivedSnapshot() throws Exception {
         List<KeyValue> allData = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ExpireSnapshotsTest.java
@@ -614,7 +614,8 @@ public class ExpireSnapshotsTest {
             }
 
             SnapshotManager slowSnapshotManager = slowStore.snapshotManager();
-            int latestSnapshotId = requireNonNull(slowSnapshotManager.latestSnapshotId()).intValue();
+            int latestSnapshotId =
+                    requireNonNull(slowSnapshotManager.latestSnapshotId()).intValue();
             for (int i = 1; i <= latestSnapshotId; i++) {
                 rewriteSnapshotTime(slowStore.fileIO(), slowSnapshotManager, i, 0);
             }
@@ -895,10 +896,7 @@ public class ExpireSnapshotsTest {
     }
 
     private void rewriteSnapshotTime(
-            FileIO fileIO,
-            SnapshotManager snapshotManager,
-            long snapshotId,
-            long newTimeMillis)
+            FileIO fileIO, SnapshotManager snapshotManager, long snapshotId, long newTimeMillis)
             throws IOException {
         String oldJson = fileIO.readFileUtf8(snapshotManager.snapshotPath(snapshotId));
         ObjectNode node = (ObjectNode) JsonSerdeUtil.OBJECT_MAPPER_INSTANCE.readTree(oldJson);
@@ -917,7 +915,9 @@ public class ExpireSnapshotsTest {
         private final AtomicInteger maxActiveReads = new AtomicInteger();
 
         private BlockingSnapshotManager(
-                SnapshotManager snapshotManager, long minBlockedSnapshotId, long maxBlockedSnapshotId) {
+                SnapshotManager snapshotManager,
+                long minBlockedSnapshotId,
+                long maxBlockedSnapshotId) {
             super(
                     snapshotManager.fileIO(),
                     snapshotManager.tablePath(),
@@ -1006,7 +1006,8 @@ public class ExpireSnapshotsTest {
             List<KeyValue> allData,
             List<Integer> snapshotPositions)
             throws Exception {
-        assertSnapshot(store, store.snapshotManager().snapshot(snapshotId), allData, snapshotPositions);
+        assertSnapshot(
+                store, store.snapshotManager().snapshot(snapshotId), allData, snapshotPositions);
     }
 
     protected void assertSnapshot(

--- a/paimon-core/src/test/java/org/apache/paimon/utils/ManifestReadThreadPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/ManifestReadThreadPoolTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
@@ -125,6 +126,16 @@ public class ManifestReadThreadPoolTest {
     public void testForSingletonInput() {
         Iterable<Integer> re =
                 sequentialBatchedExecute(i -> singletonList(i + 1), singletonList(1), null);
+        re.forEach(i -> Assertions.assertThat(i).isEqualTo(2));
+    }
+
+    @Test
+    public void testNonPositiveThreadNumUsesDefaultExecutor() {
+        ExecutorService executor = ManifestReadThreadPool.getExecutorService(0);
+        Assertions.assertThat(executor).isNotInstanceOf(SemaphoredDelegatingExecutor.class);
+
+        Iterable<Integer> re =
+                sequentialBatchedExecute(i -> singletonList(i + 1), singletonList(1), 0);
         re.forEach(i -> Assertions.assertThat(i).isEqualTo(2));
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/utils/SlowFileIO.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/SlowFileIO.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileIOLoader;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A local {@link FileIO} which adds configurable latency to each file operation. */
+public class SlowFileIO extends LocalFileIO {
+
+    public static final String SCHEME = "slow-expire";
+
+    private static final AtomicLong DELAY_MILLIS = new AtomicLong();
+    private static final AtomicLong DELAYED_OPERATIONS = new AtomicLong();
+    private static final AtomicInteger ACTIVE_OPERATIONS = new AtomicInteger();
+    private static final AtomicInteger MAX_ACTIVE_OPERATIONS = new AtomicInteger();
+
+    public static void reset() {
+        DELAY_MILLIS.set(0);
+        DELAYED_OPERATIONS.set(0);
+        ACTIVE_OPERATIONS.set(0);
+        MAX_ACTIVE_OPERATIONS.set(0);
+    }
+
+    public static void setDelayMillis(long delayMillis) {
+        DELAY_MILLIS.set(delayMillis);
+    }
+
+    public static long delayedOperations() {
+        return DELAYED_OPERATIONS.get();
+    }
+
+    public static int maxActiveOperations() {
+        return MAX_ACTIVE_OPERATIONS.get();
+    }
+
+    @Override
+    public boolean isObjectStore() {
+        return true;
+    }
+
+    @Override
+    public SeekableInputStream newInputStream(Path path) throws IOException {
+        delay();
+        return super.newInputStream(path);
+    }
+
+    @Override
+    public PositionOutputStream newOutputStream(Path path, boolean overwrite) throws IOException {
+        delay();
+        return super.newOutputStream(path, overwrite);
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path path) throws IOException {
+        delay();
+        return super.getFileStatus(path);
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path path) throws IOException {
+        delay();
+        return super.listStatus(path);
+    }
+
+    @Override
+    public boolean exists(Path path) throws IOException {
+        delay();
+        return super.exists(path);
+    }
+
+    @Override
+    public boolean delete(Path path, boolean recursive) throws IOException {
+        delay();
+        return super.delete(path, recursive);
+    }
+
+    @Override
+    public boolean mkdirs(Path path) throws IOException {
+        delay();
+        return super.mkdirs(path);
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+        delay();
+        return super.rename(src, dst);
+    }
+
+    private void delay() throws IOException {
+        long delayMillis = DELAY_MILLIS.get();
+        if (delayMillis <= 0) {
+            return;
+        }
+
+        DELAYED_OPERATIONS.incrementAndGet();
+        int active = ACTIVE_OPERATIONS.incrementAndGet();
+        updateMaxActiveOperations(active);
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException(e);
+        } finally {
+            ACTIVE_OPERATIONS.decrementAndGet();
+        }
+    }
+
+    private static void updateMaxActiveOperations(int active) {
+        int current;
+        do {
+            current = MAX_ACTIVE_OPERATIONS.get();
+            if (active <= current) {
+                return;
+            }
+        } while (!MAX_ACTIVE_OPERATIONS.compareAndSet(current, active));
+    }
+
+    /** Loader for {@link SlowFileIO}. */
+    public static class Loader implements FileIOLoader {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getScheme() {
+            return SCHEME;
+        }
+
+        @Override
+        public FileIO load(Path path) {
+            return new SlowFileIO();
+        }
+    }
+}

--- a/paimon-core/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
+++ b/paimon-core/src/test/resources/META-INF/services/org.apache.paimon.fs.FileIOLoader
@@ -15,4 +15,5 @@
 
 org.apache.paimon.utils.FailingFileIO$Loader
 org.apache.paimon.utils.TraceableFileIO$Loader
+org.apache.paimon.utils.SlowFileIO$Loader
 org.apache.paimon.rest.RESTFileIOTestLoader


### PR DESCRIPTION
## Summary

This PR parallelizes snapshot expiration planning and file IO work to reduce object-store latency impact when expiring many snapshots. It keeps final snapshot/changelog deletion ordering where required, while moving expensive snapshot reads, manifest reads, tag reads, and file deletion planning onto the existing file operation thread pool.

## Changes

- Collect snapshots concurrently and reuse the collected snapshot list during `snapshot.time-retained` checks.
- Split data/changelog/manifest cleanup into planning and centralized deletion phases so work can be planned concurrently and deleted with deduplication.
- Parallelize manifest reads used by file deletion and tag/skipping-set construction with bounded manifest read batching.
- Treat non-positive file operation thread counts as the default manifest read parallelism to preserve previous expiration behavior.
- Read tag files concurrently when `TagManager` is created with `CoreOptions`.
- Add `SlowFileIO` test support and a slow object-store expiration test that injects 20ms FileIO latency and asserts concurrent IO occurs.

## Testing

- `git diff --check`
- `mvn -pl paimon-core -am -Pfast-build -DskipTests compile`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=ExpireSnapshotsTest test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=FileDeletionTest test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=TagManagerTest test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=ExpireSnapshotsTest,FileDeletionTest,ManifestReadThreadPoolTest test`

## Notes

A local temporary benchmark with 20ms artificial FileIO latency and 24 commits measured `expire.expire()` improving from about 9.66s median to about 2.27s median in that scenario. The benchmark was only used locally; the committed coverage is the deterministic slow FileIO regression test.
