### PR TITLE
[core] Support merging sparse row ranges for global indexes

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexSingleColumnWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexSingleColumnWriter.java
@@ -20,16 +20,14 @@ package org.apache.paimon.globalindex;
 
 import javax.annotation.Nullable;
 
-/** Parallel Index writer for global index with relative row id (from 0 to rowCnt - 1). */
-public interface GlobalIndexParallelWriter extends GlobalIndexWriter {
+/** Index writer for global index that accepts one column value per row. */
+public interface GlobalIndexSingleColumnWriter extends GlobalIndexWriter {
 
     /**
-     * Write the indexed key and its related localRowId to the index File. The input row id is
-     * "local" which means it is calculated by the original row id minus the start row id of current
-     * index range.
+     * Write one record's indexed value at the given relative row id.
      *
      * @param key nullable index key
-     * @param relativeRowId local row id calculated by {@code rowId - rangeStart}.
+     * @param relativeRowId the record's row id relative to the current shard or range
      */
     void write(@Nullable Object key, long relativeRowId);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexOptions.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexOptions.java
@@ -66,4 +66,13 @@ public class BTreeIndexOptions {
                     .intType()
                     .defaultValue(4096)
                     .withDescription("The max parallelism of Flink/Spark for building BTreeIndex.");
+
+    public static final ConfigOption<Boolean> BTREE_INDEX_BUILD_MERGE_ROW_RANGES =
+            ConfigOptions.key("btree-index.build.merge-row-ranges")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to merge discontinuous row id ranges when building BTreeIndex. "
+                                    + "This should only be enabled when row id gaps are permanent and "
+                                    + "will never be filled by later writes.");
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexWriter.java
@@ -20,8 +20,7 @@ package org.apache.paimon.globalindex.btree;
 
 import org.apache.paimon.compression.BlockCompressionFactory;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.memory.MemorySlice;
@@ -42,9 +41,9 @@ import java.util.List;
 import java.util.zip.CRC32;
 
 /**
- * The {@link GlobalIndexSingletonWriter} implementation for BTree index. Note that users must keep
- * written keys monotonically incremental. All null keys are stored in a separate bitmap, which will
- * be serialized and appended to the file end on close. The layout is as below:
+ * The {@link GlobalIndexSingleColumnWriter} implementation for BTree index. Note that users must
+ * keep written keys monotonically incremental. All null keys are stored in a separate bitmap, which
+ * will be serialized and appended to the file end on close. The layout is as below:
  *
  * <pre>
  *    +-----------------------------------+------+
@@ -67,7 +66,7 @@ import java.util.zip.CRC32;
  * <p>For efficiency, we combine entries with the same keys and store a compact list of row ids for
  * each key.
  */
-public class BTreeIndexWriter implements GlobalIndexParallelWriter {
+public class BTreeIndexWriter implements GlobalIndexSingleColumnWriter {
 
     private final String fileName;
     private final PositionOutputStream out;

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -26,9 +26,9 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
 import org.apache.paimon.globalindex.GlobalIndexReader;
 import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
@@ -277,7 +277,7 @@ public abstract class AbstractIndexReaderTest {
     protected abstract GlobalIndexReader prepareDataAndCreateReader() throws Exception;
 
     protected GlobalIndexIOMeta writeData(List<Pair<Object, Long>> data) throws IOException {
-        GlobalIndexParallelWriter indexWriter = globalIndexer.createWriter(fileWriter);
+        GlobalIndexSingleColumnWriter indexWriter = globalIndexer.createWriter(fileWriter);
         for (Pair<Object, Long> pair : data) {
             indexWriter.write(pair.getKey(), pair.getValue());
         }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexMetaTest.java
@@ -23,7 +23,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.memory.MemorySliceOutput;
@@ -155,7 +155,7 @@ class BTreeIndexMetaTest {
                                 new Path(new Path(tempPath.toUri()), fileName), true);
                     }
                 };
-        GlobalIndexParallelWriter indexWriter =
+        GlobalIndexSingleColumnWriter indexWriter =
                 new BTreeGlobalIndexer(
                                 new DataField(
                                         1, "testField", new VarCharType(VarCharType.MAX_LENGTH)),

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexOptionsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexOptionsTest.java
@@ -30,4 +30,9 @@ class BTreeIndexOptionsTest {
         assertThat(BTreeIndexOptions.BTREE_INDEX_RECORDS_PER_RANGE.defaultValue())
                 .isEqualTo(10_000_000L);
     }
+
+    @Test
+    void testDefaultMergeDiscontinuousRowRanges() {
+        assertThat(BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES.defaultValue()).isFalse();
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeThreadSafetyTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeThreadSafetyTest.java
@@ -23,9 +23,9 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
 import org.apache.paimon.globalindex.GlobalIndexReader;
 import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
@@ -353,7 +353,7 @@ public class BTreeThreadSafetyTest {
     }
 
     private GlobalIndexIOMeta writeData(List<Pair<Object, Long>> subData) throws IOException {
-        GlobalIndexParallelWriter indexWriter = globalIndexer.createWriter(fileWriter);
+        GlobalIndexSingleColumnWriter indexWriter = globalIndexer.createWriter(fileWriter);
         for (Pair<Object, Long> pair : subData) {
             indexWriter.write(pair.getKey(), pair.getValue());
         }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
@@ -20,9 +20,9 @@ package org.apache.paimon.globalindex.btree;
 
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.globalindex.GlobalIndexIOMeta;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
 import org.apache.paimon.globalindex.GlobalIndexReader;
 import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
@@ -233,7 +233,7 @@ public class LazyFilteredBTreeIndexReaderTest extends AbstractIndexReaderTest {
 
     private GlobalIndexIOMeta writeDataWithIndexer(
             BTreeGlobalIndexer indexer, List<Pair<Object, Long>> subData) throws IOException {
-        GlobalIndexParallelWriter indexWriter = indexer.createWriter(fileWriter);
+        GlobalIndexSingleColumnWriter indexWriter = indexer.createWriter(fileWriter);
         for (Pair<Object, Long> pair : subData) {
             indexWriter.write(pair.getKey(), pair.getValue());
         }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/testfulltext/TestFullTextGlobalIndexReader.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/testfulltext/TestFullTextGlobalIndexReader.java
@@ -54,6 +54,7 @@ public class TestFullTextGlobalIndexReader implements GlobalIndexReader {
     private final GlobalIndexIOMeta ioMeta;
 
     private String[] documents;
+    private long[] rowIds;
     private int count;
 
     public TestFullTextGlobalIndexReader(
@@ -90,10 +91,10 @@ public class TestFullTextGlobalIndexReader implements GlobalIndexReader {
                 continue;
             }
             if (topK.size() < effectiveK) {
-                topK.offer(new ScoredRow(i, score));
+                topK.offer(new ScoredRow(rowIds[i], score));
             } else if (score > topK.peek().score) {
                 topK.poll();
-                topK.offer(new ScoredRow(i, score));
+                topK.offer(new ScoredRow(rowIds[i], score));
             }
         }
 
@@ -138,7 +139,14 @@ public class TestFullTextGlobalIndexReader implements GlobalIndexReader {
 
             // Read documents
             documents = new String[count];
+            rowIds = new long[count];
             for (int i = 0; i < count; i++) {
+                byte[] rowIdBytes = new byte[Long.BYTES];
+                readFully(in, rowIdBytes);
+                ByteBuffer rowIdBuf = ByteBuffer.wrap(rowIdBytes);
+                rowIdBuf.order(ByteOrder.LITTLE_ENDIAN);
+                rowIds[i] = rowIdBuf.getLong();
+
                 byte[] lenBytes = new byte[4];
                 readFully(in, lenBytes);
                 ByteBuffer lenBuf = ByteBuffer.wrap(lenBytes);
@@ -170,6 +178,7 @@ public class TestFullTextGlobalIndexReader implements GlobalIndexReader {
     @Override
     public void close() throws IOException {
         documents = null;
+        rowIds = null;
     }
 
     // =================== unsupported predicate operations =====================

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/testfulltext/TestFullTextGlobalIndexWriter.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/testfulltext/TestFullTextGlobalIndexWriter.java
@@ -20,9 +20,11 @@ package org.apache.paimon.globalindex.testfulltext;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,24 +43,30 @@ import java.util.List;
  * <pre>
  *   [4 bytes] count (int)
  *   For each document:
+ *     [8 bytes] row id (long)
  *     [4 bytes] text length in bytes (int)
  *     [N bytes] UTF-8 text
  * </pre>
  */
-public class TestFullTextGlobalIndexWriter implements GlobalIndexSingletonWriter {
+public class TestFullTextGlobalIndexWriter implements GlobalIndexSingleColumnWriter {
 
     private static final String FILE_NAME_PREFIX = "test-fulltext";
 
     private final GlobalIndexFileWriter fileWriter;
+    private final List<Long> rowIds;
     private final List<String> documents;
 
     public TestFullTextGlobalIndexWriter(GlobalIndexFileWriter fileWriter) {
         this.fileWriter = fileWriter;
+        this.rowIds = new ArrayList<>();
         this.documents = new ArrayList<>();
     }
 
     @Override
-    public void write(Object fieldData) {
+    public void write(@Nullable Object fieldData, long relativeRowId) {
+        if (relativeRowId < 0) {
+            throw new IllegalArgumentException("Row ID must be non-negative: " + relativeRowId);
+        }
         if (fieldData == null) {
             throw new IllegalArgumentException("Text field data must not be null");
         }
@@ -72,6 +80,7 @@ public class TestFullTextGlobalIndexWriter implements GlobalIndexSingletonWriter
             throw new IllegalArgumentException(
                     "Unsupported text type: " + fieldData.getClass().getName());
         }
+        rowIds.add(relativeRowId);
         documents.add(text);
     }
 
@@ -91,7 +100,14 @@ public class TestFullTextGlobalIndexWriter implements GlobalIndexSingletonWriter
                 out.write(header.array());
 
                 // Documents
-                for (String doc : documents) {
+                ByteBuffer rowIdBuf = ByteBuffer.allocate(Long.BYTES);
+                rowIdBuf.order(ByteOrder.LITTLE_ENDIAN);
+                for (int row = 0; row < documents.size(); row++) {
+                    rowIdBuf.clear();
+                    rowIdBuf.putLong(rowIds.get(row));
+                    out.write(rowIdBuf.array());
+
+                    String doc = documents.get(row);
                     byte[] textBytes = doc.getBytes(StandardCharsets.UTF_8);
                     ByteBuffer lenBuf = ByteBuffer.allocate(4);
                     lenBuf.order(ByteOrder.LITTLE_ENDIAN);

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/testvector/TestVectorGlobalIndexReader.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/testvector/TestVectorGlobalIndexReader.java
@@ -60,6 +60,7 @@ public class TestVectorGlobalIndexReader implements GlobalIndexReader {
     private final String requiredOptionValue;
 
     private float[][] vectors;
+    private long[] rowIds;
     private int dimension;
     private int count;
 
@@ -128,10 +129,10 @@ public class TestVectorGlobalIndexReader implements GlobalIndexReader {
             }
             float score = computeScore(queryVector, vectors[i]);
             if (topK.size() < effectiveK) {
-                topK.offer(new ScoredRow(i, score));
+                topK.offer(new ScoredRow(rowIds[i], score));
             } else if (score > topK.peek().score) {
                 topK.poll();
-                topK.offer(new ScoredRow(i, score));
+                topK.offer(new ScoredRow(rowIds[i], score));
             }
         }
 
@@ -206,8 +207,15 @@ public class TestVectorGlobalIndexReader implements GlobalIndexReader {
 
             // Read vectors
             vectors = new float[count][dimension];
+            rowIds = new long[count];
+            byte[] rowIdBytes = new byte[Long.BYTES];
             byte[] vectorBytes = new byte[dimension * Float.BYTES];
             for (int i = 0; i < count; i++) {
+                readFully(in, rowIdBytes);
+                ByteBuffer rowIdBuf = ByteBuffer.wrap(rowIdBytes);
+                rowIdBuf.order(ByteOrder.LITTLE_ENDIAN);
+                rowIds[i] = rowIdBuf.getLong();
+
                 readFully(in, vectorBytes);
                 ByteBuffer vectorBuf = ByteBuffer.wrap(vectorBytes);
                 vectorBuf.order(ByteOrder.LITTLE_ENDIAN);
@@ -236,6 +244,7 @@ public class TestVectorGlobalIndexReader implements GlobalIndexReader {
     @Override
     public void close() throws IOException {
         vectors = null;
+        rowIds = null;
     }
 
     // =================== unsupported predicate operations =====================

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/testvector/TestVectorGlobalIndexWriter.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/testvector/TestVectorGlobalIndexWriter.java
@@ -20,9 +20,11 @@ package org.apache.paimon.globalindex.testvector;
 
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -40,25 +42,32 @@ import java.util.List;
  * <pre>
  *   [4 bytes] dimension (int)
  *   [4 bytes] count (int)
- *   [count * dim * 4 bytes] float vectors (row-major order)
+ *   For each vector:
+ *     [8 bytes] row id (long)
+ *     [dim * 4 bytes] float vector
  * </pre>
  */
-public class TestVectorGlobalIndexWriter implements GlobalIndexSingletonWriter {
+public class TestVectorGlobalIndexWriter implements GlobalIndexSingleColumnWriter {
 
     private static final String FILE_NAME_PREFIX = "test-vector";
 
     private final GlobalIndexFileWriter fileWriter;
     private final int dimension;
+    private final List<Long> rowIds;
     private final List<float[]> vectors;
 
     public TestVectorGlobalIndexWriter(GlobalIndexFileWriter fileWriter, int dimension) {
         this.fileWriter = fileWriter;
         this.dimension = dimension;
+        this.rowIds = new ArrayList<>();
         this.vectors = new ArrayList<>();
     }
 
     @Override
-    public void write(Object fieldData) {
+    public void write(@Nullable Object fieldData, long relativeRowId) {
+        if (relativeRowId < 0) {
+            throw new IllegalArgumentException("Row ID must be non-negative: " + relativeRowId);
+        }
         if (fieldData == null) {
             throw new IllegalArgumentException("Vector field data must not be null");
         }
@@ -90,6 +99,7 @@ public class TestVectorGlobalIndexWriter implements GlobalIndexSingletonWriter {
                             "Vector dimension mismatch: expected %d, but got %d",
                             expectedDim, vector.length));
         }
+        rowIds.add(relativeRowId);
         vectors.add(vector);
     }
 
@@ -113,9 +123,16 @@ public class TestVectorGlobalIndexWriter implements GlobalIndexSingletonWriter {
                 out.write(header.array());
 
                 // Vector data
+                ByteBuffer rowIdBuf = ByteBuffer.allocate(Long.BYTES);
+                rowIdBuf.order(ByteOrder.LITTLE_ENDIAN);
                 ByteBuffer vectorBuf = ByteBuffer.allocate(dim * Float.BYTES);
                 vectorBuf.order(ByteOrder.LITTLE_ENDIAN);
-                for (float[] vec : vectors) {
+                for (int row = 0; row < vectors.size(); row++) {
+                    rowIdBuf.clear();
+                    rowIdBuf.putLong(rowIds.get(row));
+                    out.write(rowIdBuf.array());
+
+                    float[] vec = vectors.get(row);
                     vectorBuf.clear();
                     for (int i = 0; i < dim; i++) {
                         vectorBuf.putFloat(vec[i]);

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -89,6 +89,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.apache.paimon.catalog.Identifier.DEFAULT_MAIN_BRANCH;
+import static org.apache.paimon.globalindex.btree.BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES;
 import static org.apache.paimon.partition.PartitionExpireStrategy.createPartitionExpireStrategy;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -98,6 +99,9 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
  * @param <T> type of record to read and write.
  */
 abstract class AbstractFileStore<T> implements FileStore<T> {
+
+    private static final String VECTOR_INDEX_BUILD_MERGE_ROW_RANGES =
+            "vector-index.build.merge-row-ranges";
 
     protected final FileIO fileIO;
     protected final SchemaManager schemaManager;
@@ -303,6 +307,10 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
                                 options.deletionVectorsEnabled(),
                                 options.dataEvolutionEnabled(),
                                 options.pkClusteringOverride(),
+                                options.toConfiguration().get(BTREE_INDEX_BUILD_MERGE_ROW_RANGES)
+                                        || options.toConfiguration()
+                                                .getBoolean(
+                                                        VECTOR_INDEX_BUILD_MERGE_ROW_RANGES, false),
                                 newIndexFileHandler(),
                                 snapshotManager,
                                 scanner);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilder.java
@@ -26,7 +26,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.InternalRow.FieldGetter;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.globalindex.DataEvolutionBatchScan;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.ResultEntry;
@@ -91,6 +91,7 @@ public class BTreeGlobalIndexBuilder implements Serializable {
     private final RowType rowType;
     private final Options options;
     private final long recordsPerRange;
+    private final boolean mergeDiscontinuousRowRanges;
 
     private DataField indexField;
 
@@ -106,6 +107,8 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         this.options = this.table.coreOptions().toConfiguration();
         this.recordsPerRange =
                 (long) (options.get(BTreeIndexOptions.BTREE_INDEX_RECORDS_PER_RANGE) * FLOATING);
+        this.mergeDiscontinuousRowRanges =
+                options.get(BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES);
     }
 
     public BTreeGlobalIndexBuilder withIndexField(String indexField) {
@@ -212,8 +215,20 @@ public class BTreeGlobalIndexBuilder implements Serializable {
 
     @VisibleForTesting
     public List<CommitMessage> build(DataSplit split, IOManager ioManager) throws IOException {
-        BinaryRow partition = split.partition();
-        Range rowRange = calcRowRange(split);
+        return build((Split) split, ioManager);
+    }
+
+    @VisibleForTesting
+    public List<CommitMessage> build(Split split, IOManager ioManager) throws IOException {
+        DataSplit dataSplit =
+                split instanceof IndexedSplit
+                        ? ((IndexedSplit) split).dataSplit()
+                        : (DataSplit) split;
+        BinaryRow partition = dataSplit.partition();
+        Range rowRange =
+                split instanceof IndexedSplit
+                        ? envelope(((IndexedSplit) split).rowRanges())
+                        : calcRowRange(dataSplit);
 
         CoreOptions options = new CoreOptions(this.options);
         BinaryExternalSortBuffer buffer =
@@ -253,10 +268,14 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         return recordsPerRange;
     }
 
+    public boolean mergeDiscontinuousRowRanges() {
+        return mergeDiscontinuousRowRanges;
+    }
+
     public List<CommitMessage> buildForSinglePartition(
             Range rowRange, BinaryRow partition, Iterator<InternalRow> data) throws IOException {
         long counter = 0;
-        GlobalIndexParallelWriter currentWriter = null;
+        GlobalIndexSingleColumnWriter currentWriter = null;
         List<CommitMessage> commitMessages = new ArrayList<>();
         FieldGetter indexFieldGetter = InternalRow.createFieldGetter(indexField.type(), 0);
 
@@ -284,15 +303,15 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         return commitMessages;
     }
 
-    public GlobalIndexParallelWriter createWriter() throws IOException {
-        GlobalIndexParallelWriter currentWriter;
+    public GlobalIndexSingleColumnWriter createWriter() throws IOException {
+        GlobalIndexSingleColumnWriter currentWriter;
         GlobalIndexWriter indexWriter = createIndexWriter(table, INDEX_TYPE, indexField, options);
-        if (!(indexWriter instanceof GlobalIndexParallelWriter)) {
+        if (!(indexWriter instanceof GlobalIndexSingleColumnWriter)) {
             throw new RuntimeException(
-                    "Unexpected implementation, the index writer of BTree should be an instance of GlobalIndexParallelWriter, but found: "
+                    "Unexpected implementation, the index writer of BTree should be an instance of GlobalIndexSingleColumnWriter, but found: "
                             + indexWriter.getClass().getName());
         }
-        currentWriter = (GlobalIndexParallelWriter) indexWriter;
+        currentWriter = (GlobalIndexSingleColumnWriter) indexWriter;
         return currentWriter;
     }
 
@@ -315,6 +334,11 @@ public class BTreeGlobalIndexBuilder implements Serializable {
 
     public static List<Pair<Range, Split>> splitByRowRangeIndex(
             RowRangeIndex rowRangeIndex, DataSplit dataSplit) {
+        return splitByRowRangeIndex(rowRangeIndex, dataSplit, false);
+    }
+
+    public static List<Pair<Range, Split>> splitByRowRangeIndex(
+            RowRangeIndex rowRangeIndex, DataSplit dataSplit, boolean mergeDiscontinuousRowRanges) {
         if (rowRangeIndex == null) {
             Range range = calcRowRange(dataSplit);
             return range == null
@@ -328,14 +352,16 @@ public class BTreeGlobalIndexBuilder implements Serializable {
                                 Collections.singletonList(dataSplit), rowRangeIndex, null)
                         .splits()) {
             IndexedSplit indexedSplit = (IndexedSplit) split;
+            if (mergeDiscontinuousRowRanges
+                    && canMergeRanges(
+                            indexedSplit.rowRanges(),
+                            dataFileRowRanges(indexedSplit.dataSplit().dataFiles()))) {
+                Range rowRange = envelope(indexedSplit.rowRanges());
+                result.add(Pair.of(rowRange, indexedSplit));
+                continue;
+            }
             for (Range rowRange : indexedSplit.rowRanges()) {
-                result.add(
-                        Pair.of(
-                                rowRange,
-                                new IndexedSplit(
-                                        indexedSplit.dataSplit(),
-                                        Collections.singletonList(rowRange),
-                                        null)));
+                result.add(Pair.of(rowRange, copyIndexedSplit(indexedSplit, rowRange)));
             }
         }
         return result;
@@ -369,9 +395,21 @@ public class BTreeGlobalIndexBuilder implements Serializable {
 
     public static Map<BinaryRow, Map<Range, List<Split>>> groupSplitsByRange(
             RowRangeIndex rowRangeIndex, List<DataSplit> splits) {
+        return groupSplitsByRange(rowRangeIndex, splits, false);
+    }
+
+    public static Map<BinaryRow, Map<Range, List<Split>>> groupSplitsByRange(
+            RowRangeIndex rowRangeIndex,
+            List<DataSplit> splits,
+            boolean mergeDiscontinuousRowRanges) {
         Map<BinaryRow, List<Pair<Range, Split>>> partitionSplitRanges = new HashMap<>();
+        Map<BinaryRow, List<Range>> partitionDataRanges =
+                mergeDiscontinuousRowRanges
+                        ? dataRangesByPartition(splits)
+                        : Collections.emptyMap();
         for (DataSplit split : splits) {
-            for (Pair<Range, Split> keyPair : splitByRowRangeIndex(rowRangeIndex, split)) {
+            for (Pair<Range, Split> keyPair :
+                    splitByRowRangeIndex(rowRangeIndex, split, mergeDiscontinuousRowRanges)) {
                 Range splitRange = keyPair.getKey();
                 Split splitWithRange = keyPair.getValue();
                 if (splitRange == null) {
@@ -387,6 +425,7 @@ public class BTreeGlobalIndexBuilder implements Serializable {
         Map<BinaryRow, Map<Range, List<Split>>> result = new HashMap<>();
         for (Map.Entry<BinaryRow, List<Pair<Range, Split>>> partitionEntry :
                 partitionSplitRanges.entrySet()) {
+            BinaryRow partition = partitionEntry.getKey();
             List<Pair<Range, Split>> splitRanges = partitionEntry.getValue();
             splitRanges.sort(
                     Comparator.comparingLong((Pair<Range, Split> e) -> e.getKey().from)
@@ -402,7 +441,16 @@ public class BTreeGlobalIndexBuilder implements Serializable {
                     currentSplits.add(entry.getValue());
                     continue;
                 }
-                Range merged = Range.union(current, splitRange);
+                Range merged;
+                if (mergeDiscontinuousRowRanges) {
+                    merged =
+                            canMergeAcrossGap(
+                                            current, splitRange, partitionDataRanges.get(partition))
+                                    ? span(current, splitRange)
+                                    : null;
+                } else {
+                    merged = Range.union(current, splitRange);
+                }
                 if (merged != null) {
                     current = merged;
                     currentSplits.add(entry.getValue());
@@ -416,10 +464,85 @@ public class BTreeGlobalIndexBuilder implements Serializable {
             if (current != null) {
                 partitionRanges.put(current, currentSplits);
             }
-            result.put(partitionEntry.getKey(), partitionRanges);
+            result.put(partition, partitionRanges);
         }
 
         return result;
+    }
+
+    public static List<DataSplit> prepareDataSplitsForBuild(
+            List<DataSplit> splits, boolean mergeDiscontinuousRowRanges) {
+        return mergeDiscontinuousRowRanges ? splits : splitByContiguousRowRange(splits);
+    }
+
+    private static Range envelope(List<Range> ranges) {
+        Preconditions.checkArgument(ranges != null && !ranges.isEmpty(), "Ranges cannot be empty.");
+        long min = Long.MAX_VALUE;
+        long max = Long.MIN_VALUE;
+        for (Range range : ranges) {
+            min = Math.min(min, range.from);
+            max = Math.max(max, range.to);
+        }
+        return new Range(min, max);
+    }
+
+    private static Range span(Range left, Range right) {
+        return new Range(Math.min(left.from, right.from), Math.max(left.to, right.to));
+    }
+
+    private static IndexedSplit copyIndexedSplit(IndexedSplit indexedSplit, Range rowRange) {
+        return new IndexedSplit(
+                indexedSplit.dataSplit(), Collections.singletonList(rowRange), null);
+    }
+
+    private static Map<BinaryRow, List<Range>> dataRangesByPartition(List<DataSplit> splits) {
+        Map<BinaryRow, List<Range>> result = new HashMap<>();
+        for (DataSplit split : splits) {
+            result.computeIfAbsent(split.partition(), ignored -> new ArrayList<>())
+                    .addAll(dataFileRowRanges(split.dataFiles()));
+        }
+        for (Map.Entry<BinaryRow, List<Range>> entry : result.entrySet()) {
+            entry.setValue(Range.sortAndMergeOverlap(entry.getValue(), true));
+        }
+        return result;
+    }
+
+    private static List<Range> dataFileRowRanges(List<DataFileMeta> dataFiles) {
+        List<Range> result = new ArrayList<>();
+        for (DataFileMeta file : dataFiles) {
+            result.add(file.nonNullRowIdRange());
+        }
+        return result;
+    }
+
+    private static boolean canMergeRanges(List<Range> rowRanges, List<Range> dataRanges) {
+        List<Range> sorted = Range.sortAndMergeOverlap(rowRanges, true);
+        for (int i = 1; i < sorted.size(); i++) {
+            Range previous = sorted.get(i - 1);
+            Range current = sorted.get(i);
+            if (!canMergeAcrossGap(previous, current, dataRanges)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean canMergeAcrossGap(
+            Range previous, Range current, @Nullable List<Range> dataRanges) {
+        long gapStart = Math.min(previous.to, current.to) + 1;
+        long gapEnd = Math.max(previous.from, current.from) - 1;
+        if (gapStart > gapEnd) {
+            return true;
+        }
+        if (dataRanges == null) {
+            return true;
+        }
+        for (Range dataRange : dataRanges) {
+            if (Range.intersect(gapStart, gapEnd, dataRange.from, dataRange.to)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static List<DataSplit> splitByContiguousRowRange(DataSplit split) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/ConflictDetection.java
@@ -85,6 +85,7 @@ public class ConflictDetection {
     private final boolean deletionVectorsEnabled;
     private final boolean dataEvolutionEnabled;
     private final boolean pkClusteringOverride;
+    private final boolean globalIndexMergeDiscontinuousRowRanges;
     private final IndexFileHandler indexFileHandler;
     private final SnapshotManager snapshotManager;
     private final CommitScanner commitScanner;
@@ -109,6 +110,7 @@ public class ConflictDetection {
             boolean deletionVectorsEnabled,
             boolean dataEvolutionEnabled,
             boolean pkClusteringOverride,
+            boolean globalIndexMergeDiscontinuousRowRanges,
             IndexFileHandler indexFileHandler,
             SnapshotManager snapshotManager,
             CommitScanner commitScanner) {
@@ -121,6 +123,7 @@ public class ConflictDetection {
         this.deletionVectorsEnabled = deletionVectorsEnabled;
         this.dataEvolutionEnabled = dataEvolutionEnabled;
         this.pkClusteringOverride = pkClusteringOverride;
+        this.globalIndexMergeDiscontinuousRowRanges = globalIndexMergeDiscontinuousRowRanges;
         this.indexFileHandler = indexFileHandler;
         this.snapshotManager = snapshotManager;
         this.commitScanner = commitScanner;
@@ -585,7 +588,9 @@ public class ConflictDetection {
             Range indexRange = globalIndex.rowRange();
             RowRangeIndex rowRangeIndex =
                     rowRangeIndexes.get(Pair.of(indexEntry.partition(), indexEntry.bucket()));
-            if (rowRangeIndex == null || !rowRangeIndex.contains(indexRange)) {
+            if (rowRangeIndex == null
+                    || !globalIndexRowRangeExists(
+                            rowRangeIndex, dataRanges, indexEntry, indexRange)) {
                 return Optional.of(
                         new RuntimeException(
                                 String.format(
@@ -598,6 +603,34 @@ public class ConflictDetection {
             }
         }
         return Optional.empty();
+    }
+
+    private boolean globalIndexRowRangeExists(
+            RowRangeIndex rowRangeIndex,
+            Map<Pair<BinaryRow, Integer>, List<Range>> dataRanges,
+            IndexManifestEntry indexEntry,
+            Range indexRange) {
+        if (rowRangeIndex.contains(indexRange)) {
+            return true;
+        }
+        if (!globalIndexMergeDiscontinuousRowRanges) {
+            return false;
+        }
+
+        List<Range> ranges = dataRanges.get(Pair.of(indexEntry.partition(), indexEntry.bucket()));
+        if (ranges == null || ranges.isEmpty()) {
+            return false;
+        }
+
+        boolean hasStart = false;
+        boolean hasEnd = false;
+        for (Range range : ranges) {
+            if (Range.intersect(indexRange.from, indexRange.to, range.from, range.to)) {
+                hasStart |= range.from <= indexRange.from && range.to >= indexRange.from;
+                hasEnd |= range.from <= indexRange.to && range.to >= indexRange.to;
+            }
+        }
+        return hasStart && hasEnd;
     }
 
     private List<IndexManifestEntry> globalIndexFileAdditions(

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilderSplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/btree/BTreeGlobalIndexBuilderSplitTest.java
@@ -98,10 +98,67 @@ public class BTreeGlobalIndexBuilderSplitTest {
         assertIndexedSplitRowRanges(ranges.get(new Range(5938, 7599)), new Range(5938, 7599));
     }
 
-    private static void assertIndexedSplitRowRanges(List<Split> splits, Range rowRange) {
+    @Test
+    public void testGroupSplitsCanMergeDiscontinuousRowRangeIndex() {
+        DataFileMeta file1 = createDataFileMeta(1L, 5L);
+        DataFileMeta file2 = createDataFileMeta(10L, 6L);
+        DataSplit split =
+                DataSplit.builder()
+                        .withSnapshot(1L)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(Arrays.asList(file1, file2))
+                        .isStreaming(false)
+                        .rawConvertible(false)
+                        .build();
+
+        Map<BinaryRow, Map<Range, List<Split>>> result =
+                BTreeGlobalIndexBuilder.groupSplitsByRange(
+                        RowRangeIndex.create(Arrays.asList(new Range(1, 5), new Range(10, 15))),
+                        Collections.singletonList(split),
+                        true);
+
+        assertThat(result).containsOnlyKeys(BinaryRow.EMPTY_ROW);
+        Map<Range, List<Split>> ranges = result.get(BinaryRow.EMPTY_ROW);
+        assertThat(ranges).containsOnlyKeys(new Range(1, 15));
+        assertIndexedSplitRowRanges(
+                ranges.get(new Range(1, 15)), new Range(1, 5), new Range(10, 15));
+    }
+
+    @Test
+    public void testGroupSplitsDoesNotMergeAcrossExistingDataRange() {
+        DataFileMeta file1 = createDataFileMeta(1L, 5L);
+        DataFileMeta file2 = createDataFileMeta(6L, 4L);
+        DataFileMeta file3 = createDataFileMeta(10L, 6L);
+        DataSplit split =
+                DataSplit.builder()
+                        .withSnapshot(1L)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(Arrays.asList(file1, file2, file3))
+                        .isStreaming(false)
+                        .rawConvertible(false)
+                        .build();
+
+        Map<BinaryRow, Map<Range, List<Split>>> result =
+                BTreeGlobalIndexBuilder.groupSplitsByRange(
+                        RowRangeIndex.create(Arrays.asList(new Range(1, 5), new Range(10, 15))),
+                        Collections.singletonList(split),
+                        true);
+
+        assertThat(result).containsOnlyKeys(BinaryRow.EMPTY_ROW);
+        Map<Range, List<Split>> ranges = result.get(BinaryRow.EMPTY_ROW);
+        assertThat(ranges).containsOnlyKeys(new Range(1, 5), new Range(10, 15));
+        assertIndexedSplitRowRanges(ranges.get(new Range(1, 5)), new Range(1, 5));
+        assertIndexedSplitRowRanges(ranges.get(new Range(10, 15)), new Range(10, 15));
+    }
+
+    private static void assertIndexedSplitRowRanges(List<Split> splits, Range... rowRanges) {
         assertThat(splits).hasSize(1);
         assertThat(splits.get(0)).isInstanceOf(IndexedSplit.class);
-        assertThat(((IndexedSplit) splits.get(0)).rowRanges()).containsExactly(rowRange);
+        assertThat(((IndexedSplit) splits.get(0)).rowRanges()).containsExactly(rowRanges);
     }
 
     private static DataFileMeta createDataFileMeta(long firstRowId, long rowCount) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1171,6 +1171,7 @@ public class FileStoreCommitTest {
                                 options.deletionVectorsEnabled(),
                                 dataEvolutionEnabled,
                                 options.pkClusteringOverride(),
+                                false,
                                 store.newIndexFileHandler(),
                                 store.snapshotManager(),
                                 scanner),

--- a/paimon-core/src/test/java/org/apache/paimon/operation/commit/ConflictDetectionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/commit/ConflictDetectionTest.java
@@ -635,6 +635,7 @@ class ConflictDetectionTest {
                 false,
                 true,
                 false,
+                false,
                 null,
                 null,
                 null);

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -23,11 +23,14 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.globalindex.DataEvolutionBatchScan;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.GlobalIndexScanner;
-import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.globalindex.btree.BTreeIndexOptions;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -45,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -200,6 +202,75 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
         assertThat(rowIds.toRangeList()).containsExactly(new Range(0L, oldRowCount - 1));
     }
 
+    @Test
+    public void testBuildBTreeGlobalIndexWithDiscontinuousRowIdRanges() throws Exception {
+        Schema schema = schemaDefault();
+        schema.options().put(BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES.key(), "true");
+        catalog.createTable(identifier(), schema, false);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite()) {
+            for (int i = 0; i < 5; i++) {
+                write.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                BinaryString.fromString("b" + i)));
+            }
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                List<CommitMessage> commitMessages = write.prepareCommit();
+                setFirstRowId(commitMessages, 10L);
+                commit.commit(commitMessages);
+            }
+        }
+
+        writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite()) {
+            for (int i = 10; i < 15; i++) {
+                write.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                BinaryString.fromString("b" + i)));
+            }
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+
+        createIndex("f1", Arrays.asList(new Range(0, 4), new Range(10, 14)));
+
+        table = (FileStoreTable) catalog.getTable(identifier());
+        List<IndexManifestEntry> entries =
+                table.store().newIndexFileHandler().scan(table.latestSnapshot().get(), "btree");
+        assertThat(entries).hasSize(1);
+        GlobalIndexMeta globalIndexMeta = entries.get(0).indexFile().globalIndexMeta();
+        assertNotNull(globalIndexMeta);
+        assertThat(globalIndexMeta.rowRange()).isEqualTo(new Range(0, 14));
+
+        Predicate predicate =
+                new PredicateBuilder(table.rowType())
+                        .in(
+                                1,
+                                Arrays.asList(
+                                        BinaryString.fromString("a2"),
+                                        BinaryString.fromString("a12")));
+
+        RoaringNavigableMap64 rowIds = globalIndexScan(table, predicate);
+        assertNotNull(rowIds);
+        assertThat(rowIds.toRangeList()).containsExactly(new Range(2, 2), new Range(12, 12));
+
+        List<String> readF1 = new ArrayList<>();
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate);
+        readBuilder
+                .newRead()
+                .createReader(readBuilder.newScan().plan())
+                .forEachRemaining(row -> readF1.add(row.getString(1).toString()));
+
+        assertThat(readF1).containsExactlyInAnyOrder("a2", "a12");
+    }
+
     private void createIndex(String fieldName) throws Exception {
         createIndex(fieldName, null);
     }
@@ -216,25 +287,21 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
                                         new IllegalStateException(
                                                 "Expected scan result when building index."));
         List<CommitMessage> commitMessages = new ArrayList<>();
-        for (DataSplit dataSplit : indexSplits(table, rowRanges, dataSplits)) {
-            commitMessages.addAll(builder.build(dataSplit, ioManager));
+        for (Split split : indexSplits(table, rowRanges, dataSplits)) {
+            commitMessages.addAll(builder.build(split, ioManager));
         }
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(commitMessages);
         }
     }
 
-    private List<DataSplit> indexSplits(
+    private List<Split> indexSplits(
             FileStoreTable table, List<Range> rowRanges, List<DataSplit> fallbackSplits) {
         if (rowRanges == null) {
-            return fallbackSplits;
+            return new ArrayList<>(fallbackSplits);
         }
 
-        List<Split> splits =
-                table.newReadBuilder().withRowRanges(rowRanges).newScan().plan().splits();
-        return splits.stream()
-                .map(split -> ((IndexedSplit) split).dataSplit())
-                .collect(Collectors.toList());
+        return table.newReadBuilder().withRowRanges(rowRanges).newScan().plan().splits();
     }
 
     private RoaringNavigableMap64 globalIndexScan(FileStoreTable table, Predicate predicate)

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
@@ -25,7 +25,7 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexResult;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.globalindex.testfulltext.TestFullTextGlobalIndexerFactory;
@@ -316,15 +316,15 @@ public class FullTextSearchBuilderTest extends TableTestBase {
         Options options = table.coreOptions().toConfiguration();
         DataField textField = table.rowType().getField(TEXT_FIELD_NAME);
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestFullTextGlobalIndexerFactory.IDENTIFIER,
                                 textField,
                                 options);
-        for (String doc : documents) {
-            writer.write(doc);
+        for (int i = 0; i < documents.length; i++) {
+            writer.write(documents[i], i);
         }
         List<ResultEntry> entries = writer.finish();
 
@@ -359,15 +359,15 @@ public class FullTextSearchBuilderTest extends TableTestBase {
         int mid = documents.length / 2;
 
         // Build first index file covering rows [0, mid)
-        GlobalIndexSingletonWriter writer1 =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer1 =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestFullTextGlobalIndexerFactory.IDENTIFIER,
                                 textField,
                                 options);
         for (int i = 0; i < mid; i++) {
-            writer1.write(documents[i]);
+            writer1.write(documents[i], i);
         }
         List<ResultEntry> entries1 = writer1.finish();
         Range rowRange1 = new Range(0, mid - 1);
@@ -382,15 +382,15 @@ public class FullTextSearchBuilderTest extends TableTestBase {
                         entries1);
 
         // Build second index file covering rows [mid, end)
-        GlobalIndexSingletonWriter writer2 =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer2 =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestFullTextGlobalIndexerFactory.IDENTIFIER,
                                 textField,
                                 options);
         for (int i = mid; i < documents.length; i++) {
-            writer2.write(documents[i]);
+            writer2.write(documents[i], i - mid);
         }
         List<ResultEntry> entries2 = writer2.finish();
         Range rowRange2 = new Range(mid, documents.length - 1);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -25,9 +25,8 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
 import org.apache.paimon.globalindex.GlobalIndexResult;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
@@ -557,15 +556,15 @@ public class VectorSearchBuilderTest extends TableTestBase {
         Options options = table.coreOptions().toConfiguration();
         DataField vectorField = table.rowType().getField(VECTOR_FIELD_NAME);
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
         List<ResultEntry> entries = writer.finish();
 
@@ -600,15 +599,15 @@ public class VectorSearchBuilderTest extends TableTestBase {
         int mid = vectors.length / 2;
 
         // Build first index file covering rows [0, mid)
-        GlobalIndexSingletonWriter writer1 =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer1 =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
         for (int i = 0; i < mid; i++) {
-            writer1.write(vectors[i]);
+            writer1.write(vectors[i], i);
         }
         List<ResultEntry> entries1 = writer1.finish();
         Range rowRange1 = new Range(0, mid - 1);
@@ -623,15 +622,15 @@ public class VectorSearchBuilderTest extends TableTestBase {
                         entries1);
 
         // Build second index file covering rows [mid, end)
-        GlobalIndexSingletonWriter writer2 =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer2 =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
         for (int i = mid; i < vectors.length; i++) {
-            writer2.write(vectors[i]);
+            writer2.write(vectors[i], i - mid);
         }
         List<ResultEntry> entries2 = writer2.finish();
         Range rowRange2 = new Range(mid, vectors.length - 1);
@@ -765,15 +764,15 @@ public class VectorSearchBuilderTest extends TableTestBase {
         Options options = table.coreOptions().toConfiguration();
         DataField vectorField = table.rowType().getField(VECTOR_FIELD_NAME);
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
         List<ResultEntry> entries = writer.finish();
 
@@ -805,8 +804,8 @@ public class VectorSearchBuilderTest extends TableTestBase {
         Options options = table.coreOptions().toConfiguration();
         DataField idField = table.rowType().getField("id");
 
-        GlobalIndexParallelWriter writer =
-                (GlobalIndexParallelWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table, BTreeGlobalIndexerFactory.IDENTIFIER, idField, options);
         for (int id : ids) {
@@ -844,15 +843,15 @@ public class VectorSearchBuilderTest extends TableTestBase {
         Options options = table.coreOptions().toConfiguration();
         DataField vectorField = table.rowType().getField(VECTOR_FIELD_NAME);
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
         List<ResultEntry> entries = writer.finish();
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/btree/BTreeIndexTopoBuilder.java
@@ -37,7 +37,7 @@ import org.apache.paimon.flink.sorter.TableSorter;
 import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
 import org.apache.paimon.globalindex.btree.BTreeIndexOptions;
 import org.apache.paimon.options.Options;
@@ -78,7 +78,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.groupSplitsByRange;
-import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.splitByContiguousRowRange;
+import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.prepareDataSplitsForBuild;
 
 /** The {@link BTreeIndexTopoBuilder} for BTree index in Flink. */
 public class BTreeIndexTopoBuilder {
@@ -109,12 +109,15 @@ public class BTreeIndexTopoBuilder {
             }
 
             Pair<RowRangeIndex, List<DataSplit>> scanResult = indexRangeAndSplits.get();
-            List<DataSplit> splits = splitByContiguousRowRange(scanResult.getRight());
+            boolean mergeDiscontinuousRowRanges =
+                    userOptions.get(BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES);
+            List<DataSplit> splits =
+                    prepareDataSplitsForBuild(scanResult.getRight(), mergeDiscontinuousRowRanges);
             if (splits.isEmpty()) {
                 continue;
             }
             Map<BinaryRow, Map<Range, List<Split>>> partitionRangeSplits =
-                    groupSplitsByRange(scanResult.getLeft(), splits);
+                    groupSplitsByRange(scanResult.getLeft(), splits, mergeDiscontinuousRowRanges);
             if (partitionRangeSplits.isEmpty()) {
                 continue;
             }
@@ -377,7 +380,7 @@ public class BTreeIndexTopoBuilder {
         private transient long counter;
         private transient BTreeBuildTask currentTask;
         private transient BinaryRow currentPartition;
-        private transient GlobalIndexParallelWriter currentWriter;
+        private transient GlobalIndexSingleColumnWriter currentWriter;
         private transient List<CommitMessage> commitMessages;
         private transient Map<Integer, BTreeBuildTask> buildTasksById;
         private transient InternalRow.FieldGetter indexFieldGetter;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilder.java
@@ -30,7 +30,7 @@ import org.apache.paimon.flink.utils.BoundedOneInputOperator;
 import org.apache.paimon.flink.utils.JavaTypeInfo;
 import org.apache.paimon.flink.utils.StreamExecutionEnvironmentUtils;
 import org.apache.paimon.globalindex.GlobalIndexMultiColumnWriter;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.index.IndexFileMeta;
@@ -94,6 +94,8 @@ public class GenericIndexTopoBuilder {
 
     private static final Logger LOG = LoggerFactory.getLogger(GenericIndexTopoBuilder.class);
     public static final long NO_MAX_INDEXED_ROW_ID = -1L;
+    private static final String VECTOR_INDEX_BUILD_MERGE_ROW_RANGES =
+            "vector-index.build.merge-row-ranges";
 
     public static void buildIndexAndExecute(
             StreamExecutionEnvironment env,
@@ -312,6 +314,9 @@ public class GenericIndexTopoBuilder {
         RowType projectedRowType = SpecialFields.rowTypeWithRowId(rowType).project(readColumns);
 
         Options mergedOptions = new Options(table.options(), userOptions.toMap());
+        boolean mergeDiscontinuousRowRanges =
+                isVectorIndex(indexType)
+                        && mergedOptions.getBoolean(VECTOR_INDEX_BUILD_MERGE_ROW_RANGES, false);
 
         long rowsPerShard = mergedOptions.get(CoreOptions.GLOBAL_INDEX_ROW_COUNT_PER_SHARD);
         checkArgument(
@@ -320,7 +325,8 @@ public class GenericIndexTopoBuilder {
 
         // Compute shard tasks at file level from the provided entries
         List<ShardTask> shardTasks =
-                computeShardTasks(table, entries, rowsPerShard, maxIndexedRowId);
+                computeShardTasks(
+                        table, entries, rowsPerShard, maxIndexedRowId, mergeDiscontinuousRowRanges);
         if (shardTasks.isEmpty()) {
             LOG.info("No shard tasks generated, nothing to index.");
             return false;
@@ -404,6 +410,15 @@ public class GenericIndexTopoBuilder {
             List<ManifestEntry> entries,
             long rowsPerShard,
             long maxIndexedRowId) {
+        return computeShardTasks(table, entries, rowsPerShard, maxIndexedRowId, false);
+    }
+
+    static List<ShardTask> computeShardTasks(
+            FileStoreTable table,
+            List<ManifestEntry> entries,
+            long rowsPerShard,
+            long maxIndexedRowId,
+            boolean mergeDiscontinuousRowRanges) {
         // Group by partition (bucket is always 0 for unaware-bucket tables)
         Map<BinaryRow, List<ManifestEntry>> entriesByPartition =
                 entries.stream().collect(Collectors.groupingBy(ManifestEntry::partition));
@@ -457,6 +472,17 @@ public class GenericIndexTopoBuilder {
                 }
 
                 shardFiles.sort(Comparator.comparingLong(DataFileMeta::nonNullFirstRowId));
+                if (mergeDiscontinuousRowRanges) {
+                    tasks.add(
+                            createShardTask(
+                                    shardFiles,
+                                    effectiveStart,
+                                    shardEnd,
+                                    partition,
+                                    partBucketPath,
+                                    true));
+                    continue;
+                }
 
                 // Group contiguous files; gaps produce separate tasks
                 List<DataFileMeta> currentGroup = new ArrayList<>();
@@ -479,7 +505,8 @@ public class GenericIndexTopoBuilder {
                                         effectiveStart,
                                         shardEnd,
                                         partition,
-                                        partBucketPath));
+                                        partBucketPath,
+                                        false));
                         currentGroup = new ArrayList<>();
                         currentGroup.add(file);
                         currentGroupEnd = fileEnd;
@@ -492,7 +519,8 @@ public class GenericIndexTopoBuilder {
                                     effectiveStart,
                                     shardEnd,
                                     partition,
-                                    partBucketPath));
+                                    partBucketPath,
+                                    false));
                 }
             }
         }
@@ -504,7 +532,8 @@ public class GenericIndexTopoBuilder {
             long effectiveStart,
             long shardEnd,
             BinaryRow partition,
-            String bucketPath) {
+            String bucketPath,
+            boolean mergeDiscontinuousRowRanges) {
         long groupMinRowId = files.get(0).nonNullFirstRowId();
         long groupMaxRowId =
                 files.stream().mapToLong(f -> f.nonNullRowIdRange().to).max().getAsLong();
@@ -512,6 +541,19 @@ public class GenericIndexTopoBuilder {
         // Clamp to effective boundaries
         long rangeFrom = Math.max(groupMinRowId, effectiveStart);
         long rangeTo = Math.min(groupMaxRowId, shardEnd);
+        Range shardRange = new Range(rangeFrom, rangeTo);
+
+        List<Range> rowRanges = new ArrayList<>();
+        for (DataFileMeta file : files) {
+            Range intersection = Range.intersection(shardRange, file.nonNullRowIdRange());
+            if (intersection != null) {
+                rowRanges.add(intersection);
+            }
+        }
+        rowRanges = Range.sortAndMergeOverlap(rowRanges, true);
+        if (!mergeDiscontinuousRowRanges) {
+            rowRanges = Collections.singletonList(shardRange);
+        }
 
         DataSplit dataSplit =
                 DataSplit.builder()
@@ -522,7 +564,7 @@ public class GenericIndexTopoBuilder {
                         .rawConvertible(false)
                         .build();
 
-        return new ShardTask(dataSplit, new Range(rangeFrom, rangeTo));
+        return new ShardTask(dataSplit, shardRange, rowRanges);
     }
 
     private static List<Committable> createDeleteCommittables(
@@ -564,10 +606,12 @@ public class GenericIndexTopoBuilder {
 
         final DataSplit split;
         final Range shardRange;
+        final List<Range> rowRanges;
 
-        ShardTask(DataSplit split, Range shardRange) {
+        ShardTask(DataSplit split, Range shardRange, List<Range> rowRanges) {
             this.split = split;
             this.shardRange = shardRange;
+            this.rowRanges = rowRanges;
         }
     }
 
@@ -682,15 +726,16 @@ public class GenericIndexTopoBuilder {
                         if (currentRowId > task.shardRange.to) {
                             break;
                         }
-                        // Only write rows within this shard's range
-                        if (currentRowId >= task.shardRange.from) {
+                        // Only write rows within this shard's actual ranges
+                        if (containsRowId(task.rowRanges, currentRowId)) {
                             if (multiColumn) {
                                 long rowId = currentRowId - task.shardRange.from;
                                 ((GlobalIndexMultiColumnWriter) indexWriter)
                                         .write(rowId, writerProjection.replaceRow(row));
                             } else {
                                 Object fieldData = indexFieldGetters[0].getFieldOrNull(row);
-                                ((GlobalIndexSingletonWriter) indexWriter).write(fieldData);
+                                ((GlobalIndexSingleColumnWriter) indexWriter)
+                                        .write(fieldData, currentRowId - task.shardRange.from);
                             }
                             rowsSeen++;
                         }
@@ -698,7 +743,9 @@ public class GenericIndexTopoBuilder {
                 }
 
                 List<ResultEntry> resultEntries = indexWriter.finish();
-                if (!resultEntries.isEmpty() && resultEntries.get(0).rowCount() != rowsSeen) {
+                if (!(indexWriter instanceof GlobalIndexSingleColumnWriter)
+                        && !resultEntries.isEmpty()
+                        && resultEntries.get(0).rowCount() != rowsSeen) {
                     LOG.warn(
                             "rowCount mismatch: writer reported {} but caller saw {} rows",
                             resultEntries.get(0).rowCount(),
@@ -746,6 +793,25 @@ public class GenericIndexTopoBuilder {
         public void endInput() {
             // All work is done in processElement
         }
+    }
+
+    private static boolean containsRowId(List<Range> ranges, long rowId) {
+        for (Range range : ranges) {
+            if (rowId < range.from) {
+                return false;
+            }
+            if (rowId <= range.to) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isVectorIndex(String indexType) {
+        return "ivf-flat".equals(indexType)
+                || "ivf-pq".equals(indexType)
+                || "ivf-hnsw-flat".equals(indexType)
+                || "ivf-hnsw-sq".equals(indexType);
     }
 
     private static CommitMessage flushIndex(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/globalindex/GenericIndexTopoBuilderTest.java
@@ -136,6 +136,23 @@ class GenericIndexTopoBuilderTest {
     }
 
     @Test
+    void testMergeFilesWithGapInSameShard() throws IOException {
+        // Two files [0, 29] and [70, 99] can be merged into one envelope shard
+        // while preserving the exact row ranges to read.
+        List<ManifestEntry> entries = new ArrayList<>();
+        entries.add(createEntry(BinaryRow.EMPTY_ROW, 0L, 30));
+        entries.add(createEntry(BinaryRow.EMPTY_ROW, 70L, 30));
+
+        List<GenericIndexTopoBuilder.ShardTask> tasks =
+                GenericIndexTopoBuilder.computeShardTasks(table, entries, 100, -1, true);
+
+        assertThat(tasks).hasSize(1);
+        assertThat(tasks.get(0).shardRange).isEqualTo(new Range(0, 99));
+        assertThat(tasks.get(0).rowRanges).containsExactly(new Range(0, 29), new Range(70, 99));
+        assertThat(tasks.get(0).split.dataFiles()).hasSize(2);
+    }
+
+    @Test
     void testFileWithNullFirstRowIdSkipped() throws IOException {
         // One file with null firstRowId + one normal file
         List<ManifestEntry> entries = new ArrayList<>();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/VectorSearchProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/VectorSearchProcedureITCase.java
@@ -23,7 +23,7 @@ import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.flink.CatalogITCaseBase;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.testvector.TestVectorGlobalIndexer;
 import org.apache.paimon.globalindex.testvector.TestVectorGlobalIndexerFactory;
@@ -218,15 +218,15 @@ public class VectorSearchProcedureITCase extends CatalogITCaseBase {
         Options options = table.coreOptions().toConfiguration();
         DataField vectorField = table.rowType().getField(VECTOR_FIELD);
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TestVectorGlobalIndexerFactory.IDENTIFIER,
                                 vectorField,
                                 options);
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
         List<ResultEntry> entries = writer.finish();
 

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriter.java
@@ -21,7 +21,7 @@ package org.apache.paimon.lumina.index;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.types.ArrayType;
@@ -33,6 +33,8 @@ import org.aliyun.lumina.LuminaDataset;
 import org.aliyun.lumina.LuminaFileOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.File;
@@ -50,16 +52,17 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Vector global index writer using Lumina. Builds a single index file per shard.
  *
- * <p>Vectors are spilled to a temporary file on disk as they arrive via {@link #write(Object)},
- * keeping Java heap usage constant (~8 MB buffer) regardless of dataset size. During index build,
- * the Lumina builder streams vectors from the temp file via the {@link LuminaDataset} callback API.
+ * <p>Vectors are spilled to a temporary file on disk as they arrive via {@link #write(Object,
+ * long)}, keeping Java heap usage constant (~8 MB buffer) regardless of dataset size. During index
+ * build, the Lumina builder streams vectors from the temp file via the {@link LuminaDataset}
+ * callback API.
  *
  * <p><b>Thread safety:</b> This class is <b>not</b> thread-safe. The underlying {@code
  * LuminaBuilder} must be used from a single thread or the caller must provide external
  * synchronization. The internal Lumina executor thread pool size is controlled globally by the
  * {@code LUMINA_EXECUTOR_THREAD_COUNT} environment variable and cannot be configured per-instance.
  */
-public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Closeable {
+public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingleColumnWriter, Closeable {
 
     private static final String FILE_NAME_PREFIX = "lumina";
 
@@ -154,23 +157,26 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
     }
 
     @Override
-    public void write(Object fieldData) {
+    public void write(@Nullable Object fieldData, long relativeRowId) {
+        if (relativeRowId < 0) {
+            throw new IllegalArgumentException("Row ID must be non-negative: " + relativeRowId);
+        }
         if (fieldData == null) {
-            logicalRowId++;
+            logicalRowId = Math.max(logicalRowId, relativeRowId + 1);
             return;
         }
 
         // Validation must complete before any buffer/state mutation below
-        float[] src = materializeAndValidate(fieldData);
+        float[] src = materializeAndValidate(fieldData, relativeRowId);
 
         if (writeBuf.remaining() < recordSizeInBytes) {
             flushWriteBuffer();
         }
-        writeBuf.putLong(logicalRowId);
+        writeBuf.putLong(relativeRowId);
         for (int i = 0; i < dim; i++) {
             writeBuf.putFloat(src[i]);
         }
-        logicalRowId++;
+        logicalRowId = Math.max(logicalRowId, relativeRowId + 1);
         count++;
     }
 
@@ -179,12 +185,12 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
      * input directly (zero-copy). For InternalVector/InternalArray, reads into the reusable
      * vectorBuf field.
      */
-    private float[] materializeAndValidate(Object fieldData) {
+    private float[] materializeAndValidate(Object fieldData, long rowId) {
         if (fieldData instanceof float[]) {
             float[] vector = (float[]) fieldData;
             checkDimension(vector.length);
             for (int i = 0; i < dim; i++) {
-                checkFinite(vector[i], i);
+                checkFinite(vector[i], rowId, i);
             }
             return vector;
         } else if (fieldData instanceof InternalVector) {
@@ -192,7 +198,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
             checkDimension(vector.size());
             for (int i = 0; i < dim; i++) {
                 float v = vector.getFloat(i);
-                checkFinite(v, i);
+                checkFinite(v, rowId, i);
                 vectorBuf[i] = v;
             }
             return vectorBuf;
@@ -204,7 +210,7 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
                     throw new IllegalArgumentException("Vector element at index " + i + " is null");
                 }
                 float v = array.getFloat(i);
-                checkFinite(v, i);
+                checkFinite(v, rowId, i);
                 vectorBuf[i] = v;
             }
             return vectorBuf;
@@ -365,12 +371,12 @@ public class LuminaVectorGlobalIndexWriter implements GlobalIndexSingletonWriter
         }
     }
 
-    private void checkFinite(float value, int elementIndex) {
+    private void checkFinite(float value, long rowId, int elementIndex) {
         if (!Float.isFinite(value)) {
             throw new IllegalArgumentException(
                     String.format(
                             "Vector element at rowId=%d, index=%d is %s",
-                            logicalRowId, elementIndex, Float.toString(value)));
+                            rowId, elementIndex, Float.toString(value)));
         }
     }
 

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/JavaPyLuminaE2ETest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/JavaPyLuminaE2ETest.java
@@ -25,8 +25,7 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
-import org.apache.paimon.globalindex.GlobalIndexParallelWriter;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
 import org.apache.paimon.index.IndexFileMeta;
@@ -170,16 +169,16 @@ public class JavaPyLuminaE2ETest {
         DataField embeddingField = table.rowType().getField("embedding");
         Options indexOptions = table.coreOptions().toConfiguration();
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 LuminaVectorGlobalIndexerFactory.IDENTIFIER,
                                 embeddingField,
                                 indexOptions);
 
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
 
         List<ResultEntry> entries = writer.finish();
@@ -280,15 +279,15 @@ public class JavaPyLuminaE2ETest {
 
         // Build Lumina vector index on "embedding".
         DataField embeddingField = table.rowType().getField("embedding");
-        GlobalIndexSingletonWriter vectorWriter =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter vectorWriter =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 LuminaVectorGlobalIndexerFactory.IDENTIFIER,
                                 embeddingField,
                                 indexOptions);
-        for (float[] vec : vectors) {
-            vectorWriter.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            vectorWriter.write(vectors[i], i);
         }
         List<ResultEntry> vectorEntries = vectorWriter.finish();
         List<IndexFileMeta> vectorIndexFiles =
@@ -303,8 +302,8 @@ public class JavaPyLuminaE2ETest {
 
         // Build BTree global index on "id".
         DataField idField = table.rowType().getField("id");
-        GlobalIndexParallelWriter idWriter =
-                (GlobalIndexParallelWriter)
+        GlobalIndexSingleColumnWriter idWriter =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table, BTreeGlobalIndexerFactory.IDENTIFIER, idField, indexOptions);
         for (int i = 0; i < vectors.length; i++) {

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorBenchmark.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorBenchmark.java
@@ -388,7 +388,7 @@ public class LuminaVectorBenchmark {
                     for (int d = 0; d < dimension; d++) {
                         vec[d] = (float) insertRandom.nextDouble() * 2 - 1;
                     }
-                    writer.write(vec);
+                    writer.write(vec, i);
                 }
                 long writeEnd = System.currentTimeMillis();
                 System.out.printf(

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexScanTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexScanTest.java
@@ -212,8 +212,8 @@ public class LuminaVectorGlobalIndexScanTest {
         LuminaVectorGlobalIndexWriter indexWriter =
                 new LuminaVectorGlobalIndexWriter(
                         fileWriter, new ArrayType(DataTypes.FLOAT()), indexOptions);
-        for (float[] vec : vectors) {
-            indexWriter.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            indexWriter.write(vectors[i], i);
         }
 
         List<ResultEntry> entries = indexWriter.finish();
@@ -302,8 +302,8 @@ public class LuminaVectorGlobalIndexScanTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(
                         fileWriter, new ArrayType(DataTypes.FLOAT()), indexOptions);
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
 
         List<ResultEntry> entries = writer.finish();

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -150,7 +149,9 @@ public class LuminaVectorGlobalIndexTest {
                     new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
             List<float[]> testVectors = generateRandomVectors(numVectors, dimension);
-            testVectors.forEach(writer::write);
+            for (int i = 0; i < testVectors.size(); i++) {
+                writer.write(testVectors.get(i), i);
+            }
 
             List<ResultEntry> results = writer.finish();
             List<GlobalIndexIOMeta> metas = toIOMetas(results, metricIndexPath);
@@ -185,7 +186,9 @@ public class LuminaVectorGlobalIndexTest {
 
             int numVectors = 10;
             List<float[]> testVectors = generateRandomVectors(numVectors, dimension);
-            testVectors.forEach(writer::write);
+            for (int i = 0; i < testVectors.size(); i++) {
+                writer.write(testVectors.get(i), i);
+            }
 
             List<ResultEntry> results = writer.finish();
             List<GlobalIndexIOMeta> metas = toIOMetas(results, dimIndexPath);
@@ -216,7 +219,7 @@ public class LuminaVectorGlobalIndexTest {
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
         float[] wrongDimVector = new float[32];
-        assertThatThrownBy(() -> writer.write(wrongDimVector))
+        assertThatThrownBy(() -> writer.write(wrongDimVector, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("dimension mismatch");
     }
@@ -236,7 +239,9 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
 
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
@@ -299,7 +304,9 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorIndexOptions indexOptions = new LuminaVectorIndexOptions(options);
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
 
@@ -366,7 +373,9 @@ public class LuminaVectorGlobalIndexTest {
 
         int numVectors = 350;
         List<float[]> testVectors = generateRandomVectors(numVectors, dimension);
-        testVectors.forEach(writer::write);
+        for (int i = 0; i < testVectors.size(); i++) {
+            writer.write(testVectors.get(i), i);
+        }
 
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
@@ -417,7 +426,9 @@ public class LuminaVectorGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, writeIndexOptions);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
 
@@ -467,8 +478,8 @@ public class LuminaVectorGlobalIndexTest {
                 new LuminaVectorGlobalIndexWriter(fileWriter, vecFieldType, indexOptions);
 
         // Write using BinaryVector (InternalVector)
-        for (float[] vec : vectors) {
-            writer.write(BinaryVector.fromPrimitiveArray(vec));
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(BinaryVector.fromPrimitiveArray(vectors[i]), i);
         }
 
         List<ResultEntry> results = writer.finish();
@@ -507,8 +518,8 @@ public class LuminaVectorGlobalIndexTest {
                     new float[] {0.0f, 1.0f},
                     new float[] {0.7f, 0.7f}
                 };
-        for (float[] vec : vectors) {
-            writer.write(vec);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
         }
 
         List<ResultEntry> results = writer.finish();
@@ -548,12 +559,12 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(vectors[0]); // row 0
-        writer.write(null); // row 1 - null
-        writer.write(vectors[1]); // row 2
-        writer.write(null); // row 3 - null
-        writer.write(null); // row 4 - null
-        writer.write(vectors[2]); // row 5
+        writer.write(vectors[0], 0); // row 0
+        writer.write(null, 1); // row 1 - null
+        writer.write(vectors[1], 2); // row 2
+        writer.write(null, 3); // row 3 - null
+        writer.write(null, 4); // row 4 - null
+        writer.write(vectors[2], 5); // row 5
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
@@ -591,9 +602,9 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(null);
-        writer.write(null);
-        writer.write(null);
+        writer.write(null, 0);
+        writer.write(null, 1);
+        writer.write(null, 2);
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).isEmpty();
@@ -618,12 +629,12 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(vectors[0]); // row 0
-        writer.write(null); // row 1 - null
-        writer.write(vectors[1]); // row 2
-        writer.write(vectors[2]); // row 3
-        writer.write(null); // row 4 - null
-        writer.write(vectors[3]); // row 5
+        writer.write(vectors[0], 0); // row 0
+        writer.write(null, 1); // row 1 - null
+        writer.write(vectors[1], 2); // row 2
+        writer.write(vectors[2], 3); // row 3
+        writer.write(null, 4); // row 4 - null
+        writer.write(vectors[3], 5); // row 5
 
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
@@ -659,8 +670,8 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(null); // row 0 - null
-        writer.write(new float[] {1.0f, 0.0f}); // row 1
+        writer.write(null, 0); // row 0 - null
+        writer.write(new float[] {1.0f, 0.0f}, 1); // row 1
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
@@ -689,8 +700,8 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(new float[] {1.0f, 0.0f}); // row 0
-        writer.write(null); // row 1 - null
+        writer.write(new float[] {1.0f, 0.0f}, 0); // row 0
+        writer.write(null, 1); // row 1 - null
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
@@ -719,7 +730,7 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        assertThatThrownBy(() -> writer.write(new float[] {1.0f, Float.NaN}))
+        assertThatThrownBy(() -> writer.write(new float[] {1.0f, Float.NaN}, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rowId=0")
                 .hasMessageContaining("index=1")
@@ -736,14 +747,14 @@ public class LuminaVectorGlobalIndexTest {
         LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(fileWriter, vectorType, indexOptions);
 
-        writer.write(null); // row 0 - null, advances logicalRowId
-        assertThatThrownBy(() -> writer.write(new float[] {Float.POSITIVE_INFINITY, 0.0f}))
+        writer.write(null, 0); // row 0 - null
+        assertThatThrownBy(() -> writer.write(new float[] {Float.POSITIVE_INFINITY, 0.0f}, 1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rowId=1")
                 .hasMessageContaining("index=0")
                 .hasMessageContaining("Infinity");
 
-        assertThatThrownBy(() -> writer.write(new float[] {0.0f, Float.NEGATIVE_INFINITY}))
+        assertThatThrownBy(() -> writer.write(new float[] {0.0f, Float.NEGATIVE_INFINITY}, 1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rowId=1")
                 .hasMessageContaining("index=1")

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriterTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexWriterTest.java
@@ -54,9 +54,9 @@ public class LuminaVectorGlobalIndexWriterTest {
                                     LuminaVectorIndexOptions.DIMENSION),
                             "2");
 
-            writer.write(new float[] {1.0f, 0.0f});
+            writer.write(new float[] {1.0f, 0.0f}, 0);
 
-            assertThatThrownBy(() -> writer.write(new float[] {1.0f, 0.0f, 0.0f}))
+            assertThatThrownBy(() -> writer.write(new float[] {1.0f, 0.0f, 0.0f}, 1))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("expected 2")
                     .hasMessageContaining("got 3");
@@ -94,9 +94,9 @@ public class LuminaVectorGlobalIndexWriterTest {
         try (LuminaVectorGlobalIndexWriter writer =
                 new LuminaVectorGlobalIndexWriter(
                         createNoopFileWriter(), arrayFieldType, indexOptions)) {
-            writer.write(new float[] {1.0f, 0.0f, 0.0f});
+            writer.write(new float[] {1.0f, 0.0f, 0.0f}, 0);
 
-            assertThatThrownBy(() -> writer.write(new float[] {1.0f, 0.0f}))
+            assertThatThrownBy(() -> writer.write(new float[] {1.0f, 0.0f}, 1))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("expected 3")
                     .hasMessageContaining("got 2");

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexBuilder.java
@@ -21,7 +21,7 @@ package org.apache.paimon.spark.globalindex;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.globalindex.GlobalIndexMultiColumnWriter;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.GlobalIndexWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.index.IndexFileMeta;
@@ -165,14 +165,24 @@ public class DefaultGlobalIndexBuilder implements Serializable {
                     rowCounter.add(1);
                 }
             } else {
-                GlobalIndexSingletonWriter singleWriter = (GlobalIndexSingletonWriter) indexWriter;
+                GlobalIndexSingleColumnWriter singleWriter =
+                        (GlobalIndexSingleColumnWriter) indexWriter;
                 InternalRow.FieldGetter getter =
                         InternalRow.createFieldGetter(
                                 indexField.type(), readType.getFieldIndex(indexField.name()));
+                int rowIdFieldIndex = readType.getFieldIndex(SpecialFields.ROW_ID.name());
+                if (rowIdFieldIndex < 0) {
+                    throw new IllegalStateException(
+                            "Global index build requires " + SpecialFields.ROW_ID.name());
+                }
                 rows.forEachRemaining(
                         row -> {
+                            long rowId = row.getLong(rowIdFieldIndex);
+                            if (rowId < rowRange.from || rowId > rowRange.to) {
+                                return;
+                            }
                             Object indexO = getter.getFieldOrNull(row);
-                            singleWriter.write(indexO);
+                            singleWriter.write(indexO, rowId - rowRange.from);
                             rowCounter.add(1);
                         });
             }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -68,6 +68,9 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
         return "default";
     }
 
+    private static final String VECTOR_INDEX_BUILD_MERGE_ROW_RANGES =
+            "vector-index.build.merge-row-ranges";
+
     @Override
     public List<CommitMessage> buildIndex(
             SparkSession spark,
@@ -125,7 +128,13 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                         schemaManager, entries, indexColumns);
         entries = GlobalIndexBuilderUtils.filterEntriesBefore(entries, boundaryRowId);
         // generate splits for each partition && shard
-        Map<BinaryRow, List<IndexedSplit>> splits = split(table, entries, rowsPerShard);
+        Map<BinaryRow, List<IndexedSplit>> splits =
+                split(
+                        table,
+                        entries,
+                        rowsPerShard,
+                        isVectorIndex(indexType)
+                                && options.getBoolean(VECTOR_INDEX_BUILD_MERGE_ROW_RANGES, false));
 
         JavaSparkContext javaSparkContext = new JavaSparkContext(spark.sparkContext());
         List<Pair<byte[], byte[]>> taskList = new ArrayList<>();
@@ -134,9 +143,6 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             List<IndexedSplit> partitions = entry.getValue();
 
             for (IndexedSplit indexedSplit : partitions) {
-                checkArgument(
-                        indexedSplit.rowRanges().size() == 1,
-                        "Each IndexedSplit should contain exactly one row range.");
                 DefaultGlobalIndexBuilder builder =
                         new DefaultGlobalIndexBuilder(
                                 table,
@@ -145,7 +151,7 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                                 indexField,
                                 extraFields,
                                 indexType,
-                                indexedSplit.rowRanges().get(0),
+                                envelope(indexedSplit.rowRanges()),
                                 options);
                 byte[] builderBytes = InstantiationUtil.serializeObject(builder);
                 byte[] splitBytes = InstantiationUtil.serializeObject(indexedSplit);
@@ -182,7 +188,10 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
     }
 
     private static Map<BinaryRow, List<IndexedSplit>> split(
-            FileStoreTable table, List<ManifestEntry> entries, long rowsPerShard) {
+            FileStoreTable table,
+            List<ManifestEntry> entries,
+            long rowsPerShard,
+            boolean mergeDiscontinuousRowRanges) {
         FileStorePathFactory pathFactory = table.store().pathFactory();
 
         // Group manifest entries by partition
@@ -190,7 +199,10 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                 entries.stream().collect(Collectors.groupingBy(ManifestEntry::partition));
 
         return groupFilesIntoShardsByPartition(
-                entriesByPartition, rowsPerShard, pathFactory::bucketPath);
+                entriesByPartition,
+                rowsPerShard,
+                pathFactory::bucketPath,
+                mergeDiscontinuousRowRanges);
     }
 
     /**
@@ -206,6 +218,15 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition,
             long rowsPerShard,
             BiFunction<BinaryRow, Integer, Path> pathFactory) {
+        return groupFilesIntoShardsByPartition(
+                entriesByPartition, rowsPerShard, pathFactory, false);
+    }
+
+    public static Map<BinaryRow, List<IndexedSplit>> groupFilesIntoShardsByPartition(
+            Map<BinaryRow, List<ManifestEntry>> entriesByPartition,
+            long rowsPerShard,
+            BiFunction<BinaryRow, Integer, Path> pathFactory,
+            boolean mergeDiscontinuousRowRanges) {
         Map<BinaryRow, List<IndexedSplit>> result = new HashMap<>();
 
         for (Map.Entry<BinaryRow, List<ManifestEntry>> partitionEntry :
@@ -250,6 +271,17 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
 
                 // Sort files by firstRowId to ensure sequential order
                 shardFiles.sort(Comparator.comparingLong(DataFileMeta::nonNullFirstRowId));
+                if (mergeDiscontinuousRowRanges) {
+                    createDataSplitForGroup(
+                            shardFiles,
+                            shardStart,
+                            shardEnd,
+                            partition,
+                            pathFactory,
+                            shardSplits,
+                            true);
+                    continue;
+                }
 
                 // Group contiguous files and create separate DataSplits for each group
                 List<DataFileMeta> currentGroup = new ArrayList<>();
@@ -275,7 +307,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                                 shardEnd,
                                 partition,
                                 pathFactory,
-                                shardSplits);
+                                shardSplits,
+                                false);
                         currentGroup = new ArrayList<>();
                         currentGroup.add(file);
                         currentGroupEnd = fileEnd;
@@ -290,7 +323,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                             shardEnd,
                             partition,
                             pathFactory,
-                            shardSplits);
+                            shardSplits,
+                            false);
                 }
             }
 
@@ -308,7 +342,8 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             long shardEnd,
             BinaryRow partition,
             BiFunction<BinaryRow, Integer, Path> pathFactory,
-            List<IndexedSplit> shardSplits) {
+            List<IndexedSplit> shardSplits,
+            boolean mergeDiscontinuousRowRanges) {
         // Calculate the actual row range covered by the files
         long groupMinRowId = files.get(0).nonNullFirstRowId();
         long groupMaxRowId =
@@ -320,6 +355,17 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
         long rangeTo = Math.min(groupMaxRowId, shardEnd);
 
         Range range = new Range(rangeFrom, rangeTo);
+        List<Range> rowRanges = new ArrayList<>();
+        for (DataFileMeta file : files) {
+            Range intersection = Range.intersection(range, file.nonNullRowIdRange());
+            if (intersection != null) {
+                rowRanges.add(intersection);
+            }
+        }
+        rowRanges = Range.sortAndMergeOverlap(rowRanges, true);
+        if (!mergeDiscontinuousRowRanges) {
+            rowRanges = Collections.singletonList(range);
+        }
 
         DataSplit dataSplit =
                 DataSplit.builder()
@@ -330,6 +376,18 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
                         .rawConvertible(false)
                         .build();
 
-        shardSplits.add(new IndexedSplit(dataSplit, Collections.singletonList(range), null));
+        shardSplits.add(new IndexedSplit(dataSplit, rowRanges, null));
+    }
+
+    private static Range envelope(List<Range> ranges) {
+        checkArgument(!ranges.isEmpty(), "Row ranges must not be empty.");
+        return new Range(ranges.get(0).from, ranges.get(ranges.size() - 1).to);
+    }
+
+    private static boolean isVectorIndex(String indexType) {
+        return "ivf-flat".equals(indexType)
+                || "ivf-pq".equals(indexType)
+                || "ivf-hnsw-flat".equals(indexType)
+                || "ivf-hnsw-sq".equals(indexType);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/btree/BTreeIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/btree/BTreeIndexTopoBuilder.java
@@ -59,7 +59,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.groupSplitsByRange;
-import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.splitByContiguousRowRange;
+import static org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder.prepareDataSplitsForBuild;
 
 /** The {@link GlobalIndexTopologyBuilder} for BTree index. */
 public class BTreeIndexTopoBuilder implements GlobalIndexTopologyBuilder {
@@ -93,13 +93,16 @@ public class BTreeIndexTopoBuilder implements GlobalIndexTopologyBuilder {
         }
 
         Pair<RowRangeIndex, List<DataSplit>> scanResult = indexRangeAndSplits.get();
-        List<DataSplit> splits = splitByContiguousRowRange(scanResult.getRight());
+        boolean mergeDiscontinuousRowRanges =
+                options.get(BTreeIndexOptions.BTREE_INDEX_BUILD_MERGE_ROW_RANGES);
+        List<DataSplit> splits =
+                prepareDataSplitsForBuild(scanResult.getRight(), mergeDiscontinuousRowRanges);
         if (splits.isEmpty()) {
             return Collections.emptyList();
         }
 
         Map<BinaryRow, Map<Range, List<Split>>> partitionRangeSplits =
-                groupSplitsByRange(scanResult.getKey(), splits);
+                groupSplitsByRange(scanResult.getKey(), splits, mergeDiscontinuousRowRanges);
         if (partitionRangeSplits.isEmpty()) {
             return Collections.emptyList();
         }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/procedure/CreateGlobalIndexProcedureTest.java
@@ -377,6 +377,33 @@ public class CreateGlobalIndexProcedureTest {
     }
 
     @Test
+    void testGroupFilesIntoShardsByPartitionMergeNonContiguousFiles() {
+        BinaryRow partition = createPartition(0);
+
+        DataFileMeta file1 = createDataFileMeta(100L, 100L);
+        DataFileMeta file2 = createDataFileMeta(300L, 100L);
+
+        List<ManifestEntry> entries =
+                Arrays.asList(
+                        createManifestEntry(partition, file1),
+                        createManifestEntry(partition, file2));
+
+        Map<BinaryRow, List<ManifestEntry>> entriesByPartition = new HashMap<>();
+        entriesByPartition.put(partition, entries);
+
+        Map<BinaryRow, List<IndexedSplit>> result =
+                DefaultGlobalIndexTopoBuilder.groupFilesIntoShardsByPartition(
+                        entriesByPartition, 1000L, pathFactory, true);
+
+        assertThat(result).hasSize(1);
+        List<IndexedSplit> shardSplits = result.get(partition);
+        assertThat(shardSplits).hasSize(1);
+        assertThat(shardSplits.get(0).rowRanges())
+                .containsExactly(new Range(100L, 199L), new Range(300L, 399L));
+        assertThat(shardSplits.get(0).dataSplit().dataFiles()).containsExactly(file1, file2);
+    }
+
+    @Test
     void testGroupFilesIntoShardsByPartitionMixedContiguousAndNonContiguous() {
         // Create a partition
         BinaryRow partition = createPartition(0);

--- a/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/main/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexWriter.java
@@ -20,13 +20,15 @@ package org.apache.paimon.tantivy.index;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.tantivy.TantivyIndexWriter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.File;
@@ -48,7 +50,7 @@ import java.util.List;
  * <p>Text data is written to a local Tantivy index via JNI. On {@link #finish()}, the index
  * directory is packed into a single file and written to the global index file system.
  */
-public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWriter, Closeable {
+public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingleColumnWriter, Closeable {
 
     private static final String FILE_NAME_PREFIX = "tantivy";
     private static final Logger LOG =
@@ -84,9 +86,12 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
     }
 
     @Override
-    public void write(Object fieldData) {
+    public void write(@Nullable Object fieldData, long relativeRowId) {
+        if (relativeRowId < 0) {
+            throw new IllegalArgumentException("Row ID must be non-negative: " + relativeRowId);
+        }
         if (fieldData == null) {
-            rowId++;
+            rowId = Math.max(rowId, relativeRowId + 1);
             return;
         }
 
@@ -100,8 +105,8 @@ public class TantivyFullTextGlobalIndexWriter implements GlobalIndexSingletonWri
                     "Unsupported field type: " + fieldData.getClass().getName());
         }
 
-        writer.addDocument(rowId, text);
-        rowId++;
+        writer.addDocument(relativeRowId, text);
+        rowId = Math.max(rowId, relativeRowId + 1);
     }
 
     @Override

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/JavaPyTantivyE2ETest.java
@@ -25,7 +25,7 @@ import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
@@ -199,8 +199,8 @@ public class JavaPyTantivyE2ETest {
             indexOptions.set(TantivyFullTextIndexOptions.REMOVE_STOP_WORDS, true);
         }
 
-        GlobalIndexSingletonWriter writer =
-                (GlobalIndexSingletonWriter)
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
                         GlobalIndexBuilderUtils.createIndexWriter(
                                 table,
                                 TantivyFullTextGlobalIndexerFactory.IDENTIFIER,
@@ -208,8 +208,8 @@ public class JavaPyTantivyE2ETest {
                                 indexOptions);
 
         // Write the same text data to the index.
-        for (String content : contents) {
-            writer.write(BinaryString.fromString(content));
+        for (int i = 0; i < contents.size(); i++) {
+            writer.write(BinaryString.fromString(contents.get(i)), i);
         }
 
         List<ResultEntry> entries = writer.finish();

--- a/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
+++ b/paimon-tantivy/paimon-tantivy-index/src/test/java/org/apache/paimon/tantivy/index/TantivyFullTextGlobalIndexTest.java
@@ -125,9 +125,9 @@ public class TantivyFullTextGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer = new TantivyFullTextGlobalIndexWriter(fileWriter);
 
-        writer.write(BinaryString.fromString("Apache Paimon is a streaming data lake platform"));
-        writer.write(BinaryString.fromString("Tantivy is a full-text search engine in Rust"));
-        writer.write(BinaryString.fromString("Paimon supports real-time data ingestion"));
+        writer.write(BinaryString.fromString("Apache Paimon is a streaming data lake platform"), 0);
+        writer.write(BinaryString.fromString("Tantivy is a full-text search engine in Rust"), 1);
+        writer.write(BinaryString.fromString("Paimon supports real-time data ingestion"), 2);
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
@@ -171,7 +171,7 @@ public class TantivyFullTextGlobalIndexTest {
                         new TantivyFullTextIndexOptions(
                                 TantivyFullTextGlobalIndexerFactory.removeTantivyPrefix(options)));
 
-        writer.write(BinaryString.fromString("Apache Paimon supports Chinese text"));
+        writer.write(BinaryString.fromString("Apache Paimon supports Chinese text"), 0);
         List<ResultEntry> results = writer.finish();
 
         assertThat(results).hasSize(1);
@@ -194,8 +194,8 @@ public class TantivyFullTextGlobalIndexTest {
                         new TantivyFullTextIndexOptions(
                                 TantivyFullTextGlobalIndexerFactory.removeTantivyPrefix(options)));
 
-        writer.write(BinaryString.fromString("张华在百货公司当售货员"));
-        writer.write(BinaryString.fromString("Apache Paimon supports full text search"));
+        writer.write(BinaryString.fromString("张华在百货公司当售货员"), 0);
+        writer.write(BinaryString.fromString("Apache Paimon supports full text search"), 1);
 
         List<ResultEntry> results = writer.finish();
         TantivyFullTextIndexOptions indexOptions =
@@ -222,8 +222,8 @@ public class TantivyFullTextGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer = new TantivyFullTextGlobalIndexWriter(fileWriter);
 
-        writer.write(BinaryString.fromString("Hello world"));
-        writer.write(BinaryString.fromString("Foo bar baz"));
+        writer.write(BinaryString.fromString("Hello world"), 0);
+        writer.write(BinaryString.fromString("Foo bar baz"), 1);
 
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
@@ -245,9 +245,9 @@ public class TantivyFullTextGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer = new TantivyFullTextGlobalIndexWriter(fileWriter);
 
-        writer.write(BinaryString.fromString("Paimon data lake"));
-        writer.write(null); // row 1 is null, should be skipped
-        writer.write(BinaryString.fromString("Paimon streaming"));
+        writer.write(BinaryString.fromString("Paimon data lake"), 0);
+        writer.write(null, 1); // row 1 is null, should be skipped
+        writer.write(BinaryString.fromString("Paimon streaming"), 2);
 
         List<ResultEntry> results = writer.finish();
         assertThat(results.get(0).rowCount()).isEqualTo(3);
@@ -291,7 +291,7 @@ public class TantivyFullTextGlobalIndexTest {
             if (i % 10 == 0) {
                 text += " special_keyword";
             }
-            writer.write(BinaryString.fromString(text));
+            writer.write(BinaryString.fromString(text), i);
         }
 
         List<ResultEntry> results = writer.finish();
@@ -323,7 +323,7 @@ public class TantivyFullTextGlobalIndexTest {
         TantivyFullTextGlobalIndexWriter writer = new TantivyFullTextGlobalIndexWriter(fileWriter);
 
         for (int i = 0; i < 20; i++) {
-            writer.write(BinaryString.fromString("paimon document " + i));
+            writer.write(BinaryString.fromString("paimon document " + i), i);
         }
 
         List<ResultEntry> results = writer.finish();
@@ -346,8 +346,8 @@ public class TantivyFullTextGlobalIndexTest {
     public void testPoolReuse() throws IOException {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         TantivyFullTextGlobalIndexWriter writer = new TantivyFullTextGlobalIndexWriter(fileWriter);
-        writer.write(BinaryString.fromString("Apache Paimon streaming lake"));
-        writer.write(BinaryString.fromString("Tantivy full-text search"));
+        writer.write(BinaryString.fromString("Apache Paimon streaming lake"), 0);
+        writer.write(BinaryString.fromString("Tantivy full-text search"), 1);
 
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
@@ -379,7 +379,7 @@ public class TantivyFullTextGlobalIndexTest {
         TantivyFullTextGlobalIndexWriter writer =
                 (TantivyFullTextGlobalIndexWriter) indexer.createWriter(fileWriter);
 
-        writer.write(BinaryString.fromString("test via indexer factory"));
+        writer.write(BinaryString.fromString("test via indexer factory"), 0);
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
 

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexWriter.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorGlobalIndexWriter.java
@@ -21,7 +21,7 @@ package org.apache.paimon.vector.index;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalVector;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.globalindex.GlobalIndexSingletonWriter;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
 import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.index.vector.VectorIndexWriter;
@@ -32,6 +32,8 @@ import org.apache.paimon.types.VectorType;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.File;
@@ -48,13 +50,13 @@ import java.util.Map;
 /**
  * Vector global index writer using paimon-vector-index.
  *
- * <p>Vectors are spilled to a temporary file on disk as they arrive via {@link #write(Object)},
- * keeping Java heap usage constant (~8 MB buffer). During index build, vectors are read back for
- * training and batch insertion.
+ * <p>Vectors are spilled to a temporary file on disk as they arrive via {@link #write(Object,
+ * long)}, keeping Java heap usage constant (~8 MB buffer). During index build, vectors are read
+ * back for training and batch insertion.
  *
  * <p><b>Thread safety:</b> This class is <b>not</b> thread-safe.
  */
-public class VectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Closeable {
+public class VectorGlobalIndexWriter implements GlobalIndexSingleColumnWriter, Closeable {
 
     private static final String FILE_NAME_PREFIX = "vector";
 
@@ -129,31 +131,34 @@ public class VectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Clos
     }
 
     @Override
-    public void write(Object fieldData) {
+    public void write(@Nullable Object fieldData, long rowId) {
+        if (rowId < 0) {
+            throw new IllegalArgumentException("Row ID must be non-negative: " + rowId);
+        }
         if (fieldData == null) {
-            logicalRowId++;
+            logicalRowId = Math.max(logicalRowId, rowId + 1);
             return;
         }
 
-        float[] src = materializeAndValidate(fieldData);
+        float[] src = materializeAndValidate(fieldData, rowId);
 
         if (writeBuf.remaining() < recordSizeInBytes) {
             flushWriteBuffer();
         }
-        writeBuf.putLong(logicalRowId);
+        writeBuf.putLong(rowId);
         for (int i = 0; i < dim; i++) {
             writeBuf.putFloat(src[i]);
         }
-        logicalRowId++;
+        logicalRowId = Math.max(logicalRowId, rowId + 1);
         count++;
     }
 
-    private float[] materializeAndValidate(Object fieldData) {
+    private float[] materializeAndValidate(Object fieldData, long rowId) {
         if (fieldData instanceof float[]) {
             float[] vector = (float[]) fieldData;
             checkDimension(vector.length);
             for (int i = 0; i < dim; i++) {
-                checkFinite(vector[i], i);
+                checkFinite(vector[i], rowId, i);
             }
             return vector;
         } else if (fieldData instanceof InternalVector) {
@@ -161,7 +166,7 @@ public class VectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Clos
             checkDimension(vector.size());
             for (int i = 0; i < dim; i++) {
                 float v = vector.getFloat(i);
-                checkFinite(v, i);
+                checkFinite(v, rowId, i);
                 vectorBuf[i] = v;
             }
             return vectorBuf;
@@ -173,7 +178,7 @@ public class VectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Clos
                     throw new IllegalArgumentException("Vector element at index " + i + " is null");
                 }
                 float v = array.getFloat(i);
-                checkFinite(v, i);
+                checkFinite(v, rowId, i);
                 vectorBuf[i] = v;
             }
             return vectorBuf;
@@ -364,12 +369,12 @@ public class VectorGlobalIndexWriter implements GlobalIndexSingletonWriter, Clos
         }
     }
 
-    private void checkFinite(float value, int elementIndex) {
+    private void checkFinite(float value, long rowId, int elementIndex) {
         if (!Float.isFinite(value)) {
             throw new IllegalArgumentException(
                     String.format(
                             "Vector element at rowId=%d, index=%d is %s",
-                            logicalRowId, elementIndex, Float.toString(value)));
+                            rowId, elementIndex, Float.toString(value)));
         }
     }
 

--- a/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorIndexOptions.java
+++ b/paimon-vector/paimon-vector-index/src/main/java/org/apache/paimon/vector/index/VectorIndexOptions.java
@@ -16,11 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.paimon.globalindex;
+package org.apache.paimon.vector.index;
 
-import javax.annotation.Nullable;
+import org.apache.paimon.options.ConfigOption;
+import org.apache.paimon.options.ConfigOptions;
 
-/** Index writer for global index. */
-public interface GlobalIndexSingletonWriter extends GlobalIndexWriter {
-    void write(@Nullable Object key);
+/** Options for vector index. */
+public class VectorIndexOptions {
+
+    public static final ConfigOption<Boolean> VECTOR_INDEX_BUILD_MERGE_ROW_RANGES =
+            ConfigOptions.key("vector-index.build.merge-row-ranges")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to merge discontinuous row id ranges when building vector "
+                                    + "indexes. This should only be enabled when row id gaps are "
+                                    + "permanent and will never be filled by later writes.");
 }

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexTest.java
@@ -28,6 +28,7 @@ import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
 import org.apache.paimon.index.vector.NativeLoader;
+import org.apache.paimon.index.vector.VectorIndexWriter;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.VectorSearch;
 import org.apache.paimon.types.ArrayType;
@@ -45,7 +46,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +73,15 @@ public class VectorGlobalIndexTest {
     private static boolean isNativeAvailable() {
         try {
             NativeLoader.loadJni();
+            try (VectorIndexWriter ignored =
+                    new VectorIndexWriter(
+                            VectorGlobalIndexerFactory.nativeOptions(
+                                    new ArrayType(new FloatType()),
+                                    createDefaultOptions(2),
+                                    IVF_PQ_IDENTIFIER,
+                                    "vec"))) {
+                // Validate that the loaded native library exposes the required symbols.
+            }
             return true;
         } catch (Throwable t) {
             return false;
@@ -106,7 +115,7 @@ public class VectorGlobalIndexTest {
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
 
         float[] wrongDimVector = new float[32];
-        assertThatThrownBy(() -> writer.write(wrongDimVector))
+        assertThatThrownBy(() -> writer.write(wrongDimVector, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("dimension mismatch");
     }
@@ -130,7 +139,7 @@ public class VectorGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
 
-        assertThatThrownBy(() -> writer.write(new float[] {1.0f, Float.NaN}))
+        assertThatThrownBy(() -> writer.write(new float[] {1.0f, Float.NaN}, 0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rowId=0")
                 .hasMessageContaining("index=1")
@@ -144,12 +153,26 @@ public class VectorGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
 
-        writer.write(null); // row 0 - null, advances logicalRowId
-        assertThatThrownBy(() -> writer.write(new float[] {Float.POSITIVE_INFINITY, 0.0f}))
+        writer.write(null, 0); // row 0 - null
+        assertThatThrownBy(() -> writer.write(new float[] {Float.POSITIVE_INFINITY, 0.0f}, 1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("rowId=1")
                 .hasMessageContaining("index=0")
                 .hasMessageContaining("Infinity");
+    }
+
+    @Test
+    public void testExplicitRowIdUsedInValidation() {
+        Options options = createDefaultOptions(2);
+        options.setInteger("ivf-pq.pq.m", 1);
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
+
+        writer.write(null, 9);
+        assertThatThrownBy(() -> writer.write(new float[] {Float.NaN, 0.0f}, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("rowId=10")
+                .hasMessageContaining("NaN");
     }
 
     @Test
@@ -159,9 +182,9 @@ public class VectorGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
 
-        writer.write(null);
-        writer.write(null);
-        writer.write(null);
+        writer.write(null, 0);
+        writer.write(null, 1);
+        writer.write(null, 2);
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).isEmpty();
@@ -223,7 +246,9 @@ public class VectorGlobalIndexTest {
 
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
 
@@ -260,7 +285,9 @@ public class VectorGlobalIndexTest {
 
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
 
@@ -300,12 +327,12 @@ public class VectorGlobalIndexTest {
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
 
-        writer.write(vectors[0]); // row 0
-        writer.write(null); // row 1 - null
-        writer.write(vectors[1]); // row 2
-        writer.write(null); // row 3 - null
-        writer.write(null); // row 4 - null
-        writer.write(vectors[2]); // row 5
+        writer.write(vectors[0], 0); // row 0
+        writer.write(null, 1); // row 1 - null
+        writer.write(vectors[1], 2); // row 2
+        writer.write(null, 3); // row 3 - null
+        writer.write(null, 4); // row 4 - null
+        writer.write(vectors[2], 5); // row 5
 
         List<ResultEntry> results = writer.finish();
         assertThat(results).hasSize(1);
@@ -324,6 +351,48 @@ public class VectorGlobalIndexTest {
             assertThat(result.results().contains(1L)).isFalse();
             assertThat(result.results().contains(3L)).isFalse();
             assertThat(result.results().contains(4L)).isFalse();
+        }
+    }
+
+    @Test
+    public void testExplicitRowIdGapWithCorrectIds() throws IOException {
+        Assumptions.assumeTrue(isNativeAvailable(), "Vector index native library not available");
+
+        int dimension = 2;
+        Options options = createDefaultOptions(dimension);
+        options.setInteger("ivf-pq.nlist", 2);
+        options.setInteger("ivf-pq.pq.m", 1);
+
+        float[][] vectors =
+                new float[][] {
+                    new float[] {1.0f, 0.0f},
+                    new float[] {0.1f, 0.95f},
+                    new float[] {0.0f, 1.0f}
+                };
+
+        GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
+        VectorGlobalIndexWriter writer = createIvfPqWriter(fileWriter, vectorType, options);
+
+        writer.write(vectors[0], 0);
+        writer.write(vectors[1], 4);
+        writer.write(vectors[2], 9);
+
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).rowCount()).isEqualTo(10);
+
+        List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
+        GlobalIndexFileReader fileReader = createFileReader(indexPath);
+        try (VectorGlobalIndexReader reader =
+                new VectorGlobalIndexReader(fileReader, metas, vectorType, executor)) {
+            VectorSearch vectorSearch = new VectorSearch(vectors[0], 3, fieldName);
+            ScoredGlobalIndexResult result = reader.visitVectorSearch(vectorSearch).join().get();
+            assertThat(result.results().getLongCardinality()).isEqualTo(3);
+            assertThat(result.results().contains(0L)).isTrue();
+            assertThat(result.results().contains(4L)).isTrue();
+            assertThat(result.results().contains(9L)).isTrue();
+            assertThat(result.results().contains(1L)).isFalse();
+            assertThat(result.results().contains(5L)).isFalse();
         }
     }
 
@@ -352,7 +421,9 @@ public class VectorGlobalIndexTest {
 
         GlobalIndexFileWriter fileWriter = createFileWriter(indexPath);
         VectorGlobalIndexWriter writer = (VectorGlobalIndexWriter) indexer.createWriter(fileWriter);
-        Arrays.stream(vectors).forEach(writer::write);
+        for (int i = 0; i < vectors.length; i++) {
+            writer.write(vectors[i], i);
+        }
         List<ResultEntry> results = writer.finish();
         List<GlobalIndexIOMeta> metas = toIOMetas(results, indexPath);
 
@@ -378,7 +449,7 @@ public class VectorGlobalIndexTest {
                 IVF_PQ_IDENTIFIER);
     }
 
-    private Options createDefaultOptions(int dimension) {
+    private static Options createDefaultOptions(int dimension) {
         Options options = new Options();
         options.setInteger("ivf-pq.dimension", dimension);
         options.setString("ivf-pq.metric", "l2");

--- a/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
+++ b/paimon-vector/paimon-vector-index/src/test/java/org/apache/paimon/vector/index/VectorGlobalIndexerFactoryTest.java
@@ -44,6 +44,15 @@ public class VectorGlobalIndexerFactoryTest {
     }
 
     @Test
+    public void testVectorIndexBuildMergeRowRangesOption() {
+        Options options = new Options();
+        assertThat(options.get(VectorIndexOptions.VECTOR_INDEX_BUILD_MERGE_ROW_RANGES)).isFalse();
+
+        options.set(VectorIndexOptions.VECTOR_INDEX_BUILD_MERGE_ROW_RANGES, true);
+        assertThat(options.get(VectorIndexOptions.VECTOR_INDEX_BUILD_MERGE_ROW_RANGES)).isTrue();
+    }
+
+    @Test
     public void testLoadByIdentifier() {
         assertThat(GlobalIndexerFactoryUtils.load("ivf-flat"))
                 .isExactlyInstanceOf(IvfFlatVectorGlobalIndexerFactory.class);


### PR DESCRIPTION
## Summary

This PR adds opt-in support for building global indexes over sparse, monotonically increasing RowID ranges whose gaps are permanent. It covers BTree global indexes and vector-style single-column global indexes, allowing index metadata to use the enclosing RowID span while reads and writers still honor the actual data ranges.

## Changes

- Add `btree-index.build.merge-row-ranges` and `vector-index.build.merge-row-ranges`, both disabled by default.
- Preserve actual `IndexedSplit` row ranges while using the enclosing RowID range for index metadata when sparse ranges are merged.
- Replace the old single-column writer variants with `GlobalIndexSingleColumnWriter#write(@Nullable Object key, long relativeRowId)` so BTree, vector, Tantivy, and Lumina writers all receive explicit relative RowIDs.
- Wire sparse range merging through core, Flink, and Spark BTree index builders, plus Flink/Spark generic vector index builders.
- Relax global index RowID existence conflict checks only when the corresponding merge option is enabled and the span endpoints are covered by current data files.
- Update vector/full-text test index helpers to persist row ids, so sparse relative RowIDs are returned correctly by test readers.
- Reuse overridable table schemas in the discontinuous RowID BTree test so Lance format coverage keeps using `file.format=lance`.

## Testing

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=BtreeGlobalIndexTableTest#testBuildBTreeGlobalIndexWithDiscontinuousRowIdRanges test`
- `mvn -pl paimon-lance -am -Pfast-build -DfailIfNoTests=false -Dtest=LanceBTreeGlobalIndexTest#testBuildBTreeGlobalIndexWithDiscontinuousRowIdRanges test`
- `mvn -pl paimon-flink/paimon-flink-common -am -Pfast-build -DfailIfNoTests=false -Dtest=GenericIndexTopoBuilderTest test`
- `mvn -pl paimon-spark/paimon-spark-common -am -Pfast-build -DfailIfNoTests=false -Dtest=CreateGlobalIndexProcedureTest test`
- `mvn -pl paimon-vector/paimon-vector-index -am -Pfast-build -DfailIfNoTests=false -Dtest=VectorGlobalIndexerFactoryTest,VectorGlobalIndexTest test`
- `mvn -pl paimon-tantivy/paimon-tantivy-index -am -Pfast-build -DfailIfNoTests=false -Dtest=TantivyFullTextGlobalIndexTest test`
- `mvn -pl paimon-common,paimon-core,paimon-flink/paimon-flink-common,paimon-spark/paimon-spark-common,paimon-vector/paimon-vector-index,paimon-tantivy/paimon-tantivy-index,paimon-lumina -am -Pfast-build -DskipTests test-compile`
- `mvn -pl paimon-common,paimon-core,paimon-flink/paimon-flink-common,paimon-spark/paimon-spark-common,paimon-vector/paimon-vector-index,paimon-tantivy/paimon-tantivy-index,paimon-lumina spotless:check`
- `git diff --check`

## Notes

These options should only be enabled when RowID gaps are permanent and will not be filled later. With the default values, existing global index build behavior is unchanged.

The local Tantivy test command completed successfully, with Tantivy native test cases skipped by their test assumptions on this machine.
