### PR TITLE
[core] Wait for global index in visibility callback

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -1678,13 +1678,13 @@ If the data size allocated for the sorting task is uneven,which may lead to perf
             <td><h5>visibility-callback.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to enable the visibility wait callback that waits for compaction to complete after commit. This is useful for primary key tables with deletion vectors or postpone bucket mode to ensure data visibility, only used for batch mode or bounded stream.</td>
+            <td>Whether to enable the visibility wait callback that waits for compaction or global index build to complete after commit. This is useful for primary key tables with deletion vectors or postpone bucket mode and row-tracking tables with global indexes to ensure data visibility, only used for batch mode or bounded stream.</td>
         </tr>
         <tr>
             <td><h5>visibility-callback.timeout</h5></td>
             <td style="word-wrap: break-word;">30 min</td>
             <td>Duration</td>
-            <td>The maximum time to wait for compaction to complete when visibility callback is enabled. If the timeout is reached, an exception will be thrown.</td>
+            <td>The maximum time to wait for compaction or global index build to complete when visibility callback is enabled. If the timeout is reached, an exception will be thrown.</td>
         </tr>
         <tr>
             <td><h5>write-buffer-for-append</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2554,17 +2554,19 @@ public class CoreOptions implements Serializable {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "Whether to enable the visibility wait callback that waits for compaction to complete "
-                                    + "after commit. This is useful for primary key tables with deletion vectors or "
-                                    + "postpone bucket mode to ensure data visibility, only used for batch mode or bounded stream.");
+                            "Whether to enable the visibility wait callback that waits for compaction or global "
+                                    + "index build to complete after commit. This is useful for primary key tables "
+                                    + "with deletion vectors or postpone bucket mode and row-tracking tables with "
+                                    + "global indexes to ensure data visibility, only used for batch mode or bounded stream.");
 
     public static final ConfigOption<Duration> VISIBILITY_CALLBACK_TIMEOUT =
             key("visibility-callback.timeout")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(30))
                     .withDescription(
-                            "The maximum time to wait for compaction to complete when visibility callback is enabled. "
-                                    + "If the timeout is reached, an exception will be thrown.");
+                            "The maximum time to wait for compaction or global index build to complete when "
+                                    + "visibility callback is enabled. If the timeout is reached, an exception will "
+                                    + "be thrown.");
 
     public static final ConfigOption<Duration> VISIBILITY_CALLBACK_CHECK_INTERVAL =
             key("visibility-callback.check-interval")

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -434,15 +434,24 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
             callbacks.add(new ChainTableOverwriteCommitCallback(table));
         }
 
-        if (options.visibilityCallbackEnabled() && !schema.primaryKeys().isEmpty()) {
-            if (table.bucketMode() == BucketMode.POSTPONE_MODE
-                    || options.deletionVectorsEnabled()) {
-                callbacks.add(new VisibilityWaitCallback(table));
-            }
+        if (options.visibilityCallbackEnabled() && shouldWaitForVisibility(table)) {
+            callbacks.add(new VisibilityWaitCallback(table));
         }
 
         callbacks.addAll(CallbackUtils.loadCommitCallbacks(options, table));
         return callbacks;
+    }
+
+    private boolean shouldWaitForVisibility(FileStoreTable table) {
+        if (options.rowTrackingEnabled()) {
+            return true;
+        }
+
+        if (schema.primaryKeys().isEmpty()) {
+            return false;
+        }
+
+        return table.bucketMode() == BucketMode.POSTPONE_MODE || options.deletionVectorsEnabled();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.metastore;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileKind;
@@ -44,57 +45,73 @@ import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 class GlobalIndexVisibilityChecker {
 
     private final FileStoreTable table;
-    private final List<Range> rowIdRangesToTrack;
-    private final Set<GlobalIndexIdentifier> globalIndexesToTrack;
+    private final Map<BinaryRow, List<Range>> rowIdRangesByPartition;
+    private final Map<BinaryRow, Set<GlobalIndexIdentifier>> globalIndexesByPartition;
 
     private GlobalIndexVisibilityChecker(
             FileStoreTable table,
-            List<Range> rowIdRangesToTrack,
-            Set<GlobalIndexIdentifier> globalIndexesToTrack) {
+            Map<BinaryRow, List<Range>> rowIdRangesByPartition,
+            Map<BinaryRow, Set<GlobalIndexIdentifier>> globalIndexesByPartition) {
         this.table = table;
-        this.rowIdRangesToTrack = rowIdRangesToTrack;
-        this.globalIndexesToTrack = globalIndexesToTrack;
+        this.rowIdRangesByPartition = rowIdRangesByPartition;
+        this.globalIndexesByPartition = globalIndexesByPartition;
     }
 
     static GlobalIndexVisibilityChecker create(
             FileStoreTable table, Snapshot snapshot, List<ManifestEntry> deltaFiles) {
-        List<Range> rowIdRangesToTrack = collectRowIdRangesToTrack(deltaFiles);
-        Set<GlobalIndexIdentifier> globalIndexesToTrack =
-                rowIdRangesToTrack.isEmpty()
-                        ? new HashSet<>()
-                        : collectGlobalIndexesToTrack(table, snapshot);
-        return new GlobalIndexVisibilityChecker(table, rowIdRangesToTrack, globalIndexesToTrack);
+        Map<BinaryRow, List<Range>> rowIdRangesByPartition =
+                collectRowIdRangesByPartition(deltaFiles);
+        Map<BinaryRow, Set<GlobalIndexIdentifier>> globalIndexesByPartition =
+                rowIdRangesByPartition.isEmpty()
+                        ? new HashMap<>()
+                        : collectGlobalIndexesByPartition(
+                                table, snapshot, rowIdRangesByPartition.keySet());
+        return new GlobalIndexVisibilityChecker(
+                table, rowIdRangesByPartition, globalIndexesByPartition);
     }
 
     boolean noNeedToWait() {
-        return rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty();
+        return globalIndexesByPartition.isEmpty();
     }
 
     boolean visibleIn(Snapshot snapshot) {
-        Map<GlobalIndexIdentifier, List<Range>> indexedRanges = new HashMap<>();
+        Map<BinaryRow, Map<GlobalIndexIdentifier, List<Range>>> indexedRangesByPartition =
+                new HashMap<>();
         for (IndexManifestEntry entry : scanGlobalIndexes(table, snapshot)) {
             GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
             if (globalIndex == null) {
                 continue;
             }
 
-            GlobalIndexIdentifier identifier =
-                    new GlobalIndexIdentifier(
-                            entry.indexFile().indexType(),
-                            globalIndex.indexFieldId(),
-                            globalIndex.extraFieldIds());
-            if (globalIndexesToTrack.contains(identifier)) {
-                indexedRanges
+            Set<GlobalIndexIdentifier> identifiers =
+                    globalIndexesByPartition.get(entry.partition());
+            if (identifiers == null) {
+                continue;
+            }
+
+            GlobalIndexIdentifier identifier = identifierOf(entry);
+            if (identifiers.contains(identifier)) {
+                indexedRangesByPartition
+                        .computeIfAbsent(entry.partition().copy(), k -> new HashMap<>())
                         .computeIfAbsent(identifier, k -> new ArrayList<>())
                         .add(globalIndex.rowRange());
             }
         }
 
-        for (GlobalIndexIdentifier identifier : globalIndexesToTrack) {
-            List<Range> ranges = Range.sortAndMergeOverlap(indexedRanges.get(identifier), true);
-            for (Range rowIdRange : rowIdRangesToTrack) {
-                if (!rowIdRange.exclude(ranges).isEmpty()) {
-                    return false;
+        for (Map.Entry<BinaryRow, Set<GlobalIndexIdentifier>> partitionIndexes :
+                globalIndexesByPartition.entrySet()) {
+            BinaryRow partition = partitionIndexes.getKey();
+            List<Range> rowIdRanges = rowIdRangesByPartition.get(partition);
+            Map<GlobalIndexIdentifier, List<Range>> indexedRanges =
+                    indexedRangesByPartition.get(partition);
+            for (GlobalIndexIdentifier identifier : partitionIndexes.getValue()) {
+                List<Range> ranges =
+                        Range.sortAndMergeOverlap(
+                                indexedRanges == null ? null : indexedRanges.get(identifier), true);
+                for (Range rowIdRange : rowIdRanges) {
+                    if (!rowIdRange.exclude(ranges).isEmpty()) {
+                        return false;
+                    }
                 }
             }
         }
@@ -102,14 +119,20 @@ class GlobalIndexVisibilityChecker {
         return true;
     }
 
-    private static List<Range> collectRowIdRangesToTrack(List<ManifestEntry> deltaFiles) {
-        List<Range> ranges = new ArrayList<>();
+    private static Map<BinaryRow, List<Range>> collectRowIdRangesByPartition(
+            List<ManifestEntry> deltaFiles) {
+        Map<BinaryRow, List<Range>> rangesByPartition = new HashMap<>();
         for (ManifestEntry entry : deltaFiles) {
             if (shouldTrackGlobalIndex(entry)) {
-                ranges.add(entry.file().nonNullRowIdRange());
+                rangesByPartition
+                        .computeIfAbsent(entry.partition().copy(), k -> new ArrayList<>())
+                        .add(entry.file().nonNullRowIdRange());
             }
         }
-        return Range.sortAndMergeOverlap(ranges, true);
+        for (Map.Entry<BinaryRow, List<Range>> entry : rangesByPartition.entrySet()) {
+            entry.setValue(Range.sortAndMergeOverlap(entry.getValue(), true));
+        }
+        return rangesByPartition;
     }
 
     private static boolean shouldTrackGlobalIndex(ManifestEntry entry) {
@@ -130,20 +153,18 @@ class GlobalIndexVisibilityChecker {
         return !isBlobFile(file.fileName());
     }
 
-    private static Set<GlobalIndexIdentifier> collectGlobalIndexesToTrack(
-            FileStoreTable table, Snapshot snapshot) {
-        Set<GlobalIndexIdentifier> indexes = new HashSet<>();
+    private static Map<BinaryRow, Set<GlobalIndexIdentifier>> collectGlobalIndexesByPartition(
+            FileStoreTable table, Snapshot snapshot, Set<BinaryRow> partitionsToTrack) {
+        Map<BinaryRow, Set<GlobalIndexIdentifier>> indexesByPartition = new HashMap<>();
         for (IndexManifestEntry entry : scanGlobalIndexes(table, snapshot)) {
             GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
-            if (globalIndex != null) {
-                indexes.add(
-                        new GlobalIndexIdentifier(
-                                entry.indexFile().indexType(),
-                                globalIndex.indexFieldId(),
-                                globalIndex.extraFieldIds()));
+            if (globalIndex != null && partitionsToTrack.contains(entry.partition())) {
+                indexesByPartition
+                        .computeIfAbsent(entry.partition().copy(), k -> new HashSet<>())
+                        .add(identifierOf(entry));
             }
         }
-        return indexes;
+        return indexesByPartition;
     }
 
     private static List<IndexManifestEntry> scanGlobalIndexes(
@@ -151,6 +172,14 @@ class GlobalIndexVisibilityChecker {
         return table.store()
                 .newIndexFileHandler()
                 .scan(snapshot, entry -> entry.indexFile().globalIndexMeta() != null);
+    }
+
+    private static GlobalIndexIdentifier identifierOf(IndexManifestEntry entry) {
+        GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+        return new GlobalIndexIdentifier(
+                entry.indexFile().indexType(),
+                globalIndex.indexFieldId(),
+                globalIndex.extraFieldIds());
     }
 
     private static class GlobalIndexIdentifier {

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
-import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 
 /** Checks whether newly added data files are covered by existing global indexes. */
 class GlobalIndexVisibilityChecker {
@@ -128,8 +127,7 @@ class GlobalIndexVisibilityChecker {
             return false;
         }
 
-        String fileName = file.fileName();
-        return !isBlobFile(fileName) && !isVectorStoreFile(fileName);
+        return !isBlobFile(file.fileName());
     }
 
     private static Set<GlobalIndexIdentifier> collectGlobalIndexesToTrack(

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/GlobalIndexVisibilityChecker.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.utils.Range;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+
+/** Checks whether newly added data files are covered by existing global indexes. */
+class GlobalIndexVisibilityChecker {
+
+    private final FileStoreTable table;
+    private final List<Range> rowIdRangesToTrack;
+    private final Set<GlobalIndexIdentifier> globalIndexesToTrack;
+
+    private GlobalIndexVisibilityChecker(
+            FileStoreTable table,
+            List<Range> rowIdRangesToTrack,
+            Set<GlobalIndexIdentifier> globalIndexesToTrack) {
+        this.table = table;
+        this.rowIdRangesToTrack = rowIdRangesToTrack;
+        this.globalIndexesToTrack = globalIndexesToTrack;
+    }
+
+    static GlobalIndexVisibilityChecker create(
+            FileStoreTable table, Snapshot snapshot, List<ManifestEntry> deltaFiles) {
+        List<Range> rowIdRangesToTrack = collectRowIdRangesToTrack(deltaFiles);
+        Set<GlobalIndexIdentifier> globalIndexesToTrack =
+                rowIdRangesToTrack.isEmpty()
+                        ? new HashSet<>()
+                        : collectGlobalIndexesToTrack(table, snapshot);
+        return new GlobalIndexVisibilityChecker(table, rowIdRangesToTrack, globalIndexesToTrack);
+    }
+
+    boolean noNeedToWait() {
+        return rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty();
+    }
+
+    boolean visibleIn(Snapshot snapshot) {
+        Map<GlobalIndexIdentifier, List<Range>> indexedRanges = new HashMap<>();
+        for (IndexManifestEntry entry : scanGlobalIndexes(table, snapshot)) {
+            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+            if (globalIndex == null) {
+                continue;
+            }
+
+            GlobalIndexIdentifier identifier =
+                    new GlobalIndexIdentifier(
+                            entry.indexFile().indexType(),
+                            globalIndex.indexFieldId(),
+                            globalIndex.extraFieldIds());
+            if (globalIndexesToTrack.contains(identifier)) {
+                indexedRanges
+                        .computeIfAbsent(identifier, k -> new ArrayList<>())
+                        .add(globalIndex.rowRange());
+            }
+        }
+
+        for (GlobalIndexIdentifier identifier : globalIndexesToTrack) {
+            List<Range> ranges = Range.sortAndMergeOverlap(indexedRanges.get(identifier), true);
+            for (Range rowIdRange : rowIdRangesToTrack) {
+                if (!rowIdRange.exclude(ranges).isEmpty()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static List<Range> collectRowIdRangesToTrack(List<ManifestEntry> deltaFiles) {
+        List<Range> ranges = new ArrayList<>();
+        for (ManifestEntry entry : deltaFiles) {
+            if (shouldTrackGlobalIndex(entry)) {
+                ranges.add(entry.file().nonNullRowIdRange());
+            }
+        }
+        return Range.sortAndMergeOverlap(ranges, true);
+    }
+
+    private static boolean shouldTrackGlobalIndex(ManifestEntry entry) {
+        if (!FileKind.ADD.equals(entry.kind())) {
+            return false;
+        }
+
+        DataFileMeta file = entry.file();
+        if (file.firstRowId() == null || file.rowCount() <= 0) {
+            return false;
+        }
+
+        Optional<FileSource> fileSource = file.fileSource();
+        if (!fileSource.isPresent() || !FileSource.APPEND.equals(fileSource.get())) {
+            return false;
+        }
+
+        String fileName = file.fileName();
+        return !isBlobFile(fileName) && !isVectorStoreFile(fileName);
+    }
+
+    private static Set<GlobalIndexIdentifier> collectGlobalIndexesToTrack(
+            FileStoreTable table, Snapshot snapshot) {
+        Set<GlobalIndexIdentifier> indexes = new HashSet<>();
+        for (IndexManifestEntry entry : scanGlobalIndexes(table, snapshot)) {
+            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+            if (globalIndex != null) {
+                indexes.add(
+                        new GlobalIndexIdentifier(
+                                entry.indexFile().indexType(),
+                                globalIndex.indexFieldId(),
+                                globalIndex.extraFieldIds()));
+            }
+        }
+        return indexes;
+    }
+
+    private static List<IndexManifestEntry> scanGlobalIndexes(
+            FileStoreTable table, Snapshot snapshot) {
+        return table.store()
+                .newIndexFileHandler()
+                .scan(snapshot, entry -> entry.indexFile().globalIndexMeta() != null);
+    }
+
+    private static class GlobalIndexIdentifier {
+
+        private final String indexType;
+        private final int indexFieldId;
+        private final int[] extraFieldIds;
+
+        private GlobalIndexIdentifier(String indexType, int indexFieldId, int[] extraFieldIds) {
+            this.indexType = indexType;
+            this.indexFieldId = indexFieldId;
+            this.extraFieldIds =
+                    extraFieldIds == null
+                            ? null
+                            : Arrays.copyOf(extraFieldIds, extraFieldIds.length);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GlobalIndexIdentifier)) {
+                return false;
+            }
+
+            GlobalIndexIdentifier that = (GlobalIndexIdentifier) o;
+            return indexFieldId == that.indexFieldId
+                    && Objects.equals(indexType, that.indexType)
+                    && Arrays.equals(extraFieldIds, that.extraFieldIds);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(indexType, indexFieldId);
+            result = 31 * result + Arrays.hashCode(extraFieldIds);
+            return result;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/VisibilityWaitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/VisibilityWaitCallback.java
@@ -21,38 +21,24 @@ package org.apache.paimon.metastore;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.index.GlobalIndexMeta;
-import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileKind;
-import org.apache.paimon.manifest.FileSource;
-import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitCallback;
-import org.apache.paimon.utils.Range;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
-import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** A {@link CommitCallback} to wait for compaction and global indexes for visibility. */
@@ -82,11 +68,8 @@ public class VisibilityWaitCallback implements CommitCallback {
 
         Set<String> namesToTrack = new HashSet<>();
         Set<BinaryRow> partitionsToTrack = new HashSet<>();
-        List<Range> rowIdRangesToTrack = collectRowIdRangesToTrack(context.deltaFiles);
-        Set<GlobalIndexIdentifier> globalIndexesToTrack =
-                rowIdRangesToTrack.isEmpty()
-                        ? Collections.emptySet()
-                        : collectGlobalIndexesToTrack(context.snapshot);
+        GlobalIndexVisibilityChecker globalIndexVisibilityChecker =
+                GlobalIndexVisibilityChecker.create(table, context.snapshot, context.deltaFiles);
         for (ManifestEntry entry : context.deltaFiles) {
             if (shouldBeTracked(entry)) {
                 namesToTrack.add(entry.fileName());
@@ -94,8 +77,7 @@ public class VisibilityWaitCallback implements CommitCallback {
             }
         }
 
-        if (namesToTrack.isEmpty()
-                && (rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty())) {
+        if (namesToTrack.isEmpty() && globalIndexVisibilityChecker.noNeedToWait()) {
             return;
         }
 
@@ -104,8 +86,7 @@ public class VisibilityWaitCallback implements CommitCallback {
                     context.snapshot,
                     namesToTrack,
                     partitionsToTrack,
-                    rowIdRangesToTrack,
-                    globalIndexesToTrack);
+                    globalIndexVisibilityChecker);
         } catch (InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
@@ -120,12 +101,11 @@ public class VisibilityWaitCallback implements CommitCallback {
             Snapshot fromSnapshot,
             Set<String> namesToTrack,
             Set<BinaryRow> partitionsToTrack,
-            List<Range> rowIdRangesToTrack,
-            Set<GlobalIndexIdentifier> globalIndexesToTrack)
+            GlobalIndexVisibilityChecker globalIndexVisibilityChecker)
             throws InterruptedException, TimeoutException {
         long startTime = System.currentTimeMillis();
         boolean compactionDone = namesToTrack.isEmpty();
-        boolean globalIndexDone = rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty();
+        boolean globalIndexDone = globalIndexVisibilityChecker.noNeedToWait();
         Snapshot checkedSnapshot = fromSnapshot;
         while (System.currentTimeMillis() - startTime < timeout.toMillis()) {
             Snapshot latest = table.snapshotManager().latestSnapshot();
@@ -136,8 +116,7 @@ public class VisibilityWaitCallback implements CommitCallback {
                     && !stillInLatest(latest, namesToTrack, partitionsToTrack)) {
                 compactionDone = true;
             }
-            if (!globalIndexDone
-                    && globalIndexesBuilt(latest, rowIdRangesToTrack, globalIndexesToTrack)) {
+            if (!globalIndexDone && globalIndexVisibilityChecker.visibleIn(latest)) {
                 globalIndexDone = true;
             }
             if (compactionDone && globalIndexDone) {
@@ -188,133 +167,8 @@ public class VisibilityWaitCallback implements CommitCallback {
         return entry.bucket() == BucketMode.POSTPONE_BUCKET;
     }
 
-    private List<Range> collectRowIdRangesToTrack(List<ManifestEntry> deltaFiles) {
-        List<Range> ranges = new ArrayList<>();
-        for (ManifestEntry entry : deltaFiles) {
-            if (shouldTrackGlobalIndex(entry)) {
-                ranges.add(entry.file().nonNullRowIdRange());
-            }
-        }
-        return Range.sortAndMergeOverlap(ranges, true);
-    }
-
-    private boolean shouldTrackGlobalIndex(ManifestEntry entry) {
-        if (!FileKind.ADD.equals(entry.kind())) {
-            return false;
-        }
-
-        DataFileMeta file = entry.file();
-        if (file.firstRowId() == null || file.rowCount() <= 0) {
-            return false;
-        }
-
-        Optional<FileSource> fileSource = file.fileSource();
-        if (!fileSource.isPresent() || !FileSource.APPEND.equals(fileSource.get())) {
-            return false;
-        }
-
-        String fileName = file.fileName();
-        return !isBlobFile(fileName) && !isVectorStoreFile(fileName);
-    }
-
-    private Set<GlobalIndexIdentifier> collectGlobalIndexesToTrack(Snapshot snapshot) {
-        Set<GlobalIndexIdentifier> indexes = new HashSet<>();
-        for (IndexManifestEntry entry : scanGlobalIndexes(snapshot)) {
-            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
-            if (globalIndex != null) {
-                indexes.add(
-                        new GlobalIndexIdentifier(
-                                entry.indexFile().indexType(),
-                                globalIndex.indexFieldId(),
-                                globalIndex.extraFieldIds()));
-            }
-        }
-        return indexes;
-    }
-
-    private boolean globalIndexesBuilt(
-            Snapshot snapshot,
-            List<Range> rowIdRangesToTrack,
-            Set<GlobalIndexIdentifier> globalIndexesToTrack) {
-        Map<GlobalIndexIdentifier, List<Range>> indexedRanges = new HashMap<>();
-        for (IndexManifestEntry entry : scanGlobalIndexes(snapshot)) {
-            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
-            if (globalIndex == null) {
-                continue;
-            }
-
-            GlobalIndexIdentifier identifier =
-                    new GlobalIndexIdentifier(
-                            entry.indexFile().indexType(),
-                            globalIndex.indexFieldId(),
-                            globalIndex.extraFieldIds());
-            if (globalIndexesToTrack.contains(identifier)) {
-                indexedRanges
-                        .computeIfAbsent(identifier, k -> new ArrayList<>())
-                        .add(globalIndex.rowRange());
-            }
-        }
-
-        for (GlobalIndexIdentifier identifier : globalIndexesToTrack) {
-            List<Range> ranges = Range.sortAndMergeOverlap(indexedRanges.get(identifier), true);
-            for (Range rowIdRange : rowIdRangesToTrack) {
-                if (!rowIdRange.exclude(ranges).isEmpty()) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private List<IndexManifestEntry> scanGlobalIndexes(Snapshot snapshot) {
-        return table.store().newIndexFileHandler().scan(snapshot, this::isGlobalIndex);
-    }
-
-    private boolean isGlobalIndex(IndexManifestEntry entry) {
-        return entry.indexFile().globalIndexMeta() != null;
-    }
-
     @Override
     public void close() throws Exception {
         // No resources to close
-    }
-
-    private static class GlobalIndexIdentifier {
-
-        private final String indexType;
-        private final int indexFieldId;
-        private final int[] extraFieldIds;
-
-        private GlobalIndexIdentifier(String indexType, int indexFieldId, int[] extraFieldIds) {
-            this.indexType = indexType;
-            this.indexFieldId = indexFieldId;
-            this.extraFieldIds =
-                    extraFieldIds == null
-                            ? null
-                            : Arrays.copyOf(extraFieldIds, extraFieldIds.length);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof GlobalIndexIdentifier)) {
-                return false;
-            }
-
-            GlobalIndexIdentifier that = (GlobalIndexIdentifier) o;
-            return indexFieldId == that.indexFieldId
-                    && Objects.equals(indexType, that.indexType)
-                    && Arrays.equals(extraFieldIds, that.extraFieldIds);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hash(indexType, indexFieldId);
-            result = 31 * result + Arrays.hashCode(extraFieldIds);
-            return result;
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/metastore/VisibilityWaitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/metastore/VisibilityWaitCallback.java
@@ -21,27 +21,41 @@ package org.apache.paimon.metastore;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitCallback;
+import org.apache.paimon.utils.Range;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
-/** A {@link CommitCallback} to wait for compaction for visibility. */
+/** A {@link CommitCallback} to wait for compaction and global indexes for visibility. */
 public class VisibilityWaitCallback implements CommitCallback {
 
     private static final Logger LOG = LoggerFactory.getLogger(VisibilityWaitCallback.class);
@@ -68,6 +82,11 @@ public class VisibilityWaitCallback implements CommitCallback {
 
         Set<String> namesToTrack = new HashSet<>();
         Set<BinaryRow> partitionsToTrack = new HashSet<>();
+        List<Range> rowIdRangesToTrack = collectRowIdRangesToTrack(context.deltaFiles);
+        Set<GlobalIndexIdentifier> globalIndexesToTrack =
+                rowIdRangesToTrack.isEmpty()
+                        ? Collections.emptySet()
+                        : collectGlobalIndexesToTrack(context.snapshot);
         for (ManifestEntry entry : context.deltaFiles) {
             if (shouldBeTracked(entry)) {
                 namesToTrack.add(entry.fileName());
@@ -75,12 +94,18 @@ public class VisibilityWaitCallback implements CommitCallback {
             }
         }
 
-        if (namesToTrack.isEmpty()) {
+        if (namesToTrack.isEmpty()
+                && (rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty())) {
             return;
         }
 
         try {
-            waitForCompaction(context.snapshot, namesToTrack, partitionsToTrack);
+            waitForVisibility(
+                    context.snapshot,
+                    namesToTrack,
+                    partitionsToTrack,
+                    rowIdRangesToTrack,
+                    globalIndexesToTrack);
         } catch (InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
@@ -91,25 +116,47 @@ public class VisibilityWaitCallback implements CommitCallback {
         // No-op for retry as the callback is idempotent
     }
 
-    private void waitForCompaction(
-            Snapshot fromSnapshot, Set<String> namesToTrack, Set<BinaryRow> partitionsToTrack)
+    private void waitForVisibility(
+            Snapshot fromSnapshot,
+            Set<String> namesToTrack,
+            Set<BinaryRow> partitionsToTrack,
+            List<Range> rowIdRangesToTrack,
+            Set<GlobalIndexIdentifier> globalIndexesToTrack)
             throws InterruptedException, TimeoutException {
         long startTime = System.currentTimeMillis();
+        boolean compactionDone = namesToTrack.isEmpty();
+        boolean globalIndexDone = rowIdRangesToTrack.isEmpty() || globalIndexesToTrack.isEmpty();
+        Snapshot checkedSnapshot = fromSnapshot;
         while (System.currentTimeMillis() - startTime < timeout.toMillis()) {
             Snapshot latest = table.snapshotManager().latestSnapshot();
             checkNotNull(latest, "No latest snapshot");
-            if (latest.id() > fromSnapshot.id()
+
+            if (!compactionDone
+                    && latest.id() > checkedSnapshot.id()
                     && !stillInLatest(latest, namesToTrack, partitionsToTrack)) {
+                compactionDone = true;
+            }
+            if (!globalIndexDone
+                    && globalIndexesBuilt(latest, rowIdRangesToTrack, globalIndexesToTrack)) {
+                globalIndexDone = true;
+            }
+            if (compactionDone && globalIndexDone) {
                 return;
             }
-            fromSnapshot = latest;
+            checkedSnapshot = latest;
 
-            LOG.info("Waiting for files of table {} to be compacted...", table.fullName());
+            LOG.info(
+                    "Waiting for visibility of table {}. Compaction done: {}, global index done: {}.",
+                    table.fullName(),
+                    compactionDone,
+                    globalIndexDone);
             //noinspection BusyWait
             Thread.sleep(checkInterval.toMillis());
         }
 
-        throw new TimeoutException("Timeout waiting for files to be compacted after " + timeout);
+        throw new TimeoutException(
+                "Timeout waiting for files to be compacted or global indexes to be built after "
+                        + timeout);
     }
 
     private boolean stillInLatest(
@@ -141,8 +188,133 @@ public class VisibilityWaitCallback implements CommitCallback {
         return entry.bucket() == BucketMode.POSTPONE_BUCKET;
     }
 
+    private List<Range> collectRowIdRangesToTrack(List<ManifestEntry> deltaFiles) {
+        List<Range> ranges = new ArrayList<>();
+        for (ManifestEntry entry : deltaFiles) {
+            if (shouldTrackGlobalIndex(entry)) {
+                ranges.add(entry.file().nonNullRowIdRange());
+            }
+        }
+        return Range.sortAndMergeOverlap(ranges, true);
+    }
+
+    private boolean shouldTrackGlobalIndex(ManifestEntry entry) {
+        if (!FileKind.ADD.equals(entry.kind())) {
+            return false;
+        }
+
+        DataFileMeta file = entry.file();
+        if (file.firstRowId() == null || file.rowCount() <= 0) {
+            return false;
+        }
+
+        Optional<FileSource> fileSource = file.fileSource();
+        if (!fileSource.isPresent() || !FileSource.APPEND.equals(fileSource.get())) {
+            return false;
+        }
+
+        String fileName = file.fileName();
+        return !isBlobFile(fileName) && !isVectorStoreFile(fileName);
+    }
+
+    private Set<GlobalIndexIdentifier> collectGlobalIndexesToTrack(Snapshot snapshot) {
+        Set<GlobalIndexIdentifier> indexes = new HashSet<>();
+        for (IndexManifestEntry entry : scanGlobalIndexes(snapshot)) {
+            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+            if (globalIndex != null) {
+                indexes.add(
+                        new GlobalIndexIdentifier(
+                                entry.indexFile().indexType(),
+                                globalIndex.indexFieldId(),
+                                globalIndex.extraFieldIds()));
+            }
+        }
+        return indexes;
+    }
+
+    private boolean globalIndexesBuilt(
+            Snapshot snapshot,
+            List<Range> rowIdRangesToTrack,
+            Set<GlobalIndexIdentifier> globalIndexesToTrack) {
+        Map<GlobalIndexIdentifier, List<Range>> indexedRanges = new HashMap<>();
+        for (IndexManifestEntry entry : scanGlobalIndexes(snapshot)) {
+            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+            if (globalIndex == null) {
+                continue;
+            }
+
+            GlobalIndexIdentifier identifier =
+                    new GlobalIndexIdentifier(
+                            entry.indexFile().indexType(),
+                            globalIndex.indexFieldId(),
+                            globalIndex.extraFieldIds());
+            if (globalIndexesToTrack.contains(identifier)) {
+                indexedRanges
+                        .computeIfAbsent(identifier, k -> new ArrayList<>())
+                        .add(globalIndex.rowRange());
+            }
+        }
+
+        for (GlobalIndexIdentifier identifier : globalIndexesToTrack) {
+            List<Range> ranges = Range.sortAndMergeOverlap(indexedRanges.get(identifier), true);
+            for (Range rowIdRange : rowIdRangesToTrack) {
+                if (!rowIdRange.exclude(ranges).isEmpty()) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private List<IndexManifestEntry> scanGlobalIndexes(Snapshot snapshot) {
+        return table.store().newIndexFileHandler().scan(snapshot, this::isGlobalIndex);
+    }
+
+    private boolean isGlobalIndex(IndexManifestEntry entry) {
+        return entry.indexFile().globalIndexMeta() != null;
+    }
+
     @Override
     public void close() throws Exception {
         // No resources to close
+    }
+
+    private static class GlobalIndexIdentifier {
+
+        private final String indexType;
+        private final int indexFieldId;
+        private final int[] extraFieldIds;
+
+        private GlobalIndexIdentifier(String indexType, int indexFieldId, int[] extraFieldIds) {
+            this.indexType = indexType;
+            this.indexFieldId = indexFieldId;
+            this.extraFieldIds =
+                    extraFieldIds == null
+                            ? null
+                            : Arrays.copyOf(extraFieldIds, extraFieldIds.length);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GlobalIndexIdentifier)) {
+                return false;
+            }
+
+            GlobalIndexIdentifier that = (GlobalIndexIdentifier) o;
+            return indexFieldId == that.indexFieldId
+                    && Objects.equals(indexType, that.indexType)
+                    && Arrays.equals(extraFieldIds, that.extraFieldIds);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(indexType, indexFieldId);
+            result = 31 * result + Arrays.hashCode(extraFieldIds);
+            return result;
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/metastore/VisibilityWaitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metastore/VisibilityWaitCallbackTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.metastore;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.RowRangeIndex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link VisibilityWaitCallback}. */
+public class VisibilityWaitCallbackTest extends TableTestBase {
+
+    @Override
+    protected Schema schemaDefault() {
+        return Schema.newBuilder()
+                .column("f0", DataTypes.INT())
+                .column("f1", DataTypes.STRING())
+                .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                .option(CoreOptions.VISIBILITY_CALLBACK_ENABLED.key(), "true")
+                .option(CoreOptions.VISIBILITY_CALLBACK_CHECK_INTERVAL.key(), "100 ms")
+                .option(CoreOptions.VISIBILITY_CALLBACK_TIMEOUT.key(), "30 s")
+                .build();
+    }
+
+    @Test
+    public void testWaitForGlobalIndexBuildOfNewData() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeRows(table, 0, 3);
+        buildIndex(table, false);
+
+        long indexedSnapshotId = table.snapshotManager().latestSnapshot().id();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CompletableFuture<Void> writeFuture =
+                CompletableFuture.runAsync(
+                        () -> {
+                            try {
+                                writeRows(getTableDefault(), 3, 2);
+                            } catch (Exception e) {
+                                throw new CompletionException(e);
+                            }
+                        },
+                        executor);
+
+        try {
+            waitUntil(() -> table.snapshotManager().latestSnapshot().id() > indexedSnapshotId);
+            Thread.sleep(300L);
+            assertThat(writeFuture.isDone()).isFalse();
+
+            buildIndex(getTableDefault(), true);
+            writeFuture.get(10, TimeUnit.SECONDS);
+
+            BTreeGlobalIndexBuilder builder =
+                    new BTreeGlobalIndexBuilder(getTableDefault()).withIndexField("f1");
+            assertThat(builder.incrementalScan()).isNotPresent();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void writeRows(FileStoreTable table, int start, int count) throws Exception {
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite();
+                BatchTableCommit commit = builder.newCommit()) {
+            for (int i = start; i < start + count; i++) {
+                write.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+            }
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private void buildIndex(FileStoreTable table, boolean incremental) throws Exception {
+        BTreeGlobalIndexBuilder builder = new BTreeGlobalIndexBuilder(table).withIndexField("f1");
+        Optional<Pair<RowRangeIndex, List<DataSplit>>> scan =
+                incremental ? builder.incrementalScan() : builder.scan();
+        assertThat(scan).isPresent();
+
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        for (DataSplit dataSplit : scan.get().getRight()) {
+            commitMessages.addAll(builder.build(dataSplit, ioManager));
+        }
+
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(commitMessages);
+        }
+    }
+
+    private void waitUntil(BooleanSupplier condition) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(50L);
+        }
+        throw new AssertionError("Condition was not met before timeout.");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/metastore/VisibilityWaitCallbackTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/metastore/VisibilityWaitCallbackTest.java
@@ -19,9 +19,12 @@
 package org.apache.paimon.metastore;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.globalindex.btree.BTreeGlobalIndexBuilder;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
@@ -31,12 +34,14 @@ import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -100,12 +105,54 @@ public class VisibilityWaitCallbackTest extends TableTestBase {
         }
     }
 
+    @Test
+    public void testDoNotWaitForGlobalIndexBuildOfUnindexedPartition() throws Exception {
+        Identifier identifier = identifier("PartitionedTable");
+        catalog.createTable(identifier, partitionedSchema(), false);
+        FileStoreTable table = getTable(identifier);
+
+        writePartitionRows(table, "a", 0, 3);
+        buildPartitionIndex(table, "a");
+
+        writePartitionRows(getTable(identifier), "b", 3, 2);
+    }
+
+    private Schema partitionedSchema() {
+        return Schema.newBuilder()
+                .column("pt", DataTypes.STRING())
+                .column("f0", DataTypes.INT())
+                .column("f1", DataTypes.STRING())
+                .partitionKeys("pt")
+                .option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true")
+                .option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true")
+                .option(CoreOptions.VISIBILITY_CALLBACK_ENABLED.key(), "true")
+                .option(CoreOptions.VISIBILITY_CALLBACK_CHECK_INTERVAL.key(), "100 ms")
+                .option(CoreOptions.VISIBILITY_CALLBACK_TIMEOUT.key(), "1 s")
+                .build();
+    }
+
     private void writeRows(FileStoreTable table, int start, int count) throws Exception {
         BatchWriteBuilder builder = table.newBatchWriteBuilder();
         try (BatchTableWrite write = builder.newWrite();
                 BatchTableCommit commit = builder.newCommit()) {
             for (int i = start; i < start + count; i++) {
                 write.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+            }
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private void writePartitionRows(FileStoreTable table, String partition, int start, int count)
+            throws Exception {
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite();
+                BatchTableCommit commit = builder.newCommit()) {
+            for (int i = start; i < start + count; i++) {
+                write.write(
+                        GenericRow.of(
+                                BinaryString.fromString(partition),
+                                i,
+                                BinaryString.fromString("a" + i)));
             }
             commit.commit(write.prepareCommit());
         }
@@ -125,6 +172,33 @@ public class VisibilityWaitCallbackTest extends TableTestBase {
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(commitMessages);
         }
+    }
+
+    private void buildPartitionIndex(FileStoreTable table, String partition) throws Exception {
+        BTreeGlobalIndexBuilder builder =
+                new BTreeGlobalIndexBuilder(table)
+                        .withIndexField("f1")
+                        .withPartitionPredicate(partitionPredicate(table, partition));
+        Optional<Pair<RowRangeIndex, List<DataSplit>>> scan = builder.scan();
+        assertThat(scan).isPresent();
+
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        for (DataSplit dataSplit : scan.get().getRight()) {
+            commitMessages.addAll(builder.build(dataSplit, ioManager));
+        }
+
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(commitMessages);
+        }
+    }
+
+    private PartitionPredicate partitionPredicate(FileStoreTable table, String partition) {
+        RowType partType = table.rowType().project("pt");
+        Predicate predicate =
+                PartitionPredicate.createPartitionPredicate(
+                        partType,
+                        Collections.singletonMap("pt", BinaryString.fromString(partition)));
+        return PartitionPredicate.fromPredicate(partType, predicate);
     }
 
     private void waitUntil(BooleanSupplier condition) throws Exception {


### PR DESCRIPTION
## Summary

Support waiting for newly committed row-tracking data to be covered by existing global indexes when `visibility-callback.enabled` is enabled. This extends the visibility callback beyond compaction so batch writes do not return before global index visibility catches up.

## Changes

- Enable `VisibilityWaitCallback` for row-tracking tables when visibility callback is configured.
- Track row id ranges from newly added append data files and wait until each existing global index covers those ranges.
- Preserve the existing deletion-vector and postpone-bucket compaction wait behavior.
- Update the option documentation and generated configuration docs.
- Add a Java test that verifies a write waits until incremental BTree global index build commits.

## Testing

- `mvn -pl paimon-api,paimon-core -DskipTests compile`
- `mvn -pl paimon-core -Dtest=VisibilityWaitCallbackTest test`
- `git diff --check`

## Notes

This applies only to batch or bounded stream commits, matching the existing visibility callback behavior.