### PR TITLE
[codegen] Fix wrong sort order for float and double columns with nan

### DIFF
--- a/paimon-codegen/src/main/scala/org/apache/paimon/codegen/GenerateUtils.scala
+++ b/paimon-codegen/src/main/scala/org/apache/paimon/codegen/GenerateUtils.scala
@@ -125,8 +125,12 @@ object GenerateUtils {
       val sortUtil =
         classOf[org.apache.paimon.utils.SortUtil].getCanonicalName
       s"$sortUtil.compareBinary($leftTerm, $rightTerm)"
-    case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | DATE | TIME_WITHOUT_TIME_ZONE =>
+    case TINYINT | SMALLINT | INTEGER | BIGINT | DATE | TIME_WITHOUT_TIME_ZONE =>
       s"($leftTerm > $rightTerm ? 1 : $leftTerm < $rightTerm ? -1 : 0)"
+    case FLOAT =>
+      s"java.lang.Float.compare($leftTerm, $rightTerm)"
+    case DOUBLE =>
+      s"java.lang.Double.compare($leftTerm, $rightTerm)"
     case ARRAY | VECTOR =>
       val elementType = t.getTypeRoot match {
         case ARRAY => t.asInstanceOf[ArrayType].getElementType

--- a/paimon-core/src/test/java/org/apache/paimon/codegen/CodeGenUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/codegen/CodeGenUtilsTest.java
@@ -25,7 +25,10 @@ import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static org.apache.paimon.codegen.CodeGenUtils.newNormalizedKeyComputer;
@@ -119,6 +122,65 @@ class CodeGenUtilsTest {
         assertThat(ascending.compare(row1, row2)).isLessThan(0);
         assertThat(descending.compare(row1, row2)).isGreaterThan(0);
         assertThat(ascending.getClass()).isNotEqualTo(descending.getClass());
+    }
+
+    @Test
+    public void testFloatingPointComparatorMatchesTotalOrder() {
+        RecordComparator doubleComparator =
+                newRecordComparator(Arrays.asList(DOUBLE()), new int[] {0});
+        double[] doubles = {
+            Double.NEGATIVE_INFINITY, -1.0d, -0.0d, 0.0d, 1.0d, Double.POSITIVE_INFINITY, Double.NaN
+        };
+        for (double a : doubles) {
+            for (double b : doubles) {
+                assertThat(sign(doubleComparator.compare(GenericRow.of(a), GenericRow.of(b))))
+                        .as("compare(%s, %s)", a, b)
+                        .isEqualTo(sign(Double.compare(a, b)));
+            }
+        }
+
+        RecordComparator floatComparator =
+                newRecordComparator(Arrays.asList(FLOAT()), new int[] {0});
+        float[] floats = {
+            Float.NEGATIVE_INFINITY, -1.0f, -0.0f, 0.0f, 1.0f, Float.POSITIVE_INFINITY, Float.NaN
+        };
+        for (float a : floats) {
+            for (float b : floats) {
+                assertThat(sign(floatComparator.compare(GenericRow.of(a), GenericRow.of(b))))
+                        .as("compare(%s, %s)", a, b)
+                        .isEqualTo(sign(Float.compare(a, b)));
+            }
+        }
+    }
+
+    private static int sign(int value) {
+        return Integer.compare(value, 0);
+    }
+
+    @Test
+    public void sortByDoubleColumnWithNaNProducesTotalOrder() {
+        RecordComparator scoreComparator =
+                newRecordComparator(Arrays.asList(DOUBLE()), new int[] {0});
+
+        List<InternalRow> batch = new ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            batch.add(GenericRow.of((double) ((i % 11) - 5)));
+            if (i % 4 == 0) {
+                batch.add(GenericRow.of(Double.NaN));
+            }
+        }
+        batch.add(GenericRow.of(Double.NEGATIVE_INFINITY));
+        batch.add(GenericRow.of(Double.POSITIVE_INFINITY));
+
+        Collections.sort(batch, scoreComparator);
+
+        for (int i = 1; i < batch.size(); i++) {
+            double prev = batch.get(i - 1).getDouble(0);
+            double cur = batch.get(i).getDouble(0);
+            assertThat(Double.compare(prev, cur))
+                    .as("position %d (%s) sorted after position %d (%s)", i - 1, prev, i, cur)
+                    .isLessThanOrEqualTo(0);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Purpose
- Float and double comparators reused the integer ternary, which is not correct since nan compares equal to everything and signed zero is treated as equal.
- This silently misorders any sort or clustering on a float or double column containing nan, and can cause buggy java sort.
- Switch the float and double cases to the jdk total order comparison.

### Tests
 - UT