### PR TITLE
[Bundle] Fix the packaging and public API issue introduced by format metadata support.

### DIFF
--- a/paimon-bundle/pom.xml
+++ b/paimon-bundle/pom.xml
@@ -70,12 +70,6 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-arrow</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${snappy.version}</version>
@@ -123,25 +117,6 @@ under the License.
                                     <include>org.apache.paimon:paimon-core</include>
                                     <include>org.apache.paimon:paimon-format</include>
                                     <include>org.apache.paimon:paimon-codegen-loader</include>
-                                    <include>org.apache.paimon:paimon-arrow</include>
-
-                                    <!-- Arrow schema metadata API.
-                                    Do not relocate org.apache.arrow because paimon-format exposes
-                                    org.apache.arrow.vector.types.pojo.Schema in its public reader
-                                    capability API. -->
-                                    <include>org.apache.arrow:arrow-vector</include>
-                                    <include>org.apache.arrow:arrow-format</include>
-                                    <include>org.apache.arrow:arrow-c-data</include>
-                                    <include>org.apache.arrow:arrow-memory-core</include>
-                                    <include>org.apache.arrow:arrow-memory-unsafe</include>
-                                    <include>com.google.flatbuffers:flatbuffers-java</include>
-                                    <include>com.fasterxml.jackson.core:jackson-core</include>
-                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
-                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
-                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
-                                    <include>commons-codec:commons-codec</include>
-                                    <include>org.eclipse.collections:eclipse-collections</include>
-                                    <include>org.eclipse.collections:eclipse-collections-api</include>
 
                                     <!-- Paimon catalogs -->
                                     <include>org.apache.paimon:paimon-hive-catalog</include>

--- a/paimon-bundle/pom.xml
+++ b/paimon-bundle/pom.xml
@@ -70,6 +70,12 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-arrow</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${snappy.version}</version>
@@ -117,6 +123,25 @@ under the License.
                                     <include>org.apache.paimon:paimon-core</include>
                                     <include>org.apache.paimon:paimon-format</include>
                                     <include>org.apache.paimon:paimon-codegen-loader</include>
+                                    <include>org.apache.paimon:paimon-arrow</include>
+
+                                    <!-- Arrow schema metadata API.
+                                    Do not relocate org.apache.arrow because paimon-format exposes
+                                    org.apache.arrow.vector.types.pojo.Schema in its public reader
+                                    capability API. -->
+                                    <include>org.apache.arrow:arrow-vector</include>
+                                    <include>org.apache.arrow:arrow-format</include>
+                                    <include>org.apache.arrow:arrow-c-data</include>
+                                    <include>org.apache.arrow:arrow-memory-core</include>
+                                    <include>org.apache.arrow:arrow-memory-unsafe</include>
+                                    <include>com.google.flatbuffers:flatbuffers-java</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+                                    <include>commons-codec:commons-codec</include>
+                                    <include>org.eclipse.collections:eclipse-collections</include>
+                                    <include>org.eclipse.collections:eclipse-collections-api</include>
 
                                     <!-- Paimon catalogs -->
                                     <include>org.apache.paimon:paimon-hive-catalog</include>

--- a/paimon-format/pom.xml
+++ b/paimon-format/pom.xml
@@ -365,6 +365,18 @@ under the License.
                                     <include>commons-pool:commons-pool</include>
                                     <include>org.locationtech.jts:jts-core</include>
 
+                                    <!-- Arrow schema metadata -->
+                                    <include>org.apache.paimon:paimon-arrow</include>
+                                    <include>org.apache.arrow:arrow-vector</include>
+                                    <include>org.apache.arrow:arrow-format</include>
+                                    <include>org.apache.arrow:arrow-c-data</include>
+                                    <include>org.apache.arrow:arrow-memory-core</include>
+                                    <include>org.apache.arrow:arrow-memory-unsafe</include>
+                                    <include>com.google.flatbuffers:flatbuffers-java</include>
+                                    <include>commons-codec:commons-codec</include>
+                                    <include>org.eclipse.collections:eclipse-collections</include>
+                                    <include>org.eclipse.collections:eclipse-collections-api</include>
+
                                     <!-- compress -->
                                     <include>com.github.luben:zstd-jni</include>
                                 </includes>
@@ -427,6 +439,20 @@ under the License.
                                 <relocation>
                                     <pattern>org.locationtech.jts</pattern>
                                     <shadedPattern>org.apache.paimon.shade.org.locationtech.jts</shadedPattern>
+                                </relocation>
+
+                                <!-- Relocate Arrow. -->
+                                <relocation>
+                                    <pattern>org.apache.arrow</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.org.apache.arrow</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.flatbuffers</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.com.google.flatbuffers</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.eclipse.collections</pattern>
+                                    <shadedPattern>org.apache.paimon.shade.org.eclipse.collections</shadedPattern>
                                 </relocation>
 
                                 <!-- Relocate Common. -->

--- a/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/FormatMetadataUtils.java
@@ -68,7 +68,29 @@ public class FormatMetadataUtils {
         return decoded;
     }
 
-    public static Optional<Schema> readArrowSchema(@Nullable String encodedSchema) {
+    /**
+     * Builds serialized Arrow schema metadata from a Paimon row type and injects metadata into
+     * top-level fields.
+     *
+     * <p>The keys of {@code fieldMetadata} are top-level field names. Nested fields are converted
+     * from the {@link RowType} but do not receive metadata from this map. If injected metadata
+     * conflicts with metadata produced during Arrow conversion, the Arrow conversion metadata wins
+     * to preserve format-specific field information.
+     */
+    public static byte[] buildArrowSchemaMetadata(
+            RowType rowType, Map<String, Map<String, String>> fieldMetadata) {
+        return buildArrowSchema(rowType, fieldMetadata).serializeAsMessage();
+    }
+
+    /** Returns metadata for top-level Arrow fields only. */
+    public static Map<String, Map<String, String>> readFieldMetadata(
+            @Nullable String encodedSchema) {
+        return readArrowSchema(encodedSchema)
+                .map(FormatMetadataUtils::readFieldMetadata)
+                .orElse(Collections.emptyMap());
+    }
+
+    private static Optional<Schema> readArrowSchema(@Nullable String encodedSchema) {
         if (encodedSchema == null) {
             return Optional.empty();
         }
@@ -80,19 +102,7 @@ public class FormatMetadataUtils {
         }
     }
 
-    public static byte[] serializeArrowSchema(Schema arrowSchema) {
-        return arrowSchema.serializeAsMessage();
-    }
-
-    /**
-     * Builds an Arrow schema from a Paimon row type and injects metadata into top-level fields.
-     *
-     * <p>The keys of {@code fieldMetadata} are top-level field names. Nested fields are converted
-     * from the {@link RowType} but do not receive metadata from this map. If injected metadata
-     * conflicts with metadata produced during Arrow conversion, the Arrow conversion metadata wins
-     * to preserve format-specific field information.
-     */
-    public static Schema buildArrowSchema(
+    private static Schema buildArrowSchema(
             RowType rowType, Map<String, Map<String, String>> fieldMetadata) {
         List<Field> fields =
                 rowType.getFields().stream()
@@ -106,8 +116,7 @@ public class FormatMetadataUtils {
         return new Schema(fields);
     }
 
-    /** Returns metadata for top-level Arrow fields only. */
-    public static Map<String, Map<String, String>> readFieldMetadata(Schema arrowSchema) {
+    private static Map<String, Map<String, String>> readFieldMetadata(Schema arrowSchema) {
         Map<String, Map<String, String>> result = new LinkedHashMap<>();
         for (Field field : arrowSchema.getFields()) {
             result.put(

--- a/paimon-format/src/main/java/org/apache/paimon/format/SupportsReaderFieldMetadata.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/SupportsReaderFieldMetadata.java
@@ -18,13 +18,11 @@
 
 package org.apache.paimon.format;
 
-import org.apache.arrow.vector.types.pojo.Schema;
-
 import java.io.IOException;
-import java.util.Optional;
+import java.util.Map;
 
-/** Reader capability for formats that can recover Arrow schema from file metadata. */
-public interface SupportsReaderArrowSchema {
+/** Reader capability for formats that can recover top-level field metadata. */
+public interface SupportsReaderFieldMetadata {
 
-    Optional<Schema> readArrowSchema() throws IOException;
+    Map<String, Map<String, String>> readFieldMetadata() throws IOException;
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -27,7 +27,7 @@ import org.apache.paimon.data.columnar.VectorizedRowIterator;
 import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatReaderFactory;
 import org.apache.paimon.format.OrcFormatReaderContext;
-import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsReaderFieldMetadata;
 import org.apache.paimon.format.fs.HadoopReadOnlyFileSystem;
 import org.apache.paimon.format.orc.filter.OrcFilters;
 import org.apache.paimon.fs.FileIO;
@@ -41,7 +41,6 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Pool;
 import org.apache.paimon.utils.RoaringBitmap32;
 
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
@@ -58,8 +57,9 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 import static org.apache.paimon.format.orc.OrcTypeUtil.convertToOrcSchema;
 import static org.apache.paimon.format.orc.reader.AbstractOrcColumnVector.createPaimonVector;
@@ -230,7 +230,7 @@ public class OrcReaderFactory implements FormatReaderFactory {
      * skipped before.
      */
     private static final class OrcVectorizedReader
-            implements FileRecordReader<InternalRow>, SupportsReaderArrowSchema {
+            implements FileRecordReader<InternalRow>, SupportsReaderFieldMetadata {
 
         private final OrcRecordReader orcReader;
         private final Pool<OrcReaderBatch> pool;
@@ -257,14 +257,14 @@ public class OrcReaderFactory implements FormatReaderFactory {
         }
 
         @Override
-        public Optional<Schema> readArrowSchema() {
+        public Map<String, Map<String, String>> readFieldMetadata() {
             org.apache.orc.Reader fileReader = orcReader.fileReader;
             if (!fileReader
                     .getMetadataKeys()
                     .contains(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY)) {
-                return Optional.empty();
+                return Collections.emptyMap();
             }
-            return FormatMetadataUtils.readArrowSchema(
+            return FormatMetadataUtils.readFieldMetadata(
                     StandardCharsets.UTF_8
                             .decode(
                                     fileReader

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedParquetRecordReader.java
@@ -21,7 +21,7 @@ package org.apache.paimon.format.parquet.reader;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.columnar.writable.WritableColumnVector;
 import org.apache.paimon.format.FormatMetadataUtils;
-import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsReaderFieldMetadata;
 import org.apache.paimon.format.parquet.type.ParquetField;
 import org.apache.paimon.format.parquet.type.ParquetPrimitiveField;
 import org.apache.paimon.fs.FileIO;
@@ -43,7 +43,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -52,7 +52,7 @@ import static org.apache.paimon.format.parquet.reader.ParquetReaderUtil.createRe
 
 /** Record reader for parquet. */
 public class VectorizedParquetRecordReader
-        implements FileRecordReader<InternalRow>, SupportsReaderArrowSchema {
+        implements FileRecordReader<InternalRow>, SupportsReaderFieldMetadata {
 
     private ParquetFileReader reader;
 
@@ -274,9 +274,8 @@ public class VectorizedParquetRecordReader
     }
 
     @Override
-    public Optional<org.apache.arrow.vector.types.pojo.Schema> readArrowSchema()
-            throws IOException {
-        return FormatMetadataUtils.readArrowSchema(
+    public Map<String, Map<String, String>> readFieldMetadata() throws IOException {
+        return FormatMetadataUtils.readFieldMetadata(
                 reader.getFooter()
                         .getFileMetaData()
                         .getKeyValueMetaData()

--- a/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/FormatMetadataUtilsTest.java
@@ -21,16 +21,10 @@ package org.apache.paimon.format;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -61,29 +55,23 @@ public class FormatMetadataUtilsTest {
     }
 
     @Test
-    public void testReadArrowSchema() {
+    public void testReadFieldMetadataFromArrowSchemaMetadata() {
+        RowType rowType = DataTypes.ROW(DataTypes.FIELD(0, "field", DataTypes.STRING()));
         Map<String, String> fieldMetadata = new LinkedHashMap<>();
         fieldMetadata.put("paimon.test.field-key", "field-value");
-        Schema schema =
-                new Schema(
-                        Collections.singletonList(
-                                new Field(
-                                        "field",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.VARCHAR.getType(),
-                                                null,
-                                                fieldMetadata),
-                                        null)));
+        Map<String, Map<String, String>> expected = new LinkedHashMap<>();
+        expected.put("field", fieldMetadata);
         String encodedSchema =
                 Base64.getEncoder()
-                        .encodeToString(FormatMetadataUtils.serializeArrowSchema(schema));
+                        .encodeToString(
+                                FormatMetadataUtils.buildArrowSchemaMetadata(rowType, expected));
 
-        assertThat(FormatMetadataUtils.readArrowSchema(encodedSchema)).hasValue(schema);
-        assertThat(FormatMetadataUtils.readArrowSchema(null)).isEmpty();
-        assertThat(FormatMetadataUtils.readArrowSchema("not-base64")).isEmpty();
+        assertThat(FormatMetadataUtils.readFieldMetadata(encodedSchema).get("field"))
+                .containsAllEntriesOf(fieldMetadata);
+        assertThat(FormatMetadataUtils.readFieldMetadata(null)).isEmpty();
+        assertThat(FormatMetadataUtils.readFieldMetadata("not-base64")).isEmpty();
         assertThat(
-                        FormatMetadataUtils.readArrowSchema(
+                        FormatMetadataUtils.readFieldMetadata(
                                 Base64.getEncoder()
                                         .encodeToString(
                                                 "not-arrow-schema"
@@ -93,31 +81,23 @@ public class FormatMetadataUtilsTest {
 
     @Test
     public void testReadFieldMetadata() {
-        assertThat(FormatMetadataUtils.readFieldMetadata(new Schema(Collections.emptyList())))
-                .isEmpty();
-
+        RowType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "with_metadata", DataTypes.INT()),
+                        DataTypes.FIELD(1, "without_metadata", DataTypes.INT()));
         Map<String, String> fieldMetadata = new LinkedHashMap<>();
         fieldMetadata.put("paimon.test.field-key", "field-value");
-        Schema schema =
-                new Schema(
-                        Arrays.asList(
-                                new Field(
-                                        "with_metadata",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.INT.getType(),
-                                                null,
-                                                fieldMetadata),
-                                        null),
-                                new Field(
-                                        "without_metadata",
-                                        new FieldType(
-                                                true, Types.MinorType.INT.getType(), null, null),
-                                        null)));
+        Map<String, Map<String, String>> expected = new LinkedHashMap<>();
+        expected.put("with_metadata", fieldMetadata);
+        String encodedSchema =
+                Base64.getEncoder()
+                        .encodeToString(
+                                FormatMetadataUtils.buildArrowSchemaMetadata(rowType, expected));
 
-        assertThat(FormatMetadataUtils.readFieldMetadata(schema))
-                .containsEntry("with_metadata", fieldMetadata)
-                .containsEntry("without_metadata", Collections.emptyMap());
+        Map<String, Map<String, String>> metadata =
+                FormatMetadataUtils.readFieldMetadata(encodedSchema);
+        assertThat(metadata.get("with_metadata")).containsAllEntriesOf(fieldMetadata);
+        assertThat(metadata).containsKey("without_metadata");
     }
 
     @Test
@@ -140,13 +120,16 @@ public class FormatMetadataUtilsTest {
         Map<String, Map<String, String>> fieldMetadata = new LinkedHashMap<>();
         fieldMetadata.put("tags", tagsMetadata);
 
-        Schema schema = FormatMetadataUtils.buildArrowSchema(rowType, fieldMetadata);
+        String encodedSchema =
+                Base64.getEncoder()
+                        .encodeToString(
+                                FormatMetadataUtils.buildArrowSchemaMetadata(
+                                        rowType, fieldMetadata));
 
-        assertThat(schema.getFields())
-                .extracting(Field::getName)
-                .containsExactly("id", "tags", "nested");
-        assertThat(schema.findField("tags").getMetadata())
-                .containsEntry("paimon.test.tags", "enabled");
-        assertThat(schema.findField("nested").getMetadata()).doesNotContainKey("paimon.test.tags");
+        Map<String, Map<String, String>> metadata =
+                FormatMetadataUtils.readFieldMetadata(encodedSchema);
+        assertThat(metadata).containsOnlyKeys("id", "tags", "nested");
+        assertThat(metadata.get("tags")).containsAllEntriesOf(tagsMetadata);
+        assertThat(metadata.get("nested")).doesNotContainKey("paimon.test.tags");
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/OrcFormatReadWriteTest.java
@@ -29,7 +29,7 @@ import org.apache.paimon.format.FormatReadWriteTest;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.format.OrcOptions;
-import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsReaderFieldMetadata;
 import org.apache.paimon.format.SupportsWriterMetadata;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.options.Options;
@@ -38,10 +38,6 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -50,12 +46,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,26 +102,10 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
         Map<String, String> fieldMetadata = new HashMap<>();
         fieldMetadata.put("paimon.test.field-key", "field-value");
         fieldMetadata.put("paimon.test.field-version", "1");
-        Schema arrowSchema =
-                new Schema(
-                        Arrays.asList(
-                                new Field(
-                                        "id",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.INT.getType(),
-                                                null,
-                                                Collections.singletonMap("PARQUET:field_id", "0")),
-                                        null),
-                                new Field(
-                                        "name",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.VARCHAR.getType(),
-                                                null,
-                                                fieldMetadata),
-                                        null)));
-        byte[] arrowSchemaBytes = arrowSchema.serializeAsMessage();
+        Map<String, Map<String, String>> fieldMetadataByName = new HashMap<>();
+        fieldMetadataByName.put("name", fieldMetadata);
+        byte[] arrowSchemaBytes =
+                FormatMetadataUtils.buildArrowSchemaMetadata(rowType, fieldMetadataByName);
         Map<String, byte[]> metadata = new HashMap<>();
         metadata.put("paimon.test.key", "paimon-test-value".getBytes(StandardCharsets.UTF_8));
         metadata.put(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY, arrowSchemaBytes);
@@ -158,11 +136,10 @@ public class OrcFormatReadWriteTest extends FormatReadWriteTest {
                 newFormat
                         .createReaderFactory(emptyRowType, emptyRowType, Collections.emptyList())
                         .createReader(context)) {
-            Optional<Schema> readArrowSchema =
-                    ((SupportsReaderArrowSchema) reader).readArrowSchema();
-            assertThat(readArrowSchema).hasValue(arrowSchema);
-            assertThat(FormatMetadataUtils.readFieldMetadata(readArrowSchema.get()))
-                    .containsEntry("name", fieldMetadata);
+            Map<String, Map<String, String>> readFieldMetadata =
+                    ((SupportsReaderFieldMetadata) reader).readFieldMetadata();
+            assertThat(readFieldMetadata).containsKey("id").containsKey("name");
+            assertThat(readFieldMetadata.get("name")).containsAllEntriesOf(fieldMetadata);
         }
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFormatReadWriteTest.java
@@ -27,7 +27,7 @@ import org.apache.paimon.format.FormatMetadataUtils;
 import org.apache.paimon.format.FormatReadWriteTest;
 import org.apache.paimon.format.FormatReaderContext;
 import org.apache.paimon.format.FormatWriter;
-import org.apache.paimon.format.SupportsReaderArrowSchema;
+import org.apache.paimon.format.SupportsReaderFieldMetadata;
 import org.apache.paimon.format.SupportsWriterMetadata;
 import org.apache.paimon.format.parquet.writer.ParquetBuilder;
 import org.apache.paimon.fs.PositionOutputStream;
@@ -36,10 +36,6 @@ import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -54,12 +50,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 /** A parquet {@link FormatReadWriteTest}. */
@@ -90,26 +84,10 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         Map<String, String> fieldMetadata = new HashMap<>();
         fieldMetadata.put("paimon.test.field-key", "field-value");
         fieldMetadata.put("paimon.test.field-version", "1");
-        Schema arrowSchema =
-                new Schema(
-                        Arrays.asList(
-                                new Field(
-                                        "id",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.INT.getType(),
-                                                null,
-                                                Collections.singletonMap("PARQUET:field_id", "0")),
-                                        null),
-                                new Field(
-                                        "name",
-                                        new FieldType(
-                                                true,
-                                                Types.MinorType.VARCHAR.getType(),
-                                                null,
-                                                fieldMetadata),
-                                        null)));
-        byte[] arrowSchemaBytes = arrowSchema.serializeAsMessage();
+        Map<String, Map<String, String>> fieldMetadataByName = new HashMap<>();
+        fieldMetadataByName.put("name", fieldMetadata);
+        byte[] arrowSchemaBytes =
+                FormatMetadataUtils.buildArrowSchemaMetadata(rowType, fieldMetadataByName);
         Map<String, byte[]> metadata = new HashMap<>();
         metadata.put("paimon.test.key", "paimon-test-value".getBytes(StandardCharsets.UTF_8));
         metadata.put(FormatMetadataUtils.ARROW_SCHEMA_METADATA_KEY, arrowSchemaBytes);
@@ -138,11 +116,11 @@ public class ParquetFormatReadWriteTest extends FormatReadWriteTest {
         try (FileRecordReader<InternalRow> reader =
                 format.createReaderFactory(emptyRowType, emptyRowType, Collections.emptyList())
                         .createReader(context)) {
-            Optional<Schema> readArrowSchema =
-                    ((SupportsReaderArrowSchema) reader).readArrowSchema();
-            Assertions.assertThat(readArrowSchema).hasValue(arrowSchema);
-            Assertions.assertThat(FormatMetadataUtils.readFieldMetadata(readArrowSchema.get()))
-                    .containsEntry("name", fieldMetadata);
+            Map<String, Map<String, String>> readFieldMetadata =
+                    ((SupportsReaderFieldMetadata) reader).readFieldMetadata();
+            Assertions.assertThat(readFieldMetadata).containsKey("id").containsKey("name");
+            Assertions.assertThat(readFieldMetadata.get("name"))
+                    .containsAllEntriesOf(fieldMetadata);
         }
     }
 


### PR DESCRIPTION
### Purpose

The previous implementation exposed Arrow classes from the format metadata read API. This caused two problems:

- `paimon-format` public/runtime APIs depended on Arrow classes directly.
- `paimon-bundle` could fail with `NoClassDefFoundError` when consumers used or reflected on the metadata API, because the required Arrow artifacts were not safely available from the bundle classpath.

This PR changes the read API to expose field metadata as a plain Java map instead of Arrow `Schema`:

`Map<String, Map<String, String>>`

Arrow schema serialization is still used internally for compatibility with the `ARROW:schema` metadata convention, but Arrow types are no longer part of the public format metadata API.

This PR also shades and relocates the Arrow-related dependencies inside `paimon-format`, so bundled deployments do not expose raw `org.apache.arrow` classes and avoid conflicts with user-provided Arrow versions.

Main changes:

- Replace `SupportsReaderArrowSchema` with `SupportsReaderFieldMetadata`.
- Make ORC and Parquet readers return field metadata maps.
- Keep Arrow schema parsing/building internal to `FormatMetadataUtils`.
- Shade and relocate Arrow-related dependencies in `paimon-format`.
- Avoid adding raw Arrow dependencies directly to `paimon-bundle`.