### PR TITLE
[format] Support writing and reading Arrow schema metadata for file formats

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/format/SupportsWriterMetadata.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/SupportsWriterMetadata.java
@@ -23,6 +23,10 @@ import java.util.Map;
 /** Writer capability for adding format-specific file metadata before closing the file. */
 public interface SupportsWriterMetadata {
 
-    /** Adds raw metadata entries to the file footer. */
+    /**
+     * Adds raw metadata entries to the file footer.
+     *
+     * <p>This method must be called before {@link FormatWriter#close()}.
+     */
     void addMetadata(Map<String, byte[]> metadata);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/format/SupportsWriterMetadata.java
+++ b/paimon-common/src/main/java/org/apache/paimon/format/SupportsWriterMetadata.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import java.util.Map;
+
+/** Writer capability for adding format-specific file metadata before closing the file. */
+public interface SupportsWriterMetadata {
+
+    /** Adds raw metadata entries to the file footer. */
+    void addMetadata(Map<String, byte[]> metadata);
+}

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -48,6 +48,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${snappy.version}</version>

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -48,6 +48,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-arrow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>arrow-vector</artifactId>
             <version>${arrow.version}</version>

--- a/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Utilities for format metadata encoded at file boundaries. */
+public class FormatMetadataUtils {
+
+    public static final String ARROW_SCHEMA_METADATA_KEY = "ARROW:schema";
+
+    private FormatMetadataUtils() {}
+
+    public static Map<String, String> encodeMetadata(Map<String, byte[]> metadata) {
+        Map<String, String> encoded = new LinkedHashMap<>();
+        for (Map.Entry<String, byte[]> entry : metadata.entrySet()) {
+            encoded.put(entry.getKey(), Base64.getEncoder().encodeToString(entry.getValue()));
+        }
+        return encoded;
+    }
+
+    public static Map<String, byte[]> decodeMetadata(Map<String, String> metadata) {
+        Map<String, byte[]> decoded = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            decoded.put(entry.getKey(), Base64.getDecoder().decode(entry.getValue()));
+        }
+        return decoded;
+    }
+
+    public static Optional<Schema> readArrowSchema(String encodedSchema) {
+        if (encodedSchema == null) {
+            return Optional.empty();
+        }
+        byte[] schemaBytes = Base64.getDecoder().decode(encodedSchema);
+        return Optional.of(Schema.deserializeMessage(ByteBuffer.wrap(schemaBytes)));
+    }
+
+    /** Returns metadata for top-level Arrow fields only. */
+    public static Map<String, Map<String, String>> readFieldMetadata(Schema arrowSchema) {
+        Map<String, Map<String, String>> result = new LinkedHashMap<>();
+        for (Field field : arrowSchema.getFields()) {
+            result.put(
+                    field.getName(),
+                    Collections.unmodifiableMap(new LinkedHashMap<>(field.getMetadata())));
+        }
+        return Collections.unmodifiableMap(result);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
@@ -72,8 +72,12 @@ public class FormatMetadataUtils {
         if (encodedSchema == null) {
             return Optional.empty();
         }
-        byte[] schemaBytes = Base64.getDecoder().decode(encodedSchema);
-        return Optional.of(Schema.deserializeMessage(ByteBuffer.wrap(schemaBytes)));
+        try {
+            byte[] schemaBytes = Base64.getDecoder().decode(encodedSchema);
+            return Optional.of(Schema.deserializeMessage(ByteBuffer.wrap(schemaBytes)));
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
     }
 
     public static byte[] serializeArrowSchema(Schema arrowSchema) {
@@ -84,7 +88,9 @@ public class FormatMetadataUtils {
      * Builds an Arrow schema from a Paimon row type and injects metadata into top-level fields.
      *
      * <p>The keys of {@code fieldMetadata} are top-level field names. Nested fields are converted
-     * from the {@link RowType} but do not receive metadata from this map.
+     * from the {@link RowType} but do not receive metadata from this map. If injected metadata
+     * conflicts with metadata produced during Arrow conversion, the Arrow conversion metadata wins
+     * to preserve format-specific field information.
      */
     public static Schema buildArrowSchema(
             RowType rowType, Map<String, Map<String, String>> fieldMetadata) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
@@ -18,7 +18,11 @@
 
 package org.apache.paimon.format;
 
+import org.apache.paimon.arrow.ArrowUtils;
+import org.apache.paimon.types.RowType;
+
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import javax.annotation.Nullable;
@@ -28,8 +32,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /** Utilities for format metadata encoded at file boundaries. */
 public class FormatMetadataUtils {
@@ -70,6 +76,30 @@ public class FormatMetadataUtils {
         return Optional.of(Schema.deserializeMessage(ByteBuffer.wrap(schemaBytes)));
     }
 
+    public static byte[] serializeArrowSchema(Schema arrowSchema) {
+        return arrowSchema.serializeAsMessage();
+    }
+
+    /**
+     * Builds an Arrow schema from a Paimon row type and injects metadata into top-level fields.
+     *
+     * <p>The keys of {@code fieldMetadata} are top-level field names. Nested fields are converted
+     * from the {@link RowType} but do not receive metadata from this map.
+     */
+    public static Schema buildArrowSchema(
+            RowType rowType, Map<String, Map<String, String>> fieldMetadata) {
+        List<Field> fields =
+                rowType.getFields().stream()
+                        .map(
+                                field ->
+                                        withMetadata(
+                                                ArrowUtils.toArrowField(
+                                                        field.name(), field.id(), field.type(), 0),
+                                                fieldMetadata.get(field.name())))
+                        .collect(Collectors.toList());
+        return new Schema(fields);
+    }
+
     /** Returns metadata for top-level Arrow fields only. */
     public static Map<String, Map<String, String>> readFieldMetadata(Schema arrowSchema) {
         Map<String, Map<String, String>> result = new LinkedHashMap<>();
@@ -79,5 +109,23 @@ public class FormatMetadataUtils {
                     Collections.unmodifiableMap(new LinkedHashMap<>(field.getMetadata())));
         }
         return Collections.unmodifiableMap(result);
+    }
+
+    private static Field withMetadata(Field field, @Nullable Map<String, String> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return field;
+        }
+        FieldType fieldType = field.getFieldType();
+        Map<String, String> result = new LinkedHashMap<>();
+        result.putAll(metadata);
+        result.putAll(fieldType.getMetadata());
+        return new Field(
+                field.getName(),
+                new FieldType(
+                        fieldType.isNullable(),
+                        fieldType.getType(),
+                        fieldType.getDictionary(),
+                        result),
+                field.getChildren());
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
@@ -21,7 +21,10 @@ package org.apache.paimon.format;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -43,15 +46,23 @@ public class FormatMetadataUtils {
         return encoded;
     }
 
+    /**
+     * Decodes base64-encoded metadata values. Values that are not valid base64 are returned as
+     * UTF-8 bytes.
+     */
     public static Map<String, byte[]> decodeMetadata(Map<String, String> metadata) {
         Map<String, byte[]> decoded = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : metadata.entrySet()) {
-            decoded.put(entry.getKey(), Base64.getDecoder().decode(entry.getValue()));
+            try {
+                decoded.put(entry.getKey(), Base64.getDecoder().decode(entry.getValue()));
+            } catch (IllegalArgumentException e) {
+                decoded.put(entry.getKey(), entry.getValue().getBytes(StandardCharsets.UTF_8));
+            }
         }
         return decoded;
     }
 
-    public static Optional<Schema> readArrowSchema(String encodedSchema) {
+    public static Optional<Schema> readArrowSchema(@Nullable String encodedSchema) {
         if (encodedSchema == null) {
             return Optional.empty();
         }

--- a/paimon-format/src/main/java/org/apache/paimon/format/SupportsReaderArrowSchema.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/SupportsReaderArrowSchema.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/** Reader capability for formats that can recover Arrow schema from file metadata. */
+public interface SupportsReaderArrowSchema {
+
+    Optional<Schema> readArrowSchema() throws IOException;
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -24,8 +24,10 @@ import org.apache.paimon.data.columnar.ColumnarRow;
 import org.apache.paimon.data.columnar.ColumnarRowIterator;
 import org.apache.paimon.data.columnar.VectorizedColumnBatch;
 import org.apache.paimon.data.columnar.VectorizedRowIterator;
+import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.format.OrcFormatReaderContext;
+import org.apache.paimon.format.SupportsReaderArrowSchema;
 import org.apache.paimon.format.fs.HadoopReadOnlyFileSystem;
 import org.apache.paimon.format.orc.filter.OrcFilters;
 import org.apache.paimon.fs.FileIO;
@@ -39,6 +41,7 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Pool;
 import org.apache.paimon.utils.RoaringBitmap32;
 
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
@@ -54,7 +57,9 @@ import org.apache.orc.impl.RecordReaderImpl;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.format.orc.OrcTypeUtil.convertToOrcSchema;
 import static org.apache.paimon.format.orc.reader.AbstractOrcColumnVector.createPaimonVector;
@@ -104,7 +109,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
         Pool<OrcReaderBatch> poolOfBatches =
                 createPoolOfBatches(context.filePath(), poolSize, context.fileIO());
 
-        RecordReader orcReader =
+        OrcRecordReader orcReader =
                 createRecordReader(
                         hadoopConfig,
                         schema,
@@ -224,12 +229,14 @@ public class OrcReaderFactory implements FormatReaderFactory {
      * batch is addressed by the starting row number of the batch, plus the number of records to be
      * skipped before.
      */
-    private static final class OrcVectorizedReader implements FileRecordReader<InternalRow> {
+    private static final class OrcVectorizedReader
+            implements FileRecordReader<InternalRow>, SupportsReaderArrowSchema {
 
-        private final RecordReader orcReader;
+        private final OrcRecordReader orcReader;
         private final Pool<OrcReaderBatch> pool;
 
-        private OrcVectorizedReader(final RecordReader orcReader, final Pool<OrcReaderBatch> pool) {
+        private OrcVectorizedReader(
+                final OrcRecordReader orcReader, final Pool<OrcReaderBatch> pool) {
             this.orcReader = checkNotNull(orcReader, "orcReader");
             this.pool = checkNotNull(pool, "pool");
         }
@@ -240,8 +247,8 @@ public class OrcReaderFactory implements FormatReaderFactory {
             final OrcReaderBatch batch = getCachedEntry();
             final VectorizedRowBatch orcVectorBatch = batch.orcVectorizedRowBatch();
 
-            long rowNumber = orcReader.getRowNumber();
-            if (!nextBatch(orcReader, orcVectorBatch)) {
+            long rowNumber = orcReader.recordReader.getRowNumber();
+            if (!nextBatch(orcReader.recordReader, orcVectorBatch)) {
                 batch.recycle();
                 return null;
             }
@@ -250,8 +257,30 @@ public class OrcReaderFactory implements FormatReaderFactory {
         }
 
         @Override
+        public Optional<Schema> readArrowSchema() {
+            org.apache.orc.Reader fileReader = orcReader.fileReader;
+            if (!fileReader
+                    .getMetadataKeys()
+                    .contains(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY)) {
+                return Optional.empty();
+            }
+            return FormatMetadataUtils.readArrowSchema(
+                    StandardCharsets.UTF_8
+                            .decode(
+                                    fileReader
+                                            .getMetadataValue(
+                                                    FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY)
+                                            .duplicate())
+                            .toString());
+        }
+
+        @Override
         public void close() throws IOException {
-            orcReader.close();
+            try {
+                orcReader.recordReader.close();
+            } finally {
+                orcReader.fileReader.close();
+            }
         }
 
         private OrcReaderBatch getCachedEntry() throws IOException {
@@ -264,7 +293,18 @@ public class OrcReaderFactory implements FormatReaderFactory {
         }
     }
 
-    private static RecordReader createRecordReader(
+    private static final class OrcRecordReader {
+
+        private final org.apache.orc.Reader fileReader;
+        private final RecordReader recordReader;
+
+        private OrcRecordReader(org.apache.orc.Reader fileReader, RecordReader recordReader) {
+            this.fileReader = fileReader;
+            this.recordReader = recordReader;
+        }
+    }
+
+    private static OrcRecordReader createRecordReader(
             org.apache.hadoop.conf.Configuration conf,
             TypeDescription schema,
             List<OrcFilters.Predicate> conjunctPredicates,
@@ -314,7 +354,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
             // assign ids
             schema.getId();
 
-            return orcRowsReader;
+            return new OrcRecordReader(orcReader, orcRowsReader);
         } catch (IOException e) {
             // exception happened, we need to close the reader
             IOUtils.closeQuietly(orcReader);

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** A {@link FormatWriter} implementation that writes data in ORC format. */
 public class OrcBulkWriter implements FormatWriter, SupportsWriterMetadata {
@@ -49,6 +50,7 @@ public class OrcBulkWriter implements FormatWriter, SupportsWriterMetadata {
 
     private long currentBatchMemoryUsage = 0;
     private final long memoryLimit;
+    private boolean closed = false;
 
     public OrcBulkWriter(
             Vectorizer<InternalRow> vectorizer,
@@ -67,6 +69,7 @@ public class OrcBulkWriter implements FormatWriter, SupportsWriterMetadata {
 
     @Override
     public void addMetadata(Map<String, byte[]> metadata) {
+        checkState(!closed, "Cannot add metadata after writer is closed.");
         for (Map.Entry<String, byte[]> entry : metadata.entrySet()) {
             this.metadata.put(
                     entry.getKey(), Arrays.copyOf(entry.getValue(), entry.getValue().length));
@@ -99,6 +102,7 @@ public class OrcBulkWriter implements FormatWriter, SupportsWriterMetadata {
                     ByteBuffer.wrap(entry.getValue().getBytes(StandardCharsets.UTF_8)));
         }
         writer.close();
+        this.closed = true;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/writer/OrcBulkWriter.java
@@ -20,7 +20,9 @@ package org.apache.paimon.format.orc.writer;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.format.SupportsWriterMetadata;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.MemorySize;
 
@@ -28,16 +30,22 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.Writer;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** A {@link FormatWriter} implementation that writes data in ORC format. */
-public class OrcBulkWriter implements FormatWriter {
+public class OrcBulkWriter implements FormatWriter, SupportsWriterMetadata {
 
     private final Writer writer;
     private final Vectorizer<InternalRow> vectorizer;
     private final VectorizedRowBatch rowBatch;
     private final PositionOutputStream underlyingStream;
+    private final Map<String, byte[]> metadata;
 
     private long currentBatchMemoryUsage = 0;
     private final long memoryLimit;
@@ -54,6 +62,15 @@ public class OrcBulkWriter implements FormatWriter {
         this.rowBatch = vectorizer.getSchema().createRowBatch(batchSize);
         this.underlyingStream = underlyingStream;
         this.memoryLimit = memoryLimit.getBytes();
+        this.metadata = new HashMap<>();
+    }
+
+    @Override
+    public void addMetadata(Map<String, byte[]> metadata) {
+        for (Map.Entry<String, byte[]> entry : metadata.entrySet()) {
+            this.metadata.put(
+                    entry.getKey(), Arrays.copyOf(entry.getValue(), entry.getValue().length));
+        }
     }
 
     @Override
@@ -75,6 +92,12 @@ public class OrcBulkWriter implements FormatWriter {
     @Override
     public void close() throws IOException {
         flush();
+        for (Map.Entry<String, String> entry :
+                FormatMetadataUtils.encodeMetadata(metadata).entrySet()) {
+            writer.addUserMetadata(
+                    entry.getKey(),
+                    ByteBuffer.wrap(entry.getValue().getBytes(StandardCharsets.UTF_8)));
+        }
         writer.close();
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetWriterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetWriterFactory.java
@@ -59,6 +59,8 @@ public class ParquetWriterFactory implements FormatWriterFactory, SupportsVarian
             compression = null;
         }
 
+        // Keep this exact map instance shared by ParquetBulkWriter and WriteSupport. The writer
+        // collects metadata before close, and WriteSupport reads it when finalizing the footer.
         Map<String, byte[]> metadata = new HashMap<>();
         final ParquetWriter<InternalRow> writer =
                 writerBuilder.createWriter(out, compression, () -> metadata);
@@ -77,6 +79,8 @@ public class ParquetWriterFactory implements FormatWriterFactory, SupportsVarian
         ParquetBuilder<InternalRow> newBuilder =
                 ((RowDataParquetBuilder) writerBuilder)
                         .withShreddingSchemas(inferredShreddingSchema);
+        // Keep this exact map instance shared by ParquetBulkWriter and WriteSupport. The writer
+        // collects metadata before close, and WriteSupport reads it when finalizing the footer.
         Map<String, byte[]> metadata = new HashMap<>();
         final ParquetWriter<InternalRow> writer =
                 newBuilder.createWriter(out, compression, () -> metadata);

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetWriterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetWriterFactory.java
@@ -34,6 +34,8 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.OutputFile;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /** A factory that creates a Parquet {@link FormatWriter}. */
 public class ParquetWriterFactory implements FormatWriterFactory, SupportsVariantInference {
@@ -57,8 +59,10 @@ public class ParquetWriterFactory implements FormatWriterFactory, SupportsVarian
             compression = null;
         }
 
-        final ParquetWriter<InternalRow> writer = writerBuilder.createWriter(out, compression);
-        return new ParquetBulkWriter(writer);
+        Map<String, byte[]> metadata = new HashMap<>();
+        final ParquetWriter<InternalRow> writer =
+                writerBuilder.createWriter(out, compression, () -> metadata);
+        return new ParquetBulkWriter(writer, metadata);
     }
 
     @Override
@@ -73,7 +77,9 @@ public class ParquetWriterFactory implements FormatWriterFactory, SupportsVarian
         ParquetBuilder<InternalRow> newBuilder =
                 ((RowDataParquetBuilder) writerBuilder)
                         .withShreddingSchemas(inferredShreddingSchema);
-        final ParquetWriter<InternalRow> writer = newBuilder.createWriter(out, compression);
-        return new ParquetBulkWriter(writer);
+        Map<String, byte[]> metadata = new HashMap<>();
+        final ParquetWriter<InternalRow> writer =
+                newBuilder.createWriter(out, compression, () -> metadata);
+        return new ParquetBulkWriter(writer, metadata);
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -20,6 +20,8 @@ package org.apache.paimon.format.parquet.reader;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
+import org.apache.paimon.format.FormatMetadataUtils;
+import org.apache.paimon.format.SupportsReaderArrowSchema;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.format.parquet.type.ParquetPrimitiveField;
 import org.apache.paimon.fs.FileIO;
@@ -41,6 +43,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,7 +51,8 @@ import static java.lang.String.format;
 import static org.apache.paimon.format.parquet.reader.ParquetReaderUtil.createReadableColumnVectors;
 
 /** Record reader for parquet. */
-public class VectorizedParquetRecordReader implements FileRecordReader<InternalRow> {
+public class VectorizedParquetRecordReader
+        implements FileRecordReader<InternalRow>, SupportsReaderArrowSchema {
 
     private ParquetFileReader reader;
 
@@ -267,6 +271,16 @@ public class VectorizedParquetRecordReader implements FileRecordReader<InternalR
         } else {
             return null;
         }
+    }
+
+    @Override
+    public Optional<org.apache.arrow.vector.types.pojo.Schema> readArrowSchema()
+            throws IOException {
+        return FormatMetadataUtils.readArrowSchema(
+                reader.getFooter()
+                        .getFileMetaData()
+                        .getKeyValueMetaData()
+                        .get(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY));
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBuilder.java
@@ -40,6 +40,7 @@ public interface ParquetBuilder<T> extends Serializable {
     default ParquetWriter<T> createWriter(
             OutputFile out, String compression, Supplier<Map<String, byte[]>> metadataSupplier)
             throws IOException {
-        return createWriter(out, compression);
+        throw new UnsupportedOperationException(
+                "This ParquetBuilder does not support writer metadata.");
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBuilder.java
@@ -23,6 +23,8 @@ import org.apache.parquet.io.OutputFile;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * A builder to create a {@link ParquetWriter} from a Parquet {@link OutputFile}.
@@ -34,4 +36,10 @@ public interface ParquetBuilder<T> extends Serializable {
 
     /** Creates and configures a parquet writer to the given output file. */
     ParquetWriter<T> createWriter(OutputFile out, String compression) throws IOException;
+
+    default ParquetWriter<T> createWriter(
+            OutputFile out, String compression, Supplier<Map<String, byte[]>> metadataSupplier)
+            throws IOException {
+        return createWriter(out, compression);
+    }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
@@ -20,6 +20,7 @@ package org.apache.paimon.format.parquet.writer;
 
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.format.SupportsWriterMetadata;
 
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
@@ -27,11 +28,14 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** A simple {@link FormatWriter} implementation that wraps a {@link ParquetWriter}. */
-public class ParquetBulkWriter implements FormatWriter {
+public class ParquetBulkWriter implements FormatWriter, SupportsWriterMetadata {
 
     /** The ParquetWriter to write to. */
     private final ParquetWriter<InternalRow> parquetWriter;
@@ -39,13 +43,29 @@ public class ParquetBulkWriter implements FormatWriter {
     /** Cached footer metadata after close, used to avoid re-reading the file for stats. */
     @Nullable private ParquetMetadata footerMetadata;
 
+    private final Map<String, byte[]> metadata;
+
     /**
      * Creates a new ParquetBulkWriter wrapping the given ParquetWriter.
      *
      * @param parquetWriter The ParquetWriter to write to.
      */
     public ParquetBulkWriter(ParquetWriter<InternalRow> parquetWriter) {
+        this(parquetWriter, new HashMap<>());
+    }
+
+    public ParquetBulkWriter(
+            ParquetWriter<InternalRow> parquetWriter, Map<String, byte[]> metadata) {
         this.parquetWriter = checkNotNull(parquetWriter, "parquetWriter");
+        this.metadata = checkNotNull(metadata, "metadata");
+    }
+
+    @Override
+    public void addMetadata(Map<String, byte[]> metadata) {
+        for (Map.Entry<String, byte[]> entry : metadata.entrySet()) {
+            this.metadata.put(
+                    entry.getKey(), Arrays.copyOf(entry.getValue(), entry.getValue().length));
+        }
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetBulkWriter.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** A simple {@link FormatWriter} implementation that wraps a {@link ParquetWriter}. */
 public class ParquetBulkWriter implements FormatWriter, SupportsWriterMetadata {
@@ -44,6 +45,8 @@ public class ParquetBulkWriter implements FormatWriter, SupportsWriterMetadata {
     @Nullable private ParquetMetadata footerMetadata;
 
     private final Map<String, byte[]> metadata;
+
+    private boolean closed = false;
 
     /**
      * Creates a new ParquetBulkWriter wrapping the given ParquetWriter.
@@ -62,6 +65,7 @@ public class ParquetBulkWriter implements FormatWriter, SupportsWriterMetadata {
 
     @Override
     public void addMetadata(Map<String, byte[]> metadata) {
+        checkState(!closed, "Cannot add metadata after writer is closed.");
         for (Map.Entry<String, byte[]> entry : metadata.entrySet()) {
             this.metadata.put(
                     entry.getKey(), Arrays.copyOf(entry.getValue(), entry.getValue().length));
@@ -77,6 +81,7 @@ public class ParquetBulkWriter implements FormatWriter, SupportsWriterMetadata {
     public void close() throws IOException {
         parquetWriter.close();
         this.footerMetadata = parquetWriter.getFooter();
+        this.closed = true;
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/ParquetRowDataBuilder.java
@@ -19,12 +19,14 @@
 package org.apache.paimon.format.parquet.writer;
 
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.parquet.VariantUtils;
 import org.apache.paimon.types.RowType;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.hadoop.api.WriteSupport.FinalizedWriteContext;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
@@ -32,6 +34,8 @@ import org.apache.parquet.schema.MessageType;
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.apache.paimon.format.parquet.ParquetSchemaConverter.convertToParquetMessageType;
 
@@ -41,12 +45,20 @@ public class ParquetRowDataBuilder
 
     private final RowType rowType;
     @Nullable private final RowType shreddingSchemas;
+    private Supplier<Map<String, byte[]>> metadataSupplier;
 
     public ParquetRowDataBuilder(
             OutputFile path, RowType rowType, @Nullable RowType shreddingSchemas) {
         super(path);
         this.rowType = rowType;
         this.shreddingSchemas = shreddingSchemas;
+        this.metadataSupplier = HashMap::new;
+    }
+
+    public ParquetRowDataBuilder withMetadataSupplier(
+            Supplier<Map<String, byte[]>> metadataSupplier) {
+        this.metadataSupplier = metadataSupplier;
+        return this;
     }
 
     @Override
@@ -88,6 +100,12 @@ public class ParquetRowDataBuilder
         @Override
         public void write(InternalRow record) {
             this.writer.write(record);
+        }
+
+        @Override
+        public FinalizedWriteContext finalizeWrite() {
+            return new FinalizedWriteContext(
+                    FormatMetadataUtils.encodeMetadata(metadataSupplier.get()));
         }
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/writer/RowDataParquetBuilder.java
@@ -35,6 +35,9 @@ import org.apache.parquet.io.OutputFile;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /** A {@link ParquetBuilder} for {@link InternalRow}. */
 public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
@@ -58,8 +61,16 @@ public class RowDataParquetBuilder implements ParquetBuilder<InternalRow> {
     @Override
     public ParquetWriter<InternalRow> createWriter(OutputFile out, String compression)
             throws IOException {
+        return createWriter(out, compression, HashMap::new);
+    }
+
+    @Override
+    public ParquetWriter<InternalRow> createWriter(
+            OutputFile out, String compression, Supplier<Map<String, byte[]>> metadataSupplier)
+            throws IOException {
         ParquetRowDataBuilder builder =
                 new ParquetRowDataBuilder(out, rowType, shreddingSchemas)
+                        .withMetadataSupplier(metadataSupplier)
                         .withConf(conf)
                         .withCompressionCodec(getCompressionCodec(getCompression(compression)))
                         .withRowGroupSize(

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.format;
 
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -72,7 +75,9 @@ public class FormatMetadataUtilsTest {
                                                 null,
                                                 fieldMetadata),
                                         null)));
-        String encodedSchema = Base64.getEncoder().encodeToString(schema.serializeAsMessage());
+        String encodedSchema =
+                Base64.getEncoder()
+                        .encodeToString(FormatMetadataUtils.serializeArrowSchema(schema));
 
         assertThat(FormatMetadataUtils.readArrowSchema(encodedSchema)).hasValue(schema);
         assertThat(FormatMetadataUtils.readArrowSchema(null)).isEmpty();
@@ -105,5 +110,40 @@ public class FormatMetadataUtilsTest {
         assertThat(FormatMetadataUtils.readFieldMetadata(schema))
                 .containsEntry("with_metadata", fieldMetadata)
                 .containsEntry("without_metadata", Collections.emptyMap());
+    }
+
+    @Test
+    public void testBuildArrowSchemaWithFieldMetadata() {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "id", DataTypes.INT()),
+                        DataTypes.FIELD(
+                                1,
+                                "tags",
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
+                        DataTypes.FIELD(
+                                2,
+                                "nested",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD(3, "name", DataTypes.STRING()),
+                                        DataTypes.FIELD(
+                                                4,
+                                                "scores",
+                                                DataTypes.ARRAY(DataTypes.INT())))));
+        Map<String, String> tagsMetadata = new LinkedHashMap<>();
+        tagsMetadata.put("paimon.test.tags", "enabled");
+
+        Map<String, Map<String, String>> fieldMetadata = new LinkedHashMap<>();
+        fieldMetadata.put("tags", tagsMetadata);
+
+        Schema schema = FormatMetadataUtils.buildArrowSchema(rowType, fieldMetadata);
+
+        assertThat(schema.getFields())
+                .extracting(Field::getName)
+                .containsExactly("id", "tags", "nested");
+        assertThat(schema.findField("tags").getMetadata())
+                .containsEntry("paimon.test.tags", "enabled");
+        assertThat(schema.findField("nested").getMetadata())
+                .doesNotContainKey("paimon.test.tags");
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FormatMetadataUtils}. */
+public class FormatMetadataUtilsTest {
+
+    @Test
+    public void testDecodeMetadata() {
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put(
+                "encoded",
+                Base64.getEncoder()
+                        .encodeToString("paimon-value".getBytes(StandardCharsets.UTF_8)));
+
+        Map<String, byte[]> decoded = FormatMetadataUtils.decodeMetadata(metadata);
+
+        assertThat(new String(decoded.get("encoded"), StandardCharsets.UTF_8))
+                .isEqualTo("paimon-value");
+    }
+}

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -81,6 +81,14 @@ public class FormatMetadataUtilsTest {
 
         assertThat(FormatMetadataUtils.readArrowSchema(encodedSchema)).hasValue(schema);
         assertThat(FormatMetadataUtils.readArrowSchema(null)).isEmpty();
+        assertThat(FormatMetadataUtils.readArrowSchema("not-base64")).isEmpty();
+        assertThat(
+                        FormatMetadataUtils.readArrowSchema(
+                                Base64.getEncoder()
+                                        .encodeToString(
+                                                "not-arrow-schema"
+                                                        .getBytes(StandardCharsets.UTF_8))))
+                .isEmpty();
     }
 
     @Test

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -118,18 +118,14 @@ public class FormatMetadataUtilsTest {
                 DataTypes.ROW(
                         DataTypes.FIELD(0, "id", DataTypes.INT()),
                         DataTypes.FIELD(
-                                1,
-                                "tags",
-                                DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
+                                1, "tags", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
                         DataTypes.FIELD(
                                 2,
                                 "nested",
                                 DataTypes.ROW(
                                         DataTypes.FIELD(3, "name", DataTypes.STRING()),
                                         DataTypes.FIELD(
-                                                4,
-                                                "scores",
-                                                DataTypes.ARRAY(DataTypes.INT())))));
+                                                4, "scores", DataTypes.ARRAY(DataTypes.INT())))));
         Map<String, String> tagsMetadata = new LinkedHashMap<>();
         tagsMetadata.put("paimon.test.tags", "enabled");
 
@@ -143,7 +139,6 @@ public class FormatMetadataUtilsTest {
                 .containsExactly("id", "tags", "nested");
         assertThat(schema.findField("tags").getMetadata())
                 .containsEntry("paimon.test.tags", "enabled");
-        assertThat(schema.findField("nested").getMetadata())
-                .doesNotContainKey("paimon.test.tags");
+        assertThat(schema.findField("nested").getMetadata()).doesNotContainKey("paimon.test.tags");
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -18,10 +18,16 @@
 
 package org.apache.paimon.format;
 
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -31,16 +37,73 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FormatMetadataUtilsTest {
 
     @Test
-    public void testDecodeMetadata() {
-        Map<String, String> metadata = new LinkedHashMap<>();
-        metadata.put(
-                "encoded",
-                Base64.getEncoder()
-                        .encodeToString("paimon-value".getBytes(StandardCharsets.UTF_8)));
+    public void testEncodeAndDecodeMetadata() {
+        Map<String, byte[]> metadata = new LinkedHashMap<>();
+        metadata.put("encoded", "paimon-value".getBytes(StandardCharsets.UTF_8));
 
-        Map<String, byte[]> decoded = FormatMetadataUtils.decodeMetadata(metadata);
+        Map<String, String> encoded = FormatMetadataUtils.encodeMetadata(metadata);
+        encoded.put("plain", "plain-value");
+        assertThat(encoded)
+                .containsEntry(
+                        "encoded",
+                        Base64.getEncoder()
+                                .encodeToString("paimon-value".getBytes(StandardCharsets.UTF_8)));
+
+        Map<String, byte[]> decoded = FormatMetadataUtils.decodeMetadata(encoded);
 
         assertThat(new String(decoded.get("encoded"), StandardCharsets.UTF_8))
                 .isEqualTo("paimon-value");
+        assertThat(new String(decoded.get("plain"), StandardCharsets.UTF_8))
+                .isEqualTo("plain-value");
+    }
+
+    @Test
+    public void testReadArrowSchema() {
+        Map<String, String> fieldMetadata = new LinkedHashMap<>();
+        fieldMetadata.put("paimon.test.field-key", "field-value");
+        Schema schema =
+                new Schema(
+                        Collections.singletonList(
+                                new Field(
+                                        "field",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.VARCHAR.getType(),
+                                                null,
+                                                fieldMetadata),
+                                        null)));
+        String encodedSchema = Base64.getEncoder().encodeToString(schema.serializeAsMessage());
+
+        assertThat(FormatMetadataUtils.readArrowSchema(encodedSchema)).hasValue(schema);
+        assertThat(FormatMetadataUtils.readArrowSchema(null)).isEmpty();
+    }
+
+    @Test
+    public void testReadFieldMetadata() {
+        assertThat(FormatMetadataUtils.readFieldMetadata(new Schema(Collections.emptyList())))
+                .isEmpty();
+
+        Map<String, String> fieldMetadata = new LinkedHashMap<>();
+        fieldMetadata.put("paimon.test.field-key", "field-value");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                new Field(
+                                        "with_metadata",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.INT.getType(),
+                                                null,
+                                                fieldMetadata),
+                                        null),
+                                new Field(
+                                        "without_metadata",
+                                        new FieldType(
+                                                true, Types.MinorType.INT.getType(), null, null),
+                                        null)));
+
+        assertThat(FormatMetadataUtils.readFieldMetadata(schema))
+                .containsEntry("with_metadata", fieldMetadata)
+                .containsEntry("without_metadata", Collections.emptyMap());
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -153,9 +153,10 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
 
         FormatReaderContext context =
                 new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        RowType emptyRowType = new RowType(Collections.emptyList());
         try (FileRecordReader<InternalRow> reader =
                 newFormat
-                        .createReaderFactory(rowType, rowType, Collections.emptyList())
+                        .createReaderFactory(emptyRowType, emptyRowType, Collections.emptyList())
                         .createReader(context)) {
             Optional<Schema> readArrowSchema =
                     ((SupportsReaderArrowSchema) reader).readArrowSchema();

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -24,24 +24,38 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatReadWriteTest;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.OrcOptions;
+import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsWriterMetadata;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,6 +93,73 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
 
     protected OrcFormatReadWriteTest() {
         super("orc");
+    }
+
+    @Test
+    public void testWriteMetadata() throws IOException {
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "id", DataTypes.INT()),
+                        DataTypes.FIELD(1, "name", DataTypes.STRING()));
+
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = newFormat.createWriterFactory(rowType).create(out, "zstd");
+        Map<String, String> fieldMetadata = new HashMap<>();
+        fieldMetadata.put("paimon.test.field-key", "field-value");
+        fieldMetadata.put("paimon.test.field-version", "1");
+        Schema arrowSchema =
+                new Schema(
+                        Arrays.asList(
+                                new Field(
+                                        "id",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.INT.getType(),
+                                                null,
+                                                Collections.singletonMap("PARQUET:field_id", "0")),
+                                        null),
+                                new Field(
+                                        "name",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.VARCHAR.getType(),
+                                                null,
+                                                fieldMetadata),
+                                        null)));
+        byte[] arrowSchemaBytes = arrowSchema.serializeAsMessage();
+        Map<String, byte[]> metadata = new HashMap<>();
+        metadata.put("paimon.test.key", "paimon-test-value".getBytes(StandardCharsets.UTF_8));
+        metadata.put(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY, arrowSchemaBytes);
+        ((SupportsWriterMetadata) writer).addMetadata(metadata);
+        writer.addElement(GenericRow.of(1, org.apache.paimon.data.BinaryString.fromString("one")));
+        writer.close();
+        out.close();
+
+        try (org.apache.orc.Reader reader =
+                OrcReaderFactory.createReader(
+                        new org.apache.hadoop.conf.Configuration(false), fileIO, file, null)) {
+            ByteBuffer value = reader.getMetadataValue("paimon.test.key");
+            Map<String, byte[]> decodedMetadata =
+                    FormatMetadataUtils.decodeMetadata(
+                            Collections.singletonMap(
+                                    "paimon.test.key",
+                                    StandardCharsets.UTF_8.decode(value.duplicate()).toString()));
+            assertThat(new String(decodedMetadata.get("paimon.test.key"), StandardCharsets.UTF_8))
+                    .isEqualTo("paimon-test-value");
+        }
+
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        try (FileRecordReader<InternalRow> reader =
+                newFormat
+                        .createReaderFactory(rowType, rowType, Collections.emptyList())
+                        .createReader(context)) {
+            Optional<Schema> readArrowSchema =
+                    ((SupportsReaderArrowSchema) reader).readArrowSchema();
+            assertThat(readArrowSchema).hasValue(arrowSchema);
+            assertThat(FormatMetadataUtils.readFieldMetadata(readArrowSchema.get()))
+                    .containsEntry("name", fieldMetadata);
+        }
     }
 
     @Test

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** An orc {@link FormatReadWriteTest}. */
 public class OrcFormatReadWriteTest extends FormatReadWriteTest {
@@ -133,6 +134,8 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
         ((SupportsWriterMetadata) writer).addMetadata(metadata);
         writer.addElement(GenericRow.of(1, org.apache.paimon.data.BinaryString.fromString("one")));
         writer.close();
+        assertThatThrownBy(() -> ((SupportsWriterMetadata) writer).addMetadata(metadata))
+                .isInstanceOf(IllegalStateException.class);
         out.close();
 
         try (org.apache.orc.Reader reader =

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -29,6 +29,7 @@ import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.SupportsReaderArrowSchema;
 import org.apache.paimon.format.SupportsWriterMetadata;
+import org.apache.paimon.format.parquet.writer.ParquetBuilder;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.FileRecordReader;
@@ -41,10 +42,12 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.OutputFile;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -139,6 +142,27 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
             Assertions.assertThat(readArrowSchema).hasValue(arrowSchema);
             Assertions.assertThat(FormatMetadataUtils.readFieldMetadata(readArrowSchema.get()))
                     .containsEntry("name", fieldMetadata);
+        }
+    }
+
+    @Test
+    public void testUnsupportedMetadataBuilderFailsExplicitly() throws Exception {
+        ParquetBuilder<InternalRow> unsupportedMetadataBuilder =
+                new ParquetBuilder<InternalRow>() {
+                    @Override
+                    public ParquetWriter<InternalRow> createWriter(
+                            OutputFile out, String compression) {
+                        throw new AssertionError("Two-argument createWriter should not be called.");
+                    }
+                };
+        ParquetWriterFactory factory = new ParquetWriterFactory(unsupportedMetadataBuilder);
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        try {
+            Assertions.assertThatThrownBy(() -> factory.create(out, "zstd"))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("does not support writer metadata");
+        } finally {
+            out.close();
         }
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -134,8 +134,9 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
 
         FormatReaderContext context =
                 new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        RowType emptyRowType = new RowType(Collections.emptyList());
         try (FileRecordReader<InternalRow> reader =
-                format.createReaderFactory(rowType, rowType, Collections.emptyList())
+                format.createReaderFactory(emptyRowType, emptyRowType, Collections.emptyList())
                         .createReader(context)) {
             Optional<Schema> readArrowSchema =
                     ((SupportsReaderArrowSchema) reader).readArrowSchema();

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -113,6 +113,8 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         ((SupportsWriterMetadata) writer).addMetadata(metadata);
         writer.addElement(GenericRow.of(1, BinaryString.fromString("one")));
         writer.close();
+        Assertions.assertThatThrownBy(() -> ((SupportsWriterMetadata) writer).addMetadata(metadata))
+                .isInstanceOf(IllegalStateException.class);
         out.close();
 
         try (ParquetFileReader reader =

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -20,15 +20,25 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileFormat;
 import org.apache.paimon.format.FileFormatFactory;
+import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatReadWriteTest;
+import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
+import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsWriterMetadata;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
@@ -40,9 +50,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 /** A parquet {@link FormatReadWriteTest}. */
@@ -56,6 +70,74 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
     protected FileFormat fileFormat() {
         return new ParquetFileFormat(
                 new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+    }
+
+    @Test
+    public void testWriteMetadata() throws Exception {
+        ParquetFileFormat format =
+                new ParquetFileFormat(
+                        new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "id", DataTypes.INT()),
+                        DataTypes.FIELD(1, "name", DataTypes.STRING()));
+
+        PositionOutputStream out = fileIO.newOutputStream(file, false);
+        FormatWriter writer = format.createWriterFactory(rowType).create(out, "zstd");
+        Map<String, String> fieldMetadata = new HashMap<>();
+        fieldMetadata.put("paimon.test.field-key", "field-value");
+        fieldMetadata.put("paimon.test.field-version", "1");
+        Schema arrowSchema =
+                new Schema(
+                        Arrays.asList(
+                                new Field(
+                                        "id",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.INT.getType(),
+                                                null,
+                                                Collections.singletonMap("PARQUET:field_id", "0")),
+                                        null),
+                                new Field(
+                                        "name",
+                                        new FieldType(
+                                                true,
+                                                Types.MinorType.VARCHAR.getType(),
+                                                null,
+                                                fieldMetadata),
+                                        null)));
+        byte[] arrowSchemaBytes = arrowSchema.serializeAsMessage();
+        Map<String, byte[]> metadata = new HashMap<>();
+        metadata.put("paimon.test.key", "paimon-test-value".getBytes(StandardCharsets.UTF_8));
+        metadata.put(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY, arrowSchemaBytes);
+        ((SupportsWriterMetadata) writer).addMetadata(metadata);
+        writer.addElement(GenericRow.of(1, BinaryString.fromString("one")));
+        writer.close();
+        out.close();
+
+        try (ParquetFileReader reader =
+                ParquetUtil.getParquetReader(
+                        fileIO, file, fileIO.getFileSize(file), new Options())) {
+            Map<String, String> fileMetadata =
+                    reader.getFooter().getFileMetaData().getKeyValueMetaData();
+            Map<String, byte[]> decodedMetadata = FormatMetadataUtils.decodeMetadata(fileMetadata);
+            Assertions.assertThat(
+                            new String(
+                                    decodedMetadata.get("paimon.test.key"), StandardCharsets.UTF_8))
+                    .isEqualTo("paimon-test-value");
+        }
+
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        try (FileRecordReader<InternalRow> reader =
+                format.createReaderFactory(rowType, rowType, Collections.emptyList())
+                        .createReader(context)) {
+            Optional<Schema> readArrowSchema =
+                    ((SupportsReaderArrowSchema) reader).readArrowSchema();
+            Assertions.assertThat(readArrowSchema).hasValue(arrowSchema);
+            Assertions.assertThat(FormatMetadataUtils.readFieldMetadata(readArrowSchema.get()))
+                    .containsEntry("name", fieldMetadata);
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Purpose

This PR is a sub-PR for shared-shredding.

Shared-shredding needs to attach dictionary and other field-level metadata before closing data files. To support that flow, this PR adds a generic metadata write/read path for file formats, so upper layers can provide raw key-value metadata during writing, and readers can parse the stored metadata back when opening files.

The metadata representation follows Arrow Parquet's existing schema metadata convention: Arrow stores the original serialized schema under the `ARROW:schema` file metadata key, base64-decodes it on read, and deserializes it with Arrow IPC schema reading. See Apache Arrow's Parquet schema implementation, where `kArrowSchemaKey` is `ARROW:schema` and the value is base64-decoded before `ReadSchema`.

Related design:
https://cwiki.apache.org/confluence/display/PAIMON/PIP-43%3A+Columnar+Storage+Optimization+for+MAP+Type+in+Paimon

### Brief change log

- Add `SupportsWriterMetadata` so format writers can accept raw `Map<String, byte[]>` metadata before file close.
- Add `SupportsReaderArrowSchema` so format readers can return the stored Arrow schema metadata.
- Add `FormatMetadataUtils` for:
  - base64 encoding metadata values before storing them in format footers;
  - base64 decoding stored metadata values;
  - reading the fixed `ARROW:schema` key into an Arrow `Schema`;
  - extracting field-level metadata as `Map<String, Map<String, String>>`.
- Support metadata writing for Parquet and ORC writers.
- Support Arrow schema metadata reading from Parquet and ORC readers.
- Add Parquet/ORC tests covering metadata write/read and field-level Arrow metadata roundtrip.

### Compatibility

The metadata value is stored using Arrow-compatible base64 encoding. For Arrow schema metadata, the key is `ARROW:schema`, matching Arrow Parquet's convention.

### Tests

```shell
mvn -pl paimon-format -am -Pfast-build -DfailIfNoTests=false \
  -Dtest=ParquetFormatReadWriteTest#testWriteMetadata,OrcFormatReadWriteTest#testWriteMetadata,FormatMetadataUtilsTest test
