### PR TITLE
[iceberg] Pass table location when creating tables via the REST committer

### DIFF
--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -296,7 +296,12 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                         "Partition fieldId = 0. The Iceberg REST committer will use partition evolution to support Iceberg compatibility with the Paimon schema. If you want to avoid this, use a non-zero fieldId partition field");
             }
             Schema emptySchema = new Schema();
-            return restCatalog.createTable(icebergTableIdentifier, emptySchema);
+            // Some Iceberg REST catalogs (e.g. AWS Glue) do not auto-assign a table location,
+            // so pass the location Paimon writes its metadata to explicitly.
+            return restCatalog
+                    .buildTable(icebergTableIdentifier, emptySchema)
+                    .withLocation(toRestLocation(newMetadata.location()))
+                    .create();
         } else {
             LOG.info(
                     "Partition fieldId > 0. In order to avoid partition evlolution, dummy schema will be created first");
@@ -317,8 +322,34 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
             }
 
             Schema dummySchema = new Schema(columns);
-            return restCatalog.createTable(icebergTableIdentifier, dummySchema, spec);
+            return restCatalog
+                    .buildTable(icebergTableIdentifier, dummySchema)
+                    .withPartitionSpec(spec)
+                    .withLocation(toRestLocation(newMetadata.location()))
+                    .create();
         }
+    }
+
+    /**
+     * Normalizes a table location's scheme to {@code s3://} for the Iceberg REST catalog.
+     *
+     * <p>Paimon's warehouse runs on the {@code s3a://} (or legacy {@code s3n://}) Hadoop
+     * filesystem, but some REST catalogs (notably AWS Glue) validate the table location and only
+     * accept the {@code s3://} scheme. The schemes address the same physical object, so rewriting
+     * it is safe. Non-S3 schemes (e.g. {@code file://}, {@code hdfs://}) and {@code null} are
+     * returned unchanged.
+     */
+    static String toRestLocation(String location) {
+        if (location == null) {
+            return null;
+        }
+        if (location.startsWith("s3a://")) {
+            return "s3://" + location.substring("s3a://".length());
+        }
+        if (location.startsWith("s3n://")) {
+            return "s3://" + location.substring("s3n://".length());
+        }
+        return location;
     }
 
     private Table getTable() {

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -295,13 +295,7 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                 LOG.info(
                         "Partition fieldId = 0. The Iceberg REST committer will use partition evolution to support Iceberg compatibility with the Paimon schema. If you want to avoid this, use a non-zero fieldId partition field");
             }
-            Schema emptySchema = new Schema();
-            // Some Iceberg REST catalogs (e.g. AWS Glue) do not auto-assign a table location,
-            // so pass the location Paimon writes its metadata to explicitly.
-            return restCatalog
-                    .buildTable(icebergTableIdentifier, emptySchema)
-                    .withLocation(toRestLocation(newMetadata.location()))
-                    .create();
+            return createTable(new Schema(), null, newMetadata);
         } else {
             LOG.info(
                     "Partition fieldId > 0. In order to avoid partition evlolution, dummy schema will be created first");
@@ -321,24 +315,37 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
                 columns[f.sourceId() - 1] = newMetadata.schema().findField(f.sourceId());
             }
 
-            Schema dummySchema = new Schema(columns);
-            return restCatalog
-                    .buildTable(icebergTableIdentifier, dummySchema)
-                    .withPartitionSpec(spec)
-                    .withLocation(toRestLocation(newMetadata.location()))
-                    .create();
+            return createTable(new Schema(columns), spec, newMetadata);
         }
     }
 
-    /**
-     * Normalizes a table location's scheme to {@code s3://} for the Iceberg REST catalog.
-     *
-     * <p>Paimon's warehouse runs on the {@code s3a://} (or legacy {@code s3n://}) Hadoop
-     * filesystem, but some REST catalogs (notably AWS Glue) validate the table location and only
-     * accept the {@code s3://} scheme. The schemes address the same physical object, so rewriting
-     * it is safe. Non-S3 schemes (e.g. {@code file://}, {@code hdfs://}) and {@code null} are
-     * returned unchanged.
-     */
+    private Table createTable(
+            Schema schema, @Nullable PartitionSpec spec, TableMetadata newMetadata) {
+        try {
+            // Path-based catalogs (e.g. Hadoop) derive and assign the table location themselves
+            // and reject a custom one, so first try letting the catalog assign it.
+            return newTableBuilder(schema, spec).create();
+        } catch (RuntimeException e) {
+            // Some Iceberg REST catalogs (notably AWS Glue) do not auto-assign a table location
+            // and reject creation without one. Retry with the location Paimon writes its metadata
+            // to, normalised to the s3:// scheme such catalogs require.
+            try {
+                return newTableBuilder(schema, spec)
+                        .withLocation(toRestLocation(newMetadata.location()))
+                        .create();
+            } catch (RuntimeException retryError) {
+                e.addSuppressed(retryError);
+                throw e;
+            }
+        }
+    }
+
+    private Catalog.TableBuilder newTableBuilder(Schema schema, @Nullable PartitionSpec spec) {
+        Catalog.TableBuilder builder = restCatalog.buildTable(icebergTableIdentifier, schema);
+        return spec == null ? builder : builder.withPartitionSpec(spec);
+    }
+
+    /** Normalises a table location's URI scheme for the Iceberg REST catalog. */
     static String toRestLocation(String location) {
         if (location == null) {
             return null;

--- a/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
@@ -770,7 +770,7 @@ public class IcebergRestMetadataCommitterTest {
     }
 
     @Test
-    public void testToRestLocationNormalizesScheme() {
+    public void testToRestLocationNormalisesScheme() {
         // s3a:// and legacy s3n:// are rewritten to s3:// (Glue's REST endpoint only accepts
         // s3://).
         assertThat(IcebergRestMetadataCommitter.toRestLocation("s3a://bucket/db/t"))

--- a/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
+++ b/paimon-iceberg/src/test/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitterTest.java
@@ -769,6 +769,22 @@ public class IcebergRestMetadataCommitterTest {
         commit.close();
     }
 
+    @Test
+    public void testToRestLocationNormalizesScheme() {
+        // s3a:// and legacy s3n:// are rewritten to s3:// (Glue's REST endpoint only accepts
+        // s3://).
+        assertThat(IcebergRestMetadataCommitter.toRestLocation("s3a://bucket/db/t"))
+                .isEqualTo("s3://bucket/db/t");
+        assertThat(IcebergRestMetadataCommitter.toRestLocation("s3n://bucket/db/t"))
+                .isEqualTo("s3://bucket/db/t");
+        // s3:// and other schemes pass through unchanged; null is preserved.
+        assertThat(IcebergRestMetadataCommitter.toRestLocation("s3://bucket/db/t"))
+                .isEqualTo("s3://bucket/db/t");
+        assertThat(IcebergRestMetadataCommitter.toRestLocation("file:///tmp/db/t"))
+                .isEqualTo("file:///tmp/db/t");
+        assertThat(IcebergRestMetadataCommitter.toRestLocation(null)).isNull();
+    }
+
     private static class TestRecord {
         private final BinaryRow partition;
         private final GenericRow record;


### PR DESCRIPTION
### Purpose

`IcebergRestMetadataCommitter#createTable` creates tables without a location. Catalogs that auto-assign one tolerated this but AWS Glue's Iceberg REST endpoint does not, so creation failed. This PR passes the location Paimon already writes its metadata to normalised to s3:// (Glue rejects the s3a:// scheme Paimon's warehouse uses).
Issue: #8267

### Tests  
`IcebergRestMetadataCommitterTest#testToRestLocationNormalizesScheme;`

