### PR TITLE
[core] Add option for catalog options system table

### DIFF
--- a/docs/docs/concepts/system-tables.mdx
+++ b/docs/docs/concepts/system-tables.mdx
@@ -609,7 +609,8 @@ SELECT * FROM sys.all_table_options;
 
 ### Catalog Options Table
 
-You can query the catalog's option information through catalog options table. The options not shown will be the default value. You can take reference to [Configuration](../maintenance/configurations#coreoptions).
+You can query the catalog's option information through catalog options table when `catalog-options-table.enabled` is set to `true`.
+The options not shown will be the default value. You can take reference to [Configuration](../maintenance/configurations#coreoptions).
 
 ```sql
 SELECT * FROM sys.catalog_options;

--- a/docs/generated/catalog_configuration.html
+++ b/docs/generated/catalog_configuration.html
@@ -93,6 +93,12 @@ under the License.
             <td>Indicates whether this catalog is case-sensitive.</td>
         </tr>
         <tr>
+            <td><h5>catalog-options-table.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to support the sys.catalog_options table.</td>
+        </tr>
+        <tr>
             <td><h5>client-pool-size</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>

--- a/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/options/CatalogOptions.java
@@ -183,6 +183,12 @@ public class CatalogOptions {
                                     + "However, during these processes, it does not connect to the metastore; hence, newly added partitions will not be reflected in"
                                     + " the metastore and need to be manually added as separate partition operations.");
 
+    public static final ConfigOption<Boolean> CATALOG_OPTIONS_TABLE_ENABLED =
+            ConfigOptions.key("catalog-options-table.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to support the sys.catalog_options table.");
+
     public static final ConfigOption<Boolean> RESOLVING_FILE_IO_ENABLED =
             ConfigOptions.key("resolving-file-io.enabled")
                     .booleanType()

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -255,7 +255,7 @@ public abstract class AbstractCatalog implements Catalog {
     @Override
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         if (isSystemDatabase(databaseName)) {
-            return SystemTableLoader.loadGlobalTableNames();
+            return SystemTableLoader.loadGlobalTableNames(context.options());
         }
 
         // check db exists
@@ -289,7 +289,7 @@ public abstract class AbstractCatalog implements Catalog {
         CatalogUtils.validateTableType(this, tableType);
         if (isSystemDatabase(databaseName)) {
             List<Table> systemTables =
-                    SystemTableLoader.loadGlobalTableNames().stream()
+                    SystemTableLoader.loadGlobalTableNames(context.options()).stream()
                             .map(
                                     tableName -> {
                                         try {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -23,6 +23,7 @@ import org.apache.paimon.TableType;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.manifest.PartitionEntry;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
@@ -328,7 +329,12 @@ public class CatalogUtils {
                 return AllPartitionsTable.fromPartitions(
                         toAllPartitions(catalog, listAllTables(catalog)));
             case CATALOG_OPTIONS:
-                return new CatalogOptionsTable(Options.fromMap(catalog.options()));
+                Options catalogOptions = Options.fromMap(catalog.options());
+                if (!catalogOptions.get(CatalogOptions.CATALOG_OPTIONS_TABLE_ENABLED)) {
+                    throw new Catalog.TableNotExistException(
+                            Identifier.create(SYSTEM_DATABASE_NAME, tableName));
+                }
+                return new CatalogOptionsTable(catalogOptions);
             default:
                 throw new Catalog.TableNotExistException(
                         Identifier.create(SYSTEM_DATABASE_NAME, tableName));

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -222,7 +222,7 @@ public class RESTCatalog implements Catalog {
     public List<String> listTables(String databaseName) throws DatabaseNotExistException {
         try {
             if (isSystemDatabase(databaseName)) {
-                return SystemTableLoader.loadGlobalTableNames();
+                return SystemTableLoader.loadGlobalTableNames(context.options());
             }
             return api.listTables(databaseName);
         } catch (NoSuchResourceException e) {
@@ -241,6 +241,12 @@ public class RESTCatalog implements Catalog {
             @Nullable String tableType)
             throws DatabaseNotExistException {
         try {
+            if (isSystemDatabase(databaseName)) {
+                CatalogUtils.validateNamePattern(this, tableNamePattern);
+                CatalogUtils.validateTableType(this, tableType);
+                return new PagedList<>(
+                        SystemTableLoader.loadGlobalTableNames(context.options()), null);
+            }
             return api.listTablesPaged(
                     databaseName, maxResults, pageToken, tableNamePattern, tableType);
         } catch (NoSuchResourceException e) {
@@ -257,6 +263,23 @@ public class RESTCatalog implements Catalog {
             @Nullable String tableType)
             throws DatabaseNotExistException {
         try {
+            if (isSystemDatabase(db)) {
+                CatalogUtils.validateNamePattern(this, tableNamePattern);
+                CatalogUtils.validateTableType(this, tableType);
+                List<Table> systemTables =
+                        SystemTableLoader.loadGlobalTableNames(context.options()).stream()
+                                .map(
+                                        tableName -> {
+                                            try {
+                                                return getTable(Identifier.create(db, tableName));
+                                            } catch (TableNotExistException ignored) {
+                                                return null;
+                                            }
+                                        })
+                                .filter(Objects::nonNull)
+                                .collect(Collectors.toList());
+                return new PagedList<>(systemTables, null);
+            }
             PagedList<GetTableResponse> tables =
                     api.listTableDetailsPaged(
                             db, maxResults, pageToken, tableNamePattern, tableType);
@@ -273,6 +296,17 @@ public class RESTCatalog implements Catalog {
     @Override
     public List<Table> listTableDetails(String databaseName) throws DatabaseNotExistException {
         try {
+            if (isSystemDatabase(databaseName)) {
+                List<Table> result = new ArrayList<>();
+                for (String tableName : SystemTableLoader.loadGlobalTableNames(context.options())) {
+                    try {
+                        result.add(getTable(Identifier.create(databaseName, tableName)));
+                    } catch (TableNotExistException ignored) {
+                        // ignore
+                    }
+                }
+                return result;
+            }
             List<GetTableResponse> tables = api.listTableDetails(databaseName);
             return tables.stream().map(t -> toTable(databaseName, t)).collect(Collectors.toList());
         } catch (NoSuchResourceException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -82,6 +82,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BRANCH;
@@ -244,8 +245,7 @@ public class RESTCatalog implements Catalog {
             if (isSystemDatabase(databaseName)) {
                 CatalogUtils.validateNamePattern(this, tableNamePattern);
                 CatalogUtils.validateTableType(this, tableType);
-                return new PagedList<>(
-                        SystemTableLoader.loadGlobalTableNames(context.options()), null);
+                return listSystemTablesPaged(maxResults, pageToken, tableNamePattern, tableType);
             }
             return api.listTablesPaged(
                     databaseName, maxResults, pageToken, tableNamePattern, tableType);
@@ -266,8 +266,10 @@ public class RESTCatalog implements Catalog {
             if (isSystemDatabase(db)) {
                 CatalogUtils.validateNamePattern(this, tableNamePattern);
                 CatalogUtils.validateTableType(this, tableType);
+                PagedList<String> pagedSystemTableNames =
+                        listSystemTablesPaged(maxResults, pageToken, tableNamePattern, tableType);
                 List<Table> systemTables =
-                        SystemTableLoader.loadGlobalTableNames(context.options()).stream()
+                        pagedSystemTableNames.getElements().stream()
                                 .map(
                                         tableName -> {
                                             try {
@@ -278,7 +280,7 @@ public class RESTCatalog implements Catalog {
                                         })
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList());
-                return new PagedList<>(systemTables, null);
+                return new PagedList<>(systemTables, pagedSystemTableNames.getNextPageToken());
             }
             PagedList<GetTableResponse> tables =
                     api.listTableDetailsPaged(
@@ -291,6 +293,75 @@ public class RESTCatalog implements Catalog {
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(db);
         }
+    }
+
+    private PagedList<String> listSystemTablesPaged(
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String tableNamePattern,
+            @Nullable String tableType) {
+        if (StringUtils.isNotEmpty(tableNamePattern)) {
+            try {
+                RESTUtil.validatePrefixSqlPattern(tableNamePattern);
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException(e.getMessage());
+            }
+        }
+
+        List<String> tableNames =
+                SystemTableLoader.loadGlobalTableNames(context.options()).stream()
+                        .filter(tableName -> matchesNamePattern(tableName, tableNamePattern))
+                        .filter(tableName -> matchesTableType(tableType))
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        Integer pageSize = maxResults != null && maxResults > 0 ? maxResults : null;
+        List<String> pagedTableNames = new ArrayList<>();
+        for (String tableName : tableNames) {
+            if (pageToken != null && tableName.compareTo(pageToken) <= 0) {
+                continue;
+            }
+            if (pageSize != null && pagedTableNames.size() >= pageSize) {
+                break;
+            }
+            pagedTableNames.add(tableName);
+        }
+
+        String nextPageToken =
+                pageSize != null && pagedTableNames.size() == pageSize
+                        ? pagedTableNames.get(pagedTableNames.size() - 1)
+                        : null;
+        return new PagedList<>(pagedTableNames, nextPageToken);
+    }
+
+    private boolean matchesNamePattern(String name, @Nullable String namePattern) {
+        if (StringUtils.isEmpty(namePattern)) {
+            return true;
+        }
+        return Pattern.compile(sqlPatternToRegex(namePattern)).matcher(name).matches();
+    }
+
+    private boolean matchesTableType(@Nullable String tableType) {
+        return StringUtils.isEmpty(tableType) || TableType.TABLE.toString().equals(tableType);
+    }
+
+    private String sqlPatternToRegex(String pattern) {
+        StringBuilder regex = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                regex.append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '%') {
+                regex.append(".*");
+            } else {
+                regex.append(c);
+            }
+        }
+        return "^" + regex + "$";
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -82,7 +82,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.BRANCH;
@@ -300,68 +299,12 @@ public class RESTCatalog implements Catalog {
             @Nullable String pageToken,
             @Nullable String tableNamePattern,
             @Nullable String tableType) {
-        if (StringUtils.isNotEmpty(tableNamePattern)) {
-            try {
-                RESTUtil.validatePrefixSqlPattern(tableNamePattern);
-            } catch (IllegalArgumentException e) {
-                throw new BadRequestException(e.getMessage());
-            }
+        try {
+            return SystemTableLoader.loadGlobalTableNamesPaged(
+                    context.options(), maxResults, pageToken, tableNamePattern, tableType);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException(e.getMessage());
         }
-
-        List<String> tableNames =
-                SystemTableLoader.loadGlobalTableNames(context.options()).stream()
-                        .filter(tableName -> matchesNamePattern(tableName, tableNamePattern))
-                        .filter(tableName -> matchesTableType(tableType))
-                        .sorted()
-                        .collect(Collectors.toList());
-
-        Integer pageSize = maxResults != null && maxResults > 0 ? maxResults : null;
-        List<String> pagedTableNames = new ArrayList<>();
-        for (String tableName : tableNames) {
-            if (pageToken != null && tableName.compareTo(pageToken) <= 0) {
-                continue;
-            }
-            if (pageSize != null && pagedTableNames.size() >= pageSize) {
-                break;
-            }
-            pagedTableNames.add(tableName);
-        }
-
-        String nextPageToken =
-                pageSize != null && pagedTableNames.size() == pageSize
-                        ? pagedTableNames.get(pagedTableNames.size() - 1)
-                        : null;
-        return new PagedList<>(pagedTableNames, nextPageToken);
-    }
-
-    private boolean matchesNamePattern(String name, @Nullable String namePattern) {
-        if (StringUtils.isEmpty(namePattern)) {
-            return true;
-        }
-        return Pattern.compile(sqlPatternToRegex(namePattern)).matcher(name).matches();
-    }
-
-    private boolean matchesTableType(@Nullable String tableType) {
-        return StringUtils.isEmpty(tableType) || TableType.TABLE.toString().equals(tableType);
-    }
-
-    private String sqlPatternToRegex(String pattern) {
-        StringBuilder regex = new StringBuilder();
-        boolean escaped = false;
-        for (int i = 0; i < pattern.length(); i++) {
-            char c = pattern.charAt(i);
-            if (escaped) {
-                regex.append(c);
-                escaped = false;
-            } else if (c == '\\') {
-                escaped = true;
-            } else if (c == '%') {
-                regex.append(".*");
-            } else {
-                regex.append(c);
-            }
-        }
-        return "^" + regex + "$";
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.table.system;
 
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 
@@ -92,7 +94,15 @@ public class SystemTableLoader {
                 .orElse(null);
     }
 
+    public static List<String> loadGlobalTableNames(Options catalogOptions) {
+        List<String> tableNames = new ArrayList<>(GLOBAL_SYSTEM_TABLES);
+        if (!catalogOptions.get(CatalogOptions.CATALOG_OPTIONS_TABLE_ENABLED)) {
+            tableNames.remove(CATALOG_OPTIONS);
+        }
+        return tableNames;
+    }
+
     public static List<String> loadGlobalTableNames() {
-        return GLOBAL_SYSTEM_TABLES;
+        return loadGlobalTableNames(new Options());
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -18,10 +18,13 @@
 
 package org.apache.paimon.table.system;
 
+import org.apache.paimon.PagedList;
+import org.apache.paimon.TableType;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.utils.StringUtils;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
@@ -33,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.system.AggregationFieldsTable.AGGREGATION_FIELDS;
 import static org.apache.paimon.table.system.AllPartitionsTable.ALL_PARTITIONS;
@@ -102,7 +107,92 @@ public class SystemTableLoader {
         return tableNames;
     }
 
+    public static PagedList<String> loadGlobalTableNamesPaged(
+            Options catalogOptions,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String tableNamePattern,
+            @Nullable String tableType) {
+        validatePrefixSqlPattern(tableNamePattern);
+        List<String> tableNames =
+                loadGlobalTableNames(catalogOptions).stream()
+                        .filter(tableName -> matchesNamePattern(tableName, tableNamePattern))
+                        .filter(tableName -> matchesTableType(tableType))
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        Integer pageSize = maxResults != null && maxResults > 0 ? maxResults : null;
+        List<String> pagedTableNames = new ArrayList<>();
+        for (String tableName : tableNames) {
+            if (pageToken != null && tableName.compareTo(pageToken) <= 0) {
+                continue;
+            }
+            if (pageSize != null && pagedTableNames.size() >= pageSize) {
+                break;
+            }
+            pagedTableNames.add(tableName);
+        }
+
+        String nextPageToken =
+                pageSize != null && pagedTableNames.size() == pageSize
+                        ? pagedTableNames.get(pagedTableNames.size() - 1)
+                        : null;
+        return new PagedList<>(pagedTableNames, nextPageToken);
+    }
+
     public static List<String> loadGlobalTableNames() {
         return loadGlobalTableNames(new Options());
+    }
+
+    private static boolean matchesNamePattern(String name, @Nullable String namePattern) {
+        if (StringUtils.isEmpty(namePattern)) {
+            return true;
+        }
+        return Pattern.compile(sqlPatternToRegex(namePattern)).matcher(name).matches();
+    }
+
+    private static boolean matchesTableType(@Nullable String tableType) {
+        return StringUtils.isEmpty(tableType) || TableType.TABLE.toString().equals(tableType);
+    }
+
+    private static void validatePrefixSqlPattern(@Nullable String pattern) {
+        if (StringUtils.isEmpty(pattern)) {
+            return;
+        }
+
+        boolean escaped = false;
+        boolean inWildcardZone = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '%') {
+                inWildcardZone = true;
+            } else if (inWildcardZone) {
+                throw new IllegalArgumentException(
+                        "Can only support prefix sql like pattern query now.");
+            }
+        }
+    }
+
+    private static String sqlPatternToRegex(String pattern) {
+        StringBuilder regex = new StringBuilder();
+        boolean escaped = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                regex.append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '%') {
+                regex.append(".*");
+            } else {
+                regex.append(c);
+            }
+        }
+        return "^" + regex + "$";
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CatalogTestBase.java
@@ -47,6 +47,7 @@ import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -85,7 +86,6 @@ import static org.apache.paimon.CoreOptions.TYPE;
 import static org.apache.paimon.catalog.Catalog.SYSTEM_DATABASE_NAME;
 import static org.apache.paimon.table.system.AllTableOptionsTable.ALL_TABLE_OPTIONS;
 import static org.apache.paimon.table.system.CatalogOptionsTable.CATALOG_OPTIONS;
-import static org.apache.paimon.table.system.SystemTableLoader.GLOBAL_SYSTEM_TABLES;
 import static org.apache.paimon.testutils.assertj.PaimonAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -1037,15 +1037,19 @@ public abstract class CatalogTestBase {
         Table allTableOptionsTable =
                 catalog.getTable(Identifier.create(SYSTEM_DATABASE_NAME, ALL_TABLE_OPTIONS));
         assertThat(allTableOptionsTable).isNotNull();
-        Table catalogOptionsTable =
-                catalog.getTable(Identifier.create(SYSTEM_DATABASE_NAME, CATALOG_OPTIONS));
-        assertThat(catalogOptionsTable).isNotNull();
+        assertThatExceptionOfType(Catalog.TableNotExistException.class)
+                .isThrownBy(
+                        () ->
+                                catalog.getTable(
+                                        Identifier.create(SYSTEM_DATABASE_NAME, CATALOG_OPTIONS)));
         assertThatExceptionOfType(Catalog.TableNotExistException.class)
                 .isThrownBy(
                         () -> catalog.getTable(Identifier.create(SYSTEM_DATABASE_NAME, "1111")));
 
         List<String> sysTables = catalog.listTables(SYSTEM_DATABASE_NAME);
-        assertThat(sysTables).containsAll(GLOBAL_SYSTEM_TABLES);
+        assertThat(sysTables)
+                .containsExactlyInAnyOrderElementsOf(
+                        SystemTableLoader.loadGlobalTableNames(new Options()));
 
         assertThat(catalog.listViews(SYSTEM_DATABASE_NAME)).isEmpty();
     }

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -86,6 +86,7 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
@@ -638,6 +639,85 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         Assertions.assertThrows(
                 BadRequestException.class,
                 () -> catalog.listTableDetailsPaged(databaseName, null, null, "%tale", null));
+    }
+
+    @Test
+    public void testListSystemTablesPaged() throws Exception {
+        String[] systemTableNames =
+                SystemTableLoader.loadGlobalTableNames(options).stream()
+                        .sorted()
+                        .toArray(String[]::new);
+        List<String> allTablePrefixedNames =
+                Arrays.stream(systemTableNames)
+                        .filter(tableName -> tableName.startsWith("all_table"))
+                        .collect(Collectors.toList());
+
+        PagedList<String> pagedTables =
+                catalog.listTablesPaged(SYSTEM_DATABASE_NAME, null, null, null, null);
+        assertThat(pagedTables.getElements()).containsExactly(systemTableNames);
+        assertNull(pagedTables.getNextPageToken());
+
+        pagedTables = catalog.listTablesPaged(SYSTEM_DATABASE_NAME, 1, null, null, null);
+        assertThat(pagedTables.getElements()).containsExactly(systemTableNames[0]);
+        assertEquals(systemTableNames[0], pagedTables.getNextPageToken());
+
+        pagedTables =
+                catalog.listTablesPaged(
+                        SYSTEM_DATABASE_NAME, 1, pagedTables.getNextPageToken(), null, null);
+        assertThat(pagedTables.getElements()).containsExactly(systemTableNames[1]);
+        assertEquals(systemTableNames[1], pagedTables.getNextPageToken());
+
+        pagedTables = catalog.listTablesPaged(SYSTEM_DATABASE_NAME, null, null, "all_table%", null);
+        assertThat(pagedTables.getElements()).containsExactlyElementsOf(allTablePrefixedNames);
+        assertNull(pagedTables.getNextPageToken());
+
+        pagedTables = catalog.listTablesPaged(SYSTEM_DATABASE_NAME, null, null, "catalog_%", null);
+        assertThat(pagedTables.getElements()).isEmpty();
+        assertNull(pagedTables.getNextPageToken());
+
+        pagedTables =
+                catalog.listTablesPaged(
+                        SYSTEM_DATABASE_NAME, null, null, null, TableType.TABLE.toString());
+        assertThat(pagedTables.getElements()).containsExactly(systemTableNames);
+        assertNull(pagedTables.getNextPageToken());
+
+        pagedTables =
+                catalog.listTablesPaged(
+                        SYSTEM_DATABASE_NAME, null, null, null, TableType.OBJECT_TABLE.toString());
+        assertThat(pagedTables.getElements()).isEmpty();
+        assertNull(pagedTables.getNextPageToken());
+
+        PagedList<Table> pagedTableDetails =
+                catalog.listTableDetailsPaged(SYSTEM_DATABASE_NAME, 1, null, null, null);
+        assertPagedTableDetails(pagedTableDetails, 1, systemTableNames[0]);
+        assertEquals(systemTableNames[0], pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails =
+                catalog.listTableDetailsPaged(
+                        SYSTEM_DATABASE_NAME, null, null, "all_table%", TableType.TABLE.toString());
+        assertPagedTableDetails(
+                pagedTableDetails,
+                allTablePrefixedNames.size(),
+                allTablePrefixedNames.toArray(new String[0]));
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        pagedTableDetails =
+                catalog.listTableDetailsPaged(
+                        SYSTEM_DATABASE_NAME, null, null, null, TableType.OBJECT_TABLE.toString());
+        assertThat(pagedTableDetails.getElements()).isEmpty();
+        assertNull(pagedTableDetails.getNextPageToken());
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () ->
+                        catalog.listTablesPaged(
+                                SYSTEM_DATABASE_NAME, null, null, "all%tables", null));
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () ->
+                        catalog.listTableDetailsPaged(
+                                SYSTEM_DATABASE_NAME, null, null, "all%tables", null));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/CatalogOptionsTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/CatalogOptionsTableTest.java
@@ -55,6 +55,7 @@ public class CatalogOptionsTableTest extends TableTestBase {
     public void before() throws Exception {
         catalogOptions = new Options();
         catalogOptions.set(CatalogOptions.TABLE_TYPE, CatalogTableType.MANAGED);
+        catalogOptions.set(CatalogOptions.CATALOG_OPTIONS_TABLE_ENABLED, true);
         catalogOptions.set("table-default.scan.infer-parallelism", "false");
         catalogOptions.set(CatalogOptions.WAREHOUSE, tempDir.toUri().toString());
         catalog = CatalogFactory.createCatalog(CatalogContext.create(catalogOptions));

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -192,8 +192,7 @@ public class CatalogTableITCase extends CatalogITCaseBase {
         List<Row> result = sql("SELECT * FROM sys.catalog_options");
         assertThat(result)
                 .containsExactlyInAnyOrder(
-                        Row.of("catalog-options-table.enabled", "true"),
-                        Row.of("warehouse", path));
+                        Row.of("catalog-options-table.enabled", "true"), Row.of("warehouse", path));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/CatalogTableITCase.java
@@ -60,6 +60,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class CatalogTableITCase extends CatalogITCaseBase {
 
     @Override
+    protected Map<String, String> catalogOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("catalog-options-table.enabled", "true");
+        return options;
+    }
+
+    @Override
     protected boolean inferScanParallelism() {
         return true;
     }
@@ -183,7 +190,10 @@ public class CatalogTableITCase extends CatalogITCaseBase {
     @Test
     public void testCatalogOptionsTable() {
         List<Row> result = sql("SELECT * FROM sys.catalog_options");
-        assertThat(result).containsExactly(Row.of("warehouse", path));
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        Row.of("catalog-options-table.enabled", "true"),
+                        Row.of("warehouse", path));
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonSystemTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/table/PaimonSystemTableTest.scala
@@ -30,7 +30,7 @@ class PaimonSystemTableTest extends PaimonSparkTestBase {
   test("system table: show all global system tables") {
     checkAnswer(
       sql("SHOW TABLES IN sys").select("tableName"),
-      SystemTableLoader.GLOBAL_SYSTEM_TABLES.asScala.map(Row(_)).toSeq
+      SystemTableLoader.loadGlobalTableNames().asScala.map(Row(_)).toSeq
     )
   }
 }


### PR DESCRIPTION
## Summary

Add a catalog option to control whether the `sys.catalog_options` system table is available. The table is disabled by default and can be enabled explicitly with `catalog-options-table.enabled=true`.

## Changes

- Added `catalog-options-table.enabled` to catalog options.
- Filtered `sys.catalog_options` from global system table listings unless the option is enabled.
- Guarded direct loading of `sys.catalog_options` with the same option.
- Updated docs and generated catalog configuration reference.
- Adjusted core, Flink, and Spark tests for the new default behavior.

## Testing

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=CatalogOptionsTableTest test`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=FileSystemCatalogTest#testGetTable test`
- `mvn -pl paimon-spark/paimon-spark-ut -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=org.apache.paimon.spark.table.PaimonSystemTableTest -Dtest=none test`
- `mvn -pl paimon-flink/paimon-flink-common -am -Pfast-build -DfailIfNoTests=false -Dtest=CatalogTableITCase#testCatalogOptionsTable,CatalogTableITCase#testSystemDatabase test`