### PR TITLE
[core][flink] Support external sort for manifest sort

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -35,9 +35,7 @@ import java.util.Map;
 /** Commit operation which provides commit and overwrite. */
 public interface FileStoreCommit extends AutoCloseable {
 
-    default FileStoreCommit withIOManager(IOManager ioManager) {
-        return this;
-    }
+    FileStoreCommit withIOManager(IOManager ioManager);
 
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.operation.metrics.CommitMetrics;
@@ -33,6 +34,10 @@ import java.util.Map;
 
 /** Commit operation which provides commit and overwrite. */
 public interface FileStoreCommit extends AutoCloseable {
+
+    default FileStoreCommit withIOManager(IOManager ioManager) {
+        return this;
+    }
 
     FileStoreCommit ignoreEmptyCommit(boolean ignoreEmptyCommit);
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -25,6 +25,7 @@ import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
@@ -164,6 +165,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
     private boolean appendCommitCheckConflict = false;
     private long lastCommittedSnapshotId = -1L;
     @Nullable private Snapshot.Operation operation;
+    @Nullable private IOManager ioManager;
 
     public FileStoreCommitImpl(
             SnapshotCommit snapshotCommit,
@@ -226,6 +228,12 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         .orElse(null);
         this.conflictDetection = conflictDetectFactory.create(scanner);
         this.commitCleaner = new CommitCleaner(manifestList, manifestFile, indexManifestFile);
+    }
+
+    @Override
+    public FileStoreCommit withIOManager(IOManager ioManager) {
+        this.ioManager = ioManager;
+        return this;
     }
 
     @Override
@@ -1019,7 +1027,11 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             } else {
                 mergeAfterManifests =
                         ManifestFileMerger.merge(
-                                mergeBeforeManifests, manifestFile, partitionType, options);
+                                mergeBeforeManifests,
+                                manifestFile,
+                                partitionType,
+                                options,
+                                ioManager);
             }
             baseManifestList = manifestList.write(mergeAfterManifests);
 
@@ -1317,7 +1329,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                         mergeBeforeManifests,
                         manifestFile,
                         partitionType,
-                        new CoreOptions(compactOptions));
+                        new CoreOptions(compactOptions),
+                        ioManager);
 
         if (new HashSet<>(mergeBeforeManifests).equals(new HashSet<>(mergeAfterManifests))) {
             // no need to commit this snapshot, because no compact were happened

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -102,27 +102,35 @@ public class ManifestEntryExternalSort {
         final int maxNumFileHandles;
         final CompressOptions compression;
         final MemorySize maxDiskSize;
+        @Nullable final IOManager ioManager;
 
         ExternalSortConfig(
                 long bufferSize,
                 int pageSize,
                 int maxNumFileHandles,
                 CompressOptions compression,
-                MemorySize maxDiskSize) {
+                MemorySize maxDiskSize,
+                @Nullable IOManager ioManager) {
             this.bufferSize = bufferSize;
             this.pageSize = pageSize;
             this.maxNumFileHandles = maxNumFileHandles;
             this.compression = compression;
             this.maxDiskSize = maxDiskSize;
+            this.ioManager = ioManager;
         }
 
         static ExternalSortConfig from(CoreOptions options) {
+            return from(options, null);
+        }
+
+        static ExternalSortConfig from(CoreOptions options, @Nullable IOManager ioManager) {
             return new ExternalSortConfig(
                     options.sortSpillBufferSize(),
                     options.pageSize(),
                     options.localSortMaxNumFileHandles(),
                     options.spillCompressOptions(),
-                    options.writeBufferSpillDiskSize());
+                    options.writeBufferSpillDiskSize(),
+                    ioManager);
         }
     }
 
@@ -131,12 +139,17 @@ public class ManifestEntryExternalSort {
         private final ManifestFileSorter.ManifestSortKey sortKey;
         private final ManifestEntrySerializer entrySerializer;
         private final IOManager ioManager;
+        private final boolean ownedIOManager;
         private final BinaryExternalSortBuffer sortBuffer;
 
         private EntrySorter(ManifestFileSorter.ManifestSortKey sortKey, ExternalSortConfig config) {
             this.sortKey = sortKey;
             this.entrySerializer = new ManifestEntrySerializer();
-            this.ioManager = IOManager.create(System.getProperty("java.io.tmpdir"));
+            this.ioManager =
+                    config.ioManager == null
+                            ? IOManager.create(System.getProperty("java.io.tmpdir"))
+                            : config.ioManager;
+            this.ownedIOManager = config.ioManager == null;
             this.sortBuffer =
                     BinaryExternalSortBuffer.create(
                             ioManager,
@@ -227,7 +240,9 @@ public class ManifestEntryExternalSort {
         @Override
         public void close() throws Exception {
             sortBuffer.clear();
-            ioManager.close();
+            if (ownedIOManager) {
+                ioManager.close();
+            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -56,6 +56,7 @@ public class ManifestEntryExternalSort {
             ManifestFileSorter.ManifestSortKey sortKey,
             ExternalSortConfig config,
             ManifestFile manifestFile,
+            List<ManifestFileMeta> newFilesForAbort,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
         try (EntrySorter sorter = new EntrySorter(sortKey, config)) {
@@ -73,8 +74,14 @@ public class ManifestEntryExternalSort {
 
             List<ManifestFileMeta> addFiles =
                     sorter.writeSurvivingAddsToManifest(manifestFile, deleteEntries);
+            // Register ADD files for abort cleanup right after they are written, before the
+            // DELETE files below. Otherwise, if sortAndWriteDeleteEntries throws, the already
+            // written ADD manifest files would not be in newFilesForAbort and would leak as
+            // orphan files on commit abort.
+            newFilesForAbort.addAll(addFiles);
             List<ManifestFileMeta> deleteFiles =
                     sortAndWriteDeleteEntries(deleteEntries.values(), sortKey, manifestFile);
+            newFilesForAbort.addAll(deleteFiles);
             return Pair.of(addFiles, deleteFiles);
         }
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -19,9 +19,10 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.codegen.CodeGenUtils;
+import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.compression.CompressOptions;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.manifest.FileEntry;
@@ -32,64 +33,52 @@ import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.sort.BinaryExternalSortBuffer;
-import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.MutableObjectIterator;
 import org.apache.paimon.utils.Pair;
 
 import javax.annotation.Nullable;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
-import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 
 /** Spillable external sort utilities for manifest entries. */
-final class ManifestEntryExternalSort {
+public class ManifestEntryExternalSort {
 
-    private ManifestEntryExternalSort() {}
-
-    static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> cancelAndWriteMinorEntries(
+    static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sortAndWriteMinorEntries(
             List<ManifestFileMeta> section,
             ManifestFileSorter.ManifestSortKey sortKey,
             Config config,
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        try (EntryCanceler canceler = new EntryCanceler(config);
-                EntrySorter addSorter = new EntrySorter(sortKey, config);
-                EntrySorter deleteSorter = new EntrySorter(sortKey, config)) {
+        try (EntrySorter sorter = new EntrySorter(sortKey, config)) {
+            Map<FileEntry.Identifier, ManifestEntry> deleteEntries = new HashMap<>();
             Function<ManifestFileMeta, List<ManifestEntry>> reader =
                     meta -> manifestFile.read(meta.fileName(), meta.fileSize());
             for (ManifestEntry entry :
                     sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
-                canceler.write(entry);
+                sorter.write(entry);
+                if (entry.kind() == FileKind.DELETE) {
+                    deleteEntries.put(entry.identifier(), entry);
+                }
             }
 
-            canceler.writeSurvivors(addSorter, deleteSorter);
-
-            List<ManifestFileMeta> addFiles = Collections.emptyList();
-            if (!addSorter.isEmpty()) {
-                addFiles = addSorter.writeToManifest(manifestFile);
-            }
-
-            List<ManifestFileMeta> deleteFiles = Collections.emptyList();
-            if (!deleteSorter.isEmpty()) {
-                deleteFiles = deleteSorter.writeToManifest(manifestFile);
-            }
-
+            List<ManifestFileMeta> addFiles =
+                    sorter.writeSurvivingAddsToManifest(manifestFile, deleteEntries);
+            List<ManifestFileMeta> deleteFiles =
+                    sortAndWriteDeleteEntries(deleteEntries.values(), sortKey, manifestFile);
             return Pair.of(addFiles, deleteFiles);
         }
     }
 
-    static List<ManifestFileMeta> sortAndWriteEntries(
+    static List<ManifestFileMeta> sortAndWriteFullEntries(
             Iterable<ManifestEntry> entries,
             ManifestFileSorter.ManifestSortKey sortKey,
             Config config,
@@ -134,105 +123,6 @@ final class ManifestEntryExternalSort {
                     options.localSortMaxNumFileHandles(),
                     options.spillCompressOptions(),
                     options.writeBufferSpillDiskSize());
-        }
-    }
-
-    /** Spillable identifier join that cancels ADD/DELETE pairs without keeping a hash map. */
-    private static class EntryCanceler implements AutoCloseable {
-        private static final int IDENTIFIER_FIELD = 0;
-        private static final int KIND_FIELD = 1;
-        private static final int ENTRY_FIELD = 2;
-        private static final RowType ROW_TYPE =
-                DataTypes.ROW(DataTypes.BYTES(), DataTypes.TINYINT(), DataTypes.BYTES());
-        private static final int[] KEY_FIELDS = new int[] {IDENTIFIER_FIELD};
-
-        private final ManifestEntrySerializer entrySerializer;
-        private final IOManager ioManager;
-        private final BinaryExternalSortBuffer sortBuffer;
-
-        private EntryCanceler(Config config) {
-            this.entrySerializer = new ManifestEntrySerializer();
-            this.ioManager = IOManager.create(System.getProperty("java.io.tmpdir"));
-            this.sortBuffer =
-                    BinaryExternalSortBuffer.create(
-                            ioManager,
-                            ROW_TYPE,
-                            KEY_FIELDS,
-                            config.bufferSize,
-                            config.pageSize,
-                            config.maxNumFileHandles,
-                            config.compression,
-                            config.maxDiskSize);
-        }
-
-        private void write(ManifestEntry entry) throws Exception {
-            GenericRow row = new GenericRow(ROW_TYPE.getFieldCount());
-            row.setField(IDENTIFIER_FIELD, identifierBytes(entry.identifier()));
-            row.setField(KIND_FIELD, entry.kind().toByteValue());
-            row.setField(ENTRY_FIELD, entrySerializer.serializeToBytes(entry));
-            sortBuffer.write(row);
-        }
-
-        private void writeSurvivors(EntrySorter addSorter, EntrySorter deleteSorter)
-                throws Exception {
-            if (sortBuffer.isEmpty()) {
-                return;
-            }
-
-            MutableObjectIterator<BinaryRow> iterator = sortBuffer.sortedIterator();
-            BinaryRow reuse = new BinaryRow(ROW_TYPE.getFieldCount());
-            BinaryRow row;
-            byte[] currentIdentifier = null;
-            byte[] addEntry = null;
-            byte[] deleteEntry = null;
-
-            while ((row = iterator.next(reuse)) != null) {
-                byte[] identifier = row.getBinary(IDENTIFIER_FIELD);
-                if (currentIdentifier != null && !Arrays.equals(currentIdentifier, identifier)) {
-                    writeSurvivorGroup(addEntry, deleteEntry, addSorter, deleteSorter);
-                    addEntry = null;
-                    deleteEntry = null;
-                }
-
-                currentIdentifier = identifier;
-                if (row.getByte(KIND_FIELD) == FileKind.ADD.toByteValue()) {
-                    addEntry = row.getBinary(ENTRY_FIELD);
-                } else {
-                    deleteEntry = row.getBinary(ENTRY_FIELD);
-                }
-            }
-
-            if (currentIdentifier != null) {
-                writeSurvivorGroup(addEntry, deleteEntry, addSorter, deleteSorter);
-            }
-        }
-
-        private void writeSurvivorGroup(
-                @Nullable byte[] addEntry,
-                @Nullable byte[] deleteEntry,
-                EntrySorter addSorter,
-                EntrySorter deleteSorter)
-                throws Exception {
-            if (addEntry != null && deleteEntry != null) {
-                return;
-            }
-
-            if (addEntry != null) {
-                writeEntry(addEntry, addSorter);
-            }
-            if (deleteEntry != null) {
-                writeEntry(deleteEntry, deleteSorter);
-            }
-        }
-
-        private void writeEntry(byte[] entry, EntrySorter sorter) throws Exception {
-            sorter.write(entrySerializer.deserializeFromBytes(entry));
-        }
-
-        @Override
-        public void close() throws Exception {
-            sortBuffer.clear();
-            ioManager.close();
         }
     }
 
@@ -291,6 +181,49 @@ final class ManifestEntryExternalSort {
             return writer.result();
         }
 
+        private List<ManifestFileMeta> writeSurvivingAddsToManifest(
+                ManifestFile manifestFile, Map<FileEntry.Identifier, ManifestEntry> deleteEntries)
+                throws Exception {
+            if (isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            RollingFileWriter<ManifestEntry, ManifestFileMeta> writer = null;
+            Exception exception = null;
+            try {
+                MutableObjectIterator<BinaryRow> iterator = sortBuffer.sortedIterator();
+                BinaryRow reuse = new BinaryRow(sortKey.externalSortRowType().getFieldCount());
+                BinaryRow row;
+                while ((row = iterator.next(reuse)) != null) {
+                    ManifestEntry entry =
+                            entrySerializer.deserializeFromBytes(sortKey.entryBytes(row));
+                    if (entry.kind() == FileKind.DELETE) {
+                        continue;
+                    }
+                    if (deleteEntries.remove(entry.identifier()) != null) {
+                        continue;
+                    }
+                    if (writer == null) {
+                        writer = manifestFile.createRollingWriter();
+                    }
+                    writer.write(entry);
+                }
+            } catch (Exception e) {
+                exception = e;
+            } finally {
+                if (exception != null) {
+                    if (writer != null) {
+                        writer.abort();
+                    }
+                    throw exception;
+                }
+                if (writer != null) {
+                    writer.close();
+                }
+            }
+            return writer == null ? Collections.emptyList() : writer.result();
+        }
+
         @Override
         public void close() throws Exception {
             sortBuffer.clear();
@@ -298,49 +231,40 @@ final class ManifestEntryExternalSort {
         }
     }
 
-    private static byte[] identifierBytes(FileEntry.Identifier identifier) throws IOException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(bytes);
-        writeString(out, identifier.getClass().getName());
-        writeBytes(out, serializeBinaryRow(identifier.partition));
-        out.writeInt(identifier.bucket);
-        out.writeInt(identifier.level);
-        writeString(out, identifier.fileName);
-        writeStrings(out, identifier.extraFiles);
-        writeBytes(out, identifier.embeddedIndex);
-        writeString(out, identifier.externalPath);
-        out.flush();
-        return bytes.toByteArray();
-    }
+    private static List<ManifestFileMeta> sortAndWriteDeleteEntries(
+            Collection<ManifestEntry> entries,
+            ManifestFileSorter.ManifestSortKey sortKey,
+            ManifestFile manifestFile)
+            throws Exception {
+        if (entries.isEmpty()) {
+            return Collections.emptyList();
+        }
 
-    private static void writeStrings(DataOutputStream out, @Nullable List<String> values)
-            throws IOException {
-        if (values == null) {
-            out.writeInt(-1);
-            return;
-        }
-        out.writeInt(values.size());
-        for (String value : values) {
-            writeString(out, value);
-        }
-    }
+        List<ManifestEntry> sorted = new ArrayList<>(entries);
+        RecordComparator comparator =
+                CodeGenUtils.newRecordComparator(
+                        sortKey.externalSortRowType().getFieldTypes(),
+                        sortKey.externalSortKeyFields());
+        sorted.sort(
+                (a, b) ->
+                        comparator.compare(
+                                sortKey.toExternalSortRow(a, new byte[0]),
+                                sortKey.toExternalSortRow(b, new byte[0])));
 
-    private static void writeString(DataOutputStream out, @Nullable String value)
-            throws IOException {
-        if (value == null) {
-            out.writeInt(-1);
-            return;
+        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
+                manifestFile.createRollingWriter();
+        Exception exception = null;
+        try {
+            writer.write(sorted);
+        } catch (Exception e) {
+            exception = e;
+        } finally {
+            if (exception != null) {
+                writer.abort();
+                throw exception;
+            }
+            writer.close();
         }
-        writeBytes(out, value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static void writeBytes(DataOutputStream out, @Nullable byte[] value)
-            throws IOException {
-        if (value == null) {
-            out.writeInt(-1);
-            return;
-        }
-        out.writeInt(value.length);
-        out.write(value);
+        return writer.result();
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.operation;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.compression.CompressOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.manifest.FileEntry;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.manifest.ManifestEntrySerializer;
+import org.apache.paimon.manifest.ManifestFile;
+import org.apache.paimon.manifest.ManifestFileMeta;
+import org.apache.paimon.options.MemorySize;
+import org.apache.paimon.sort.BinaryExternalSortBuffer;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.MutableObjectIterator;
+import org.apache.paimon.utils.Pair;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
+import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
+
+/** Spillable external sort utilities for manifest entries. */
+final class ManifestEntryExternalSort {
+
+    private ManifestEntryExternalSort() {}
+
+    static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> cancelAndWriteEntries(
+            List<ManifestFileMeta> section,
+            ManifestFileSorter.ManifestSortKey sortKey,
+            Config config,
+            ManifestFile manifestFile,
+            @Nullable Integer manifestReadParallelism,
+            CancelMode cancelMode)
+            throws Exception {
+        try (EntryCanceler canceler = new EntryCanceler(config);
+                EntrySorter addSorter = new EntrySorter(sortKey, config);
+                EntrySorter deleteSorter =
+                        cancelMode == CancelMode.MINOR ? new EntrySorter(sortKey, config) : null) {
+            Function<ManifestFileMeta, List<ManifestEntry>> reader =
+                    meta -> manifestFile.read(meta.fileName(), meta.fileSize());
+            for (ManifestEntry entry :
+                    sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
+                canceler.write(entry);
+            }
+
+            canceler.writeSurvivors(cancelMode, addSorter, deleteSorter);
+
+            List<ManifestFileMeta> addFiles = Collections.emptyList();
+            if (!addSorter.isEmpty()) {
+                addFiles = addSorter.writeToManifest(manifestFile);
+            }
+
+            List<ManifestFileMeta> deleteFiles = Collections.emptyList();
+            if (deleteSorter != null && !deleteSorter.isEmpty()) {
+                deleteFiles = deleteSorter.writeToManifest(manifestFile);
+            }
+
+            return Pair.of(addFiles, deleteFiles);
+        }
+    }
+
+    static List<ManifestFileMeta> sortAndWriteEntries(
+            Iterable<ManifestEntry> entries,
+            ManifestFileSorter.ManifestSortKey sortKey,
+            Config config,
+            ManifestFile manifestFile)
+            throws Exception {
+        try (EntrySorter sorter = new EntrySorter(sortKey, config)) {
+            for (ManifestEntry entry : entries) {
+                sorter.write(entry);
+            }
+            if (sorter.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return sorter.writeToManifest(manifestFile);
+        }
+    }
+
+    enum CancelMode {
+        FULL,
+        MINOR
+    }
+
+    /** Config used by manifest entry external sort. */
+    static class Config {
+        final long bufferSize;
+        final int pageSize;
+        final int maxNumFileHandles;
+        final CompressOptions compression;
+        final MemorySize maxDiskSize;
+
+        Config(
+                long bufferSize,
+                int pageSize,
+                int maxNumFileHandles,
+                CompressOptions compression,
+                MemorySize maxDiskSize) {
+            this.bufferSize = bufferSize;
+            this.pageSize = pageSize;
+            this.maxNumFileHandles = maxNumFileHandles;
+            this.compression = compression;
+            this.maxDiskSize = maxDiskSize;
+        }
+
+        static Config from(CoreOptions options) {
+            return new Config(
+                    options.sortSpillBufferSize(),
+                    options.pageSize(),
+                    options.localSortMaxNumFileHandles(),
+                    options.spillCompressOptions(),
+                    options.writeBufferSpillDiskSize());
+        }
+    }
+
+    /** Spillable identifier join that cancels ADD/DELETE pairs without keeping a hash map. */
+    private static class EntryCanceler implements AutoCloseable {
+        private static final int IDENTIFIER_FIELD = 0;
+        private static final int KIND_FIELD = 1;
+        private static final int ENTRY_FIELD = 2;
+        private static final RowType ROW_TYPE =
+                DataTypes.ROW(DataTypes.BYTES(), DataTypes.TINYINT(), DataTypes.BYTES());
+        private static final int[] KEY_FIELDS = new int[] {IDENTIFIER_FIELD};
+
+        private final ManifestEntrySerializer entrySerializer;
+        private final IOManager ioManager;
+        private final BinaryExternalSortBuffer sortBuffer;
+
+        private EntryCanceler(Config config) {
+            this.entrySerializer = new ManifestEntrySerializer();
+            this.ioManager = IOManager.create(System.getProperty("java.io.tmpdir"));
+            this.sortBuffer =
+                    BinaryExternalSortBuffer.create(
+                            ioManager,
+                            ROW_TYPE,
+                            KEY_FIELDS,
+                            config.bufferSize,
+                            config.pageSize,
+                            config.maxNumFileHandles,
+                            config.compression,
+                            config.maxDiskSize);
+        }
+
+        private void write(ManifestEntry entry) throws Exception {
+            GenericRow row = new GenericRow(ROW_TYPE.getFieldCount());
+            row.setField(IDENTIFIER_FIELD, identifierBytes(entry.identifier()));
+            row.setField(KIND_FIELD, entry.kind().toByteValue());
+            row.setField(ENTRY_FIELD, entrySerializer.serializeToBytes(entry));
+            sortBuffer.write(row);
+        }
+
+        private void writeSurvivors(
+                CancelMode cancelMode, EntrySorter addSorter, @Nullable EntrySorter deleteSorter)
+                throws Exception {
+            if (sortBuffer.isEmpty()) {
+                return;
+            }
+
+            MutableObjectIterator<BinaryRow> iterator = sortBuffer.sortedIterator();
+            BinaryRow reuse = new BinaryRow(ROW_TYPE.getFieldCount());
+            BinaryRow row;
+            byte[] currentIdentifier = null;
+            List<byte[]> addEntries = new ArrayList<>(1);
+            List<byte[]> deleteEntries = new ArrayList<>(1);
+
+            while ((row = iterator.next(reuse)) != null) {
+                byte[] identifier = row.getBinary(IDENTIFIER_FIELD);
+                if (currentIdentifier != null && !Arrays.equals(currentIdentifier, identifier)) {
+                    writeSurvivorGroup(
+                            cancelMode, addEntries, deleteEntries, addSorter, deleteSorter);
+                    addEntries.clear();
+                    deleteEntries.clear();
+                }
+
+                currentIdentifier = identifier;
+                if (row.getByte(KIND_FIELD) == FileKind.ADD.toByteValue()) {
+                    addEntries.add(row.getBinary(ENTRY_FIELD));
+                } else {
+                    deleteEntries.add(row.getBinary(ENTRY_FIELD));
+                }
+            }
+
+            if (currentIdentifier != null) {
+                writeSurvivorGroup(cancelMode, addEntries, deleteEntries, addSorter, deleteSorter);
+            }
+        }
+
+        private void writeSurvivorGroup(
+                CancelMode cancelMode,
+                List<byte[]> addEntries,
+                List<byte[]> deleteEntries,
+                EntrySorter addSorter,
+                @Nullable EntrySorter deleteSorter)
+                throws Exception {
+            if (cancelMode == CancelMode.FULL) {
+                if (deleteEntries.isEmpty()) {
+                    writeEntries(addEntries, addSorter);
+                }
+                return;
+            }
+
+            if (!addEntries.isEmpty() && !deleteEntries.isEmpty()) {
+                if (deleteSorter != null) {
+                    for (int i = 1; i < deleteEntries.size(); i++) {
+                        writeEntry(deleteEntries.get(i), deleteSorter);
+                    }
+                }
+                return;
+            }
+
+            writeEntries(addEntries, addSorter);
+            if (deleteSorter != null) {
+                writeEntries(deleteEntries, deleteSorter);
+            }
+        }
+
+        private void writeEntries(List<byte[]> entries, EntrySorter sorter) throws Exception {
+            for (byte[] entry : entries) {
+                writeEntry(entry, sorter);
+            }
+        }
+
+        private void writeEntry(byte[] entry, EntrySorter sorter) throws Exception {
+            sorter.write(entrySerializer.deserializeFromBytes(entry));
+        }
+
+        @Override
+        public void close() throws Exception {
+            sortBuffer.clear();
+            ioManager.close();
+        }
+    }
+
+    /** Spillable sorter that stores sort keys plus serialized manifest entries in BinaryRow. */
+    private static class EntrySorter implements AutoCloseable {
+        private final ManifestFileSorter.ManifestSortKey sortKey;
+        private final ManifestEntrySerializer entrySerializer;
+        private final IOManager ioManager;
+        private final BinaryExternalSortBuffer sortBuffer;
+
+        private EntrySorter(ManifestFileSorter.ManifestSortKey sortKey, Config config) {
+            this.sortKey = sortKey;
+            this.entrySerializer = new ManifestEntrySerializer();
+            this.ioManager = IOManager.create(System.getProperty("java.io.tmpdir"));
+            this.sortBuffer =
+                    BinaryExternalSortBuffer.create(
+                            ioManager,
+                            sortKey.externalSortRowType(),
+                            sortKey.externalSortKeyFields(),
+                            config.bufferSize,
+                            config.pageSize,
+                            config.maxNumFileHandles,
+                            config.compression,
+                            config.maxDiskSize);
+        }
+
+        private void write(ManifestEntry entry) throws Exception {
+            sortBuffer.write(
+                    sortKey.toExternalSortRow(entry, entrySerializer.serializeToBytes(entry)));
+        }
+
+        private boolean isEmpty() {
+            return sortBuffer.isEmpty();
+        }
+
+        private List<ManifestFileMeta> writeToManifest(ManifestFile manifestFile) throws Exception {
+            RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
+                    manifestFile.createRollingWriter();
+            Exception exception = null;
+            try {
+                MutableObjectIterator<BinaryRow> iterator = sortBuffer.sortedIterator();
+                BinaryRow reuse = new BinaryRow(sortKey.externalSortRowType().getFieldCount());
+                BinaryRow row;
+                while ((row = iterator.next(reuse)) != null) {
+                    writer.write(entrySerializer.deserializeFromBytes(sortKey.entryBytes(row)));
+                }
+            } catch (Exception e) {
+                exception = e;
+            } finally {
+                if (exception != null) {
+                    writer.abort();
+                    throw exception;
+                }
+                writer.close();
+            }
+            return writer.result();
+        }
+
+        @Override
+        public void close() throws Exception {
+            sortBuffer.clear();
+            ioManager.close();
+        }
+    }
+
+    private static byte[] identifierBytes(FileEntry.Identifier identifier) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bytes);
+        writeString(out, identifier.getClass().getName());
+        writeBytes(out, serializeBinaryRow(identifier.partition));
+        out.writeInt(identifier.bucket);
+        out.writeInt(identifier.level);
+        writeString(out, identifier.fileName);
+        writeStrings(out, identifier.extraFiles);
+        writeBytes(out, identifier.embeddedIndex);
+        writeString(out, identifier.externalPath);
+        out.flush();
+        return bytes.toByteArray();
+    }
+
+    private static void writeStrings(DataOutputStream out, @Nullable List<String> values)
+            throws IOException {
+        if (values == null) {
+            out.writeInt(-1);
+            return;
+        }
+        out.writeInt(values.size());
+        for (String value : values) {
+            writeString(out, value);
+        }
+    }
+
+    private static void writeString(DataOutputStream out, @Nullable String value)
+            throws IOException {
+        if (value == null) {
+            out.writeInt(-1);
+            return;
+        }
+        writeBytes(out, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void writeBytes(DataOutputStream out, @Nullable byte[] value)
+            throws IOException {
+        if (value == null) {
+            out.writeInt(-1);
+            return;
+        }
+        out.writeInt(value.length);
+        out.write(value);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -119,10 +119,6 @@ public class ManifestEntryExternalSort {
             this.ioManager = ioManager;
         }
 
-        static ExternalSortConfig from(CoreOptions options) {
-            return from(options, null);
-        }
-
         static ExternalSortConfig from(CoreOptions options, @Nullable IOManager ioManager) {
             return new ExternalSortConfig(
                     options.sortSpillBufferSize(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -89,9 +89,6 @@ public class ManifestEntryExternalSort {
             for (ManifestEntry entry : entries) {
                 sorter.write(entry);
             }
-            if (sorter.isEmpty()) {
-                return Collections.emptyList();
-            }
             return sorter.writeToManifest(manifestFile);
         }
     }
@@ -169,6 +166,10 @@ public class ManifestEntryExternalSort {
         }
 
         private List<ManifestFileMeta> writeToManifest(ManifestFile manifestFile) throws Exception {
+            if (isEmpty()) {
+                return Collections.emptyList();
+            }
+
             RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
                     manifestFile.createRollingWriter();
             Exception exception = null;
@@ -198,7 +199,8 @@ public class ManifestEntryExternalSort {
                 return Collections.emptyList();
             }
 
-            RollingFileWriter<ManifestEntry, ManifestFileMeta> writer = null;
+            RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
+                    manifestFile.createRollingWriter();
             Exception exception = null;
             try {
                 MutableObjectIterator<BinaryRow> iterator = sortBuffer.sortedIterator();
@@ -210,25 +212,18 @@ public class ManifestEntryExternalSort {
                     if (deleteEntries.remove(entry.identifier()) != null) {
                         continue;
                     }
-                    if (writer == null) {
-                        writer = manifestFile.createRollingWriter();
-                    }
                     writer.write(entry);
                 }
             } catch (Exception e) {
                 exception = e;
             } finally {
                 if (exception != null) {
-                    if (writer != null) {
-                        writer.abort();
-                    }
+                    writer.abort();
                     throw exception;
                 }
-                if (writer != null) {
-                    writer.close();
-                }
+                writer.close();
             }
-            return writer == null ? Collections.emptyList() : writer.result();
+            return writer.result();
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -43,7 +43,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -57,18 +56,16 @@ final class ManifestEntryExternalSort {
 
     private ManifestEntryExternalSort() {}
 
-    static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> cancelAndWriteEntries(
+    static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> cancelAndWriteMinorEntries(
             List<ManifestFileMeta> section,
             ManifestFileSorter.ManifestSortKey sortKey,
             Config config,
             ManifestFile manifestFile,
-            @Nullable Integer manifestReadParallelism,
-            CancelMode cancelMode)
+            @Nullable Integer manifestReadParallelism)
             throws Exception {
         try (EntryCanceler canceler = new EntryCanceler(config);
                 EntrySorter addSorter = new EntrySorter(sortKey, config);
-                EntrySorter deleteSorter =
-                        cancelMode == CancelMode.MINOR ? new EntrySorter(sortKey, config) : null) {
+                EntrySorter deleteSorter = new EntrySorter(sortKey, config)) {
             Function<ManifestFileMeta, List<ManifestEntry>> reader =
                     meta -> manifestFile.read(meta.fileName(), meta.fileSize());
             for (ManifestEntry entry :
@@ -76,7 +73,7 @@ final class ManifestEntryExternalSort {
                 canceler.write(entry);
             }
 
-            canceler.writeSurvivors(cancelMode, addSorter, deleteSorter);
+            canceler.writeSurvivors(addSorter, deleteSorter);
 
             List<ManifestFileMeta> addFiles = Collections.emptyList();
             if (!addSorter.isEmpty()) {
@@ -84,7 +81,7 @@ final class ManifestEntryExternalSort {
             }
 
             List<ManifestFileMeta> deleteFiles = Collections.emptyList();
-            if (deleteSorter != null && !deleteSorter.isEmpty()) {
+            if (!deleteSorter.isEmpty()) {
                 deleteFiles = deleteSorter.writeToManifest(manifestFile);
             }
 
@@ -107,11 +104,6 @@ final class ManifestEntryExternalSort {
             }
             return sorter.writeToManifest(manifestFile);
         }
-    }
-
-    enum CancelMode {
-        FULL,
-        MINOR
     }
 
     /** Config used by manifest entry external sort. */
@@ -181,8 +173,7 @@ final class ManifestEntryExternalSort {
             sortBuffer.write(row);
         }
 
-        private void writeSurvivors(
-                CancelMode cancelMode, EntrySorter addSorter, @Nullable EntrySorter deleteSorter)
+        private void writeSurvivors(EntrySorter addSorter, EntrySorter deleteSorter)
                 throws Exception {
             if (sortBuffer.isEmpty()) {
                 return;
@@ -192,63 +183,45 @@ final class ManifestEntryExternalSort {
             BinaryRow reuse = new BinaryRow(ROW_TYPE.getFieldCount());
             BinaryRow row;
             byte[] currentIdentifier = null;
-            List<byte[]> addEntries = new ArrayList<>(1);
-            List<byte[]> deleteEntries = new ArrayList<>(1);
+            byte[] addEntry = null;
+            byte[] deleteEntry = null;
 
             while ((row = iterator.next(reuse)) != null) {
                 byte[] identifier = row.getBinary(IDENTIFIER_FIELD);
                 if (currentIdentifier != null && !Arrays.equals(currentIdentifier, identifier)) {
-                    writeSurvivorGroup(
-                            cancelMode, addEntries, deleteEntries, addSorter, deleteSorter);
-                    addEntries.clear();
-                    deleteEntries.clear();
+                    writeSurvivorGroup(addEntry, deleteEntry, addSorter, deleteSorter);
+                    addEntry = null;
+                    deleteEntry = null;
                 }
 
                 currentIdentifier = identifier;
                 if (row.getByte(KIND_FIELD) == FileKind.ADD.toByteValue()) {
-                    addEntries.add(row.getBinary(ENTRY_FIELD));
+                    addEntry = row.getBinary(ENTRY_FIELD);
                 } else {
-                    deleteEntries.add(row.getBinary(ENTRY_FIELD));
+                    deleteEntry = row.getBinary(ENTRY_FIELD);
                 }
             }
 
             if (currentIdentifier != null) {
-                writeSurvivorGroup(cancelMode, addEntries, deleteEntries, addSorter, deleteSorter);
+                writeSurvivorGroup(addEntry, deleteEntry, addSorter, deleteSorter);
             }
         }
 
         private void writeSurvivorGroup(
-                CancelMode cancelMode,
-                List<byte[]> addEntries,
-                List<byte[]> deleteEntries,
+                @Nullable byte[] addEntry,
+                @Nullable byte[] deleteEntry,
                 EntrySorter addSorter,
-                @Nullable EntrySorter deleteSorter)
+                EntrySorter deleteSorter)
                 throws Exception {
-            if (cancelMode == CancelMode.FULL) {
-                if (deleteEntries.isEmpty()) {
-                    writeEntries(addEntries, addSorter);
-                }
+            if (addEntry != null && deleteEntry != null) {
                 return;
             }
 
-            if (!addEntries.isEmpty() && !deleteEntries.isEmpty()) {
-                if (deleteSorter != null) {
-                    for (int i = 1; i < deleteEntries.size(); i++) {
-                        writeEntry(deleteEntries.get(i), deleteSorter);
-                    }
-                }
-                return;
+            if (addEntry != null) {
+                writeEntry(addEntry, addSorter);
             }
-
-            writeEntries(addEntries, addSorter);
-            if (deleteSorter != null) {
-                writeEntries(deleteEntries, deleteSorter);
-            }
-        }
-
-        private void writeEntries(List<byte[]> entries, EntrySorter sorter) throws Exception {
-            for (byte[] entry : entries) {
-                writeEntry(entry, sorter);
+            if (deleteEntry != null) {
+                writeEntry(deleteEntry, deleteSorter);
             }
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -54,7 +54,7 @@ public class ManifestEntryExternalSort {
     static Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sortAndWriteMinorEntries(
             List<ManifestFileMeta> section,
             ManifestFileSorter.ManifestSortKey sortKey,
-            Config config,
+            ExternalSortConfig config,
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
@@ -81,7 +81,7 @@ public class ManifestEntryExternalSort {
     static List<ManifestFileMeta> sortAndWriteFullEntries(
             Iterable<ManifestEntry> entries,
             ManifestFileSorter.ManifestSortKey sortKey,
-            Config config,
+            ExternalSortConfig config,
             ManifestFile manifestFile)
             throws Exception {
         try (EntrySorter sorter = new EntrySorter(sortKey, config)) {
@@ -96,14 +96,14 @@ public class ManifestEntryExternalSort {
     }
 
     /** Config used by manifest entry external sort. */
-    static class Config {
+    static class ExternalSortConfig {
         final long bufferSize;
         final int pageSize;
         final int maxNumFileHandles;
         final CompressOptions compression;
         final MemorySize maxDiskSize;
 
-        Config(
+        ExternalSortConfig(
                 long bufferSize,
                 int pageSize,
                 int maxNumFileHandles,
@@ -116,8 +116,8 @@ public class ManifestEntryExternalSort {
             this.maxDiskSize = maxDiskSize;
         }
 
-        static Config from(CoreOptions options) {
-            return new Config(
+        static ExternalSortConfig from(CoreOptions options) {
+            return new ExternalSortConfig(
                     options.sortSpillBufferSize(),
                     options.pageSize(),
                     options.localSortMaxNumFileHandles(),
@@ -133,7 +133,7 @@ public class ManifestEntryExternalSort {
         private final IOManager ioManager;
         private final BinaryExternalSortBuffer sortBuffer;
 
-        private EntrySorter(ManifestFileSorter.ManifestSortKey sortKey, Config config) {
+        private EntrySorter(ManifestFileSorter.ManifestSortKey sortKey, ExternalSortConfig config) {
             this.sortKey = sortKey;
             this.entrySerializer = new ManifestEntrySerializer();
             this.ioManager = IOManager.create(System.getProperty("java.io.tmpdir"));

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -33,6 +33,7 @@ import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.sort.BinaryExternalSortBuffer;
+import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.MutableObjectIterator;
 import org.apache.paimon.utils.Pair;
 
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
@@ -87,13 +89,31 @@ public class ManifestEntryExternalSort {
     }
 
     static List<ManifestFileMeta> sortAndWriteFullEntries(
-            Iterable<ManifestEntry> entries,
+            List<ManifestFileMeta> section,
             ManifestFileSorter.ManifestSortKey sortKey,
             ExternalSortConfig config,
-            ManifestFile manifestFile)
+            ManifestFile manifestFile,
+            Set<FileEntry.Identifier> deleteEntries,
+            @Nullable Integer manifestReadParallelism)
             throws Exception {
         try (EntrySorter sorter = new EntrySorter(sortKey, config)) {
-            for (ManifestEntry entry : entries) {
+            Function<ManifestFileMeta, List<ManifestEntry>> reader =
+                    meta -> {
+                        List<ManifestEntry> batch = new ArrayList<>();
+                        for (ManifestEntry entry :
+                                manifestFile.read(
+                                        meta.fileName(),
+                                        meta.fileSize(),
+                                        FileEntry.addFilter(),
+                                        Filter.alwaysTrue())) {
+                            if (!deleteEntries.contains(entry.identifier())) {
+                                batch.add(entry);
+                            }
+                        }
+                        return batch;
+                    };
+            for (ManifestEntry entry :
+                    sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
                 sorter.write(entry);
             }
             return sorter.writeToManifest(manifestFile);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -64,9 +64,10 @@ public class ManifestEntryExternalSort {
                     meta -> manifestFile.read(meta.fileName(), meta.fileSize());
             for (ManifestEntry entry :
                     sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
-                sorter.write(entry);
                 if (entry.kind() == FileKind.DELETE) {
                     deleteEntries.put(entry.identifier(), entry);
+                } else {
+                    sorter.write(entry);
                 }
             }
 
@@ -206,9 +207,6 @@ public class ManifestEntryExternalSort {
                 while ((row = iterator.next(reuse)) != null) {
                     ManifestEntry entry =
                             entrySerializer.deserializeFromBytes(sortKey.entryBytes(row));
-                    if (entry.kind() == FileKind.DELETE) {
-                        continue;
-                    }
                     if (deleteEntries.remove(entry.identifier()) != null) {
                         continue;
                     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestEntryExternalSort.java
@@ -93,6 +93,7 @@ public class ManifestEntryExternalSort {
             ManifestFileSorter.ManifestSortKey sortKey,
             ExternalSortConfig config,
             ManifestFile manifestFile,
+            List<ManifestFileMeta> newFilesForAbort,
             Set<FileEntry.Identifier> deleteEntries,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
@@ -116,7 +117,9 @@ public class ManifestEntryExternalSort {
                     sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
                 sorter.write(entry);
             }
-            return sorter.writeToManifest(manifestFile);
+            List<ManifestFileMeta> files = sorter.writeToManifest(manifestFile);
+            newFilesForAbort.addAll(files);
+            return files;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileMerger.java
@@ -20,6 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.io.RollingFileWriter;
 import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.ManifestEntry;
@@ -66,6 +67,15 @@ public class ManifestFileMerger {
             ManifestFile manifestFile,
             RowType partitionType,
             CoreOptions options) {
+        return merge(input, manifestFile, partitionType, options, null);
+    }
+
+    public static List<ManifestFileMeta> merge(
+            List<ManifestFileMeta> input,
+            ManifestFile manifestFile,
+            RowType partitionType,
+            CoreOptions options,
+            @Nullable IOManager ioManager) {
         // Extract configuration from options
         long suggestedMetaSize = options.manifestTargetSize().getBytes();
         int suggestedMinMetaCount = options.manifestMergeMinCount();
@@ -83,7 +93,7 @@ public class ManifestFileMerger {
                     && (partitionType.getFieldCount() > 0
                             || (options.dataEvolutionEnabled() && allContainsRowId(input)))) {
                 return ManifestFileSorter.trySortCompaction(
-                        input, newFilesForAbort, manifestFile, partitionType, options);
+                        input, newFilesForAbort, manifestFile, partitionType, options, ioManager);
             } else {
                 // Otherwise try full compaction first, then minor compaction if needed
                 Optional<List<ManifestFileMeta>> fullCompacted =

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
@@ -146,6 +147,18 @@ public class ManifestFileSorter {
             RowType partitionType,
             CoreOptions options)
             throws Exception {
+        return trySortCompaction(
+                input, newFilesForAbort, manifestFile, partitionType, options, null);
+    }
+
+    static List<ManifestFileMeta> trySortCompaction(
+            List<ManifestFileMeta> input,
+            List<ManifestFileMeta> newFilesForAbort,
+            ManifestFile manifestFile,
+            RowType partitionType,
+            CoreOptions options,
+            @Nullable IOManager ioManager)
+            throws Exception {
         String sortPartitionField = options.manifestSortPartitionField();
         long suggestedMetaSize = options.manifestTargetSize().getBytes();
         int suggestedMinMetaCount = options.manifestMergeMinCount();
@@ -155,7 +168,7 @@ public class ManifestFileSorter {
         int sortedRunSizeRatio = options.sortedRunSizeRatio();
         Integer manifestReadParallelism = options.scanManifestParallelism();
         ManifestEntryExternalSort.ExternalSortConfig externalSortConfig =
-                ManifestEntryExternalSort.ExternalSortConfig.from(options);
+                ManifestEntryExternalSort.ExternalSortConfig.from(options, ioManager);
 
         Optional<List<ManifestFileMeta>> fullCompacted =
                 tryFullCompaction(

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -982,11 +982,11 @@ public class ManifestFileSorter {
                         ctx.sortKey,
                         ctx.externalSortConfig,
                         manifestFile,
+                        sortNewFiles,
                         ctx.deleteEntries,
                         manifestReadParallelism);
         if (!sorted.isEmpty()) {
             output.addSortedFiles(sorted);
-            sortNewFiles.addAll(sorted);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -959,7 +959,9 @@ public class ManifestFileSorter {
             return;
         }
 
-        if (ctx.fullCompaction) {
+        // Add-only minor sections can use the full rewrite path to avoid keeping DELETE entries in
+        // memory.
+        if (ctx.fullCompaction || containsNoDeleteEntries(section)) {
             rewriteFull(section, output, sortNewFiles, ctx, manifestFile, manifestReadParallelism);
         } else {
             rewriteMinor(section, output, sortNewFiles, ctx, manifestFile, manifestReadParallelism);
@@ -1020,11 +1022,6 @@ public class ManifestFileSorter {
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        if (containsNoDeleteEntries(section)) {
-            rewriteFull(section, output, sortNewFiles, ctx, manifestFile, manifestReadParallelism);
-            return;
-        }
-
         Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sorted =
                 ManifestEntryExternalSort.sortAndWriteMinorEntries(
                         section,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -22,13 +22,16 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.manifest.FileEntry;
-import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFile;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Pair;
@@ -39,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -53,7 +55,6 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.function.Function;
 
-import static java.util.Collections.singletonList;
 import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
 
 /**
@@ -68,7 +69,8 @@ public class ManifestFileSorter {
     static class CompactionContext {
         final boolean fullCompaction;
         final ManifestSortKey sortKey;
-        final Set<FileEntry.Identifier> deleteEntries;
+        final ManifestEntryExternalSort.Config externalSortConfig;
+        final boolean hasDeleteEntries;
         /**
          * Manifest files that need unsorted compaction.
          *
@@ -85,13 +87,15 @@ public class ManifestFileSorter {
         CompactionContext(
                 boolean fullCompaction,
                 ManifestSortKey sortKey,
-                Set<FileEntry.Identifier> deleteEntries,
+                ManifestEntryExternalSort.Config externalSortConfig,
+                boolean hasDeleteEntries,
                 Map<ManifestFileMeta, Boolean> compactWithoutSort,
                 List<ManifestAdjacentSortedRun> levelRuns,
                 List<ManifestAdjacentSortedRun> pickedRuns) {
             this.fullCompaction = fullCompaction;
             this.sortKey = sortKey;
-            this.deleteEntries = deleteEntries;
+            this.externalSortConfig = externalSortConfig;
+            this.hasDeleteEntries = hasDeleteEntries;
             this.compactWithoutSort = compactWithoutSort;
             this.levelRuns = levelRuns;
             this.pickedRuns = pickedRuns;
@@ -106,7 +110,7 @@ public class ManifestFileSorter {
     /** Result of classifying manifest files. */
     private static class ClassifyResult {
         final List<ManifestFileMeta> lsmFiles;
-        final Set<FileEntry.Identifier> deleteEntries;
+        final boolean hasDeleteEntries;
         /**
          * Manifest files that need unsorted compaction.
          *
@@ -119,10 +123,10 @@ public class ManifestFileSorter {
 
         ClassifyResult(
                 List<ManifestFileMeta> lsmFiles,
-                Set<FileEntry.Identifier> deleteEntries,
+                boolean hasDeleteEntries,
                 Map<ManifestFileMeta, Boolean> compactWithoutSort) {
             this.lsmFiles = lsmFiles;
-            this.deleteEntries = deleteEntries;
+            this.hasDeleteEntries = hasDeleteEntries;
             this.compactWithoutSort = compactWithoutSort;
         }
     }
@@ -149,6 +153,8 @@ public class ManifestFileSorter {
         int maxSizeAmplificationPercent = options.maxSizeAmplificationPercent();
         int sortedRunSizeRatio = options.sortedRunSizeRatio();
         Integer manifestReadParallelism = options.scanManifestParallelism();
+        ManifestEntryExternalSort.Config externalSortConfig =
+                ManifestEntryExternalSort.Config.from(options);
 
         Optional<List<ManifestFileMeta>> fullCompacted =
                 tryFullCompaction(
@@ -164,6 +170,7 @@ public class ManifestFileSorter {
                         maxRewriteSize,
                         maxSizeAmplificationPercent,
                         sortedRunSizeRatio,
+                        externalSortConfig,
                         manifestReadParallelism);
         if (fullCompacted.isPresent()) {
             return fullCompacted.get();
@@ -180,6 +187,7 @@ public class ManifestFileSorter {
                 maxRewriteSize,
                 maxSizeAmplificationPercent,
                 sortedRunSizeRatio,
+                externalSortConfig,
                 manifestReadParallelism);
     }
 
@@ -202,6 +210,7 @@ public class ManifestFileSorter {
             long maxRewriteSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
+            ManifestEntryExternalSort.Config externalSortConfig,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
         // Step 1: Check if full compaction threshold is met
@@ -226,6 +235,7 @@ public class ManifestFileSorter {
                         suggestedMetaSize,
                         maxSizeAmplificationPercent,
                         sortedRunSizeRatio,
+                        externalSortConfig,
                         manifestReadParallelism);
         List<ManifestAdjacentSortedRun> levelRuns = ctx.levelRuns;
         List<ManifestAdjacentSortedRun> pickedRuns = ctx.pickedRuns;
@@ -305,6 +315,7 @@ public class ManifestFileSorter {
             long maxRewriteSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
+            ManifestEntryExternalSort.Config externalSortConfig,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
         // Step 1: Prepare compaction context (early-return if nothing to compact)
@@ -319,6 +330,7 @@ public class ManifestFileSorter {
                         suggestedMetaSize,
                         maxSizeAmplificationPercent,
                         sortedRunSizeRatio,
+                        externalSortConfig,
                         manifestReadParallelism);
         List<ManifestAdjacentSortedRun> levelRuns = ctx.levelRuns;
         List<ManifestAdjacentSortedRun> pickedRuns = ctx.pickedRuns;
@@ -427,6 +439,7 @@ public class ManifestFileSorter {
             long suggestedMetaSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
+            ManifestEntryExternalSort.Config externalSortConfig,
             @Nullable Integer manifestReadParallelism) {
 
         // Step 1: Resolve sort key. Data evolution tables prefer RowID ranges when available.
@@ -456,7 +469,8 @@ public class ManifestFileSorter {
         return new CompactionContext(
                 fullCompaction,
                 sortKey,
-                classifyResult.deleteEntries,
+                externalSortConfig,
+                classifyResult.hasDeleteEntries,
                 classifyResult.compactWithoutSort,
                 levelRuns,
                 pickedRuns);
@@ -471,7 +485,7 @@ public class ManifestFileSorter {
      * <p>Non-full compaction: small files go to compactWithoutSort for minor-style merge; the rest
      * are returned as lsmFiles.
      *
-     * @return ClassifyResult containing lsmFiles, deleteEntries, and compactWithoutSort
+     * @return ClassifyResult containing lsmFiles, delete-entry existence, and compactWithoutSort
      */
     private static ClassifyResult classifyManifests(
             List<ManifestFileMeta> input,
@@ -483,23 +497,23 @@ public class ManifestFileSorter {
         // Initialize classification containers and read delete entries
         Map<ManifestFileMeta, Boolean> compactWithoutSort = new LinkedHashMap<>();
         List<ManifestFileMeta> lsmFiles = new LinkedList<>(input);
-        Set<FileEntry.Identifier> classifiedDeleteEntries = Collections.emptySet();
+        boolean hasDeleteEntries = false;
         PartitionPredicate predicate = null;
         if (fullCompaction) {
-            classifiedDeleteEntries =
-                    FileEntry.readDeletedEntries(manifestFile, input, manifestReadParallelism);
-
-            // Build partition predicate from delete entries for overlap detection
-            if (classifiedDeleteEntries.isEmpty()) {
-                predicate = PartitionPredicate.ALWAYS_FALSE;
-            } else {
-                if (partitionType.getFieldCount() > 0) {
-                    Set<BinaryRow> deletePartitions =
-                            ManifestFileMerger.computeDeletePartitions(classifiedDeleteEntries);
-                    predicate = PartitionPredicate.fromMultiple(partitionType, deletePartitions);
-                } else {
-                    predicate = PartitionPredicate.ALWAYS_TRUE;
+            for (ManifestFileMeta meta : input) {
+                if (meta.numDeletedFiles() > 0) {
+                    hasDeleteEntries = true;
+                    break;
                 }
+            }
+
+            if (hasDeleteEntries) {
+                // Avoid keeping all delete identifiers or delete partitions in heap. Full
+                // compaction with deletes is handled by an external identifier sort, so all files
+                // are conservatively included in the cleanup scope.
+                predicate = PartitionPredicate.ALWAYS_TRUE;
+            } else {
+                predicate = PartitionPredicate.ALWAYS_FALSE;
             }
         }
 
@@ -521,7 +535,7 @@ public class ManifestFileSorter {
             }
         }
 
-        return new ClassifyResult(lsmFiles, classifiedDeleteEntries, compactWithoutSort);
+        return new ClassifyResult(lsmFiles, hasDeleteEntries, compactWithoutSort);
     }
 
     /**
@@ -726,6 +740,17 @@ public class ManifestFileSorter {
         for (int i = 0; i < sections.size(); i++) {
             Section section = sections.get(i);
 
+            if (ctx.fullCompaction && ctx.hasDeleteEntries) {
+                rewriteSection(
+                        section.files,
+                        output,
+                        sortNewFiles,
+                        ctx,
+                        manifestFile,
+                        manifestReadParallelism);
+                continue;
+            }
+
             // A single-file section is always handled directly, regardless of the budget.
             if (section.files.size() == 1) {
                 rewriteSection(
@@ -908,7 +933,8 @@ public class ManifestFileSorter {
         }
         // Flush tail only if delete entries exist or file count >= minCount.
         if (!candidates.isEmpty()) {
-            if (!ctx.deleteEntries.isEmpty() || candidates.size() >= suggestedMinMetaCount) {
+            if ((ctx.fullCompaction && ctx.hasDeleteEntries)
+                    || candidates.size() >= suggestedMinMetaCount) {
                 rewriteSection(
                         candidates,
                         output,
@@ -961,7 +987,24 @@ public class ManifestFileSorter {
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        // Read surviving ADD entries: filter out entries cancelled by deleteEntries.
+        if (ctx.hasDeleteEntries) {
+            List<ManifestFileMeta> sorted =
+                    ManifestEntryExternalSort.cancelAndWriteEntries(
+                                    section,
+                                    ctx.sortKey,
+                                    ctx.externalSortConfig,
+                                    manifestFile,
+                                    manifestReadParallelism,
+                                    ManifestEntryExternalSort.CancelMode.FULL)
+                            .getLeft();
+            if (!sorted.isEmpty()) {
+                output.addSortedFiles(sorted);
+                sortNewFiles.addAll(sorted);
+            }
+            return;
+        }
+
+        // Read ADD entries and write them through the external sorter.
         Function<ManifestFileMeta, List<ManifestEntry>> reader =
                 meta -> {
                     List<ManifestEntry> batch = new ArrayList<>();
@@ -971,33 +1014,26 @@ public class ManifestFileSorter {
                                     meta.fileSize(),
                                     FileEntry.addFilter(),
                                     Filter.alwaysTrue())) {
-                        if (!ctx.deleteEntries.contains(entry.identifier())) {
-                            batch.add(entry);
-                        }
+                        batch.add(entry);
                     }
                     return batch;
                 };
 
-        List<ManifestEntry> entries = new ArrayList<>();
-        for (ManifestEntry entry :
-                sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
-            entries.add(entry);
-        }
-
-        if (!entries.isEmpty()) {
-            List<ManifestFileMeta> sorted = sortAndWriteEntries(entries, ctx.sortKey, manifestFile);
+        List<ManifestFileMeta> sorted =
+                ManifestEntryExternalSort.sortAndWriteEntries(
+                        sequentialBatchedExecute(reader, section, manifestReadParallelism),
+                        ctx.sortKey,
+                        ctx.externalSortConfig,
+                        manifestFile);
+        if (!sorted.isEmpty()) {
             output.addSortedFiles(sorted);
             sortNewFiles.addAll(sorted);
         }
     }
 
     /**
-     * Minor compaction path: read entries with ADD/DELETE classified in a single pass per file,
-     * then sort each group independently and write them to output.
-     *
-     * <p>Each file is read in parallel (via sequentialBatchedExecute). The reader classifies
-     * entries into ADD and DELETE within each file, returning a Pair. Results are merged in the
-     * main thread.
+     * Minor compaction path: cancel ADD/DELETE pairs with an external identifier sort, then sort
+     * surviving ADD and DELETE entries independently and write them to output.
      */
     private static void rewriteMinor(
             List<ManifestFileMeta> section,
@@ -1007,90 +1043,38 @@ public class ManifestFileSorter {
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        // Read and classify ADD/DELETE in one pass per file.
-        Function<ManifestFileMeta, List<Pair<List<ManifestEntry>, List<ManifestEntry>>>> reader =
-                meta -> {
-                    List<ManifestEntry> addBatch = new ArrayList<>();
-                    List<ManifestEntry> deleteBatch = new ArrayList<>();
-                    for (ManifestEntry entry :
-                            manifestFile.read(meta.fileName(), meta.fileSize())) {
-                        if (entry.kind() == FileKind.ADD) {
-                            addBatch.add(entry);
-                        } else {
-                            deleteBatch.add(entry);
-                        }
-                    }
-                    return singletonList(Pair.of(addBatch, deleteBatch));
-                };
-
-        Map<FileEntry.Identifier, ManifestEntry> addMap = new HashMap<>();
-        List<ManifestEntry> minorDeleteEntries = new ArrayList<>();
-        for (Pair<List<ManifestEntry>, List<ManifestEntry>> pair :
-                sequentialBatchedExecute(reader, section, manifestReadParallelism)) {
-            for (ManifestEntry entry : pair.getLeft()) {
-                addMap.put(entry.identifier(), entry);
-            }
-            minorDeleteEntries.addAll(pair.getRight());
+        if (containsNoDeleteEntries(section)) {
+            rewriteFull(section, output, sortNewFiles, ctx, manifestFile, manifestReadParallelism);
+            return;
         }
 
-        // Cancel out ADD+DELETE pairs with the same identifier within the section.
-        minorDeleteEntries.removeIf(
-                manifestEntry -> addMap.remove(manifestEntry.identifier()) != null);
-        List<ManifestEntry> addEntries = new ArrayList<>(addMap.values());
+        Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sorted =
+                ManifestEntryExternalSort.cancelAndWriteEntries(
+                        section,
+                        ctx.sortKey,
+                        ctx.externalSortConfig,
+                        manifestFile,
+                        manifestReadParallelism,
+                        ManifestEntryExternalSort.CancelMode.MINOR);
 
-        if (!addEntries.isEmpty()) {
-            List<ManifestFileMeta> sorted =
-                    sortAndWriteEntries(addEntries, ctx.sortKey, manifestFile);
-            output.addSortedFiles(sorted);
-            sortNewFiles.addAll(sorted);
+        if (!sorted.getLeft().isEmpty()) {
+            output.addSortedFiles(sorted.getLeft());
+            sortNewFiles.addAll(sorted.getLeft());
         }
 
-        if (!minorDeleteEntries.isEmpty()) {
-            List<ManifestFileMeta> sorted =
-                    sortAndWriteEntries(minorDeleteEntries, ctx.sortKey, manifestFile);
-            output.addDeleteFiles(sorted);
-            sortNewFiles.addAll(sorted);
+        if (!sorted.getRight().isEmpty()) {
+            output.addDeleteFiles(sorted.getRight());
+            sortNewFiles.addAll(sorted.getRight());
         }
     }
 
-    /** Sort entries and write them to a new manifest file with proper error handling. */
-    private static List<ManifestFileMeta> sortAndWriteEntries(
-            List<ManifestEntry> entries, ManifestSortKey sortKey, ManifestFile manifestFile)
-            throws Exception {
-        entries.sort((a, b) -> compareSortKey(a, b, sortKey));
-        RollingFileWriter<ManifestEntry, ManifestFileMeta> writer =
-                manifestFile.createRollingWriter();
-        Exception exception = null;
-        try {
-            writer.write(entries);
-        } catch (Exception e) {
-            exception = e;
-        } finally {
-            if (exception != null) {
-                writer.abort();
-                throw exception;
+    private static boolean containsNoDeleteEntries(List<ManifestFileMeta> section) {
+        for (ManifestFileMeta meta : section) {
+            if (meta.numDeletedFiles() > 0) {
+                return false;
             }
-            writer.close();
         }
-        return writer.result();
-    }
-
-    /**
-     * Compare two {@link ManifestEntry}s by the composite key {@code (sort-key, kind, fileName)}.
-     * {@code fileName} is used as the tie-breaker so that all entries sharing the same sort-field
-     * value AND the same data file are emitted contiguously.
-     */
-    private static int compareSortKey(ManifestEntry a, ManifestEntry b, ManifestSortKey sortKey) {
-        int c = sortKey.compareEntry(a, b);
-        if (c != 0) {
-            return c;
-        }
-        // ADD before DELETE
-        int kindCmp = a.kind().compareTo(b.kind());
-        if (kindCmp != 0) {
-            return kindCmp;
-        }
-        return a.file().fileName().compareTo(b.file().fileName());
+        return true;
     }
 
     private static ManifestSortKey createSortKey(
@@ -1102,9 +1086,11 @@ public class ManifestFileSorter {
             // RowID sorting uses the configured partition field as the primary key when specified,
             // otherwise it uses the full partition row to preserve partition locality. It then
             // orders files by RowID.
+            int[] partitionSortFields =
+                    createPartitionSortFields(sortPartitionField, partitionType);
             RecordComparator partitionComparator =
-                    createPartitionComparator(sortPartitionField, partitionType);
-            return new RowIdSortKey(partitionComparator);
+                    createPartitionComparator(partitionType, partitionSortFields);
+            return new RowIdSortKey(partitionComparator, partitionType, partitionSortFields);
         }
 
         if (partitionType.getFieldCount() == 0) {
@@ -1124,11 +1110,10 @@ public class ManifestFileSorter {
         RecordComparator fieldComparator =
                 CodeGenUtils.newRecordComparator(
                         partitionType.getFieldTypes(), new int[] {sortFieldIndex});
-        return new PartitionSortKey(fieldComparator);
+        return new PartitionSortKey(fieldComparator, partitionType, sortFieldIndex);
     }
 
-    @Nullable
-    private static RecordComparator createPartitionComparator(
+    private static int[] createPartitionSortFields(
             String sortPartitionField, RowType partitionType) {
         if (sortPartitionField != null && !sortPartitionField.isEmpty()) {
             int sortFieldIndex = partitionType.getFieldNames().indexOf(sortPartitionField);
@@ -1138,15 +1123,24 @@ public class ManifestFileSorter {
                                 "Cannot resolve sort field '%s' for manifest sort rewrite.",
                                 sortPartitionField));
             }
-            return CodeGenUtils.newRecordComparator(
-                    partitionType.getFieldTypes(), new int[] {sortFieldIndex});
+            return new int[] {sortFieldIndex};
         }
 
-        if (partitionType.getFieldCount() == 0) {
+        int fieldCount = partitionType.getFieldCount();
+        int[] sortFields = new int[fieldCount];
+        for (int i = 0; i < fieldCount; i++) {
+            sortFields[i] = i;
+        }
+        return sortFields;
+    }
+
+    @Nullable
+    private static RecordComparator createPartitionComparator(
+            RowType partitionType, int[] sortFields) {
+        if (sortFields.length == 0) {
             return null;
         }
-
-        return CodeGenUtils.newRecordComparator(partitionType.getFieldTypes());
+        return CodeGenUtils.newRecordComparator(partitionType.getFieldTypes(), sortFields);
     }
 
     interface ManifestSortKey {
@@ -1157,15 +1151,36 @@ public class ManifestFileSorter {
 
         boolean isAfterMax(ManifestFileMeta file, ManifestFileMeta maxFile);
 
-        int compareEntry(ManifestEntry a, ManifestEntry b);
+        RowType externalSortRowType();
+
+        int[] externalSortKeyFields();
+
+        InternalRow toExternalSortRow(ManifestEntry entry, byte[] entryBytes);
+
+        byte[] entryBytes(BinaryRow row);
     }
 
     private static class PartitionSortKey implements ManifestSortKey {
 
         private final RecordComparator fieldComparator;
+        private final InternalRow.FieldGetter sortFieldGetter;
+        private final RowType externalSortRowType;
+        private final int[] externalSortKeyFields;
+        private final int payloadField;
 
-        private PartitionSortKey(RecordComparator fieldComparator) {
+        private PartitionSortKey(
+                RecordComparator fieldComparator, RowType partitionType, int sortFieldIndex) {
             this.fieldComparator = fieldComparator;
+            DataType sortFieldType = partitionType.getTypeAt(sortFieldIndex);
+            this.sortFieldGetter = InternalRow.createFieldGetter(sortFieldType, sortFieldIndex);
+            this.payloadField = 3;
+            this.externalSortRowType =
+                    DataTypes.ROW(
+                            sortFieldType,
+                            DataTypes.TINYINT(),
+                            DataTypes.STRING(),
+                            DataTypes.BYTES());
+            this.externalSortKeyFields = createSequentialFields(payloadField);
         }
 
         @Override
@@ -1188,17 +1203,60 @@ public class ManifestFileSorter {
         }
 
         @Override
-        public int compareEntry(ManifestEntry a, ManifestEntry b) {
-            return fieldComparator.compare(a.partition(), b.partition());
+        public RowType externalSortRowType() {
+            return externalSortRowType;
+        }
+
+        @Override
+        public int[] externalSortKeyFields() {
+            return externalSortKeyFields;
+        }
+
+        @Override
+        public InternalRow toExternalSortRow(ManifestEntry entry, byte[] entryBytes) {
+            GenericRow row = new GenericRow(externalSortRowType.getFieldCount());
+            row.setField(0, sortFieldGetter.getFieldOrNull(entry.partition()));
+            row.setField(1, entry.kind().toByteValue());
+            row.setField(2, BinaryString.fromString(entry.file().fileName()));
+            row.setField(3, entryBytes);
+            return row;
+        }
+
+        @Override
+        public byte[] entryBytes(BinaryRow row) {
+            return row.getBinary(payloadField);
         }
     }
 
     private static class RowIdSortKey implements ManifestSortKey {
 
         @Nullable private final RecordComparator partitionComparator;
+        private final InternalRow.FieldGetter[] partitionFieldGetters;
+        private final RowType externalSortRowType;
+        private final int[] externalSortKeyFields;
+        private final int payloadField;
 
-        private RowIdSortKey(@Nullable RecordComparator partitionComparator) {
+        private RowIdSortKey(
+                @Nullable RecordComparator partitionComparator,
+                RowType partitionType,
+                int[] partitionSortFields) {
             this.partitionComparator = partitionComparator;
+            this.partitionFieldGetters =
+                    createPartitionFieldGetters(partitionType, partitionSortFields);
+
+            List<DataType> fieldTypes = new ArrayList<>();
+            for (int partitionSortField : partitionSortFields) {
+                fieldTypes.add(partitionType.getTypeAt(partitionSortField));
+            }
+            fieldTypes.add(DataTypes.BIGINT());
+            fieldTypes.add(DataTypes.BIGINT());
+            fieldTypes.add(DataTypes.BIGINT());
+            fieldTypes.add(DataTypes.TINYINT());
+            fieldTypes.add(DataTypes.STRING());
+            fieldTypes.add(DataTypes.BYTES());
+            this.externalSortRowType = DataTypes.ROW(fieldTypes.toArray(new DataType[0]));
+            this.payloadField = externalSortRowType.getFieldCount() - 1;
+            this.externalSortKeyFields = createSequentialFields(payloadField);
         }
 
         @Override
@@ -1234,23 +1292,34 @@ public class ManifestFileSorter {
         }
 
         @Override
-        public int compareEntry(ManifestEntry a, ManifestEntry b) {
-            int c = 0;
-            if (partitionComparator != null) {
-                c = partitionComparator.compare(a.partition(), b.partition());
-                if (c != 0) {
-                    return c;
-                }
+        public RowType externalSortRowType() {
+            return externalSortRowType;
+        }
+
+        @Override
+        public int[] externalSortKeyFields() {
+            return externalSortKeyFields;
+        }
+
+        @Override
+        public InternalRow toExternalSortRow(ManifestEntry entry, byte[] entryBytes) {
+            GenericRow row = new GenericRow(externalSortRowType.getFieldCount());
+            int pos = 0;
+            for (InternalRow.FieldGetter partitionFieldGetter : partitionFieldGetters) {
+                row.setField(pos++, partitionFieldGetter.getFieldOrNull(entry.partition()));
             }
-            c = Long.compare(a.file().nonNullFirstRowId(), b.file().nonNullFirstRowId());
-            if (c != 0) {
-                return c;
-            }
-            c = Long.compare(rowIdRangeEnd(a), rowIdRangeEnd(b));
-            if (c != 0) {
-                return c;
-            }
-            return Long.compare(b.file().maxSequenceNumber(), a.file().maxSequenceNumber());
+            row.setField(pos++, entry.file().nonNullFirstRowId());
+            row.setField(pos++, rowIdRangeEnd(entry));
+            row.setField(pos++, Long.MAX_VALUE - entry.file().maxSequenceNumber());
+            row.setField(pos++, entry.kind().toByteValue());
+            row.setField(pos++, BinaryString.fromString(entry.file().fileName()));
+            row.setField(pos, entryBytes);
+            return row;
+        }
+
+        @Override
+        public byte[] entryBytes(BinaryRow row) {
+            return row.getBinary(payloadField);
         }
 
         private int comparePartitionMin(ManifestFileMeta a, ManifestFileMeta b) {
@@ -1290,6 +1359,26 @@ public class ManifestFileSorter {
         private static long rowIdRangeEnd(ManifestEntry entry) {
             return entry.file().nonNullFirstRowId() + entry.file().rowCount() - 1;
         }
+    }
+
+    private static int[] createSequentialFields(int fieldCount) {
+        int[] fields = new int[fieldCount];
+        for (int i = 0; i < fieldCount; i++) {
+            fields[i] = i;
+        }
+        return fields;
+    }
+
+    private static InternalRow.FieldGetter[] createPartitionFieldGetters(
+            RowType partitionType, int[] partitionSortFields) {
+        InternalRow.FieldGetter[] fieldGetters =
+                new InternalRow.FieldGetter[partitionSortFields.length];
+        for (int i = 0; i < partitionSortFields.length; i++) {
+            int fieldIndex = partitionSortFields[i];
+            fieldGetters[i] =
+                    InternalRow.createFieldGetter(partitionType.getTypeAt(fieldIndex), fieldIndex);
+        }
+        return fieldGetters;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -994,7 +994,7 @@ public class ManifestFileSorter {
                 };
 
         List<ManifestFileMeta> sorted =
-                ManifestEntryExternalSort.sortAndWriteEntries(
+                ManifestEntryExternalSort.sortAndWriteFullEntries(
                         sequentialBatchedExecute(reader, section, manifestReadParallelism),
                         ctx.sortKey,
                         ctx.externalSortConfig,
@@ -1006,8 +1006,9 @@ public class ManifestFileSorter {
     }
 
     /**
-     * Minor compaction path: cancel ADD/DELETE pairs with an external identifier sort, then sort
-     * surviving ADD and DELETE entries independently and write them to output.
+     * Minor compaction path: collect DELETE entries in memory while external-sorting all entries,
+     * then write surviving ADD entries from the sorted stream and remaining DELETE entries from
+     * memory.
      */
     private static void rewriteMinor(
             List<ManifestFileMeta> section,
@@ -1023,7 +1024,7 @@ public class ManifestFileSorter {
         }
 
         Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sorted =
-                ManifestEntryExternalSort.cancelAndWriteMinorEntries(
+                ManifestEntryExternalSort.sortAndWriteMinorEntries(
                         section,
                         ctx.sortKey,
                         ctx.externalSortConfig,

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -1023,13 +1023,12 @@ public class ManifestFileSorter {
         }
 
         Pair<List<ManifestFileMeta>, List<ManifestFileMeta>> sorted =
-                ManifestEntryExternalSort.cancelAndWriteEntries(
+                ManifestEntryExternalSort.cancelAndWriteMinorEntries(
                         section,
                         ctx.sortKey,
                         ctx.externalSortConfig,
                         manifestFile,
-                        manifestReadParallelism,
-                        ManifestEntryExternalSort.CancelMode.MINOR);
+                        manifestReadParallelism);
 
         if (!sorted.getLeft().isEmpty()) {
             output.addSortedFiles(sorted.getLeft());

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -34,7 +34,6 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Pair;
 
 import org.slf4j.Logger;
@@ -55,9 +54,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
-import java.util.function.Function;
-
-import static org.apache.paimon.utils.ManifestReadThreadPool.sequentialBatchedExecute;
 
 /**
  * Manifest file sorter that sorts and rewrites manifest files by a configured partition field, or
@@ -980,29 +976,14 @@ public class ManifestFileSorter {
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        // Read ADD entries and write them through the external sorter.
-        Function<ManifestFileMeta, List<ManifestEntry>> reader =
-                meta -> {
-                    List<ManifestEntry> batch = new ArrayList<>();
-                    for (ManifestEntry entry :
-                            manifestFile.read(
-                                    meta.fileName(),
-                                    meta.fileSize(),
-                                    FileEntry.addFilter(),
-                                    Filter.alwaysTrue())) {
-                        if (!ctx.deleteEntries.contains(entry.identifier())) {
-                            batch.add(entry);
-                        }
-                    }
-                    return batch;
-                };
-
         List<ManifestFileMeta> sorted =
                 ManifestEntryExternalSort.sortAndWriteFullEntries(
-                        sequentialBatchedExecute(reader, section, manifestReadParallelism),
+                        section,
                         ctx.sortKey,
                         ctx.externalSortConfig,
-                        manifestFile);
+                        manifestFile,
+                        ctx.deleteEntries,
+                        manifestReadParallelism);
         if (!sorted.isEmpty()) {
             output.addSortedFiles(sorted);
             sortNewFiles.addAll(sorted);

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -70,7 +71,7 @@ public class ManifestFileSorter {
         final boolean fullCompaction;
         final ManifestSortKey sortKey;
         final ManifestEntryExternalSort.Config externalSortConfig;
-        final boolean hasDeleteEntries;
+        final Set<FileEntry.Identifier> deleteEntries;
         /**
          * Manifest files that need unsorted compaction.
          *
@@ -88,14 +89,14 @@ public class ManifestFileSorter {
                 boolean fullCompaction,
                 ManifestSortKey sortKey,
                 ManifestEntryExternalSort.Config externalSortConfig,
-                boolean hasDeleteEntries,
+                Set<FileEntry.Identifier> deleteEntries,
                 Map<ManifestFileMeta, Boolean> compactWithoutSort,
                 List<ManifestAdjacentSortedRun> levelRuns,
                 List<ManifestAdjacentSortedRun> pickedRuns) {
             this.fullCompaction = fullCompaction;
             this.sortKey = sortKey;
             this.externalSortConfig = externalSortConfig;
-            this.hasDeleteEntries = hasDeleteEntries;
+            this.deleteEntries = deleteEntries;
             this.compactWithoutSort = compactWithoutSort;
             this.levelRuns = levelRuns;
             this.pickedRuns = pickedRuns;
@@ -110,7 +111,7 @@ public class ManifestFileSorter {
     /** Result of classifying manifest files. */
     private static class ClassifyResult {
         final List<ManifestFileMeta> lsmFiles;
-        final boolean hasDeleteEntries;
+        final Set<FileEntry.Identifier> deleteEntries;
         /**
          * Manifest files that need unsorted compaction.
          *
@@ -123,10 +124,10 @@ public class ManifestFileSorter {
 
         ClassifyResult(
                 List<ManifestFileMeta> lsmFiles,
-                boolean hasDeleteEntries,
+                Set<FileEntry.Identifier> deleteEntries,
                 Map<ManifestFileMeta, Boolean> compactWithoutSort) {
             this.lsmFiles = lsmFiles;
-            this.hasDeleteEntries = hasDeleteEntries;
+            this.deleteEntries = deleteEntries;
             this.compactWithoutSort = compactWithoutSort;
         }
     }
@@ -470,7 +471,7 @@ public class ManifestFileSorter {
                 fullCompaction,
                 sortKey,
                 externalSortConfig,
-                classifyResult.hasDeleteEntries,
+                classifyResult.deleteEntries,
                 classifyResult.compactWithoutSort,
                 levelRuns,
                 pickedRuns);
@@ -485,7 +486,7 @@ public class ManifestFileSorter {
      * <p>Non-full compaction: small files go to compactWithoutSort for minor-style merge; the rest
      * are returned as lsmFiles.
      *
-     * @return ClassifyResult containing lsmFiles, delete-entry existence, and compactWithoutSort
+     * @return ClassifyResult containing lsmFiles, deleteEntries, and compactWithoutSort
      */
     private static ClassifyResult classifyManifests(
             List<ManifestFileMeta> input,
@@ -497,23 +498,23 @@ public class ManifestFileSorter {
         // Initialize classification containers and read delete entries
         Map<ManifestFileMeta, Boolean> compactWithoutSort = new LinkedHashMap<>();
         List<ManifestFileMeta> lsmFiles = new LinkedList<>(input);
-        boolean hasDeleteEntries = false;
+        Set<FileEntry.Identifier> classifiedDeleteEntries = Collections.emptySet();
         PartitionPredicate predicate = null;
         if (fullCompaction) {
-            for (ManifestFileMeta meta : input) {
-                if (meta.numDeletedFiles() > 0) {
-                    hasDeleteEntries = true;
-                    break;
-                }
-            }
+            classifiedDeleteEntries =
+                    FileEntry.readDeletedEntries(manifestFile, input, manifestReadParallelism);
 
-            if (hasDeleteEntries) {
-                // Avoid keeping all delete identifiers or delete partitions in heap. Full
-                // compaction with deletes is handled by an external identifier sort, so all files
-                // are conservatively included in the cleanup scope.
-                predicate = PartitionPredicate.ALWAYS_TRUE;
-            } else {
+            // Build partition predicate from delete entries for overlap detection.
+            if (classifiedDeleteEntries.isEmpty()) {
                 predicate = PartitionPredicate.ALWAYS_FALSE;
+            } else {
+                if (partitionType.getFieldCount() > 0) {
+                    Set<BinaryRow> deletePartitions =
+                            ManifestFileMerger.computeDeletePartitions(classifiedDeleteEntries);
+                    predicate = PartitionPredicate.fromMultiple(partitionType, deletePartitions);
+                } else {
+                    predicate = PartitionPredicate.ALWAYS_TRUE;
+                }
             }
         }
 
@@ -535,7 +536,7 @@ public class ManifestFileSorter {
             }
         }
 
-        return new ClassifyResult(lsmFiles, hasDeleteEntries, compactWithoutSort);
+        return new ClassifyResult(lsmFiles, classifiedDeleteEntries, compactWithoutSort);
     }
 
     /**
@@ -740,17 +741,6 @@ public class ManifestFileSorter {
         for (int i = 0; i < sections.size(); i++) {
             Section section = sections.get(i);
 
-            if (ctx.fullCompaction && ctx.hasDeleteEntries) {
-                rewriteSection(
-                        section.files,
-                        output,
-                        sortNewFiles,
-                        ctx,
-                        manifestFile,
-                        manifestReadParallelism);
-                continue;
-            }
-
             // A single-file section is always handled directly, regardless of the budget.
             if (section.files.size() == 1) {
                 rewriteSection(
@@ -933,8 +923,7 @@ public class ManifestFileSorter {
         }
         // Flush tail only if delete entries exist or file count >= minCount.
         if (!candidates.isEmpty()) {
-            if ((ctx.fullCompaction && ctx.hasDeleteEntries)
-                    || candidates.size() >= suggestedMinMetaCount) {
+            if (!ctx.deleteEntries.isEmpty() || candidates.size() >= suggestedMinMetaCount) {
                 rewriteSection(
                         candidates,
                         output,
@@ -987,23 +976,6 @@ public class ManifestFileSorter {
             ManifestFile manifestFile,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
-        if (ctx.hasDeleteEntries) {
-            List<ManifestFileMeta> sorted =
-                    ManifestEntryExternalSort.cancelAndWriteEntries(
-                                    section,
-                                    ctx.sortKey,
-                                    ctx.externalSortConfig,
-                                    manifestFile,
-                                    manifestReadParallelism,
-                                    ManifestEntryExternalSort.CancelMode.FULL)
-                            .getLeft();
-            if (!sorted.isEmpty()) {
-                output.addSortedFiles(sorted);
-                sortNewFiles.addAll(sorted);
-            }
-            return;
-        }
-
         // Read ADD entries and write them through the external sorter.
         Function<ManifestFileMeta, List<ManifestEntry>> reader =
                 meta -> {
@@ -1014,7 +986,9 @@ public class ManifestFileSorter {
                                     meta.fileSize(),
                                     FileEntry.addFilter(),
                                     Filter.alwaysTrue())) {
-                        batch.add(entry);
+                        if (!ctx.deleteEntries.contains(entry.identifier())) {
+                            batch.add(entry);
+                        }
                     }
                     return batch;
                 };

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -145,17 +145,6 @@ public class ManifestFileSorter {
             List<ManifestFileMeta> newFilesForAbort,
             ManifestFile manifestFile,
             RowType partitionType,
-            CoreOptions options)
-            throws Exception {
-        return trySortCompaction(
-                input, newFilesForAbort, manifestFile, partitionType, options, null);
-    }
-
-    static List<ManifestFileMeta> trySortCompaction(
-            List<ManifestFileMeta> input,
-            List<ManifestFileMeta> newFilesForAbort,
-            ManifestFile manifestFile,
-            RowType partitionType,
             CoreOptions options,
             @Nullable IOManager ioManager)
             throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -70,7 +70,7 @@ public class ManifestFileSorter {
     static class CompactionContext {
         final boolean fullCompaction;
         final ManifestSortKey sortKey;
-        final ManifestEntryExternalSort.Config externalSortConfig;
+        final ManifestEntryExternalSort.ExternalSortConfig externalSortConfig;
         final Set<FileEntry.Identifier> deleteEntries;
         /**
          * Manifest files that need unsorted compaction.
@@ -88,7 +88,7 @@ public class ManifestFileSorter {
         CompactionContext(
                 boolean fullCompaction,
                 ManifestSortKey sortKey,
-                ManifestEntryExternalSort.Config externalSortConfig,
+                ManifestEntryExternalSort.ExternalSortConfig externalSortConfig,
                 Set<FileEntry.Identifier> deleteEntries,
                 Map<ManifestFileMeta, Boolean> compactWithoutSort,
                 List<ManifestAdjacentSortedRun> levelRuns,
@@ -154,8 +154,8 @@ public class ManifestFileSorter {
         int maxSizeAmplificationPercent = options.maxSizeAmplificationPercent();
         int sortedRunSizeRatio = options.sortedRunSizeRatio();
         Integer manifestReadParallelism = options.scanManifestParallelism();
-        ManifestEntryExternalSort.Config externalSortConfig =
-                ManifestEntryExternalSort.Config.from(options);
+        ManifestEntryExternalSort.ExternalSortConfig externalSortConfig =
+                ManifestEntryExternalSort.ExternalSortConfig.from(options);
 
         Optional<List<ManifestFileMeta>> fullCompacted =
                 tryFullCompaction(
@@ -211,7 +211,7 @@ public class ManifestFileSorter {
             long maxRewriteSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
-            ManifestEntryExternalSort.Config externalSortConfig,
+            ManifestEntryExternalSort.ExternalSortConfig externalSortConfig,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
         // Step 1: Check if full compaction threshold is met
@@ -316,7 +316,7 @@ public class ManifestFileSorter {
             long maxRewriteSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
-            ManifestEntryExternalSort.Config externalSortConfig,
+            ManifestEntryExternalSort.ExternalSortConfig externalSortConfig,
             @Nullable Integer manifestReadParallelism)
             throws Exception {
         // Step 1: Prepare compaction context (early-return if nothing to compact)
@@ -440,7 +440,7 @@ public class ManifestFileSorter {
             long suggestedMetaSize,
             int maxSizeAmplificationPercent,
             int sortedRunSizeRatio,
-            ManifestEntryExternalSort.Config externalSortConfig,
+            ManifestEntryExternalSort.ExternalSortConfig externalSortConfig,
             @Nullable Integer manifestReadParallelism) {
 
         // Step 1: Resolve sort key. Data evolution tables prefer RowID ranges when available.
@@ -1140,21 +1140,21 @@ public class ManifestFileSorter {
         private final InternalRow.FieldGetter sortFieldGetter;
         private final RowType externalSortRowType;
         private final int[] externalSortKeyFields;
-        private final int payloadField;
+        private final int sortFieldNum;
 
         private PartitionSortKey(
                 RecordComparator fieldComparator, RowType partitionType, int sortFieldIndex) {
             this.fieldComparator = fieldComparator;
             DataType sortFieldType = partitionType.getTypeAt(sortFieldIndex);
             this.sortFieldGetter = InternalRow.createFieldGetter(sortFieldType, sortFieldIndex);
-            this.payloadField = 3;
+            this.sortFieldNum = 3;
             this.externalSortRowType =
                     DataTypes.ROW(
                             sortFieldType,
                             DataTypes.TINYINT(),
                             DataTypes.STRING(),
                             DataTypes.BYTES());
-            this.externalSortKeyFields = createSequentialFields(payloadField);
+            this.externalSortKeyFields = createSequentialFields(sortFieldNum);
         }
 
         @Override
@@ -1198,7 +1198,7 @@ public class ManifestFileSorter {
 
         @Override
         public byte[] entryBytes(BinaryRow row) {
-            return row.getBinary(payloadField);
+            return row.getBinary(sortFieldNum);
         }
     }
 
@@ -1208,7 +1208,7 @@ public class ManifestFileSorter {
         private final InternalRow.FieldGetter[] partitionFieldGetters;
         private final RowType externalSortRowType;
         private final int[] externalSortKeyFields;
-        private final int payloadField;
+        private final int sortFieldNum;
 
         private RowIdSortKey(
                 @Nullable RecordComparator partitionComparator,
@@ -1229,8 +1229,8 @@ public class ManifestFileSorter {
             fieldTypes.add(DataTypes.STRING());
             fieldTypes.add(DataTypes.BYTES());
             this.externalSortRowType = DataTypes.ROW(fieldTypes.toArray(new DataType[0]));
-            this.payloadField = externalSortRowType.getFieldCount() - 1;
-            this.externalSortKeyFields = createSequentialFields(payloadField);
+            this.sortFieldNum = externalSortRowType.getFieldCount() - 1;
+            this.externalSortKeyFields = createSequentialFields(sortFieldNum);
         }
 
         @Override
@@ -1293,7 +1293,7 @@ public class ManifestFileSorter {
 
         @Override
         public byte[] entryBytes(BinaryRow row) {
-            return row.getBinary(payloadField);
+            return row.getBinary(sortFieldNum);
         }
 
         private int comparePartitionMin(ManifestFileMeta a, ManifestFileMeta b) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ManifestFileSorter.java
@@ -1028,16 +1028,15 @@ public class ManifestFileSorter {
                         ctx.sortKey,
                         ctx.externalSortConfig,
                         manifestFile,
+                        sortNewFiles,
                         manifestReadParallelism);
 
         if (!sorted.getLeft().isEmpty()) {
             output.addSortedFiles(sorted.getLeft());
-            sortNewFiles.addAll(sorted.getLeft());
         }
 
         if (!sorted.getRight().isEmpty()) {
             output.addDeleteFiles(sorted.getRight());
-            sortNewFiles.addAll(sorted.getRight());
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommit.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.sink;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.table.Table;
 
@@ -35,6 +36,11 @@ import java.util.List;
  */
 @Public
 public interface TableCommit extends AutoCloseable {
+
+    /** With {@link IOManager}, this is needed if commit-time external sort is used. */
+    default TableCommit withIOManager(IOManager ioManager) {
+        return this;
+    }
 
     /** Set {@link MetricRegistry} to table commit. */
     TableCommit withMetricRegistry(MetricRegistry registry);

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -21,6 +21,7 @@ package org.apache.paimon.table.sink;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.consumer.ConsumerManager;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.io.DataFileMeta;
@@ -174,6 +175,12 @@ public class TableCommitImpl implements InnerTableCommit {
     @Override
     public TableCommitImpl withOperation(Snapshot.Operation operation) {
         commit.withOperation(operation);
+        return this;
+    }
+
+    @Override
+    public TableCommitImpl withIOManager(IOManager ioManager) {
+        commit.withIOManager(ioManager);
         return this;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
@@ -1003,6 +1004,51 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
                         .isGreaterThanOrEqualTo(prevPartition);
             }
         }
+    }
+
+    @Test
+    public void testManifestSortUsesExternalIOManagerWithoutClosingIt() throws Exception {
+        List<ManifestFileMeta> input = new ArrayList<>();
+        for (int manifest = 0; manifest < 2; manifest++) {
+            List<ManifestEntry> entries = new ArrayList<>();
+            for (int i = 0; i < 40; i++) {
+                int partition = manifest == 0 ? 39 - i : i;
+                entries.add(
+                        makeEntry(
+                                true,
+                                String.format(
+                                        "external-io-manager-%02d-entry-%03d-payload-%040d",
+                                        manifest, i, i),
+                                partition));
+            }
+            input.add(makeManifest(entries.toArray(new ManifestEntry[0])));
+        }
+
+        Options testOptions = new Options();
+        testOptions.set("manifest-sort.enabled", "true");
+        testOptions.set("manifest.full-compaction-threshold-size", "1B");
+        testOptions.set("page-size", "1kb");
+        testOptions.set("sort-spill-buffer-size", "4kb");
+
+        java.nio.file.Path spillBase = tempDir.resolve("manifest-spill");
+        java.nio.file.Files.createDirectories(spillBase);
+        IOManager ioManager = IOManager.create(spillBase.toString());
+        try {
+            List<ManifestFileMeta> merged =
+                    ManifestFileMerger.merge(
+                            input,
+                            manifestFile,
+                            getPartitionType(),
+                            CoreOptions.fromMap(testOptions.toMap()),
+                            ioManager);
+
+            assertEquivalentEntries(input, merged);
+            assertThat(spillBase.toFile().list((dir, name) -> name.startsWith("paimon-")))
+                    .isNotEmpty();
+        } finally {
+            ioManager.close();
+        }
+        assertThat(spillBase.toFile().list()).isEmpty();
     }
 
     /**

--- a/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/manifest/ManifestFileMetaTest.java
@@ -960,6 +960,51 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         }
     }
 
+    @Test
+    public void testManifestSortWithSpillableExternalSortBuffer() {
+        List<ManifestFileMeta> input = new ArrayList<>();
+        for (int manifest = 0; manifest < 4; manifest++) {
+            List<ManifestEntry> entries = new ArrayList<>();
+            for (int i = 0; i < 80; i++) {
+                int partition = manifest % 2 == 0 ? 79 - i : i;
+                entries.add(
+                        makeEntry(
+                                true,
+                                String.format(
+                                        "spill-manifest-%02d-entry-%03d-payload-padding-%040d",
+                                        manifest, i, i),
+                                partition));
+            }
+            input.add(makeManifest(entries.toArray(new ManifestEntry[0])));
+        }
+
+        Options testOptions = new Options();
+        testOptions.set("manifest-sort.enabled", "true");
+        testOptions.set("manifest.full-compaction-threshold-size", "1B");
+        testOptions.set("page-size", "1kb");
+        testOptions.set("sort-spill-buffer-size", "4kb");
+        testOptions.set("local-sort.max-num-file-handles", "2");
+
+        List<ManifestFileMeta> merged =
+                ManifestFileMerger.merge(
+                        input,
+                        manifestFile,
+                        getPartitionType(),
+                        CoreOptions.fromMap(testOptions.toMap()));
+
+        assertEquivalentEntries(input, merged);
+        for (ManifestFileMeta meta : merged) {
+            List<ManifestEntry> entries = manifestFile.read(meta.fileName(), meta.fileSize());
+            for (int i = 1; i < entries.size(); i++) {
+                int prevPartition = entries.get(i - 1).partition().getInt(0);
+                int currPartition = entries.get(i).partition().getInt(0);
+                assertThat(currPartition)
+                        .as("Entries within a manifest should be sorted after spill")
+                        .isGreaterThanOrEqualTo(prevPartition);
+            }
+        }
+    }
+
     /**
      * Test that sort rewrite correctly eliminates DELETE entries and their corresponding ADD
      * entries. The key condition is that totalDeltaFileSize must reach manifestFullCompactionSize
@@ -1021,6 +1066,10 @@ public class ManifestFileMetaTest extends ManifestFileMetaTestBase {
         Options testOptions = new Options();
         testOptions.set("manifest-sort.enabled", "true");
         testOptions.set("manifest.full-compaction-threshold-size", "10B");
+        testOptions.set("manifest-sort.max-rewrite-size", "1B");
+        testOptions.set("page-size", "1kb");
+        testOptions.set("sort-spill-buffer-size", "4kb");
+        testOptions.set("local-sort.max-num-file-handles", "2");
 
         List<ManifestFileMeta> merged =
                 ManifestFileMerger.merge(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -94,6 +94,10 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
         int getParallelism();
 
         int getSubtaskIndex();
+
+        default String[] tempDirs() {
+            return new String[] {System.getProperty("java.io.tmpdir")};
+        }
     }
 
     static Context createContext(
@@ -104,6 +108,26 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             StateStore stateStore,
             int parallelism,
             int subtaskIndex) {
+        return createContext(
+                commitUser,
+                metricGroup,
+                streamingCheckpointEnabled,
+                isRestored,
+                stateStore,
+                parallelism,
+                subtaskIndex,
+                new String[] {System.getProperty("java.io.tmpdir")});
+    }
+
+    static Context createContext(
+            String commitUser,
+            @Nullable MetricGroup metricGroup,
+            boolean streamingCheckpointEnabled,
+            boolean isRestored,
+            StateStore stateStore,
+            int parallelism,
+            int subtaskIndex,
+            String[] tempDirs) {
         return new Committer.Context() {
             @Override
             public String commitUser() {
@@ -138,6 +162,11 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             @Override
             public int getSubtaskIndex() {
                 return subtaskIndex;
+            }
+
+            @Override
+            public String[] tempDirs() {
+                return tempDirs;
             }
         };
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/Committer.java
@@ -95,8 +95,9 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
 
         int getSubtaskIndex();
 
+        @Nullable
         default String[] tempDirs() {
-            return new String[] {System.getProperty("java.io.tmpdir")};
+            return null;
         }
     }
 
@@ -116,7 +117,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
                 stateStore,
                 parallelism,
                 subtaskIndex,
-                new String[] {System.getProperty("java.io.tmpdir")});
+                null);
     }
 
     static Context createContext(
@@ -127,7 +128,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             StateStore stateStore,
             int parallelism,
             int subtaskIndex,
-            String[] tempDirs) {
+            @Nullable String[] tempDirs) {
         return new Committer.Context() {
             @Override
             public String commitUser() {
@@ -165,6 +166,7 @@ public interface Committer<CommitT, GlobalCommitT> extends AutoCloseable {
             }
 
             @Override
+            @Nullable
             public String[] tempDirs() {
                 return tempDirs;
             }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -134,6 +134,8 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         int index = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
 
         // parallelism of commit operator is always 1, so commitUser will never be null
+        org.apache.flink.runtime.io.disk.iomanager.IOManager flinkIOManager =
+                getContainingTask().getEnvironment().getIOManager();
         Committer.Context committerContext =
                 Committer.createContext(
                         commitUser,
@@ -142,7 +144,8 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                         context.isRestored(),
                         new OperatorBackendStateStore(context.getOperatorStateStore()),
                         parallelism,
-                        index);
+                        index,
+                        flinkIOManager.getSpillingDirectoriesPaths());
         committer = committerFactory.create(committerContext);
 
         committableStateManager.initializeState(committerContext, committer);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CommitterOperator.java
@@ -134,8 +134,6 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
         int index = RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext());
 
         // parallelism of commit operator is always 1, so commitUser will never be null
-        org.apache.flink.runtime.io.disk.iomanager.IOManager flinkIOManager =
-                getContainingTask().getEnvironment().getIOManager();
         Committer.Context committerContext =
                 Committer.createContext(
                         commitUser,
@@ -145,7 +143,10 @@ public class CommitterOperator<CommitT, GlobalCommitT> extends AbstractStreamOpe
                         new OperatorBackendStateStore(context.getOperatorStateStore()),
                         parallelism,
                         index,
-                        flinkIOManager.getSpillingDirectoriesPaths());
+                        getContainingTask()
+                                .getEnvironment()
+                                .getIOManager()
+                                .getSpillingDirectoriesPaths());
         committer = committerFactory.create(committerContext);
 
         committableStateManager.initializeState(committerContext, committer);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
 import org.apache.paimon.flink.sink.listener.CommitListeners;
 import org.apache.paimon.io.DataFileMeta;
@@ -45,6 +46,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     private final TableCommitImpl commit;
     @Nullable private final CommitterMetrics committerMetrics;
     private final CommitListeners commitListeners;
+    private final IOManager commitIOManager;
     private final boolean allowLogOffsetDuplicate;
 
     public StoreCommitter(FileStoreTable table, TableCommit commit, Context context) {
@@ -62,6 +64,9 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+
+        this.commitIOManager = IOManager.create(context.tempDirs());
+        this.commit.withIOManager(commitIOManager);
         allowLogOffsetDuplicate = table.bucketMode() == BucketMode.BUCKET_UNAWARE;
     }
 
@@ -132,8 +137,15 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
 
     @Override
     public void close() throws Exception {
-        commit.close();
-        commitListeners.close();
+        try {
+            commit.close();
+        } finally {
+            try {
+                commitListeners.close();
+            } finally {
+                commitIOManager.close();
+            }
+        }
     }
 
     public boolean allowLogOffsetDuplicate() {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/StoreCommitter.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.TableCommit;
 import org.apache.paimon.table.sink.TableCommitImpl;
+import org.apache.paimon.utils.IOUtils;
 
 import javax.annotation.Nullable;
 
@@ -46,7 +47,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
     private final TableCommitImpl commit;
     @Nullable private final CommitterMetrics committerMetrics;
     private final CommitListeners commitListeners;
-    private final IOManager commitIOManager;
+    @Nullable private final IOManager commitIOManager;
     private final boolean allowLogOffsetDuplicate;
 
     public StoreCommitter(FileStoreTable table, TableCommit commit, Context context) {
@@ -65,8 +66,13 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
             throw new RuntimeException(e);
         }
 
-        this.commitIOManager = IOManager.create(context.tempDirs());
-        this.commit.withIOManager(commitIOManager);
+        String[] tempDirs = context.tempDirs();
+        if (tempDirs == null) {
+            this.commitIOManager = null;
+        } else {
+            this.commitIOManager = IOManager.create(tempDirs);
+            this.commit.withIOManager(commitIOManager);
+        }
         allowLogOffsetDuplicate = table.bucketMode() == BucketMode.BUCKET_UNAWARE;
     }
 
@@ -137,15 +143,7 @@ public class StoreCommitter implements Committer<Committable, ManifestCommittabl
 
     @Override
     public void close() throws Exception {
-        try {
-            commit.close();
-        } finally {
-            try {
-                commitListeners.close();
-            } finally {
-                commitIOManager.close();
-            }
-        }
+        IOUtils.closeAll(commit, commitListeners, commitIOManager);
     }
 
     public boolean allowLogOffsetDuplicate() {


### PR DESCRIPTION
### Purpose

Improve manifest file sort compaction to avoid heap-heavy in-memory sorting for large manifest entries by introducing spillable external sorting. The change also propagates a Paimon IOManager through commit paths so manifest sort can use configured spill directories in Flink, while non-Flink/default contexts can keep IOManager creation local to the sorter.

### Tests

- mvn -pl paimon-core -Pfast-build -Dtest=ManifestFileMetaTest#testManifestSortUsesExternalIOManagerWithoutClosingIt test
- mvn -pl paimon-flink/paimon-flink-common -am -Pfast-build -DskipTests compile
- mvn -pl paimon-core,paimon-flink/paimon-flink-common -am -Pfast-build -DfailIfNoTests=false -Dtest=CommitterOperatorTest test
- mvn -pl paimon-core,paimon-flink/paimon-flink-common -am -Pfast-build -DfailIfNoTests=false -Dtest=StoreMultiCommitterTest test