### PR TITLE
[core] Fix JDBC connection leak in ClientPool and JdbcCatalog

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
@@ -68,9 +68,10 @@ public interface ClientPool<C, E extends Exception> {
                     client = ensureActiveClient(client);
                     return action.run(client);
                 } finally {
-                    if (this.clients != null) {
-                        clients.addFirst(client);
-                    } else {
+                    // Return client to the deque, then check if close() raced us.
+                    // The deque's lock ensures either drainTo or remove sees the client.
+                    clients.addFirst(client);
+                    if (this.clients == null && clients.remove(client)) {
                         close(client);
                     }
                 }

--- a/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
@@ -68,7 +68,11 @@ public interface ClientPool<C, E extends Exception> {
                     client = ensureActiveClient(client);
                     return action.run(client);
                 } finally {
-                    clients.addFirst(client);
+                    if (this.clients != null) {
+                        clients.addFirst(client);
+                    } else {
+                        close(client);
+                    }
                 }
             }
         }
@@ -92,6 +96,10 @@ public interface ClientPool<C, E extends Exception> {
         }
 
         protected abstract void close(C client);
+
+        public boolean isClosed() {
+            return this.clients == null;
+        }
 
         @Override
         public void close() {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLock.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLock.java
@@ -83,7 +83,7 @@ public class JdbcCatalogLock implements CatalogLock {
 
     @Override
     public void close() throws IOException {
-        // Do nothing
+        connections.close();
     }
 
     public static long checkMaxSleep(Map<String, String> conf) {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLockContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLockContext.java
@@ -40,7 +40,7 @@ public class JdbcCatalogLockContext implements CatalogLockContext {
     }
 
     public JdbcClientPool connections() {
-        if (connections == null) {
+        if (connections == null || connections.isClosed()) {
             connections =
                     new JdbcClientPool(
                             options.get(CatalogOptions.CLIENT_POOL_SIZE),

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcClientPoolTest.java
@@ -18,15 +18,23 @@
 
 package org.apache.paimon.jdbc;
 
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link JdbcClientPool} connection validation. */
 public class JdbcClientPoolTest {
@@ -148,5 +156,90 @@ public class JdbcClientPoolTest {
         } finally {
             pool.close();
         }
+    }
+
+    @Test
+    public void testIsClosedReportsCorrectly() {
+        JdbcClientPool pool = createPool(1);
+        assertThat(pool.isClosed()).isFalse();
+        pool.close();
+        assertThat(pool.isClosed()).isTrue();
+    }
+
+    @Test
+    public void testConnectionClosedWhenPoolClosedDuringAction() throws Exception {
+        JdbcClientPool pool = createPool(1);
+        AtomicReference<Connection> connRef = new AtomicReference<>();
+        CountDownLatch actionStarted = new CountDownLatch(1);
+        CountDownLatch poolClosed = new CountDownLatch(1);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> future =
+                    executor.submit(
+                            () -> {
+                                try {
+                                    pool.run(
+                                            connection -> {
+                                                connRef.set(connection);
+                                                actionStarted.countDown();
+                                                try {
+                                                    poolClosed.await();
+                                                } catch (InterruptedException e) {
+                                                    Thread.currentThread().interrupt();
+                                                }
+                                                return null;
+                                            });
+                                } catch (Exception e) {
+                                    // expected
+                                }
+                            });
+
+            actionStarted.await();
+            pool.close();
+            poolClosed.countDown();
+            future.get();
+
+            assertThat(connRef.get().isClosed()).isTrue();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Test
+    public void testPoolThrowsAfterClose() {
+        JdbcClientPool pool = createPool(1);
+        pool.close();
+
+        assertThatThrownBy(
+                        () ->
+                                pool.run(
+                                        connection -> {
+                                            return null;
+                                        }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("closed pool");
+    }
+
+    @Test
+    public void testLockContextRecreatesPoolAfterClose() {
+        String dbUrl =
+                "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+        Options options = new Options();
+        options.set(CatalogOptions.CLIENT_POOL_SIZE, 1);
+        options.set(CatalogOptions.URI.key(), dbUrl);
+
+        JdbcCatalogLockContext context = new JdbcCatalogLockContext("test-catalog", options);
+
+        JdbcClientPool firstPool = context.connections();
+        assertThat(firstPool.isClosed()).isFalse();
+
+        firstPool.close();
+        assertThat(firstPool.isClosed()).isTrue();
+
+        JdbcClientPool secondPool = context.connections();
+        assertThat(secondPool).isNotSameAs(firstPool);
+        assertThat(secondPool.isClosed()).isFalse();
+        secondPool.close();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/spits/CloneSplitsFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/spits/CloneSplitsFunction.java
@@ -67,6 +67,19 @@ public class CloneSplitsFunction extends ProcessFunction<CloneSplitInfo, CommitM
     }
 
     @Override
+    public void close() throws Exception {
+        super.close();
+        if (sourceCatalog != null) {
+            sourceCatalog.close();
+            sourceCatalog = null;
+        }
+        if (targetCatalog != null) {
+            targetCatalog.close();
+            targetCatalog = null;
+        }
+    }
+
+    @Override
     public void processElement(
             CloneSplitInfo cloneSplitInfo,
             ProcessFunction<CloneSplitInfo, CommitMessageInfo>.Context context,

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/spits/ListCloneSplitsFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/clone/spits/ListCloneSplitsFunction.java
@@ -78,6 +78,19 @@ public class ListCloneSplitsFunction extends ProcessFunction<CloneSchemaInfo, Cl
     }
 
     @Override
+    public void close() throws Exception {
+        super.close();
+        if (sourceCatalog != null) {
+            sourceCatalog.close();
+            sourceCatalog = null;
+        }
+        if (targetCatalog != null) {
+            targetCatalog.close();
+            targetCatalog = null;
+        }
+    }
+
+    @Override
     public void processElement(
             CloneSchemaInfo cloneSchemaInfo,
             ProcessFunction<CloneSchemaInfo, CloneSplitInfo>.Context context,


### PR DESCRIPTION
### Purpose

Fixes the Jdbc connection leaks that happen when Flink TMs restart. 
Issue: #8267

### Tests

There are some tests added specially the `testConnectionClosedWhenPoolClosedDuringAction` that simulates the scenario.
