### PR TITLE
[iceberg] Fix missing parent snapshot id in createMetadataWithoutBase

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -395,7 +395,7 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                 new IcebergSnapshot(
                         snapshotId,
                         snapshotId,
-                        null,
+                        snapshotId == Snapshot.FIRST_SNAPSHOT_ID ? null : (Long) (snapshotId - 1),
                         System.currentTimeMillis(),
                         snapshotSummary,
                         pathFactory.toManifestListPath(manifestListFileName).toString(),


### PR DESCRIPTION
## Summary
- Fix `parent_id` incorrectly set to `null` for non-first snapshots when `createMetadataWithoutBase` is used
- Iceberg snapshots 2+ now have `parentId = snapshotId - 1` instead of `null`

## Root cause
When previous Iceberg metadata files are expired, `createMetadata` falls back to `createMetadataWithoutBase`, which hardcoded `parentId = null` regardless of whether it's the first snapshot or not. This breaks the Iceberg snapshot parent chain.

## Fix
Use `snapshotId - 1` as `parentId` for non-first snapshots (snapshot 1 correctly keeps `parentId = null`).

Closes #5860