### PR TITLE
[core] Reject mixed hybrid route builder settings

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/HybridSearchRoute.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/HybridSearchRoute.java
@@ -196,11 +196,13 @@ public class HybridSearchRoute implements Serializable {
         private String fieldName;
         private float[] vector;
         private FullTextQuery fullTextQuery;
+        private RouteType routeType;
         private int limit;
         private float weight = 1.0f;
         private Map<String, String> options = new HashMap<>();
 
         public Builder vectorColumn(String fieldName) {
+            setRouteType(RouteType.VECTOR);
             this.fieldName = fieldName;
             return this;
         }
@@ -210,6 +212,7 @@ public class HybridSearchRoute implements Serializable {
         }
 
         public Builder queryVector(float[] vector) {
+            setRouteType(RouteType.VECTOR);
             this.vector = vector;
             return this;
         }
@@ -219,9 +222,24 @@ public class HybridSearchRoute implements Serializable {
         }
 
         public Builder query(String queryJson) {
-            this.fullTextQuery = FullTextQuery.fromJson(queryJson);
+            checkRouteType(RouteType.FULL_TEXT);
+            FullTextQuery fullTextQuery = FullTextQuery.fromJson(queryJson);
+            this.routeType = RouteType.FULL_TEXT;
+            this.fullTextQuery = fullTextQuery;
             this.fieldName = fullTextQuery.columns().get(0);
             return this;
+        }
+
+        private void setRouteType(RouteType routeType) {
+            checkRouteType(routeType);
+            this.routeType = routeType;
+        }
+
+        private void checkRouteType(RouteType routeType) {
+            if (this.routeType != null && this.routeType != routeType) {
+                throw new IllegalArgumentException(
+                        "Cannot mix vector and full-text hybrid route settings");
+            }
         }
 
         public Builder limit(int limit) {
@@ -247,7 +265,7 @@ public class HybridSearchRoute implements Serializable {
         }
 
         public HybridSearchRoute build() {
-            if (fullTextQuery != null) {
+            if (routeType == RouteType.FULL_TEXT) {
                 checkFullTextOptions(options);
                 return new HybridSearchRoute(
                         RouteType.FULL_TEXT,

--- a/paimon-common/src/test/java/org/apache/paimon/predicate/FullTextQueryTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/predicate/FullTextQueryTest.java
@@ -201,6 +201,51 @@ public class FullTextQueryTest {
     }
 
     @Test
+    public void testHybridRouteBuilderRejectsMixedRouteTypes() {
+        assertThatThrownBy(
+                        () ->
+                                HybridSearchRoute.builder()
+                                        .vectorColumn("embedding")
+                                        .queryVector(new float[] {1.0f, 2.0f})
+                                        .query(
+                                                "{\"match\":{\"column\":\"content\","
+                                                        + "\"terms\":\"paimon lake\"}}")
+                                        .limit(10)
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot mix vector and full-text hybrid route settings");
+
+        assertThatThrownBy(
+                        () ->
+                                HybridSearchRoute.builder()
+                                        .query(
+                                                "{\"match\":{\"column\":\"content\","
+                                                        + "\"terms\":\"paimon lake\"}}")
+                                        .vectorColumn("embedding")
+                                        .limit(10)
+                                        .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot mix vector and full-text hybrid route settings");
+    }
+
+    @Test
+    public void testHybridRouteBuilderKeepsRouteUnsetAfterInvalidFullTextQuery() {
+        HybridSearchRoute.Builder builder = HybridSearchRoute.builder();
+
+        assertThatThrownBy(() -> builder.query("{\"match\":{"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        HybridSearchRoute route =
+                builder.vectorColumn("embedding")
+                        .queryVector(new float[] {1.0f, 2.0f})
+                        .limit(10)
+                        .build();
+
+        assertThat(route.isVector()).isTrue();
+        assertThat(route.fieldName()).isEqualTo("embedding");
+    }
+
+    @Test
     public void testHybridRouteRejectsNonFiniteWeight() {
         assertThatThrownBy(
                         () ->


### PR DESCRIPTION
### Purpose

`HybridSearchRoute.Builder` previously inferred the route type from whether a full-text query was set. If callers mixed vector settings and full-text settings on the same builder, the builder silently produced a full-text route and discarded the vector configuration.

This change tracks the builder route type explicitly and rejects mixed vector/full-text route settings.

### Tests

  - `mvn -pl paimon-common -Dtest=FullTextQueryTest test`
