### PR TITLE
[python] Support delete by filter for data evolution

### DIFF
--- a/docs/docs/pypaimon/data-evolution.md
+++ b/docs/docs/pypaimon/data-evolution.md
@@ -195,6 +195,8 @@ the old file group is removed and the remaining rows are written back as continu
 - If the predicate explicitly references `_ROW_ID`, the requested row IDs must exist in the current snapshot.
 - Tables with dedicated blob or vector files are supported. The normal data file and its `.blob` / `.vector.*`
   companion files are deleted and rewritten together for the affected row-id range.
+- Tables with global indexes in affected partitions are not currently supported, because deleting rows rewrites full
+  file groups and would otherwise leave stale global index entries.
 
 ### Batch Mode
 

--- a/docs/docs/pypaimon/data-evolution.md
+++ b/docs/docs/pypaimon/data-evolution.md
@@ -53,6 +53,7 @@ Method signatures that differ between modes:
 |---------------------------------|------------------------------------------------|-------------------------------------------------------------------|
 | `prepare_commit()`              | `write.prepare_commit()`                       | `write.prepare_commit(commit_identifier)`                         |
 | `update_by_arrow_with_row_id()` | `update.update_by_arrow_with_row_id(table)`    | `update.update_by_arrow_with_row_id(table, commit_identifier)`    |
+| `delete_by_filter()`            | `update.delete_by_filter(predicate)`           | `update.delete_by_filter(predicate, commit_identifier)`           |
 | `upsert_by_arrow_with_key()`    | `update.upsert_by_arrow_with_key(table, keys)` | `update.upsert_by_arrow_with_key(table, keys, commit_identifier)` |
 | `commit()`                      | `commit.commit(messages)`                      | `commit.commit(messages, commit_identifier)`                      |
 
@@ -178,6 +179,87 @@ Requires the same [Prerequisites](#prerequisites) (row-tracking and data-evoluti
 pb = table.new_read_builder().new_predicate_builder()
 rb = table.new_read_builder().with_filter(pb.equal('_ROW_ID', 0))
 result = rb.new_read().to_arrow(rb.new_scan().plan().splits())
+```
+
+## Delete By Filter
+
+You can use `delete_by_filter` to delete rows matching a PyPaimon `Predicate` from an append-only data evolution
+table. The delete operation rewrites only the affected file groups: when a row in the middle of a file is deleted,
+the old file group is removed and the remaining rows are written back as continuous row-id segments.
+
+**Requirements**
+
+- The table must have `data-evolution.enabled = true` and `row-tracking.enabled = true`.
+- Only append-only tables are supported; primary-key tables are not supported.
+- The predicate may reference table fields and `_ROW_ID`.
+- If the predicate explicitly references `_ROW_ID`, the requested row IDs must exist in the current snapshot.
+- Tables with dedicated blob or vector files are supported. The normal data file and its `.blob` / `.vector.*`
+  companion files are deleted and rewritten together for the affected row-id range.
+
+### Batch Mode
+
+```python
+import pyarrow as pa
+from pypaimon import CatalogFactory, Schema
+
+catalog = CatalogFactory.create({'warehouse': '/tmp/warehouse'})
+catalog.create_database('default', False)
+
+pa_schema = pa.schema([
+    ('id', pa.int32()),
+    ('name', pa.string()),
+    ('age', pa.int32()),
+])
+schema = Schema.from_pyarrow_schema(
+    pa_schema,
+    options={'row-tracking.enabled': 'true', 'data-evolution.enabled': 'true'},
+)
+catalog.create_table('default.users_delete', schema, False)
+table = catalog.get_table('default.users_delete')
+
+# write initial data
+write_builder = table.new_batch_write_builder()
+write = write_builder.new_write()
+commit = write_builder.new_commit()
+write.write_arrow(pa.Table.from_pydict(
+    {
+        'id': [1, 2, 3, 4],
+        'name': ['Alice', 'Bob', 'Charlie', 'David'],
+        'age': [30, 25, 28, 40],
+    },
+    schema=pa_schema,
+))
+commit.commit(write.prepare_commit())
+write.close()
+commit.close()
+
+# delete rows matching the predicate
+pb = table.new_read_builder().new_predicate_builder()
+predicate = pb.equal('id', 3)
+
+write_builder = table.new_batch_write_builder()
+table_update = write_builder.new_update()
+table_commit = write_builder.new_commit()
+cmts = table_update.delete_by_filter(predicate)
+table_commit.commit(cmts)
+table_commit.close()
+
+# content should contain ids: 1, 2, 4
+```
+
+### Stream Mode
+
+```python
+stream_builder = table.new_stream_write_builder()
+table_update = stream_builder.new_update()
+table_commit = stream_builder.new_commit()
+
+pb = table.new_read_builder().new_predicate_builder()
+predicate = pb.between('_ROW_ID', 10, 20)
+
+cmts = table_update.delete_by_filter(predicate, commit_identifier=1)
+table_commit.commit(cmts, commit_identifier=1)
+table_commit.close()
 ```
 
 ## Upsert By Key

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -54,9 +54,12 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 if manifest_entry.file.first_row_id is not None
                 else float('-inf')
             )
-            is_blob = 1 if DataFileMeta.is_blob_file(manifest_entry.file.file_name) else 0
+            is_special = (
+                1 if DataEvolutionSplitGenerator._is_dedicated_file(
+                    manifest_entry.file.file_name) else 0
+            )
             max_seq = manifest_entry.file.max_sequence_number
-            return first_row_id, is_blob, -max_seq
+            return first_row_id, is_special, -max_seq
 
         sorted_entries = sorted(file_entries, key=sort_key)
 
@@ -242,25 +245,26 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
     def _filter_files_by_row_ranges(partitioned_files: defaultdict, row_ranges: List[Range]) -> defaultdict:
         """
         Filter files by Row ID ranges. Keep files that overlap with the given ranges.
-        Blob files are only included if they overlap with non-blob files that match the ranges.
+        Dedicated blob/vector files are only included if they overlap with
+        non-dedicated files that match the ranges.
         """
         filtered_partitioned_files = defaultdict(list)
 
         for key, file_entries in partitioned_files.items():
-            # Separate blob and non-blob files
-            non_blob_entries = []
-            blob_entries = []
+            # Separate dedicated field files and row-range carrier files.
+            non_dedicated_entries = []
+            dedicated_entries = []
             
             for entry in file_entries:
-                if DataFileMeta.is_blob_file(entry.file.file_name):
-                    blob_entries.append(entry)
+                if DataEvolutionSplitGenerator._is_dedicated_file(
+                        entry.file.file_name):
+                    dedicated_entries.append(entry)
                 else:
-                    non_blob_entries.append(entry)
+                    non_dedicated_entries.append(entry)
             
-            # First, filter non-blob files based on row ranges
-            filtered_non_blob_entries = []
-            non_blob_ranges = []
-            for entry in non_blob_entries:
+            filtered_non_dedicated_entries = []
+            non_dedicated_ranges = []
+            for entry in non_dedicated_entries:
                 file_range = entry.file.row_id_range()
 
                 # Check if file overlaps with any of the row ranges
@@ -271,28 +275,32 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                         break
                 
                 if overlaps:
-                    filtered_non_blob_entries.append(entry)
-                    non_blob_ranges.append(file_range)
+                    filtered_non_dedicated_entries.append(entry)
+                    non_dedicated_ranges.append(file_range)
             
-            # Then, filter blob files based on row ID range of non-blob files
-            filtered_blob_entries = []
-            non_blob_ranges = Range.sort_and_merge_overlap(non_blob_ranges, True, True)
-            # Only keep blob files that overlap with merged non-blob ranges
-            for entry in blob_entries:
-                blob_range = entry.file.row_id_range()
-                # Check if blob file overlaps with any merged range
-                for merged_range in non_blob_ranges:
-                    if merged_range.overlaps(blob_range):
-                        filtered_blob_entries.append(entry)
+            filtered_dedicated_entries = []
+            non_dedicated_ranges = Range.sort_and_merge_overlap(
+                non_dedicated_ranges, True, True)
+            for entry in dedicated_entries:
+                dedicated_range = entry.file.row_id_range()
+                for merged_range in non_dedicated_ranges:
+                    if merged_range.overlaps(dedicated_range):
+                        filtered_dedicated_entries.append(entry)
                         break
             
-            # Combine filtered non-blob and blob files
-            filtered_entries = filtered_non_blob_entries + filtered_blob_entries
+            filtered_entries = (
+                filtered_non_dedicated_entries + filtered_dedicated_entries
+            )
             
             if filtered_entries:
                 filtered_partitioned_files[key] = filtered_entries
 
         return filtered_partitioned_files
+
+    @staticmethod
+    def _is_dedicated_file(file_name: str) -> bool:
+        return (DataFileMeta.is_blob_file(file_name)
+                or DataFileMeta.is_vector_file(file_name))
 
     @staticmethod
     def _split_by_row_id(files: List[DataFileMeta]) -> List[List[DataFileMeta]]:

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -514,6 +514,95 @@ class TestFileStoreCommit(unittest.TestCase):
             [tuple(entry.partition.values) for entry in entries],
         )
 
+    @patch('pypaimon.write.global_index_update_checker.scan_global_index_entries')
+    def test_delete_rewrite_with_global_index_throws(
+            self, mock_scan_global_index_entries,
+            mock_manifest_list_manager, mock_manifest_file_manager):
+        from pypaimon.globalindex.global_index_meta import GlobalIndexMeta
+        from pypaimon.index.index_file_meta import IndexFileMeta
+        from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        from pypaimon.schema.data_types import AtomicType, DataField
+
+        file_store_commit = self._create_file_store_commit()
+        self.mock_table.identifier = 'default.test_table'
+        self.mock_table.partition_keys = ['dt']
+        self.mock_table.partition_keys_fields = [
+            DataField(0, 'dt', AtomicType('STRING'))
+        ]
+        self.mock_table.fields = [
+            DataField(0, 'dt', AtomicType('STRING')),
+            DataField(1, 'payload', AtomicType('STRING')),
+        ]
+        self.mock_table.total_buckets = None
+
+        partition = GenericRow(
+            ['2024-01-15'], self.mock_table.partition_keys_fields)
+        index_entry = IndexManifestEntry(
+            kind=0,
+            partition=partition,
+            bucket=0,
+            index_file=IndexFileMeta(
+                index_type='btree',
+                file_name='global-index-payload.index',
+                file_size=100,
+                row_count=5,
+                global_index_meta=GlobalIndexMeta(
+                    row_range_start=0,
+                    row_range_end=4,
+                    index_field_id=1,
+                ),
+            ),
+        )
+        mock_scan_global_index_entries.return_value = [index_entry]
+        file_store_commit.snapshot_manager.get_latest_snapshot.return_value = Mock()
+        file_store_commit._try_commit = Mock()
+
+        deleted_file = DataFileMeta.create(
+            file_name="old.parquet",
+            file_size=100,
+            row_count=5,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=SimpleStats.empty_stats(),
+            min_sequence_number=1,
+            max_sequence_number=1,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            first_row_id=0,
+        )
+        new_file = DataFileMeta.create(
+            file_name="left.parquet",
+            file_size=40,
+            row_count=2,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=SimpleStats.empty_stats(),
+            min_sequence_number=0,
+            max_sequence_number=0,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            first_row_id=0,
+            write_cols=None,
+        )
+
+        with self.assertRaisesRegex(
+                RuntimeError,
+                "Full-row rewrite or delete is not supported"):
+            file_store_commit.commit([
+                CommitMessage(
+                    partition=('2024-01-15',),
+                    bucket=0,
+                    new_files=[new_file],
+                    deleted_files=[deleted_file],
+                    check_from_snapshot=1,
+                )
+            ], commit_identifier=42)
+
     def test_null_partition_value(
             self, mock_manifest_list_manager, mock_manifest_file_manager):
         from pypaimon.data.timestamp import Timestamp

--- a/paimon-python/pypaimon/tests/file_store_commit_test.py
+++ b/paimon-python/pypaimon/tests/file_store_commit_test.py
@@ -448,6 +448,72 @@ class TestFileStoreCommit(unittest.TestCase):
             snapshot_commit.commit.call_args[0][0].index_manifest
         )
 
+    def test_commit_messages_emit_delete_manifest_entries(
+            self, mock_manifest_list_manager, mock_manifest_file_manager):
+        from pypaimon.manifest.schema.simple_stats import SimpleStats
+        from pypaimon.schema.data_types import AtomicType, DataField
+
+        file_store_commit = self._create_file_store_commit()
+        self.mock_table.identifier = 'default.test_table'
+        self.mock_table.partition_keys = ['dt']
+        self.mock_table.partition_keys_fields = [
+            DataField(0, 'dt', AtomicType('STRING'))
+        ]
+        self.mock_table.total_buckets = None
+        self.mock_table.options.row_tracking_enabled.return_value = False
+
+        deleted_file = DataFileMeta.create(
+            file_name="old.parquet",
+            file_size=100,
+            row_count=5,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=SimpleStats.empty_stats(),
+            min_sequence_number=1,
+            max_sequence_number=1,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            first_row_id=0,
+        )
+        new_file = DataFileMeta.create(
+            file_name="left.parquet",
+            file_size=40,
+            row_count=2,
+            min_key=GenericRow([], []),
+            max_key=GenericRow([], []),
+            key_stats=SimpleStats.empty_stats(),
+            value_stats=SimpleStats.empty_stats(),
+            min_sequence_number=0,
+            max_sequence_number=0,
+            schema_id=0,
+            level=0,
+            extra_files=[],
+            first_row_id=0,
+        )
+
+        captured = {}
+        file_store_commit._try_commit = Mock(
+            side_effect=lambda **kwargs: captured.update(kwargs))
+
+        file_store_commit.commit([
+            CommitMessage(
+                partition=('2024-01-15',),
+                bucket=0,
+                new_files=[new_file],
+                deleted_files=[deleted_file],
+            )
+        ], commit_identifier=42)
+
+        entries = captured['commit_entries_plan'](None)
+        self.assertEqual([1, 0], [entry.kind for entry in entries])
+        self.assertEqual([deleted_file, new_file], [entry.file for entry in entries])
+        self.assertEqual(
+            [('2024-01-15',), ('2024-01-15',)],
+            [tuple(entry.partition.values) for entry in entries],
+        )
+
     def test_null_partition_value(
             self, mock_manifest_list_manager, mock_manifest_file_manager):
         from pypaimon.data.timestamp import Timestamp

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -28,6 +28,7 @@ from pypaimon.tests.data_evolution_test_helpers import (
     DataEvolutionTestBase,
     StreamModeMixin,
 )
+from pypaimon.table.special_fields import SpecialFields
 
 
 # ======================================================================
@@ -570,6 +571,68 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         with self.assertRaises(ValueError) as ctx:
             self._apply_delete(tu, predicate, self._next_commit_id())
         self.assertIn('missing_field', str(ctx.exception))
+
+    def test_delete_by_filter_validates_read_rows_match_predicate(self):
+        from pypaimon.write.table_delete_by_filter import TableDeleteByFilter
+
+        table = self._create_seeded_table()
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        deleter = TableDeleteByFilter(table, 'test_user', self._next_commit_id())
+        original_new_read_builder = table.new_read_builder
+
+        class _FakePlan:
+            def splits(self):
+                return []
+
+        class _FakeScan:
+            def plan(self):
+                return _FakePlan()
+
+        class _FakeRead:
+            def __init__(self, builder):
+                self.builder = builder
+
+            def to_arrow(self, splits):
+                values = {
+                    'id': [3, 4],
+                    SpecialFields.ROW_ID.name: [2, 3],
+                }
+                return pa.Table.from_pydict({
+                    name: values[name] for name in self.builder.projection
+                })
+
+        class _FakeReadBuilder:
+            def __init__(self):
+                self.projection = None
+
+            def with_projection(self, projection):
+                self.projection = projection
+                return self
+
+            def with_filter(self, predicate):
+                return self
+
+            def new_scan(self):
+                return _FakeScan()
+
+            def new_read(self):
+                return _FakeRead(self)
+
+            def read_type(self):
+                return (
+                    original_new_read_builder()
+                    .with_projection(self.projection)
+                    .read_type()
+                )
+
+        try:
+            table.new_read_builder = lambda: _FakeReadBuilder()
+            with self.assertRaises(RuntimeError) as ctx:
+                deleter._matched_row_ids(predicate)
+        finally:
+            table.new_read_builder = original_new_read_builder
+
+        self.assertIn('does not match predicate', str(ctx.exception))
 
     def test_delete_by_filter_after_update_removes_delta_files(self):
         table = self._create_seeded_table()

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -23,6 +23,7 @@ import unittest
 import pyarrow as pa
 
 from pypaimon.common.predicate import Predicate
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.tests.data_evolution_test_helpers import (
     BatchModeMixin,
     DataEvolutionTestBase,
@@ -106,6 +107,21 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         self._apply_commit(tc, msgs, cid)
         tc.close()
         return msgs
+
+    @staticmethod
+    def _fixed_size_float_vectors(values):
+        return pa.FixedSizeListArray.from_arrays(
+            pa.array([item for row in values for item in row], type=pa.float32()),
+            len(values[0]),
+        )
+
+    @staticmethod
+    def _current_files(table):
+        return [
+            file
+            for split in table.new_read_builder().new_scan().plan().splits()
+            for file in split.files
+        ]
 
     # ==================================================================
     # Shared tests (run under both batch and stream modes)
@@ -658,6 +674,221 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         self.assertEqual(
             [(0, 2), (3, 2)],
             sorted((file.first_row_id, file.row_count) for file in files),
+        )
+
+    def test_delete_by_filter_rewrites_blob_files(self):
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('picture', pa.large_binary()),
+        ])
+        table = self._create_table(pa_schema=pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'blob.target-file-size': '1 b',
+        })
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['a', 'b', 'c', 'd', 'e'],
+            'picture': [b'p1', b'p2', b'p3', b'p4', b'p5'],
+        }, schema=pa_schema))
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        msgs = self._do_delete(table, predicate)
+
+        deleted_files = [file for msg in msgs for file in msg.deleted_files]
+        new_files = [file for msg in msgs for file in msg.new_files]
+        blob_deleted_files = [
+            file for file in deleted_files
+            if DataFileMeta.is_blob_file(file.file_name)
+        ]
+        blob_new_files = [
+            file for file in new_files
+            if DataFileMeta.is_blob_file(file.file_name)
+        ]
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in new_files))
+        self.assertGreater(len(blob_deleted_files), len(blob_new_files))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+        self.assertEqual([b'p1', b'p2', b'p4', b'p5'],
+                         result['picture'].to_pylist())
+
+        self.assertEqual(
+            [(0, 2), (0, 2), (3, 2), (3, 2)],
+            sorted(
+                (file.first_row_id, file.row_count)
+                for file in self._current_files(table)
+            ),
+        )
+
+    def test_delete_by_filter_rewrites_vector_files(self):
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('embedding', pa.list_(pa.float32(), 3)),
+        ])
+        table = self._create_table(pa_schema=pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'file.format': 'parquet',
+            'vector.file.format': 'parquet',
+        })
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['a', 'b', 'c', 'd', 'e'],
+            'embedding': self._fixed_size_float_vectors([
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 1.0],
+            ]),
+        }, schema=pa_schema))
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        msgs = self._do_delete(table, predicate)
+
+        deleted_files = [file for msg in msgs for file in msg.deleted_files]
+        new_files = [file for msg in msgs for file in msg.new_files]
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in new_files))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+        self.assertEqual(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+             [1.0, 1.0, 0.0], [0.0, 1.0, 1.0]],
+            result['embedding'].to_pylist(),
+        )
+
+        self.assertEqual(
+            [(0, 2), (0, 2), (3, 2), (3, 2)],
+            sorted(
+                (file.first_row_id, file.row_count)
+                for file in self._current_files(table)
+            ),
+        )
+
+    def test_delete_by_filter_rewrites_blob_and_vector_files(self):
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('doc', pa.large_binary()),
+            ('embedding', pa.list_(pa.float32(), 3)),
+        ])
+        table = self._create_table(pa_schema=pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'file.format': 'parquet',
+            'vector.file.format': 'parquet',
+        })
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'doc': [b'd1', b'd2', b'd3', b'd4', b'd5'],
+            'embedding': self._fixed_size_float_vectors([
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 1.0],
+            ]),
+        }, schema=pa_schema))
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        msgs = self._do_delete(table, predicate)
+
+        deleted_files = [file for msg in msgs for file in msg.deleted_files]
+        new_files = [file for msg in msgs for file in msg.new_files]
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in new_files))
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in new_files))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+        self.assertEqual([b'd1', b'd2', b'd4', b'd5'],
+                         result['doc'].to_pylist())
+        self.assertEqual(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+             [1.0, 1.0, 0.0], [0.0, 1.0, 1.0]],
+            result['embedding'].to_pylist(),
+        )
+
+        self.assertEqual(
+            [(0, 2), (0, 2), (0, 2), (3, 2), (3, 2), (3, 2)],
+            sorted(
+                (file.first_row_id, file.row_count)
+                for file in self._current_files(table)
+            ),
+        )
+
+    def test_delete_by_filter_after_update_rewrites_dedicated_files(self):
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('doc', pa.large_binary()),
+            ('embedding', pa.list_(pa.float32(), 3)),
+        ])
+        table = self._create_table(pa_schema=pa_schema, options={
+            'row-tracking.enabled': 'true',
+            'data-evolution.enabled': 'true',
+            'file.format': 'parquet',
+            'vector.file.format': 'parquet',
+        })
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['a', 'b', 'c', 'd', 'e'],
+            'doc': [b'd1', b'd2', b'd3', b'd4', b'd5'],
+            'embedding': self._fixed_size_float_vectors([
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 1.0],
+            ]),
+        }, schema=pa_schema))
+        self._do_update(
+            table,
+            pa.Table.from_pydict({'_ROW_ID': [1], 'name': ['bb']}),
+            ['name'],
+        )
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        msgs = self._do_delete(table, predicate)
+
+        deleted_files = [file for msg in msgs for file in msg.deleted_files]
+        new_files = [file for msg in msgs for file in msg.new_files]
+        self.assertTrue(any(file.write_cols == ['name']
+                            for file in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in deleted_files))
+        self.assertTrue(any(DataFileMeta.is_blob_file(f.file_name)
+                            for f in new_files))
+        self.assertTrue(any(DataFileMeta.is_vector_file(f.file_name)
+                            for f in new_files))
+        self.assertFalse(any(file.write_cols == ['name']
+                             for file in new_files))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+        self.assertEqual(['a', 'bb', 'd', 'e'], result['name'].to_pylist())
+        self.assertEqual([b'd1', b'd2', b'd4', b'd5'],
+                         result['doc'].to_pylist())
+        self.assertEqual(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+             [1.0, 1.0, 0.0], [0.0, 1.0, 1.0]],
+            result['embedding'].to_pylist(),
         )
 
     # ------------------------------------------------------------------

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -22,6 +22,7 @@ import unittest
 
 import pyarrow as pa
 
+from pypaimon.common.predicate import Predicate
 from pypaimon.tests.data_evolution_test_helpers import (
     BatchModeMixin,
     DataEvolutionTestBase,
@@ -48,6 +49,9 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
     # ------------------------------------------------------------------
 
     def _apply_update(self, table_update, data, cid):
+        raise NotImplementedError
+
+    def _apply_delete(self, table_update, predicate, cid):
         raise NotImplementedError
 
     # ------------------------------------------------------------------
@@ -86,6 +90,17 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         tu = wb.new_update().with_update_type(columns)
         cid = self._next_commit_id()
         msgs = self._apply_update(tu, data, cid)
+        tc = wb.new_commit()
+        self._apply_commit(tc, msgs, cid)
+        tc.close()
+        return msgs
+
+    def _do_delete(self, table, predicate):
+        """End-to-end ``delete_by_filter`` + commit."""
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete(tu, predicate, cid)
         tc = wb.new_commit()
         self._apply_commit(tc, msgs, cid)
         tc.close()
@@ -401,6 +416,187 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         self.assertEqual(0, all_files[0].first_row_id)
         self.assertEqual(N, all_files[0].row_count)
 
+    def test_delete_by_filter_splits_file(self):
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            'age': [25, 30, 35, 40, 45],
+            'city': ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+        }, schema=self.pa_schema))
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete(tu, predicate, cid)
+        tc = wb.new_commit()
+        self._apply_commit(tc, msgs, cid)
+        tc.close()
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+
+        files = [
+            file
+            for split in table.new_read_builder().new_scan().plan().splits()
+            for file in split.files
+        ]
+        ranges = sorted(
+            (file.first_row_id, file.row_count)
+            for file in files
+            if not file.file_name.endswith('.blob')
+        )
+        self.assertEqual([(0, 2), (3, 2)], ranges)
+
+    def test_delete_by_filter_empty_match_returns_no_commit_messages(self):
+        table = self._create_seeded_table()
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 999)
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete(tu, predicate, cid)
+
+        self.assertEqual([], msgs)
+        self.assertEqual([1, 2, 3, 4, 5], self._read_all(table).sort_by('id')['id'].to_pylist())
+
+    def test_delete_by_filter_deletes_whole_file(self):
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'name': ['Alice', 'Bob', 'Charlie'],
+            'age': [25, 30, 35],
+            'city': ['NYC', 'LA', 'Chicago'],
+        }, schema=self.pa_schema))
+
+        predicate = table.new_read_builder().new_predicate_builder().less_or_equal('id', 3)
+        msgs = self._do_delete(table, predicate)
+
+        self.assertEqual(1, len(msgs))
+        self.assertEqual([], msgs[0].new_files)
+        self.assertEqual(1, len(msgs[0].deleted_files))
+        self.assertEqual([], self._read_all(table)['id'].to_pylist())
+
+    def test_delete_by_filter_deleted_row_id_cannot_be_updated(self):
+        table = self._create_seeded_table()
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        self._do_delete(table, predicate)
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update().with_update_type(['age'])
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_update(
+                tu,
+                pa.Table.from_pydict({'_ROW_ID': [2], 'age': [999]}),
+                self._next_commit_id(),
+            )
+        self.assertIn('does not belong to any valid range', str(ctx.exception))
+
+    def test_delete_by_filter_invalid_row_id_raises(self):
+        table = self._create_seeded_table()
+        predicate = Predicate('equal', 0, '_ROW_ID', [999])
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_delete(tu, predicate, self._next_commit_id())
+        self.assertIn('Row ID 999 does not belong', str(ctx.exception))
+
+    def test_delete_by_filter_row_id_between_splits_file(self):
+        table = self._create_table()
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5],
+            'name': ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+            'age': [25, 30, 35, 40, 45],
+            'city': ['NYC', 'LA', 'Chicago', 'Houston', 'Phoenix'],
+        }, schema=self.pa_schema))
+        predicate = Predicate('between', 0, '_ROW_ID', [1, 3])
+
+        self._do_delete(table, predicate)
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 5], result['id'].to_pylist())
+
+        files = [
+            file
+            for split in table.new_read_builder().new_scan().plan().splits()
+            for file in split.files
+        ]
+        self.assertEqual(
+            [(0, 1), (4, 1)],
+            sorted((file.first_row_id, file.row_count) for file in files),
+        )
+
+    def test_delete_by_filter_validates_row_id_inside_or_predicate(self):
+        table = self._create_seeded_table()
+        pb = table.new_read_builder().new_predicate_builder()
+        predicate = Predicate(
+            'or',
+            None,
+            None,
+            [Predicate('equal', 0, '_ROW_ID', [999]), pb.equal('id', 1)],
+        )
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_delete(tu, predicate, self._next_commit_id())
+        self.assertIn('Row ID 999 does not belong', str(ctx.exception))
+
+    def test_delete_by_filter_requires_data_evolution(self):
+        table = self._create_table(options={'row-tracking.enabled': 'true'})
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [1],
+            'name': ['Alice'],
+            'age': [25],
+            'city': ['NYC'],
+        }, schema=self.pa_schema))
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 1)
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_delete(tu, predicate, self._next_commit_id())
+        self.assertIn('data-evolution.enabled', str(ctx.exception))
+
+    def test_delete_by_filter_unknown_predicate_field_raises(self):
+        table = self._create_seeded_table()
+        predicate = Predicate('equal', 0, 'missing_field', [1])
+
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        with self.assertRaises(ValueError) as ctx:
+            self._apply_delete(tu, predicate, self._next_commit_id())
+        self.assertIn('missing_field', str(ctx.exception))
+
+    def test_delete_by_filter_after_update_removes_delta_files(self):
+        table = self._create_seeded_table()
+        self._do_update(
+            table,
+            pa.Table.from_pydict({'_ROW_ID': [2], 'age': [99]}),
+            ['age'],
+        )
+
+        predicate = table.new_read_builder().new_predicate_builder().equal('id', 3)
+        self._do_delete(table, predicate)
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2, 4, 5], result['id'].to_pylist())
+        self.assertEqual([25, 30, 40, 45], result['age'].to_pylist())
+
+        files = [
+            file
+            for split in table.new_read_builder().new_scan().plan().splits()
+            for file in split.files
+        ]
+        self.assertTrue(all(file.write_cols is None for file in files))
+        self.assertEqual(
+            [(0, 2), (3, 2)],
+            sorted((file.first_row_id, file.row_count) for file in files),
+        )
+
     # ------------------------------------------------------------------
     # Validation tests
     # ------------------------------------------------------------------
@@ -659,10 +855,16 @@ class _BatchModeMixin(BatchModeMixin):
     def _apply_update(self, table_update, data, cid):
         return table_update.update_by_arrow_with_row_id(data)
 
+    def _apply_delete(self, table_update, predicate, cid):
+        return table_update.delete_by_filter(predicate)
+
 
 class _StreamModeMixin(StreamModeMixin):
     def _apply_update(self, table_update, data, cid):
         return table_update.update_by_arrow_with_row_id(data, cid)
+
+    def _apply_delete(self, table_update, predicate, cid):
+        return table_update.delete_by_filter(predicate, cid)
 
 
 # ======================================================================

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -157,10 +157,27 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNone(
             detection.check_row_id_existence(base, delta, next_row_id=200))
 
+    def test_no_conflict_when_vector_file_range_is_covered(self):
+        detection = self._make_detection()
+        base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
+        delta = [_make_entry("p1.vector.parquet", kind=0,
+                             first_row_id=20, row_count=10)]
+        self.assertIsNone(
+            detection.check_row_id_existence(base, delta, next_row_id=200))
+
     def test_conflict_when_blob_file_range_is_not_covered(self):
         detection = self._make_detection()
         base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
         delta = [_make_entry("p1.blob", kind=0, first_row_id=95, row_count=10)]
+        result = detection.check_row_id_existence(base, delta, next_row_id=200)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
+    def test_conflict_when_vector_file_range_is_not_covered(self):
+        detection = self._make_detection()
+        base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]
+        delta = [_make_entry("p1.vector.parquet", kind=0,
+                             first_row_id=95, row_count=10)]
         result = detection.check_row_id_existence(base, delta, next_row_id=200)
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
@@ -182,6 +199,19 @@ class TestCheckRowIdExistence(unittest.TestCase):
             _make_entry("p0.blob", kind=0, first_row_id=50, row_count=50),
         ]
         delta = [_make_entry("p1.blob", kind=0, first_row_id=60, row_count=10)]
+        result = detection.check_row_id_existence(base, delta, next_row_id=200)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
+    def test_conflict_when_vector_file_range_is_only_covered_by_base_vector_file(self):
+        detection = self._make_detection()
+        base = [
+            _make_entry("f1", kind=0, first_row_id=0, row_count=50),
+            _make_entry("p0.vector.parquet", kind=0,
+                        first_row_id=50, row_count=50),
+        ]
+        delta = [_make_entry("p1.vector.parquet", kind=0,
+                             first_row_id=60, row_count=10)]
         result = detection.check_row_id_existence(base, delta, next_row_id=200)
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
@@ -281,6 +311,10 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         return [_make_entry("d.blob", first_row_id=0, row_count=51,
                             write_cols=["col_a"])]
 
+    def _vector_delta(self):
+        return [_make_entry("d.vector.parquet", first_row_id=0, row_count=51,
+                            write_cols=["col_a"])]
+
     def test_compact_blob_delete_raises_at_first_match(self):
         check_snap = _FakeSnapshot(1, "APPEND", next_row_id=200)
         compact1 = _FakeSnapshot(2, "COMPACT", next_row_id=200)
@@ -292,6 +326,24 @@ class TestCheckRowIdFromSnapshot(unittest.TestCase):
         detection = self._make_detection(
             [check_snap, compact1, compact2], entries)
         result = detection.check_row_id_from_snapshot(compact2, self._blob_delta())
+        self.assertIsNotNone(result)
+        self.assertIn("snapshot 2", str(result))
+        self.assertIn("COMPACT", str(result))
+
+    def test_compact_vector_delete_raises_at_first_match(self):
+        check_snap = _FakeSnapshot(1, "APPEND", next_row_id=200)
+        compact1 = _FakeSnapshot(2, "COMPACT", next_row_id=200)
+        compact2 = _FakeSnapshot(3, "COMPACT", next_row_id=200)
+        entries = {
+            2: [_make_entry("first.vector.parquet", kind=1,
+                            first_row_id=0, row_count=200)],
+            3: [_make_entry("second.vector.parquet", kind=1,
+                            first_row_id=0, row_count=200)],
+        }
+        detection = self._make_detection(
+            [check_snap, compact1, compact2], entries)
+        result = detection.check_row_id_from_snapshot(
+            compact2, self._vector_delta())
         self.assertIsNotNone(result)
         self.assertIn("snapshot 2", str(result))
         self.assertIn("COMPACT", str(result))

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -127,6 +127,29 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
 
+    def test_no_conflict_when_replacement_ranges_are_deleted_in_same_commit(self):
+        detection = self._make_detection()
+        base = [_make_entry("old", kind=0, first_row_id=0, row_count=5)]
+        delta = [
+            _make_entry("old", kind=1, first_row_id=0, row_count=5),
+            _make_entry("left", kind=0, first_row_id=0, row_count=2),
+            _make_entry("right", kind=0, first_row_id=3, row_count=2),
+        ]
+        self.assertIsNone(
+            detection.check_row_id_existence(base, delta, next_row_id=5))
+
+    def test_conflict_when_delete_entry_does_not_match_base_file_identity(self):
+        detection = self._make_detection()
+        base = [_make_entry("old", kind=0, first_row_id=0, row_count=5)]
+        delta = [
+            _make_entry("other", kind=1, first_row_id=0, row_count=5),
+            _make_entry("left", kind=0, first_row_id=0, row_count=2),
+            _make_entry("right", kind=0, first_row_id=3, row_count=2),
+        ]
+        result = detection.check_row_id_existence(base, delta, next_row_id=5)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
     def test_no_conflict_when_blob_file_range_is_covered(self):
         detection = self._make_detection()
         base = [_make_entry("f1", kind=0, first_row_id=0, row_count=100)]

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -30,6 +30,11 @@ from pypaimon.utils.range_helper import RangeHelper
 from pypaimon.write.commit.commit_scanner import CommitScanner
 
 
+def _is_dedicated_file(file_name):
+    return (DataFileMeta.is_blob_file(file_name)
+            or DataFileMeta.is_vector_file(file_name))
+
+
 class RowIdColumnConflictChecker:
     """Checks for row ID × column conflicts between delta files and committed files.
 
@@ -211,7 +216,7 @@ class ConflictDetection:
         for base in base_entries:
             if base.file.first_row_id is not None:
                 existing_identifiers.add(base.identifier())
-                if not DataFileMeta.is_blob_file(base.file.file_name):
+                if not _is_dedicated_file(base.file.file_name):
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
         for entry in delta_entries:
@@ -237,7 +242,7 @@ class ConflictDetection:
                     and not entry.file.row_id_range().exclude(own_deleted_ranges)
                     and not entry.file.row_id_range().exclude(base_ranges)):
                 continue
-            if DataFileMeta.is_blob_file(entry.file.file_name):
+            if _is_dedicated_file(entry.file.file_name):
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
 
@@ -280,7 +285,7 @@ class ConflictDetection:
         for group in merged_groups:
             data_files = [
                 entry for entry in group
-                if not DataFileMeta.is_blob_file(entry.file.file_name)
+                if not _is_dedicated_file(entry.file.file_name)
             ]
             if not range_helper.are_all_ranges_same(data_files):
                 file_descriptions = [
@@ -319,13 +324,14 @@ class ConflictDetection:
         check_next_row_id = check_snapshot.next_row_id
 
         # Pair each delta with its anchor file type so a parquet-only
-        # compact does not flag a blob delta whose .blob anchor is intact.
+        # compact does not flag a blob/vector delta whose dedicated anchor
+        # is intact.
         delta_signatures = []
         for f in delta_files:
             r = f.row_id_range()
             if r is not None:
                 delta_signatures.append(
-                    (DataFileMeta.is_blob_file(f.file_name), r.from_, r.to))
+                    (self._file_kind(f.file_name), r.from_, r.to))
 
         for snapshot_id in range(
                 self._row_id_check_from_snapshot + 1,
@@ -364,8 +370,8 @@ class ConflictDetection:
         staged delta; otherwise None.
 
         File-type match guards against `write_cols=None` ambiguity (an
-        initial full-row parquet does not actually contain blob columns);
-        column_checker guards against unrelated column-write shards
+        initial full-row parquet does not actually contain blob/vector
+        columns); column_checker guards against unrelated column-write shards
         (compacting an f1-only parquet must not block an f2 update on
         the same row range).
         """
@@ -379,16 +385,16 @@ class ConflictDetection:
             file_range = entry.file.row_id_range()
             if file_range is None:
                 continue
-            deleted_is_blob = DataFileMeta.is_blob_file(entry.file.file_name)
-            for delta_is_blob, from_, to in delta_signatures:
-                if delta_is_blob != deleted_is_blob:
+            deleted_kind = self._file_kind(entry.file.file_name)
+            for delta_kind, from_, to in delta_signatures:
+                if delta_kind != deleted_kind:
                     continue
                 if file_range.from_ > to or from_ > file_range.to:
                     continue
                 if not column_checker.conflicts_with(entry.file):
                     continue
                 return RuntimeError(
-                    "Blob/row-id update conflicts with concurrent COMPACT "
+                    "Dedicated/row-id update conflicts with concurrent COMPACT "
                     "(snapshot {sid}): anchor file {name} [{ff}, {ft}] "
                     "was compacted away, overlaps staged delta "
                     "[{df}, {dt}].".format(
@@ -399,3 +405,11 @@ class ConflictDetection:
                         df=from_,
                         dt=to))
         return None
+
+    @staticmethod
+    def _file_kind(file_name):
+        if DataFileMeta.is_blob_file(file_name):
+            return "blob"
+        if DataFileMeta.is_vector_file(file_name):
+            return "vector"
+        return "data"

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -241,8 +241,6 @@ class ConflictDetection:
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
 
-            key = (entry.partition, entry.bucket,
-                   entry.file.first_row_id, entry.file.row_count)
             if not any(
                     base.partition == entry.partition
                     and base.bucket == entry.bucket

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -205,31 +205,50 @@ class ConflictDetection:
         if not files_to_check:
             return None
 
-        existing_index = set()
+        existing_identifiers = set()
         existing_ranges = {}
+        deleted_ranges = {}
         for base in base_entries:
             if base.file.first_row_id is not None:
-                existing_index.add((
-                    base.partition, base.bucket,
-                    base.file.first_row_id, base.file.row_count))
+                existing_identifiers.add(base.identifier())
                 if not DataFileMeta.is_blob_file(base.file.file_name):
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
+        for entry in delta_entries:
+            if (entry.kind == 1
+                    and entry.file.first_row_id is not None
+                    and entry.identifier() in existing_identifiers):
+                deleted_ranges.setdefault((entry.partition, entry.bucket), []).append(
+                    entry.file.row_id_range())
 
         existing_ranges = {
             key: Range.sort_and_merge_overlap(ranges, True, True)
             for key, ranges in existing_ranges.items()
         }
+        deleted_ranges = {
+            key: Range.sort_and_merge_overlap(ranges, True, True)
+            for key, ranges in deleted_ranges.items()
+        }
 
         for entry in files_to_check:
+            base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
+            own_deleted_ranges = deleted_ranges.get((entry.partition, entry.bucket), [])
+            if (own_deleted_ranges
+                    and not entry.file.row_id_range().exclude(own_deleted_ranges)
+                    and not entry.file.row_id_range().exclude(base_ranges)):
+                continue
             if DataFileMeta.is_blob_file(entry.file.file_name):
-                base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
                 if not entry.file.row_id_range().exclude(base_ranges):
                     continue
 
             key = (entry.partition, entry.bucket,
                    entry.file.first_row_id, entry.file.row_count)
-            if key not in existing_index:
+            if not any(
+                    base.partition == entry.partition
+                    and base.bucket == entry.bucket
+                    and base.file.first_row_id == entry.file.first_row_id
+                    and base.file.row_count == entry.file.row_count
+                    for base in base_entries):
                 return RuntimeError(
                     "Row ID existence conflict: file '{}' references "
                     "firstRowId={}, rowCount={} in bucket {}, "

--- a/paimon-python/pypaimon/write/commit_message.py
+++ b/paimon-python/pypaimon/write/commit_message.py
@@ -30,8 +30,14 @@ class CommitMessage:
     bucket: int
     new_files: List[DataFileMeta]
     check_from_snapshot: Optional[int] = -1
+    deleted_files: List[DataFileMeta] = field(default_factory=list)
     index_deletes: List['IndexManifestEntry'] = field(default_factory=list)
     changelog_files: List[DataFileMeta] = field(default_factory=list)
 
     def is_empty(self):
-        return not self.new_files and not self.index_deletes and not self.changelog_files
+        return (
+            not self.new_files
+            and not self.deleted_files
+            and not self.index_deletes
+            and not self.changelog_files
+        )

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -165,18 +165,28 @@ class FileStoreCommit:
         if not index_deletes:
             from pypaimon.write.global_index_update_checker import (
                 apply_global_index_update_action,
+                validate_no_global_index_for_full_row_rewrite,
             )
             updated_cols = set()
             written_partitions = set()
+            full_row_rewrite_partitions = set()
             for msg in commit_messages:
                 if msg.check_from_snapshot == -1:
                     continue
+                if msg.deleted_files:
+                    full_row_rewrite_partitions.add(msg.partition)
                 for f in msg.new_files:
-                    if f.write_cols:
+                    if f.write_cols is None:
+                        full_row_rewrite_partitions.add(msg.partition)
+                    elif f.write_cols:
                         updated_cols.update(f.write_cols)
                         written_partitions.add(msg.partition)
-            if updated_cols:
+            if updated_cols or full_row_rewrite_partitions:
                 snapshot = self.snapshot_manager.get_latest_snapshot()
+                validate_no_global_index_for_full_row_rewrite(
+                    self.table, snapshot, full_row_rewrite_partitions,
+                )
+            if updated_cols:
                 index_msgs = apply_global_index_update_action(
                     self.table, snapshot, list(updated_cols), written_partitions,
                 )

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -137,6 +137,14 @@ class FileStoreCommit:
         commit_entries = []
         for msg in commit_messages:
             partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
+            for file in msg.deleted_files:
+                commit_entries.append(ManifestEntry(
+                    kind=1,
+                    partition=partition,
+                    bucket=msg.bucket,
+                    total_buckets=self.table.total_buckets,
+                    file=file
+                ))
             for file in msg.new_files:
                 commit_entries.append(ManifestEntry(
                     kind=0,

--- a/paimon-python/pypaimon/write/file_store_write.py
+++ b/paimon-python/pypaimon/write/file_store_write.py
@@ -21,10 +21,12 @@ from typing import Dict, List, Tuple
 
 import pyarrow as pa
 
+from pypaimon.common.memory_size import MemorySize
+from pypaimon.common.options.core_options import CoreOptions
+
 
 logger = logging.getLogger(__name__)
 
-from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.writer.append_only_data_writer import AppendOnlyDataWriter
 from pypaimon.write.writer.dedicated_format_writer import DedicatedFormatWriter
@@ -55,8 +57,10 @@ class FileStoreWrite:
 
     def disable_rolling(self):
         """Disable file rolling by setting target_file_size to max."""
-        self.options.set(
-            CoreOptions.TARGET_FILE_SIZE, str(2 ** 63 - 1))
+        max_size = MemorySize.MAX_VALUE
+        self.options.set(CoreOptions.TARGET_FILE_SIZE, max_size)
+        self.options.set(CoreOptions.BLOB_TARGET_FILE_SIZE, max_size)
+        self.options.set(CoreOptions.VECTOR_TARGET_FILE_SIZE, max_size)
 
     def write(self, partition: Tuple, bucket: int, data: pa.RecordBatch):
         key = (partition, bucket)

--- a/paimon-python/pypaimon/write/global_index_update_checker.py
+++ b/paimon-python/pypaimon/write/global_index_update_checker.py
@@ -47,6 +47,38 @@ def build_index_delete_msgs(entries) -> list:
     ]
 
 
+def validate_no_global_index_for_full_row_rewrite(
+    table,
+    snapshot,
+    rewritten_partitions: Set[Tuple],
+) -> None:
+    if snapshot is None or not rewritten_partitions:
+        return
+    entries = scan_global_index_entries(table, snapshot)
+    if not entries:
+        return
+    affected = [
+        e for e in entries
+        if tuple(e.partition.values) in rewritten_partitions
+    ]
+    if not affected:
+        return
+    field_by_id = {f.id: f.name for f in table.fields}
+    conflicted = sorted({
+        field_by_id.get(
+            e.index_file.global_index_meta.index_field_id,
+            str(e.index_file.global_index_meta.index_field_id),
+        )
+        for e in affected
+    })
+    raise RuntimeError(
+        "Full-row rewrite or delete is not supported when global indexes "
+        "exist in affected partitions.\n"
+        f"Affected partitions: {sorted(rewritten_partitions)}\n"
+        f"Conflicted columns: {conflicted}"
+    )
+
+
 def apply_global_index_update_action(
     table,
     snapshot,

--- a/paimon-python/pypaimon/write/table_delete_by_filter.py
+++ b/paimon-python/pypaimon/write/table_delete_by_filter.py
@@ -22,8 +22,10 @@ import pyarrow as pa
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.read.push_down_utils import rewrite_predicate_indices
 from pypaimon.read.split import DataSplit
 from pypaimon.table.special_fields import SpecialFields
+from pypaimon.table.row.offset_row import OffsetRow
 from pypaimon.utils.range import Range
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.file_store_write import FileStoreWrite
@@ -140,8 +142,23 @@ class TableDeleteByFilter:
             read_builder.new_scan().plan().splits())
         if table is None or table.num_rows == 0:
             return []
+        self._validate_matched_rows(predicate, table, read_builder.read_type())
         row_ids = table[SpecialFields.ROW_ID.name].to_pylist()
         return sorted(set(row_ids))
+
+    @staticmethod
+    def _validate_matched_rows(
+            predicate: Predicate, table: pa.Table, read_type
+    ) -> None:
+        predicate_for_rows = rewrite_predicate_indices(predicate, read_type)
+        for row in table.to_pylist():
+            row_tuple = tuple(row[field.name] for field in read_type)
+            offset_row = OffsetRow(row_tuple, 0, len(row_tuple))
+            if not predicate_for_rows.test(offset_row):
+                row_id = row.get(SpecialFields.ROW_ID.name)
+                raise RuntimeError(
+                    f"Read row with _ROW_ID {row_id} does not match predicate."
+                )
 
     def _predicate_fields(self, predicate: Predicate) -> Set[str]:
         if predicate.field is not None:

--- a/paimon-python/pypaimon/write/table_delete_by_filter.py
+++ b/paimon-python/pypaimon/write/table_delete_by_filter.py
@@ -1,0 +1,274 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+import pyarrow as pa
+
+from pypaimon.common.predicate import Predicate
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.read.split import DataSplit
+from pypaimon.table.special_fields import SpecialFields
+from pypaimon.utils.range import Range
+from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.file_store_write import FileStoreWrite
+from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
+
+
+class TableDeleteByFilter:
+    """Delete rows from a data-evolution table by rewriting affected files."""
+
+    def __init__(self, table, commit_user: str, commit_identifier: int):
+        from pypaimon.table.file_store_table import FileStoreTable
+
+        self.table: FileStoreTable = table
+        self.commit_user = commit_user
+        self.commit_identifier = commit_identifier
+        self._row_id_update = TableUpdateByRowId(
+            table, commit_user, commit_identifier)
+        self.snapshot_id = self._row_id_update.snapshot_id
+        self._first_row_id_index = self._row_id_update._first_row_id_index
+        self.valid_row_id_ranges = self._row_id_update.valid_row_id_ranges
+
+    def delete_by_filter(self, predicate: Predicate) -> List[CommitMessage]:
+        if predicate is None:
+            raise ValueError("predicate cannot be None")
+        if not self.table.options.row_tracking_enabled():
+            raise ValueError(
+                "delete_by_filter requires 'row-tracking.enabled=true'.")
+        if not self.table.options.data_evolution_enabled():
+            raise ValueError(
+                "delete_by_filter requires 'data-evolution.enabled=true'.")
+        if self.table.is_primary_key_table:
+            raise NotImplementedError(
+                "delete_by_filter is only supported for append-only "
+                "data-evolution tables.")
+        if self._has_dedicated_files():
+            raise NotImplementedError(
+                "delete_by_filter is not yet supported for tables with "
+                "dedicated blob or vector files.")
+
+        self._validate_row_id_predicate(predicate)
+        row_ids = self._matched_row_ids(predicate)
+        if not row_ids:
+            return []
+        self._validate_row_ids_exist(row_ids)
+        return self._rewrite_affected_files(row_ids)
+
+    def _validate_row_id_predicate(self, predicate: Predicate) -> None:
+        requested = self._explicit_row_id_ranges(predicate)
+        if requested:
+            self._validate_row_id_ranges_exist(requested)
+
+    def _explicit_row_id_ranges(self, predicate: Predicate) -> List[Range]:
+        requested = []
+        if predicate.method in ('and', 'or'):
+            for child in predicate.literals or []:
+                requested.extend(self._explicit_row_id_ranges(child))
+            return requested
+
+        ranges = self._row_id_ranges_from_leaf(predicate)
+        return ranges if ranges is not None else []
+
+    def _row_id_ranges_from_leaf(self, predicate: Predicate):
+        if predicate.field != SpecialFields.ROW_ID.name:
+            return None
+        if predicate.method == 'equal':
+            if not predicate.literals:
+                return []
+            value = int(predicate.literals[0])
+            return [Range(value, value)]
+        if predicate.method == 'in':
+            if not predicate.literals:
+                return []
+            return Range.to_ranges([int(v) for v in predicate.literals])
+        if predicate.method == 'between':
+            if not predicate.literals or len(predicate.literals) < 2:
+                return []
+            return [Range(int(predicate.literals[0]), int(predicate.literals[1]))]
+        return None
+
+    def _validate_row_id_ranges_exist(self, row_id_ranges: List[Range]) -> None:
+        for row_id_range in row_id_ranges:
+            uncovered = row_id_range.exclude(self.valid_row_id_ranges)
+            if uncovered:
+                if row_id_range.from_ == row_id_range.to:
+                    raise ValueError(
+                        f"Row ID {row_id_range.from_} does not belong to "
+                        f"any valid range "
+                        f"{[f'[{r.from_}, {r.to}]' for r in self.valid_row_id_ranges]}"
+                    )
+                raise ValueError(
+                    f"Row ID range [{row_id_range.from_}, {row_id_range.to}] "
+                    f"does not belong to valid ranges "
+                    f"{[f'[{r.from_}, {r.to}]' for r in self.valid_row_id_ranges]}"
+                )
+
+    def _matched_row_ids(self, predicate: Predicate) -> List[int]:
+        projection = list(self._predicate_fields(predicate))
+        unknown_fields = [
+            field for field in projection
+            if field not in self.table.field_names
+            and field != SpecialFields.ROW_ID.name
+        ]
+        if unknown_fields:
+            raise ValueError(
+                f"Predicate references unknown fields: {unknown_fields}")
+        if SpecialFields.ROW_ID.name not in projection:
+            projection.append(SpecialFields.ROW_ID.name)
+        read_builder = (
+            self.table.new_read_builder()
+            .with_projection(projection)
+            .with_filter(predicate)
+        )
+        table = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        if table is None or table.num_rows == 0:
+            return []
+        row_ids = table[SpecialFields.ROW_ID.name].to_pylist()
+        return sorted(set(row_ids))
+
+    def _predicate_fields(self, predicate: Predicate) -> Set[str]:
+        if predicate.field is not None:
+            return {predicate.field}
+        fields = set()
+        for child in predicate.literals or []:
+            fields.update(self._predicate_fields(child))
+        return fields
+
+    def _validate_row_ids_exist(self, row_ids: List[int]) -> None:
+        if len(row_ids) != len(set(row_ids)):
+            raise ValueError("Input data contains duplicate _ROW_ID values")
+        for row_id in row_ids:
+            if not any(r.contains(row_id) for r in self.valid_row_id_ranges):
+                raise ValueError(
+                    f"Row ID {row_id} does not belong to any valid range "
+                    f"{[f'[{r.from_}, {r.to}]' for r in self.valid_row_id_ranges]}"
+                )
+
+    def _rewrite_affected_files(self, row_ids: List[int]) -> List[CommitMessage]:
+        row_ids_by_first: Dict[int, Set[int]] = defaultdict(set)
+        for row_id in row_ids:
+            first_row_id = self._first_row_id_for(row_id)
+            row_ids_by_first[first_row_id].add(row_id)
+
+        commit_messages: List[CommitMessage] = []
+        for first_row_id, delete_row_ids in row_ids_by_first.items():
+            split, files = self._first_row_id_index[first_row_id]
+            data_files = [
+                file for file in files
+                if not DataFileMeta.is_blob_file(file.file_name)
+                and not DataFileMeta.is_vector_file(file.file_name)
+            ]
+            if not data_files:
+                raise ValueError(
+                    f"No data files found for first_row_id {first_row_id}.")
+
+            old_range = self._merged_data_range(data_files)
+            if not all(old_range.contains(row_id) for row_id in delete_row_ids):
+                raise ValueError(
+                    f"Row IDs {sorted(delete_row_ids)} do not belong to "
+                    f"file range [{old_range.from_}, {old_range.to}].")
+
+            original_data = self._read_file_data(split, data_files)
+            new_files = self._write_remaining_segments(
+                split, old_range, original_data, delete_row_ids)
+            commit_messages.append(CommitMessage(
+                partition=tuple(split.partition.values),
+                bucket=split.bucket,
+                new_files=new_files,
+                check_from_snapshot=self.snapshot_id,
+                deleted_files=data_files,
+            ))
+
+        return commit_messages
+
+    def _first_row_id_for(self, row_id: int) -> int:
+        for first_row_id, (split, files) in self._first_row_id_index.items():
+            for file in files:
+                if DataFileMeta.is_blob_file(file.file_name):
+                    continue
+                file_range = file.row_id_range()
+                if file_range is not None and file_range.contains(row_id):
+                    return first_row_id
+        raise ValueError(f"Row ID {row_id} does not belong to any valid file")
+
+    @staticmethod
+    def _merged_data_range(files: List[DataFileMeta]) -> Range:
+        ranges = Range.sort_and_merge_overlap(
+            [file.row_id_range() for file in files], True, True)
+        if len(ranges) != 1:
+            raise NotImplementedError(
+                "delete_by_filter requires affected data files to cover one "
+                f"continuous logical range, got {ranges}.")
+        return ranges[0]
+
+    def _read_file_data(self, split: DataSplit, files: List[DataFileMeta]) -> pa.Table:
+        origin_split = DataSplit(
+            files=files,
+            partition=split.partition,
+            bucket=split.bucket,
+            raw_convertible=len(files) == 1,
+        )
+        return self.table.new_read_builder().new_read().to_arrow([origin_split])
+
+    def _write_remaining_segments(
+            self,
+            split: DataSplit,
+            old_range: Range,
+            original_data: pa.Table,
+            delete_row_ids: Set[int],
+    ) -> List[DataFileMeta]:
+        remaining_ranges = old_range.exclude(Range.to_ranges(list(delete_row_ids)))
+        if not remaining_ranges:
+            return []
+
+        new_files: List[DataFileMeta] = []
+        for remaining in remaining_ranges:
+            offset = remaining.from_ - old_range.from_
+            segment = original_data.slice(offset, remaining.count())
+            new_files.extend(self._write_segment(split, segment, remaining.from_))
+        return new_files
+
+    def _write_segment(
+            self, split: DataSplit, segment: pa.Table, first_row_id: int
+    ) -> List[DataFileMeta]:
+        file_store_write = FileStoreWrite(self.table, self.commit_user)
+        file_store_write.disable_rolling()
+        partition_tuple = tuple(split.partition.values)
+        try:
+            for batch in segment.to_batches():
+                file_store_write.write(partition_tuple, split.bucket, batch)
+            messages = file_store_write.prepare_commit(self.commit_identifier)
+            new_files = [file for msg in messages for file in msg.new_files]
+            for file in new_files:
+                file.first_row_id = first_row_id
+            return new_files
+        finally:
+            file_store_write.close()
+
+    def _has_dedicated_files(self) -> bool:
+        for field in self.table.fields:
+            if getattr(field.type, 'type', None) == 'BLOB':
+                return True
+        for split, files in self._first_row_id_index.values():
+            for file in files:
+                if (DataFileMeta.is_blob_file(file.file_name)
+                        or DataFileMeta.is_vector_file(file.file_name)):
+                    return True
+        return False

--- a/paimon-python/pypaimon/write/table_delete_by_filter.py
+++ b/paimon-python/pypaimon/write/table_delete_by_filter.py
@@ -22,7 +22,10 @@ import pyarrow as pa
 
 from pypaimon.common.predicate import Predicate
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
-from pypaimon.read.push_down_utils import rewrite_predicate_indices
+from pypaimon.read.push_down_utils import (
+    _get_all_fields,
+    rewrite_predicate_indices,
+)
 from pypaimon.read.split import DataSplit
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.table.row.offset_row import OffsetRow
@@ -122,7 +125,7 @@ class TableDeleteByFilter:
                 )
 
     def _matched_row_ids(self, predicate: Predicate) -> List[int]:
-        projection = list(self._predicate_fields(predicate))
+        projection = list(_get_all_fields(predicate))
         unknown_fields = [
             field for field in projection
             if field not in self.table.field_names
@@ -159,14 +162,6 @@ class TableDeleteByFilter:
                 raise RuntimeError(
                     f"Read row with _ROW_ID {row_id} does not match predicate."
                 )
-
-    def _predicate_fields(self, predicate: Predicate) -> Set[str]:
-        if predicate.field is not None:
-            return {predicate.field}
-        fields = set()
-        for child in predicate.literals or []:
-            fields.update(self._predicate_fields(child))
-        return fields
 
     def _validate_row_ids_exist(self, row_ids: List[int]) -> None:
         if len(row_ids) != len(set(row_ids)):

--- a/paimon-python/pypaimon/write/table_delete_by_filter.py
+++ b/paimon-python/pypaimon/write/table_delete_by_filter.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set
 
 import pyarrow as pa
 

--- a/paimon-python/pypaimon/write/table_delete_by_filter.py
+++ b/paimon-python/pypaimon/write/table_delete_by_filter.py
@@ -63,11 +63,6 @@ class TableDeleteByFilter:
             raise NotImplementedError(
                 "delete_by_filter is only supported for append-only "
                 "data-evolution tables.")
-        if self._has_dedicated_files():
-            raise NotImplementedError(
-                "delete_by_filter is not yet supported for tables with "
-                "dedicated blob or vector files.")
-
         self._validate_row_id_predicate(predicate)
         row_ids = self._matched_row_ids(predicate)
         if not row_ids:
@@ -184,8 +179,7 @@ class TableDeleteByFilter:
             split, files = self._first_row_id_index[first_row_id]
             data_files = [
                 file for file in files
-                if not DataFileMeta.is_blob_file(file.file_name)
-                and not DataFileMeta.is_vector_file(file.file_name)
+                if not self._is_dedicated_file(file)
             ]
             if not data_files:
                 raise ValueError(
@@ -197,7 +191,7 @@ class TableDeleteByFilter:
                     f"Row IDs {sorted(delete_row_ids)} do not belong to "
                     f"file range [{old_range.from_}, {old_range.to}].")
 
-            original_data = self._read_file_data(split, data_files)
+            original_data = self._read_file_data(split, files)
             new_files = self._write_remaining_segments(
                 split, old_range, original_data, delete_row_ids)
             commit_messages.append(CommitMessage(
@@ -205,7 +199,7 @@ class TableDeleteByFilter:
                 bucket=split.bucket,
                 new_files=new_files,
                 check_from_snapshot=self.snapshot_id,
-                deleted_files=data_files,
+                deleted_files=files,
             ))
 
         return commit_messages
@@ -213,7 +207,7 @@ class TableDeleteByFilter:
     def _first_row_id_for(self, row_id: int) -> int:
         for first_row_id, (split, files) in self._first_row_id_index.items():
             for file in files:
-                if DataFileMeta.is_blob_file(file.file_name):
+                if self._is_dedicated_file(file):
                     continue
                 file_range = file.row_id_range()
                 if file_range is not None and file_range.contains(row_id):
@@ -274,13 +268,7 @@ class TableDeleteByFilter:
         finally:
             file_store_write.close()
 
-    def _has_dedicated_files(self) -> bool:
-        for field in self.table.fields:
-            if getattr(field.type, 'type', None) == 'BLOB':
-                return True
-        for split, files in self._first_row_id_index.values():
-            for file in files:
-                if (DataFileMeta.is_blob_file(file.file_name)
-                        or DataFileMeta.is_vector_file(file.file_name)):
-                    return True
-        return False
+    @staticmethod
+    def _is_dedicated_file(file: DataFileMeta) -> bool:
+        return (DataFileMeta.is_blob_file(file.file_name)
+                or DataFileMeta.is_vector_file(file.file_name))

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple
 import pyarrow
 import pyarrow as pa
 
+from pypaimon.common.predicate import Predicate
 from pypaimon.common.memory_size import MemorySize
 from pypaimon.globalindex import Range
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
@@ -173,6 +174,15 @@ class TableUpdate:
             self.table, self.commit_user, commit_identifier
         ).upsert(table, upsert_keys, self.update_cols)
 
+    def _delete_by_filter(
+            self, predicate: Predicate, commit_identifier: int
+    ) -> List[CommitMessage]:
+        from pypaimon.write.table_delete_by_filter import TableDeleteByFilter
+
+        return TableDeleteByFilter(
+            self.table, self.commit_user, commit_identifier
+        ).delete_by_filter(predicate)
+
 
 class BatchTableUpdate(TableUpdate):
     """Batch-mode table update; commit messages always use
@@ -189,6 +199,10 @@ class BatchTableUpdate(TableUpdate):
         return self._upsert_by_arrow_with_key(
             table, upsert_keys, BATCH_COMMIT_IDENTIFIER
         )
+
+    def delete_by_filter(self, predicate: Predicate) -> List[CommitMessage]:
+        """Delete rows matching ``predicate`` from a data-evolution table."""
+        return self._delete_by_filter(predicate, BATCH_COMMIT_IDENTIFIER)
 
 
 class StreamTableUpdate(TableUpdate):
@@ -213,6 +227,12 @@ class StreamTableUpdate(TableUpdate):
         return self._upsert_by_arrow_with_key(
             table, upsert_keys, commit_identifier
         )
+
+    def delete_by_filter(
+            self, predicate: Predicate, commit_identifier: int
+    ) -> List[CommitMessage]:
+        """Delete rows matching ``predicate`` from a data-evolution table."""
+        return self._delete_by_filter(predicate, commit_identifier)
 
 
 class ShardTableUpdator:

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -113,10 +113,10 @@ class TableUpdateByRowId:
             ]
             data_files = [
                 file for file in files_with_row_id
-                if not DataFileMeta.is_blob_file(file.file_name)
+                if not self._is_dedicated_file(file)
             ]
             for file in split.files:
-                if file.first_row_id is None or DataFileMeta.is_blob_file(file.file_name):
+                if file.first_row_id is None or self._is_dedicated_file(file):
                     continue
                 row_id_ranges.append(file.row_id_range())
             for file in data_files:
@@ -154,6 +154,11 @@ class TableUpdateByRowId:
     @staticmethod
     def _overlaps(left: Range, right: Range) -> bool:
         return left.from_ <= right.to and right.from_ <= left.to
+
+    @staticmethod
+    def _is_dedicated_file(file: DataFileMeta) -> bool:
+        return (DataFileMeta.is_blob_file(file.file_name)
+                or DataFileMeta.is_vector_file(file.file_name))
 
     def update_columns(self, data: pa.Table, column_names: List[str]) -> List[CommitMessage]:
         """

--- a/paimon-python/pypaimon/write/writer/blob_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_writer.py
@@ -42,8 +42,7 @@ class BlobWriter(AppendOnlyDataWriter):
         # Store blob column name for use in metadata creation
         self.blob_column = blob_column
 
-        options = self.table.options
-        self.blob_target_file_size = CoreOptions.blob_target_file_size(options)
+        self.blob_target_file_size = CoreOptions.blob_target_file_size(self.options)
 
         self._blob_consumer = blob_consumer
         self.current_writer: Optional[BlobFileWriter] = None


### PR DESCRIPTION
## Summary

Add Python `delete_by_filter` support for append-only Data Evolution tables. The API deletes rows matching a `Predicate` by rewriting affected files into remaining RowID-contiguous segments, preserving valid Data Evolution row-id ranges.

## Changes

- Add batch and stream `TableUpdate.delete_by_filter` APIs.
- Implement predicate-based deletion for row-tracking Data Evolution tables, including explicit `_ROW_ID` validation and file splitting around deleted rows.
- Extend commit messages and file-store commits to emit manifest delete entries for rewritten files.
- Update row-id conflict detection so a commit may add replacement subranges only when it also deletes the matching base file.
- Add coverage for split deletes, whole-file deletes, no-op deletes, invalid RowIDs, post-update cleanup, manifest delete entries, and replacement-range conflict checks.

## Testing

- `python -m unittest pypaimon.tests.table_update_test`
- `python -m unittest pypaimon.tests.file_store_commit_test pypaimon.tests.write.conflict_detection_test pypaimon.tests.table_commit_test`
- `python -m compileall -q pypaimon/write pypaimon/tests/table_update_test.py pypaimon/tests/file_store_commit_test.py pypaimon/tests/write/conflict_detection_test.py`
- `git diff --check`

## Notes

This support is intentionally limited to append-only Data Evolution tables with row tracking enabled. Primary-key tables and tables with dedicated blob/vector files are rejected for now.
