### PR TITLE
[hive] Fix DROP TABLE fails when table directory has been deleted from filesystem

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/AbstractCatalog.java
@@ -390,7 +390,7 @@ public abstract class AbstractCatalog implements Catalog {
         dropTableImpl(identifier, new ArrayList<>(externalPaths));
     }
 
-    private List<Path> getSchemaExternalPaths(List<TableSchema> schemas) {
+    protected List<Path> getSchemaExternalPaths(List<TableSchema> schemas) {
         if (schemas == null) {
             return Collections.emptyList();
         }

--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/HiveCatalog.java
@@ -1084,6 +1084,44 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
+    public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
+            throws TableNotExistException {
+        checkNotBranch(identifier, "dropTable");
+        checkNotSystemTable(identifier, "dropTable");
+
+        try {
+            getHmsTable(identifier);
+        } catch (TableNotExistException e) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotExistException(identifier);
+        }
+
+        Set<Path> externalPaths = new HashSet<>();
+        try {
+            org.apache.paimon.table.Table table = getTable(identifier);
+            if (table instanceof FileStoreTable) {
+                FileStoreTable fileStoreTable = (FileStoreTable) table;
+                List<Path> schemaExternalPaths =
+                        getSchemaExternalPaths(fileStoreTable.schemaManager().listAll());
+                externalPaths.addAll(schemaExternalPaths);
+                List<String> branches = fileStoreTable.branchManager().branches();
+                for (String branch : branches) {
+                    SchemaManager schemaManager =
+                            fileStoreTable.schemaManager().copyWithBranch(branch);
+                    externalPaths.addAll(getSchemaExternalPaths(schemaManager.listAll()));
+                }
+            }
+        } catch (TableNotExistException e) {
+            // Filesystem data may have been deleted but HMS metadata still exists.
+            // Proceed with drop to clean up the orphaned HMS record.
+        }
+
+        dropTableImpl(identifier, new ArrayList<>(externalPaths));
+    }
+
+    @Override
     protected void createTableImpl(Identifier identifier, Schema schema) {
         try {
             boolean tableExists =

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/HiveCatalogTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogTestBase;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.client.ClientPool;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
@@ -551,6 +552,21 @@ public class HiveCatalogTest extends CatalogTestBase {
                                 catalog.alterPartitions(
                                         Identifier.create(databaseName, "non_existing_table"),
                                         Collections.singletonList(partition)));
+    }
+
+    @Test
+    public void testDropTableWhenFilesystemDeleted() throws Exception {
+        catalog.createDatabase("test_db", false);
+        Identifier identifier = Identifier.create("test_db", "table_to_drop");
+        catalog.createTable(identifier, DEFAULT_TABLE_SCHEMA, false);
+
+        Path tablePath = ((HiveCatalog) catalog).getTableLocation(identifier);
+        ((HiveCatalog) catalog).fileIO().deleteDirectoryQuietly(tablePath);
+
+        catalog.dropTable(identifier, false);
+
+        assertThatThrownBy(() -> catalog.getTable(identifier))
+                .isInstanceOf(Catalog.TableNotExistException.class);
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fix #4853: When using Hive catalog, DROP TABLE fails if the table directory has been deleted from the filesystem, leaving orphaned HMS metadata.

HiveCatalog's `dropTable` inherited `AbstractCatalog.dropTable()` which calls `getTable()` first as an existence check. `getTable()` → `loadTableSchema()` → `tableSchemaInFileSystem()` requires reading schema from the filesystem, so when the directory was deleted, it threw `TableNotExistException` before `dropTableImpl()` could clean up the HMS record.

## Fix

Override `dropTable()` in HiveCatalog to:
1. Check HMS directly via `getHmsTable()` for existence
2. Tolerate missing filesystem when collecting external paths
3. Always proceed to `dropTableImpl()` which drops the HMS metadata

Also make `AbstractCatalog.getSchemaExternalPaths` protected so subclasses can reuse it.

## Test

Added `testDropTableWhenFilesystemDeleted` in `HiveCatalogTest` — creates table, deletes filesystem directory, verifies `dropTable` succeeds and the table is fully cleaned up.