### PR TITLE
[core] Share JDBC connection pool across catalog instances in same JVM

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
+++ b/paimon-common/src/main/java/org/apache/paimon/client/ClientPool.java
@@ -68,7 +68,12 @@ public interface ClientPool<C, E extends Exception> {
                     client = ensureActiveClient(client);
                     return action.run(client);
                 } finally {
+                    // Return client to the deque, then check if close() raced us.
+                    // The deque's lock ensures either drainTo or remove sees the client.
                     clients.addFirst(client);
+                    if (this.clients == null && clients.remove(client)) {
+                        close(client);
+                    }
                 }
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
@@ -21,14 +21,11 @@ package org.apache.paimon.jdbc;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.options.Options;
 
-import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
-import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
-
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
-import static org.apache.paimon.jdbc.JdbcCatalogOptions.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS;
 import static org.apache.paimon.options.CatalogOptions.CLIENT_POOL_SIZE;
 import static org.apache.paimon.options.CatalogOptions.URI;
 
@@ -37,59 +34,55 @@ import static org.apache.paimon.options.CatalogOptions.URI;
  * same JVM. This prevents each Flink operator from creating its own connection pool when using the
  * JDBC catalog.
  *
- * <p>The cache is keyed by JDBC URI and catalog key. Pools are evicted after a configurable
- * inactivity duration.
+ * <p>The cache is keyed by JDBC URI and catalog key. Pools live for the lifetime of the JVM and are
+ * closed via a shutdown hook.
  */
 public class CachedJdbcClientPool {
 
-    private static volatile Cache<Key, JdbcClientPool> clientPoolCache;
+    private static final ConcurrentMap<Key, JdbcClientPool> CLIENT_POOLS =
+            new ConcurrentHashMap<>();
+
+    static {
+        Runtime.getRuntime()
+                .addShutdownHook(
+                        new Thread(
+                                () -> {
+                                    for (JdbcClientPool pool : CLIENT_POOLS.values()) {
+                                        pool.close();
+                                    }
+                                    CLIENT_POOLS.clear();
+                                },
+                                "jdbc-client-pool-shutdown"));
+    }
 
     private final Key key;
     private final int poolSize;
     private final String dbUrl;
     private final Map<String, String> props;
-    private final long evictionInterval;
 
     public CachedJdbcClientPool(Options options, Map<String, String> props) {
         this.dbUrl = options.get(URI);
         this.poolSize = options.get(CLIENT_POOL_SIZE);
-        this.evictionInterval = options.get(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
         this.props = props;
         this.key = Key.of(dbUrl, options.get(JdbcCatalogOptions.CATALOG_KEY));
-        init();
-    }
-
-    private synchronized void init() {
-        if (clientPoolCache == null) {
-            clientPoolCache =
-                    Caffeine.newBuilder()
-                            .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
-                            .removalListener(
-                                    (ignored, value, cause) -> {
-                                        if (value != null) {
-                                            ((JdbcClientPool) value).close();
-                                        }
-                                    })
-                            .build();
-        }
     }
 
     /** Returns the shared {@link JdbcClientPool} for this cache key, creating one if needed. */
     public JdbcClientPool get() {
-        return clientPoolCache.get(key, k -> new JdbcClientPool(poolSize, dbUrl, props));
+        return CLIENT_POOLS.computeIfAbsent(key, k -> new JdbcClientPool(poolSize, dbUrl, props));
     }
 
     @VisibleForTesting
-    static Cache<Key, JdbcClientPool> clientPoolCache() {
-        return clientPoolCache;
+    static ConcurrentMap<Key, JdbcClientPool> clientPools() {
+        return CLIENT_POOLS;
     }
 
     @VisibleForTesting
-    static synchronized void resetCache() {
-        if (clientPoolCache != null) {
-            clientPoolCache.invalidateAll();
-            clientPoolCache = null;
+    static void resetCache() {
+        for (JdbcClientPool pool : CLIENT_POOLS.values()) {
+            pool.close();
         }
+        CLIENT_POOLS.clear();
     }
 
     static class Key {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jdbc;
+
+import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.options.Options;
+
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
+import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.paimon.jdbc.JdbcCatalogOptions.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS;
+import static org.apache.paimon.options.CatalogOptions.CLIENT_POOL_SIZE;
+import static org.apache.paimon.options.CatalogOptions.URI;
+
+/**
+ * A cache that shares {@link JdbcClientPool} instances across multiple catalog instances in the
+ * same JVM. This prevents each Flink operator from creating its own connection pool when using the
+ * JDBC catalog.
+ *
+ * <p>The cache is keyed by JDBC URI and catalog key. Pools are evicted after a configurable
+ * inactivity duration.
+ */
+public class CachedJdbcClientPool {
+
+    private static volatile Cache<Key, JdbcClientPool> clientPoolCache;
+
+    private final Key key;
+    private final int poolSize;
+    private final String dbUrl;
+    private final Map<String, String> props;
+    private final long evictionInterval;
+
+    public CachedJdbcClientPool(Options options, Map<String, String> props) {
+        this.dbUrl = options.get(URI);
+        this.poolSize = options.get(CLIENT_POOL_SIZE);
+        this.evictionInterval = options.get(CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS);
+        this.props = props;
+        this.key = Key.of(dbUrl, options.get(JdbcCatalogOptions.CATALOG_KEY));
+        init();
+    }
+
+    private synchronized void init() {
+        if (clientPoolCache == null) {
+            clientPoolCache =
+                    Caffeine.newBuilder()
+                            .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
+                            .removalListener(
+                                    (ignored, value, cause) -> {
+                                        if (value != null) {
+                                            ((JdbcClientPool) value).close();
+                                        }
+                                    })
+                            .build();
+        }
+    }
+
+    /** Returns the shared {@link JdbcClientPool} for this cache key, creating one if needed. */
+    public JdbcClientPool get() {
+        return clientPoolCache.get(key, k -> new JdbcClientPool(poolSize, dbUrl, props));
+    }
+
+    @VisibleForTesting
+    static Cache<Key, JdbcClientPool> clientPoolCache() {
+        return clientPoolCache;
+    }
+
+    @VisibleForTesting
+    static synchronized void resetCache() {
+        if (clientPoolCache != null) {
+            clientPoolCache.invalidateAll();
+            clientPoolCache = null;
+        }
+    }
+
+    static class Key {
+        private final String uri;
+        private final String catalogKey;
+
+        private Key(String uri, String catalogKey) {
+            this.uri = uri;
+            this.catalogKey = catalogKey;
+        }
+
+        static Key of(String uri, String catalogKey) {
+            return new Key(uri, catalogKey);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Key that = (Key) o;
+            return Objects.equals(uri, that.uri) && Objects.equals(catalogKey, that.catalogKey);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(uri, catalogKey);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/CachedJdbcClientPool.java
@@ -23,6 +23,8 @@ import org.apache.paimon.options.Options;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -34,8 +36,9 @@ import static org.apache.paimon.options.CatalogOptions.URI;
  * same JVM. This prevents each Flink operator from creating its own connection pool when using the
  * JDBC catalog.
  *
- * <p>The cache is keyed by JDBC URI and catalog key. Pools live for the lifetime of the JVM and are
- * closed via a shutdown hook.
+ * <p>The cache is keyed by JDBC URI, catalog key, pool size, and JDBC connection properties
+ * (credentials, driver settings). Pools live for the lifetime of the JVM and are closed via a
+ * shutdown hook.
  */
 public class CachedJdbcClientPool {
 
@@ -64,7 +67,9 @@ public class CachedJdbcClientPool {
         this.dbUrl = options.get(URI);
         this.poolSize = options.get(CLIENT_POOL_SIZE);
         this.props = props;
-        this.key = Key.of(dbUrl, options.get(JdbcCatalogOptions.CATALOG_KEY));
+        Properties jdbcProps =
+                JdbcUtils.extractJdbcConfiguration(props, JdbcCatalog.PROPERTY_PREFIX);
+        this.key = Key.of(dbUrl, options.get(JdbcCatalogOptions.CATALOG_KEY), poolSize, jdbcProps);
     }
 
     /** Returns the shared {@link JdbcClientPool} for this cache key, creating one if needed. */
@@ -88,14 +93,22 @@ public class CachedJdbcClientPool {
     static class Key {
         private final String uri;
         private final String catalogKey;
+        private final int poolSize;
+        private final Map<String, String> jdbcProperties;
 
-        private Key(String uri, String catalogKey) {
+        private Key(String uri, String catalogKey, int poolSize, Properties jdbcProps) {
             this.uri = uri;
             this.catalogKey = catalogKey;
+            this.poolSize = poolSize;
+            TreeMap<String, String> sorted = new TreeMap<>();
+            for (String name : jdbcProps.stringPropertyNames()) {
+                sorted.put(name, jdbcProps.getProperty(name));
+            }
+            this.jdbcProperties = sorted;
         }
 
-        static Key of(String uri, String catalogKey) {
-            return new Key(uri, catalogKey);
+        static Key of(String uri, String catalogKey, int poolSize, Properties jdbcProps) {
+            return new Key(uri, catalogKey, poolSize, jdbcProps);
         }
 
         @Override
@@ -107,12 +120,15 @@ public class CachedJdbcClientPool {
                 return false;
             }
             Key that = (Key) o;
-            return Objects.equals(uri, that.uri) && Objects.equals(catalogKey, that.catalogKey);
+            return poolSize == that.poolSize
+                    && Objects.equals(uri, that.uri)
+                    && Objects.equals(catalogKey, that.catalogKey)
+                    && Objects.equals(jdbcProperties, that.jdbcProperties);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(uri, catalogKey);
+            return Objects.hash(uri, catalogKey, poolSize, jdbcProperties);
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -98,11 +98,7 @@ public class JdbcCatalog extends AbstractCatalog {
         this.options = context.options();
         this.warehouse = warehouse;
         Preconditions.checkNotNull(options, "Invalid catalog properties: null");
-        this.connections =
-                new JdbcClientPool(
-                        options.get(CatalogOptions.CLIENT_POOL_SIZE),
-                        options.get(CatalogOptions.URI.key()),
-                        options.toMap());
+        this.connections = new CachedJdbcClientPool(options, options.toMap()).get();
         try {
             initializeCatalogTablesIfNeed();
         } catch (SQLException e) {
@@ -569,7 +565,8 @@ public class JdbcCatalog extends AbstractCatalog {
 
     @Override
     public void close() throws Exception {
-        connections.close();
+        // Do not close the connection pool here — it is shared across catalog instances
+        // via CachedJdbcClientPool and will be evicted/closed by the cache when idle.
     }
 
     private boolean syncTableProperties() {

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLockContext.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogLockContext.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.jdbc;
 
 import org.apache.paimon.catalog.CatalogLockContext;
-import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
 /** Jdbc lock context. */
@@ -41,11 +40,7 @@ public class JdbcCatalogLockContext implements CatalogLockContext {
 
     public JdbcClientPool connections() {
         if (connections == null) {
-            connections =
-                    new JdbcClientPool(
-                            options.get(CatalogOptions.CLIENT_POOL_SIZE),
-                            options.get(CatalogOptions.URI.key()),
-                            options.toMap());
+            connections = new CachedJdbcClientPool(options, options.toMap()).get();
         }
         return connections;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
@@ -22,8 +22,6 @@ import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
 
-import java.util.concurrent.TimeUnit;
-
 /** Options for jdbc catalog. */
 public final class JdbcCatalogOptions {
 
@@ -39,15 +37,6 @@ public final class JdbcCatalogOptions {
                     .defaultValue(255)
                     .withDescription(
                             "Set the maximum length of the lock key. The 'lock-key' is composed of concatenating three fields : 'catalog-key', 'database', and 'table'.");
-
-    public static final ConfigOption<Long> CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS =
-            ConfigOptions.key("client-pool-cache.eviction-interval-ms")
-                    .longType()
-                    .defaultValue(TimeUnit.MINUTES.toMillis(5))
-                    .withDescription(
-                            "Eviction interval for the shared JDBC client pool cache. "
-                                    + "When multiple catalog instances in the same JVM share a connection pool, "
-                                    + "idle pools are evicted after this duration of inactivity.");
 
     private JdbcCatalogOptions() {}
 

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalogOptions.java
@@ -22,6 +22,8 @@ import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
 
+import java.util.concurrent.TimeUnit;
+
 /** Options for jdbc catalog. */
 public final class JdbcCatalogOptions {
 
@@ -37,6 +39,15 @@ public final class JdbcCatalogOptions {
                     .defaultValue(255)
                     .withDescription(
                             "Set the maximum length of the lock key. The 'lock-key' is composed of concatenating three fields : 'catalog-key', 'database', and 'table'.");
+
+    public static final ConfigOption<Long> CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS =
+            ConfigOptions.key("client-pool-cache.eviction-interval-ms")
+                    .longType()
+                    .defaultValue(TimeUnit.MINUTES.toMillis(5))
+                    .withDescription(
+                            "Eviction interval for the shared JDBC client pool cache. "
+                                    + "When multiple catalog instances in the same JVM share a connection pool, "
+                                    + "idle pools are evicted after this duration of inactivity.");
 
     private JdbcCatalogOptions() {}
 

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jdbc;
+
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CachedJdbcClientPool}. */
+public class CachedJdbcClientPoolTest {
+
+    @AfterEach
+    void tearDown() {
+        CachedJdbcClientPool.resetCache();
+    }
+
+    @Test
+    void testSameKeyReturnsSamePool() {
+        String uri = sqliteUri();
+        Options options = createOptions(uri, "my-catalog");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options, options.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options, options.toMap());
+
+        assertThat(cache1.get()).isSameAs(cache2.get());
+    }
+
+    @Test
+    void testDifferentUriReturnsDifferentPool() {
+        Options options1 = createOptions(sqliteUri(), "my-catalog");
+        Options options2 = createOptions(sqliteUri(), "my-catalog");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isNotSameAs(cache2.get());
+    }
+
+    @Test
+    void testDifferentCatalogKeyReturnsDifferentPool() {
+        String uri = sqliteUri();
+        Options options1 = createOptions(uri, "catalog-a");
+        Options options2 = createOptions(uri, "catalog-b");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isNotSameAs(cache2.get());
+    }
+
+    @Test
+    void testPoolIsUsable() throws SQLException, InterruptedException {
+        Options options = createOptions(sqliteUri(), "test-catalog");
+        CachedJdbcClientPool cache = new CachedJdbcClientPool(options, options.toMap());
+
+        JdbcClientPool pool = cache.get();
+        Boolean result = pool.run(conn -> !conn.isClosed());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testMultipleCatalogInstancesSharePool() {
+        String uri = sqliteUri();
+        Options options = createOptions(uri, "shared-catalog");
+
+        JdbcCatalog catalog1 =
+                new JdbcCatalog(
+                        new org.apache.paimon.fs.local.LocalFileIO(),
+                        "shared-catalog",
+                        org.apache.paimon.catalog.CatalogContext.create(options),
+                        "/tmp/warehouse1");
+        JdbcCatalog catalog2 =
+                new JdbcCatalog(
+                        new org.apache.paimon.fs.local.LocalFileIO(),
+                        "shared-catalog",
+                        org.apache.paimon.catalog.CatalogContext.create(options),
+                        "/tmp/warehouse2");
+
+        assertThat(catalog1.getConnections()).isSameAs(catalog2.getConnections());
+    }
+
+    @Test
+    void testResetCacheClearsAllPools() {
+        Options options = createOptions(sqliteUri(), "test-catalog");
+        CachedJdbcClientPool cache = new CachedJdbcClientPool(options, options.toMap());
+        JdbcClientPool pool = cache.get();
+
+        assertThat(pool).isNotNull();
+        assertThat(CachedJdbcClientPool.clientPoolCache().estimatedSize()).isGreaterThan(0);
+
+        CachedJdbcClientPool.resetCache();
+
+        assertThat(CachedJdbcClientPool.clientPoolCache()).isNull();
+    }
+
+    private static Options createOptions(String uri, String catalogKey) {
+        Options options = new Options();
+        options.set(CatalogOptions.URI, uri);
+        options.set(JdbcCatalogOptions.CATALOG_KEY, catalogKey);
+        options.set(CatalogOptions.CLIENT_POOL_SIZE, 2);
+        return options;
+    }
+
+    private static String sqliteUri() {
+        return "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
@@ -110,11 +110,11 @@ public class CachedJdbcClientPoolTest {
         JdbcClientPool pool = cache.get();
 
         assertThat(pool).isNotNull();
-        assertThat(CachedJdbcClientPool.clientPoolCache().estimatedSize()).isGreaterThan(0);
+        assertThat(CachedJdbcClientPool.clientPools()).isNotEmpty();
 
         CachedJdbcClientPool.resetCache();
 
-        assertThat(CachedJdbcClientPool.clientPoolCache()).isNull();
+        assertThat(CachedJdbcClientPool.clientPools()).isEmpty();
     }
 
     private static Options createOptions(String uri, String catalogKey) {

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/CachedJdbcClientPoolTest.java
@@ -104,6 +104,70 @@ public class CachedJdbcClientPoolTest {
     }
 
     @Test
+    void testDifferentCredentialsReturnsDifferentPool() {
+        String uri = sqliteUri();
+        Options options1 = createOptions(uri, "my-catalog");
+        options1.set("jdbc.user", "user1");
+        options1.set("jdbc.password", "pass1");
+
+        Options options2 = createOptions(uri, "my-catalog");
+        options2.set("jdbc.user", "user2");
+        options2.set("jdbc.password", "pass2");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isNotSameAs(cache2.get());
+    }
+
+    @Test
+    void testSameCredentialsReturnsSamePool() {
+        String uri = sqliteUri();
+        Options options1 = createOptions(uri, "my-catalog");
+        options1.set("jdbc.user", "user1");
+        options1.set("jdbc.password", "pass1");
+
+        Options options2 = createOptions(uri, "my-catalog");
+        options2.set("jdbc.user", "user1");
+        options2.set("jdbc.password", "pass1");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isSameAs(cache2.get());
+    }
+
+    @Test
+    void testDifferentJdbcPropertyReturnsDifferentPool() {
+        String uri = sqliteUri();
+        Options options1 = createOptions(uri, "my-catalog");
+        options1.set("jdbc.useSSL", "true");
+
+        Options options2 = createOptions(uri, "my-catalog");
+        options2.set("jdbc.useSSL", "false");
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isNotSameAs(cache2.get());
+    }
+
+    @Test
+    void testDifferentPoolSizeReturnsDifferentPool() {
+        String uri = sqliteUri();
+        Options options1 = createOptions(uri, "my-catalog");
+        options1.set(CatalogOptions.CLIENT_POOL_SIZE, 2);
+
+        Options options2 = createOptions(uri, "my-catalog");
+        options2.set(CatalogOptions.CLIENT_POOL_SIZE, 5);
+
+        CachedJdbcClientPool cache1 = new CachedJdbcClientPool(options1, options1.toMap());
+        CachedJdbcClientPool cache2 = new CachedJdbcClientPool(options2, options2.toMap());
+
+        assertThat(cache1.get()).isNotSameAs(cache2.get());
+    }
+
+    @Test
     void testResetCacheClearsAllPools() {
         Options options = createOptions(sqliteUri(), "test-catalog");
         CachedJdbcClientPool cache = new CachedJdbcClientPool(options, options.toMap());


### PR DESCRIPTION
## Summary

- Introduces `CachedJdbcClientPool`, a static cache that shares `JdbcClientPool` instances across all `JdbcCatalog` instances in the same JVM, keyed by `(JDBC URI, catalog-key)`.
- Mirrors the existing pattern used by Hive's `CachedClientPool` for HMS Thrift connections.
- Reduces JDBC connections from `O(parallelism × operators × pool_size)` to `O(TaskManagers × pool_size)` in Flink CDC jobs.

For high parallelism jobs this reduces jdbc connection count by 8x or more.

## Motivation

In Flink CDC sync jobs, every operator subtask that calls `catalogLoader.load()` creates a new `JdbcCatalog` with its own dedicated connection pool (default size: 2). With parallelism 16, a single job creates ~128 JDBC connections across parser, schema evolution, writer, and committer operators. The HiveCatalog avoids this via `CachedClientPool` — a static Caffeine cache that shares a single HMS client pool across all catalog instances in the same JVM.

This PR applies this pattern to `JdbcCatalog`.

## Design Decision: ConcurrentHashMap vs Caffeine

HiveCatalog uses Caffeine with `expireAfterAccess` and avoids premature eviction by never exposing the raw pool — `CachedClientPool` implements `ClientPool` and delegates every `run()` call through `clientPoolCache.get(key)`, which refreshes the access timer on each operation.

Using Caffeine for JDBC would require a larger change because all 16 methods in `JdbcUtils` are typed to accept `JdbcClientPool`, not the `ClientPool` interface. If using Caffeine is preferred I will do that instead. I have started with the simpler change. Please let me know.

Instead we use a `ConcurrentHashMap` with no time-based eviction. Pools live for the JVM lifetime and are closed via a shutdown hook. This is safe because:
- Connection pools are lightweight to hold
- In Flink, catalogs are long-lived (created at job start, used for hours)
- The shutdown hook ensures deterministic cleanup

## Changes

- **`CachedJdbcClientPool`** (new): Static `ConcurrentHashMap<Key, JdbcClientPool>` keyed on `(URI, catalog-key)`. JVM shutdown hook closes all pools.
- **`JdbcCatalog`**: Uses `CachedJdbcClientPool.get()` instead of creating a dedicated pool. `close()` no longer closes the shared pool.
- **`JdbcCatalogLockContext`**: Same — uses the shared cached pool.

## Test plan

- [x] `JdbcCatalogTest` (70 tests) — passes
- [x] `JdbcClientPoolTest` (4 tests) — passes
- [x] `CachedJdbcClientPoolTest` (6 tests) — new tests for pool sharing semantics