### PR TITLE
[lumina] Support per-field vector index options

### DIFF
--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexerFactory.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorGlobalIndexerFactory.java
@@ -35,6 +35,7 @@ public class LuminaVectorGlobalIndexerFactory implements GlobalIndexerFactory {
 
     @Override
     public GlobalIndexer create(DataField field, Options options) {
-        return new LuminaVectorGlobalIndexer(field.type(), options);
+        Options fieldOptions = LuminaVectorIndexOptions.resolveFieldOptions(field.name(), options);
+        return new LuminaVectorGlobalIndexer(field.type(), fieldOptions);
     }
 }

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
@@ -18,14 +18,17 @@
 
 package org.apache.paimon.lumina.index;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Options for the Lumina vector index. */
 public class LuminaVectorIndexOptions {
@@ -125,6 +128,53 @@ public class LuminaVectorIndexOptions {
     }
 
     /**
+     * Resolves per-field Lumina options for {@code fieldName} into an effective {@link Options}.
+     *
+     * <p>Following the convention shared with {@code paimon-vector-index} (PR #8239), a field-level
+     * option is written {@code fields.<fieldName>.<option>} — <b>without</b> the {@code lumina.}
+     * index-type prefix — and overrides the column-agnostic {@code lumina.<option>} for that field
+     * only. For example {@code fields.embed.distance.metric} overrides {@code
+     * lumina.distance.metric} for column {@code embed}. The {@code <option>} suffix is exactly the
+     * key used after {@code lumina.} at the table level.
+     *
+     * <p>Only recognized Lumina options (the keys in {@code FIELD_OVERRIDABLE_KEYS}) are accepted;
+     * any other {@code fields.<fieldName>.*} key (e.g. a merge/aggregation option) is left
+     * untouched, mirroring how {@code paimon-vector-index} ignores keys it does not recognize.
+     *
+     * <p>Each recognized field option is flattened back to its plain {@code lumina.*} form, so the
+     * rest of this class still sees only {@code lumina.*} keys and the metadata produced from these
+     * options keeps the exact same native-key shape as before (no {@code fields.*} keys ever reach
+     * the meta) — only the resolved value changes. This is what lets the reader consume the meta
+     * unchanged.
+     *
+     * <p>The same resolution runs on both the write and read paths, since both build the indexer
+     * through {@link LuminaVectorGlobalIndexerFactory#create}.
+     */
+    public static Options resolveFieldOptions(String fieldName, Options options) {
+        String fieldPrefix = CoreOptions.FIELDS_PREFIX + "." + fieldName + ".";
+        Map<String, String> result = new LinkedHashMap<>();
+        // Base: table-level options, including the column-agnostic lumina.* options. Drop all
+        // fields.* keys; this field's recognized options are re-added below as lumina.* keys.
+        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+            if (!entry.getKey().startsWith(CoreOptions.FIELDS_PREFIX + ".")) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        // Overlay this field's options. fields.<field>.<option> (no lumina. prefix) overrides the
+        // column-agnostic lumina.<option>. Only recognized Lumina options are taken.
+        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+            String key = entry.getKey();
+            if (key.startsWith(fieldPrefix)) {
+                String option = key.substring(fieldPrefix.length());
+                if (FIELD_OVERRIDABLE_KEYS.contains(option)) {
+                    result.put(LUMINA_PREFIX + option, entry.getValue());
+                }
+            }
+        }
+        return Options.fromMap(result);
+    }
+
+    /**
      * Returns all {@code lumina.*} options with the prefix stripped, producing native Lumina keys.
      * For example, {@code lumina.diskann.build.ef_construction} becomes {@code
      * diskann.build.ef_construction}.
@@ -185,6 +235,22 @@ public class LuminaVectorIndexOptions {
                     DISKANN_SEARCH_BEAM_WIDTH,
                     ENCODING_PQ_M,
                     SEARCH_PARALLEL_NUMBER);
+
+    /**
+     * Native Lumina keys (the {@code lumina.} prefix stripped) that may be overridden per field via
+     * {@code fields.<fieldName>.<key>}. Any {@code fields.<fieldName>.*} key outside this set is
+     * ignored, so unrelated per-field options do not leak into the Lumina index metadata.
+     */
+    private static final Set<String> FIELD_OVERRIDABLE_KEYS = buildFieldOverridableKeys();
+
+    private static Set<String> buildFieldOverridableKeys() {
+        Set<String> keys = new HashSet<>();
+        for (ConfigOption<?> opt : ALL_OPTIONS) {
+            keys.add(toLuminaKey(opt));
+        }
+        keys.add(toLuminaKey(DISKANN_SEARCH_LIST_SIZE));
+        return keys;
+    }
 
     /**
      * Builds native Lumina options by first populating all known ConfigOptions (with defaults) and

--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
@@ -152,17 +152,18 @@ public class LuminaVectorIndexOptions {
      */
     public static Options resolveFieldOptions(String fieldName, Options options) {
         String fieldPrefix = CoreOptions.FIELDS_PREFIX + "." + fieldName + ".";
+        Map<String, String> tableOptions = options.toMap();
         Map<String, String> result = new LinkedHashMap<>();
         // Base: table-level options, including the column-agnostic lumina.* options. Drop all
         // fields.* keys; this field's recognized options are re-added below as lumina.* keys.
-        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
             if (!entry.getKey().startsWith(CoreOptions.FIELDS_PREFIX + ".")) {
                 result.put(entry.getKey(), entry.getValue());
             }
         }
         // Overlay this field's options. fields.<field>.<option> (no lumina. prefix) overrides the
         // column-agnostic lumina.<option>. Only recognized Lumina options are taken.
-        for (Map.Entry<String, String> entry : options.toMap().entrySet()) {
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
             String key = entry.getKey();
             if (key.startsWith(fieldPrefix)) {
                 String option = key.substring(fieldPrefix.length());

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorOptionsTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorOptionsTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.lumina.index;
 
+import org.apache.paimon.options.Options;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -48,5 +50,78 @@ public class LuminaVectorOptionsTest {
                 .containsEntry("search.parallel_number", "2")
                 .containsEntry("index.dimension", "4")
                 .containsEntry("hnsw.ef_search", "128");
+    }
+
+    @Test
+    public void testFieldOptionsOverrideGlobal() {
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("lumina.distance.metric", "l2");
+        tableOptions.put("lumina.index.dimension", "128");
+        // Field-level keys follow the #8239 convention: fields.<field>.<option>, no lumina. prefix.
+        tableOptions.put("fields.embed.distance.metric", "inner_product");
+        tableOptions.put("fields.embed.index.dimension", "256");
+
+        Map<String, String> meta = metaFor("embed", tableOptions);
+
+        // The per-field value wins over the global one.
+        assertThat(meta)
+                .containsEntry("distance.metric", "inner_product")
+                .containsEntry("index.dimension", "256");
+        // The meta keeps the native key shape; no fields.* keys ever leak into it.
+        assertThat(meta.keySet()).noneMatch(k -> k.startsWith("fields"));
+    }
+
+    @Test
+    public void testForeignFieldOptionsAreIgnored() {
+        Map<String, String> globalOnly = new HashMap<>();
+        globalOnly.put("lumina.distance.metric", "l2");
+        globalOnly.put("lumina.index.dimension", "128");
+
+        Map<String, String> withForeign = new HashMap<>(globalOnly);
+        // A per-field option that is not a recognized Lumina key (e.g. a merge/agg option) must be
+        // ignored, never flattened into the index meta as a bogus native key.
+        withForeign.put("fields.embed.aggregate-function", "sum");
+
+        Map<String, String> meta = metaFor("embed", withForeign);
+        assertThat(meta).isEqualTo(metaFor("embed", globalOnly));
+        assertThat(meta).doesNotContainKey("aggregate-function");
+    }
+
+    @Test
+    public void testFieldOptionsForOtherFieldDoNotAffectMeta() {
+        Map<String, String> globalOnly = new HashMap<>();
+        globalOnly.put("lumina.distance.metric", "l2");
+        globalOnly.put("lumina.index.dimension", "128");
+
+        Map<String, String> withOtherField = new HashMap<>(globalOnly);
+        // Per-field config for a different column must not influence "embed".
+        withOtherField.put("fields.other.distance.metric", "inner_product");
+        withOtherField.put("fields.other.index.dimension", "256");
+
+        // The meta for "embed" is byte-for-byte the same as before per-field support existed.
+        assertThat(metaFor("embed", withOtherField)).isEqualTo(metaFor("embed", globalOnly));
+    }
+
+    @Test
+    public void testResolvedFieldMetaIsReadable() {
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("lumina.distance.metric", "l2");
+        tableOptions.put("lumina.index.dimension", "128");
+        tableOptions.put("fields.embed.distance.metric", "inner_product");
+        tableOptions.put("fields.embed.index.dimension", "256");
+
+        // The reader reconstructs everything it needs from the serialized meta.
+        LuminaIndexMeta meta = new LuminaIndexMeta(metaFor("embed", tableOptions));
+        assertThat(meta.dim()).isEqualTo(256);
+        assertThat(meta.distanceMetric()).isEqualTo("inner_product");
+        assertThat(meta.metric()).isEqualTo(LuminaVectorMetric.INNER_PRODUCT);
+    }
+
+    /** Builds the native lumina meta map (what gets serialized into the index file) for a field. */
+    private static Map<String, String> metaFor(String fieldName, Map<String, String> tableOptions) {
+        Options resolved =
+                LuminaVectorIndexOptions.resolveFieldOptions(
+                        fieldName, Options.fromMap(tableOptions));
+        return new LuminaVectorIndexOptions(resolved).toLuminaOptions();
     }
 }


### PR DESCRIPTION
### Purpose

`paimon-lumina` only allowed Lumina vector index options to be configured globally via `lumina.*` table options. A table with multiple vector columns could therefore not configure each column independently (e.g. a different `distance.metric` or `index.dimension`).

This PR adds per-field configuration, **following the same convention as #8239** (`paimon-vector-index`):

- Column-agnostic: `lumina.<option>` (unchanged — `lumina` is the index-type identifier).
- Per-field: `fields.<fieldName>.<option>`, **without** the index-type prefix. It overrides `lumina.<option>` for that column only.

```
'lumina.distance.metric' = 'l2', -- shared by every lumina column
'fields.embed.distance.metric' = 'inner_product', -- override for column `embed`
'fields.embed.index.dimension' = '256'
```


### Tests

`LuminaVectorOptionsTest`:
- `testFieldOptionsOverrideGlobal` — `fields.embed.distance.metric` / `fields.embed.index.dimension` override the global values; the meta contains only native lumina keys (no `fields.*`).
- `testForeignFieldOptionsAreIgnored` — a non-Lumina per-field key (e.g. `fields.embed.aggregate-function`) is ignored and never leaks into the meta.
- `testFieldOptionsForOtherFieldDoNotAffectMeta` — per-field config for a different column leaves this column's meta byte-for-byte identical to the global-only case.
- `testResolvedFieldMetaIsReadable` — `LuminaIndexMeta` rebuilt from the resolved meta exposes the per-field `dim`/`metric` to the reader.

### API and Format

No change to the index file format or the serialized metadata shape. Adds the per-field table-option pattern `fields.<fieldName>.<option>`, consistent with #8239; existing global `lumina.*` options keep working as the default for all vector columns.
