### PR TITLE
[core][spark][flink] Support sub-field-level data evolution for nested columns

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -516,7 +516,7 @@ under the License.
             <td><h5>data-evolution.nested-field.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to enable sub-field-level data evolution for nested (struct) columns. When enabled, an update that only touches some sub-fields of a nested column writes an incremental file containing just those sub-fields (aligned by row id); when disabled, the whole top-level column is rewritten. Requires data-evolution.enabled=true.</td>
+            <td>Whether to enable sub-field-level data evolution for nested (struct) columns. When enabled, an update that only touches some sub-fields of a nested column writes an incremental file containing just those sub-fields (aligned by row id); when disabled, the whole top-level column is rewritten. Requires data-evolution.enabled=true. Mixed-version compatibility warning: once a file's write columns record a nested sub-field path (e.g. 'nest.a'), a reader, writer, compactor, or other maintenance job on an older version cannot reconstruct it. Every such component reading or writing this table must be upgraded before enabling this option, and downgrading the binary is unsafe once such files have been committed.</td>
         </tr>
         <tr>
             <td><h5>data-evolution.reassign.skip-contiguous-row-count</h5></td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -513,6 +513,12 @@ under the License.
             <td>Whether to persist source when process merge into action on data evolution table.</td>
         </tr>
         <tr>
+            <td><h5>data-evolution.nested-field.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable sub-field-level data evolution for nested (struct) columns. When enabled, an update that only touches some sub-fields of a nested column writes an incremental file containing just those sub-fields (aligned by row id); when disabled, the whole top-level column is rewritten. Requires data-evolution.enabled=true.</td>
+        </tr>
+        <tr>
             <td><h5>data-evolution.reassign.skip-contiguous-row-count</h5></td>
             <td style="word-wrap: break-word;">1000000000</td>
             <td>Long</td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2503,6 +2503,18 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_NESTED_FIELD_ENABLED =
+            key("data-evolution.nested-field.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable sub-field-level data evolution for nested (struct) "
+                                    + "columns. When enabled, an update that only touches some "
+                                    + "sub-fields of a nested column writes an incremental file "
+                                    + "containing just those sub-fields (aligned by row id); when "
+                                    + "disabled, the whole top-level column is rewritten. Requires "
+                                    + "data-evolution.enabled=true.");
+
     public static final ConfigOption<Long> DATA_EVOLUTION_REASSIGN_SKIP_CONTIGUOUS_ROW_COUNT =
             key("data-evolution.reassign.skip-contiguous-row-count")
                     .longType()
@@ -4358,6 +4370,10 @@ public class CoreOptions implements Serializable {
 
     public boolean dataEvolutionEnabled() {
         return options.get(DATA_EVOLUTION_ENABLED);
+    }
+
+    public boolean dataEvolutionNestedFieldEnabled() {
+        return options.get(DATA_EVOLUTION_NESTED_FIELD_ENABLED);
     }
 
     public long dataEvolutionReassignSkipContiguousRowCount() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2498,6 +2498,18 @@ public class CoreOptions implements Serializable {
                     .defaultValue(false)
                     .withDescription("Whether enable data evolution for row tracking table.");
 
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_NESTED_FIELD_ENABLED =
+            key("data-evolution.nested-field.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable sub-field-level data evolution for nested (struct) "
+                                    + "columns. When enabled, an update that only touches some "
+                                    + "sub-fields of a nested column writes an incremental file "
+                                    + "containing just those sub-fields (aligned by row id); when "
+                                    + "disabled, the whole top-level column is rewritten. Requires "
+                                    + "data-evolution.enabled=true.");
+
     public static final ConfigOption<Long> DATA_EVOLUTION_REASSIGN_SKIP_CONTIGUOUS_ROW_COUNT =
             key("data-evolution.reassign.skip-contiguous-row-count")
                     .longType()
@@ -4245,6 +4257,10 @@ public class CoreOptions implements Serializable {
 
     public boolean dataEvolutionEnabled() {
         return options.get(DATA_EVOLUTION_ENABLED);
+    }
+
+    public boolean dataEvolutionNestedFieldEnabled() {
+        return options.get(DATA_EVOLUTION_NESTED_FIELD_ENABLED);
     }
 
     public long dataEvolutionReassignSkipContiguousRowCount() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2513,7 +2513,14 @@ public class CoreOptions implements Serializable {
                                     + "sub-fields of a nested column writes an incremental file "
                                     + "containing just those sub-fields (aligned by row id); when "
                                     + "disabled, the whole top-level column is rewritten. Requires "
-                                    + "data-evolution.enabled=true.");
+                                    + "data-evolution.enabled=true. Mixed-version compatibility "
+                                    + "warning: once a file's write columns record a nested "
+                                    + "sub-field path (e.g. 'nest.a'), a reader, writer, compactor, "
+                                    + "or other maintenance job on an older version cannot "
+                                    + "reconstruct it. Every such component reading or writing this "
+                                    + "table must be upgraded before enabling this option, and "
+                                    + "downgrading the binary is unsafe once such files have been "
+                                    + "committed.");
 
     public static final ConfigOption<Long> DATA_EVOLUTION_REASSIGN_SKIP_CONTIGUOUS_ROW_COUNT =
             key("data-evolution.reassign.skip-contiguous-row-count")

--- a/paimon-api/src/main/java/org/apache/paimon/schema/TableSchema.java
+++ b/paimon-api/src/main/java/org/apache/paimon/schema/TableSchema.java
@@ -288,7 +288,9 @@ public class TableSchema implements Serializable {
         return new TableSchema(
                 version,
                 id,
-                new RowType(fields).project(writeCols).getFields(),
+                // writeCols may contain nested dotted paths (e.g. "nest.a") for sub-field-level
+                // data evolution; projectByPaths handles both plain top-level names and paths
+                new RowType(fields).projectByPaths(writeCols).getFields(),
                 highestFieldId,
                 partitionKeys,
                 primaryKeys,

--- a/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
@@ -418,12 +418,16 @@ public final class RowType extends DataType {
      */
     public List<String> leafPaths(RowType fullType) {
         List<String> result = new ArrayList<>();
-        collectLeafPaths(getFields(), fullType, "", result);
+        collectLeafPaths(getFields(), fullType, fullType, "", result);
         return result;
     }
 
     private static void collectLeafPaths(
-            List<DataField> writeFields, RowType fullType, String prefix, List<String> out) {
+            List<DataField> writeFields,
+            RowType fullType,
+            RowType topLevelFullType,
+            String prefix,
+            List<String> out) {
         for (DataField writeField : writeFields) {
             String path = prefix.isEmpty() ? writeField.name() : prefix + "." + writeField.name();
             // A field absent from the reference type (e.g. the _ROW_ID / _SEQUENCE_NUMBER special
@@ -467,24 +471,48 @@ public final class RowType extends DataType {
                 collectLeafPaths(
                         ((RowType) writeField.type()).getFields(),
                         (RowType) fullField.type(),
+                        topLevelFullType,
                         path,
                         out);
             } else {
+                // A dotted leaf path is only unambiguous if it cannot also be read as a literal
+                // top-level field name: projectByPaths prefers an exact top-level name match, so
+                // a schema that has both a nested leaf "a.b" and a literal top-level field named
+                // "a.b" cannot be told apart once flattened into this same string. Reject such a
+                // write up front rather than silently reconstructing the wrong field on read.
+                if (!prefix.isEmpty() && topLevelFullType.containsField(path)) {
+                    throw new UnsupportedOperationException(
+                            "Sub-field-level data evolution cannot write the nested sub-field '"
+                                    + path
+                                    + "' because a top-level field named '"
+                                    + path
+                                    + "' already exists in the table, making the encoded write "
+                                    + "path ambiguous. Rename one of the two fields.");
+                }
                 out.add(path);
             }
         }
     }
 
-    /** Whether {@code part} contains every (recursively nested) field of {@code full}. */
+    /**
+     * Whether {@code part} contains every (recursively nested) field of {@code full} in the same
+     * physical order. Order matters here: {@code part} describes the physical layout a file was
+     * actually written with, and a caller that finds this returns {@code true} collapses the leaf
+     * path to the bare top-level field name, relying on {@code full}'s declared order to describe
+     * that physical layout on read.
+     */
     private static boolean coversFully(RowType part, RowType full) {
         if (part.getFieldCount() != full.getFieldCount()) {
             return false;
         }
-        for (DataField fullField : full.getFields()) {
-            if (!part.containsField(fullField.id())) {
+        List<DataField> partFields = part.getFields();
+        List<DataField> fullFields = full.getFields();
+        for (int i = 0; i < fullFields.size(); i++) {
+            DataField partField = partFields.get(i);
+            DataField fullField = fullFields.get(i);
+            if (partField.id() != fullField.id()) {
                 return false;
             }
-            DataField partField = part.getField(fullField.id());
             if (partField.type() instanceof RowType && fullField.type() instanceof RowType) {
                 if (!coversFully((RowType) partField.type(), (RowType) fullField.type())) {
                     return false;

--- a/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/RowType.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -331,6 +332,166 @@ public final class RowType extends DataType {
 
     public RowType project(String... names) {
         return project(Arrays.asList(names));
+    }
+
+    /**
+     * Project this row type by a list of (possibly nested) dotted paths, e.g. {@code ["f0",
+     * "nest.a"]}. A path without a dot selects the whole top-level field (same as {@link
+     * #project(List)}); a dotted path selects only the addressed sub-field of a nested {@link
+     * RowType}, preserving field ids and nullability of every level. Fields are emitted in the
+     * order the paths are given (exactly like {@link #project(List)}), not in schema declaration
+     * order. This is used by data evolution to reconstruct the partial nested schema of a
+     * column-group file from its {@code writeCols}.
+     */
+    public RowType projectByPaths(List<String> paths) {
+        return projectTypeByPaths(this, paths);
+    }
+
+    private static RowType projectTypeByPaths(RowType type, List<String> paths) {
+        // group paths by their immediate child name, keeping the order in which the paths are
+        // given; a child appearing without a tail (or also with a tail) is selected as a whole
+        // field
+        Map<String, List<String>> childToSubPaths = new LinkedHashMap<>();
+        Set<String> wholeChildren = new HashSet<>();
+        Map<String, DataField> fieldByName = new LinkedHashMap<>();
+        for (DataField field : type.getFields()) {
+            fieldByName.put(field.name(), field);
+        }
+        for (String path : paths) {
+            int dot = path.indexOf('.');
+            // Prefer an exact field-name match so a column whose name itself contains a dot (and
+            // any
+            // plain top-level name) is selected whole; only split into head.tail for genuine nested
+            // sub-field paths that do not name a field directly. This keeps backward compatibility
+            // with the legacy exact-name project(List).
+            if (dot < 0 || fieldByName.containsKey(path)) {
+                childToSubPaths.computeIfAbsent(path, k -> new ArrayList<>());
+                wholeChildren.add(path);
+            } else {
+                String head = path.substring(0, dot);
+                String tail = path.substring(dot + 1);
+                childToSubPaths.computeIfAbsent(head, k -> new ArrayList<>()).add(tail);
+            }
+        }
+
+        // Emit fields in the order the paths were given, exactly like project(List). Callers such
+        // as TableSchema.project(writeCols) rebuild the physical layout of a data file from its
+        // writeCols, and that order is not necessarily the schema declaration order; reordering
+        // here would silently describe the file with the columns permuted.
+        List<DataField> result = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : childToSubPaths.entrySet()) {
+            String name = entry.getKey();
+            DataField field = fieldByName.get(name);
+            if (field == null) {
+                throw new IllegalArgumentException(
+                        "Cannot project by paths, unknown field '" + name + "' in " + type);
+            }
+            List<String> subPaths = entry.getValue();
+            if (wholeChildren.contains(name) || subPaths.isEmpty()) {
+                result.add(field);
+            } else if (field.type() instanceof RowType) {
+                RowType prunedChild =
+                        projectTypeByPaths((RowType) field.type(), subPaths)
+                                .copy(field.type().isNullable());
+                result.add(field.newType(prunedChild));
+            } else {
+                // a dotted path addresses a sub-field, but this field is not a ROW; reject rather
+                // than silently selecting the whole field, so invalid dotted paths surface early
+                throw new IllegalArgumentException(
+                        "Cannot project sub-field(s) "
+                                + subPaths
+                                + " of non-ROW field '"
+                                + name
+                                + "' in "
+                                + type);
+            }
+        }
+        return new RowType(type.isNullable(), result);
+    }
+
+    /**
+     * Compute the dotted paths describing this (possibly partially nested) write type relative to a
+     * full row type. A top-level field, or a nested field whose structure fully covers the
+     * corresponding field in {@code fullType}, is emitted by its name; a nested field that only
+     * covers some sub-fields is expanded into dotted leaf paths. This is the inverse of {@link
+     * #projectByPaths(List)} and is used to derive {@code writeCols}.
+     */
+    public List<String> leafPaths(RowType fullType) {
+        List<String> result = new ArrayList<>();
+        collectLeafPaths(getFields(), fullType, "", result);
+        return result;
+    }
+
+    private static void collectLeafPaths(
+            List<DataField> writeFields, RowType fullType, String prefix, List<String> out) {
+        for (DataField writeField : writeFields) {
+            String path = prefix.isEmpty() ? writeField.name() : prefix + "." + writeField.name();
+            // A field absent from the reference type (e.g. the _ROW_ID / _SEQUENCE_NUMBER special
+            // fields added by row tracking, which are not part of the table's logical row type) has
+            // no sub-field split: emit it whole by name, matching the legacy getFieldNames()
+            // output.
+            if (!fullType.containsField(writeField.id())) {
+                out.add(path);
+                continue;
+            }
+            DataField fullField = fullType.getField(writeField.id());
+            boolean willExpand =
+                    writeField.type() instanceof RowType
+                            && fullField.type() instanceof RowType
+                            && !coversFully(
+                                    (RowType) writeField.type(), (RowType) fullField.type());
+            // A dotted path is only unambiguous if no name segment contains a literal '.'. A name
+            // with a dot is fine when emitted whole at top level (projectByPaths matches it
+            // exactly),
+            // but not when it participates in a multi-segment nested path.
+            if (writeField.name().indexOf('.') >= 0 && (!prefix.isEmpty() || willExpand)) {
+                throw new UnsupportedOperationException(
+                        "Sub-field-level data evolution does not support a nested field whose name "
+                                + "contains '.': "
+                                + path);
+            }
+            if (willExpand) {
+                // A partial struct nested inside another partial struct (a path deeper than one
+                // level, e.g. nest.sub.x) cannot be composed back on read — the data-evolution read
+                // path only assembles one nested level. Reject it here so such a file is never
+                // written/committed and later breaks full-table reads.
+                if (!prefix.isEmpty()) {
+                    throw new UnsupportedOperationException(
+                            "Sub-field-level data evolution supports only one level of partial "
+                                    + "nesting; the nested sub-field '"
+                                    + path
+                                    + "' cannot be partially written. Write the whole '"
+                                    + path
+                                    + "' sub-field instead.");
+                }
+                collectLeafPaths(
+                        ((RowType) writeField.type()).getFields(),
+                        (RowType) fullField.type(),
+                        path,
+                        out);
+            } else {
+                out.add(path);
+            }
+        }
+    }
+
+    /** Whether {@code part} contains every (recursively nested) field of {@code full}. */
+    private static boolean coversFully(RowType part, RowType full) {
+        if (part.getFieldCount() != full.getFieldCount()) {
+            return false;
+        }
+        for (DataField fullField : full.getFields()) {
+            if (!part.containsField(fullField.id())) {
+                return false;
+            }
+            DataField partField = part.getField(fullField.id());
+            if (partField.type() instanceof RowType && fullField.type() instanceof RowType) {
+                if (!coversFully((RowType) partField.type(), (RowType) fullField.type())) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private Map<String, DataField> nameToField() {

--- a/paimon-api/src/test/java/org/apache/paimon/types/RowTypeTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/types/RowTypeTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link RowType#leafPaths} and {@link RowType#projectByPaths}. */
+class RowTypeTest {
+
+    @Test
+    void leafPathsRejectsDottedPathCollidingWithTopLevelFieldName() {
+        // fullType has a top-level field literally named "a.b" (id 5), plus a struct "a" (id 6)
+        // with children x (id 7) and b (id 8).
+        RowType fullType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(5, "a.b", new IntType()),
+                                new DataField(
+                                        6,
+                                        "a",
+                                        new RowType(
+                                                Arrays.asList(
+                                                        new DataField(7, "x", new IntType()),
+                                                        new DataField(8, "b", new IntType()))))));
+
+        // Partial write: only the "b" child of struct "a" is written (id 8), not "x". Its
+        // flattened dotted path "a.b" would collide with the literal top-level field of the same
+        // name.
+        RowType writeType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(
+                                        6,
+                                        "a",
+                                        new RowType(
+                                                Arrays.asList(
+                                                        new DataField(8, "b", new IntType()))))));
+
+        assertThatThrownBy(() -> writeType.leafPaths(fullType))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("a.b");
+    }
+
+    @Test
+    void leafPathsPreservesReorderedFullStructWriteOrder() {
+        // fullType: nest<a INT, b STRING> declared in order a, b.
+        RowType nestFull =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(2, "a", new IntType()),
+                                new DataField(3, "b", VarCharType.STRING_TYPE)));
+        RowType fullType = new RowType(Arrays.asList(new DataField(1, "nest", nestFull)));
+
+        // Physically written in reversed order: nest<b, a>.
+        RowType writeType = fullType.projectByPaths(Arrays.asList("nest.b", "nest.a"));
+        RowType writtenNest = (RowType) writeType.getFields().get(0).type();
+        assertThat(writtenNest.getFieldNames()).containsExactly("b", "a");
+
+        // Even though every sub-field of "nest" is present, the reordered layout must not
+        // collapse to the bare top-level name "nest" (that would silently discard the physical
+        // write order and let a reader reconstruct schema-declaration order instead).
+        List<String> leafPaths = writeType.leafPaths(fullType);
+        assertThat(leafPaths).containsExactly("nest.b", "nest.a");
+
+        RowType reconstructed = fullType.projectByPaths(leafPaths);
+        RowType reconstructedNest = (RowType) reconstructed.getFields().get(0).type();
+        assertThat(reconstructedNest.getFieldNames()).isEqualTo(writtenNest.getFieldNames());
+    }
+
+    @Test
+    void leafPathsCollapsesToWholeFieldWhenOrderMatches() {
+        // Same schema, but written in declaration order: coversFully should still collapse to
+        // the bare top-level name, since nothing is ambiguous or reordered here.
+        RowType nestFull =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(2, "a", new IntType()),
+                                new DataField(3, "b", VarCharType.STRING_TYPE)));
+        RowType fullType = new RowType(Arrays.asList(new DataField(1, "nest", nestFull)));
+
+        RowType writeType = fullType.projectByPaths(Arrays.asList("nest.a", "nest.b"));
+        assertThat(writeType.leafPaths(fullType)).containsExactly("nest");
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/reader/DataEvolutionFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/DataEvolutionFileReader.java
@@ -57,9 +57,18 @@ public class DataEvolutionFileReader implements RecordReader<InternalRow> {
     private final int[] rowOffsets;
     private final int[] fieldOffsets;
     private final RecordReader<InternalRow>[] readers;
+    @Nullable private final DataEvolutionRow.NestedField[] nested;
 
     public DataEvolutionFileReader(
             int[] rowOffsets, int[] fieldOffsets, RecordReader<InternalRow>[] readers) {
+        this(rowOffsets, fieldOffsets, readers, null);
+    }
+
+    public DataEvolutionFileReader(
+            int[] rowOffsets,
+            int[] fieldOffsets,
+            RecordReader<InternalRow>[] readers,
+            @Nullable DataEvolutionRow.NestedField[] nested) {
         checkArgument(rowOffsets != null, "Row offsets must not be null");
         checkArgument(fieldOffsets != null, "Field offsets must not be null");
         checkArgument(
@@ -70,12 +79,14 @@ public class DataEvolutionFileReader implements RecordReader<InternalRow> {
         this.rowOffsets = rowOffsets;
         this.fieldOffsets = fieldOffsets;
         this.readers = readers;
+        this.nested = nested;
     }
 
     @Override
     @Nullable
     public RecordIterator<InternalRow> readBatch() throws IOException {
         DataEvolutionRow row = new DataEvolutionRow(readers.length, rowOffsets, fieldOffsets);
+        row.setNested(nested);
         RecordIterator<InternalRow>[] iterators = new RecordIterator[readers.length];
         for (int i = 0; i < readers.length; i++) {
             RecordReader<InternalRow> reader = readers[i];

--- a/paimon-common/src/main/java/org/apache/paimon/reader/DataEvolutionRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/DataEvolutionRow.java
@@ -35,12 +35,24 @@ public class DataEvolutionRow implements InternalRow {
     private final InternalRow[] rows;
     private final int[] rowOffsets;
     private final int[] fieldOffsets;
+
+    /**
+     * Optional per-top-level-field plan to assemble a nested struct whose sub-fields are spread
+     * across several source files (sub-field-level data evolution). {@code null} (or a {@code null}
+     * entry) means the field is taken whole from a single source row (the common case).
+     */
+    private NestedField[] nested;
+
     private RowKind rowKind;
 
     public DataEvolutionRow(int rowNumber, int[] rowOffsets, int[] fieldOffsets) {
         this.rows = new InternalRow[rowNumber];
         this.rowOffsets = rowOffsets;
         this.fieldOffsets = fieldOffsets;
+    }
+
+    public void setNested(NestedField[] nested) {
+        this.nested = nested;
     }
 
     public int rowNumber() {
@@ -56,6 +68,21 @@ public class DataEvolutionRow implements InternalRow {
                 this.rowKind = row.getRowKind();
             }
             rows[pos] = row;
+        }
+    }
+
+    private void setRowsAllowNull(InternalRow[] newRows) {
+        for (int i = 0; i < newRows.length; i++) {
+            this.rows[i] = newRows[i];
+            if (rowKind == null && newRows[i] != null) {
+                this.rowKind = newRows[i].getRowKind();
+            }
+        }
+        if (rowKind == null) {
+            // a composed struct whose every source partial is null still needs a defined kind so
+            // getRowKind() never returns null; the kind of an assembled struct value is not
+            // meaningful, so default to INSERT
+            this.rowKind = RowKind.INSERT;
         }
     }
 
@@ -97,10 +124,22 @@ public class DataEvolutionRow implements InternalRow {
 
     @Override
     public boolean isNullAt(int pos) {
+        if (nested != null && nested[pos] != null) {
+            // a composed struct is null only when none of its source files provide it
+            NestedField nf = nested[pos];
+            for (int k = 0; k < nf.numPartials; k++) {
+                InternalRow src = rows[nf.partialReader[k]];
+                if (src != null && !src.isNullAt(nf.partialOffset[k])) {
+                    return false;
+                }
+            }
+            return true;
+        }
         if (rowOffsets[pos] < 0) {
             return true;
         }
-        return chooseRow(pos).isNullAt(offsetInRow(pos));
+        InternalRow row = chooseRow(pos);
+        return row == null || row.isNullAt(offsetInRow(pos));
     }
 
     @Override
@@ -185,6 +224,54 @@ public class DataEvolutionRow implements InternalRow {
 
     @Override
     public InternalRow getRow(int pos, int numFields) {
+        if (nested != null && nested[pos] != null) {
+            NestedField nf = nested[pos];
+            InternalRow[] partials = new InternalRow[nf.numPartials];
+            for (int k = 0; k < nf.numPartials; k++) {
+                InternalRow src = rows[nf.partialReader[k]];
+                partials[k] =
+                        (src == null || src.isNullAt(nf.partialOffset[k]))
+                                ? null
+                                : src.getRow(nf.partialOffset[k], nf.partialSize[k]);
+            }
+            DataEvolutionRow composed =
+                    new DataEvolutionRow(nf.numPartials, nf.subRowOffsets, nf.subFieldOffsets);
+            composed.setRowsAllowNull(partials);
+            return composed;
+        }
         return chooseRow(pos).getRow(offsetInRow(pos), numFields);
+    }
+
+    /**
+     * Plan to assemble one nested struct from sub-fields spread across several source files. A
+     * "partial" is the projection of the struct read from a single source file; each output
+     * sub-field is sourced from one partial via {@code subRowOffsets}/{@code subFieldOffsets}.
+     */
+    public static class NestedField {
+
+        final int numPartials;
+        // per partial struct: the source reader, the struct's position in that reader's row, and
+        // the
+        // number of fields of the struct as read from that file
+        final int[] partialReader;
+        final int[] partialOffset;
+        final int[] partialSize;
+        // per output sub-field: which partial it comes from, and its offset within that partial
+        final int[] subRowOffsets;
+        final int[] subFieldOffsets;
+
+        public NestedField(
+                int[] partialReader,
+                int[] partialOffset,
+                int[] partialSize,
+                int[] subRowOffsets,
+                int[] subFieldOffsets) {
+            this.numPartials = partialReader.length;
+            this.partialReader = partialReader;
+            this.partialOffset = partialOffset;
+            this.partialSize = partialSize;
+            this.subRowOffsets = subRowOffsets;
+            this.subFieldOffsets = subFieldOffsets;
+        }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/types/DataTypesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/types/DataTypesTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -204,6 +205,189 @@ public class DataTypesTest {
                                         Collections.singletonList(
                                                 new DataField(0, "", new VarCharType()))))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProjectByPaths() {
+        RowType type =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(2, "a", DataTypes.INT()),
+                                                new DataField(3, "b", DataTypes.STRING())))));
+
+        // dotted path selects only the addressed sub-field, preserving ids
+        RowType onlyNestA = type.projectByPaths(Collections.singletonList("nest.a"));
+        Assertions.assertThat(onlyNestA.getFieldNames()).containsExactly("nest");
+        RowType nestSub = (RowType) onlyNestA.getField("nest").type();
+        Assertions.assertThat(nestSub.getFieldNames()).containsExactly("a");
+        Assertions.assertThat(nestSub.getField("a").id()).isEqualTo(2);
+
+        // a plain top-level name selects the whole field
+        RowType wholeNest =
+                (RowType)
+                        type.projectByPaths(Collections.singletonList("nest"))
+                                .getField("nest")
+                                .type();
+        Assertions.assertThat(wholeNest.getFieldNames()).containsExactly("a", "b");
+
+        // mixing a whole column and a sub-field
+        Assertions.assertThat(type.projectByPaths(Arrays.asList("id", "nest.b")).getFieldNames())
+                .containsExactly("id", "nest");
+
+        // a dotted path whose head is not a ROW is rejected (not silently widened to the scalar)
+        assertThatThrownBy(() -> type.projectByPaths(Collections.singletonList("id.a")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("non-ROW field 'id'");
+
+        // an unknown path is rejected
+        assertThatThrownBy(() -> type.projectByPaths(Collections.singletonList("missing")))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        // a column whose name itself contains a dot is matched exactly (not split)
+        RowType dotted =
+                new RowType(Collections.singletonList(new DataField(0, "a.b", DataTypes.INT())));
+        Assertions.assertThat(
+                        dotted.projectByPaths(Collections.singletonList("a.b")).getFieldNames())
+                .containsExactly("a.b");
+    }
+
+    /**
+     * projectByPaths replaced project(List) in TableSchema.project(writeCols), which rebuilds the
+     * physical layout of a data file from the column order recorded in its writeCols. That order is
+     * not guaranteed to be the schema declaration order, so the two must agree field-for-field —
+     * including when the requested names are given out of schema order.
+     */
+    @Test
+    void testProjectByPathsMatchesLegacyProjectIncludingOrder() {
+        RowType type =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(1, "name", DataTypes.STRING()),
+                                new DataField(
+                                        2,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(3, "a", DataTypes.INT()),
+                                                new DataField(4, "b", DataTypes.STRING())))));
+
+        for (List<String> names :
+                Arrays.asList(
+                        Arrays.asList("id", "name", "nest"),
+                        Arrays.asList("nest", "id"),
+                        Arrays.asList("name", "nest", "id"),
+                        Collections.singletonList("nest"))) {
+            Assertions.assertThat(type.projectByPaths(names))
+                    .as("projectByPaths must equal project for plain names %s", names)
+                    .isEqualTo(type.project(names));
+        }
+
+        // the projected order follows the given paths, not the schema declaration order
+        Assertions.assertThat(type.projectByPaths(Arrays.asList("nest", "id")).getFieldNames())
+                .containsExactly("nest", "id");
+        // ... and that holds when a dotted sub-field path is mixed in
+        Assertions.assertThat(type.projectByPaths(Arrays.asList("nest.b", "id")).getFieldNames())
+                .containsExactly("nest", "id");
+        // within a struct, sub-fields also follow the given order
+        RowType reordered = type.projectByPaths(Arrays.asList("nest.b", "nest.a"));
+        Assertions.assertThat(((RowType) reordered.getField("nest").type()).getFieldNames())
+                .containsExactly("b", "a");
+        // ... but leafPaths still collapses it to the whole column: coversFully compares field ids,
+        // not positions, so a complete-though-reordered struct is not a partial write
+        Assertions.assertThat(reordered.leafPaths(type)).containsExactly("nest");
+    }
+
+    /**
+     * leafPaths replaced getFieldNames() on the write path, and its result is persisted into the
+     * manifest as writeCols. Metadata written there is permanent, so for any write type that
+     * contains no partially-written struct the two must produce exactly the same list.
+     */
+    @Test
+    void testLeafPathsEqualsFieldNamesWithoutPartialStruct() {
+        RowType full =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(1, "name", DataTypes.STRING()),
+                                new DataField(
+                                        2,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(3, "a", DataTypes.INT()),
+                                                new DataField(4, "b", DataTypes.STRING())))));
+
+        for (List<String> names :
+                Arrays.asList(
+                        Arrays.asList("id", "name", "nest"),
+                        Arrays.asList("nest", "id"),
+                        Collections.singletonList("nest"),
+                        Collections.singletonList("id"))) {
+            RowType writeType = full.projectByPaths(names);
+            Assertions.assertThat(writeType.leafPaths(full))
+                    .as("leafPaths must equal getFieldNames for whole-column write type %s", names)
+                    .isEqualTo(writeType.getFieldNames());
+        }
+
+        // a field absent from the reference type (row-tracking system fields) is emitted whole
+        RowType withSystemField =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(-1, "_ROW_ID", DataTypes.BIGINT())));
+        Assertions.assertThat(withSystemField.leafPaths(full))
+                .isEqualTo(withSystemField.getFieldNames());
+
+        // a top-level column whose name contains a dot is still emitted whole, not rejected
+        RowType dotted =
+                new RowType(Collections.singletonList(new DataField(0, "a.b", DataTypes.INT())));
+        Assertions.assertThat(dotted.leafPaths(dotted)).containsExactly("a.b");
+    }
+
+    @Test
+    void testLeafPaths() {
+        RowType full =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(2, "a", DataTypes.INT()),
+                                                new DataField(
+                                                        3,
+                                                        "sub",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        4, "x", DataTypes.INT()),
+                                                                new DataField(
+                                                                        5,
+                                                                        "y",
+                                                                        DataTypes.INT())))))));
+
+        // a full write collapses to top-level names (no dotted paths)
+        Assertions.assertThat(full.leafPaths(full)).containsExactly("id", "nest");
+
+        // one level of partial nesting: a direct sub-field of a top-level struct
+        Assertions.assertThat(
+                        full.projectByPaths(Collections.singletonList("nest.a")).leafPaths(full))
+                .containsExactly("nest.a");
+
+        // a whole sub-struct under a partial top-level struct is still one level
+        Assertions.assertThat(
+                        full.projectByPaths(Collections.singletonList("nest.sub")).leafPaths(full))
+                .containsExactly("nest.sub");
+
+        // deeper than one level (a partial sub-struct) is rejected so it can never be committed
+        RowType deepPartial = full.projectByPaths(Collections.singletonList("nest.sub.x"));
+        assertThatThrownBy(() -> deepPartial.leafPaths(full))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("one level");
     }
 
     // --------------------------------------------------------------------------------------------

--- a/paimon-common/src/test/java/org/apache/paimon/types/DataTypesTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/types/DataTypesTest.java
@@ -297,9 +297,12 @@ public class DataTypesTest {
         RowType reordered = type.projectByPaths(Arrays.asList("nest.b", "nest.a"));
         Assertions.assertThat(((RowType) reordered.getField("nest").type()).getFieldNames())
                 .containsExactly("b", "a");
-        // ... but leafPaths still collapses it to the whole column: coversFully compares field ids,
-        // not positions, so a complete-though-reordered struct is not a partial write
-        Assertions.assertThat(reordered.leafPaths(type)).containsExactly("nest");
+        // ... and leafPaths does not collapse it to the whole column name: coversFully requires
+        // the same physical order as the full type, not just the same field ids, so a
+        // complete-but-reordered struct is still treated as a partial (order-preserving) write.
+        // Collapsing it to "nest" would let a reader reconstruct schema-declaration order (a, b)
+        // instead of the physical write order (b, a).
+        Assertions.assertThat(reordered.leafPaths(type)).containsExactly("nest.b", "nest.a");
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -190,9 +190,10 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
         if (blobContext != null) {
             blobContext = blobContext.withWriteType(writeType);
         }
-        int fullCount = rowType.getFieldCount();
         List<String> fullNames = rowType.getFieldNames();
-        this.writeCols = writeType.getFieldNames();
+        // writeCols carries (possibly nested) dotted paths, e.g. ["f0", "nest.a"]; a plain
+        // top-level name means the whole column, a dotted path means only that sub-field is written
+        this.writeCols = writeType.leafPaths(rowType);
         // optimize writeCols to null in following cases:
         // writeType contains all columns (without _ROW_ID and _SEQUENCE_NUMBER)
         if (writeCols.equals(fullNames)) {
@@ -312,7 +313,9 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
                 FileSource.COMPACT,
                 options.asyncFileWrite(),
                 options.statsDenseStore(),
-                rowType.equals(writeType) ? null : writeType.getFieldNames(),
+                // use the same dotted-leaf-path encoding as withWriteType so a partial nested
+                // writeType records its real sub-field content consistently across write paths
+                rowType.equals(writeType) ? null : writeType.leafPaths(rowType),
                 rowSidecarFileFormat(),
                 Long.MAX_VALUE);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BaseAppendFileStoreWrite.java
@@ -197,9 +197,10 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
         if (blobContext != null) {
             blobContext = blobContext.withWriteType(writeType);
         }
-        int fullCount = rowType.getFieldCount();
         List<String> fullNames = rowType.getFieldNames();
-        this.writeCols = writeType.getFieldNames();
+        // writeCols carries (possibly nested) dotted paths, e.g. ["f0", "nest.a"]; a plain
+        // top-level name means the whole column, a dotted path means only that sub-field is written
+        this.writeCols = writeType.leafPaths(rowType);
         // optimize writeCols to null in following cases:
         // writeType contains all columns (without _ROW_ID and _SEQUENCE_NUMBER)
         if (writeCols.equals(fullNames)) {
@@ -319,7 +320,9 @@ public abstract class BaseAppendFileStoreWrite extends MemoryFileStoreWrite<Inte
                 FileSource.COMPACT,
                 options.asyncFileWrite(),
                 options.statsDenseStore(),
-                rowType.equals(writeType) ? null : writeType.getFieldNames(),
+                // use the same dotted-leaf-path encoding as withWriteType so a partial nested
+                // writeType records its real sub-field content consistently across write paths
+                rowType.equals(writeType) ? null : writeType.leafPaths(rowType),
                 rowSidecarFileFormat(),
                 Long.MAX_VALUE);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -354,6 +354,12 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
             EvolutionStatsCache.FileFieldStats fileStats =
                     projectedSchemas[provider].fieldStats(allFields[j]);
             Range fileRange = file.nonNullRowIdRange();
+            // A sub-field-level data evolution file may store only part of a nested struct
+            // (e.g. nest<a> of nest<a,b>); its file type then does not equal the full target
+            // struct and fails the type check below. Skipping stats for such a field is
+            // intentional: it is left as "no stats" so no file is wrongly pruned, rather than
+            // composing partial-struct stats across files. Struct columns rarely carry useful
+            // min/max and data evolution does not push predicates down, so little is lost.
             if (tiedLatestProviders[j]
                     || !fileStats.hasStats()
                     || !fileStats.type().equalsIgnoreFieldId(targetTypes[j])

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -331,6 +331,12 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
                     continue;
                 }
                 DataType fileType = fileFieldStats.type();
+                // A sub-field-level data evolution file may store only part of a nested struct
+                // (e.g. nest<a> of nest<a,b>); its file type then does not equal the full target
+                // struct and lands here. Skipping stats for such a field is intentional: it is
+                // left as "no stats" so no file is wrongly pruned, rather than composing
+                // partial-struct stats across files. Struct columns rarely carry useful min/max
+                // and data evolution does not push predicates down, so little is lost.
                 if (!fileType.equalsIgnoreFieldId(targetTypes[j])) {
                     typeMismatchedFieldIds.add(targetFieldId);
                     continue;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionReadPlanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionReadPlanner.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.reader.DataEvolutionRow;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/**
+ * Pure (no-IO) planner for sub-field-level data evolution reads. Given the requested read row type
+ * and, for each column-group file ("bunch"), the row type it physically provides (its written
+ * columns, already wrapped with row-tracking fields), it decides for every read field whether it is
+ * taken whole from a single file or composed sub-field by sub-field across several files (latest
+ * file wins per leaf), and produces the offset maps and the per-field {@link
+ * DataEvolutionRow.NestedField} assembly plans.
+ *
+ * <p>Separating this from {@link DataEvolutionSplitRead} keeps the reader-building (IO) thin and
+ * lets the layout logic be unit-tested directly. Only one level of nested composition is supported;
+ * deeper or cross-file splits of a sub-struct throw {@link UnsupportedOperationException}.
+ */
+class DataEvolutionReadPlanner {
+
+    private final RowType readRowType;
+    // for each bunch, the (row-tracked) row type it physically provides
+    private final List<RowType> bunchAvailTypes;
+
+    DataEvolutionReadPlanner(RowType readRowType, List<RowType> bunchAvailTypes) {
+        this.readRowType = readRowType;
+        this.bunchAvailTypes = bunchAvailTypes;
+    }
+
+    DataEvolutionReadPlan plan() {
+        List<DataField> allReadFields = readRowType.getFields();
+        int numFields = allReadFields.size();
+        int numBunches = bunchAvailTypes.size();
+
+        // gather, per bunch, the set of leaf field ids it physically provides
+        List<Set<Integer>> bunchLeaves = new ArrayList<>();
+        for (int i = 0; i < numBunches; i++) {
+            Set<Integer> leaves = new HashSet<>();
+            collectLeafIds(bunchAvailTypes.get(i).getFields(), leaves);
+            bunchLeaves.add(leaves);
+        }
+
+        // decide, per read field, whether it is taken whole from one file or composed from several
+        // files at sub-field granularity. Files are already sorted latest-first, so the first bunch
+        // providing a leaf wins (latest-wins semantics, now at sub-field level).
+        // selection per bunch: topFieldId -> null (whole) or set of selected sub-field ids
+        List<Map<Integer, Set<Integer>>> bunchSelection = new ArrayList<>();
+        for (int i = 0; i < numBunches; i++) {
+            bunchSelection.add(new LinkedHashMap<>());
+        }
+
+        int[] rowOffsets = new int[numFields];
+        int[] fieldOffsets = new int[numFields];
+        Arrays.fill(rowOffsets, -1);
+        Arrays.fill(fieldOffsets, -1);
+        DataEvolutionRow.NestedField[] nested = new DataEvolutionRow.NestedField[numFields];
+        boolean[] composite = new boolean[numFields];
+        int[] wholeBunch = new int[numFields];
+        Arrays.fill(wholeBunch, -1);
+
+        for (int j = 0; j < numFields; j++) {
+            DataField rf = allReadFields.get(j);
+            List<Integer> leaves = leafIdsOf(rf);
+            Map<Integer, Integer> leafProvider = new HashMap<>();
+            Set<Integer> providers = new HashSet<>();
+            for (int leaf : leaves) {
+                int p = providerOf(leaf, bunchLeaves);
+                if (p >= 0) {
+                    leafProvider.put(leaf, p);
+                    providers.add(p);
+                }
+            }
+            if (providers.isEmpty()) {
+                // no file provides this field; it stays null (nullability checked below)
+                continue;
+            }
+            // Only read a field whole from a single file when that file covers ALL of its leaves.
+            // If a single file provides only some leaves of a struct (the rest absent everywhere),
+            // we must prune to the provided sub-fields so the reader is not asked for sub-fields
+            // the
+            // file does not physically contain; the missing ones stay null via the composite plan.
+            boolean allLeavesCovered = leafProvider.size() == leaves.size();
+            if (providers.size() == 1 && allLeavesCovered) {
+                int b = providers.iterator().next();
+                bunchSelection.get(b).put(rf.id(), null);
+                wholeBunch[j] = b;
+            } else {
+                checkArgument(
+                        rf.type() instanceof RowType,
+                        "Field %s is split across files but is not a struct.",
+                        rf.name());
+                composite[j] = true;
+                for (DataField sub : ((RowType) rf.type()).getFields()) {
+                    List<Integer> subLeaves = leafIdsOf(sub);
+                    Set<Integer> subProviders = new HashSet<>();
+                    int coveredSubLeaves = 0;
+                    for (int leaf : subLeaves) {
+                        int p = leafProvider.getOrDefault(leaf, -1);
+                        if (p >= 0) {
+                            subProviders.add(p);
+                            coveredSubLeaves++;
+                        }
+                    }
+                    if (subProviders.size() > 1) {
+                        throw new UnsupportedOperationException(
+                                "Sub-field-level data evolution does not yet support splitting a "
+                                        + "nested sub-field ("
+                                        + rf.name()
+                                        + "."
+                                        + sub.name()
+                                        + ") across multiple files.");
+                    }
+                    if (subProviders.size() == 1) {
+                        if (sub.type() instanceof RowType && coveredSubLeaves < subLeaves.size()) {
+                            // the single provider holds only part of this nested sub-struct;
+                            // reading
+                            // it whole would request leaves it lacks, and one-level composition
+                            // cannot prune deeper than this level yet
+                            throw new UnsupportedOperationException(
+                                    "Sub-field-level data evolution does not yet support reading a "
+                                            + "partially-written nested sub-field ("
+                                            + rf.name()
+                                            + "."
+                                            + sub.name()
+                                            + ") deeper than one level.");
+                        }
+                        int b = subProviders.iterator().next();
+                        bunchSelection
+                                .get(b)
+                                .computeIfAbsent(rf.id(), k -> new LinkedHashSet<>())
+                                .add(sub.id());
+                    }
+                    // else: sub-field absent everywhere -> stays null
+                }
+            }
+        }
+
+        // materialize each bunch's partial read row type and the offset maps.
+        List<List<DataField>> bunchReadFields = new ArrayList<>();
+        List<Map<Integer, Integer>> bunchTopOffset = new ArrayList<>();
+        List<Map<Integer, Map<Integer, Integer>>> bunchSubOffset = new ArrayList<>();
+        for (int i = 0; i < numBunches; i++) {
+            Map<Integer, Set<Integer>> sel = bunchSelection.get(i);
+            List<DataField> readFields = new ArrayList<>();
+            Map<Integer, Integer> topOffset = new HashMap<>();
+            Map<Integer, Map<Integer, Integer>> subOffset = new HashMap<>();
+            for (Map.Entry<Integer, Set<Integer>> e : sel.entrySet()) {
+                int topId = e.getKey();
+                Set<Integer> subs = e.getValue();
+                DataField readTop = readRowType.getField(topId);
+                if (subs == null) {
+                    readFields.add(readTop);
+                    topOffset.put(topId, readFields.size() - 1);
+                } else {
+                    RowType readStruct = (RowType) readTop.type();
+                    List<DataField> chosen = new ArrayList<>();
+                    Map<Integer, Integer> subToIdx = new HashMap<>();
+                    for (DataField s : readStruct.getFields()) {
+                        if (subs.contains(s.id())) {
+                            subToIdx.put(s.id(), chosen.size());
+                            chosen.add(s);
+                        }
+                    }
+                    RowType partial = new RowType(readStruct.isNullable(), chosen);
+                    readFields.add(readTop.newType(partial));
+                    topOffset.put(topId, readFields.size() - 1);
+                    subOffset.put(topId, subToIdx);
+                }
+            }
+            bunchReadFields.add(readFields);
+            bunchTopOffset.add(topOffset);
+            bunchSubOffset.add(subOffset);
+        }
+
+        // wire output offsets (whole fields) and nested composition plans (split structs).
+        for (int j = 0; j < numFields; j++) {
+            DataField rf = allReadFields.get(j);
+            if (composite[j]) {
+                List<DataField> subFields = ((RowType) rf.type()).getFields();
+                int subCount = subFields.size();
+                int[] subRowOffsets = new int[subCount];
+                int[] subFieldOffsets = new int[subCount];
+                Arrays.fill(subRowOffsets, -1);
+                Arrays.fill(subFieldOffsets, -1);
+                Map<Integer, Integer> bunchToPartial = new LinkedHashMap<>();
+                List<int[]> partials = new ArrayList<>();
+                for (int s = 0; s < subCount; s++) {
+                    int subId = subFields.get(s).id();
+                    int b = findSubProvider(rf.id(), subId, bunchSubOffset);
+                    if (b < 0) {
+                        // no file provides this sub-field; it stays null, so it must be nullable
+                        checkArgument(
+                                subFields.get(s).type().isNullable(),
+                                "Sub-field %s.%s is not null but can't find any file contains it.",
+                                rf.name(),
+                                subFields.get(s).name());
+                        continue;
+                    }
+                    Integer pIdx = bunchToPartial.get(b);
+                    if (pIdx == null) {
+                        int topOff = bunchTopOffset.get(b).get(rf.id());
+                        int size = bunchSubOffset.get(b).get(rf.id()).size();
+                        pIdx = partials.size();
+                        bunchToPartial.put(b, pIdx);
+                        partials.add(new int[] {b, topOff, size});
+                    }
+                    subRowOffsets[s] = pIdx;
+                    subFieldOffsets[s] = bunchSubOffset.get(b).get(rf.id()).get(subId);
+                }
+                int p = partials.size();
+                int[] pr = new int[p];
+                int[] po = new int[p];
+                int[] ps = new int[p];
+                for (int k = 0; k < p; k++) {
+                    pr[k] = partials.get(k)[0];
+                    po[k] = partials.get(k)[1];
+                    ps[k] = partials.get(k)[2];
+                }
+                nested[j] =
+                        new DataEvolutionRow.NestedField(
+                                pr, po, ps, subRowOffsets, subFieldOffsets);
+            } else if (wholeBunch[j] >= 0) {
+                int b = wholeBunch[j];
+                rowOffsets[j] = b;
+                fieldOffsets[j] = bunchTopOffset.get(b).get(rf.id());
+            }
+        }
+
+        return new DataEvolutionReadPlan(rowOffsets, fieldOffsets, nested, bunchReadFields);
+    }
+
+    /** Collect (recursively) the leaf field ids of {@code fields}; only ROW types recurse. */
+    private static void collectLeafIds(List<DataField> fields, Collection<Integer> out) {
+        for (DataField f : fields) {
+            if (f.type() instanceof RowType) {
+                collectLeafIds(((RowType) f.type()).getFields(), out);
+            } else {
+                out.add(f.id());
+            }
+        }
+    }
+
+    private static List<Integer> leafIdsOf(DataField field) {
+        List<Integer> result = new ArrayList<>();
+        collectLeafIds(Collections.singletonList(field), result);
+        return result;
+    }
+
+    private static int providerOf(int leafId, List<Set<Integer>> bunchLeaves) {
+        for (int i = 0; i < bunchLeaves.size(); i++) {
+            if (bunchLeaves.get(i).contains(leafId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findSubProvider(
+            int topId, int subId, List<Map<Integer, Map<Integer, Integer>>> bunchSubOffset) {
+        for (int b = 0; b < bunchSubOffset.size(); b++) {
+            Map<Integer, Integer> sm = bunchSubOffset.get(b).get(topId);
+            if (sm != null && sm.containsKey(subId)) {
+                return b;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Immutable result of {@link DataEvolutionReadPlanner#plan()}: how each read field is sourced
+     * (whole via {@code rowOffsets}/{@code fieldOffsets}, or composed via {@code nested}) and, per
+     * bunch, the (possibly partial nested) fields to physically read.
+     */
+    static class DataEvolutionReadPlan {
+
+        // per read field: the bunch a whole field is taken from (-1 if absent or composed)
+        final int[] rowOffsets;
+        // per read field: the field offset within that bunch's read row (-1 if absent or composed)
+        final int[] fieldOffsets;
+        // per read field: the sub-field assembly plan for a struct split across files (null if
+        // whole)
+        final DataEvolutionRow.NestedField[] nested;
+        // per bunch: the fields (with partial nested structs) to read from that file
+        final List<List<DataField>> bunchReadFields;
+
+        DataEvolutionReadPlan(
+                int[] rowOffsets,
+                int[] fieldOffsets,
+                DataEvolutionRow.NestedField[] nested,
+                List<List<DataField>> bunchReadFields) {
+            this.rowOffsets = rowOffsets;
+            this.fieldOffsets = fieldOffsets;
+            this.nested = nested;
+            this.bunchReadFields = bunchReadFields;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionReadPlanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionReadPlanner.java
@@ -107,10 +107,9 @@ class DataEvolutionReadPlanner {
                 continue;
             }
             // Only read a field whole from a single file when that file covers ALL of its leaves.
-            // If a single file provides only some leaves of a struct (the rest absent everywhere),
-            // we must prune to the provided sub-fields so the reader is not asked for sub-fields
-            // the
-            // file does not physically contain; the missing ones stay null via the composite plan.
+            // If a single file provides only some leaves of a struct, go through the composite
+            // plan so the selection is made per direct sub-field: the sub-fields it does provide
+            // are read from it, and the ones absent everywhere stay null.
             boolean allLeavesCovered = leafProvider.size() == leaves.size();
             if (providers.size() == 1 && allLeavesCovered) {
                 int b = providers.iterator().next();
@@ -123,14 +122,11 @@ class DataEvolutionReadPlanner {
                         rf.name());
                 composite[j] = true;
                 for (DataField sub : ((RowType) rf.type()).getFields()) {
-                    List<Integer> subLeaves = leafIdsOf(sub);
                     Set<Integer> subProviders = new HashSet<>();
-                    int coveredSubLeaves = 0;
-                    for (int leaf : subLeaves) {
+                    for (int leaf : leafIdsOf(sub)) {
                         int p = leafProvider.getOrDefault(leaf, -1);
                         if (p >= 0) {
                             subProviders.add(p);
-                            coveredSubLeaves++;
                         }
                     }
                     if (subProviders.size() > 1) {
@@ -143,19 +139,11 @@ class DataEvolutionReadPlanner {
                                         + ") across multiple files.");
                     }
                     if (subProviders.size() == 1) {
-                        if (sub.type() instanceof RowType && coveredSubLeaves < subLeaves.size()) {
-                            // the single provider holds only part of this nested sub-struct;
-                            // reading
-                            // it whole would request leaves it lacks, and one-level composition
-                            // cannot prune deeper than this level yet
-                            throw new UnsupportedOperationException(
-                                    "Sub-field-level data evolution does not yet support reading a "
-                                            + "partially-written nested sub-field ("
-                                            + rf.name()
-                                            + "."
-                                            + sub.name()
-                                            + ") deeper than one level.");
-                        }
+                        // The single provider may hold only part of this nested sub-struct, but
+                        // the leaves it lacks are then absent from EVERY bunch (a cross-provider
+                        // deep split is already rejected above). That is the normal shape after a
+                        // deep ADD COLUMN, so read the sub-field whole from its provider and let
+                        // the schema-evolution mapping null-fill the leaves the file predates.
                         int b = subProviders.iterator().next();
                         bunchSelection
                                 .get(b)

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -69,7 +69,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -311,90 +310,76 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             }
         }
 
-        // Init all we need to create a compound reader
+        // Init all we need to create a compound reader: resolve each bunch's physically-provided
+        // (row-tracked) row type, then delegate the no-IO layout planning (leaf-level matching and
+        // nested sub-field assembly) to DataEvolutionReadPlanner; this class only builds readers.
         List<DataField> allReadFields = readRowType.getFields();
-        RecordReader<InternalRow>[] fileRecordReaders = new RecordReader[fieldsFiles.size()];
-        int[] readFieldIndex = allReadFields.stream().mapToInt(DataField::id).toArray();
-        // which row the read field index belongs to
-        int[] rowOffsets = new int[allReadFields.size()];
-        // which field index in the reading row
-        int[] fieldOffsets = new int[allReadFields.size()];
-        Arrays.fill(rowOffsets, -1);
-        Arrays.fill(fieldOffsets, -1);
+        int numBunches = fieldsFiles.size();
+        RecordReader<InternalRow>[] fileRecordReaders = new RecordReader[numBunches];
 
-        for (int i = 0; i < fieldsFiles.size(); i++) {
+        TableSchema[] bunchDataSchemas = new TableSchema[numBunches];
+        List<RowType> bunchAvailTypes = new ArrayList<>(numBunches);
+        for (int i = 0; i < numBunches; i++) {
+            DataFileMeta first = fieldsFiles.get(i).files().get(0);
+            bunchDataSchemas[i] = schemaFetcher.apply(first.schemaId()).project(first.writeCols());
+            bunchAvailTypes.add(rowTypeWithRowTracking(bunchDataSchemas[i].logicalRowType()));
+        }
+        DataEvolutionReadPlanner.DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(readRowType, bunchAvailTypes).plan();
+
+        // Build the per-bunch readers from the planned partial read row types.
+        for (int i = 0; i < numBunches; i++) {
+            List<DataField> readFields = plan.bunchReadFields.get(i);
+            if (readFields.isEmpty()) {
+                fileRecordReaders[i] = null;
+                continue;
+            }
             FieldBunch bunch = fieldsFiles.get(i);
             DataFileMeta firstFile = bunch.files().get(0);
             FileReadTarget readTarget = readTarget(firstFile, dataFilePathFactory, rowRanges);
             String formatIdentifier = readTarget.formatIdentifier;
             long schemaId = firstFile.schemaId();
-            TableSchema dataSchema = schemaFetcher.apply(schemaId).project(firstFile.writeCols());
-            int[] fieldIds =
-                    SpecialFields.rowTypeWithRowTracking(dataSchema.logicalRowType()).getFields()
-                            .stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-            List<DataField> readFields = new ArrayList<>();
-            for (int j = 0; j < readFieldIndex.length; j++) {
-                for (int fieldId : fieldIds) {
-                    // Check if the read field index matches the file field
-                    // index
-                    if (readFieldIndex[j] == fieldId) {
-                        // If the row offset is not set, set it to the current
-                        // file reader
-                        if (rowOffsets[j] == -1) {
-                            // "i" is the reader index, and "readFields.size()"
-                            // is the offset the that row
-                            rowOffsets[j] = i;
-                            fieldOffsets[j] = readFields.size();
-                            readFields.add(allReadFields.get(j));
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (readFields.isEmpty()) {
-                fileRecordReaders[i] = null;
-            } else {
-                // create new FormatReaderMapping for read partial fields
-                List<String> readFieldNames =
-                        readFields.stream().map(DataField::name).collect(Collectors.toList());
-                FormatReaderMapping formatReaderMapping =
-                        formatReaderMappings.computeIfAbsent(
-                                new FormatKey(schemaId, formatIdentifier, readFieldNames),
-                                key ->
-                                        formatBuilder.build(
-                                                formatIdentifier,
-                                                schema,
-                                                dataSchema,
-                                                readFields,
-                                                false));
-                RowType partialReadRowType = new RowType(readFields);
-                fileRecordReaders[i] =
-                        new ForceSingleBatchReader(
-                                createFieldBunchReader(
-                                        partition,
-                                        bunch,
-                                        dataFilePathFactory,
-                                        formatReaderMapping,
-                                        rowRanges,
-                                        partialReadRowType,
-                                        deletionVector));
-            }
+            TableSchema dataSchema = bunchDataSchemas[i];
+            RowType partialReadRowType = new RowType(readFields);
+            // cache key must use paths relative to the full schema so that two files reading
+            // different sub-fields of the same struct (e.g. nest.a vs nest.b) do not collide
+            RowType fullRef =
+                    rowTypeWithRowTracking(schemaFetcher.apply(schemaId).logicalRowType());
+            List<String> readFieldNames = partialReadRowType.leafPaths(fullRef);
+            FormatReaderMapping formatReaderMapping =
+                    formatReaderMappings.computeIfAbsent(
+                            new FormatKey(schemaId, formatIdentifier, readFieldNames),
+                            key ->
+                                    formatBuilder.build(
+                                            formatIdentifier,
+                                            schema,
+                                            dataSchema,
+                                            readFields,
+                                            false));
+            fileRecordReaders[i] =
+                    new ForceSingleBatchReader(
+                            createFieldBunchReader(
+                                    partition,
+                                    bunch,
+                                    dataFilePathFactory,
+                                    formatReaderMapping,
+                                    rowRanges,
+                                    partialReadRowType,
+                                    deletionVector));
         }
 
-        for (int i = 0; i < rowOffsets.length; i++) {
-            if (rowOffsets[i] == -1) {
+        for (int j = 0; j < allReadFields.size(); j++) {
+            if (plan.rowOffsets[j] == -1 && plan.nested[j] == null) {
                 checkArgument(
-                        allReadFields.get(i).type().isNullable(),
+                        allReadFields.get(j).type().isNullable(),
                         format(
                                 "Field %s is not null but can't find any file contains it.",
-                                allReadFields.get(i)));
+                                allReadFields.get(j)));
             }
         }
 
-        return new DataEvolutionFileReader(rowOffsets, fieldOffsets, fileRecordReaders);
+        return new DataEvolutionFileReader(
+                plan.rowOffsets, plan.fieldOffsets, fileRecordReaders, plan.nested);
     }
 
     private RecordReader<InternalRow> createFieldBunchReader(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -70,7 +70,6 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -319,90 +318,76 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             }
         }
 
-        // Init all we need to create a compound reader
+        // Init all we need to create a compound reader: resolve each bunch's physically-provided
+        // (row-tracked) row type, then delegate the no-IO layout planning (leaf-level matching and
+        // nested sub-field assembly) to DataEvolutionReadPlanner; this class only builds readers.
         List<DataField> allReadFields = readRowType.getFields();
-        RecordReader<InternalRow>[] fileRecordReaders = new RecordReader[fieldsFiles.size()];
-        int[] readFieldIndex = allReadFields.stream().mapToInt(DataField::id).toArray();
-        // which row the read field index belongs to
-        int[] rowOffsets = new int[allReadFields.size()];
-        // which field index in the reading row
-        int[] fieldOffsets = new int[allReadFields.size()];
-        Arrays.fill(rowOffsets, -1);
-        Arrays.fill(fieldOffsets, -1);
+        int numBunches = fieldsFiles.size();
+        RecordReader<InternalRow>[] fileRecordReaders = new RecordReader[numBunches];
 
-        for (int i = 0; i < fieldsFiles.size(); i++) {
+        TableSchema[] bunchDataSchemas = new TableSchema[numBunches];
+        List<RowType> bunchAvailTypes = new ArrayList<>(numBunches);
+        for (int i = 0; i < numBunches; i++) {
+            DataFileMeta first = fieldsFiles.get(i).files().get(0);
+            bunchDataSchemas[i] = schemaFetcher.apply(first.schemaId()).project(first.writeCols());
+            bunchAvailTypes.add(rowTypeWithRowTracking(bunchDataSchemas[i].logicalRowType()));
+        }
+        DataEvolutionReadPlanner.DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(readRowType, bunchAvailTypes).plan();
+
+        // Build the per-bunch readers from the planned partial read row types.
+        for (int i = 0; i < numBunches; i++) {
+            List<DataField> readFields = plan.bunchReadFields.get(i);
+            if (readFields.isEmpty()) {
+                fileRecordReaders[i] = null;
+                continue;
+            }
             FieldBunch bunch = fieldsFiles.get(i);
             DataFileMeta firstFile = bunch.files().get(0);
             FileReadTarget readTarget = readTarget(firstFile, dataFilePathFactory, rowRanges);
             String formatIdentifier = readTarget.formatIdentifier;
             long schemaId = firstFile.schemaId();
-            TableSchema dataSchema = schemaFetcher.apply(schemaId).project(firstFile.writeCols());
-            int[] fieldIds =
-                    SpecialFields.rowTypeWithRowTracking(dataSchema.logicalRowType()).getFields()
-                            .stream()
-                            .mapToInt(DataField::id)
-                            .toArray();
-            List<DataField> readFields = new ArrayList<>();
-            for (int j = 0; j < readFieldIndex.length; j++) {
-                for (int fieldId : fieldIds) {
-                    // Check if the read field index matches the file field
-                    // index
-                    if (readFieldIndex[j] == fieldId) {
-                        // If the row offset is not set, set it to the current
-                        // file reader
-                        if (rowOffsets[j] == -1) {
-                            // "i" is the reader index, and "readFields.size()"
-                            // is the offset the that row
-                            rowOffsets[j] = i;
-                            fieldOffsets[j] = readFields.size();
-                            readFields.add(allReadFields.get(j));
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if (readFields.isEmpty()) {
-                fileRecordReaders[i] = null;
-            } else {
-                // create new FormatReaderMapping for read partial fields
-                List<String> readFieldNames =
-                        readFields.stream().map(DataField::name).collect(Collectors.toList());
-                FormatReaderMapping formatReaderMapping =
-                        formatReaderMappings.computeIfAbsent(
-                                new FormatKey(schemaId, formatIdentifier, readFieldNames),
-                                key ->
-                                        formatBuilder.build(
-                                                formatIdentifier,
-                                                schema,
-                                                dataSchema,
-                                                readFields,
-                                                false));
-                RowType partialReadRowType = new RowType(readFields);
-                fileRecordReaders[i] =
-                        new ForceSingleBatchReader(
-                                createFieldBunchReader(
-                                        partition,
-                                        bunch,
-                                        dataFilePathFactory,
-                                        formatReaderMapping,
-                                        rowRanges,
-                                        partialReadRowType,
-                                        deletionVector));
-            }
+            TableSchema dataSchema = bunchDataSchemas[i];
+            RowType partialReadRowType = new RowType(readFields);
+            // cache key must use paths relative to the full schema so that two files reading
+            // different sub-fields of the same struct (e.g. nest.a vs nest.b) do not collide
+            RowType fullRef =
+                    rowTypeWithRowTracking(schemaFetcher.apply(schemaId).logicalRowType());
+            List<String> readFieldNames = partialReadRowType.leafPaths(fullRef);
+            FormatReaderMapping formatReaderMapping =
+                    formatReaderMappings.computeIfAbsent(
+                            new FormatKey(schemaId, formatIdentifier, readFieldNames),
+                            key ->
+                                    formatBuilder.build(
+                                            formatIdentifier,
+                                            schema,
+                                            dataSchema,
+                                            readFields,
+                                            false));
+            fileRecordReaders[i] =
+                    new ForceSingleBatchReader(
+                            createFieldBunchReader(
+                                    partition,
+                                    bunch,
+                                    dataFilePathFactory,
+                                    formatReaderMapping,
+                                    rowRanges,
+                                    partialReadRowType,
+                                    deletionVector));
         }
 
-        for (int i = 0; i < rowOffsets.length; i++) {
-            if (rowOffsets[i] == -1) {
+        for (int j = 0; j < allReadFields.size(); j++) {
+            if (plan.rowOffsets[j] == -1 && plan.nested[j] == null) {
                 checkArgument(
-                        allReadFields.get(i).type().isNullable(),
+                        allReadFields.get(j).type().isNullable(),
                         format(
                                 "Field %s is not null but can't find any file contains it.",
-                                allReadFields.get(i)));
+                                allReadFields.get(j)));
             }
         }
 
-        return new DataEvolutionFileReader(rowOffsets, fieldOffsets, fileRecordReaders);
+        return new DataEvolutionFileReader(
+                plan.rowOffsets, plan.fieldOffsets, fileRecordReaders, plan.nested);
     }
 
     private RecordReader<InternalRow> createFieldBunchReader(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionSplitRead.java
@@ -349,14 +349,9 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
             long schemaId = firstFile.schemaId();
             TableSchema dataSchema = bunchDataSchemas[i];
             RowType partialReadRowType = new RowType(readFields);
-            // cache key must use paths relative to the full schema so that two files reading
-            // different sub-fields of the same struct (e.g. nest.a vs nest.b) do not collide
-            RowType fullRef =
-                    rowTypeWithRowTracking(schemaFetcher.apply(schemaId).logicalRowType());
-            List<String> readFieldNames = partialReadRowType.leafPaths(fullRef);
             FormatReaderMapping formatReaderMapping =
                     formatReaderMappings.computeIfAbsent(
-                            new FormatKey(schemaId, formatIdentifier, readFieldNames),
+                            new FormatKey(schemaId, formatIdentifier, readerCacheKey(readFields)),
                             key ->
                                     formatBuilder.build(
                                             formatIdentifier,
@@ -388,6 +383,39 @@ public class DataEvolutionSplitRead implements SplitRead<InternalRow> {
 
         return new DataEvolutionFileReader(
                 plan.rowOffsets, plan.fieldOffsets, fileRecordReaders, plan.nested);
+    }
+
+    /**
+     * A cache key describing the exact (possibly partially nested) fields read from one bunch. It
+     * encodes field ids and nesting structure rather than names, so two bunches reading different
+     * sub-fields of the same struct (e.g. {@code nest.a} vs {@code nest.b}) never collide.
+     *
+     * <p>Deliberately not {@link RowType#leafPaths(RowType)}: that describes a written type
+     * relative to the schema it was written against and therefore enforces the write-side
+     * restrictions (at most one level of partial nesting, no dotted names). A read type is not
+     * bound by those — it may be pruned arbitrarily deep by the engine, and it may be *wider* than
+     * the file's own schema after a nested {@code ADD COLUMN}.
+     */
+    private static List<String> readerCacheKey(List<DataField> readFields) {
+        List<String> key = new ArrayList<>(readFields.size());
+        for (DataField field : readFields) {
+            StringBuilder builder = new StringBuilder();
+            appendFieldKey(field, builder);
+            key.add(builder.toString());
+        }
+        return key;
+    }
+
+    private static void appendFieldKey(DataField field, StringBuilder builder) {
+        builder.append(field.id());
+        if (field.type() instanceof RowType) {
+            builder.append('<');
+            for (DataField sub : ((RowType) field.type()).getFields()) {
+                appendFieldKey(sub, builder);
+                builder.append(',');
+            }
+            builder.append('>');
+        }
     }
 
     private RecordReader<InternalRow> createFieldBunchReader(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowIdColumnConflictChecker.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/commit/RowIdColumnConflictChecker.java
@@ -22,6 +22,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
 
@@ -50,7 +51,7 @@ public class RowIdColumnConflictChecker implements RowIdConflictChecker {
 
     private final SchemaManager schemaManager;
     private final List<WriteRange> writeRanges;
-    private final Map<Long, Map<String, Integer>> fieldIdByNameCache = new HashMap<>();
+    private final Map<Long, RowType> rowTypeCache = new HashMap<>();
 
     private RowIdColumnConflictChecker(SchemaManager schemaManager, List<DataFileMeta> deltaFiles) {
         this.schemaManager = schemaManager;
@@ -96,18 +97,13 @@ public class RowIdColumnConflictChecker implements RowIdConflictChecker {
     private void addWriteFieldIds(Set<Integer> fieldIds, DataFileMeta file) {
         List<String> writeCols = file.writeCols();
         if (writeCols == null) {
-            fieldIds.addAll(
-                    fieldIdByNameCache
-                            .computeIfAbsent(file.schemaId(), this::fieldIdByName)
-                            .values());
+            // full-schema write touches every leaf field
+            collectLeafIds(rowType(file.schemaId()).getFields(), fieldIds);
             return;
         }
 
         for (String writeCol : writeCols) {
-            Integer fieldId = fieldId(file, writeCol);
-            if (fieldId != null) {
-                fieldIds.add(fieldId);
-            }
+            fieldIds.addAll(leafFieldIds(file.schemaId(), writeCol));
         }
     }
 
@@ -187,37 +183,54 @@ public class RowIdColumnConflictChecker implements RowIdConflictChecker {
         }
 
         for (String writeCol : writeCols) {
-            Integer fieldId = fieldId(file, writeCol);
-            if (fieldId != null && fieldIds.contains(fieldId)) {
-                return true;
+            for (Integer fieldId : leafFieldIds(file.schemaId(), writeCol)) {
+                if (fieldIds.contains(fieldId)) {
+                    return true;
+                }
             }
         }
         return false;
     }
 
-    private Integer fieldId(DataFileMeta file, String writeCol) {
-        Integer fieldId =
-                fieldIdByNameCache
-                        .computeIfAbsent(file.schemaId(), this::fieldIdByName)
-                        .get(writeCol);
-        if (fieldId == null) {
-            if (SpecialFields.isSystemField(writeCol)) {
-                return null;
-            }
+    /**
+     * Resolve a (possibly nested, dotted) write column such as {@code "nest.a"} to the set of leaf
+     * field ids it covers. A whole top-level struct column (e.g. {@code "nest"}) expands to all of
+     * its leaf ids, so a whole-struct write and a sub-field write of the same struct still
+     * conflict.
+     */
+    private List<Integer> leafFieldIds(long schemaId, String writeCol) {
+        if (SpecialFields.isSystemField(writeCol)) {
+            return Collections.emptyList();
+        }
+        // projectByPaths handles both plain top-level names and dotted nested paths, and throws if
+        // the path does not exist in the schema
+        RowType projected;
+        try {
+            projected = rowType(schemaId).projectByPaths(Collections.singletonList(writeCol));
+        } catch (IllegalArgumentException e) {
             throw new RuntimeException(
                     String.format(
-                            "Cannot find write column '%s' in schema %s.",
-                            writeCol, file.schemaId()));
+                            "Cannot find write column '%s' in schema %s.", writeCol, schemaId),
+                    e);
         }
-        return fieldId;
+        List<Integer> ids = new ArrayList<>();
+        collectLeafIds(projected.getFields(), ids);
+        return ids;
     }
 
-    private Map<String, Integer> fieldIdByName(long schemaId) {
-        Map<String, Integer> fieldIdByName = new HashMap<>();
-        for (DataField field : schemaManager.schema(schemaId).logicalRowType().getFields()) {
-            fieldIdByName.put(field.name(), field.id());
+    private static void collectLeafIds(List<DataField> fields, java.util.Collection<Integer> out) {
+        for (DataField field : fields) {
+            if (field.type() instanceof RowType) {
+                collectLeafIds(((RowType) field.type()).getFields(), out);
+            } else {
+                out.add(field.id());
+            }
         }
-        return fieldIdByName;
+    }
+
+    private RowType rowType(long schemaId) {
+        return rowTypeCache.computeIfAbsent(
+                schemaId, id -> schemaManager.schema(id).logicalRowType());
     }
 
     /** Range and field id Set. */

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -96,17 +96,36 @@ public class DataEvolutionUtils {
     private static Set<Integer> resolveFileFieldIds(
             List<DataField> schemaFields, DataFileMeta file, boolean strict) {
         List<String> writeCols = file.writeCols();
-        Set<String> writeColNames = writeCols == null ? null : new HashSet<>(writeCols);
-        Set<String> unresolved =
-                strict && writeColNames != null ? new HashSet<>(writeColNames) : null;
         Set<Integer> ids = new HashSet<>();
-        for (DataField field : schemaFields) {
-            // writeCols may also contain physical row-tracking fields outside the table schema.
-            if (writeColNames == null || writeColNames.contains(field.name())) {
+        if (writeCols == null) {
+            for (DataField field : schemaFields) {
                 ids.add(field.id());
-                if (unresolved != null) {
-                    unresolved.remove(field.name());
+            }
+            return ids;
+        }
+
+        Map<String, DataField> byName = new HashMap<>();
+        for (DataField field : schemaFields) {
+            byName.put(field.name(), field);
+        }
+        Set<String> unresolved = strict ? new HashSet<>() : null;
+        for (String writeCol : writeCols) {
+            // A write column is either a plain top-level name or, for sub-field-level data
+            // evolution, a dotted path into a nested column such as "nest.a"; both identify the
+            // same top-level field. Try the exact name first so a column whose own name contains a
+            // dot is not split, matching RowType#projectByPaths.
+            DataField field = byName.get(writeCol);
+            if (field == null) {
+                int dot = writeCol.indexOf('.');
+                if (dot > 0) {
+                    field = byName.get(writeCol.substring(0, dot));
                 }
+            }
+            // writeCols may also contain physical row-tracking fields outside the table schema.
+            if (field != null) {
+                ids.add(field.id());
+            } else if (unresolved != null) {
+                unresolved.add(writeCol);
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -24,8 +24,10 @@ import org.apache.paimon.types.DataField;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -45,11 +47,32 @@ public class DataEvolutionUtils {
             Function<Long, TableSchema> scanTableSchema, DataFileMeta file) {
         TableSchema schema = scanTableSchema.apply(file.schemaId());
         List<String> writeCols = file.writeCols();
-        Set<String> writeColNames = writeCols == null ? null : new HashSet<>(writeCols);
         Set<Integer> ids = new HashSet<>();
+        if (writeCols == null) {
+            for (DataField field : schema.fields()) {
+                ids.add(field.id());
+            }
+            return ids;
+        }
+
+        Map<String, DataField> byName = new HashMap<>();
         for (DataField field : schema.fields()) {
+            byName.put(field.name(), field);
+        }
+        for (String writeCol : writeCols) {
+            // A write column is either a plain top-level name or, for sub-field-level data
+            // evolution, a dotted path into a nested column such as "nest.a"; both identify the
+            // same top-level field. Try the exact name first so a column whose own name contains a
+            // dot is not split, matching RowType#projectByPaths.
+            DataField field = byName.get(writeCol);
+            if (field == null) {
+                int dot = writeCol.indexOf('.');
+                if (dot > 0) {
+                    field = byName.get(writeCol.substring(0, dot));
+                }
+            }
             // writeCols may also contain physical row-tracking fields outside the table schema.
-            if (writeColNames == null || writeColNames.contains(field.name())) {
+            if (field != null) {
                 ids.add(field.id());
             }
         }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionReadPlannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionReadPlannerTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.operation.DataEvolutionReadPlanner.DataEvolutionReadPlan;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link DataEvolutionReadPlanner} (pure, no-IO layout planning). */
+class DataEvolutionReadPlannerTest {
+
+    // read type: id INT, nest ROW<a INT, b STRING>
+    private static final RowType READ_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new DataField(0, "id", DataTypes.INT()),
+                            new DataField(
+                                    1,
+                                    "nest",
+                                    DataTypes.ROW(
+                                            new DataField(2, "a", DataTypes.INT()),
+                                            new DataField(3, "b", DataTypes.STRING())))));
+
+    private static RowType nest(DataField... subFields) {
+        return new RowType(
+                Collections.singletonList(new DataField(1, "nest", DataTypes.ROW(subFields))));
+    }
+
+    @Test
+    void testStructSplitAcrossFilesIsComposed() {
+        // bunch0 (latest) provides nest.a; bunch1 provides id + nest.b
+        RowType avail0 = nest(new DataField(2, "a", DataTypes.INT()));
+        RowType avail1 =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(new DataField(3, "b", DataTypes.STRING())))));
+
+        DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(READ_TYPE, Arrays.asList(avail0, avail1)).plan();
+
+        // id is taken whole from bunch1
+        assertThat(plan.nested[0]).isNull();
+        assertThat(plan.rowOffsets[0]).isEqualTo(1);
+        // nest is composed across files (a from bunch0, b from bunch1)
+        assertThat(plan.rowOffsets[1]).isEqualTo(-1);
+        assertThat(plan.nested[1]).isNotNull();
+        // each bunch only physically reads what it provides
+        assertThat(plan.bunchReadFields.get(0)).hasSize(1); // nest<a>
+        assertThat(plan.bunchReadFields.get(1)).hasSize(2); // id, nest<b>
+    }
+
+    @Test
+    void testStructWholeFromSingleFile() {
+        // bunch0 provides the whole nest; bunch1 provides id
+        RowType avail0 =
+                nest(
+                        new DataField(2, "a", DataTypes.INT()),
+                        new DataField(3, "b", DataTypes.STRING()));
+        RowType avail1 =
+                new RowType(Collections.singletonList(new DataField(0, "id", DataTypes.INT())));
+
+        DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(READ_TYPE, Arrays.asList(avail0, avail1)).plan();
+
+        // nest is taken whole from bunch0, not composed
+        assertThat(plan.nested[1]).isNull();
+        assertThat(plan.rowOffsets[1]).isEqualTo(0);
+        assertThat(plan.rowOffsets[0]).isEqualTo(1);
+    }
+
+    @Test
+    void testSubFieldAbsentEverywhereStaysNullWhenNullable() {
+        // only nest.a is provided anywhere; nest.b (nullable) is absent
+        RowType avail0 = nest(new DataField(2, "a", DataTypes.INT()));
+        RowType avail1 =
+                new RowType(Collections.singletonList(new DataField(0, "id", DataTypes.INT())));
+
+        DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(READ_TYPE, Arrays.asList(avail0, avail1)).plan();
+
+        // nest still composed (only a present), no exception since b is nullable
+        assertThat(plan.nested[1]).isNotNull();
+        assertThat(plan.bunchReadFields.get(0)).hasSize(1);
+    }
+
+    @Test
+    void testDeeperThanOneLevelSplitThrows() {
+        // read type: nest ROW<sub ROW<x INT, y INT>>; x and y provided by different files
+        RowType readType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        4,
+                                                        "sub",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        5, "x", DataTypes.INT()),
+                                                                new DataField(
+                                                                        6,
+                                                                        "y",
+                                                                        DataTypes.INT())))))));
+        RowType avail0 =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        4,
+                                                        "sub",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        5,
+                                                                        "x",
+                                                                        DataTypes.INT())))))));
+        RowType avail1 =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        1,
+                                        "nest",
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        4,
+                                                        "sub",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        6,
+                                                                        "y",
+                                                                        DataTypes.INT())))))));
+
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionReadPlanner(
+                                                readType, Arrays.asList(avail0, avail1))
+                                        .plan())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionReadPlannerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/DataEvolutionReadPlannerTest.java
@@ -170,4 +170,57 @@ class DataEvolutionReadPlannerTest {
                                         .plan())
                 .isInstanceOf(UnsupportedOperationException.class);
     }
+
+    @Test
+    void testDeepAddColumnIsNullFilledInsteadOfRejected() {
+        // read type: id INT, payload ROW<inner ROW<x INT, y INT>>
+        // "y" was added later by ALTER TABLE ADD COLUMN payload.inner.y, so no file has it yet.
+        RowType readType =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "payload",
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        2,
+                                                        "inner",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        3, "x", DataTypes.INT()),
+                                                                new DataField(
+                                                                        4,
+                                                                        "y",
+                                                                        DataTypes.INT())))))));
+        // bunch0 (latest): an unrelated partial update touching only the top-level "id"
+        RowType avail0 =
+                new RowType(Collections.singletonList(new DataField(0, "id", DataTypes.INT())));
+        // bunch1: the original file, written before the deep ADD COLUMN
+        RowType avail1 =
+                new RowType(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT()),
+                                new DataField(
+                                        1,
+                                        "payload",
+                                        DataTypes.ROW(
+                                                new DataField(
+                                                        2,
+                                                        "inner",
+                                                        DataTypes.ROW(
+                                                                new DataField(
+                                                                        3,
+                                                                        "x",
+                                                                        DataTypes.INT())))))));
+
+        DataEvolutionReadPlan plan =
+                new DataEvolutionReadPlanner(readType, Arrays.asList(avail0, avail1)).plan();
+
+        // id comes whole from the latest partial file
+        assertThat(plan.rowOffsets[0]).isEqualTo(0);
+        // payload.inner is entirely provided by bunch1; the missing leaf "y" must be null-filled
+        // by schema evolution rather than rejected as an unsupported deep split.
+        assertThat(plan.bunchReadFields.get(1)).anySatisfy(f -> assertThat(f.id()).isEqualTo(1));
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/commit/RowIdColumnConflictCheckerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/commit/RowIdColumnConflictCheckerTest.java
@@ -114,6 +114,43 @@ class RowIdColumnConflictCheckerTest {
                 .hasMessageContaining("Cannot find write column 'missing'");
     }
 
+    @Test
+    void testSubFieldDisjointLeavesDoNotConflict() {
+        // schema 2: id INT, nest ROW<a INT, b INT>
+        RowIdColumnConflictChecker checker =
+                checker(file("current", 0L, 10L, 2L, Arrays.asList("nest.a")));
+
+        assertThat(checker.conflictsWith(file("historical", 0L, 10L, 2L, Arrays.asList("nest.b"))))
+                .isFalse();
+    }
+
+    @Test
+    void testSubFieldSameLeafConflicts() {
+        RowIdColumnConflictChecker checker =
+                checker(file("current", 0L, 10L, 2L, Arrays.asList("nest.a")));
+
+        assertThat(checker.conflictsWith(file("historical", 0L, 10L, 2L, Arrays.asList("nest.a"))))
+                .isTrue();
+    }
+
+    @Test
+    void testWholeStructConflictsWithSubField() {
+        // a whole-struct write expands to all of its leaves, so it conflicts with a sub-field write
+        RowIdColumnConflictChecker checker =
+                checker(file("current", 0L, 10L, 2L, Arrays.asList("nest")));
+
+        assertThat(checker.conflictsWith(file("historical", 0L, 10L, 2L, Arrays.asList("nest.a"))))
+                .isTrue();
+    }
+
+    @Test
+    void testFullSchemaWriteConflictsWithSubField() {
+        RowIdColumnConflictChecker checker = checker(file("current", 0L, 10L, 2L, null));
+
+        assertThat(checker.conflictsWith(file("historical", 0L, 10L, 2L, Arrays.asList("nest.a"))))
+                .isTrue();
+    }
+
     private RowIdColumnConflictChecker checker(DataFileMeta... files) {
         return RowIdColumnConflictChecker.fromDataFiles(
                 createSchemaManager(), Arrays.asList(files));
@@ -166,6 +203,23 @@ class RowIdColumnConflictCheckerTest {
                                         new DataField(0, "id", DataTypes.INT()),
                                         new DataField(1, "b_renamed", DataTypes.INT()),
                                         new DataField(2, "c", DataTypes.INT())),
+                                Collections.emptyList(),
+                                Collections.singletonList("id"),
+                                Collections.emptyMap(),
+                                "")));
+        schemas.put(
+                2L,
+                org.apache.paimon.schema.TableSchema.create(
+                        2L,
+                        new Schema(
+                                Arrays.asList(
+                                        new DataField(0, "id", DataTypes.INT()),
+                                        new DataField(
+                                                1,
+                                                "nest",
+                                                DataTypes.ROW(
+                                                        new DataField(2, "a", DataTypes.INT()),
+                                                        new DataField(3, "b", DataTypes.INT())))),
                                 Collections.emptyList(),
                                 Collections.singletonList("id"),
                                 Collections.emptyMap(),

--- a/paimon-core/src/test/java/org/apache/paimon/table/NestedDataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/NestedDataEvolutionTableTest.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.DataEvolutionFileReader;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for data-evolution + row-tracking with nested columns (ROW / ARRAY / MAP).
+ *
+ * <p>These tests verify that a nested column is handled as a single, indivisible top-level field by
+ * data evolution: it can live in its own column-group file and be merged back by field id, while
+ * {@code _ROW_ID} / {@code _SEQUENCE_NUMBER} stay aligned by {@code firstRowId + position}. They
+ * also pin down the limitation that sub-fields of a nested ROW cannot be split into a separate
+ * column group (the minimum granularity is a top-level column).
+ */
+public class NestedDataEvolutionTableTest extends DataEvolutionTestBase {
+
+    // f0(0) INT, f1(1) STRING, nest(2) ROW<a INT, b STRING>, arr(3) ARRAY<INT>, mp(4)
+    // MAP<STRING,INT>
+    @Override
+    protected Schema schemaDefault() {
+        Schema.Builder b = Schema.newBuilder();
+        b.column("f0", DataTypes.INT());
+        b.column("f1", DataTypes.STRING());
+        b.column("nest", DataTypes.ROW(DataTypes.INT(), DataTypes.STRING()));
+        b.column("arr", DataTypes.ARRAY(DataTypes.INT()));
+        b.column("mp", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()));
+        b.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        b.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        return b.build();
+    }
+
+    private static GenericRow nestOf(int a, String bStr) {
+        return GenericRow.of(a, BinaryString.fromString(bStr));
+    }
+
+    private static GenericArray arrOf(int... values) {
+        return new GenericArray(values);
+    }
+
+    private static GenericMap mapOf(String k, int v) {
+        Map<Object, Object> m = new HashMap<>();
+        m.put(BinaryString.fromString(k), v);
+        return new GenericMap(m);
+    }
+
+    /** G1 + G2: nested column as its own column group, merged by field id, row-id aligned. */
+    @Test
+    public void testNestedColumnGroupMerge() throws Exception {
+        createTableDefault();
+        Schema schema = schemaDefault();
+        int n = 50;
+
+        RowType cgA = schema.rowType().project(Arrays.asList("f0", "f1"));
+        RowType cgB = schema.rowType().project(Collections.singletonList("nest"));
+        RowType cgC = schema.rowType().project(Arrays.asList("arr", "mp"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        // column group A: {f0, f1}
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgA)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(i, BinaryString.fromString("a" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(w.prepareCommit());
+        }
+
+        // column group B: {nest}
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgB)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(nestOf(i, "n" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = w.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        // column group C: {arr, mp}
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgC)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(arrOf(i, i + 1), mapOf("k" + i, i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = w.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        assertThat(reader).isInstanceOf(DataEvolutionFileReader.class);
+
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    assertThat(r.getString(1).toString()).isEqualTo("a" + i);
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i);
+                    assertThat(nest.getString(1).toString()).isEqualTo("n" + i);
+                    assertThat(r.getArray(3).getInt(0)).isEqualTo(i);
+                    assertThat(r.getArray(3).getInt(1)).isEqualTo(i + 1);
+                    assertThat(r.getMap(4).keyArray().getString(0).toString()).isEqualTo("k" + i);
+                    assertThat(r.getMap(4).valueArray().getInt(0)).isEqualTo(i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+
+        // _ROW_ID is contiguous 0..n-1 across the merged column groups.
+        List<Long> rowIds = readRowIds();
+        assertThat(rowIds).hasSize(n);
+        for (int i = 0; i < n; i++) {
+            assertThat(rowIds.get(i)).isEqualTo((long) i);
+        }
+    }
+
+    /**
+     * G3: a later snapshot rewrites only the nested column group; other columns keep old values.
+     */
+    @Test
+    public void testNestedColumnLateOverwrite() throws Exception {
+        createTableDefault();
+        Schema schema = schemaDefault();
+        int n = 20;
+
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+        // full write
+        try (BatchTableWrite w = builder.newWrite().withWriteType(schema.rowType())) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                nestOf(i, "old" + i),
+                                arrOf(i),
+                                mapOf("k" + i, i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(w.prepareCommit());
+        }
+
+        // later snapshot: overwrite only the nest column group, aligned to the same row-id range
+        RowType cgNest = schema.rowType().project(Collections.singletonList("nest"));
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgNest)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(nestOf(i * 10, "new" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = w.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            commit.commit(commitables);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    // untouched columns keep old values
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    assertThat(r.getString(1).toString()).isEqualTo("a" + i);
+                    assertThat(r.getArray(3).getInt(0)).isEqualTo(i);
+                    // nest column reflects the new values
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i * 10);
+                    assertThat(nest.getString(1).toString()).isEqualTo("new" + i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+
+        // row ids unchanged
+        List<Long> rowIds = readRowIds();
+        for (int i = 0; i < n; i++) {
+            assertThat(rowIds.get(i)).isEqualTo((long) i);
+        }
+    }
+
+    /** G4: projection covering special fields and nested columns. */
+    @Test
+    public void testProjectionWithNested() throws Exception {
+        createTableDefault();
+        Schema schema = schemaDefault();
+        int n = 10;
+
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+        try (BatchTableWrite w = builder.newWrite().withWriteType(schema.rowType())) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                nestOf(i, "n" + i),
+                                arrOf(i),
+                                mapOf("k" + i, i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(w.prepareCommit());
+        }
+
+        // project only the nested column (keep the real "nest" field id via project)
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder
+                        .withReadType(
+                                getTableDefault()
+                                        .rowType()
+                                        .project(Collections.singletonList("nest")))
+                        .newRead()
+                        .createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    InternalRow nest = r.getRow(0, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i);
+                    assertThat(nest.getString(1).toString()).isEqualTo("n" + i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+
+        // project only _ROW_ID
+        assertThat(readRowIds()).hasSize(n);
+    }
+
+    /**
+     * G5 (limitation): a sub-field of a nested ROW cannot be addressed as a top-level write column,
+     * because data evolution splits at top-level column granularity. {@code RowType.project}
+     * matches only top-level field names, so a nested sub-field name has no match.
+     */
+    @Test
+    public void testNestedSubFieldCannotBeSplit() {
+        RowType rowType = schemaDefault().rowType();
+        // "a" / "b" are sub-fields inside "nest"; they are not top-level columns.
+        assertThatThrownBy(() -> rowType.project(Collections.singletonList("a")))
+                .isInstanceOf(IndexOutOfBoundsException.class);
+        // a nested ROW can only be projected as a whole top-level column.
+        assertThat(rowType.project(Collections.singletonList("nest")).getFieldNames())
+                .containsExactly("nest");
+    }
+
+    /**
+     * G6: compacting column-group files (one of which is the nested column) merges them into a
+     * single file; data values and row ids survive the {@code DataEvolutionRowIdReassigner}.
+     */
+    @Test
+    public void testCompactionWithNested() throws Exception {
+        createTableDefault();
+        Schema schema = schemaDefault();
+        int n = 30;
+
+        RowType cgA = schema.rowType().project(Arrays.asList("f0", "f1", "arr", "mp"));
+        RowType cgB = schema.rowType().project(Collections.singletonList("nest"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgA)) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i, BinaryString.fromString("a" + i), arrOf(i), mapOf("k" + i, i)));
+            }
+            builder.newCommit().commit(w.prepareCommit());
+        }
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgB)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(nestOf(i, "n" + i)));
+            }
+            List<CommitMessage> commitables = w.prepareCommit();
+            setFirstRowId(commitables, 0L);
+            builder.newCommit().commit(commitables);
+        }
+
+        // run data-evolution compaction via the coordinator (merges the two column groups)
+        FileStoreTable table = getTableDefault();
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        List<DataEvolutionCompactTask> tasks;
+        try {
+            while (!(tasks = coordinator.plan()).isEmpty()) {
+                for (DataEvolutionCompactTask task : tasks) {
+                    commitMessages.add(task.doCompact(table, "nested-compact"));
+                }
+            }
+        } catch (EndOfScanException ignore) {
+        }
+        if (!commitMessages.isEmpty()) {
+            table.newBatchWriteBuilder().newCommit().commit(commitMessages);
+        }
+
+        // data and row ids must be unchanged after compaction
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    assertThat(r.getString(1).toString()).isEqualTo("a" + i);
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i);
+                    assertThat(nest.getString(1).toString()).isEqualTo("n" + i);
+                    assertThat(r.getArray(3).getInt(0)).isEqualTo(i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+
+        List<Long> rowIds = readRowIds();
+        assertThat(rowIds).hasSize(n);
+        for (int i = 0; i < n; i++) {
+            assertThat(rowIds.get(i)).isEqualTo((long) i);
+        }
+    }
+
+    private List<Long> readRowIds() throws Exception {
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder
+                        .withReadType(RowType.of(SpecialFields.ROW_ID))
+                        .newRead()
+                        .createReader(readBuilder.newScan().plan());
+        List<Long> rowIds = new ArrayList<>();
+        reader.forEachRemaining(r -> rowIds.add(r.getLong(0)));
+        return rowIds;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/NestedSubfieldDataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/NestedSubfieldDataEvolutionTableTest.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.sink.BatchTableCommit;
+import org.apache.paimon.table.sink.BatchTableWrite;
+import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <b>sub-field-level</b> data evolution + row-tracking: updating a single sub-field of a
+ * nested ROW column by writing an incremental file that only contains that sub-field, aligned by
+ * row-id, and reading the struct back by assembling sub-fields from several files.
+ */
+public class NestedSubfieldDataEvolutionTableTest extends DataEvolutionTestBase {
+
+    // f0(0) INT, f1(1) STRING, nest(2) ROW<a INT, b STRING>, arr(3) ARRAY<INT>, mp(4)
+    // MAP<STRING,INT>
+    @Override
+    protected Schema schemaDefault() {
+        Schema.Builder b = Schema.newBuilder();
+        b.column("f0", DataTypes.INT());
+        b.column("f1", DataTypes.STRING());
+        b.column(
+                "nest",
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "a", DataTypes.INT()),
+                        DataTypes.FIELD(1, "b", DataTypes.STRING())));
+        b.column("arr", DataTypes.ARRAY(DataTypes.INT()));
+        b.column("mp", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()));
+        b.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        b.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        return b.build();
+    }
+
+    private static GenericArray arrOf(int v) {
+        return new GenericArray(new int[] {v});
+    }
+
+    private static GenericMap mapOf(String k, int v) {
+        Map<Object, Object> m = new HashMap<>();
+        m.put(BinaryString.fromString(k), v);
+        return new GenericMap(m);
+    }
+
+    private void commit(BatchWriteBuilder builder, List<CommitMessage> messages) throws Exception {
+        try (BatchTableCommit commit = builder.newCommit()) {
+            commit.commit(messages);
+        }
+    }
+
+    /**
+     * Core: write sub-field {@code nest.a} and {@code nest.b} into two separate files (plus the
+     * rest of the columns in a third), then read the full struct assembled from all three.
+     */
+    @Test
+    public void testSubFieldGroupsAssembled() throws Exception {
+        createTableDefault();
+        RowType full = getTableDefault().rowType();
+        int n = 40;
+
+        RowType cgRest = full.projectByPaths(Arrays.asList("f0", "f1", "arr", "mp"));
+        RowType cgA = full.projectByPaths(Collections.singletonList("nest.a"));
+        RowType cgB = full.projectByPaths(Collections.singletonList("nest.b"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgRest)) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i, BinaryString.fromString("a" + i), arrOf(i), mapOf("k" + i, i)));
+            }
+            commit(builder, w.prepareCommit());
+        }
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgA)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(GenericRow.of(i * 2)));
+            }
+            List<CommitMessage> messages = w.prepareCommit();
+            // a file that only writes nest.a must record a nested dotted path
+            assertThat(((CommitMessageImpl) messages.get(0)).newFilesIncrement().newFiles())
+                    .allSatisfy(f -> assertThat(f.writeCols()).containsExactly("nest.a"));
+            setFirstRowId(messages, 0L);
+            commit(builder, messages);
+        }
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgB)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(GenericRow.of(BinaryString.fromString("b" + i))));
+            }
+            List<CommitMessage> messages = w.prepareCommit();
+            setFirstRowId(messages, 0L);
+            commit(builder, messages);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    assertThat(r.getString(1).toString()).isEqualTo("a" + i);
+                    // nest assembled: a from file A, b from file B
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i * 2);
+                    assertThat(nest.getString(1).toString()).isEqualTo("b" + i);
+                    assertThat(r.getArray(3).getInt(0)).isEqualTo(i);
+                    assertThat(r.getMap(4).valueArray().getInt(0)).isEqualTo(i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+
+        assertThat(readRowIds()).containsExactlyElementsOf(rangeLongs(n));
+    }
+
+    /**
+     * A later snapshot updates only {@code nest.a} via an incremental sub-field file; {@code
+     * nest.b} and all other columns keep their original values, row-ids unchanged.
+     */
+    @Test
+    public void testSubFieldLateOverwrite() throws Exception {
+        createTableDefault();
+        RowType full = getTableDefault().rowType();
+        int n = 25;
+
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+        // full write: nest = (i, "old"+i)
+        try (BatchTableWrite w = builder.newWrite().withWriteType(full)) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i,
+                                BinaryString.fromString("a" + i),
+                                GenericRow.of(i, BinaryString.fromString("old" + i)),
+                                arrOf(i),
+                                mapOf("k" + i, i)));
+            }
+            commit(builder, w.prepareCommit());
+        }
+
+        // incremental: overwrite only nest.a
+        RowType cgA = full.projectByPaths(Collections.singletonList("nest.a"));
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgA)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(GenericRow.of(i + 1000)));
+            }
+            List<CommitMessage> messages = w.prepareCommit();
+            setFirstRowId(messages, 0L);
+            commit(builder, messages);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i + 1000); // updated sub-field
+                    assertThat(nest.getString(1).toString()).isEqualTo("old" + i); // kept
+                });
+        assertThat(idx.get()).isEqualTo(n);
+        assertThat(readRowIds()).containsExactlyElementsOf(rangeLongs(n));
+    }
+
+    /** Compaction merges sub-field files into one full file; values and row-ids are preserved. */
+    @Test
+    public void testCompactionMergesSubFields() throws Exception {
+        createTableDefault();
+        RowType full = getTableDefault().rowType();
+        int n = 20;
+
+        RowType cgRest = full.projectByPaths(Arrays.asList("f0", "f1", "arr", "mp"));
+        RowType cgA = full.projectByPaths(Collections.singletonList("nest.a"));
+        RowType cgB = full.projectByPaths(Collections.singletonList("nest.b"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgRest)) {
+            for (int i = 0; i < n; i++) {
+                w.write(
+                        GenericRow.of(
+                                i, BinaryString.fromString("a" + i), arrOf(i), mapOf("k" + i, i)));
+            }
+            commit(builder, w.prepareCommit());
+        }
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgA)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(GenericRow.of(i * 2)));
+            }
+            List<CommitMessage> messages = w.prepareCommit();
+            setFirstRowId(messages, 0L);
+            commit(builder, messages);
+        }
+        try (BatchTableWrite w = builder.newWrite().withWriteType(cgB)) {
+            for (int i = 0; i < n; i++) {
+                w.write(GenericRow.of(GenericRow.of(BinaryString.fromString("b" + i))));
+            }
+            List<CommitMessage> messages = w.prepareCommit();
+            setFirstRowId(messages, 0L);
+            commit(builder, messages);
+        }
+
+        FileStoreTable table = getTableDefault();
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
+        List<CommitMessage> compactMessages = new ArrayList<>();
+        List<DataEvolutionCompactTask> tasks;
+        try {
+            while (!(tasks = coordinator.plan()).isEmpty()) {
+                for (DataEvolutionCompactTask task : tasks) {
+                    compactMessages.add(task.doCompact(table, "subfield-compact"));
+                }
+            }
+        } catch (EndOfScanException ignore) {
+        }
+        if (!compactMessages.isEmpty()) {
+            commit(table.newBatchWriteBuilder(), compactMessages);
+        }
+
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan());
+        AtomicInteger idx = new AtomicInteger(0);
+        reader.forEachRemaining(
+                r -> {
+                    int i = idx.getAndIncrement();
+                    assertThat(r.getInt(0)).isEqualTo(i);
+                    InternalRow nest = r.getRow(2, 2);
+                    assertThat(nest.getInt(0)).isEqualTo(i * 2);
+                    assertThat(nest.getString(1).toString()).isEqualTo("b" + i);
+                });
+        assertThat(idx.get()).isEqualTo(n);
+        assertThat(readRowIds()).containsExactlyElementsOf(rangeLongs(n));
+    }
+
+    private List<Long> rangeLongs(int n) {
+        List<Long> out = new ArrayList<>();
+        for (long i = 0; i < n; i++) {
+            out.add(i);
+        }
+        return out;
+    }
+
+    private List<Long> readRowIds() throws Exception {
+        ReadBuilder readBuilder = getTableDefault().newReadBuilder();
+        RecordReader<InternalRow> reader =
+                readBuilder
+                        .withReadType(RowType.of(SpecialFields.ROW_ID))
+                        .newRead()
+                        .createReader(readBuilder.newScan().plan());
+        List<Long> rowIds = new ArrayList<>();
+        reader.forEachRemaining(r -> rowIds.add(r.getLong(0)));
+        return rowIds;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -477,13 +477,66 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
     /**
      * Parse a SET target into a path relative to the target table: strip an optional leading
      * table-qualifier segment (the target table name/alias), leaving {@code [topColumn, sub...]}.
+     *
+     * <p>Stripping is not unconditional. When the target table (or its alias) is also the name of a
+     * struct column, both readings can resolve against the schema — with a table named {@code
+     * payload} holding both a struct column {@code payload} with a sub-field {@code a} and a
+     * top-level column {@code a}, the target {@code payload.a} is either the qualified top-level
+     * {@code a} or the nested {@code payload.a}. Resolve both and reject the input instead of
+     * silently updating one of them.
      */
     private List<String> parseTargetPath(String target) {
         List<String> segs = new ArrayList<>(Arrays.asList(target.split("\\.")));
         if (segs.size() > 1 && segs.get(0).equals(targetTableName())) {
-            segs.remove(0);
+            List<String> unqualified = new ArrayList<>(segs.subList(1, segs.size()));
+            boolean asQualified = resolvesAgainstTarget(unqualified);
+            boolean asColumnPath = resolvesAgainstTarget(segs);
+            if (asQualified && asColumnPath) {
+                throw new RuntimeException(
+                        String.format(
+                                "Ambiguous SET target '%s': it addresses both the top-level column "
+                                        + "'%s' of target table '%s' and the sub-field '%s' of the "
+                                        + "struct column '%s'. Write it unambiguously, e.g. '%s' "
+                                        + "for the nested sub-field or '%s' for the top-level "
+                                        + "column.",
+                                target,
+                                String.join(".", unqualified),
+                                targetTableName(),
+                                String.join(".", unqualified),
+                                segs.get(0),
+                                targetTableName() + "." + target,
+                                String.join(".", unqualified)));
+            }
+            if (asQualified || !asColumnPath) {
+                // a genuine qualifier, or invalid either way: keep the historical behaviour so an
+                // unresolvable target still raises the standard "invalid column reference" error
+                return unqualified;
+            }
         }
         return segs;
+    }
+
+    /** Whether {@code path} names an existing (possibly nested) field of the target table. */
+    private boolean resolvesAgainstTarget(List<String> path) {
+        if (path.isEmpty()) {
+            return false;
+        }
+        RowType rowType = table.rowType();
+        if (!rowType.containsField(path.get(0))) {
+            return false;
+        }
+        DataType type = rowType.getField(path.get(0)).type();
+        for (int i = 1; i < path.size(); i++) {
+            if (!(type instanceof RowType)) {
+                return false;
+            }
+            RowType struct = (RowType) type;
+            if (!struct.containsField(path.get(i))) {
+                return false;
+            }
+            type = struct.getField(path.get(i)).type();
+        }
+        return true;
     }
 
     /**

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -74,6 +74,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -344,6 +345,7 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
      * Also sets {@link #writePaths}.
      */
     private List<String> buildExplicitProject() {
+        checkNoDuplicateSetTargets();
         Map<String, String> changes = parseCommaSeparatedKeyValues(matchedUpdateSet);
 
         // group by top-level column, preserving first-seen order
@@ -482,6 +484,33 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
             segs.remove(0);
         }
         return segs;
+    }
+
+    /**
+     * {@link org.apache.paimon.utils.ParameterUtils#parseCommaSeparatedKeyValues} collapses {@link
+     * #matchedUpdateSet} into a {@code Map}, so a duplicate SET target (e.g. {@code "nest.a = x,
+     * nest.a = y"}) silently loses the earlier entry with no error. Detect duplicates here, before
+     * that collapse, comparing paths normalized via {@link #parseTargetPath} so a qualified ({@code
+     * T.nest.a}) and unqualified ({@code nest.a}) form of the same target are treated as the same
+     * duplicate.
+     */
+    private void checkNoDuplicateSetTargets() {
+        if (matchedUpdateSet == null || matchedUpdateSet.trim().isEmpty()) {
+            return;
+        }
+        Set<String> seen = new HashSet<>();
+        for (String raw : matchedUpdateSet.split(",")) {
+            String[] kv = raw.split("=", 2);
+            if (kv.length != 2) {
+                // malformed entry: let parseCommaSeparatedKeyValues raise the standard error
+                continue;
+            }
+            String canonicalKey = String.join(".", parseTargetPath(kv[0].trim()));
+            if (!seen.add(canonicalKey)) {
+                throw new RuntimeException(
+                        "Duplicate SET target '" + kv[0].trim() + "' in matched-upsert action.");
+            }
+        }
     }
 
     public DataStream<Tuple2<Long, RowData>> shuffleByFirstRowId(
@@ -760,15 +789,26 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
 
     /**
      * Whether {@code source} fully covers the target struct {@code target} for a whole-column
-     * assignment: every target sub-field must exist in {@code source} (by name) with a compatible
-     * cast. A source missing a target sub-field (a narrower struct) is rejected.
+     * assignment: every target sub-field must be present in {@code source} at the same position
+     * (same name, same physical order) with a compatible cast. The write is positional (the source
+     * struct is written through as-is, not projected by name), so a source struct that is merely
+     * name-compatible but has a different field order or extra fields would silently store values
+     * under the wrong field; both are rejected here rather than accepted and mis-written. A source
+     * missing a target sub-field (a narrower struct) is also rejected.
      */
     private boolean isFullyCompatibleStruct(RowType source, RowType target) {
-        for (DataField targetField : target.getFields()) {
-            if (!source.containsField(targetField.name())) {
+        List<DataField> sourceFields = source.getFields();
+        List<DataField> targetFields = target.getFields();
+        if (sourceFields.size() != targetFields.size()) {
+            return false;
+        }
+        for (int i = 0; i < targetFields.size(); i++) {
+            DataField sourceField = sourceFields.get(i);
+            DataField targetField = targetFields.get(i);
+            if (!sourceField.name().equals(targetField.name())) {
                 return false;
             }
-            DataType sourceSubType = source.getField(targetField.name()).type();
+            DataType sourceSubType = sourceField.type();
             DataType targetSubType = targetField.type();
             if (sourceSubType instanceof RowType && targetSubType instanceof RowType) {
                 if (!isFullyCompatibleStruct((RowType) sourceSubType, (RowType) targetSubType)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -67,8 +67,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,6 +131,10 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
 
     // the snapshot id this action based on
     private long baseSnapshotId;
+
+    // columns written by this merge, as (possibly nested) dotted paths, e.g. ["id", "nest.a"];
+    // derived in buildSource() and consumed by writePartialColumns().
+    private List<String> writePaths;
 
     public DataEvolutionMergeIntoAction(
             String databaseName, String tableName, Map<String, String> catalogConfig) {
@@ -251,32 +257,15 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         handleSqls();
 
         // assign row id for each source row
+        boolean updateAll = matchedUpdateSet.equals("*");
         List<String> project;
-        if (matchedUpdateSet.equals("*")) {
+        if (updateAll) {
             // if sourceName is qualified like 'default.S', we should build a project like S.*
             project = Collections.singletonList(sourceTableName() + ".*");
         } else {
-            // validate upsert changes
-            Map<String, String> changes = parseCommaSeparatedKeyValues(matchedUpdateSet);
-            for (String targetField : changes.keySet()) {
-                if (!targetFieldNames.contains(extractFieldName(targetField))) {
-                    throw new RuntimeException(
-                            String.format(
-                                    "Invalid column reference '%s' of table '%s' at matched-upsert action.",
-                                    targetField, identifier.getFullName()));
-                }
-            }
-
-            // rename source table's selected columns according to SET statement
-            project =
-                    changes.entrySet().stream()
-                            .map(
-                                    entry ->
-                                            String.format(
-                                                    "%s AS `%s`",
-                                                    entry.getValue(),
-                                                    extractFieldName(entry.getKey())))
-                            .collect(Collectors.toList());
+            // validate upsert changes and build the projection (top-level columns and, for
+            // sub-field-level data evolution, partial nested structs via dotted paths)
+            project = buildExplicitProject();
         }
 
         String query;
@@ -319,11 +308,176 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         Table source = batchTEnv.sqlQuery(query);
 
         checkSchema(source);
-        RowType sourceType =
-                SpecialFields.rowTypeWithRowId(table.rowType())
-                        .project(source.getResolvedSchema().getColumnNames());
+
+        RowType sourceType;
+        if (updateAll) {
+            List<String> columnNames = source.getResolvedSchema().getColumnNames();
+            sourceType = SpecialFields.rowTypeWithRowId(table.rowType()).project(columnNames);
+            writePaths =
+                    columnNames.stream()
+                            .filter(name -> !SpecialFields.ROW_ID.name().equals(name))
+                            .collect(Collectors.toList());
+        } else {
+            // build the source type manually so _ROW_ID is first and the column order matches the
+            // SQL projection order; for nested columns the field is the partial (pruned) struct.
+            RowType pruned = table.rowType().projectByPaths(writePaths);
+            List<DataField> srcFields = new ArrayList<>();
+            srcFields.add(SpecialFields.ROW_ID);
+            for (String topCol : explicitTopColumnOrder(writePaths)) {
+                srcFields.add(pruned.getField(table.rowType().getField(topCol).id()));
+            }
+            sourceType = new RowType(srcFields);
+        }
 
         return Tuple2.of(toDataStream(source), sourceType);
+    }
+
+    /**
+     * Validate the SET targets and build the SQL projection list. A target may address a top-level
+     * column ({@code col} / {@code T.col}) or, for sub-field-level data evolution, a nested
+     * sub-field ({@code nest.a} / {@code T.nest.a}). A partially-updated struct column is rebuilt
+     * as a partial {@code CAST(ROW(...) AS ROW<...>)} so only the touched sub-fields are written.
+     * Also sets {@link #writePaths}.
+     */
+    private List<String> buildExplicitProject() {
+        Map<String, String> changes = parseCommaSeparatedKeyValues(matchedUpdateSet);
+
+        // group by top-level column, preserving first-seen order
+        Map<String, String> wholeCols = new LinkedHashMap<>();
+        Map<String, LinkedHashMap<String, String>> nestedCols = new LinkedHashMap<>();
+        List<String> order = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : changes.entrySet()) {
+            List<String> path = parseTargetPath(entry.getKey());
+            String topCol = path.get(0);
+            if (!targetFieldNames.contains(topCol)) {
+                throw new RuntimeException(
+                        String.format(
+                                "Invalid column reference '%s' of table '%s' at matched-upsert action.",
+                                entry.getKey(), identifier.getFullName()));
+            }
+            if (!order.contains(topCol)) {
+                order.add(topCol);
+            }
+            if (path.size() == 1) {
+                // whole top-level column
+                if (nestedCols.containsKey(topCol) || wholeCols.containsKey(topCol)) {
+                    throw new RuntimeException(
+                            "Conflicting updates for column '" + topCol + "' in SET clause.");
+                }
+                wholeCols.put(topCol, entry.getValue());
+            } else {
+                // nested sub-field update
+                if (!coreOptions.dataEvolutionNestedFieldEnabled()) {
+                    throw new UnsupportedOperationException(
+                            "Updating a nested sub-field ('"
+                                    + entry.getKey()
+                                    + "') requires '"
+                                    + CoreOptions.DATA_EVOLUTION_NESTED_FIELD_ENABLED.key()
+                                    + "=true'.");
+                }
+                if (path.size() > 2) {
+                    throw new UnsupportedOperationException(
+                            "Sub-field-level data evolution only supports one level of nesting, "
+                                    + "but got '"
+                                    + entry.getKey()
+                                    + "'.");
+                }
+                if (wholeCols.containsKey(topCol)) {
+                    throw new RuntimeException(
+                            "Conflicting updates for column '" + topCol + "' in SET clause.");
+                }
+                String subName = path.get(1);
+                LinkedHashMap<String, String> subs =
+                        nestedCols.computeIfAbsent(topCol, k -> new LinkedHashMap<>());
+                if (subs.containsKey(subName)) {
+                    throw new RuntimeException(
+                            "Duplicated update for sub-field '"
+                                    + topCol
+                                    + "."
+                                    + subName
+                                    + "' in SET clause.");
+                }
+                subs.put(subName, entry.getValue());
+            }
+        }
+
+        // first pass: writePaths (so projectByPaths can build the pruned nested types)
+        writePaths = new ArrayList<>();
+        for (String topCol : order) {
+            if (wholeCols.containsKey(topCol)) {
+                writePaths.add(topCol);
+            } else {
+                // Emit sub-fields in schema declaration order rather than SET-clause order: the
+                // write paths become the physical column layout of the incremental file (both
+                // projectByPaths and the writeCols recorded in the manifest keep the given order),
+                // and that layout should not depend on how the user happened to order the SET
+                // clauses. The projection values below follow the pruned struct, so they adapt.
+                LinkedHashMap<String, String> subs = nestedCols.get(topCol);
+                RowType topColType = (RowType) table.rowType().getField(topCol).type();
+                for (DataField subField : topColType.getFields()) {
+                    if (subs.containsKey(subField.name())) {
+                        writePaths.add(topCol + "." + subField.name());
+                    }
+                }
+            }
+        }
+
+        // second pass: build projection expressions
+        RowType pruned = table.rowType().projectByPaths(writePaths);
+        List<String> project = new ArrayList<>();
+        for (String topCol : order) {
+            if (wholeCols.containsKey(topCol)) {
+                project.add(String.format("%s AS `%s`", wholeCols.get(topCol), topCol));
+            } else {
+                LinkedHashMap<String, String> subs = nestedCols.get(topCol);
+                DataType prunedColType =
+                        pruned.getField(table.rowType().getField(topCol).id()).type();
+                // value order must match the pruned struct's schema field order
+                List<String> values = new ArrayList<>();
+                for (DataField subField : ((RowType) prunedColType).getFields()) {
+                    String value = subs.get(subField.name());
+                    Preconditions.checkState(
+                            value != null,
+                            "Missing value for sub-field '%s.%s', it's a bug.",
+                            topCol,
+                            subField.name());
+                    values.add(value);
+                }
+                String typeStr =
+                        LogicalTypeConversion.toLogicalType(prunedColType).asSerializableString();
+                project.add(
+                        String.format(
+                                "CAST(ROW(%s) AS %s) AS `%s`",
+                                String.join(", ", values), typeStr, topCol));
+            }
+        }
+        return project;
+    }
+
+    /** The first-seen order of top-level columns present in the (dotted) write paths. */
+    private List<String> explicitTopColumnOrder(List<String> paths) {
+        List<String> order = new ArrayList<>();
+        for (String path : paths) {
+            int dot = path.indexOf('.');
+            String topCol = dot < 0 ? path : path.substring(0, dot);
+            if (!order.contains(topCol)) {
+                order.add(topCol);
+            }
+        }
+        return order;
+    }
+
+    /**
+     * Parse a SET target into a path relative to the target table: strip an optional leading
+     * table-qualifier segment (the target table name/alias), leaving {@code [topColumn, sub...]}.
+     */
+    private List<String> parseTargetPath(String target) {
+        List<String> segs = new ArrayList<>(Arrays.asList(target.split("\\.")));
+        if (segs.size() > 1 && segs.get(0).equals(targetTableName())) {
+            segs.remove(0);
+        }
+        return segs;
     }
 
     public DataStream<Tuple2<Long, RowData>> shuffleByFirstRowId(
@@ -392,7 +546,7 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                         "PARTIAL WRITE COLUMNS",
                         new CommittableTypeInfo(),
                         new DataEvolutionPartialWriteOperator(
-                                (FileStoreTable) table, rowType, baseSnapshotId))
+                                (FileStoreTable) table, rowType, writePaths, baseSnapshotId))
                 .setParallelism(sinkParallelism);
     }
 
@@ -527,7 +681,23 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                                         .getTypeRoot()
                                         .getFamilies()
                                         .contains(DataTypeFamily.BINARY_STRING);
+                // Struct columns need a structural compatibility check: DataTypeCasts does not
+                // support ROW-to-ROW casts. For a sub-field write (dotted paths like nest.a) the
+                // source is a partial (subset) struct carrying only the updated sub-fields, so a
+                // subset check is correct. For a whole-column assignment (e.g. T.nest=S.nest) the
+                // source must fully cover the target struct, so a narrower source is rejected
+                // instead of being written as an incomplete whole-struct file.
+                boolean structCompatible = false;
+                if (paimonType instanceof RowType && targetField.type() instanceof RowType) {
+                    RowType sourceStruct = (RowType) paimonType;
+                    RowType targetStruct = (RowType) targetField.type();
+                    structCompatible =
+                            isSubFieldWrite(flinkColumn.getName())
+                                    ? isCompatiblePartialStruct(sourceStruct, targetStruct)
+                                    : isFullyCompatibleStruct(sourceStruct, targetStruct);
+                }
                 if (!blobCompatible
+                        && !structCompatible
                         && !DataTypeCasts.supportsCompatibleCast(paimonType, targetField.type())) {
                     throw new IllegalStateException(
                             String.format(
@@ -539,6 +709,61 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         if (!foundRowIdColumn) {
             throw new IllegalStateException("_ROW_ID column not found in generated source.");
         }
+    }
+
+    /**
+     * Whether {@code part} is a valid partial (subset) of the full struct {@code full}: every
+     * sub-field of {@code part} must exist in {@code full} (by name) with a compatible cast.
+     */
+    private boolean isCompatiblePartialStruct(RowType part, RowType full) {
+        for (DataField partField : part.getFields()) {
+            if (!full.containsField(partField.name())) {
+                return false;
+            }
+            DataType fullSubType = full.getField(partField.name()).type();
+            if (partField.type() instanceof RowType && fullSubType instanceof RowType) {
+                if (!isCompatiblePartialStruct((RowType) partField.type(), (RowType) fullSubType)) {
+                    return false;
+                }
+            } else if (!DataTypeCasts.supportsCompatibleCast(partField.type(), fullSubType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether {@code source} fully covers the target struct {@code target} for a whole-column
+     * assignment: every target sub-field must exist in {@code source} (by name) with a compatible
+     * cast. A source missing a target sub-field (a narrower struct) is rejected.
+     */
+    private boolean isFullyCompatibleStruct(RowType source, RowType target) {
+        for (DataField targetField : target.getFields()) {
+            if (!source.containsField(targetField.name())) {
+                return false;
+            }
+            DataType sourceSubType = source.getField(targetField.name()).type();
+            DataType targetSubType = targetField.type();
+            if (sourceSubType instanceof RowType && targetSubType instanceof RowType) {
+                if (!isFullyCompatibleStruct((RowType) sourceSubType, (RowType) targetSubType)) {
+                    return false;
+                }
+            } else if (!DataTypeCasts.supportsCompatibleCast(sourceSubType, targetSubType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether the given top-level column is written through dotted sub-field paths (e.g. nest.a).
+     */
+    private boolean isSubFieldWrite(String topColumn) {
+        if (writePaths == null) {
+            return false;
+        }
+        String prefix = topColumn + ".";
+        return writePaths.stream().anyMatch(p -> p.startsWith(prefix));
     }
 
     private void handleSqls() {
@@ -569,11 +794,6 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         return Arrays.stream(sourceTable.split("\\."))
                 .map(s -> String.format("`%s`", s))
                 .collect(Collectors.joining("."));
-    }
-
-    private String extractFieldName(String sourceField) {
-        String[] fieldPath = sourceField.split("\\.");
-        return fieldPath[fieldPath.length - 1];
     }
 
     private String escapedRowTrackingTargetName() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -71,8 +71,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -133,6 +135,10 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
 
     // the snapshot id this action based on
     private long baseSnapshotId;
+
+    // columns written by this merge, as (possibly nested) dotted paths, e.g. ["id", "nest.a"];
+    // derived in buildSource() and consumed by writePartialColumns().
+    private List<String> writePaths;
 
     public DataEvolutionMergeIntoAction(
             String databaseName, String tableName, Map<String, String> catalogConfig) {
@@ -255,32 +261,15 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         handleSqls();
 
         // assign row id for each source row
+        boolean updateAll = matchedUpdateSet.equals("*");
         List<String> project;
-        if (matchedUpdateSet.equals("*")) {
+        if (updateAll) {
             // if sourceName is qualified like 'default.S', we should build a project like S.*
             project = Collections.singletonList(sourceTableName() + ".*");
         } else {
-            // validate upsert changes
-            Map<String, String> changes = parseCommaSeparatedKeyValues(matchedUpdateSet);
-            for (String targetField : changes.keySet()) {
-                if (!targetFieldNames.contains(extractFieldName(targetField))) {
-                    throw new RuntimeException(
-                            String.format(
-                                    "Invalid column reference '%s' of table '%s' at matched-upsert action.",
-                                    targetField, identifier.getFullName()));
-                }
-            }
-
-            // rename source table's selected columns according to SET statement
-            project =
-                    changes.entrySet().stream()
-                            .map(
-                                    entry ->
-                                            String.format(
-                                                    "%s AS `%s`",
-                                                    entry.getValue(),
-                                                    extractFieldName(entry.getKey())))
-                            .collect(Collectors.toList());
+            // validate upsert changes and build the projection (top-level columns and, for
+            // sub-field-level data evolution, partial nested structs via dotted paths)
+            project = buildExplicitProject();
         }
 
         String query;
@@ -323,11 +312,176 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         Table source = batchTEnv.sqlQuery(query);
 
         checkSchema(source);
-        RowType sourceType =
-                SpecialFields.rowTypeWithRowId(table.rowType())
-                        .project(source.getResolvedSchema().getColumnNames());
+
+        RowType sourceType;
+        if (updateAll) {
+            List<String> columnNames = source.getResolvedSchema().getColumnNames();
+            sourceType = SpecialFields.rowTypeWithRowId(table.rowType()).project(columnNames);
+            writePaths =
+                    columnNames.stream()
+                            .filter(name -> !SpecialFields.ROW_ID.name().equals(name))
+                            .collect(Collectors.toList());
+        } else {
+            // build the source type manually so _ROW_ID is first and the column order matches the
+            // SQL projection order; for nested columns the field is the partial (pruned) struct.
+            RowType pruned = table.rowType().projectByPaths(writePaths);
+            List<DataField> srcFields = new ArrayList<>();
+            srcFields.add(SpecialFields.ROW_ID);
+            for (String topCol : explicitTopColumnOrder(writePaths)) {
+                srcFields.add(pruned.getField(table.rowType().getField(topCol).id()));
+            }
+            sourceType = new RowType(srcFields);
+        }
 
         return Tuple2.of(toDataStream(source), sourceType);
+    }
+
+    /**
+     * Validate the SET targets and build the SQL projection list. A target may address a top-level
+     * column ({@code col} / {@code T.col}) or, for sub-field-level data evolution, a nested
+     * sub-field ({@code nest.a} / {@code T.nest.a}). A partially-updated struct column is rebuilt
+     * as a partial {@code CAST(ROW(...) AS ROW<...>)} so only the touched sub-fields are written.
+     * Also sets {@link #writePaths}.
+     */
+    private List<String> buildExplicitProject() {
+        Map<String, String> changes = parseCommaSeparatedKeyValues(matchedUpdateSet);
+
+        // group by top-level column, preserving first-seen order
+        Map<String, String> wholeCols = new LinkedHashMap<>();
+        Map<String, LinkedHashMap<String, String>> nestedCols = new LinkedHashMap<>();
+        List<String> order = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : changes.entrySet()) {
+            List<String> path = parseTargetPath(entry.getKey());
+            String topCol = path.get(0);
+            if (!targetFieldNames.contains(topCol)) {
+                throw new RuntimeException(
+                        String.format(
+                                "Invalid column reference '%s' of table '%s' at matched-upsert action.",
+                                entry.getKey(), identifier.getFullName()));
+            }
+            if (!order.contains(topCol)) {
+                order.add(topCol);
+            }
+            if (path.size() == 1) {
+                // whole top-level column
+                if (nestedCols.containsKey(topCol) || wholeCols.containsKey(topCol)) {
+                    throw new RuntimeException(
+                            "Conflicting updates for column '" + topCol + "' in SET clause.");
+                }
+                wholeCols.put(topCol, entry.getValue());
+            } else {
+                // nested sub-field update
+                if (!coreOptions.dataEvolutionNestedFieldEnabled()) {
+                    throw new UnsupportedOperationException(
+                            "Updating a nested sub-field ('"
+                                    + entry.getKey()
+                                    + "') requires '"
+                                    + CoreOptions.DATA_EVOLUTION_NESTED_FIELD_ENABLED.key()
+                                    + "=true'.");
+                }
+                if (path.size() > 2) {
+                    throw new UnsupportedOperationException(
+                            "Sub-field-level data evolution only supports one level of nesting, "
+                                    + "but got '"
+                                    + entry.getKey()
+                                    + "'.");
+                }
+                if (wholeCols.containsKey(topCol)) {
+                    throw new RuntimeException(
+                            "Conflicting updates for column '" + topCol + "' in SET clause.");
+                }
+                String subName = path.get(1);
+                LinkedHashMap<String, String> subs =
+                        nestedCols.computeIfAbsent(topCol, k -> new LinkedHashMap<>());
+                if (subs.containsKey(subName)) {
+                    throw new RuntimeException(
+                            "Duplicated update for sub-field '"
+                                    + topCol
+                                    + "."
+                                    + subName
+                                    + "' in SET clause.");
+                }
+                subs.put(subName, entry.getValue());
+            }
+        }
+
+        // first pass: writePaths (so projectByPaths can build the pruned nested types)
+        writePaths = new ArrayList<>();
+        for (String topCol : order) {
+            if (wholeCols.containsKey(topCol)) {
+                writePaths.add(topCol);
+            } else {
+                // Emit sub-fields in schema declaration order rather than SET-clause order: the
+                // write paths become the physical column layout of the incremental file (both
+                // projectByPaths and the writeCols recorded in the manifest keep the given order),
+                // and that layout should not depend on how the user happened to order the SET
+                // clauses. The projection values below follow the pruned struct, so they adapt.
+                LinkedHashMap<String, String> subs = nestedCols.get(topCol);
+                RowType topColType = (RowType) table.rowType().getField(topCol).type();
+                for (DataField subField : topColType.getFields()) {
+                    if (subs.containsKey(subField.name())) {
+                        writePaths.add(topCol + "." + subField.name());
+                    }
+                }
+            }
+        }
+
+        // second pass: build projection expressions
+        RowType pruned = table.rowType().projectByPaths(writePaths);
+        List<String> project = new ArrayList<>();
+        for (String topCol : order) {
+            if (wholeCols.containsKey(topCol)) {
+                project.add(String.format("%s AS `%s`", wholeCols.get(topCol), topCol));
+            } else {
+                LinkedHashMap<String, String> subs = nestedCols.get(topCol);
+                DataType prunedColType =
+                        pruned.getField(table.rowType().getField(topCol).id()).type();
+                // value order must match the pruned struct's schema field order
+                List<String> values = new ArrayList<>();
+                for (DataField subField : ((RowType) prunedColType).getFields()) {
+                    String value = subs.get(subField.name());
+                    Preconditions.checkState(
+                            value != null,
+                            "Missing value for sub-field '%s.%s', it's a bug.",
+                            topCol,
+                            subField.name());
+                    values.add(value);
+                }
+                String typeStr =
+                        LogicalTypeConversion.toLogicalType(prunedColType).asSerializableString();
+                project.add(
+                        String.format(
+                                "CAST(ROW(%s) AS %s) AS `%s`",
+                                String.join(", ", values), typeStr, topCol));
+            }
+        }
+        return project;
+    }
+
+    /** The first-seen order of top-level columns present in the (dotted) write paths. */
+    private List<String> explicitTopColumnOrder(List<String> paths) {
+        List<String> order = new ArrayList<>();
+        for (String path : paths) {
+            int dot = path.indexOf('.');
+            String topCol = dot < 0 ? path : path.substring(0, dot);
+            if (!order.contains(topCol)) {
+                order.add(topCol);
+            }
+        }
+        return order;
+    }
+
+    /**
+     * Parse a SET target into a path relative to the target table: strip an optional leading
+     * table-qualifier segment (the target table name/alias), leaving {@code [topColumn, sub...]}.
+     */
+    private List<String> parseTargetPath(String target) {
+        List<String> segs = new ArrayList<>(Arrays.asList(target.split("\\.")));
+        if (segs.size() > 1 && segs.get(0).equals(targetTableName())) {
+            segs.remove(0);
+        }
+        return segs;
     }
 
     public DataStream<Tuple2<Long, RowData>> shuffleByFirstRowId(
@@ -396,7 +550,7 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                         "PARTIAL WRITE COLUMNS",
                         new CommittableTypeInfo(),
                         new DataEvolutionPartialWriteOperator(
-                                (FileStoreTable) table, rowType, baseSnapshotId))
+                                (FileStoreTable) table, rowType, writePaths, baseSnapshotId))
                 .setParallelism(sinkParallelism);
     }
 
@@ -553,7 +707,23 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                                         .getTypeRoot()
                                         .getFamilies()
                                         .contains(DataTypeFamily.BINARY_STRING);
+                // Struct columns need a structural compatibility check: DataTypeCasts does not
+                // support ROW-to-ROW casts. For a sub-field write (dotted paths like nest.a) the
+                // source is a partial (subset) struct carrying only the updated sub-fields, so a
+                // subset check is correct. For a whole-column assignment (e.g. T.nest=S.nest) the
+                // source must fully cover the target struct, so a narrower source is rejected
+                // instead of being written as an incomplete whole-struct file.
+                boolean structCompatible = false;
+                if (paimonType instanceof RowType && targetField.type() instanceof RowType) {
+                    RowType sourceStruct = (RowType) paimonType;
+                    RowType targetStruct = (RowType) targetField.type();
+                    structCompatible =
+                            isSubFieldWrite(flinkColumn.getName())
+                                    ? isCompatiblePartialStruct(sourceStruct, targetStruct)
+                                    : isFullyCompatibleStruct(sourceStruct, targetStruct);
+                }
                 if (!blobCompatible
+                        && !structCompatible
                         && !DataTypeCasts.supportsCompatibleCast(paimonType, targetField.type())) {
                     throw new IllegalStateException(
                             String.format(
@@ -565,6 +735,61 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         if (!foundRowIdColumn) {
             throw new IllegalStateException("_ROW_ID column not found in generated source.");
         }
+    }
+
+    /**
+     * Whether {@code part} is a valid partial (subset) of the full struct {@code full}: every
+     * sub-field of {@code part} must exist in {@code full} (by name) with a compatible cast.
+     */
+    private boolean isCompatiblePartialStruct(RowType part, RowType full) {
+        for (DataField partField : part.getFields()) {
+            if (!full.containsField(partField.name())) {
+                return false;
+            }
+            DataType fullSubType = full.getField(partField.name()).type();
+            if (partField.type() instanceof RowType && fullSubType instanceof RowType) {
+                if (!isCompatiblePartialStruct((RowType) partField.type(), (RowType) fullSubType)) {
+                    return false;
+                }
+            } else if (!DataTypeCasts.supportsCompatibleCast(partField.type(), fullSubType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether {@code source} fully covers the target struct {@code target} for a whole-column
+     * assignment: every target sub-field must exist in {@code source} (by name) with a compatible
+     * cast. A source missing a target sub-field (a narrower struct) is rejected.
+     */
+    private boolean isFullyCompatibleStruct(RowType source, RowType target) {
+        for (DataField targetField : target.getFields()) {
+            if (!source.containsField(targetField.name())) {
+                return false;
+            }
+            DataType sourceSubType = source.getField(targetField.name()).type();
+            DataType targetSubType = targetField.type();
+            if (sourceSubType instanceof RowType && targetSubType instanceof RowType) {
+                if (!isFullyCompatibleStruct((RowType) sourceSubType, (RowType) targetSubType)) {
+                    return false;
+                }
+            } else if (!DataTypeCasts.supportsCompatibleCast(sourceSubType, targetSubType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether the given top-level column is written through dotted sub-field paths (e.g. nest.a).
+     */
+    private boolean isSubFieldWrite(String topColumn) {
+        if (writePaths == null) {
+            return false;
+        }
+        String prefix = topColumn + ".";
+        return writePaths.stream().anyMatch(p -> p.startsWith(prefix));
     }
 
     private void handleSqls() {
@@ -595,11 +820,6 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
         return Arrays.stream(sourceTable.split("\\."))
                 .map(s -> String.format("`%s`", s))
                 .collect(Collectors.joining("."));
-    }
-
-    private String extractFieldName(String sourceField) {
-        String[] fieldPath = sourceField.split("\\.");
-        return fieldPath[fieldPath.length - 1];
     }
 
     private String escapedRowTrackingTargetName() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionPartialWriteOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/dataevolution/DataEvolutionPartialWriteOperator.java
@@ -54,7 +54,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
@@ -101,16 +100,18 @@ public class DataEvolutionPartialWriteOperator
     }
 
     public DataEvolutionPartialWriteOperator(
-            FileStoreTable table, RowType dataType, Long baseSnapshotId) {
+            FileStoreTable table,
+            RowType sourceType,
+            List<String> writePaths,
+            Long baseSnapshotId) {
         this.table = table.copy(dataEvolutionWriteOptions());
         this.baseSnapshotId = baseSnapshotId;
-        List<String> fieldNames =
-                dataType.getFieldNames().stream()
-                        .filter(name -> !SpecialFields.ROW_ID.name().equals(name))
-                        .collect(Collectors.toList());
-        this.writeType = table.rowType().project(fieldNames);
-        this.dataType =
-                SpecialFields.rowTypeWithRowId(table.rowType()).project(dataType.getFieldNames());
+        // writePaths may carry nested dotted paths (e.g. "nest.a") for sub-field-level data
+        // evolution; projectByPaths handles both plain top-level names and nested paths.
+        this.writeType = table.rowType().projectByPaths(writePaths);
+        // sourceType is already pruned to the written columns (with partial nested structs) and
+        // carries the table's field ids, so it is used directly as the read/data type.
+        this.dataType = sourceType;
         this.rowIdIndex = this.dataType.getFieldIndex(SpecialFields.ROW_ID.name());
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow;
+import static org.apache.paimon.CoreOptions.DATA_EVOLUTION_ENABLED;
+import static org.apache.paimon.CoreOptions.DATA_EVOLUTION_NESTED_FIELD_ENABLED;
+import static org.apache.paimon.CoreOptions.ROW_TRACKING_ENABLED;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.buildDdl;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.init;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.insertInto;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.sEnv;
+import static org.apache.paimon.flink.util.ReadWriteTableTestUtil.testBatchRead;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ITCase for sub-field-level data evolution via {@link DataEvolutionMergeIntoAction}: updating a
+ * single sub-field of a nested struct column should write an incremental file containing only that
+ * sub-field (a dotted write column like {@code nest.a}) aligned by row id, while the rest of the
+ * struct is read back from the original file.
+ */
+public class NestedSubfieldMergeIntoActionITCase extends ActionITCaseBase {
+
+    @BeforeEach
+    @Override
+    public void before() throws IOException {
+        super.before();
+        init(warehouse);
+    }
+
+    private void prepareNestedTarget(boolean nestedFieldEnabled) throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "T",
+                        Arrays.asList("id INT", "nest ROW<a INT, b STRING>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                if (nestedFieldEnabled) {
+                                    put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                                }
+                            }
+                        }));
+        insertInto(
+                "T",
+                "(1, CAST(ROW(10, 'x') AS ROW<a INT, b STRING>))",
+                "(2, CAST(ROW(20, 'y') AS ROW<a INT, b STRING>))");
+    }
+
+    private void prepareSubFieldSource() throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "newa INT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, 100)");
+    }
+
+    @Test
+    public void testUpdateSingleSubFieldWritesOnlyThatLeaf() throws Exception {
+        prepareNestedTarget(true);
+        prepareSubFieldSource();
+
+        builder(warehouse, database, "T")
+                .withMergeCondition("T.id=S.id")
+                .withMatchedUpdateSet("T.nest.a=S.newa")
+                .withSourceTable("S")
+                .withSinkParallelism(2)
+                .build()
+                .run();
+
+        // correctness: nest.a updated for id=1, nest.b preserved, other row untouched
+        testBatchRead(
+                "SELECT id, nest.a, nest.b FROM T",
+                Arrays.asList(changelogRow("+I", 1, 100, "x"), changelogRow("+I", 2, 20, "y")));
+
+        // feature engaged: an incremental file written by the merge only contains nest.a
+        assertThat(deltaWriteCols("T")).contains(Collections.singletonList("nest.a"));
+    }
+
+    @Test
+    public void testUpdateSubFieldDisabledThrows() throws Exception {
+        // data-evolution.nested-field.enabled left at its default (false)
+        prepareNestedTarget(false);
+        prepareSubFieldSource();
+
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest.a=S.newa")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key());
+    }
+
+    @Test
+    public void testUpdateWholeStructStillWorks() throws Exception {
+        prepareNestedTarget(true);
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "nest ROW<a INT, b STRING>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, CAST(ROW(100, 'z') AS ROW<a INT, b STRING>))");
+
+        builder(warehouse, database, "T")
+                .withMergeCondition("T.id=S.id")
+                .withMatchedUpdateSet("T.nest=S.nest")
+                .withSourceTable("S")
+                .withSinkParallelism(2)
+                .build()
+                .run();
+
+        testBatchRead(
+                "SELECT id, nest.a, nest.b FROM T",
+                Arrays.asList(changelogRow("+I", 1, 100, "z"), changelogRow("+I", 2, 20, "y")));
+    }
+
+    @Test
+    public void testWholeStructAssignmentWithNarrowerSourceThrows() throws Exception {
+        // target nest is ROW<a, b>; a whole-column assignment from a narrower source ROW<a> must be
+        // rejected (it would otherwise be written as an incomplete whole-struct file)
+        prepareNestedTarget(true);
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "nest ROW<a INT>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, CAST(ROW(100) AS ROW<a INT>))");
+
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest=S.nest")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("incompatible");
+    }
+
+    @Test
+    public void testUpdateMultipleSubFieldsWritesOnlyThoseLeaves() throws Exception {
+        // a 3-field struct so that updating two sub-fields is a strict subset (stays
+        // sub-field-level
+        // rather than collapsing to a whole-column write)
+        sEnv.executeSql(
+                buildDdl(
+                        "T",
+                        Arrays.asList("id INT", "nest ROW<a INT, b STRING, c INT>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto(
+                "T",
+                "(1, CAST(ROW(10, 'x', 30) AS ROW<a INT, b STRING, c INT>))",
+                "(2, CAST(ROW(20, 'y', 40) AS ROW<a INT, b STRING, c INT>))");
+
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "newa INT", "newc INT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, 100, 300)");
+
+        builder(warehouse, database, "T")
+                .withMergeCondition("T.id=S.id")
+                .withMatchedUpdateSet("T.nest.a=S.newa,T.nest.c=S.newc")
+                .withSourceTable("S")
+                .withSinkParallelism(2)
+                .build()
+                .run();
+
+        // correctness: a and c updated for id=1, b preserved, other row untouched
+        testBatchRead(
+                "SELECT id, nest.a, nest.b, nest.c FROM T",
+                Arrays.asList(
+                        changelogRow("+I", 1, 100, "x", 300), changelogRow("+I", 2, 20, "y", 40)));
+
+        // feature engaged: the incremental file contains exactly the two touched leaves, in schema
+        // order (a before c)
+        assertThat(deltaWriteCols("T")).contains(Arrays.asList("nest.a", "nest.c"));
+    }
+
+    @Test
+    public void testUpdateDeeplyNestedSubFieldThrows() throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "T",
+                        Arrays.asList("id INT", "nest ROW<a INT, sub ROW<x INT, y INT>>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("T", "(1, CAST(ROW(10, ROW(1, 2)) AS ROW<a INT, sub ROW<x INT, y INT>>))");
+
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "newx INT"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, 100)");
+
+        // deeper-than-one-level sub-field updates are rejected (the reader composes only one level)
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest.sub.x=S.newx")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("one level");
+    }
+
+    /** The write columns of every data file in the latest snapshot of {@code tableName}. */
+    private List<List<String>> deltaWriteCols(String tableName) throws Exception {
+        FileStoreTable table = getFileStoreTable(tableName);
+        List<List<String>> result = new ArrayList<>();
+        for (ManifestEntry entry : table.store().newScan().plan().files()) {
+            DataFileMeta file = entry.file();
+            result.add(file.writeCols());
+        }
+        return result;
+    }
+
+    private DataEvolutionMergeIntoActionBuilder builder(
+            String warehouse, String database, String table) {
+        return new DataEvolutionMergeIntoActionBuilder(warehouse, database, table);
+    }
+
+    private static class DataEvolutionMergeIntoActionBuilder {
+        private final List<String> args;
+
+        DataEvolutionMergeIntoActionBuilder(String warehouse, String database, String table) {
+            this.args =
+                    new ArrayList<>(
+                            Arrays.asList(
+                                    "data_evolution_merge_into",
+                                    "--warehouse",
+                                    warehouse,
+                                    "--database",
+                                    database,
+                                    "--table",
+                                    table));
+        }
+
+        DataEvolutionMergeIntoActionBuilder withSourceTable(String sourceTable) {
+            args.add("--source_table");
+            args.add(sourceTable);
+            return this;
+        }
+
+        DataEvolutionMergeIntoActionBuilder withMergeCondition(String mergeCondition) {
+            args.add("--on");
+            args.add(mergeCondition);
+            return this;
+        }
+
+        DataEvolutionMergeIntoActionBuilder withMatchedUpdateSet(String matchedUpdateSet) {
+            args.add("--matched_update_set");
+            args.add(matchedUpdateSet);
+            return this;
+        }
+
+        DataEvolutionMergeIntoActionBuilder withSinkParallelism(int sinkParallelism) {
+            args.add("--sink_parallelism");
+            args.add(String.valueOf(sinkParallelism));
+            return this;
+        }
+
+        DataEvolutionMergeIntoAction build() {
+            return (DataEvolutionMergeIntoAction)
+                    ActionFactory.createAction(args.toArray(new String[0]))
+                            .orElseThrow(RuntimeException::new);
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
@@ -199,6 +199,78 @@ public class NestedSubfieldMergeIntoActionITCase extends ActionITCaseBase {
     }
 
     @Test
+    public void testWholeStructAssignmentWithReorderedSourceThrows() throws Exception {
+        // target nest is ROW<a, b>; a whole-column assignment from a same-named-but-reordered
+        // source ROW<b, a> must be rejected. The write is positional (the source struct is
+        // written through as-is), so accepting a reordered source would silently swap the a/b
+        // values instead of failing loudly (regression for #8334 review comment on
+        // isFullyCompatibleStruct).
+        prepareNestedTarget(true);
+        sEnv.executeSql(
+                buildDdl(
+                        "S",
+                        Arrays.asList("id INT", "nest ROW<b STRING, a INT>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("S", "(1, CAST(ROW('z', 100) AS ROW<b STRING, a INT>))");
+
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest=S.nest")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("incompatible");
+    }
+
+    @Test
+    public void testDuplicateSetTargetThrows() throws Exception {
+        prepareNestedTarget(true);
+        prepareSubFieldSource();
+
+        // T.nest.a is targeted twice; parseCommaSeparatedKeyValues would otherwise silently keep
+        // only the last assignment (regression for #8334 review comment on buildExplicitProject).
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest.a=S.newa,T.nest.a=S.newa")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
+    public void testDuplicateSetTargetWithMixedQualifierThrows() throws Exception {
+        prepareNestedTarget(true);
+        prepareSubFieldSource();
+
+        // the same target written once qualified (T.nest.a) and once unqualified (nest.a) must
+        // still be caught as a duplicate.
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "T")
+                                        .withMergeCondition("T.id=S.id")
+                                        .withMatchedUpdateSet("T.nest.a=S.newa,nest.a=S.newa")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("Duplicate");
+    }
+
+    @Test
     public void testUpdateMultipleSubFieldsWritesOnlyThoseLeaves() throws Exception {
         // a 3-field struct so that updating two sub-fields is a strict subset (stays
         // sub-field-level

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/NestedSubfieldMergeIntoActionITCase.java
@@ -271,6 +271,115 @@ public class NestedSubfieldMergeIntoActionITCase extends ActionITCaseBase {
     }
 
     @Test
+    public void testAmbiguousTargetPathIsRejected() throws Exception {
+        // the target table is named "payload" and the schema holds BOTH a struct column "payload"
+        // and a top-level column "a", so the unqualified nested target "payload.a" is ambiguous:
+        // it can be read as the nested payload.a, or as the qualified form of the top-level "a".
+        sEnv.executeSql(
+                buildDdl(
+                        "payload",
+                        Arrays.asList("id INT", "a INT", "payload ROW<a INT, b STRING>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("payload", "(1, 1, CAST(ROW(10, 'x') AS ROW<a INT, b STRING>))");
+        prepareSubFieldSource();
+
+        assertThatThrownBy(
+                        () ->
+                                builder(warehouse, database, "payload")
+                                        .withMergeCondition("payload.id=S.id")
+                                        .withMatchedUpdateSet("payload.a=S.newa")
+                                        .withSourceTable("S")
+                                        .withSinkParallelism(2)
+                                        .build()
+                                        .run())
+                .hasMessageContaining("mbiguous");
+
+        // and neither interpretation must have been written. Note the alias: Flink SQL itself
+        // reads a bare "payload.a" here as the table-qualified top-level column, which is exactly
+        // the ambiguity the action now refuses to guess at.
+        testBatchRead(
+                "SELECT p.id, p.a, p.payload.a, p.payload.b FROM payload AS p",
+                Collections.singletonList(changelogRow("+I", 1, 1, 10, "x")));
+    }
+
+    @Test
+    public void testAmbiguousTargetPathAcceptsTheExplicitlyQualifiedForm() throws Exception {
+        // the way out of the ambiguity above, as recommended by that error message: qualify the
+        // nested target with the table name so the path is unmistakable.
+        sEnv.executeSql(
+                buildDdl(
+                        "payload",
+                        Arrays.asList("id INT", "a INT", "payload ROW<a INT, b STRING>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("payload", "(1, 1, CAST(ROW(10, 'x') AS ROW<a INT, b STRING>))");
+        prepareSubFieldSource();
+
+        builder(warehouse, database, "payload")
+                .withMergeCondition("payload.id=S.id")
+                .withMatchedUpdateSet("payload.payload.a=S.newa")
+                .withSourceTable("S")
+                .withSinkParallelism(2)
+                .build()
+                .run();
+
+        // the NESTED payload.a moved; the top-level "a" is untouched
+        testBatchRead(
+                "SELECT p.id, p.a, p.payload.a, p.payload.b FROM payload AS p",
+                Collections.singletonList(changelogRow("+I", 1, 1, 100, "x")));
+        assertThat(deltaWriteCols("payload")).contains(Collections.singletonList("payload.a"));
+    }
+
+    @Test
+    public void testUnqualifiedNestedTargetResolvesWhenOnlyOneReadingIsValid() throws Exception {
+        // same table name / struct column name clash, but there is no top-level "a", so stripping
+        // the qualifier yields nothing resolvable and "payload.a" can only be the nested sub-field.
+        sEnv.executeSql(
+                buildDdl(
+                        "payload",
+                        Arrays.asList("id INT", "payload ROW<a INT, b STRING>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_NESTED_FIELD_ENABLED.key(), "true");
+                            }
+                        }));
+        insertInto("payload", "(1, CAST(ROW(10, 'x') AS ROW<a INT, b STRING>))");
+        prepareSubFieldSource();
+
+        builder(warehouse, database, "payload")
+                .withMergeCondition("payload.id=S.id")
+                .withMatchedUpdateSet("payload.a=S.newa")
+                .withSourceTable("S")
+                .withSinkParallelism(2)
+                .build()
+                .run();
+
+        testBatchRead(
+                "SELECT p.id, p.payload.a, p.payload.b FROM payload AS p",
+                Collections.singletonList(changelogRow("+I", 1, 100, "x")));
+        assertThat(deltaWriteCols("payload")).contains(Collections.singletonList("payload.a"));
+    }
+
+    @Test
     public void testUpdateMultipleSubFieldsWritesOnlyThoseLeaves() throws Exception {
         // a 3-field struct so that updating two sub-fields is a strict subset (stays
         // sub-field-level

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, If, IsNull, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -590,17 +590,30 @@ case class MergeIntoPaimonDataEvolutionTable(
                   if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
                     None
                   } else {
-                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    val actionOrderedUnion = perAction.flatten.flatten.map(_._1).distinct
                     // The reader composes a split struct only one level deep, so only prune when
                     // every change addresses a direct sub-field of the top-level struct (depth 1).
                     // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
                     // which the read path does not support, so fall back to a whole-column write.
                     // Prune only when the changed direct sub-fields are a strict subset of all of
                     // them (otherwise the whole column is rewritten anyway).
-                    val allDepthOne = union.forall(_.size == 1)
-                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                    val allDepthOne = actionOrderedUnion.forall(_.size == 1)
+                    if (
+                      actionOrderedUnion.isEmpty || !allDepthOne ||
+                      actionOrderedUnion.size >= st.fields.length
+                    ) {
                       None
                     } else {
+                      // actionOrderedUnion reflects the order the SET clauses were written in,
+                      // which need not match st's field declaration order. buildPrunedStruct /
+                      // prunedStructType always lay the physical output struct out in st's
+                      // declaration order (they use the path set only as a filter, not an
+                      // ordering), so canonicalize here once and reuse this exact order for
+                      // writePaths below - otherwise the persisted writeType/writeCols order can
+                      // disagree with the physical column order and a reader would decode values
+                      // under the wrong field names.
+                      val fieldOrder = st.fieldNames.zipWithIndex.toMap
+                      val union = actionOrderedUnion.sortBy(p => fieldOrder(p.head))
                       Some(attr.exprId -> (union, prunedStructType(st, union)))
                     }
                   }
@@ -665,17 +678,29 @@ case class MergeIntoPaimonDataEvolutionTable(
             Literal(null, attr.dataType)
           } else {
             prunedByExprId.get(attr.exprId) match {
-              case Some((paths, _)) =>
+              case Some((paths, prunedType)) =>
                 val st = attr.dataType.asInstanceOf[StructType]
                 val actionMap =
                   changedLeaves(assignmentValue(action, attr), st, attr)
                     .getOrElse(Seq.empty)
                     .toMap
-                buildPrunedStruct(
+                val built = buildPrunedStruct(
                   st,
                   Nil,
                   paths,
                   p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+                if (actionMap.isEmpty) {
+                  // This action's assignment doesn't touch any leaf of this column (e.g. a
+                  // different WHEN MATCHED clause set it, or the rebuild was a no-op), so this is
+                  // a pure passthrough of attr - same guard as copyOutput below, a NULL source
+                  // struct must stay NULL rather than becoming a non-null struct of null leaves.
+                  If(IsNull(attr), Literal(null, prunedType), built)
+                } else {
+                  // At least one leaf was explicitly set by this action: the struct must
+                  // materialize even if attr was NULL (e.g. `SET nest.a = 5` on a previously NULL
+                  // nest), or the explicit assignment would be silently discarded.
+                  built
+                }
               case None => assignmentValue(action, attr)
             }
           }
@@ -700,9 +725,11 @@ case class MergeIntoPaimonDataEvolutionTable(
             Literal(null, attr.dataType)
           } else {
             prunedByExprId.get(attr.exprId) match {
-              case Some((paths, _)) =>
+              case Some((paths, prunedType)) =>
                 val st = attr.dataType.asInstanceOf[StructType]
-                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+                val built = buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+                // Same NULL guard as updateOutput: a copied-through NULL struct must stay NULL.
+                If(IsNull(attr), Literal(null, prunedType), built)
               case None => attr
             }
           }

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -46,7 +46,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -473,7 +473,64 @@ case class MergeIntoPaimonDataEvolutionTable(
       AttributeReference(MERGE_DELETED_NAME, BooleanType, nullable = false)()
     // Row metadata, _FIRST_ROW_ID added by addFirstRowId, and the delete marker.
     val fixedMergeOutputColumnCount = metadataColumns.size + 2
-    val mergeOutput = (updateColumnsSorted ++ metadataColumns ++ rawBlobMarkerAttributes) :+
+
+    // Sub-field-level pruning: for a struct column whose SET only touches some sub-fields, only the
+    // changed leaves are written (an incremental column-group file containing the partial struct);
+    // the rest are copied from the target. Falls back to whole-column write when the changed leaves
+    // cannot be safely determined, so behaviour never regresses.
+    val matchedUpdateActions = matchedActions.collect { case ua: UpdateAction => ua }
+    // Gated by data-evolution.nested-field.enabled (default off): when disabled, no column is
+    // pruned, so every struct column is rewritten whole (behaviour identical to before this
+    // feature). When enabled, struct columns whose SET only touches some sub-fields are pruned.
+    val nestedFieldEnabled = table.coreOptions().dataEvolutionNestedFieldEnabled()
+    val prunedByExprId: Map[ExprId, (Seq[Seq[String]], StructType)] =
+      if (!nestedFieldEnabled) Map.empty
+      else
+        updateColumnsSorted.flatMap {
+          attr =>
+            if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+              None
+            } else {
+              attr.dataType match {
+                case st: StructType =>
+                  val perAction = matchedUpdateActions.flatMap {
+                    ua =>
+                      ua.assignments
+                        .find(
+                          a => isModifiedAssignment(a) && assignmentKeyAttribute(a).sameRef(attr))
+                        .map(a => changedLeaves(a.value, st, attr))
+                  }
+                  if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
+                    None
+                  } else {
+                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    // The reader composes a split struct only one level deep, so only prune when
+                    // every change addresses a direct sub-field of the top-level struct (depth 1).
+                    // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
+                    // which the read path does not support, so fall back to a whole-column write.
+                    // Prune only when the changed direct sub-fields are a strict subset of all of
+                    // them (otherwise the whole column is rewritten anyway).
+                    val allDepthOne = union.forall(_.size == 1)
+                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                      None
+                    } else {
+                      Some(attr.exprId -> (union, prunedStructType(st, union)))
+                    }
+                  }
+                case _ => None
+              }
+            }
+        }.toMap
+
+    val prunedUpdateColumns = updateColumnsSorted.map {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((_, prunedType)) =>
+            AttributeReference(attr.name, prunedType, attr.nullable)()
+          case None => attr
+        }
+    }
+    val mergeOutput = (prunedUpdateColumns ++ metadataColumns ++ rawBlobMarkerAttributes) :+
       deletedAttribute
 
     val targetMatchedActions = matchedActions.map {
@@ -520,7 +577,20 @@ case class MergeIntoPaimonDataEvolutionTable(
           ) {
             Literal(null, attr.dataType)
           } else {
-            assignmentValue(action, attr)
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                val actionMap =
+                  changedLeaves(assignmentValue(action, attr), st, attr)
+                    .getOrElse(Seq.empty)
+                    .toMap
+                buildPrunedStruct(
+                  st,
+                  Nil,
+                  paths,
+                  p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+              case None => assignmentValue(action, attr)
+            }
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
@@ -542,7 +612,12 @@ case class MergeIntoPaimonDataEvolutionTable(
           if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
-            attr
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+              case None => attr
+            }
           }
       }
       val deletedLiteral = if (deleted) TrueLiteral else FalseLiteral
@@ -690,6 +765,16 @@ case class MergeIntoPaimonDataEvolutionTable(
         .sortWithinPartitions(FIRST_ROW_ID_NAME, ROW_ID_NAME)
     }
 
+    // dotted write paths: a whole column -> its name; a pruned struct -> "col.subfield..." leaves
+    val writePaths = updateColumnsSorted.flatMap {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((paths, _)) => paths.map(p => (attr.name +: p).mkString("."))
+          case None => Seq(attr.name)
+        }
+    }
+    val writeType = table.rowType().projectByPaths(writePaths.asJava)
+
     val writePartialFields = updateColumnsSorted.nonEmpty
     val shouldPersistOutput = writePartialFields && hasMatchedDeleteActions
     val output: Dataset[Row] =
@@ -702,7 +787,7 @@ case class MergeIntoPaimonDataEvolutionTable(
           val dataEvolutionWriter = DataEvolutionPaimonWriter(table, dataSplits)
           val partialCommit = dataEvolutionWriter.writePartialFields(
             reorderPartialWriteColumns(output),
-            updateColumnsSorted.map(_.name),
+            writeType,
             rawBlobUpdateColumns
               .map(attr => attr.name -> rawBlobMarkerNamesByColumn(attr.name))
               .toMap
@@ -1115,6 +1200,135 @@ object MergeIntoPaimonDataEvolutionTable {
 
   private def quotedColumn(name: String) = {
     col("`" + name.replace("`", "``") + "`")
+  }
+
+  /**
+   * For an aligned UPDATE value of a struct column, return the changed leaf paths (relative to the
+   * column) paired with their new value expression, or `None` if the value is not a recognizable
+   * named-struct rebuild (in which case the whole column must be written).
+   */
+  private[commands] def changedLeaves(
+      value: Expression,
+      structType: StructType,
+      base: Expression): Option[Seq[(Seq[String], Expression)]] = {
+    val out = mutable.LinkedHashMap.empty[Seq[String], Expression]
+    if (collectChanges(value, structType, base, Nil, out)) Some(out.toSeq) else None
+  }
+
+  private def collectChanges(
+      value: Expression,
+      structType: StructType,
+      base: Expression,
+      prefix: Seq[String],
+      out: mutable.LinkedHashMap[Seq[String], Expression]): Boolean = {
+    value match {
+      case cns: CreateNamedStruct =>
+        val pairs = cns.children.grouped(2).toSeq
+        if (pairs.exists(_.size != 2)) {
+          return false
+        }
+        var ok = true
+        pairs.foreach {
+          pair =>
+            val nameExpr = pair.head
+            val v = pair(1)
+            nameExpr match {
+              case Literal(nameVal, _) if nameVal != null =>
+                val name = nameVal.toString
+                val ordinalOpt = {
+                  val i = structType.fieldNames.indexOf(name)
+                  if (i >= 0) Some(i) else None
+                }
+                ordinalOpt match {
+                  case Some(ordinal) =>
+                    val fieldType = structType(ordinal).dataType
+                    val passthrough = GetStructField(base, ordinal, Some(name))
+                    if (!v.semanticEquals(passthrough)) {
+                      (fieldType, v) match {
+                        case (st: StructType, inner: CreateNamedStruct) =>
+                          ok = collectChanges(
+                            inner,
+                            st,
+                            GetStructField(base, ordinal, Some(name)),
+                            prefix :+ name,
+                            out) && ok
+                        case _ =>
+                          out.put(prefix :+ name, v)
+                      }
+                    }
+                  case None => ok = false
+                }
+              case _ => ok = false
+            }
+        }
+        ok
+      case _ => false
+    }
+  }
+
+  /** Build a Spark StructType containing only the given (possibly nested) leaf paths. */
+  private[commands] def prunedStructType(
+      structType: StructType,
+      paths: Seq[Seq[String]]): StructType = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val fields = structType.fields.filter(f => byHead.contains(f.name)).map {
+      f =>
+        val sub = byHead(f.name)
+        if (sub.exists(_.size == 1)) {
+          f
+        } else {
+          f.copy(dataType = prunedStructType(f.dataType.asInstanceOf[StructType], sub.map(_.tail)))
+        }
+    }
+    StructType(fields)
+  }
+
+  /** Build a named_struct over the given leaf paths; each terminal leaf value comes from valueFn. */
+  private[commands] def buildPrunedStruct(
+      structType: StructType,
+      prefix: Seq[String],
+      paths: Seq[Seq[String]],
+      valueFn: Seq[String] => Expression): CreateNamedStruct = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val args = structType.fields.flatMap {
+      f =>
+        byHead.get(f.name) match {
+          case None => Seq.empty[Expression]
+          case Some(sub) =>
+            val fieldPath = prefix :+ f.name
+            val expr =
+              if (sub.exists(_.size == 1)) {
+                valueFn(fieldPath)
+              } else {
+                buildPrunedStruct(
+                  f.dataType.asInstanceOf[StructType],
+                  fieldPath,
+                  sub.map(_.tail),
+                  valueFn)
+              }
+            Seq(Literal(f.name): Expression, expr)
+        }
+    }
+    CreateNamedStruct(args.toSeq)
+  }
+
+  /** Read a (possibly nested) leaf from a base expression via GetStructField chain. */
+  private[commands] def passthroughExpr(
+      base: Expression,
+      structType: StructType,
+      path: Seq[String]): Expression = {
+    if (path.isEmpty) {
+      base
+    } else {
+      val head = path.head
+      val ordinal = structType.fieldIndex(head)
+      val child = GetStructField(base, ordinal, Some(head))
+      if (path.tail.isEmpty) {
+        child
+      } else {
+        passthroughExpr(child, structType(ordinal).dataType.asInstanceOf[StructType], path.tail)
+      }
+    }
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -560,7 +560,64 @@ case class MergeIntoPaimonDataEvolutionTable(
       AttributeReference(MERGE_DELETED_NAME, BooleanType, nullable = false)()
     // Row metadata, _FIRST_ROW_ID added by addFirstRowId, and the delete marker.
     val fixedMergeOutputColumnCount = metadataColumns.size + 2
-    val mergeOutput = (updateColumnsSorted ++ metadataColumns ++ rawBlobMarkerAttributes) :+
+
+    // Sub-field-level pruning: for a struct column whose SET only touches some sub-fields, only the
+    // changed leaves are written (an incremental column-group file containing the partial struct);
+    // the rest are copied from the target. Falls back to whole-column write when the changed leaves
+    // cannot be safely determined, so behaviour never regresses.
+    val matchedUpdateActions = matchedActions.collect { case ua: UpdateAction => ua }
+    // Gated by data-evolution.nested-field.enabled (default off): when disabled, no column is
+    // pruned, so every struct column is rewritten whole (behaviour identical to before this
+    // feature). When enabled, struct columns whose SET only touches some sub-fields are pruned.
+    val nestedFieldEnabled = table.coreOptions().dataEvolutionNestedFieldEnabled()
+    val prunedByExprId: Map[ExprId, (Seq[Seq[String]], StructType)] =
+      if (!nestedFieldEnabled) Map.empty
+      else
+        updateColumnsSorted.flatMap {
+          attr =>
+            if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+              None
+            } else {
+              attr.dataType match {
+                case st: StructType =>
+                  val perAction = matchedUpdateActions.flatMap {
+                    ua =>
+                      ua.assignments
+                        .find(
+                          a => isModifiedAssignment(a) && assignmentKeyAttribute(a).sameRef(attr))
+                        .map(a => changedLeaves(a.value, st, attr))
+                  }
+                  if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
+                    None
+                  } else {
+                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    // The reader composes a split struct only one level deep, so only prune when
+                    // every change addresses a direct sub-field of the top-level struct (depth 1).
+                    // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
+                    // which the read path does not support, so fall back to a whole-column write.
+                    // Prune only when the changed direct sub-fields are a strict subset of all of
+                    // them (otherwise the whole column is rewritten anyway).
+                    val allDepthOne = union.forall(_.size == 1)
+                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                      None
+                    } else {
+                      Some(attr.exprId -> (union, prunedStructType(st, union)))
+                    }
+                  }
+                case _ => None
+              }
+            }
+        }.toMap
+
+    val prunedUpdateColumns = updateColumnsSorted.map {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((_, prunedType)) =>
+            AttributeReference(attr.name, prunedType, attr.nullable)()
+          case None => attr
+        }
+    }
+    val mergeOutput = (prunedUpdateColumns ++ metadataColumns ++ rawBlobMarkerAttributes) :+
       deletedAttribute
 
     val targetMatchedActions = matchedActions.map {
@@ -607,7 +664,20 @@ case class MergeIntoPaimonDataEvolutionTable(
           ) {
             Literal(null, attr.dataType)
           } else {
-            assignmentValue(action, attr)
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                val actionMap =
+                  changedLeaves(assignmentValue(action, attr), st, attr)
+                    .getOrElse(Seq.empty)
+                    .toMap
+                buildPrunedStruct(
+                  st,
+                  Nil,
+                  paths,
+                  p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+              case None => assignmentValue(action, attr)
+            }
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
@@ -629,7 +699,12 @@ case class MergeIntoPaimonDataEvolutionTable(
           if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
-            attr
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+              case None => attr
+            }
           }
       }
       val deletedLiteral = if (deleted) TrueLiteral else FalseLiteral
@@ -782,6 +857,16 @@ case class MergeIntoPaimonDataEvolutionTable(
         .sortWithinPartitions(FIRST_ROW_ID_NAME, ROW_ID_NAME)
     }
 
+    // dotted write paths: a whole column -> its name; a pruned struct -> "col.subfield..." leaves
+    val writePaths = updateColumnsSorted.flatMap {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((paths, _)) => paths.map(p => (attr.name +: p).mkString("."))
+          case None => Seq(attr.name)
+        }
+    }
+    val writeType = table.rowType().projectByPaths(writePaths.asJava)
+
     val writePartialFields = updateColumnsSorted.nonEmpty
     val shouldPersistOutput = writePartialFields && hasMatchedDeleteActions
     val output: Dataset[Row] =
@@ -794,7 +879,7 @@ case class MergeIntoPaimonDataEvolutionTable(
           val dataEvolutionWriter = DataEvolutionPaimonWriter(table, dataSplits)
           val partialCommit = dataEvolutionWriter.writePartialFields(
             reorderPartialWriteColumns(output),
-            updateColumnsSorted.map(_.name),
+            writeType,
             rawBlobUpdateColumns
               .map(attr => attr.name -> rawBlobMarkerNamesByColumn(attr.name))
               .toMap
@@ -1207,6 +1292,135 @@ object MergeIntoPaimonDataEvolutionTable {
 
   private def quotedColumn(name: String) = {
     col("`" + name.replace("`", "``") + "`")
+  }
+
+  /**
+   * For an aligned UPDATE value of a struct column, return the changed leaf paths (relative to the
+   * column) paired with their new value expression, or `None` if the value is not a recognizable
+   * named-struct rebuild (in which case the whole column must be written).
+   */
+  private[commands] def changedLeaves(
+      value: Expression,
+      structType: StructType,
+      base: Expression): Option[Seq[(Seq[String], Expression)]] = {
+    val out = mutable.LinkedHashMap.empty[Seq[String], Expression]
+    if (collectChanges(value, structType, base, Nil, out)) Some(out.toSeq) else None
+  }
+
+  private def collectChanges(
+      value: Expression,
+      structType: StructType,
+      base: Expression,
+      prefix: Seq[String],
+      out: mutable.LinkedHashMap[Seq[String], Expression]): Boolean = {
+    value match {
+      case cns: CreateNamedStruct =>
+        val pairs = cns.children.grouped(2).toSeq
+        if (pairs.exists(_.size != 2)) {
+          return false
+        }
+        var ok = true
+        pairs.foreach {
+          pair =>
+            val nameExpr = pair.head
+            val v = pair(1)
+            nameExpr match {
+              case Literal(nameVal, _) if nameVal != null =>
+                val name = nameVal.toString
+                val ordinalOpt = {
+                  val i = structType.fieldNames.indexOf(name)
+                  if (i >= 0) Some(i) else None
+                }
+                ordinalOpt match {
+                  case Some(ordinal) =>
+                    val fieldType = structType(ordinal).dataType
+                    val passthrough = GetStructField(base, ordinal, Some(name))
+                    if (!v.semanticEquals(passthrough)) {
+                      (fieldType, v) match {
+                        case (st: StructType, inner: CreateNamedStruct) =>
+                          ok = collectChanges(
+                            inner,
+                            st,
+                            GetStructField(base, ordinal, Some(name)),
+                            prefix :+ name,
+                            out) && ok
+                        case _ =>
+                          out.put(prefix :+ name, v)
+                      }
+                    }
+                  case None => ok = false
+                }
+              case _ => ok = false
+            }
+        }
+        ok
+      case _ => false
+    }
+  }
+
+  /** Build a Spark StructType containing only the given (possibly nested) leaf paths. */
+  private[commands] def prunedStructType(
+      structType: StructType,
+      paths: Seq[Seq[String]]): StructType = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val fields = structType.fields.filter(f => byHead.contains(f.name)).map {
+      f =>
+        val sub = byHead(f.name)
+        if (sub.exists(_.size == 1)) {
+          f
+        } else {
+          f.copy(dataType = prunedStructType(f.dataType.asInstanceOf[StructType], sub.map(_.tail)))
+        }
+    }
+    StructType(fields)
+  }
+
+  /** Build a named_struct over the given leaf paths; each terminal leaf value comes from valueFn. */
+  private[commands] def buildPrunedStruct(
+      structType: StructType,
+      prefix: Seq[String],
+      paths: Seq[Seq[String]],
+      valueFn: Seq[String] => Expression): CreateNamedStruct = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val args = structType.fields.flatMap {
+      f =>
+        byHead.get(f.name) match {
+          case None => Seq.empty[Expression]
+          case Some(sub) =>
+            val fieldPath = prefix :+ f.name
+            val expr =
+              if (sub.exists(_.size == 1)) {
+                valueFn(fieldPath)
+              } else {
+                buildPrunedStruct(
+                  f.dataType.asInstanceOf[StructType],
+                  fieldPath,
+                  sub.map(_.tail),
+                  valueFn)
+              }
+            Seq(Literal(f.name): Expression, expr)
+        }
+    }
+    CreateNamedStruct(args.toSeq)
+  }
+
+  /** Read a (possibly nested) leaf from a base expression via GetStructField chain. */
+  private[commands] def passthroughExpr(
+      base: Expression,
+      structType: StructType,
+      path: Seq[String]): Expression = {
+    if (path.isEmpty) {
+      base
+    } else {
+      val head = path.head
+      val ordinal = structType.fieldIndex(head)
+      val child = GetStructField(base, ordinal, Some(head))
+      if (path.tail.isEmpty) {
+        child
+      } else {
+        passthroughExpr(child, structType(ordinal).dataType.asInstanceOf[StructType], path.tail)
+      }
+    }
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionCompactMergeConflictRewriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionCompactMergeConflictRewriter.scala
@@ -29,6 +29,7 @@ import org.apache.paimon.table.{FileStoreTable, SpecialFields}
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl}
 import org.apache.paimon.table.source.{DataSplit, IncrementalSplit}
 import org.apache.paimon.table.source.snapshot.SnapshotReader
+import org.apache.paimon.types.{RowType => PaimonRowType}
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 import org.apache.paimon.utils.{Range, RowRangeIndex}
 
@@ -121,12 +122,10 @@ class DataEvolutionCompactMergeConflictRewriter(
       target =>
         val files = additionsByTarget.get(target).map(_.toSeq).getOrElse(Seq.empty)
         if (files.nonEmpty) {
-          val updatedFields = table
-            .rowType()
-            .getFieldNames
-            .asScala
-            .filter(name => files.exists(_.file.writeCols().contains(name)))
-            .toSeq
+          // write columns may be dotted sub-field paths (e.g. "nest.a"), so they cannot be matched
+          // against top-level field names; collect their union instead, ordered by the schema.
+          val updatedFields =
+            updatedWritePaths(files.flatMap(_.file.writeCols().asScala).distinct.toSet)
           if (updatedFields.isEmpty) {
             return JOptional.empty()
           }
@@ -155,6 +154,35 @@ class DataEvolutionCompactMergeConflictRewriter(
       }
 
     JOptional.of((messageImpls ++ rewrittenMessages).map(_.asInstanceOf[CommitMessage]).asJava)
+  }
+
+  /**
+   * The write paths covered by the staged MERGE files, laid out in schema order: a top-level column
+   * written whole by any file is taken whole, otherwise its written sub-fields are listed in the
+   * struct's declaration order. Ordering here has to be deterministic because [[TargetRewrite]]s
+   * are grouped by it and it becomes the physical layout of the rebased file.
+   */
+  private def updatedWritePaths(writePaths: Set[String]): Seq[String] = {
+    val fieldNames = table.rowType().getFieldNames.asScala.toSet
+    table.rowType().getFields.asScala.toSeq.flatMap {
+      field =>
+        val forField = writePaths.filter(
+          path => DataEvolutionPartialColumns.topLevelOf(path, fieldNames) == field.name)
+        if (forField.isEmpty) {
+          Seq.empty[String]
+        } else if (forField.contains(field.name)) {
+          // some file wrote the whole column, which subsumes any sub-field write of it
+          Seq(field.name)
+        } else {
+          field.`type`() match {
+            case struct: PaimonRowType =>
+              struct.getFields.asScala.toSeq
+                .map(sub => field.name + "." + sub.name)
+                .filter(forField.contains)
+            case _ => Seq(field.name)
+          }
+        }
+    }
   }
 
   private def targetReader(snapshot: Snapshot, targetScan: TargetScan): SnapshotReader = {
@@ -236,7 +264,13 @@ class DataEvolutionCompactMergeConflictRewriter(
     }
 
     val rowIdAttribute = attribute(ROW_ID_NAME)
-    val readOutput = updatedFields.map(attribute) :+ rowIdAttribute
+    // updatedFields are write paths and may address a single leaf of a struct (e.g. "nest.a"); the
+    // scan is in terms of top-level columns and the projection prunes each partially written
+    // struct, so the rebased file carries exactly the leaves the staged MERGE files carried.
+    val fieldNames = table.rowType().getFieldNames.asScala.toSet
+    val topColumns = DataEvolutionPartialColumns.topLevelColumns(updatedFields, fieldNames)
+    val projections = DataEvolutionPartialColumns.projections(table, updatedFields)
+    val readOutput = topColumns.map(attribute) :+ rowIdAttribute
     val relation = createNewScanPlan(relevantSplits, targetRelation)
     val readPlan =
       SparkShimLoader.shim.copyDataSourceV2Relation(relation, relation.table, readOutput)
@@ -244,7 +278,7 @@ class DataEvolutionCompactMergeConflictRewriter(
     val rangeIndex = new CompactRowIdRangeIndex(targetRanges)
     val firstRowId = udf((rowId: Long) => rangeIndex.firstRowId(rowId))
     val rewrittenRows = createDataset(sparkSession, readPlan)
-      .select((updatedFields.map(quotedColumn) :+ quotedColumn(ROW_ID_NAME)): _*)
+      .select((projections :+ quotedColumn(ROW_ID_NAME)): _*)
       .withColumn(FIRST_ROW_ID_NAME, firstRowId(quotedColumn(ROW_ID_NAME)))
       .filter(quotedColumn(FIRST_ROW_ID_NAME).isNotNull)
       .repartition(col(FIRST_ROW_ID_NAME))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPaimonWriter.scala
@@ -25,6 +25,7 @@ import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink._
 import org.apache.paimon.table.source.DataSplit
 import org.apache.paimon.types.BlobType
+import org.apache.paimon.types.RowType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
 import org.apache.paimon.utils.SerializationUtils
 
@@ -45,15 +46,28 @@ case class DataEvolutionPaimonWriter(paimonTable: FileStoreTable, dataSplits: Se
     paimonTable.copy(writeOptions.asJava)
   }
 
+  // Whole top-level column write (kept for callers that only update full columns).
   def writePartialFields(
       data: DataFrame,
       columnNames: Seq[String],
       rawBlobPlaceholderMarkerColumns: Map[String, String] = Map.empty): Seq[CommitMessage] = {
+    writePartialFields(
+      data,
+      table.rowType().projectByPaths(columnNames.asJava),
+      rawBlobPlaceholderMarkerColumns)
+  }
+
+  // Sub-field-aware write: writeType is already pruned to the written top-level columns and
+  // (possibly) nested sub-fields via dotted paths.
+  def writePartialFields(
+      data: DataFrame,
+      writeType: RowType,
+      rawBlobPlaceholderMarkerColumns: Map[String, String]): Seq[CommitMessage] = {
     val sparkSession = data.sparkSession
     val uriReaderFactory = uriReaderFactoryForBlobDescriptor
     import sparkSession.implicits._
-    assert(data.columns.length == columnNames.size + 2 + rawBlobPlaceholderMarkerColumns.size)
-    val writeType = table.rowType().project(columnNames.asJava)
+    assert(
+      data.columns.length == writeType.getFieldCount + 2 + rawBlobPlaceholderMarkerColumns.size)
 
     val options = new CoreOptions(table.schema().options())
     val blobInlineFields = options.blobInlineField().asScala.toSeq

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPartialColumns.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionPartialColumns.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.commands
+
+import org.apache.paimon.spark.SparkTypeUtils
+import org.apache.paimon.table.FileStoreTable
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{col, lit, struct, when}
+import org.apache.spark.sql.types.StructType
+
+import scala.collection.JavaConverters._
+
+/**
+ * Helpers for the conflict rewriters, which have to read and re-write the exact columns a
+ * partial-column data evolution file holds. Since sub-field-level data evolution those write
+ * columns may be dotted paths addressing a single leaf of a struct (e.g. `Seq("value", "nest.a")`)
+ * rather than plain top-level names.
+ */
+private[spark] object DataEvolutionPartialColumns {
+
+  /**
+   * The top-level column a write path addresses. A path that names a field exactly is that field
+   * even when its own name contains a dot, mirroring `RowType#projectByPaths`.
+   */
+  def topLevelOf(path: String, fieldNames: Set[String]): String = {
+    val dot = path.indexOf('.')
+    if (dot < 0 || fieldNames.contains(path)) path else path.substring(0, dot)
+  }
+
+  /** Distinct top-level column names addressed by `paths`, in first-seen order. */
+  def topLevelColumns(paths: Seq[String], fieldNames: Set[String]): Seq[String] =
+    paths.map(path => topLevelOf(path, fieldNames)).distinct
+
+  /** Whether any path addresses a sub-field rather than a whole top-level column. */
+  def hasNestedPaths(paths: Seq[String], fieldNames: Set[String]): Boolean =
+    paths.exists(path => topLevelOf(path, fieldNames) != path)
+
+  /**
+   * The Spark type of the row a file with these write paths physically holds, i.e. the Spark view
+   * of `table.rowType().projectByPaths(paths)`. Its fields are in write-path order, which is the
+   * order [[DataEvolutionPaimonWriter.writePartialFields]] expects the data frame to be in.
+   */
+  def writeStructType(table: FileStoreTable, paths: Seq[String]): StructType =
+    SparkTypeUtils.fromPaimonRowType(table.rowType().projectByPaths(paths.asJava))
+
+  /**
+   * One projection per top-level column, in write-path order and aliased to the column's name. A
+   * whole column is read as it is; a partially written struct is rebuilt carrying only the written
+   * leaves, so re-writing the file leaves its untouched siblings alone instead of overwriting them
+   * with nulls.
+   */
+  def projections(table: FileStoreTable, paths: Seq[String]): Seq[Column] = {
+    val fieldNames = table.rowType().getFieldNames.asScala.toSet
+    val topCols = topLevelColumns(paths, fieldNames)
+    val writeType = writeStructType(table, paths)
+    topCols.zip(writeType.fields).map {
+      case (name, field) =>
+        val column = quotedColumn(name)
+        field.dataType match {
+          // a struct that got pruned by projectByPaths must be rebuilt to that pruned shape
+          case pruned: StructType if !paths.contains(name) =>
+            rebuild(column, pruned).as(name)
+          case _ => column
+        }
+    }
+  }
+
+  /**
+   * Rebuild `input` as `pruned`, keeping only the sub-fields that survive the projection. A NULL
+   * struct stays NULL: rebuilding it field by field would otherwise turn it into a non-null struct
+   * of NULL children.
+   */
+  private def rebuild(input: Column, pruned: StructType): Column = {
+    val fields = pruned.fields.map {
+      field =>
+        val child = input.getField(field.name)
+        field.dataType match {
+          case nested: StructType => rebuild(child, nested).as(field.name)
+          case _ => child.as(field.name)
+        }
+    }
+    when(input.isNull, lit(null).cast(pruned)).otherwise(struct(fields: _*))
+  }
+
+  def quotedColumn(name: String): Column = col("`" + name.replace("`", "``") + "`")
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionRowIdConflictRewriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionRowIdConflictRewriter.scala
@@ -169,13 +169,19 @@ private[spark] class DataEvolutionRowIdConflictRewriter(
     }
 
     val rowIdAttribute = attribute(ROW_ID_NAME)
-    val readOutput = columnNames.map(attribute) :+ rowIdAttribute
+    // columnNames are write paths and may address a single leaf of a struct (e.g. "nest.a"); the
+    // scan is always in terms of the top-level columns, and the projection then prunes each
+    // partially written struct down to the leaves the file actually holds.
+    val fieldNames = table.rowType().getFieldNames.asScala.toSet
+    val topColumns = DataEvolutionPartialColumns.topLevelColumns(columnNames, fieldNames)
+    val projections = DataEvolutionPartialColumns.projections(table, columnNames)
+    val readOutput = topColumns.map(attribute) :+ rowIdAttribute
     def readRows(splits: Seq[DataSplit]) = {
       val relation = createNewScanPlan(splits, targetRelation)
       val readPlan =
         SparkShimLoader.shim.copyDataSourceV2Relation(relation, relation.table, readOutput)
       createDataset(sparkSession, readPlan)
-        .select((columnNames.map(quotedColumn) :+ quotedColumn(ROW_ID_NAME)): _*)
+        .select((projections :+ quotedColumn(ROW_ID_NAME)): _*)
     }
 
     val stagedRows = readRows(stagedSplits)
@@ -185,7 +191,7 @@ private[spark] class DataEvolutionRowIdConflictRewriter(
     val mergedRows = currentRows
       .join(stagedRows.select(quotedColumn(ROW_ID_NAME)), Seq(ROW_ID_NAME), "left_anti")
       .unionByName(stagedRows)
-      .select((columnNames.map(quotedColumn) :+ quotedColumn(ROW_ID_NAME)): _*)
+      .select((topColumns.map(quotedColumn) :+ quotedColumn(ROW_ID_NAME)): _*)
     val firstRowIdUdf = udf((rowId: Long) => floorBinarySearch(firstRowIds, rowId))
     val rewrittenRows = mergedRows
       .withColumn(FIRST_ROW_ID_NAME, firstRowIdUdf(quotedColumn(ROW_ID_NAME)))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionRowIdConflictRewriter.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/DataEvolutionRowIdConflictRewriter.scala
@@ -170,7 +170,7 @@ private[spark] class DataEvolutionRowIdConflictRewriter(
 
     val rowIdAttribute = attribute(ROW_ID_NAME)
     // columnNames are write paths and may address a single leaf of a struct (e.g. "nest.a"); the
-    // scan is always in terms of the top-level columns, and the projection then prunes each
+    // scan is always in terms of the top-level columns, and a projection then prunes each
     // partially written struct down to the leaves the file actually holds.
     val fieldNames = table.rowType().getFieldNames.asScala.toSet
     val topColumns = DataEvolutionPartialColumns.topLevelColumns(columnNames, fieldNames)
@@ -178,8 +178,13 @@ private[spark] class DataEvolutionRowIdConflictRewriter(
     val readOutput = topColumns.map(attribute) :+ rowIdAttribute
     def readRows(splits: Seq[DataSplit]) = {
       val relation = createNewScanPlan(splits, targetRelation)
+      // Each relation needs its own expression ids. The staged and the current scan are pruned
+      // independently, so sharing one set of attributes lets nested column pruning rewrite the
+      // struct on one side only and leave two attributes with the same expression id but
+      // different types, which fails Spark's plan validation.
+      val output = readOutput.map(_.newInstance())
       val readPlan =
-        SparkShimLoader.shim.copyDataSourceV2Relation(relation, relation.table, readOutput)
+        SparkShimLoader.shim.copyDataSourceV2Relation(relation, relation.table, output)
       createDataset(sparkSession, readPlan)
         .select((projections :+ quotedColumn(ROW_ID_NAME)): _*)
     }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, If, IsNull, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -589,17 +589,30 @@ case class MergeIntoPaimonDataEvolutionTable(
                   if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
                     None
                   } else {
-                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    val actionOrderedUnion = perAction.flatten.flatten.map(_._1).distinct
                     // The reader composes a split struct only one level deep, so only prune when
                     // every change addresses a direct sub-field of the top-level struct (depth 1).
                     // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
                     // which the read path does not support, so fall back to a whole-column write.
                     // Prune only when the changed direct sub-fields are a strict subset of all of
                     // them (otherwise the whole column is rewritten anyway).
-                    val allDepthOne = union.forall(_.size == 1)
-                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                    val allDepthOne = actionOrderedUnion.forall(_.size == 1)
+                    if (
+                      actionOrderedUnion.isEmpty || !allDepthOne ||
+                      actionOrderedUnion.size >= st.fields.length
+                    ) {
                       None
                     } else {
+                      // actionOrderedUnion reflects the order the SET clauses were written in,
+                      // which need not match st's field declaration order. buildPrunedStruct /
+                      // prunedStructType always lay the physical output struct out in st's
+                      // declaration order (they use the path set only as a filter, not an
+                      // ordering), so canonicalize here once and reuse this exact order for
+                      // writePaths below - otherwise the persisted writeType/writeCols order can
+                      // disagree with the physical column order and a reader would decode values
+                      // under the wrong field names.
+                      val fieldOrder = st.fieldNames.zipWithIndex.toMap
+                      val union = actionOrderedUnion.sortBy(p => fieldOrder(p.head))
                       Some(attr.exprId -> (union, prunedStructType(st, union)))
                     }
                   }
@@ -664,17 +677,29 @@ case class MergeIntoPaimonDataEvolutionTable(
             Literal(null, attr.dataType)
           } else {
             prunedByExprId.get(attr.exprId) match {
-              case Some((paths, _)) =>
+              case Some((paths, prunedType)) =>
                 val st = attr.dataType.asInstanceOf[StructType]
                 val actionMap =
                   changedLeaves(assignmentValue(action, attr), st, attr)
                     .getOrElse(Seq.empty)
                     .toMap
-                buildPrunedStruct(
+                val built = buildPrunedStruct(
                   st,
                   Nil,
                   paths,
                   p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+                if (actionMap.isEmpty) {
+                  // This action's assignment doesn't touch any leaf of this column (e.g. a
+                  // different WHEN MATCHED clause set it, or the rebuild was a no-op), so this is
+                  // a pure passthrough of attr - same guard as copyOutput below, a NULL source
+                  // struct must stay NULL rather than becoming a non-null struct of null leaves.
+                  If(IsNull(attr), Literal(null, prunedType), built)
+                } else {
+                  // At least one leaf was explicitly set by this action: the struct must
+                  // materialize even if attr was NULL (e.g. `SET nest.a = 5` on a previously NULL
+                  // nest), or the explicit assignment would be silently discarded.
+                  built
+                }
               case None => assignmentValue(action, attr)
             }
           }
@@ -699,9 +724,11 @@ case class MergeIntoPaimonDataEvolutionTable(
             Literal(null, attr.dataType)
           } else {
             prunedByExprId.get(attr.exprId) match {
-              case Some((paths, _)) =>
+              case Some((paths, prunedType)) =>
                 val st = attr.dataType.asInstanceOf[StructType]
-                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+                val built = buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+                // Same NULL guard as updateOutput: a copied-through NULL struct must stay NULL.
+                If(IsNull(attr), Literal(null, prunedType), built)
               case None => attr
             }
           }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -559,7 +559,64 @@ case class MergeIntoPaimonDataEvolutionTable(
       AttributeReference(MERGE_DELETED_NAME, BooleanType, nullable = false)()
     // Row metadata, _FIRST_ROW_ID added by addFirstRowId, and the delete marker.
     val fixedMergeOutputColumnCount = metadataColumns.size + 2
-    val mergeOutput = (updateColumnsSorted ++ metadataColumns ++ rawBlobMarkerAttributes) :+
+
+    // Sub-field-level pruning: for a struct column whose SET only touches some sub-fields, only the
+    // changed leaves are written (an incremental column-group file containing the partial struct);
+    // the rest are copied from the target. Falls back to whole-column write when the changed leaves
+    // cannot be safely determined, so behaviour never regresses.
+    val matchedUpdateActions = matchedActions.collect { case ua: UpdateAction => ua }
+    // Gated by data-evolution.nested-field.enabled (default off): when disabled, no column is
+    // pruned, so every struct column is rewritten whole (behaviour identical to before this
+    // feature). When enabled, struct columns whose SET only touches some sub-fields are pruned.
+    val nestedFieldEnabled = table.coreOptions().dataEvolutionNestedFieldEnabled()
+    val prunedByExprId: Map[ExprId, (Seq[Seq[String]], StructType)] =
+      if (!nestedFieldEnabled) Map.empty
+      else
+        updateColumnsSorted.flatMap {
+          attr =>
+            if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+              None
+            } else {
+              attr.dataType match {
+                case st: StructType =>
+                  val perAction = matchedUpdateActions.flatMap {
+                    ua =>
+                      ua.assignments
+                        .find(
+                          a => isModifiedAssignment(a) && assignmentKeyAttribute(a).sameRef(attr))
+                        .map(a => changedLeaves(a.value, st, attr))
+                  }
+                  if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
+                    None
+                  } else {
+                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    // The reader composes a split struct only one level deep, so only prune when
+                    // every change addresses a direct sub-field of the top-level struct (depth 1).
+                    // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
+                    // which the read path does not support, so fall back to a whole-column write.
+                    // Prune only when the changed direct sub-fields are a strict subset of all of
+                    // them (otherwise the whole column is rewritten anyway).
+                    val allDepthOne = union.forall(_.size == 1)
+                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                      None
+                    } else {
+                      Some(attr.exprId -> (union, prunedStructType(st, union)))
+                    }
+                  }
+                case _ => None
+              }
+            }
+        }.toMap
+
+    val prunedUpdateColumns = updateColumnsSorted.map {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((_, prunedType)) =>
+            AttributeReference(attr.name, prunedType, attr.nullable)()
+          case None => attr
+        }
+    }
+    val mergeOutput = (prunedUpdateColumns ++ metadataColumns ++ rawBlobMarkerAttributes) :+
       deletedAttribute
 
     val targetMatchedActions = matchedActions.map {
@@ -606,7 +663,20 @@ case class MergeIntoPaimonDataEvolutionTable(
           ) {
             Literal(null, attr.dataType)
           } else {
-            assignmentValue(action, attr)
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                val actionMap =
+                  changedLeaves(assignmentValue(action, attr), st, attr)
+                    .getOrElse(Seq.empty)
+                    .toMap
+                buildPrunedStruct(
+                  st,
+                  Nil,
+                  paths,
+                  p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+              case None => assignmentValue(action, attr)
+            }
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
@@ -628,7 +698,12 @@ case class MergeIntoPaimonDataEvolutionTable(
           if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
-            attr
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+              case None => attr
+            }
           }
       }
       val deletedLiteral = if (deleted) TrueLiteral else FalseLiteral
@@ -781,6 +856,16 @@ case class MergeIntoPaimonDataEvolutionTable(
         .sortWithinPartitions(FIRST_ROW_ID_NAME, ROW_ID_NAME)
     }
 
+    // dotted write paths: a whole column -> its name; a pruned struct -> "col.subfield..." leaves
+    val writePaths = updateColumnsSorted.flatMap {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((paths, _)) => paths.map(p => (attr.name +: p).mkString("."))
+          case None => Seq(attr.name)
+        }
+    }
+    val writeType = table.rowType().projectByPaths(writePaths.asJava)
+
     val writePartialFields = updateColumnsSorted.nonEmpty
     val shouldPersistOutput = writePartialFields && hasMatchedDeleteActions
     val output: Dataset[Row] =
@@ -793,7 +878,7 @@ case class MergeIntoPaimonDataEvolutionTable(
           val dataEvolutionWriter = DataEvolutionPaimonWriter(table, dataSplits)
           val partialCommit = dataEvolutionWriter.writePartialFields(
             reorderPartialWriteColumns(output),
-            updateColumnsSorted.map(_.name),
+            writeType,
             rawBlobUpdateColumns
               .map(attr => attr.name -> rawBlobMarkerNamesByColumn(attr.name))
               .toMap
@@ -1206,6 +1291,135 @@ object MergeIntoPaimonDataEvolutionTable {
 
   private def quotedColumn(name: String) = {
     col("`" + name.replace("`", "``") + "`")
+  }
+
+  /**
+   * For an aligned UPDATE value of a struct column, return the changed leaf paths (relative to the
+   * column) paired with their new value expression, or `None` if the value is not a recognizable
+   * named-struct rebuild (in which case the whole column must be written).
+   */
+  private[commands] def changedLeaves(
+      value: Expression,
+      structType: StructType,
+      base: Expression): Option[Seq[(Seq[String], Expression)]] = {
+    val out = mutable.LinkedHashMap.empty[Seq[String], Expression]
+    if (collectChanges(value, structType, base, Nil, out)) Some(out.toSeq) else None
+  }
+
+  private def collectChanges(
+      value: Expression,
+      structType: StructType,
+      base: Expression,
+      prefix: Seq[String],
+      out: mutable.LinkedHashMap[Seq[String], Expression]): Boolean = {
+    value match {
+      case cns: CreateNamedStruct =>
+        val pairs = cns.children.grouped(2).toSeq
+        if (pairs.exists(_.size != 2)) {
+          return false
+        }
+        var ok = true
+        pairs.foreach {
+          pair =>
+            val nameExpr = pair.head
+            val v = pair(1)
+            nameExpr match {
+              case Literal(nameVal, _) if nameVal != null =>
+                val name = nameVal.toString
+                val ordinalOpt = {
+                  val i = structType.fieldNames.indexOf(name)
+                  if (i >= 0) Some(i) else None
+                }
+                ordinalOpt match {
+                  case Some(ordinal) =>
+                    val fieldType = structType(ordinal).dataType
+                    val passthrough = GetStructField(base, ordinal, Some(name))
+                    if (!v.semanticEquals(passthrough)) {
+                      (fieldType, v) match {
+                        case (st: StructType, inner: CreateNamedStruct) =>
+                          ok = collectChanges(
+                            inner,
+                            st,
+                            GetStructField(base, ordinal, Some(name)),
+                            prefix :+ name,
+                            out) && ok
+                        case _ =>
+                          out.put(prefix :+ name, v)
+                      }
+                    }
+                  case None => ok = false
+                }
+              case _ => ok = false
+            }
+        }
+        ok
+      case _ => false
+    }
+  }
+
+  /** Build a Spark StructType containing only the given (possibly nested) leaf paths. */
+  private[commands] def prunedStructType(
+      structType: StructType,
+      paths: Seq[Seq[String]]): StructType = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val fields = structType.fields.filter(f => byHead.contains(f.name)).map {
+      f =>
+        val sub = byHead(f.name)
+        if (sub.exists(_.size == 1)) {
+          f
+        } else {
+          f.copy(dataType = prunedStructType(f.dataType.asInstanceOf[StructType], sub.map(_.tail)))
+        }
+    }
+    StructType(fields)
+  }
+
+  /** Build a named_struct over the given leaf paths; each terminal leaf value comes from valueFn. */
+  private[commands] def buildPrunedStruct(
+      structType: StructType,
+      prefix: Seq[String],
+      paths: Seq[Seq[String]],
+      valueFn: Seq[String] => Expression): CreateNamedStruct = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val args = structType.fields.flatMap {
+      f =>
+        byHead.get(f.name) match {
+          case None => Seq.empty[Expression]
+          case Some(sub) =>
+            val fieldPath = prefix :+ f.name
+            val expr =
+              if (sub.exists(_.size == 1)) {
+                valueFn(fieldPath)
+              } else {
+                buildPrunedStruct(
+                  f.dataType.asInstanceOf[StructType],
+                  fieldPath,
+                  sub.map(_.tail),
+                  valueFn)
+              }
+            Seq(Literal(f.name): Expression, expr)
+        }
+    }
+    CreateNamedStruct(args.toSeq)
+  }
+
+  /** Read a (possibly nested) leaf from a base expression via GetStructField chain. */
+  private[commands] def passthroughExpr(
+      base: Expression,
+      structType: StructType,
+      path: Seq[String]): Expression = {
+    if (path.isEmpty) {
+      base
+    } else {
+      val head = path.head
+      val ordinal = structType.fieldIndex(head)
+      val child = GetStructField(base, ordinal, Some(head))
+      if (path.tail.isEmpty) {
+        child
+      } else {
+        passthroughExpr(child, structType(ordinal).dataType.asInstanceOf[StructType], path.tail)
+      }
+    }
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -46,7 +46,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, CreateNamedStruct, EqualTo, Expression, ExprId, GetStructField, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -472,7 +472,64 @@ case class MergeIntoPaimonDataEvolutionTable(
       AttributeReference(MERGE_DELETED_NAME, BooleanType, nullable = false)()
     // Row metadata, _FIRST_ROW_ID added by addFirstRowId, and the delete marker.
     val fixedMergeOutputColumnCount = metadataColumns.size + 2
-    val mergeOutput = (updateColumnsSorted ++ metadataColumns ++ rawBlobMarkerAttributes) :+
+
+    // Sub-field-level pruning: for a struct column whose SET only touches some sub-fields, only the
+    // changed leaves are written (an incremental column-group file containing the partial struct);
+    // the rest are copied from the target. Falls back to whole-column write when the changed leaves
+    // cannot be safely determined, so behaviour never regresses.
+    val matchedUpdateActions = matchedActions.collect { case ua: UpdateAction => ua }
+    // Gated by data-evolution.nested-field.enabled (default off): when disabled, no column is
+    // pruned, so every struct column is rewritten whole (behaviour identical to before this
+    // feature). When enabled, struct columns whose SET only touches some sub-fields are pruned.
+    val nestedFieldEnabled = table.coreOptions().dataEvolutionNestedFieldEnabled()
+    val prunedByExprId: Map[ExprId, (Seq[Seq[String]], StructType)] =
+      if (!nestedFieldEnabled) Map.empty
+      else
+        updateColumnsSorted.flatMap {
+          attr =>
+            if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
+              None
+            } else {
+              attr.dataType match {
+                case st: StructType =>
+                  val perAction = matchedUpdateActions.flatMap {
+                    ua =>
+                      ua.assignments
+                        .find(
+                          a => isModifiedAssignment(a) && assignmentKeyAttribute(a).sameRef(attr))
+                        .map(a => changedLeaves(a.value, st, attr))
+                  }
+                  if (perAction.isEmpty || perAction.exists(_.isEmpty)) {
+                    None
+                  } else {
+                    val union = perAction.flatten.flatten.map(_._1).distinct
+                    // The reader composes a split struct only one level deep, so only prune when
+                    // every change addresses a direct sub-field of the top-level struct (depth 1).
+                    // A deeper change (e.g. nest.inner.x) would split an inner struct across files,
+                    // which the read path does not support, so fall back to a whole-column write.
+                    // Prune only when the changed direct sub-fields are a strict subset of all of
+                    // them (otherwise the whole column is rewritten anyway).
+                    val allDepthOne = union.forall(_.size == 1)
+                    if (union.isEmpty || !allDepthOne || union.size >= st.fields.length) {
+                      None
+                    } else {
+                      Some(attr.exprId -> (union, prunedStructType(st, union)))
+                    }
+                  }
+                case _ => None
+              }
+            }
+        }.toMap
+
+    val prunedUpdateColumns = updateColumnsSorted.map {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((_, prunedType)) =>
+            AttributeReference(attr.name, prunedType, attr.nullable)()
+          case None => attr
+        }
+    }
+    val mergeOutput = (prunedUpdateColumns ++ metadataColumns ++ rawBlobMarkerAttributes) :+
       deletedAttribute
 
     val targetMatchedActions = matchedActions.map {
@@ -519,7 +576,20 @@ case class MergeIntoPaimonDataEvolutionTable(
           ) {
             Literal(null, attr.dataType)
           } else {
-            assignmentValue(action, attr)
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                val actionMap =
+                  changedLeaves(assignmentValue(action, attr), st, attr)
+                    .getOrElse(Seq.empty)
+                    .toMap
+                buildPrunedStruct(
+                  st,
+                  Nil,
+                  paths,
+                  p => actionMap.getOrElse(p, passthroughExpr(attr, st, p)))
+              case None => assignmentValue(action, attr)
+            }
           }
       }
       val metadata = metadataColumns.map(attr => assignmentValue(action, attr))
@@ -541,7 +611,12 @@ case class MergeIntoPaimonDataEvolutionTable(
           if (rawBlobUpdateColumns.exists(_.sameRef(attr))) {
             Literal(null, attr.dataType)
           } else {
-            attr
+            prunedByExprId.get(attr.exprId) match {
+              case Some((paths, _)) =>
+                val st = attr.dataType.asInstanceOf[StructType]
+                buildPrunedStruct(st, Nil, paths, p => passthroughExpr(attr, st, p))
+              case None => attr
+            }
           }
       }
       val deletedLiteral = if (deleted) TrueLiteral else FalseLiteral
@@ -689,6 +764,16 @@ case class MergeIntoPaimonDataEvolutionTable(
         .sortWithinPartitions(FIRST_ROW_ID_NAME, ROW_ID_NAME)
     }
 
+    // dotted write paths: a whole column -> its name; a pruned struct -> "col.subfield..." leaves
+    val writePaths = updateColumnsSorted.flatMap {
+      attr =>
+        prunedByExprId.get(attr.exprId) match {
+          case Some((paths, _)) => paths.map(p => (attr.name +: p).mkString("."))
+          case None => Seq(attr.name)
+        }
+    }
+    val writeType = table.rowType().projectByPaths(writePaths.asJava)
+
     val writePartialFields = updateColumnsSorted.nonEmpty
     val shouldPersistOutput = writePartialFields && hasMatchedDeleteActions
     val output: Dataset[Row] =
@@ -701,7 +786,7 @@ case class MergeIntoPaimonDataEvolutionTable(
           val dataEvolutionWriter = DataEvolutionPaimonWriter(table, dataSplits)
           val partialCommit = dataEvolutionWriter.writePartialFields(
             reorderPartialWriteColumns(output),
-            updateColumnsSorted.map(_.name),
+            writeType,
             rawBlobUpdateColumns
               .map(attr => attr.name -> rawBlobMarkerNamesByColumn(attr.name))
               .toMap
@@ -1114,6 +1199,135 @@ object MergeIntoPaimonDataEvolutionTable {
 
   private def quotedColumn(name: String) = {
     col("`" + name.replace("`", "``") + "`")
+  }
+
+  /**
+   * For an aligned UPDATE value of a struct column, return the changed leaf paths (relative to the
+   * column) paired with their new value expression, or `None` if the value is not a recognizable
+   * named-struct rebuild (in which case the whole column must be written).
+   */
+  private[commands] def changedLeaves(
+      value: Expression,
+      structType: StructType,
+      base: Expression): Option[Seq[(Seq[String], Expression)]] = {
+    val out = mutable.LinkedHashMap.empty[Seq[String], Expression]
+    if (collectChanges(value, structType, base, Nil, out)) Some(out.toSeq) else None
+  }
+
+  private def collectChanges(
+      value: Expression,
+      structType: StructType,
+      base: Expression,
+      prefix: Seq[String],
+      out: mutable.LinkedHashMap[Seq[String], Expression]): Boolean = {
+    value match {
+      case cns: CreateNamedStruct =>
+        val pairs = cns.children.grouped(2).toSeq
+        if (pairs.exists(_.size != 2)) {
+          return false
+        }
+        var ok = true
+        pairs.foreach {
+          pair =>
+            val nameExpr = pair.head
+            val v = pair(1)
+            nameExpr match {
+              case Literal(nameVal, _) if nameVal != null =>
+                val name = nameVal.toString
+                val ordinalOpt = {
+                  val i = structType.fieldNames.indexOf(name)
+                  if (i >= 0) Some(i) else None
+                }
+                ordinalOpt match {
+                  case Some(ordinal) =>
+                    val fieldType = structType(ordinal).dataType
+                    val passthrough = GetStructField(base, ordinal, Some(name))
+                    if (!v.semanticEquals(passthrough)) {
+                      (fieldType, v) match {
+                        case (st: StructType, inner: CreateNamedStruct) =>
+                          ok = collectChanges(
+                            inner,
+                            st,
+                            GetStructField(base, ordinal, Some(name)),
+                            prefix :+ name,
+                            out) && ok
+                        case _ =>
+                          out.put(prefix :+ name, v)
+                      }
+                    }
+                  case None => ok = false
+                }
+              case _ => ok = false
+            }
+        }
+        ok
+      case _ => false
+    }
+  }
+
+  /** Build a Spark StructType containing only the given (possibly nested) leaf paths. */
+  private[commands] def prunedStructType(
+      structType: StructType,
+      paths: Seq[Seq[String]]): StructType = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val fields = structType.fields.filter(f => byHead.contains(f.name)).map {
+      f =>
+        val sub = byHead(f.name)
+        if (sub.exists(_.size == 1)) {
+          f
+        } else {
+          f.copy(dataType = prunedStructType(f.dataType.asInstanceOf[StructType], sub.map(_.tail)))
+        }
+    }
+    StructType(fields)
+  }
+
+  /** Build a named_struct over the given leaf paths; each terminal leaf value comes from valueFn. */
+  private[commands] def buildPrunedStruct(
+      structType: StructType,
+      prefix: Seq[String],
+      paths: Seq[Seq[String]],
+      valueFn: Seq[String] => Expression): CreateNamedStruct = {
+    val byHead = paths.filter(_.nonEmpty).groupBy(_.head)
+    val args = structType.fields.flatMap {
+      f =>
+        byHead.get(f.name) match {
+          case None => Seq.empty[Expression]
+          case Some(sub) =>
+            val fieldPath = prefix :+ f.name
+            val expr =
+              if (sub.exists(_.size == 1)) {
+                valueFn(fieldPath)
+              } else {
+                buildPrunedStruct(
+                  f.dataType.asInstanceOf[StructType],
+                  fieldPath,
+                  sub.map(_.tail),
+                  valueFn)
+              }
+            Seq(Literal(f.name): Expression, expr)
+        }
+    }
+    CreateNamedStruct(args.toSeq)
+  }
+
+  /** Read a (possibly nested) leaf from a base expression via GetStructField chain. */
+  private[commands] def passthroughExpr(
+      base: Expression,
+      structType: StructType,
+      path: Seq[String]): Expression = {
+    if (path.isEmpty) {
+      base
+    } else {
+      val head = path.head
+      val ordinal = structType.fieldIndex(head)
+      val child = GetStructField(base, ordinal, Some(head))
+      if (path.tail.isEmpty) {
+        child
+      } else {
+        passthroughExpr(child, structType(ordinal).dataType.asInstanceOf[StructType], path.tail)
+      }
+    }
   }
 
   private def sameAttributeReference(left: Expression, right: Expression): Boolean = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTableTest.scala
@@ -19,9 +19,9 @@
 package org.apache.paimon.spark.commands
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GetStructField, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, GetStructField, If, IsNull, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Assignment
-import org.apache.spark.sql.types.{BinaryType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BinaryType, IntegerType, StringType, StructField, StructType}
 
 class MergeIntoPaimonDataEvolutionTableTest extends SparkFunSuite {
 
@@ -55,5 +55,52 @@ class MergeIntoPaimonDataEvolutionTableTest extends SparkFunSuite {
       MergeIntoPaimonDataEvolutionTable.assignmentKeyAttribute(
         Assignment(nestedKey, Literal("new-name")))
     }
+  }
+
+  // JingsongLi's review on apache/paimon#8334 found that prunedStructType / buildPrunedStruct
+  // lay out fields in table-schema order while the action-ordered path list was used verbatim for
+  // writePaths, so a reversed SET clause order could make the persisted writeType disagree with
+  // the physical column order. The fix canonicalizes the path list to schema order before it's
+  // used for either the output struct or writePaths.
+  test("pruned struct type uses canonical schema order regardless of input path order") {
+    val nestType =
+      StructType(
+        Seq(
+          StructField("a", IntegerType),
+          StructField("b", IntegerType),
+          StructField("c", IntegerType)))
+
+    // MATCHED clause 1 sets c, clause 2 sets a: action order is [c, a].
+    val actionOrderedPaths: Seq[Seq[String]] = Seq(Seq("c"), Seq("a"))
+    val fieldOrder = nestType.fieldNames.zipWithIndex.toMap
+    val canonicalPaths = actionOrderedPaths.sortBy(p => fieldOrder(p.head))
+
+    assert(canonicalPaths.map(_.mkString(".")) == Seq("a", "c"))
+    val outputStructType =
+      MergeIntoPaimonDataEvolutionTable.prunedStructType(nestType, canonicalPaths)
+    assert(outputStructType.fieldNames.toSeq == Seq("a", "c"))
+    assert(canonicalPaths.map(_.mkString(".")) == outputStructType.fieldNames.toSeq)
+  }
+
+  // JingsongLi's review also found that buildPrunedStruct has no null-guard, so copying a NULL
+  // struct through the pruned path silently turned it into a non-null struct of null leaves. The
+  // call sites now wrap the built expression with If(IsNull(attr), Literal(null, ...), built).
+  test("guarding buildPrunedStruct with IsNull preserves a NULL source struct") {
+    val nestType =
+      StructType(Seq(StructField("a", IntegerType), StructField("b", IntegerType)))
+    val prunedType = StructType(Seq(StructField("b", IntegerType)))
+    val nullNest = Literal(null, nestType)
+
+    val built = MergeIntoPaimonDataEvolutionTable.buildPrunedStruct(
+      nestType,
+      Nil,
+      Seq(Seq("b")),
+      p => MergeIntoPaimonDataEvolutionTable.passthroughExpr(nullNest, nestType, p))
+
+    // Unguarded, this still reproduces the bug: a non-null struct from a NULL source.
+    assert(built.eval() != null)
+
+    val guarded = If(IsNull(nullNest), Literal(null, prunedType), built)
+    assert(guarded.eval() == null)
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/CompactProcedureTestBase.scala
@@ -2094,6 +2094,143 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
     }
   }
 
+  test("Paimon Procedure: compact rebase preserves nested sub-field merge updates") {
+    withTable("T") {
+      sql("""
+            |CREATE TABLE T (id INT, value INT, nest STRUCT<a: INT, b: STRING>)
+            |TBLPROPERTIES (
+            |  'bucket' = '-1',
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true',
+            |  'data-evolution.nested-field.enabled' = 'true',
+            |  'compaction.min.file-num' = '2',
+            |  'commit.max-retries' = '3',
+            |  'commit.min-retry-wait' = '1 ms',
+            |  'commit.max-retry-wait' = '1 ms')
+            |""".stripMargin)
+      sql("""
+            |INSERT INTO T
+            |SELECT /*+ REPARTITION(1) */ id, value, named_struct('a', a, 'b', b)
+            |FROM VALUES (1, 10, 100, 'x'), (2, 20, 200, 'y') AS S(id, value, a, b)
+            |""".stripMargin)
+      val table = loadTable("T")
+      val relation =
+        PaimonRelation.getPaimonRelation(spark.table("T").queryExecution.analyzed)
+
+      // a whole-column partial update, so the staged compact task has two files to merge
+      nestedPartialUpdate(
+        table,
+        "T.value = S.value",
+        "SELECT * FROM VALUES (1, 11), (2, 21) AS S(id, value)")
+      val normalFiles = normalDataFiles(table)
+      assert(normalFiles.size == 2)
+
+      val stagedTask = new DataEvolutionNormalCompactTask(BinaryRow.EMPTY_ROW, normalFiles.asJava)
+      val stagedMessage = stagedTask.doCompact(table, "staged-compact")
+      val baseSnapshot = table.latestSnapshot().get()
+
+      // a MERGE landing after the compact was staged, touching a top-level column AND a sub-field
+      val mergeFile = nestedPartialUpdate(
+        table,
+        "T.value = S.value, T.nest.a = S.value * 10",
+        "SELECT * FROM VALUES (1, 12), (2, 22) AS S(id, value)")
+      assert(
+        mergeFile.writeCols().asScala == Seq("value", "nest.a"),
+        s"unexpected write cols: ${mergeFile.writeCols()}")
+      val beforeRebase = sql("SELECT id, value, nest.a, nest.b FROM T ORDER BY id").collect().toSeq
+      assert(
+        beforeRebase == Seq(Row(1, 12, 120, "x"), Row(2, 22, 220, "y")),
+        s"the MERGE itself is wrong before any rebase: $beforeRebase")
+
+      val latestSnapshot = table.latestSnapshot().get()
+      val rewritten = new DataEvolutionCompactMergeConflictRewriter(table, relation)
+        .rewrite(spark, baseSnapshot, latestSnapshot, util.Collections.singletonList(stagedMessage))
+      assert(rewritten.isPresent)
+
+      val commit = table.newCommit("rebased-compact")
+      try {
+        commit.commit(rewritten.get())
+      } finally {
+        commit.close()
+      }
+
+      // the rebased compact output must still carry the merged nest.a values
+      checkAnswer(
+        sql("SELECT id, value, nest.a, nest.b FROM T ORDER BY id"),
+        Seq(Row(1, 12, 120, "x"), Row(2, 22, 220, "y")))
+    }
+  }
+
+  test("Paimon Procedure: compact rebase covers a column written both whole and per sub-field") {
+    withTable("T") {
+      sql("""
+            |CREATE TABLE T (id INT, value INT, nest STRUCT<a: INT, b: STRING>)
+            |TBLPROPERTIES (
+            |  'bucket' = '-1',
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true',
+            |  'data-evolution.nested-field.enabled' = 'true',
+            |  'compaction.min.file-num' = '2',
+            |  'commit.max-retries' = '3',
+            |  'commit.min-retry-wait' = '1 ms',
+            |  'commit.max-retry-wait' = '1 ms')
+            |""".stripMargin)
+      sql("""
+            |INSERT INTO T
+            |SELECT /*+ REPARTITION(1) */ id, value, named_struct('a', a, 'b', b)
+            |FROM VALUES (1, 10, 100, 'x'), (2, 20, 200, 'y') AS S(id, value, a, b)
+            |""".stripMargin)
+      val table = loadTable("T")
+      val relation =
+        PaimonRelation.getPaimonRelation(spark.table("T").queryExecution.analyzed)
+
+      nestedPartialUpdate(
+        table,
+        "T.value = S.value",
+        "SELECT * FROM VALUES (1, 11), (2, 21) AS S(id, value)")
+      val normalFiles = normalDataFiles(table)
+      assert(normalFiles.size == 2)
+
+      val stagedTask = new DataEvolutionNormalCompactTask(BinaryRow.EMPTY_ROW, normalFiles.asJava)
+      val stagedMessage = stagedTask.doCompact(table, "staged-compact")
+      val baseSnapshot = table.latestSnapshot().get()
+
+      // one MERGE writes only the sub-field nest.a, a later one replaces the WHOLE nest column;
+      // the write paths of the two staged files must collapse to the whole column
+      val subFieldFile = nestedPartialUpdate(
+        table,
+        "T.nest.a = S.value * 10",
+        "SELECT * FROM VALUES (1, 12), (2, 22) AS S(id, value)")
+      assert(subFieldFile.writeCols().asScala == Seq("nest.a"))
+      val wholeColumnFile = nestedPartialUpdate(
+        table,
+        "T.nest = named_struct('a', S.value * 100, 'b', 'z')",
+        "SELECT * FROM VALUES (1, 13), (2, 23) AS S(id, value)")
+      assert(wholeColumnFile.writeCols().asScala == Seq("nest"))
+
+      val beforeRebase = sql("SELECT id, value, nest.a, nest.b FROM T ORDER BY id").collect().toSeq
+      assert(
+        beforeRebase == Seq(Row(1, 11, 1300, "z"), Row(2, 21, 2300, "z")),
+        s"the MERGEs themselves are wrong before any rebase: $beforeRebase")
+
+      val latestSnapshot = table.latestSnapshot().get()
+      val rewritten = new DataEvolutionCompactMergeConflictRewriter(table, relation)
+        .rewrite(spark, baseSnapshot, latestSnapshot, util.Collections.singletonList(stagedMessage))
+      assert(rewritten.isPresent)
+
+      val commit = table.newCommit("rebased-compact")
+      try {
+        commit.commit(rewritten.get())
+      } finally {
+        commit.close()
+      }
+
+      checkAnswer(
+        sql("SELECT id, value, nest.a, nest.b FROM T ORDER BY id"),
+        Seq(Row(1, 11, 1300, "z"), Row(2, 21, 2300, "z")))
+    }
+  }
+
   test("Paimon Procedure: reject compact rebase when compact lands after rewrite") {
     withTable("T") {
       val table = createCompactMergeRaceTable()
@@ -2496,6 +2633,35 @@ abstract class CompactProcedureTestBase extends PaimonSparkTestBase with StreamT
             |ON T.id = S.id
             |WHEN MATCHED THEN UPDATE SET T.id = S.id, T.value = S.value
             |""".stripMargin)
+    } finally {
+      spark.catalog.dropTempView("merge_source")
+    }
+    table
+      .newSnapshotReader()
+      .withSnapshot(table.latestSnapshot().get())
+      .readIncrementalDiff(beforeMerge)
+      .splits()
+      .asScala
+      .collect { case split: IncrementalSplit => split }
+      .flatMap(_.afterFiles().asScala)
+      .find(file => !BlobFileFormat.isBlobFile(file.fileName()))
+      .get
+  }
+
+  /** Like [[partialUpdate]] but with an explicit SET list, so sub-field targets can be used. */
+  private def nestedPartialUpdate(
+      table: FileStoreTable,
+      setList: String,
+      sourceQuery: String): DataFileMeta = {
+    val beforeMerge = table.latestSnapshot().get()
+    sql(sourceQuery).createOrReplaceTempView("merge_source")
+    try {
+      sql(s"""
+             |MERGE INTO T
+             |USING merge_source AS S
+             |ON T.id = S.id
+             |WHEN MATCHED THEN UPDATE SET $setList
+             |""".stripMargin)
     } finally {
       spark.catalog.dropTempView("merge_source")
     }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.table.source.DataSplit
+
+import org.apache.spark.sql.Row
+
+import scala.collection.JavaConverters._
+
+/**
+ * End-to-end tests for sub-field-level data evolution via Spark `MERGE INTO`: updating a single
+ * sub-field of a nested struct column should write an incremental file containing only that
+ * sub-field (a dotted write column like `nest.a`), aligned by row-id, while the rest of the struct
+ * is read back from the original file.
+ */
+class NestedSubfieldMergeIntoTest extends PaimonSparkTestBase {
+
+  import testImplicits._
+
+  private def latestDeltaWriteCols(tableName: String): Seq[Seq[String]] = {
+    val t = loadTable(tableName)
+    val splits = t.newSnapshotReader().read().splits().asScala
+    splits
+      .flatMap(_.asInstanceOf[DataSplit].dataFiles().asScala)
+      .map(f => Option(f.writeCols()).map(_.asScala.toSeq).getOrElse(Seq.empty))
+      .toSeq
+  }
+
+  test("Sub-field data evolution: MERGE INTO updating one struct sub-field writes only that leaf") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, named_struct('a', 20, 'b', 'y'))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      // correctness: nest.a updated for id=1, nest.b preserved, other row untouched
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b FROM t ORDER BY id"),
+        Seq(Row(1, 100, "x"), Row(2, 20, "y")))
+
+      // feature engaged: the incremental file written by the merge only contains nest.a
+      val deltaCols = latestDeltaWriteCols("t")
+      assert(
+        deltaCols.exists(cols => cols == Seq("nest.a")),
+        s"expected an incremental file with writeCols == [nest.a], got: $deltaCols")
+    }
+  }
+
+  test("Sub-field data evolution: updating whole struct still writes the whole column") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x'))")
+
+      Seq((1, 100, "z")).toDF("id", "newa", "newb").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest = named_struct('a', s.newa, 'b', s.newb)
+             |""".stripMargin).collect()
+
+      checkAnswer(sql("SELECT id, nest.a, nest.b FROM t"), Seq(Row(1, 100, "z")))
+    }
+  }
+
+  test("Sub-field data evolution: disabled by default, sub-field update rewrites the whole column") {
+    withTable("s", "t") {
+      // data-evolution.nested-field.enabled is left at its default (false)
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x'))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      // correctness still holds: nest.a updated, nest.b preserved
+      checkAnswer(sql("SELECT id, nest.a, nest.b FROM t"), Seq(Row(1, 100, "x")))
+
+      // but no sub-field incremental file is produced: the whole nest column is rewritten
+      val deltaCols = latestDeltaWriteCols("t")
+      assert(
+        !deltaCols.exists(cols => cols.contains("nest.a")),
+        s"expected no dotted (sub-field) writeCols when feature is disabled, got: $deltaCols")
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
@@ -405,4 +405,71 @@ class NestedSubfieldMergeIntoTest extends PaimonSparkTestBase {
       checkAnswer(sql("SELECT id, nest.a, nest.b FROM t"), Seq(Row(1, 100, "z")))
     }
   }
+
+  test("Data evolution: deep ADD COLUMN plus an unrelated partial update stays readable") {
+    withTable("s", "t") {
+      // NOTE: 'data-evolution.nested-field.enabled' is deliberately NOT set. Every write here is
+      // a whole-column write, so this is a plain data-evolution table.
+      sql(s"""
+             |CREATE TABLE t (id INT, v INT, payload STRUCT<inner: STRUCT<x: INT>>)
+             |TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, 5, named_struct('inner', named_struct('x', 10)))")
+
+      // a nested column is added one level deeper than the existing struct
+      sql("ALTER TABLE t ADD COLUMN payload.inner.y INT")
+
+      // an unrelated partial update that only touches the top-level column "v"
+      Seq((1, 6)).toDF("id", "newv").createOrReplaceTempView("s")
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.v = s.newv
+             |""".stripMargin).collect()
+
+      // the row-id group now holds two files, so the read goes through the union reader:
+      // payload.inner.x comes from the original file and payload.inner.y is null-filled
+      checkAnswer(
+        sql("SELECT id, v, payload.inner.x, payload.inner.y FROM t"),
+        Seq(Row(1, 6, 10, null)))
+
+      // compaction over the same group must work too
+      sql("CALL sys.compact(table => 't')").collect()
+      checkAnswer(
+        sql("SELECT id, v, payload.inner.x, payload.inner.y FROM t"),
+        Seq(Row(1, 6, 10, null)))
+    }
+  }
+
+  test("Data evolution: projecting a single leaf of a two-level struct reads correctly") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, v INT, payload STRUCT<inner: STRUCT<x: INT, y: INT>>)
+             |TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, 5, named_struct('inner', named_struct('x', 10, 'y', 20)))")
+
+      // an unrelated partial update, so the read goes through the union reader
+      Seq((1, 6)).toDF("id", "newv").createOrReplaceTempView("s")
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.v = s.newv
+             |""".stripMargin).collect()
+
+      // the engine prunes the read type down to a single leaf two levels deep; that is a read-side
+      // projection, not a partial write, so it must not hit any write-side nesting restriction
+      checkAnswer(sql("SELECT payload.inner.x FROM t"), Seq(Row(10)))
+      checkAnswer(sql("SELECT id, v, payload.inner.y FROM t"), Seq(Row(1, 6, 20)))
+      checkAnswer(
+        sql("SELECT id, v, payload.inner.x, payload.inner.y FROM t"),
+        Seq(Row(1, 6, 10, 20)))
+    }
+  }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/NestedSubfieldMergeIntoTest.scala
@@ -78,6 +78,99 @@ class NestedSubfieldMergeIntoTest extends PaimonSparkTestBase {
     }
   }
 
+  // Guards the read path: DataEvolutionSplitRead calls leafPaths() on the planned read type,
+  // which now requires recursive field order to match the schema. A reversed nested projection
+  // must still read back correctly rather than tripping that check.
+  test("Sub-field data evolution: reversed nested projection reads correctly") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, named_struct('a', 20, 'b', 'y'))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      // sub-field incremental file exists; now read the nested fields in REVERSE schema order
+      assert(latestDeltaWriteCols("t").exists(cols => cols == Seq("nest.a")))
+      checkAnswer(sql("SELECT nest.b, nest.a FROM t ORDER BY id"), Seq(Row("x", 100), Row("y", 20)))
+      // and the whole struct plus a reversed pair together
+      checkAnswer(
+        sql("SELECT id, nest.b, nest.a, nest FROM t ORDER BY id"),
+        Seq(Row(1, "x", 100, Row(100, "x")), Row(2, "y", 20, Row(20, "y"))))
+    }
+  }
+
+  test("Sub-field data evolution: compaction merges sub-field files without changing data") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, named_struct('a', 20, 'b', 'y'))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+      assert(latestDeltaWriteCols("t").exists(c => c == Seq("nest.a")))
+
+      sql("CALL sys.compact(table => 't', options => 'compaction.min.file-num=2')").collect()
+
+      // data survives the compaction and the dotted write columns are gone (single full file)
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b FROM t ORDER BY id"),
+        Seq(Row(1, 100, "x"), Row(2, 20, "y")))
+      assert(!latestDeltaWriteCols("t").exists(c => c.exists(_.contains("."))))
+    }
+  }
+
+  test("Sub-field data evolution: adding a nested sub-field after sub-field files exist") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, named_struct('a', 20, 'b', 'y'))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+      assert(latestDeltaWriteCols("t").exists(c => c == Seq("nest.a")))
+
+      // the pre-existing sub-field files must still reconstruct against the evolved struct
+      sql("ALTER TABLE t ADD COLUMN nest.c INT")
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b, nest.c FROM t ORDER BY id"),
+        Seq(Row(1, 100, "x", null), Row(2, 20, "y", null)))
+    }
+  }
+
   test("Sub-field data evolution: updating whole struct still writes the whole column") {
     withTable("s", "t") {
       sql(s"""
@@ -128,6 +221,188 @@ class NestedSubfieldMergeIntoTest extends PaimonSparkTestBase {
       assert(
         !deltaCols.exists(cols => cols.contains("nest.a")),
         s"expected no dotted (sub-field) writeCols when feature is disabled, got: $deltaCols")
+    }
+  }
+
+  test(
+    "Sub-field data evolution: sub-fields touched by separate WHEN MATCHED clauses in reverse " +
+      "schema order are not swapped (regression for #8334 review)") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING, c: INT>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x', 'c', 100)), " +
+          "(2, named_struct('a', 200, 'b', 'y', 'c', 40))")
+
+      Seq((1, 1, 999, 111), (2, 2, 222, 888))
+        .toDF("id", "kind", "newc", "newa")
+        .createOrReplaceTempView("s")
+
+      // TWO separate WHEN MATCHED clauses: the first touches c, the second touches a.
+      // The per-action union therefore starts in clause order [c, a], not schema order [a, c].
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED AND s.kind = 1 THEN UPDATE SET t.nest.c = s.newc
+             |WHEN MATCHED AND s.kind = 2 THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      // row1: only c updated -> (10, x, 999); row2: only a updated -> (888, y, 40)
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b, nest.c FROM t ORDER BY id"),
+        Seq(Row(1, 10, "x", 999), Row(2, 888, "y", 40)))
+    }
+  }
+
+  test(
+    "Sub-field data evolution: a matched row whose clause leaves its NULL struct untouched stays " +
+      "NULL (regression for #8334 review)") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, CAST(NULL AS STRUCT<a: INT, b: STRING>))")
+
+      // BOTH rows are matched by the source, but only row 1 satisfies the update condition,
+      // so row 2 flows through the copy instruction with its NULL nest.
+      Seq((1, 1, 100), (2, 2, 200)).toDF("id", "kind", "newa").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED AND s.kind = 1 THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      checkAnswer(
+        sql("SELECT id, nest FROM t ORDER BY id"),
+        Seq(Row(1, Row(100, "x")), Row(2, null)))
+      checkAnswer(sql("SELECT id FROM t WHERE nest IS NULL"), Seq(Row(2)))
+    }
+  }
+
+  // Note: a single clause with several assignments is normalised into schema order by Spark's
+  // own assignment alignment, so this case cannot expose the ordering bug; the multi-clause test
+  // above is the one that does. Kept as a plain correctness check.
+  test("Sub-field data evolution: several sub-field assignments in one clause keep their values") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING, c: INT>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x', 'c', 100)), " +
+          "(2, named_struct('a', 200, 'b', 'y', 'c', 40))")
+
+      Seq((1, 999, 111), (2, 222, 888)).toDF("id", "newc", "newa").createOrReplaceTempView("s")
+
+      // note: SET touches c before a, i.e. in reverse of the struct's declaration order (a,b,c)
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.c = s.newc, t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b, nest.c FROM t ORDER BY id"),
+        Seq(Row(1, 111, "x", 999), Row(2, 888, "y", 222)))
+    }
+  }
+
+  // Note: a row that is not matched at all keeps its parent-struct nullness from the base file,
+  // so this case cannot expose the null-guard bug; the matched-but-untouched test above is the one
+  // that does. Kept as a plain correctness check.
+  test("Sub-field data evolution: an unmatched row keeps its NULL struct") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql(
+        "INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x')), " +
+          "(2, CAST(NULL AS STRUCT<a: INT, b: STRING>))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      checkAnswer(
+        sql("SELECT id, nest FROM t ORDER BY id"),
+        Seq(Row(1, Row(100, "x")), Row(2, null)))
+      checkAnswer(sql("SELECT id FROM t WHERE nest IS NULL"), Seq(Row(2)))
+    }
+  }
+
+  test(
+    "Sub-field data evolution: SET on a sub-field materializes a previously-NULL struct " +
+      "(regression for #8334 review)") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, CAST(NULL AS STRUCT<a: INT, b: STRING>))")
+
+      Seq((1, 100)).toDF("id", "newa").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest.a = s.newa
+             |""".stripMargin).collect()
+
+      // An explicit sub-field assignment must materialize the struct even though the target
+      // struct was NULL; the untouched sibling stays NULL.
+      checkAnswer(sql("SELECT id, nest.a, nest.b FROM t"), Seq(Row(1, 100, null)))
+      assert(latestDeltaWriteCols("t").exists(cols => cols == Seq("nest.a")))
+    }
+  }
+
+  test(
+    "Sub-field data evolution: MERGE INTO whole-struct SET on a previously-NULL struct " +
+      "materializes correctly") {
+    withTable("s", "t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, CAST(NULL AS STRUCT<a: INT, b: STRING>))")
+
+      Seq((1, 100, "z")).toDF("id", "newa", "newb").createOrReplaceTempView("s")
+
+      sql(s"""
+             |MERGE INTO t
+             |USING s
+             |ON t.id = s.id
+             |WHEN MATCHED THEN UPDATE SET t.nest = named_struct('a', s.newa, 'b', s.newb)
+             |""".stripMargin).collect()
+
+      checkAnswer(sql("SELECT id, nest.a, nest.b FROM t"), Seq(Row(1, 100, "z")))
     }
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -193,6 +193,66 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
     }
   }
 
+  test("Data Evolution: rebase staged nested sub-field updates after concurrent compact") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'compaction.min.file-num' = '2',
+             |  'commit.max-retries' = '0',
+             |  'data-evolution.row-id-conflict-rewrite.max-size' = '0 B',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x'))")
+      sql("INSERT INTO t VALUES (2, named_struct('a', 20, 'b', 'y'))")
+
+      val table = loadTable("t")
+      val readSnapshot = table.latestSnapshot().get()
+      val dataSplits = table
+        .newSnapshotReader()
+        .withSnapshot(readSnapshot)
+        .read()
+        .splits()
+        .asScala
+        .collect { case split: DataSplit => split }
+        .toSeq
+      val firstRowIds = dataSplits
+        .flatMap(_.dataFiles().asScala)
+        .map(_.firstRowId().longValue())
+        .sorted
+      val firstRowId = udf((rowId: Long) => firstRowIds.takeWhile(_ <= rowId).last)
+      // a staged sub-field update: the pruned struct carries only "a"
+      val stagedRows =
+        sql("SELECT named_struct('a', nest.a + 1) AS nest, _ROW_ID FROM t WHERE id = 1")
+          .withColumn("_FIRST_ROW_ID", firstRowId(col("_ROW_ID")))
+          .select("nest", "_FIRST_ROW_ID", "_ROW_ID")
+      val stagedUpdates =
+        DataEvolutionPaimonWriter(table, dataSplits).writePartialFields(stagedRows, Seq("nest.a"))
+
+      sql("CALL sys.compact(table => 't')").collect()
+
+      val writer = PaimonSparkWriter(table)
+      writer.rowIdCheckConflict(readSnapshot.id())
+      val targetRelation =
+        PaimonRelation.getPaimonRelation(spark.table("t").queryExecution.analyzed)
+      DataEvolutionRowIdConflictCommitter.commit(
+        spark,
+        table,
+        targetRelation,
+        writer,
+        stagedUpdates,
+        Nil,
+        readSnapshot.id(),
+        Operation.MERGE)
+
+      // nest.a is rebased onto the compacted boundaries and nest.b must survive untouched
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b FROM t ORDER BY id"),
+        Seq(Row(1, 11, "x"), Row(2, 20, "y")))
+    }
+  }
+
   test("Data Evolution: rebase rejects same-column update after concurrent compact") {
     withTable("t") {
       sql(s"""
@@ -331,6 +391,114 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
       Await.result(mergeC, 60.seconds)
 
       checkAnswer(sql("SELECT * FROM t"), Seq(Row(1, 10, 10)))
+    }
+  }
+
+  test("Data Evolution: concurrent merge with disjoint sub-field updates") {
+    withTable("sb", "sc", "t") {
+      sql(s"""
+            CREATE TABLE t (id INT, nest STRUCT<b: INT, c: INT>) TBLPROPERTIES (
+                 'row-tracking.enabled' = 'true',
+                 'data-evolution.enabled' = 'true',
+                 'data-evolution.nested-field.enabled' = 'true')
+          """)
+      sql("INSERT INTO t VALUES (1, named_struct('b', 0, 'c', 0))")
+      Seq((1, 1)).toDF("id", "b").createOrReplaceTempView("sb")
+      Seq((1, 1)).toDF("id", "c").createOrReplaceTempView("sc")
+
+      // two writers updating disjoint leaves of the SAME struct column; neither may clobber the
+      // other's leaf, so both counters must reach 10
+      val mergeB = Future {
+        for (_ <- 1 to 10) {
+          doWithRetry(() => sql(s"""
+                                   |MERGE INTO t
+                                   |USING sb
+                                   |ON t.id = sb.id
+                                   |WHEN MATCHED THEN
+                                   |UPDATE SET t.nest.b = sb.b + t.nest.b
+                                   |""".stripMargin).collect())
+        }
+      }
+
+      val mergeC = Future {
+        for (_ <- 1 to 10) {
+          doWithRetry(() => sql(s"""
+                                   |MERGE INTO t
+                                   |USING sc
+                                   |ON t.id = sc.id
+                                   |WHEN MATCHED THEN
+                                   |UPDATE SET t.nest.c = sc.c + t.nest.c
+                                   |""".stripMargin).collect())
+        }
+      }
+
+      Await.result(mergeB, 60.seconds)
+      Await.result(mergeC, 60.seconds)
+
+      checkAnswer(sql("SELECT id, nest.b, nest.c FROM t"), Seq(Row(1, 10, 10)))
+    }
+  }
+
+  test("Data Evolution: rebasing a staged sub-field update keeps a NULL struct null") {
+    withTable("t") {
+      sql(s"""
+             |CREATE TABLE t (id INT, nest STRUCT<a: INT, b: STRING>) TBLPROPERTIES (
+             |  'row-tracking.enabled' = 'true',
+             |  'compaction.min.file-num' = '2',
+             |  'commit.max-retries' = '0',
+             |  'data-evolution.row-id-conflict-rewrite.max-size' = '0 B',
+             |  'data-evolution.enabled' = 'true',
+             |  'data-evolution.nested-field.enabled' = 'true')
+             |""".stripMargin)
+      sql("INSERT INTO t VALUES (1, named_struct('a', 10, 'b', 'x'))")
+      // a row whose whole struct is NULL, which the rebase has to carry through untouched
+      sql("INSERT INTO t VALUES (2, CAST(NULL AS STRUCT<a: INT, b: STRING>))")
+
+      val table = loadTable("t")
+      val readSnapshot = table.latestSnapshot().get()
+      val dataSplits = table
+        .newSnapshotReader()
+        .withSnapshot(readSnapshot)
+        .read()
+        .splits()
+        .asScala
+        .collect { case split: DataSplit => split }
+        .toSeq
+      val firstRowIds = dataSplits
+        .flatMap(_.dataFiles().asScala)
+        .map(_.firstRowId().longValue())
+        .sorted
+      val firstRowId = udf((rowId: Long) => firstRowIds.takeWhile(_ <= rowId).last)
+      // the staged update only covers id = 1; id = 2 is pulled in by the rebase because the
+      // compacted row-id range covers it
+      val stagedRows =
+        sql("SELECT named_struct('a', nest.a + 1) AS nest, _ROW_ID FROM t WHERE id = 1")
+          .withColumn("_FIRST_ROW_ID", firstRowId(col("_ROW_ID")))
+          .select("nest", "_FIRST_ROW_ID", "_ROW_ID")
+      val stagedUpdates =
+        DataEvolutionPaimonWriter(table, dataSplits).writePartialFields(stagedRows, Seq("nest.a"))
+
+      sql("CALL sys.compact(table => 't')").collect()
+
+      val writer = PaimonSparkWriter(table)
+      writer.rowIdCheckConflict(readSnapshot.id())
+      val targetRelation =
+        PaimonRelation.getPaimonRelation(spark.table("t").queryExecution.analyzed)
+      DataEvolutionRowIdConflictCommitter.commit(
+        spark,
+        table,
+        targetRelation,
+        writer,
+        stagedUpdates,
+        Nil,
+        readSnapshot.id(),
+        Operation.MERGE)
+
+      checkAnswer(
+        sql("SELECT id, nest.a, nest.b FROM t ORDER BY id"),
+        Seq(Row(1, 11, "x"), Row(2, null, null)))
+      // the NULL struct must not have been resurrected as a struct of NULL children
+      checkAnswer(sql("SELECT id FROM t WHERE nest IS NULL"), Seq(Row(2)))
     }
   }
 


### PR DESCRIPTION
## Motivation

Local, high-frequency updates on a **wide nested struct** are expensive under today's data evolution: because the smallest evolvable unit is a **top-level column**, changing one sub-field (`nest.a`) rewrites the entire `nest` column — including all the unchanged sub-fields — into a new column-group file. This causes significant write amplification and storage waste exactly in the workloads that update structs most often. This PR lowers the column-group granularity to the **leaf field**, so "update one sub-field" only incrementally writes that sub-field, eliminating this class of write amplification at the root.

## Purpose

This PR pushes column-group granularity down to the **leaf field**: updating a single sub-field writes an incremental file containing only that leaf (a dotted write column like `nest.a`), aligned by row id; on read the sub-fields scattered across files are reassembled into the full struct.

**Use cases** — "wide nested struct + frequent local updates":

1. **Local update of a user/entity profile.** A row holds a wide `profile STRUCT<age, city, tags, last_login, score, ...>`, but each operation only updates one or two sub-fields (login updates `last_login`, risk-control updates `score`).
   - Without this: every update rewrites the whole `profile` (dozens of unchanged sub-fields).
   - With this: only a `profile.last_login` incremental file is written, aligned by row id; the full `profile` is reassembled on read.
   - Benefit: write amplification drops sharply, especially for wide structs.

2. **Different pipelines/teams own different sub-fields of one struct.** Pipeline A owns `nest.a`, pipeline B owns `nest.b`.
   - Each only incrementally writes its own part without rewriting the other's, and the full struct is merged back by row id on read.
   - Fits wide tables where a row is assembled by multiple owners.

Gated by a new table option `data-evolution.nested-field.enabled` (default `false`); when disabled the behavior is identical to before (whole-column rewrite). Engine entries: **Spark `MERGE INTO`** and **Flink `data_evolution_merge_into` action**.

## Design (high level)

- Encode `writeCols` as **dotted paths** (`nest.a`) instead of only top-level names — no `DataFileMeta` serialization change. New `RowType.projectByPaths` / `leafPaths` convert between a (partial) nested type and its dotted paths, preserving field ids.
- **Write**: a partial-struct write records its real sub-field content as dotted `writeCols`.
- **Read** (`DataEvolutionSplitRead`): match files at **leaf field-id** granularity and assemble a struct split across files sub-field by sub-field (latest-wins per leaf). `DataEvolutionRow` composes the struct from several source files.
- **Spark** (`MergeIntoPaimonDataEvolutionTable`): prune the aligned update to only the changed leaves; fall back to whole-column write when not safely determinable.
- **Flink** (`DataEvolutionMergeIntoAction`): parse dotted SET targets, rebuild a partial struct as `CAST(ROW(...) AS ROW<...>)`, and write via `projectByPaths`. Reuses the existing top-level pipeline (row-id assign / shuffle / partial-write operator / commit).
- **Compaction** works through the merged read unchanged.

## Tests

- **core**: `NestedDataEvolutionTableTest` (5), `NestedSubfieldDataEvolutionTableTest` (3) — sub-field groups assembled, late overwrite, projection, compaction merges sub-fields.
- **spark**: `NestedSubfieldMergeIntoTest` — single sub-field incremental write, whole-struct write, flag-off fallback.
- **flink**: `NestedSubfieldMergeIntoActionITCase` (5) — single/multiple sub-fields (asserting dotted `writeCols`), whole-struct, flag-off rejection, deeper-than-one-level rejection.

## API and Format

- New table option: `data-evolution.nested-field.enabled` (Boolean, default `false`).
- No change to `DataFileMeta` / manifest format — `writeCols` semantics extended (a dotted entry means a written sub-field; a plain entry still means the whole column). Backward compatible with existing files.

## Documentation

- Regenerated `docs/generated/core_configuration.html` for the new option.

## Limitations (follow-ups)

- Cross-file struct assembly supports **one level of ROW** only; deeper splits are rejected (or fall back to whole-column write).
- Global index on nested sub-fields is **out of scope**.
- Predicate stats are skipped for partially-written nested struct files (correctness-safe; loses file skipping).
- Columnar fast-path and escaping for column names containing `.` are follow-ups.
