### PR TITLE
[docs] Split global index documentation

### DIFF
--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -3,9 +3,6 @@ title: "Global Index"
 sidebar_position: 8
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -32,9 +29,17 @@ under the License.
 Global Index is a powerful indexing mechanism for Data Evolution (append) tables. It enables efficient row-level lookups and filtering
 without full-table scans. Paimon supports multiple global index types:
 
-- **BTree Index**: A B-tree based index for scalar column lookups. Supports equality, IN, range predicates, and can be combined across multiple columns with AND/OR logic.
-- **Vector Index**: An approximate nearest neighbor (ANN) index powered by Paimon's vector index library for vector similarity search.
-- **Full-Text Index**: A full-text search index powered by Tantivy for text retrieval. Supports term matching and relevance scoring.
+- **[BTree Index](./global-index/btree)**: A B-tree based index for scalar column lookups. Supports equality, IN, range predicates, and can be combined across multiple columns with AND/OR logic.
+- **[Vector Index](./global-index/vector)**: An approximate nearest neighbor (ANN) index powered by Paimon's vector index library for vector similarity search.
+- **[Full-Text Index](./global-index/full-text)**: A full-text search index powered by Tantivy for text retrieval. Supports term matching and relevance scoring.
+- **[Hybrid Search](./global-index/hybrid-search)**: A multi-route search API that combines vector and full-text results before reading table rows.
+
+| Index Type | Best For | Notes |
+|---|---|---|
+| BTree | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
+| Vector | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
+| Full-Text | Keyword search over text columns | Uses Tantivy scoring and tokenizer configuration stored with each index file. |
+| Hybrid Search | Combining vector and full-text retrieval | Runs multiple scored routes and merges them with a ranker before reading rows. |
 
 Global indexes work on top of Data Evolution tables. To use global indexes, your table **must** have:
 
@@ -62,635 +67,108 @@ CREATE TABLE my_table (
 );
 ```
 
-## BTree Index
+## Lifecycle
 
-BTree index builds a logical B-tree structure over SST files, enabling efficient point lookups and range queries on scalar columns.
-
-**Build BTree Index**
+Create global indexes with the `create_global_index` procedure. You can build an index for all
+partitions or only selected partitions:
 
 ```sql
--- Create BTree index on 'name' column
 CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree'
+);
+
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree',
+    partitions => 'dt=2026-06-18;dt=2026-06-19'
+);
+```
+
+Drop index files with `drop_global_index`:
+
+```sql
+CALL sys.drop_global_index(
     table => 'db.my_table',
     index_column => 'name',
     index_type => 'btree'
 );
 ```
 
-**Query with BTree Index**
-
-Once a BTree index is built, it is automatically used during scan when a filter predicate matches the indexed column.
-
-<Tabs groupId="btree-search">
-
-<TabItem value="sql" label="SQL">
+Global indexes are stored in index files and recorded in table metadata. To inspect index files and
+their row-id coverage, query the `table_indexes` system table:
 
 ```sql
-SELECT * FROM my_table WHERE name IN ('a200', 'a300');
+SELECT index_type, index_field_name, row_range_start, row_range_end
+FROM my_table$table_indexes
+WHERE index_field_name IS NOT NULL;
 ```
 
-</TabItem>
+You can also query `file_key_ranges` to inspect data file row-id ranges and diagnose coverage:
 
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-from pypaimon.common.predicate_builder import PredicateBuilder
-
-table = catalog.get_table("db.my_table")
-
-read_builder = table.new_read_builder()
-read_builder = read_builder.with_filter(
-    PredicateBuilder(table.fields)
-    .is_in("name", ["a200", "a300"])
-)
-
-scan = read_builder.new_scan()
-read = read_builder.new_read()
-pa_table = read.to_arrow(scan.plan().splits())
-print(pa_table)
+```sql
+SELECT file_path, first_row_id, record_count
+FROM my_table$file_key_ranges;
 ```
 
-</TabItem>
+For workloads that need newly appended rows to become visible only after existing global indexes
+cover them, enable the visibility callback:
 
-</Tabs>
+```sql
+ALTER TABLE my_table SET (
+    'visibility-callback.enabled' = 'true',
+    'visibility-callback.timeout' = '30 min'
+);
+```
+
+## Coverage and Freshness
+
+Global index files cover row-id ranges. If more rows are appended after an index is built, those
+new rows are not automatically covered by the existing index files. Run `create_global_index` again
+to build index files for newly uncovered data. A query that can be answered by a matching global
+index reads indexed row ranges; rows in uncovered ranges are not returned for that indexed query.
+
+To temporarily disable global-index scan acceleration while keeping the index files, set:
+
+```sql
+ALTER TABLE my_table SET ('global-index.enabled' = 'false');
+```
+
+Set it back to `true` to use global indexes during scans again.
+
+## Build Options
+
+These table options affect global index build and read behavior:
+
+| Option | Default | Description |
+|---|---|---|
+| `global-index.enabled` | `true` | Whether scans can use global indexes. |
+| `global-index.external-path` | Not set | Root directory for global index files. If not set, files are stored under the table index directory. |
+| `global-index.row-count-per-shard` | `100000` | Target row count per shard for non-BTree global index builds. |
+| `global-index.build.max-shard` | `32` | Preferred maximum shard count for global index builds. |
+| `global-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building global indexes. |
+| `global-index.thread-num` | `32` | Maximum number of concurrent threads for global index I/O. |
+| `visibility-callback.enabled` | `false` | Whether batch or bounded-stream commits wait until existing global indexes cover newly added files. |
+| `visibility-callback.timeout` | `30 min` | Maximum wait time for visibility callback. |
+
+## BTree Index
+
+Use BTree indexes for scalar column lookups and range predicates. See [BTree Index](./global-index/btree)
+for build and query examples.
 
 ## Vector Index
 
-Vector Index provides approximate nearest neighbor (ANN) search for vector similarity search scenarios such as
-recommendation systems, image retrieval, and RAG (Retrieval Augmented Generation) applications.
-
-Supported vector index types:
-
-| Index Type | Description |
-|---|---|
-| `ivf-flat` | IVF index with flat vector storage. |
-| `ivf-pq` | IVF index with product quantization. |
-| `ivf-hnsw-flat` | IVF index with HNSW flat quantizer. |
-| `ivf-hnsw-sq` | IVF index with HNSW scalar quantizer. |
-
-**Build Vector Index**
-
-```sql
--- Create IVF-PQ vector index on 'embedding' column
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
-);
-```
-
-For `ARRAY<FLOAT>` vector columns, specify the vector dimension with `<index-type>.dimension`.
-For `VECTOR<FLOAT>` columns, Paimon uses the dimension from the column type.
-
-Supported vector index options:
-
-| Option | Default | Description |
-|---|---|---|
-| `<index-type>.dimension` | `128` | Vector dimension for `ARRAY<FLOAT>` columns. Ignored for `VECTOR<FLOAT>` columns. |
-| `<index-type>.distance.metric` | `inner_product` | Distance metric. Supported values: `l2`, `cosine`, `inner_product`. |
-| `<index-type>.nlist` | `256` | Number of IVF clusters used during index build. |
-| `<index-type>.pq.m` | `16` | Number of PQ sub-vectors for `ivf-pq`. The vector dimension must be divisible by this value. |
-| `<index-type>.pq.use-opq` | `false` | Whether to enable OPQ for `ivf-pq`. |
-| `<index-type>.hnsw.m` | `20` | HNSW graph out-degree for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
-| `<index-type>.hnsw.ef-construction` | `150` | HNSW construction search width for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
-| `<index-type>.hnsw.max-level` | `7` | Maximum HNSW level for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
-
-**Per-Field Options**
-
-The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
-by every vector column of the same index type. When a table has multiple vector columns, you can
-scope an option to a single column with `fields.<field-name>.<option>`. The field-level
-form takes precedence over the column-agnostic `<index-type>.<option>` for that column. Use the
-stored table column name exactly as `<field-name>`. Field-level vector options do not include the
-index-type prefix; for example, use `fields.image_embedding.nlist` to override the shared
-`ivf-pq.nlist` option for `image_embedding`:
-
-```sql
-CREATE TABLE my_table (
-    id INT,
-    title_embedding ARRAY<FLOAT>,
-    image_embedding ARRAY<FLOAT>
-) TBLPROPERTIES (
-    'bucket' = '-1',
-    'row-tracking.enabled' = 'true',
-    'data-evolution.enabled' = 'true',
-    'global-index.enabled' = 'true',
-    -- per-column dimensions
-    'fields.title_embedding.dimension' = '768',
-    'fields.image_embedding.dimension' = '512',
-    -- shared by every ivf-pq column, overridden only for 'image_embedding'
-    'ivf-pq.nlist' = '256',
-    'fields.image_embedding.nlist' = '512'
-);
-```
-
-With the properties above, `title_embedding` is indexed with `nlist=256` while `image_embedding`
-uses `nlist=512`.
-
-**Vector Search**
-
-Search-time options are passed with each vector search request:
-
-| Option | Default | Description |
-|---|---|---|
-| `ivf.nprobe` | `16` | Number of IVF clusters to probe during search. |
-| `hnsw.ef_search` | `0` | HNSW search width during search. `0` uses the native library default. |
-
-<Tabs groupId="vector-search">
-
-<TabItem value="spark-sql" label="Spark SQL">
-
-```sql
--- Search for top-5 nearest neighbors
-SELECT * FROM vector_search('my_table', 'embedding', array(1.0f, 2.0f, 3.0f), 5);
-```
-
-</TabItem>
-
-<TabItem value="flink-sql-procedure" label="Flink SQL (Procedure)">
-
-Unlike Spark's table-valued function, Flink uses a `CALL` procedure to perform vector search.
-The procedure returns JSON-serialized rows as strings.
-
-```sql
--- Search for top-5 nearest neighbors
-CALL sys.vector_search(
-    `table` => 'db.my_table',
-    vector_column => 'embedding',
-    query_vector => '1.0,2.0,3.0',
-    top_k => 5
-);
-
--- With projection (only return specific columns)
-CALL sys.vector_search(
-    `table` => 'db.my_table',
-    vector_column => 'embedding',
-    query_vector => '1.0,2.0,3.0',
-    top_k => 5,
-    projection => 'id,name'
-);
-```
-
-</TabItem>
-
-<TabItem value="java-api" label="Java API">
-
-```java
-Table table = catalog.getTable(identifier);
-
-// Step 1: Build vector search
-float[] queryVector = {1.0f, 2.0f, 3.0f};
-GlobalIndexResult result = table.newVectorSearchBuilder()
-        .withVector(queryVector)
-        .withLimit(5)
-        .withVectorColumn("embedding")
-        .withOption("ivf.nprobe", "16")
-        .executeLocal();
-
-// Step 2: Read matching rows using the search result
-ReadBuilder readBuilder = table.newReadBuilder();
-TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
-try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
-    reader.forEachRemaining(row -> {
-        System.out.println("id=" + row.getInt(0) + ", name=" + row.getString(1));
-    });
-}
-```
-
-For Java, use `Table.newVectorSearchBuilder()` to produce a global index result, then pass
-the result to `TableScan.withGlobalIndexResult`.
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-# Step 1: Build vector search
-result = (
-    table.new_vector_search_builder()
-    .with_vector_column("embedding")
-    .with_query_vector([1.0, 2.0, 3.0])
-    .with_limit(5)
-    .with_option("ivf.nprobe", "16")
-    .execute_local()
-)
-
-# Step 2: Read matching rows using the search result
-read_builder = table.new_read_builder()
-scan = read_builder.new_scan().with_global_index_result(result)
-plan = scan.plan()
-table_read = read_builder.new_read()
-pa_table = table_read.to_arrow(plan.splits())
-print(pa_table)
-```
-
-You can also add a scalar filter to pre-filter rows before vector search:
-
-```python
-from pypaimon.common.predicate_builder import PredicateBuilder
-
-predicate = (
-    PredicateBuilder(table.fields)
-    .equal("category", "electronics")
-)
-
-result = (
-    table.new_vector_search_builder()
-    .with_vector_column("embedding")
-    .with_query_vector([1.0, 2.0, 3.0])
-    .with_limit(5)
-    .with_filter(predicate)
-    .execute_local()
-)
-```
-
-</TabItem>
-
-</Tabs>
+Use Vector indexes for approximate nearest neighbor (ANN) search. See [Vector Index](./global-index/vector)
+for supported index types, options, and search examples.
 
 ## Full-Text Index
 
-Full-Text Index provides text search capabilities powered by Tantivy. It is suitable for text retrieval scenarios
-such as document search, log analysis, and content-based filtering.
-
-**Build Full-Text Index**
-
-```sql
--- Create full-text index on 'content' column
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'tantivy-fulltext'
-);
-```
-
-For other content where users often search by short character fragments, build the
-index with Tantivy's `ngram` tokenizer:
-
-```sql
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'tantivy-fulltext',
-    options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2'
-);
-```
-
-For Chinese word segmentation, build the index with the `jieba` tokenizer:
-
-```sql
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'tantivy-fulltext',
-    options => 'tantivy.tokenizer=jieba'
-);
-```
-
-For LanceDB-style analyzer customization, choose a base tokenizer and compose token filters:
-
-```sql
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'tantivy-fulltext',
-    options => 'tantivy.tokenizer=simple,tantivy.stem=true,tantivy.remove-stop-words=true'
-);
-```
-
-Supported tokenizer options:
-
-| Option | Default | Description |
-|---|---|---|
-| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `simple`, `whitespace`, `raw`, `ngram`, `jieba`. |
-| `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
-| `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
-| `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
-| `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
-| `tantivy.max-token-length` | `40` | Maximum token length kept by configurable tokenizers. |
-| `tantivy.ascii-folding` | `false` | Whether to normalize non-ASCII Latin characters to ASCII. |
-| `tantivy.stem` | `false` | Whether to apply stemming to emitted tokens. |
-| `tantivy.language` | `english` | Language used by stemming and built-in stop word filters. |
-| `tantivy.remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
-| `tantivy.stop-words` | ` ` | Semicolon-separated custom stop words to remove. |
-| `tantivy.with-position` | `true` | Whether to store term positions for phrase queries. Disable it to reduce index size when phrase queries are not needed. |
-
-Tokenizer settings are persisted in global index metadata. Existing index files keep using the
-tokenizer they were built with, even if later index builds use different options.
-Paimon does not load arbitrary Rust tokenizer plugins from configuration; custom analysis is
-provided by composing the supported tokenizer and filter options above. PyPaimon can query
-`jieba` indexes when the Python `jieba` package is installed.
-
-**Full-Text Search**
-
-<Tabs groupId="fulltext-search">
-
-<TabItem value="spark-sql" label="Spark SQL">
-
-```sql
--- Search for top-10 documents matching the query
-SELECT * FROM full_text_search('my_table', 'content', 'paimon lake format', 10);
-```
-
-</TabItem>
-
-<TabItem value="java-api" label="Java API">
-
-```java
-Table table = catalog.getTable(identifier);
-
-// Step 1: Build full-text search
-GlobalIndexResult result = table.newFullTextSearchBuilder()
-        .withQueryText("paimon lake format")
-        .withQueryOperator("and")
-        .withLimit(10)
-        .withTextColumn("content")
-        .executeLocal();
-
-// Step 2: Read matching rows using the search result
-ReadBuilder readBuilder = table.newReadBuilder();
-TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
-try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
-    reader.forEachRemaining(row -> {
-        System.out.println("id=" + row.getInt(0) + ", content=" + row.getString(1));
-    });
-}
-```
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-# Step 1: Build full-text search
-result = (
-    table.new_full_text_search_builder()
-    .with_text_column("content")
-    .with_query_text("paimon lake format")
-    .with_query_operator("and")
-    .with_limit(10)
-    .execute_local()
-)
-
-# Step 2: Read matching rows using the search result
-read_builder = table.new_read_builder()
-scan = read_builder.new_scan().with_global_index_result(result)
-plan = scan.plan()
-table_read = read_builder.new_read()
-pa_table = table_read.to_arrow(plan.splits())
-print(pa_table)
-```
-
-PyPaimon reads the Tantivy tokenizer settings stored in the global index metadata. Indexes built
-with `tantivy.tokenizer=ngram` can be queried from Python when the installed `tantivy-py` package
-provides custom tokenizer support. Indexes built with `tantivy.tokenizer=jieba` can be queried
-when the `jieba` package is installed.
-
-</TabItem>
-
-</Tabs>
+Use Full-Text indexes for text retrieval powered by Tantivy. See [Full-Text Index](./global-index/full-text)
+for tokenizer options and search examples.
 
 ## Hybrid Search
 
-Hybrid search queries multiple vector and full-text routes in one request and ranks the scored
-results before reading table rows. This is useful when one table stores several searchable
-representations for the same record, such as title embeddings, body embeddings, and content text.
-
-Before running hybrid search, create a global index for every vector or text column used by
-the query:
-
-```sql
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'title_embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
-);
-
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'body_embedding',
-    index_type => 'ivf-pq',
-    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
-);
-
-CALL sys.create_global_index(
-    table => 'db.my_table',
-    index_column => 'content',
-    index_type => 'tantivy-fulltext'
-);
-```
-
-For Spark SQL, use the `hybrid_search(table_name, vector_routes, full_text_routes, limit[, ranker])`
-table-valued function. The fourth argument is the final number of ranked results to return.
-The optional fifth argument selects the ranker. Supported rankers are `rrf` and
-`weighted_score`; the default is `rrf`.
-
-The second argument is an array of vector route configs created by `named_struct`:
-
-| Field | Required | Default | Description |
-|---|---|---|---|
-| `field` or `vector_column` | Yes | N/A | Vector column to search. |
-| `query_vector` | Yes | N/A | Query vector for this route. |
-| `limit` | No | Final limit | Top K results to retrieve from this vector column before ranking. |
-| `weight` | No | `1.0` | Weight for this route when ranking results. |
-| `options` | No | Empty map | Route-specific vector search options such as `ivf.nprobe` and `hnsw.ef_search`. |
-
-The third argument is an array of full-text route configs created by `named_struct`:
-
-| Field | Required | Default | Description |
-|---|---|---|---|
-| `field` or `text_column` | Yes | N/A | Text column to search. |
-| `query_text` | Yes | N/A | Full-text query for this route. |
-| `query_operator` | No | `or` | Term operator. Supported values are `or` and `and`. |
-| `limit` | No | Final limit | Top K results to retrieve from this text column before ranking. |
-| `weight` | No | `1.0` | Weight for this route when ranking results. |
-| `options` | No | Empty map | Route-specific full-text search options. |
-
-Within each route array, every `named_struct` should use the same fields because
-Spark requires array elements to have the same struct type.
-
-<Tabs groupId="hybrid-search">
-
-<TabItem value="spark-sql" label="Spark SQL">
-
-Vector and full-text routes can be searched together:
-
-```sql
-SELECT id, __paimon_search_score
-FROM hybrid_search(
-  'my_table',
-  array(
-    named_struct(
-      'field', 'title_embedding',
-      'query_vector', array(1.0f, 0.0f, 0.0f),
-      'limit', 50,
-      'weight', 2.0f,
-      'options', map('ivf.nprobe', '32'))),
-  array(
-    named_struct(
-      'field', 'content',
-      'query_text', 'paimon search',
-      'query_operator', 'or',
-      'limit', 50,
-      'weight', 1.0f,
-      'options', map())),
-  10,
-  'rrf');
-```
-
-To search two vector indexes without a full-text route, pass `array()` as the third argument:
-
-```sql
-SELECT id, __paimon_search_score
-FROM hybrid_search(
-  'my_table',
-  array(
-    named_struct(
-      'field', 'title_embedding',
-      'query_vector', array(1.0f, 0.0f, 0.0f),
-      'limit', 50,
-      'weight', 2.0f,
-      'options', map('ivf.nprobe', '32')),
-    named_struct(
-      'field', 'body_embedding',
-      'query_vector', array(0.0f, 1.0f, 0.0f),
-      'limit', 50,
-      'weight', 1.0f,
-      'options', map('ivf.nprobe', '32'))),
-  array(),
-  10,
-  'weighted_score');
-```
-
-Spark SQL adds `__paimon_search_score` to expose the ranked score.
-
-</TabItem>
-
-<TabItem value="java-api" label="Java API">
-
-```java
-Table table = catalog.getTable(identifier);
-
-HybridSearchBuilder searchBuilder =
-        table.newHybridSearchBuilder()
-                .addVectorRoute(
-                        "title_embedding",
-                        new float[] {1.0f, 0.0f, 0.0f},
-                        50,
-                        2.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
-                .addFullTextRoute(
-                        "content",
-                        "paimon search",
-                        "or",
-                        50,
-                        1.0f,
-                        java.util.Collections.emptyMap())
-                .withLimit(10)
-                .withRrfRanker();
-GlobalIndexResult result = searchBuilder.executeLocal();
-
-ReadBuilder readBuilder = table.newReadBuilder();
-TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
-try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
-    reader.forEachRemaining(row -> {
-        System.out.println("id=" + row.getInt(0));
-    });
-}
-```
-
-To search two vector indexes without a full-text route, add two vector routes:
-
-```java
-GlobalIndexResult vectorOnlyResult =
-        table.newHybridSearchBuilder()
-                .addVectorRoute(
-                        "title_embedding",
-                        new float[] {1.0f, 0.0f, 0.0f},
-                        50,
-                        2.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
-                .addVectorRoute(
-                        "body_embedding",
-                        new float[] {0.0f, 1.0f, 0.0f},
-                        50,
-                        1.0f,
-                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
-                .withLimit(10)
-                .withWeightedScoreRanker()
-                .executeLocal();
-```
-
-For Java, use `Table.newHybridSearchBuilder()` to configure routes, final limit, and ranker
-directly. `VectorSearch` and `HybridSearch` are internal pushdown representations.
-
-</TabItem>
-
-<TabItem value="python-sdk" label="Python SDK">
-
-```python
-table = catalog.get_table("db.my_table")
-
-result = (
-    table.new_hybrid_search_builder()
-    .add_vector_route(
-        "title_embedding",
-        [1.0, 0.0, 0.0],
-        limit=50,
-        weight=2.0,
-        options={"ivf.nprobe": "32"},
-    )
-    .add_full_text_route(
-        "content",
-        "paimon search",
-        limit=50,
-        weight=1.0,
-        query_operator="or",
-    )
-    .with_limit(10)
-    .with_rrf_ranker()
-    .execute_local()
-)
-
-read_builder = table.new_read_builder()
-scan = read_builder.new_scan().with_global_index_result(result)
-plan = scan.plan()
-table_read = read_builder.new_read()
-pa_table = table_read.to_arrow(plan.splits())
-print(pa_table)
-```
-
-To search two vector indexes without a full-text route, add two vector routes:
-
-```python
-result = (
-    table.new_hybrid_search_builder()
-    .add_vector_route(
-        "title_embedding",
-        [1.0, 0.0, 0.0],
-        limit=50,
-        weight=2.0,
-        options={"ivf.nprobe": "32"},
-    )
-    .add_vector_route(
-        "body_embedding",
-        [0.0, 1.0, 0.0],
-        limit=50,
-        weight=1.0,
-        options={"ivf.nprobe": "32"},
-    )
-    .with_limit(10)
-    .with_weighted_score_ranker()
-    .execute_local()
-)
-```
-
-</TabItem>
-
-</Tabs>
+Use Hybrid Search to query multiple vector and full-text routes in one request. See
+[Hybrid Search](./global-index/hybrid-search) for route configuration, rankers, and API examples.

--- a/docs/docs/multimodal-table/global-index.mdx
+++ b/docs/docs/multimodal-table/global-index.mdx
@@ -32,14 +32,14 @@ without full-table scans. Paimon supports multiple global index types:
 - **[BTree Index](./global-index/btree)**: A B-tree based index for scalar column lookups. Supports equality, IN, range predicates, and can be combined across multiple columns with AND/OR logic.
 - **[Vector Index](./global-index/vector)**: An approximate nearest neighbor (ANN) index powered by Paimon's vector index library for vector similarity search.
 - **[Full-Text Index](./global-index/full-text)**: A full-text search index powered by Tantivy for text retrieval. Supports term matching and relevance scoring.
-- **[Hybrid Search](./global-index/hybrid-search)**: A multi-route search API that combines vector and full-text results before reading table rows.
+- **[Hybrid Search](./global-index/hybrid-search)**: A multi-route search API that combines results from multiple vector routes, multiple full-text routes, or both before reading table rows.
 
 | Index Type | Best For | Notes |
 |---|---|---|
 | BTree | Scalar filters on numeric, string, date, and timestamp columns | Best when predicates are selective, such as equality, IN, range, and null checks. |
 | Vector | Top-K similarity search on embeddings | Uses ANN algorithms. Tune build-time and search-time options to balance recall, latency, and index size. |
 | Full-Text | Keyword search over text columns | Uses Tantivy scoring and tokenizer configuration stored with each index file. |
-| Hybrid Search | Combining vector and full-text retrieval | Runs multiple scored routes and merges them with a ranker before reading rows. |
+| Hybrid Search | Combining multiple vector routes, multiple full-text routes, or vector and full-text retrieval together | Runs multiple scored routes and merges them with a ranker before reading rows. |
 
 Global indexes work on top of Data Evolution tables. To use global indexes, your table **must** have:
 
@@ -170,5 +170,5 @@ for tokenizer options and search examples.
 
 ## Hybrid Search
 
-Use Hybrid Search to query multiple vector and full-text routes in one request. See
+Use Hybrid Search to query multiple vector routes, multiple full-text routes, or a mix of both in one request. See
 [Hybrid Search](./global-index/hybrid-search) for route configuration, rankers, and API examples.

--- a/docs/docs/multimodal-table/global-index/btree.mdx
+++ b/docs/docs/multimodal-table/global-index/btree.mdx
@@ -1,0 +1,114 @@
+---
+title: "BTree Index"
+sidebar_position: 1
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# BTree Index
+
+BTree index builds a logical B-tree structure over SST files, enabling efficient point lookups and range queries on scalar columns.
+Use it for selective predicates on scalar columns such as identifiers, timestamps, categories with
+many distinct values, or other columns frequently used in `WHERE` clauses.
+
+Supported predicate shapes include:
+
+| Predicate | Example |
+|---|---|
+| Equality | `name = 'a200'` |
+| IN | `name IN ('a200', 'a300')` |
+| Range | `price >= 10 AND price < 100` |
+| Null checks | `name IS NOT NULL` |
+| AND / OR combinations | `name = 'a200' OR name = 'a300'` |
+
+`LIKE`, `startsWith`, `contains`, and `NOT IN` predicates may still need broader index file reads.
+For keyword-style text retrieval, use [Full-Text Index](./full-text) instead.
+
+## Build BTree Index
+
+```sql
+-- Create BTree index on 'name' column
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree'
+);
+```
+
+You can build only selected partitions:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'name',
+    index_type => 'btree',
+    partitions => 'dt=2026-06-18;dt=2026-06-19'
+);
+```
+
+## BTree Options
+
+| Option | Default | Description |
+|---|---|---|
+| `btree-index.records-per-range` | `10000000` | Expected number of records per BTree index file. |
+| `btree-index.build.max-parallelism` | `4096` | Maximum Flink or Spark parallelism for building BTree indexes. |
+| `btree-index.block-size` | `64 kb` | Block size used by BTree index files. |
+| `btree-index.cache-size` | `128 mb` | Cache size used by BTree index readers. |
+| `btree-index.compression` | `none` | Compression algorithm used by BTree index blocks. |
+
+## Query with BTree Index
+
+Once a BTree index is built, it is automatically used during scan when a filter predicate matches the indexed column.
+
+<Tabs groupId="btree-search">
+
+<TabItem value="sql" label="SQL">
+
+```sql
+SELECT * FROM my_table WHERE name IN ('a200', 'a300');
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+from pypaimon.common.predicate_builder import PredicateBuilder
+
+table = catalog.get_table("db.my_table")
+
+read_builder = table.new_read_builder()
+read_builder = read_builder.with_filter(
+    PredicateBuilder(table.fields)
+    .is_in("name", ["a200", "a300"])
+)
+
+scan = read_builder.new_scan()
+read = read_builder.new_read()
+pa_table = read.to_arrow(scan.plan().splits())
+print(pa_table)
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/docs/multimodal-table/global-index/full-text.mdx
+++ b/docs/docs/multimodal-table/global-index/full-text.mdx
@@ -1,0 +1,190 @@
+---
+title: "Full-Text Index"
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Full-Text Index
+
+Full-Text Index provides text search capabilities powered by Tantivy. It is suitable for text retrieval scenarios
+such as document search, log analysis, and content-based filtering. Search results are scored by
+the full-text index and can be consumed directly or combined with vector routes in
+[Hybrid Search](./hybrid-search).
+
+## Build Full-Text Index
+
+```sql
+-- Create full-text index on 'content' column
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext'
+);
+```
+
+For other content where users often search by short character fragments, build the
+index with Tantivy's `ngram` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=ngram,tantivy.ngram.min-gram=2,tantivy.ngram.max-gram=2'
+);
+```
+
+For Chinese word segmentation, build the index with the `jieba` tokenizer:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=jieba'
+);
+```
+
+To customize text analysis, choose a base tokenizer and compose token filters:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext',
+    options => 'tantivy.tokenizer=simple,tantivy.stem=true,tantivy.remove-stop-words=true'
+);
+```
+
+Supported tokenizer options:
+
+| Option | Default | Description |
+|---|---|---|
+| `tantivy.tokenizer` | `default` | Tokenizer used by the full-text index. Supported values: `default`, `simple`, `whitespace`, `raw`, `ngram`, `jieba`. |
+| `tantivy.ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
+| `tantivy.ngram.prefix-only` | `false` | Whether the `ngram` tokenizer only emits prefix ngrams. |
+| `tantivy.lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+| `tantivy.max-token-length` | `40` | Maximum token length kept by configurable tokenizers. |
+| `tantivy.ascii-folding` | `false` | Whether to normalize non-ASCII Latin characters to ASCII. |
+| `tantivy.stem` | `false` | Whether to apply stemming to emitted tokens. |
+| `tantivy.language` | `english` | Language used by stemming and built-in stop word filters. |
+| `tantivy.remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
+| `tantivy.stop-words` | ` ` | Semicolon-separated custom stop words to remove. |
+| `tantivy.with-position` | `true` | Whether to store term positions for phrase queries. Disable it to reduce index size when phrase queries are not needed. |
+
+Tokenizer settings are persisted in global index metadata. Existing index files keep using the
+tokenizer they were built with, even if later index builds use different options.
+Paimon does not load arbitrary Rust tokenizer plugins from configuration; custom analysis is
+provided by composing the supported tokenizer and filter options above. PyPaimon can query
+`jieba` indexes when the Python `jieba` package is installed.
+
+Choose tokenizer settings based on the query pattern:
+
+| Query Pattern | Suggested Options |
+|---|---|
+| Natural-language English text | Use the default tokenizer, or enable `tantivy.stem=true` and `tantivy.remove-stop-words=true`. |
+| Short fragments or substring-like lookup | Use `tantivy.tokenizer=ngram` and tune `tantivy.ngram.min-gram` / `tantivy.ngram.max-gram`. |
+| Chinese text | Use `tantivy.tokenizer=jieba`. |
+| Exact token matching | Use `tantivy.tokenizer=raw` or `tantivy.tokenizer=whitespace`, depending on how the field is written. |
+
+Set `tantivy.with-position=false` to reduce index size when phrase queries are not needed.
+
+## Full-Text Search
+
+The query operator controls how multiple query terms are matched:
+
+| Operator | Meaning |
+|---|---|
+| `or` | Return rows matching any query term. |
+| `and` | Return rows matching all query terms. |
+
+<Tabs groupId="fulltext-search">
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+-- Search for top-10 documents matching the query
+SELECT * FROM full_text_search('my_table', 'content', 'paimon lake format', 10);
+```
+
+</TabItem>
+
+<TabItem value="java-api" label="Java API">
+
+```java
+Table table = catalog.getTable(identifier);
+
+// Step 1: Build full-text search
+GlobalIndexResult result = table.newFullTextSearchBuilder()
+        .withQueryText("paimon lake format")
+        .withQueryOperator("and")
+        .withLimit(10)
+        .withTextColumn("content")
+        .executeLocal();
+
+// Step 2: Read matching rows using the search result
+ReadBuilder readBuilder = table.newReadBuilder();
+TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
+try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+    reader.forEachRemaining(row -> {
+        System.out.println("id=" + row.getInt(0) + ", content=" + row.getString(1));
+    });
+}
+```
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+# Step 1: Build full-text search
+result = (
+    table.new_full_text_search_builder()
+    .with_text_column("content")
+    .with_query_text("paimon lake format")
+    .with_query_operator("and")
+    .with_limit(10)
+    .execute_local()
+)
+
+# Step 2: Read matching rows using the search result
+read_builder = table.new_read_builder()
+scan = read_builder.new_scan().with_global_index_result(result)
+plan = scan.plan()
+table_read = read_builder.new_read()
+pa_table = table_read.to_arrow(plan.splits())
+print(pa_table)
+```
+
+PyPaimon reads the Tantivy tokenizer settings stored in the global index metadata. Indexes built
+with `tantivy.tokenizer=ngram` can be queried from Python when the installed `tantivy-py` package
+provides custom tokenizer support. Indexes built with `tantivy.tokenizer=jieba` can be queried
+when the `jieba` package is installed.
+
+</TabItem>
+
+</Tabs>

--- a/docs/docs/multimodal-table/global-index/hybrid-search.mdx
+++ b/docs/docs/multimodal-table/global-index/hybrid-search.mdx
@@ -27,9 +27,11 @@ under the License.
 
 # Hybrid Search
 
-Hybrid search queries multiple vector and full-text routes in one request and ranks the scored
-results before reading table rows. This is useful when one table stores several searchable
-representations for the same record, such as title embeddings, body embeddings, and content text.
+Hybrid search queries multiple scored routes in one request and ranks the results before reading
+table rows. A route can be a vector search route or a full-text search route, so hybrid search can
+combine multiple vector indexes, multiple full-text indexes, or a mix of vector and full-text
+indexes. This is useful when one table stores several searchable representations for the same
+record, such as title embeddings, body embeddings, and content text.
 
 Before running hybrid search, create a global index for every vector or text column used by
 the query:

--- a/docs/docs/multimodal-table/global-index/hybrid-search.mdx
+++ b/docs/docs/multimodal-table/global-index/hybrid-search.mdx
@@ -1,0 +1,277 @@
+---
+title: "Hybrid Search"
+sidebar_position: 4
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Hybrid Search
+
+Hybrid search queries multiple vector and full-text routes in one request and ranks the scored
+results before reading table rows. This is useful when one table stores several searchable
+representations for the same record, such as title embeddings, body embeddings, and content text.
+
+Before running hybrid search, create a global index for every vector or text column used by
+the query:
+
+```sql
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'title_embedding',
+    index_type => 'ivf-pq',
+    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
+);
+
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'body_embedding',
+    index_type => 'ivf-pq',
+    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
+);
+
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'content',
+    index_type => 'tantivy-fulltext'
+);
+```
+
+For Spark SQL, use the `hybrid_search(table_name, vector_routes, full_text_routes, limit[, ranker])`
+table-valued function. The fourth argument is the final number of ranked results to return.
+The optional fifth argument selects the ranker. Supported rankers are `rrf` and
+`weighted_score`; the default is `rrf`.
+
+Rankers combine route scores differently:
+
+| Ranker | Best For | Description |
+|---|---|---|
+| `rrf` | Combining routes with different score scales | Reciprocal rank fusion uses each route's rank order, so vector and full-text scores do not need to be normalized. |
+| `weighted_score` | Combining routes with comparable score scales | Adds weighted scores from each route. Tune route weights carefully when score distributions differ. |
+
+The second argument is an array of vector route configs created by `named_struct`:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `field` or `vector_column` | Yes | N/A | Vector column to search. |
+| `query_vector` | Yes | N/A | Query vector for this route. |
+| `limit` | No | Final limit | Top K results to retrieve from this vector column before ranking. |
+| `weight` | No | `1.0` | Weight for this route when ranking results. |
+| `options` | No | Empty map | Route-specific vector search options such as `ivf.nprobe` and `hnsw.ef_search`. |
+
+The third argument is an array of full-text route configs created by `named_struct`:
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| `field` or `text_column` | Yes | N/A | Text column to search. |
+| `query_text` | Yes | N/A | Full-text query for this route. |
+| `query_operator` | No | `or` | Term operator. Supported values are `or` and `and`. |
+| `limit` | No | Final limit | Top K results to retrieve from this text column before ranking. |
+| `weight` | No | `1.0` | Weight for this route when ranking results. |
+| `options` | No | Empty map | Route-specific full-text search options. |
+
+Within each route array, every `named_struct` should use the same fields because
+Spark requires array elements to have the same struct type.
+
+Use route `limit` values larger than the final limit when each route should contribute enough
+candidates for ranking. For example, with a final limit of `10`, route limits such as `50` or `100`
+give the ranker more candidates to merge.
+
+<Tabs groupId="hybrid-search">
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+Vector and full-text routes can be searched together:
+
+```sql
+SELECT id, __paimon_search_score
+FROM hybrid_search(
+  'my_table',
+  array(
+    named_struct(
+      'field', 'title_embedding',
+      'query_vector', array(1.0f, 0.0f, 0.0f),
+      'limit', 50,
+      'weight', 2.0f,
+      'options', map('ivf.nprobe', '32'))),
+  array(
+    named_struct(
+      'field', 'content',
+      'query_text', 'paimon search',
+      'query_operator', 'or',
+      'limit', 50,
+      'weight', 1.0f,
+      'options', map())),
+  10,
+  'rrf');
+```
+
+To search two vector indexes without a full-text route, pass `array()` as the third argument:
+
+```sql
+SELECT id, __paimon_search_score
+FROM hybrid_search(
+  'my_table',
+  array(
+    named_struct(
+      'field', 'title_embedding',
+      'query_vector', array(1.0f, 0.0f, 0.0f),
+      'limit', 50,
+      'weight', 2.0f,
+      'options', map('ivf.nprobe', '32')),
+    named_struct(
+      'field', 'body_embedding',
+      'query_vector', array(0.0f, 1.0f, 0.0f),
+      'limit', 50,
+      'weight', 1.0f,
+      'options', map('ivf.nprobe', '32'))),
+  array(),
+  10,
+  'weighted_score');
+```
+
+Spark SQL adds `__paimon_search_score` to expose the ranked score.
+
+</TabItem>
+
+<TabItem value="java-api" label="Java API">
+
+```java
+Table table = catalog.getTable(identifier);
+
+HybridSearchBuilder searchBuilder =
+        table.newHybridSearchBuilder()
+                .addVectorRoute(
+                        "title_embedding",
+                        new float[] {1.0f, 0.0f, 0.0f},
+                        50,
+                        2.0f,
+                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                .addFullTextRoute(
+                        "content",
+                        "paimon search",
+                        "or",
+                        50,
+                        1.0f,
+                        java.util.Collections.emptyMap())
+                .withLimit(10)
+                .withRrfRanker();
+GlobalIndexResult result = searchBuilder.executeLocal();
+
+ReadBuilder readBuilder = table.newReadBuilder();
+TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
+try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+    reader.forEachRemaining(row -> {
+        System.out.println("id=" + row.getInt(0));
+    });
+}
+```
+
+To search two vector indexes without a full-text route, add two vector routes:
+
+```java
+GlobalIndexResult vectorOnlyResult =
+        table.newHybridSearchBuilder()
+                .addVectorRoute(
+                        "title_embedding",
+                        new float[] {1.0f, 0.0f, 0.0f},
+                        50,
+                        2.0f,
+                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                .addVectorRoute(
+                        "body_embedding",
+                        new float[] {0.0f, 1.0f, 0.0f},
+                        50,
+                        1.0f,
+                        java.util.Collections.singletonMap("ivf.nprobe", "32"))
+                .withLimit(10)
+                .withWeightedScoreRanker()
+                .executeLocal();
+```
+
+For Java, use `Table.newHybridSearchBuilder()` to configure routes, final limit, and ranker
+directly. `VectorSearch` and `HybridSearch` are internal pushdown representations.
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+result = (
+    table.new_hybrid_search_builder()
+    .add_vector_route(
+        "title_embedding",
+        [1.0, 0.0, 0.0],
+        limit=50,
+        weight=2.0,
+        options={"ivf.nprobe": "32"},
+    )
+    .add_full_text_route(
+        "content",
+        "paimon search",
+        limit=50,
+        weight=1.0,
+        query_operator="or",
+    )
+    .with_limit(10)
+    .with_rrf_ranker()
+    .execute_local()
+)
+
+read_builder = table.new_read_builder()
+scan = read_builder.new_scan().with_global_index_result(result)
+plan = scan.plan()
+table_read = read_builder.new_read()
+pa_table = table_read.to_arrow(plan.splits())
+print(pa_table)
+```
+
+To search two vector indexes without a full-text route, add two vector routes:
+
+```python
+result = (
+    table.new_hybrid_search_builder()
+    .add_vector_route(
+        "title_embedding",
+        [1.0, 0.0, 0.0],
+        limit=50,
+        weight=2.0,
+        options={"ivf.nprobe": "32"},
+    )
+    .add_vector_route(
+        "body_embedding",
+        [0.0, 1.0, 0.0],
+        limit=50,
+        weight=1.0,
+        options={"ivf.nprobe": "32"},
+    )
+    .with_limit(10)
+    .with_weighted_score_ranker()
+    .execute_local()
+)
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/docs/multimodal-table/global-index/vector.mdx
+++ b/docs/docs/multimodal-table/global-index/vector.mdx
@@ -1,0 +1,240 @@
+---
+title: "Vector Index"
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Vector Index
+
+Vector Index provides approximate nearest neighbor (ANN) search for vector similarity search scenarios such as
+recommendation systems, image retrieval, and RAG (Retrieval Augmented Generation) applications.
+
+Supported vector index types:
+
+| Index Type | Description |
+|---|---|
+| `ivf-flat` | IVF index with flat vector storage. |
+| `ivf-pq` | IVF index with product quantization. |
+| `ivf-hnsw-flat` | IVF index with HNSW flat quantizer. |
+| `ivf-hnsw-sq` | IVF index with HNSW scalar quantizer. |
+
+Choose the index type based on the trade-off you want:
+
+| Index Type | Best For |
+|---|---|
+| `ivf-flat` | Highest recall among IVF variants when storage and memory are acceptable. |
+| `ivf-pq` | Smaller index files and a balanced recall, latency, and storage trade-off. |
+| `ivf-hnsw-flat` | Better recall inside IVF partitions with raw vector storage. |
+| `ivf-hnsw-sq` | HNSW search quality with scalar quantization to reduce index size. |
+
+## Build Vector Index
+
+```sql
+-- Create IVF-PQ vector index on 'embedding' column
+CALL sys.create_global_index(
+    table => 'db.my_table',
+    index_column => 'embedding',
+    index_type => 'ivf-pq',
+    options => 'ivf-pq.distance.metric=cosine,ivf-pq.nlist=256,ivf-pq.pq.m=16'
+);
+```
+
+For `ARRAY<FLOAT>` vector columns, specify the vector dimension with `<index-type>.dimension`.
+For `VECTOR<FLOAT>` columns, Paimon uses the dimension from the column type.
+
+Supported vector index options:
+
+| Option | Default | Description |
+|---|---|---|
+| `<index-type>.dimension` | `128` | Vector dimension for `ARRAY<FLOAT>` columns. Ignored for `VECTOR<FLOAT>` columns. |
+| `<index-type>.distance.metric` | `inner_product` | Distance metric. Supported values: `l2`, `cosine`, `inner_product`. |
+| `<index-type>.nlist` | `256` | Number of IVF clusters used during index build. Higher values create more partitions and can improve recall for large datasets, but may increase build cost. |
+| `<index-type>.pq.m` | `16` | Number of PQ sub-vectors for `ivf-pq`. The vector dimension must be divisible by this value. Higher values usually improve recall with larger index files. |
+| `<index-type>.pq.use-opq` | `false` | Whether to enable OPQ for `ivf-pq`. |
+| `<index-type>.hnsw.m` | `20` | HNSW graph out-degree for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
+| `<index-type>.hnsw.ef-construction` | `150` | HNSW construction search width for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
+| `<index-type>.hnsw.max-level` | `7` | Maximum HNSW level for `ivf-hnsw-flat` and `ivf-hnsw-sq`. |
+
+## Per-Field Options
+
+The options above can also be set at the table level (in `TBLPROPERTIES`), where they are shared
+by every vector column of the same index type. When a table has multiple vector columns, you can
+scope an option to a single column with `fields.<field-name>.<option>`. The field-level
+form takes precedence over the column-agnostic `<index-type>.<option>` for that column. Use the
+stored table column name exactly as `<field-name>`. Field-level vector options do not include the
+index-type prefix; for example, use `fields.image_embedding.nlist` to override the shared
+`ivf-pq.nlist` option for `image_embedding`:
+
+```sql
+CREATE TABLE my_table (
+    id INT,
+    title_embedding ARRAY<FLOAT>,
+    image_embedding ARRAY<FLOAT>
+) TBLPROPERTIES (
+    'bucket' = '-1',
+    'row-tracking.enabled' = 'true',
+    'data-evolution.enabled' = 'true',
+    'global-index.enabled' = 'true',
+    -- per-column dimensions
+    'fields.title_embedding.dimension' = '768',
+    'fields.image_embedding.dimension' = '512',
+    -- shared by every ivf-pq column, overridden only for 'image_embedding'
+    'ivf-pq.nlist' = '256',
+    'fields.image_embedding.nlist' = '512'
+);
+```
+
+With the properties above, `title_embedding` is indexed with `nlist=256` while `image_embedding`
+uses `nlist=512`.
+
+## Vector Search
+
+Search-time options are passed with each vector search request:
+
+| Option | Default | Description |
+|---|---|---|
+| `ivf.nprobe` | `16` | Number of IVF clusters to probe during search. Higher values usually improve recall but increase latency. |
+| `hnsw.ef_search` | `0` | HNSW search width during search. Higher values usually improve recall but increase latency. `0` uses the native library default. |
+
+Use the same distance metric at build time and query time. Search options can be passed per query,
+so you can use a larger `ivf.nprobe` or `hnsw.ef_search` for higher recall queries and a smaller
+value for latency-sensitive queries.
+
+<Tabs groupId="vector-search">
+
+<TabItem value="spark-sql" label="Spark SQL">
+
+```sql
+-- Search for top-5 nearest neighbors
+SELECT * FROM vector_search('my_table', 'embedding', array(1.0f, 2.0f, 3.0f), 5);
+```
+
+</TabItem>
+
+<TabItem value="flink-sql-procedure" label="Flink SQL (Procedure)">
+
+Unlike Spark's table-valued function, Flink uses a `CALL` procedure to perform vector search.
+The procedure returns JSON-serialized rows as strings.
+
+```sql
+-- Search for top-5 nearest neighbors
+CALL sys.vector_search(
+    `table` => 'db.my_table',
+    vector_column => 'embedding',
+    query_vector => '1.0,2.0,3.0',
+    top_k => 5
+);
+
+-- With projection (only return specific columns)
+CALL sys.vector_search(
+    `table` => 'db.my_table',
+    vector_column => 'embedding',
+    query_vector => '1.0,2.0,3.0',
+    top_k => 5,
+    projection => 'id,name'
+);
+```
+
+</TabItem>
+
+<TabItem value="java-api" label="Java API">
+
+```java
+Table table = catalog.getTable(identifier);
+
+// Step 1: Build vector search
+float[] queryVector = {1.0f, 2.0f, 3.0f};
+GlobalIndexResult result = table.newVectorSearchBuilder()
+        .withVector(queryVector)
+        .withLimit(5)
+        .withVectorColumn("embedding")
+        .withOption("ivf.nprobe", "16")
+        .executeLocal();
+
+// Step 2: Read matching rows using the search result
+ReadBuilder readBuilder = table.newReadBuilder();
+TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
+try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+    reader.forEachRemaining(row -> {
+        System.out.println("id=" + row.getInt(0) + ", name=" + row.getString(1));
+    });
+}
+```
+
+For Java, use `Table.newVectorSearchBuilder()` to produce a global index result, then pass
+the result to `TableScan.withGlobalIndexResult`.
+
+</TabItem>
+
+<TabItem value="python-sdk" label="Python SDK">
+
+```python
+table = catalog.get_table("db.my_table")
+
+# Step 1: Build vector search
+result = (
+    table.new_vector_search_builder()
+    .with_vector_column("embedding")
+    .with_query_vector([1.0, 2.0, 3.0])
+    .with_limit(5)
+    .with_option("ivf.nprobe", "16")
+    .execute_local()
+)
+
+# Step 2: Read matching rows using the search result
+read_builder = table.new_read_builder()
+scan = read_builder.new_scan().with_global_index_result(result)
+plan = scan.plan()
+table_read = read_builder.new_read()
+pa_table = table_read.to_arrow(plan.splits())
+print(pa_table)
+```
+
+You can also add a scalar filter to pre-filter rows before vector search:
+
+```python
+from pypaimon.common.predicate_builder import PredicateBuilder
+
+predicate = (
+    PredicateBuilder(table.fields)
+    .equal("category", "electronics")
+)
+
+result = (
+    table.new_vector_search_builder()
+    .with_vector_column("embedding")
+    .with_query_vector([1.0, 2.0, 3.0])
+    .with_limit(5)
+    .with_filter(predicate)
+    .execute_local()
+)
+```
+
+The scalar filter is evaluated with matching scalar global indexes before vector search. Build a
+BTree index for frequently used metadata filters, such as `category`, `tenant_id`, or `event_time`,
+so vector search can restrict the candidate row ids before running ANN search.
+
+</TabItem>
+
+</Tabs>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -114,7 +114,21 @@ const sidebars = {
       "multimodal-table/data-evolution",
       "multimodal-table/blob",
       "multimodal-table/vector",
-      "multimodal-table/global-index"
+      {
+        type: "category",
+        "label": "Global Index",
+        "collapsed": true,
+        "link": {
+          type: "doc",
+          "id": "multimodal-table/global-index"
+        },
+        "items": [
+          "multimodal-table/global-index/btree",
+          "multimodal-table/global-index/vector",
+          "multimodal-table/global-index/full-text",
+          "multimodal-table/global-index/hybrid-search"
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
## Summary

Split the Global Index documentation into focused pages and expand it with indexing guidance inspired by common indexing-doc patterns: index selection, lifecycle, coverage, tuning, and troubleshooting.

## Changes

- Keep `/multimodal-table/global-index` as the overview page while moving detailed content into dedicated BTree, Vector, Full-Text, and Hybrid Search pages.
- Update the Multimodal Table sidebar so Global Index appears as a category with the new subpages.
- Add global index lifecycle docs for `create_global_index`, partition-scoped builds, `drop_global_index`, index coverage inspection, freshness semantics, and relevant table options.
- Add more guidance for BTree predicate support, vector index selection and tuning, full-text tokenizer/query-operator choices, and hybrid search rankers.

## Testing

- [x] `git diff --check`
- [x] `cd docs && yarn build`

## Notes

`yarn build` succeeds but still reports the existing site-wide broken footer/navbar link to `/docs/master/concepts/overview`; this warning is unrelated to this change.
