### PR TITLE
[spark] Lazy partition pruning for engine format table

### DIFF
--- a/docs/generated/spark_connector_configuration.html
+++ b/docs/generated/spark_connector_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>format-table.engine.lazy-partition-pruning</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If true, engine format table defers file listing and prunes partition directories level-by-level using partition filters.</td>
+        </tr>
+        <tr>
             <td><h5>read.allow.fullScan</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, GeneratedColumn, IdentityC
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Identifier, StagingTableCatalog, Table, TableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.write.BatchWrite
-import org.apache.spark.sql.execution.{SparkFormatTable, SparkPlan}
+import org.apache.spark.sql.execution.{SparkFormatTableFileIndex, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{PartitioningAwareFileIndex, PartitionSpec}
 import org.apache.spark.sql.execution.datasources.v2.{AtomicReplaceTableAsSelectExec, AtomicReplaceTableExec, ReplaceTableAsSelectExec, ReplaceTableExec}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -355,7 +355,7 @@ object Spark4Shim {
     extends MetadataLogFileIndex(sparkSession, path, parameters, userSpecifiedSchema) {
 
     override def partitionSpec(): PartitionSpec = {
-      SparkFormatTable.alignPartitionSpec(super.partitionSpec(), partitionSchema)
+      SparkFormatTableFileIndex.alignPartitionSpec(super.partitionSpec(), partitionSchema)
     }
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -106,6 +106,14 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "Whether to read row in the form of changelog (add rowkind column in row to represent its change type).");
 
+    public static final ConfigOption<Boolean> FORMAT_TABLE_LAZY_PARTITION_PRUNING =
+            key("format-table.engine.lazy-partition-pruning")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "If true, engine format table defers file listing and prunes partition "
+                                    + "directories level-by-level using partition filters.");
+
     public static final ConfigOption<Boolean> READ_ALLOW_FULL_SCAN =
             key("read.allow.fullScan")
                     .booleanType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -126,6 +126,10 @@ object OptionUtils extends SQLConfHelper with Logging {
     getOptionString(SparkConnectorOptions.READ_ALLOW_FULL_SCAN).toBoolean
   }
 
+  def readFormatTableLazyPartitionPruning(): Boolean = {
+    getOptionString(SparkConnectorOptions.FORMAT_TABLE_LAZY_PARTITION_PRUNING).toBoolean
+  }
+
   def sourceSplitTargetSizeWithColumnPruning(): Boolean = {
     getOptionString(SparkConnectorOptions.SOURCE_SPLIT_TARGET_SIZE_WITH_COLUMN_PRUNING).toBoolean
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTable.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.execution
 
 import org.apache.paimon.utils.StringUtils
 
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Literal}
@@ -30,108 +29,19 @@ import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.expressions.{Expressions, Transform}
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsOverwriteV2, Write, WriteBuilder}
-import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
 import org.apache.spark.sql.execution.datasources.v2.csv.{CSVScanBuilder, CSVTable}
 import org.apache.spark.sql.execution.datasources.v2.json.JsonTable
 import org.apache.spark.sql.execution.datasources.v2.orc.OrcTable
 import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetTable
 import org.apache.spark.sql.execution.datasources.v2.text.{TextScanBuilder, TextTable}
-import org.apache.spark.sql.paimon.shims.SparkShimLoader
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import java.util
 
 import scala.collection.JavaConverters._
-
-/** Format Table implementation with spark. */
-object SparkFormatTable {
-
-  // Copy from spark and override FileIndex's partitionSchema
-  def createFileIndex(
-      options: CaseInsensitiveStringMap,
-      sparkSession: SparkSession,
-      paths: Seq[String],
-      userSpecifiedSchema: Option[StructType],
-      partitionSchema: StructType): PartitioningAwareFileIndex = {
-
-    def globPaths: Boolean = {
-      val entry = options.get(DataSource.GLOB_PATHS_KEY)
-      Option(entry).forall(_ == "true")
-    }
-
-    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
-    // Hadoop Configurations are case-sensitive.
-    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
-    if (
-      SparkShimLoader.shim.hasFileStreamSinkMetadata(
-        paths,
-        hadoopConf,
-        sparkSession.sessionState.conf)
-    ) {
-      // We are reading from the results of a streaming query. We will load files from
-      // the metadata log instead of listing them using HDFS APIs.
-      SparkShimLoader.shim.createPartitionedMetadataLogFileIndex(
-        sparkSession,
-        new Path(paths.head),
-        options.asScala.toMap,
-        userSpecifiedSchema,
-        partitionSchema = partitionSchema)
-    } else {
-      // This is a non-streaming file based datasource.
-      val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(
-        paths,
-        hadoopConf,
-        checkEmptyGlobPath = true,
-        checkFilesExist = true,
-        enableGlobbing = globPaths)
-      val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
-
-      new PartitionedInMemoryFileIndex(
-        sparkSession,
-        rootPathsSpecified,
-        caseSensitiveMap,
-        userSpecifiedSchema,
-        fileStatusCache,
-        partitionSchema = partitionSchema)
-    }
-  }
-
-  // Visible to shim-local PartitionedMetadataLogFileIndex subclasses.
-  private[sql] def alignPartitionSpec(
-      inferred: PartitionSpec,
-      partitionSchema: StructType): PartitionSpec = {
-    if (inferred.partitionColumns.isEmpty && partitionSchema.nonEmpty) {
-      PartitionSpec(partitionSchema, inferred.partitions)
-    } else {
-      inferred
-    }
-  }
-
-  // Extend from InMemoryFileIndex to override partitionSchema
-  private class PartitionedInMemoryFileIndex(
-      sparkSession: SparkSession,
-      rootPathsSpecified: Seq[Path],
-      parameters: Map[String, String],
-      userSpecifiedSchema: Option[StructType],
-      fileStatusCache: FileStatusCache = NoopCache,
-      userSpecifiedPartitionSpec: Option[PartitionSpec] = None,
-      metadataOpsTimeNs: Option[Long] = None,
-      override val partitionSchema: StructType)
-    extends InMemoryFileIndex(
-      sparkSession,
-      rootPathsSpecified,
-      parameters,
-      userSpecifiedSchema,
-      fileStatusCache,
-      userSpecifiedPartitionSpec,
-      metadataOpsTimeNs) {
-
-    override def partitionSpec(): PartitionSpec = {
-      alignPartitionSpec(super.partitionSpec(), partitionSchema)
-    }
-  }
-}
 
 trait PartitionedFormatTable extends SupportsPartitionManagement {
 
@@ -216,7 +126,7 @@ class PartitionedCSVTable(
   }
 
   override lazy val fileIndex: PartitioningAwareFileIndex = {
-    SparkFormatTable.createFileIndex(
+    SparkFormatTableFileIndex.createFileIndex(
       options,
       sparkSession,
       paths,
@@ -252,7 +162,7 @@ class PartitionedTextTable(
   }
 
   override lazy val fileIndex: PartitioningAwareFileIndex = {
-    SparkFormatTable.createFileIndex(
+    SparkFormatTableFileIndex.createFileIndex(
       options,
       sparkSession,
       paths,
@@ -277,7 +187,7 @@ class PartitionedOrcTable(
   }
 
   override lazy val fileIndex: PartitioningAwareFileIndex = {
-    SparkFormatTable.createFileIndex(
+    SparkFormatTableFileIndex.createFileIndex(
       options,
       sparkSession,
       paths,
@@ -302,7 +212,7 @@ class PartitionedParquetTable(
   }
 
   override lazy val fileIndex: PartitioningAwareFileIndex = {
-    SparkFormatTable.createFileIndex(
+    SparkFormatTableFileIndex.createFileIndex(
       options,
       sparkSession,
       paths,
@@ -327,7 +237,7 @@ class PartitionedJsonTable(
   }
 
   override lazy val fileIndex: PartitioningAwareFileIndex = {
-    SparkFormatTable.createFileIndex(
+    SparkFormatTableFileIndex.createFileIndex(
       options,
       sparkSession,
       paths,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
@@ -154,15 +154,28 @@ class LazyPartitionPruningFileIndex(
 
   override def hashCode(): Int = rootPaths.toSet.hashCode()
 
-  override def refresh(): Unit = fileStatusCache.invalidateAll()
+  @volatile private var _fullIndex: InMemoryFileIndex = _
 
-  private lazy val fullIndex: InMemoryFileIndex =
-    new InMemoryFileIndex(
-      sparkSession,
-      tableLocations,
-      parameters,
-      userSpecifiedSchema,
-      fileStatusCache)
+  private def fullIndex: InMemoryFileIndex = {
+    if (_fullIndex == null) {
+      synchronized {
+        if (_fullIndex == null) {
+          _fullIndex = new InMemoryFileIndex(
+            sparkSession,
+            tableLocations,
+            parameters,
+            userSpecifiedSchema,
+            fileStatusCache)
+        }
+      }
+    }
+    _fullIndex
+  }
+
+  override def refresh(): Unit = {
+    fileStatusCache.invalidateAll()
+    synchronized { _fullIndex = null }
+  }
 
   // Required by PartitioningAwareFileIndex but never accessed — all callers are overridden.
   override protected def leafFiles: mutable.LinkedHashMap[Path, FileStatus] =
@@ -173,7 +186,7 @@ class LazyPartitionPruningFileIndex(
   override def partitionSpec(): PartitionSpec =
     PartitionSpec(_partitionSchema, Seq.empty)
 
-  override lazy val sizeInBytes: Long = fullIndex.sizeInBytes
+  override def sizeInBytes: Long = fullIndex.sizeInBytes
 
   override def inputFiles: Array[String] = fullIndex.inputFiles
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
@@ -203,7 +203,7 @@ class LazyPartitionPruningFileIndex(
   override def listFiles(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
-    if (_partitionSchema.isEmpty || partitionFilters.isEmpty) {
+    if (_partitionSchema.isEmpty || partitionFilters.isEmpty || _fullIndex != null) {
       return fullIndex.listFiles(partitionFilters, dataFilters)
     }
     if (recursiveFileLookup) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.spark.catalyst.Compatibility
+import org.apache.paimon.spark.util.OptionUtils
+
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BoundReference, Expression, InterpretedPredicate, Literal, Predicate => ExprPredicate}
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.paimon.shims.SparkShimLoader
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/** Factory for creating partition-aware file indexes for format tables. */
+object SparkFormatTableFileIndex {
+
+  def createFileIndex(
+      options: CaseInsensitiveStringMap,
+      sparkSession: SparkSession,
+      paths: Seq[String],
+      userSpecifiedSchema: Option[StructType],
+      partitionSchema: StructType): PartitioningAwareFileIndex = {
+
+    def globPaths: Boolean = {
+      val entry = options.get(DataSource.GLOB_PATHS_KEY)
+      Option(entry).forall(_ == "true")
+    }
+
+    val caseSensitiveMap = options.asCaseSensitiveMap.asScala.toMap
+    val hadoopConf = sparkSession.sessionState.newHadoopConfWithOptions(caseSensitiveMap)
+    if (
+      SparkShimLoader.shim.hasFileStreamSinkMetadata(
+        paths,
+        hadoopConf,
+        sparkSession.sessionState.conf)
+    ) {
+      SparkShimLoader.shim.createPartitionedMetadataLogFileIndex(
+        sparkSession,
+        new Path(paths.head),
+        options.asScala.toMap,
+        userSpecifiedSchema,
+        partitionSchema = partitionSchema)
+    } else {
+      val rootPathsSpecified = DataSource.checkAndGlobPathIfNecessary(
+        paths,
+        hadoopConf,
+        checkEmptyGlobPath = true,
+        checkFilesExist = true,
+        enableGlobbing = globPaths)
+      val fileStatusCache = FileStatusCache.getOrCreate(sparkSession)
+
+      val lazyPruning =
+        partitionSchema.nonEmpty && OptionUtils.readFormatTableLazyPartitionPruning()
+
+      if (lazyPruning) {
+        new LazyPartitionPruningFileIndex(
+          sparkSession,
+          rootPathsSpecified,
+          caseSensitiveMap,
+          userSpecifiedSchema,
+          fileStatusCache,
+          partitionSchema)
+      } else {
+        new EagerPartitionListingFileIndex(
+          sparkSession,
+          rootPathsSpecified,
+          caseSensitiveMap,
+          userSpecifiedSchema,
+          fileStatusCache,
+          partitionSchema)
+      }
+    }
+  }
+
+  // Visible to shim-local PartitionedMetadataLogFileIndex subclasses.
+  private[sql] def alignPartitionSpec(
+      inferred: PartitionSpec,
+      partitionSchema: StructType): PartitionSpec = {
+    if (inferred.partitionColumns.isEmpty && partitionSchema.nonEmpty) {
+      PartitionSpec(partitionSchema, inferred.partitions)
+    } else {
+      inferred
+    }
+  }
+}
+
+/** Eagerly lists all files at construction time, like the default [[InMemoryFileIndex]]. */
+class EagerPartitionListingFileIndex(
+    sparkSession: SparkSession,
+    rootPathsSpecified: Seq[Path],
+    parameters: Map[String, String],
+    userSpecifiedSchema: Option[StructType],
+    fileStatusCache: FileStatusCache,
+    override val partitionSchema: StructType)
+  extends InMemoryFileIndex(
+    sparkSession,
+    rootPathsSpecified,
+    parameters,
+    userSpecifiedSchema,
+    fileStatusCache) {
+
+  override def partitionSpec(): PartitionSpec =
+    SparkFormatTableFileIndex.alignPartitionSpec(super.partitionSpec(), partitionSchema)
+}
+
+/**
+ * A [[PartitioningAwareFileIndex]] that prunes partition directories level-by-level using partition
+ * filters, similar to [[CatalogFileIndex]] but discovers partitions from the filesystem instead of
+ * the metastore.
+ */
+class LazyPartitionPruningFileIndex(
+    sparkSession: SparkSession,
+    tableLocations: Seq[Path],
+    parameters: Map[String, String],
+    userSpecifiedSchema: Option[StructType],
+    fileStatusCache: FileStatusCache,
+    _partitionSchema: StructType)
+  extends PartitioningAwareFileIndex(sparkSession, parameters, userSpecifiedSchema, fileStatusCache)
+  with Logging {
+
+  override val rootPaths: Seq[Path] = tableLocations
+
+  override def partitionSchema: StructType = _partitionSchema
+
+  override def equals(other: Any): Boolean = other match {
+    case o: LazyPartitionPruningFileIndex => rootPaths.toSet == o.rootPaths.toSet
+    case _ => false
+  }
+
+  override def hashCode(): Int = rootPaths.toSet.hashCode()
+
+  override def refresh(): Unit = fileStatusCache.invalidateAll()
+
+  private lazy val fullIndex: InMemoryFileIndex =
+    new InMemoryFileIndex(
+      sparkSession,
+      tableLocations,
+      parameters,
+      userSpecifiedSchema,
+      fileStatusCache)
+
+  // Required by PartitioningAwareFileIndex but never accessed — all callers are overridden.
+  override protected def leafFiles: mutable.LinkedHashMap[Path, FileStatus] =
+    throw new IllegalStateException()
+  override protected def leafDirToChildrenFiles: Map[Path, Array[FileStatus]] =
+    throw new IllegalStateException()
+
+  override def partitionSpec(): PartitionSpec =
+    PartitionSpec(_partitionSchema, Seq.empty)
+
+  override lazy val sizeInBytes: Long = fullIndex.sizeInBytes
+
+  override def inputFiles: Array[String] = fullIndex.inputFiles
+
+  private def isDataPath(name: String): Boolean =
+    !((name.startsWith("_") && !name.contains("=")) || name.startsWith("."))
+
+  private lazy val defaultPartNames: Set[String] = Set(
+    ExternalCatalogUtils.DEFAULT_PARTITION_NAME,
+    parameters.getOrElse(
+      CoreOptions.PARTITION_DEFAULT_NAME.key(),
+      CoreOptions.PARTITION_DEFAULT_NAME.defaultValue())
+  )
+
+  override def listFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    if (_partitionSchema.isEmpty || partitionFilters.isEmpty) {
+      return fullIndex.listFiles(partitionFilters, dataFilters)
+    }
+    if (recursiveFileLookup) {
+      throw new IllegalArgumentException(
+        "Datasource with partition do not allow recursive file loading.")
+    }
+
+    val fields = _partitionSchema.fields.toSeq
+    val perColumnFilters = splitFiltersByColumn(partitionFilters, fields)
+    val levelPredicates =
+      fields.map(f => perColumnFilters.get(f.name).map(ExprPredicate.createInterpreted))
+    val tz = Some(sparkSession.sessionState.conf.sessionLocalTimeZone)
+    val resolver = sparkSession.sessionState.conf.resolver
+
+    val discovered = tableLocations.flatMap {
+      root => discoverPartitions(root, 0, fields, levelPredicates, tz, resolver, Seq.empty)
+    }
+
+    logInfo(s"Discovered ${discovered.size} partitions by level-by-level pruning.")
+
+    if (discovered.isEmpty) {
+      return Seq.empty
+    }
+
+    val partitionPaths = discovered.map {
+      case (values, path) => PartitionPath(InternalRow.fromSeq(values), path)
+    }
+    val prunedIndex = new InMemoryFileIndex(
+      sparkSession,
+      rootPathsSpecified = partitionPaths.map(_.path),
+      parameters = parameters,
+      userSpecifiedSchema = Some(_partitionSchema),
+      fileStatusCache = fileStatusCache,
+      userSpecifiedPartitionSpec = Some(PartitionSpec(_partitionSchema, partitionPaths))
+    )
+
+    prunedIndex.listFiles(partitionFilters, dataFilters)
+  }
+
+  private def splitFiltersByColumn(
+      filters: Seq[Expression],
+      fields: Seq[StructField]): Map[String, Expression] = {
+    val resolver = sparkSession.sessionState.conf.resolver
+    val partitionNames = fields.map(_.name).toSet
+    val grouped = mutable.Map.empty[String, Seq[Expression]]
+
+    for (filter <- filters) {
+      val refs = filter.references.map(_.name).toSet
+      if (refs.size == 1) {
+        val refName = refs.head
+        val matchedCol = partitionNames.find(n => resolver(n, refName))
+        matchedCol.foreach { col => grouped(col) = grouped.getOrElse(col, Seq.empty) :+ filter }
+      }
+    }
+
+    grouped.map {
+      case (col, exprs) =>
+        val field = fields.find(f => resolver(f.name, col)).get
+        val combined = exprs.reduce(And)
+        val bound = combined.transform {
+          case a: AttributeReference if resolver(a.name, col) =>
+            BoundReference(0, field.dataType, nullable = true)
+        }
+        col -> bound
+    }.toMap
+  }
+
+  private def discoverPartitions(
+      currentPath: Path,
+      level: Int,
+      fields: Seq[StructField],
+      levelPredicates: Seq[Option[InterpretedPredicate]],
+      tz: Option[String],
+      resolver: (String, String) => Boolean,
+      accumulatedValues: Seq[Any]): Seq[(Seq[Any], Path)] = {
+
+    if (level == fields.length) {
+      return Seq((accumulatedValues, currentPath))
+    }
+
+    val field = fields(level)
+    val fs = currentPath.getFileSystem(hadoopConf)
+
+    val subdirs =
+      try {
+        fs.listStatus(currentPath).filter(s => s.isDirectory && isDataPath(s.getPath.getName))
+      } catch {
+        case _: java.io.FileNotFoundException => return Seq.empty
+      }
+
+    val predicate = levelPredicates(level)
+
+    subdirs.toSeq.flatMap {
+      subdir =>
+        val dirName = subdir.getPath.getName
+        val eqIdx = dirName.indexOf('=')
+        if (eqIdx < 0) {
+          Seq.empty
+        } else {
+          val colName = ExternalCatalogUtils.unescapePathName(dirName.substring(0, eqIdx))
+          if (!resolver(colName, field.name)) {
+            Seq.empty
+          } else {
+            val rawValue = ExternalCatalogUtils.unescapePathName(dirName.substring(eqIdx + 1))
+            val typedValue =
+              if (defaultPartNames.contains(rawValue)) {
+                null
+              } else {
+                Compatibility
+                  .cast(Literal.create(rawValue, StringType), field.dataType, tz)
+                  .eval(null)
+              }
+
+            if (predicate.forall(_.eval(InternalRow(typedValue)))) {
+              discoverPartitions(
+                subdir.getPath,
+                level + 1,
+                fields,
+                levelPredicates,
+                tz,
+                resolver,
+                accumulatedValues :+ typedValue)
+            } else {
+              Seq.empty
+            }
+          }
+        }
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/spark/sql/execution/SparkFormatTableFileIndex.scala
@@ -156,6 +156,11 @@ class LazyPartitionPruningFileIndex(
 
   @volatile private var _fullIndex: InMemoryFileIndex = _
 
+  @volatile private var _estimatedSizeInBytes: Long = -1L
+
+  // Leaf partitions sampled to estimate the average partition size.
+  private val SAMPLE_PARTITIONS = 3
+
   private def fullIndex: InMemoryFileIndex = {
     if (_fullIndex == null) {
       synchronized {
@@ -174,7 +179,10 @@ class LazyPartitionPruningFileIndex(
 
   override def refresh(): Unit = {
     fileStatusCache.invalidateAll()
-    synchronized { _fullIndex = null }
+    synchronized {
+      _fullIndex = null
+      _estimatedSizeInBytes = -1L
+    }
   }
 
   // Required by PartitioningAwareFileIndex but never accessed — all callers are overridden.
@@ -186,7 +194,79 @@ class LazyPartitionPruningFileIndex(
   override def partitionSpec(): PartitionSpec =
     PartitionSpec(_partitionSchema, Seq.empty)
 
-  override def sizeInBytes: Long = fullIndex.sizeInBytes
+  // Used only by the optimizer for broadcast decisions; a full listing would defeat lazy pruning,
+  // so estimate cheaply (idempotent, cached) until the full index exists, then report its exact size.
+  override def sizeInBytes: Long = {
+    val idx = _fullIndex
+    if (idx != null) {
+      idx.sizeInBytes
+    } else {
+      if (_estimatedSizeInBytes < 0) {
+        _estimatedSizeInBytes = estimateSizeBySampling()
+      }
+      _estimatedSizeInBytes
+    }
+  }
+
+  /**
+   * Cheap whole-table size estimate without a full listing: partition count from per-level fan-outs
+   * along one path, times the average size of up to [[SAMPLE_PARTITIONS]] sampled leaf partitions.
+   * Falls back to `defaultSizeInBytes` (not broadcast) on empty table / empty sample / overflow, so
+   * we never underestimate and wrongly broadcast a large table. Reads via `fs.listStatus`, so it
+   * never touches `HiveCatalogMetrics`.
+   */
+  private def estimateSizeBySampling(): Long = {
+    val unknownSize = sparkSession.sessionState.conf.defaultSizeInBytes
+    val levels = _partitionSchema.fields.length
+
+    var path = tableLocations.head
+    var partitionCount = 1L
+    var leafSiblings: Array[FileStatus] = Array.empty
+    var level = 0
+    while (level < levels) {
+      val fs = path.getFileSystem(hadoopConf)
+      val subdirs =
+        try {
+          fs.listStatus(path)
+            .filter(s => s.isDirectory && isDataPath(s.getPath.getName))
+            .filter(_.getPath.getName.contains("="))
+        } catch {
+          case _: java.io.FileNotFoundException => Array.empty[FileStatus]
+        }
+      if (subdirs.isEmpty) {
+        return unknownSize
+      }
+      partitionCount *= subdirs.length
+      leafSiblings = subdirs
+      path = subdirs.head.getPath
+      level += 1
+    }
+
+    // leafSiblings are the leaf partition dirs under the last visited parent.
+    val samples = leafSiblings.take(SAMPLE_PARTITIONS)
+    if (samples.isEmpty) {
+      return unknownSize
+    }
+    val sampledSizes = samples.map {
+      leaf =>
+        val fs = leaf.getPath.getFileSystem(hadoopConf)
+        try {
+          fs.listStatus(leaf.getPath).filter(_.isFile).map(_.getLen).sum
+        } catch {
+          case _: java.io.FileNotFoundException => 0L
+        }
+    }
+    val avgPartitionSize = sampledSizes.sum / sampledSizes.length
+    if (avgPartitionSize <= 0) {
+      return unknownSize
+    }
+
+    try {
+      Math.multiplyExact(avgPartitionSize, partitionCount)
+    } catch {
+      case _: ArithmeticException => unknownSize
+    }
+  }
 
   override def inputFiles: Array[String] = fullIndex.inputFiles
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 
 abstract class FormatTableTestBase extends PaimonHiveTestBase with AdaptiveSparkPlanHelper {
 
@@ -498,12 +499,6 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase with AdaptiveSpark
         withSparkSQLConf(
           "spark.paimon.format-table.engine.lazy-partition-pruning" -> lazyPruning.toString) {
 
-          def filesDiscoveredFor(query: String): Long = {
-            HiveCatalogMetrics.reset()
-            sql(query).collect()
-            HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount
-          }
-
           assert(filesDiscoveredFor("SELECT * FROM t") == totalPartitions)
 
           if (lazyPruning) {
@@ -638,6 +633,111 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase with AdaptiveSpark
 
       // full scan after overwrite
       checkAnswer(sql("SELECT id, pt FROM t ORDER BY id"), Row(3, 2) :: Row(10, 1) :: Nil)
+    }
+  }
+
+  private def filesDiscoveredFor(query: String): Long = {
+    HiveCatalogMetrics.reset()
+    sql(query).collect()
+    HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount
+  }
+
+  private def withMultiLevelFormatTable(p1Count: Int, p2Count: Int)(f: => Unit): Unit = {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, value STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (p1 INT, p2 INT)
+             |""".stripMargin)
+      sql(s"""INSERT INTO t
+             |SELECT p1, 'v', p1, p2
+             |FROM (SELECT id AS p1 FROM range(1, ${p1Count + 1}))
+             |CROSS JOIN (SELECT id AS p2 FROM range(1, ${p2Count + 1}))
+             |""".stripMargin)
+      f
+    }
+  }
+
+  test("Format table: lazy stats keeps partition pruning for filtered broadcast join") {
+    val (p1Count, p2Count) = (6, 5)
+    withMultiLevelFormatTable(p1Count, p2Count) {
+      // A tiny dimension joined on the partition column. Backed by VALUES so it never adds to the
+      // file-discovery metric; it forces planning to estimate `t`'s stats (fileIndex.sizeInBytes).
+      sql("CREATE OR REPLACE TEMP VIEW dim AS SELECT * FROM VALUES (1), (2) AS dim(p1)")
+
+      withSparkSQLConf("spark.paimon.format-table.engine.lazy-partition-pruning" -> "true") {
+        // Planning-time size estimate must not list every partition: only pruned ones are discovered.
+        assert(
+          filesDiscoveredFor(
+            "SELECT t.* FROM t JOIN dim ON t.p1 = dim.p1 WHERE t.p1 = 1") == p2Count)
+        assert(
+          filesDiscoveredFor(
+            "SELECT t.* FROM t JOIN dim ON t.p1 = dim.p1 WHERE t.p1 = 1 AND t.p2 = 1") == 1)
+      }
+
+      withSparkSQLConf("spark.paimon.format-table.engine.lazy-partition-pruning" -> "false") {
+        // Eager listing materializes the whole table regardless of the partition filter.
+        assert(
+          filesDiscoveredFor("SELECT t.* FROM t JOIN dim ON t.p1 = dim.p1 WHERE t.p1 = 1")
+            == p1Count * p2Count)
+      }
+    }
+  }
+
+  test("Format table: lazy stats serves an unfiltered broadcast join from the full index") {
+    val (p1Count, p2Count) = (6, 5)
+    withMultiLevelFormatTable(p1Count, p2Count) {
+      sql("CREATE OR REPLACE TEMP VIEW dim AS SELECT * FROM VALUES (1), (2) AS dim(p1)")
+      withSparkSQLConf("spark.paimon.format-table.engine.lazy-partition-pruning" -> "true") {
+        // No partition filter: the full index is materialized once and lists every partition.
+        val df = sql("SELECT t.* FROM t JOIN dim ON t.p1 = dim.p1")
+        assert(
+          filesDiscoveredFor("SELECT t.* FROM t JOIN dim ON t.p1 = dim.p1") == p1Count * p2Count)
+        assert(df.collect().length == 2 * p2Count)
+      }
+    }
+  }
+
+  test("Format table: small partitioned table is broadcast via estimated size") {
+    withTable("s") {
+      sql(s"""
+             |CREATE TABLE s (v STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (p1 INT)
+             |""".stripMargin)
+      // Two tiny partitions: the sampled-size estimate is far below the threshold below.
+      sql("INSERT INTO s VALUES ('a', 1), ('b', 2)")
+
+      withSparkSQLConf(
+        "spark.paimon.format-table.engine.lazy-partition-pruning" -> "true",
+        "spark.sql.adaptive.enabled" -> "false",
+        // 10KB: comfortably fits the tiny `s` but not the 100k-row range below.
+        "spark.sql.autoBroadcastJoinThreshold" -> "10240"
+      ) {
+        // `s` can only be the broadcast side here, so a BroadcastExchange proves its estimated size
+        // is small. With the old default (Long.MaxValue) `s` would plan as a SortMergeJoin instead.
+        val df = sql("SELECT s.v FROM s JOIN range(100000) r ON s.p1 = r.id")
+        val plan = df.queryExecution.executedPlan
+        assert(
+          collect(plan) { case b: BroadcastExchangeExec => b }.nonEmpty,
+          s"small partitioned table should be broadcast, plan:\n$plan")
+        assert(df.collect().map(_.getString(0)).sorted.toSeq == Seq("a", "b"))
+      }
+    }
+  }
+
+  test("Format table: empty engine table join does not fail or wrongly broadcast") {
+    withTable("e") {
+      sql(s"""
+             |CREATE TABLE e (v STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (p1 INT)
+             |""".stripMargin)
+      // No data => no partition directories: the estimate must fall back to the conservative default
+      // size instead of estimating 0 (which would wrongly mark the table broadcastable).
+      withSparkSQLConf("spark.paimon.format-table.engine.lazy-partition-pruning" -> "true") {
+        assert(sql("SELECT e.v FROM e JOIN range(10) r ON e.p1 = r.id").collect().isEmpty)
+      }
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FormatTableTestBase.scala
@@ -27,6 +27,7 @@ import org.apache.paimon.table.FormatTable
 import org.apache.paimon.table.source.Split
 import org.apache.paimon.utils.CompressUtils
 
+import org.apache.spark.metrics.source.HiveCatalogMetrics
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.SparkPlan
@@ -426,6 +427,217 @@ abstract class FormatTableTestBase extends PaimonHiveTestBase with AdaptiveSpark
 
       val filteredSplits = collectFilteredInputSplits(df.queryExecution.executedPlan, "fact_table")
       assert(filteredSplits.size == 2)
+    }
+  }
+
+  test("Format table: engine static partition overwrite") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (age INT, name STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (id INT)
+             |""".stripMargin)
+
+      sql("INSERT INTO t PARTITION (id = 1) VALUES (5, 'Ben'), (7, 'Larry')")
+      sql("INSERT INTO t PARTITION (id = 2) VALUES (10, 'Alice')")
+
+      checkAnswer(
+        sql("SELECT id, age, name FROM t ORDER BY id, age"),
+        Row(1, 5, "Ben") :: Row(1, 7, "Larry") :: Row(2, 10, "Alice") :: Nil)
+
+      sql("INSERT OVERWRITE t PARTITION (id = 1) VALUES (5, 'Jerry'), (7, 'Tom')")
+
+      checkAnswer(
+        sql("SELECT id, age, name FROM t ORDER BY id, age"),
+        Row(1, 5, "Jerry") :: Row(1, 7, "Tom") :: Row(2, 10, "Alice") :: Nil)
+    }
+  }
+
+  test("Format table: engine dynamic partition overwrite") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (age INT, name STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (id INT)
+             |""".stripMargin)
+
+      sql("INSERT INTO t PARTITION (id = 1) VALUES (5, 'Ben'), (7, 'Larry')")
+      sql("INSERT INTO t PARTITION (id = 2) VALUES (10, 'Alice')")
+      sql("INSERT INTO t PARTITION (id = 3) VALUES (20, 'Bob')")
+
+      withSparkSQLConf("spark.sql.sources.partitionOverwriteMode" -> "dynamic") {
+        sql("INSERT OVERWRITE t VALUES (5, 'Jerry', 1), (7, 'Tom', 2)")
+      }
+
+      checkAnswer(
+        sql("SELECT id, age, name FROM t ORDER BY id, age"),
+        Row(1, 5, "Jerry") :: Row(2, 7, "Tom") :: Row(3, 20, "Bob") :: Nil)
+    }
+  }
+
+  test("Format table: engine partition pruning on multi-level partitions") {
+    val p1Count = 20
+    val p2Count = 30
+    val totalPartitions = p1Count * p2Count
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, value STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (p1 INT, p2 INT)
+             |""".stripMargin)
+
+      sql(s"""INSERT INTO t
+             |SELECT p1, 'v', p1, p2
+             |FROM (SELECT id AS p1 FROM range(1, ${p1Count + 1}))
+             |CROSS JOIN (SELECT id AS p2 FROM range(1, ${p2Count + 1}))
+             |""".stripMargin)
+
+      val rangeThreshold = p1Count - 5
+
+      for (lazyPruning <- Seq(true, false)) {
+        withSparkSQLConf(
+          "spark.paimon.format-table.engine.lazy-partition-pruning" -> lazyPruning.toString) {
+
+          def filesDiscoveredFor(query: String): Long = {
+            HiveCatalogMetrics.reset()
+            sql(query).collect()
+            HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount
+          }
+
+          assert(filesDiscoveredFor("SELECT * FROM t") == totalPartitions)
+
+          if (lazyPruning) {
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p1 = 1 AND p2 = 1") == 1)
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p1 = 1") == p2Count)
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p2 = 1") == p1Count)
+            assert(filesDiscoveredFor(s"SELECT * FROM t WHERE p1 > $rangeThreshold") == 5 * p2Count)
+            assert(
+              filesDiscoveredFor(s"SELECT * FROM t WHERE p1 > $rangeThreshold AND p2 = 1") == 5)
+          } else {
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p1 = 1 AND p2 = 1") == totalPartitions)
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p1 = 1") == totalPartitions)
+            assert(filesDiscoveredFor("SELECT * FROM t WHERE p2 = 1") == totalPartitions)
+          }
+        }
+      }
+    }
+  }
+
+  test("Format table: engine partition pruning with all basic types") {
+    val types = Seq(
+      ("INT", "1", "2"),
+      ("BIGINT", "1000000000000", "2000000000000"),
+      ("SMALLINT", "1", "2"),
+      ("TINYINT", "1", "2"),
+      ("FLOAT", "1.5", "2.5"),
+      ("DOUBLE", "1.5", "2.5"),
+      ("DECIMAL(10,2)", "1.50", "2.50"),
+      ("STRING", "'aaa'", "'bbb'"),
+      ("BOOLEAN", "true", "false"),
+      ("DATE", "DATE'2025-01-01'", "DATE'2025-06-15'"),
+      ("TIMESTAMP", "TIMESTAMP'2025-01-01 00:00:00'", "TIMESTAMP'2025-06-15 12:00:00'")
+    )
+    for ((partType, v1, v2) <- types) {
+      val tableName = s"t_${partType.replaceAll("[^a-zA-Z]", "").toLowerCase}"
+      withTable(tableName) {
+        sql(s"""
+               |CREATE TABLE $tableName (id INT, data STRING)
+               |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+               |PARTITIONED BY (pt $partType)
+               |""".stripMargin)
+
+        sql(s"INSERT INTO $tableName VALUES (1, 'a', $v1)")
+        sql(s"INSERT INTO $tableName VALUES (2, 'b', $v2)")
+
+        HiveCatalogMetrics.reset()
+        val result = sql(s"SELECT id, data FROM $tableName WHERE pt = $v1 ORDER BY id").collect()
+        val filesDiscovered = HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount
+
+        assert(result.length == 1, s"[$partType] should return 1 row, got ${result.length}")
+        assert(result.head.getInt(0) == 1, s"[$partType] row id should be 1")
+        assert(
+          filesDiscovered == 1,
+          s"[$partType] partition pruning should discover 1 file, got $filesDiscovered")
+      }
+    }
+  }
+
+  test("Format table: engine partition pruning with null partition values") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, data STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (pt STRING)
+             |""".stripMargin)
+
+      sql("INSERT INTO t VALUES (1, 'a', 'x')")
+      sql("INSERT INTO t VALUES (2, 'b', null)")
+      sql("INSERT INTO t VALUES (3, 'c', 'y')")
+
+      checkAnswer(sql("SELECT id FROM t WHERE pt = 'x'"), Row(1) :: Nil)
+
+      checkAnswer(sql("SELECT id FROM t WHERE pt IS NULL ORDER BY id"), Row(2) :: Nil)
+
+      checkAnswer(sql("SELECT id FROM t ORDER BY id"), Row(1) :: Row(2) :: Row(3) :: Nil)
+
+      HiveCatalogMetrics.reset()
+      sql("SELECT * FROM t WHERE pt = 'x'").collect()
+      assert(HiveCatalogMetrics.METRIC_FILES_DISCOVERED.getCount == 1)
+    }
+  }
+
+  test("Format table: engine partition pruning with multi-column predicate fallback") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, value STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (p1 INT, p2 INT)
+             |""".stripMargin)
+
+      sql("INSERT INTO t VALUES (1, 'a', 1, 1)")
+      sql("INSERT INTO t VALUES (2, 'b', 1, 2)")
+      sql("INSERT INTO t VALUES (3, 'c', 2, 1)")
+      sql("INSERT INTO t VALUES (4, 'd', 2, 2)")
+
+      // p1 = 1 is a single-column predicate (pruned at level), p1 + p2 handled by final pruning
+      checkAnswer(sql("SELECT id FROM t WHERE p1 = 1 AND p1 + p2 < 3 ORDER BY id"), Row(1) :: Nil)
+
+      // pure multi-column predicate — level-by-level can't prune, but result is still correct
+      checkAnswer(sql("SELECT id FROM t WHERE p1 + p2 = 3 ORDER BY id"), Row(2) :: Row(3) :: Nil)
+    }
+  }
+
+  test("Format table: engine should see data after insert to same and new partitions") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, data STRING)
+             |USING csv TBLPROPERTIES ('format-table.implementation'='engine')
+             |PARTITIONED BY (pt INT)
+             |""".stripMargin)
+
+      sql("INSERT INTO t VALUES (1, 'a', 1)")
+      checkAnswer(sql("SELECT * FROM t"), Row(1, "a", 1) :: Nil)
+
+      // insert to same partition
+      sql("INSERT INTO t VALUES (2, 'b', 1)")
+      checkAnswer(sql("SELECT id FROM t WHERE pt = 1 ORDER BY id"), Row(1) :: Row(2) :: Nil)
+
+      // insert to new partition
+      sql("INSERT INTO t VALUES (3, 'c', 2)")
+      checkAnswer(sql("SELECT id FROM t ORDER BY id"), Row(1) :: Row(2) :: Row(3) :: Nil)
+      checkAnswer(sql("SELECT id FROM t WHERE pt = 2"), Row(3) :: Nil)
+
+      // full scan after inserts
+      checkAnswer(
+        sql("SELECT id, pt FROM t ORDER BY id"),
+        Row(1, 1) :: Row(2, 1) :: Row(3, 2) :: Nil)
+
+      // overwrite existing partition, other partition untouched
+      sql("INSERT OVERWRITE t PARTITION (pt = 1) VALUES (10, 'x')")
+      checkAnswer(sql("SELECT id FROM t ORDER BY id"), Row(3) :: Row(10) :: Nil)
+
+      // full scan after overwrite
+      checkAnswer(sql("SELECT id, pt FROM t ORDER BY id"), Row(3, 2) :: Row(10, 1) :: Nil)
     }
   }
 

--- a/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
+++ b/paimon-spark/paimon-spark3-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark3Shim.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.connector.catalog.{Column, Identifier, StagingTableC
 import org.apache.spark.sql.connector.catalog.CatalogV2Util.structTypeToV2Columns
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.write.BatchWrite
-import org.apache.spark.sql.execution.{SparkFormatTable, SparkPlan}
+import org.apache.spark.sql.execution.{SparkFormatTableFileIndex, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{PartitioningAwareFileIndex, PartitionSpec}
 import org.apache.spark.sql.execution.datasources.v2.{AtomicReplaceTableAsSelectExec, AtomicReplaceTableExec, ReplaceTableAsSelectExec, ReplaceTableExec}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -338,7 +338,7 @@ object Spark3Shim {
     extends MetadataLogFileIndex(sparkSession, path, parameters, userSpecifiedSchema) {
 
     override def partitionSpec(): PartitionSpec = {
-      SparkFormatTable.alignPartitionSpec(super.partitionSpec(), partitionSchema)
+      SparkFormatTableFileIndex.alignPartitionSpec(super.partitionSpec(), partitionSchema)
     }
   }
 }

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/spark/sql/paimon/shims/Spark4Shim.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, GeneratedColumn, IdentityC
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Column, Identifier, StagingTableCatalog, Table, TableCatalog}
 import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.connector.write.BatchWrite
-import org.apache.spark.sql.execution.{SparkFormatTable, SparkPlan}
+import org.apache.spark.sql.execution.{SparkFormatTableFileIndex, SparkPlan}
 import org.apache.spark.sql.execution.datasources.{PartitioningAwareFileIndex, PartitionSpec}
 import org.apache.spark.sql.execution.datasources.v2.{AtomicReplaceTableAsSelectExec, AtomicReplaceTableExec, ReplaceTableAsSelectExec, ReplaceTableExec}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -333,7 +333,7 @@ object Spark4Shim {
     extends MetadataLogFileIndex(sparkSession, path, parameters, userSpecifiedSchema) {
 
     override def partitionSpec(): PartitionSpec = {
-      SparkFormatTable.alignPartitionSpec(super.partitionSpec(), partitionSchema)
+      SparkFormatTableFileIndex.alignPartitionSpec(super.partitionSpec(), partitionSchema)
     }
   }
 }


### PR DESCRIPTION
### Purpose

Replace the eager `InMemoryFileIndex` (which recursively lists all files at construction time) with `LazyPartitionPruningFileIndex` that defers file listing until `listFiles()` is called and prunes partition directories level-by-level using partition filters.

For a table with 20×30=600 partitions, querying a single partition (`p1=1 AND p2=1`) now discovers 1 file instead of 600. Range queries (`p1>15`) and non-leading column filters (`p2=1`) also benefit from per-level pruning.

Controlled by `spark.paimon.format-table.engine.lazy-partition-pruning` (default `true`). Set to `false` to fall back to eager listing.

### Tests

- Engine static/dynamic partition overwrite
- Partition pruning on multi-level partitions with config comparison (lazy vs eager)
- Partition pruning with all basic types (11 types)
- Null partition values and multi-column predicate fallback
- Data visibility after insert to same/new partitions