### PR TITLE
[common] Fix duplicate file index predicate traversal

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexPredicate.java
@@ -42,7 +42,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -115,24 +114,7 @@ public class FileIndexPredicate implements Closeable {
     }
 
     private Set<String> getRequiredNames(Predicate filePredicate) {
-        return filePredicate.visit(
-                new PredicateVisitor<Set<String>>() {
-
-                    @Override
-                    public Set<String> visit(LeafPredicate predicate) {
-                        return new HashSet<>(predicate.fieldNames());
-                    }
-
-                    @Override
-                    public Set<String> visit(CompoundPredicate predicate) {
-                        Set<String> result = new HashSet<>();
-                        for (Predicate child : predicate.children()) {
-                            child.visit(this);
-                            result.addAll(child.visit(this));
-                        }
-                        return result;
-                    }
-                });
+        return PredicateVisitor.collectFieldNames(filePredicate);
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexPredicateTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexPredicateTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fileindex;
+
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.Equal;
+import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.Or;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link FileIndexPredicate}. */
+public class FileIndexPredicateTest {
+
+    @Test
+    public void testGetRequiredNamesVisitsEachChildOnce() throws Exception {
+        CountingLeafPredicate left = new CountingLeafPredicate(0, "a");
+        CountingLeafPredicate right = new CountingLeafPredicate(1, "b");
+        Predicate predicate = new CompoundPredicate(Or.INSTANCE, Arrays.asList(left, right));
+
+        Set<String> requiredNames = getRequiredNames(predicate);
+
+        assertThat(requiredNames).containsExactlyInAnyOrder("a", "b");
+        assertThat(left.visitCount).isEqualTo(1);
+        assertThat(right.visitCount).isEqualTo(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> getRequiredNames(Predicate predicate) throws Exception {
+        Method method =
+                FileIndexPredicate.class.getDeclaredMethod("getRequiredNames", Predicate.class);
+        method.setAccessible(true);
+        return (Set<String>) method.invoke(emptyFileIndexPredicate(), predicate);
+    }
+
+    private static FileIndexPredicate emptyFileIndexPredicate() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FileIndexFormat.Writer writer = FileIndexFormat.createWriter(baos);
+        writer.writeColumnIndexes(new HashMap<String, java.util.Map<String, byte[]>>());
+        writer.close();
+        return new FileIndexPredicate(baos.toByteArray(), RowType.builder().build());
+    }
+
+    private static class CountingLeafPredicate extends LeafPredicate {
+
+        private int visitCount;
+
+        private CountingLeafPredicate(int fieldIndex, String fieldName) {
+            super(
+                    Equal.INSTANCE,
+                    DataTypes.INT(),
+                    fieldIndex,
+                    fieldName,
+                    Collections.singletonList(1));
+        }
+
+        @Override
+        public <T> T visit(PredicateVisitor<T> visitor) {
+            visitCount++;
+            return super.visit(visitor);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Fixes #7230.

`FileIndexPredicate#getRequiredNames` visited each child predicate twice while collecting required field names. This could make nested compound predicates traverse much more work than needed.

This patch reuses the existing `PredicateVisitor.collectFieldNames` helper instead of keeping a duplicate visitor implementation in `FileIndexPredicate`.

### Tests

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl paimon-common -Dtest=FileIndexPredicateTest#testGetRequiredNamesVisitsEachChildOnce test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl paimon-common -Dtest=FileIndexFormatFormatTest test`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl paimon-common -Dtest=FileIndexPredicateTest,FileIndexFormatFormatTest test`
- `git diff --check`
