### PR TITLE
[python] Reuse base entries on commit retry instead of full re-scan

### DIFF
--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -228,6 +228,71 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
         self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
 
+    def test_falls_back_to_full_scan_when_intermediate_snapshot_missing(self):
+        # A missing/expired intermediate snapshot -> read_incremental_changes
+        # returns None and the retry falls back to a full scan.
+        K = 1
+        missing_id = self.table.snapshot_manager().get_latest_snapshot().id + 1
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        full_scans = {'n': 0}
+        incr_results = []
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+
+        def spy_full(*a, **k):
+            full_scans['n'] += 1
+            return orig_full(*a, **k)
+
+        def spy_incr(*a, **k):
+            r = orig_incr(*a, **k)
+            incr_results.append(r)
+            return r
+
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+
+        # Only the scanner's lookups see missing_id as absent; the commit's own
+        # manager (bound earlier) is untouched.
+        real_mgr = fsc.commit_scanner.table.snapshot_manager()
+
+        class _Wrap:
+            def __getattr__(self, name):
+                return getattr(real_mgr, name)
+
+            def get_snapshot_by_id(self, i):
+                return None if i == missing_id else real_mgr.get_snapshot_by_id(i)
+
+        fsc.commit_scanner.table.snapshot_manager = lambda: _Wrap()
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [99], 'f1': ['x']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        # Incremental hit the missing snapshot and returned None, so the retry
+        # fell back to a full scan (first attempt + fallback = 2).
+        self.assertIn(None, incr_results)
+        self.assertEqual(full_scans['n'], 2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -15,18 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Regression test for conflict-detection scan reuse across commit retries.
+"""Conflict-detection base scan is reused across commit retries.
 
-When a commit detects conflicts, it reads the base entries of the changed
-partitions from the latest snapshot. Previously every retry re-ran that full
-scan (``read_all_entries_from_changed_partitions``), making each retry as
-expensive as the first under concurrent writers. Now the base entries from the
-previous attempt are reused and only the incremental changes committed since are
-read (``read_incremental_changes``).
-
-The test deterministically forces ``K`` conflicts, each advancing the latest
-snapshot with an append to an unrelated partition, and asserts the full scan
-runs once (not ``K + 1``) while the incremental read runs once per retry.
+The first attempt full-scans the changed partitions; later retries reuse that
+base and read only the incremental changes since (read_incremental_changes).
 """
 
 import os
@@ -49,28 +41,20 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.catalog.create_database("test_db", True)
 
         pa_schema = pa.schema([('f0', pa.int32()), ('f1', pa.string())])
-        # Static overwrite (dynamic-partition-overwrite=false) so the overwrite
-        # is scoped to the explicit partition f0=1.
+        # Static overwrite, scoped to the explicit partition f0=1.
         schema = Schema.from_pyarrow_schema(
-            pa_schema,
-            partition_keys=['f0'],
-            options={'dynamic-partition-overwrite': 'false'},
-        )
+            pa_schema, partition_keys=['f0'],
+            options={'dynamic-partition-overwrite': 'false'})
         self.catalog.create_table('test_db.t', schema, False)
         self.table = self.catalog.get_table('test_db.t')
 
-        # Seed base data: partition f0=1 is the overwrite target, f0=2 untouched.
+        # f0=1 is the overwrite target, f0=2 untouched.
         self._append(pd.DataFrame({'f0': [1, 1, 2], 'f1': ['a', 'b', 'c']}))
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def _append(self, df):
-        """A normal append commit on a fresh write builder.
-
-        Used both to seed data and, during the test, as the "concurrent writer"
-        that advances the latest snapshot between retries.
-        """
         wb = self.table.new_batch_write_builder()
         w = wb.new_write()
         c = wb.new_commit()
@@ -79,10 +63,32 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         w.close()
         c.close()
 
-    def test_conflict_scan_runs_once_not_once_per_retry(self):
-        K = 3  # force 3 conflicts; the 4th attempt wins
+    def _overwrite_target(self, f1_val):
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
 
-        # Build the overwrite of partition f0=1 (do not commit yet).
+    def _compact_target(self, f1_val):
+        # pypaimon has no compact API; produce a COMPACT-kind snapshot by running
+        # an overwrite of f0=1 but labelling the snapshot COMPACT.
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        tc = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
+        cfsc = tc.file_store_commit
+        orig_try = cfsc._try_commit
+        cfsc._try_commit = lambda commit_kind, *a, **k: orig_try("COMPACT", *a, **k)
+        tc.commit(w.prepare_commit())
+        w.close()
+        tc.close()
+
+    def test_conflict_scan_runs_once_not_once_per_retry(self):
+        K = 3
+
         wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
         w = wb.new_write()
         c = wb.new_commit()
@@ -90,8 +96,6 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         messages = w.prepare_commit()
 
         fsc = c.file_store_commit
-
-        # --- count the conflict-detection base scans -------------------------
         counts = {'full_scan': 0, 'incremental': 0}
         orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
         orig_incr = fsc.commit_scanner.read_incremental_changes
@@ -107,14 +111,12 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
         fsc.commit_scanner.read_incremental_changes = spy_incr
 
-        # --- inject K CAS conflicts ------------------------------------------
-        # Each forced failure first advances the latest snapshot via an append to
-        # an unrelated partition (f0=99), so retries face a genuinely newer
-        # snapshot (and a real incremental delta), then fails our CAS.
         orig_cas = fsc.snapshot_commit.commit
         cas = {'fails': 0}
 
         def patched_cas(snapshot, statistics):
+            # Each conflict appends to an unrelated partition (f0=99), advancing
+            # latest, then fails our CAS.
             if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
                 cas['fails'] += 1
                 self._append(pd.DataFrame({'f0': [99], 'f1': [f'x{cas["fails"]}']}))
@@ -123,29 +125,13 @@ class OverwriteCommitConflictTest(unittest.TestCase):
 
         fsc.snapshot_commit.commit = patched_cas
 
-        # --- run the overwrite commit ----------------------------------------
         c.commit(messages)
         c.close()
 
-        # Harness sanity: we really did force K conflicts and then converged.
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+        self.assertEqual(counts['full_scan'], 1)   # once, then incremental on retry
+        self.assertEqual(counts['incremental'], K)
 
-        print(f"\n[overwrite-conflict] K={K} conflicts -> "
-              f"full_scan={counts['full_scan']}, incremental={counts['incremental']} "
-              f"(target: full_scan=1, incremental=K)")
-
-        # The full base scan runs once; every retry reuses the previous base and
-        # reads only the incremental changes since.
-        self.assertEqual(
-            counts['full_scan'], 1,
-            f"read_all_entries_from_changed_partitions ran {counts['full_scan']}x; "
-            f"should run once and read incremental on retry")
-        self.assertEqual(
-            counts['incremental'], K,
-            f"read_incremental_changes ran {counts['incremental']}x; should run "
-            f"once per retry (= K = {K})")
-
-        # Sanity: f0=1 overwritten, f0=2 preserved, f0=99 appended K times.
         read_builder = self.table.new_read_builder()
         actual = read_builder.new_read().to_pandas(
             read_builder.new_scan().plan().splits())
@@ -154,8 +140,8 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(len(actual[actual['f0'] == 99]), K)
 
     def test_incremental_merge_when_concurrent_append_hits_target_partition(self):
-        # Concurrent appends hit the SAME partition being overwritten, so the
-        # incremental read is non-empty and must be merged into the reused base.
+        # Concurrent appends hit the target partition, so the incremental read is
+        # non-empty and must be merged into the reused base.
         K = 3
 
         wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
@@ -165,10 +151,9 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         messages = w.prepare_commit()
 
         fsc = c.file_store_commit
-
         full_scans = {'n': 0}
         incr_lengths = []
-        captured = []  # (latest_snapshot, base_entries, delta_entries) per check
+        captured = []
         orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
         orig_incr = fsc.commit_scanner.read_incremental_changes
         orig_check = fsc.conflict_detection.check_conflicts
@@ -206,22 +191,18 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         c.close()
 
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
-
-        # One full scan; each retry takes the incremental path with non-empty deltas.
         self.assertEqual(full_scans['n'], 1)
         self.assertEqual(len(incr_lengths), K)
         self.assertTrue(all(incr_lengths),
                         f"expected non-empty incremental on every retry, got {incr_lengths}")
 
-        # The incremental-merged base must equal a fresh full scan at that snapshot.
+        # The incremental-merged base must equal a fresh full scan.
         last_snapshot, merged_base, last_delta = captured[-1]
         full = orig_full(last_snapshot, last_delta)
         self.assertEqual(
             set(e.identifier() for e in merged_base),
-            set(e.identifier() for e in full),
-            "incremental-merged base must equal a full scan of the target partition")
+            set(e.identifier() for e in full))
 
-        # Overwrite wins: f0=1 is just 'new', f0=2 untouched.
         read_builder = self.table.new_read_builder()
         actual = read_builder.new_read().to_pandas(
             read_builder.new_scan().plan().splits())
@@ -229,8 +210,8 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
 
     def test_falls_back_to_full_scan_when_intermediate_snapshot_missing(self):
-        # A missing/expired intermediate snapshot -> read_incremental_changes
-        # returns None and the retry falls back to a full scan.
+        # A missing intermediate snapshot -> read_incremental_changes returns None
+        # and the retry falls back to a full scan.
         K = 1
         missing_id = self.table.snapshot_manager().get_latest_snapshot().id + 1
 
@@ -241,7 +222,6 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         messages = w.prepare_commit()
 
         fsc = c.file_store_commit
-
         full_scans = {'n': 0}
         incr_results = []
         orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
@@ -288,14 +268,18 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         c.close()
 
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
-        # Incremental hit the missing snapshot and returned None, so the retry
-        # fell back to a full scan (first attempt + fallback = 2).
-        self.assertIn(None, incr_results)
-        self.assertEqual(full_scans['n'], 2)
+        self.assertIn(None, incr_results)          # incremental bailed on missing
+        self.assertEqual(full_scans['n'], 2)       # first attempt + fallback
 
     def test_incremental_merge_across_non_append_snapshot(self):
-        # A non-APPEND (OVERWRITE) snapshot lands between retries; merging its
-        # delta (ADD+DELETE) must still yield a base equal to a fresh full scan.
+        self._assert_merge_equals_full_scan(self._overwrite_target)
+
+    def test_incremental_merge_across_compact_snapshot(self):
+        self._assert_merge_equals_full_scan(self._compact_target)
+
+    def _assert_merge_equals_full_scan(self, concurrent_fn):
+        # A non-APPEND snapshot (OVERWRITE/COMPACT, delta = ADD+DELETE) lands
+        # between retries; the merged base must still equal a fresh full scan.
         K = 2
 
         wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
@@ -305,7 +289,6 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         messages = w.prepare_commit()
 
         fsc = c.file_store_commit
-
         captured = []
         orig_check = fsc.conflict_detection.check_conflicts
         orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
@@ -322,8 +305,7 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         def patched_cas(snapshot, statistics):
             if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
                 cas['fails'] += 1
-                # Concurrent OVERWRITE of the target partition -> a non-APPEND snapshot.
-                self._overwrite_target(f'z{cas["fails"]}')
+                concurrent_fn(f'z{cas["fails"]}')
                 return False
             return orig_cas(snapshot, statistics)
 
@@ -334,28 +316,16 @@ class OverwriteCommitConflictTest(unittest.TestCase):
 
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
 
-        # Across OVERWRITE snapshots, the merged base on the final attempt must
-        # still equal a fresh full scan.
         last_snapshot, merged_base, last_delta = captured[-1]
         full = orig_full(last_snapshot, last_delta)
         self.assertEqual(
             set(e.identifier() for e in merged_base),
-            set(e.identifier() for e in full),
-            "merged base must equal a full scan even across non-APPEND snapshots")
+            set(e.identifier() for e in full))
 
         read_builder = self.table.new_read_builder()
         actual = read_builder.new_read().to_pandas(
             read_builder.new_scan().plan().splits())
         self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
-
-    def _overwrite_target(self, f1_val):
-        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
-        w = wb.new_write()
-        c = wb.new_commit()
-        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
-        c.commit(w.prepare_commit())
-        w.close()
-        c.close()
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -1,0 +1,178 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Regression test for overwrite-commit conflict retries.
+
+Reproduces the behaviour that makes a single OVERWRITE commit slow under
+concurrent writers: on every retry, pypaimon re-runs *two* full manifest
+scans of the changed partitions instead of reusing the previous attempt's
+work and reading only the incremental changes (as the Java side does).
+
+The test deterministically forces ``K`` commit conflicts (each one advances
+the latest snapshot via an external append to an unrelated partition, then
+makes our CAS fail) and counts how many times the two full scans run:
+
+  * ``_generate_overwrite_entries``            (computes the DELETE set)
+  * ``read_all_entries_from_changed_partitions`` (feeds conflict detection)
+
+Current behaviour:  each is called ``K + 1`` times (once per attempt).
+Target behaviour:   each is called exactly once; retries read only the
+                    incremental delta.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import pandas as pd
+import pyarrow as pa
+
+from pypaimon import CatalogFactory, Schema
+
+
+class OverwriteCommitConflictTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="ow_conflict_")
+        self.warehouse = os.path.join(self.temp_dir, 'wh')
+        self.catalog = CatalogFactory.create({"warehouse": self.warehouse})
+        self.catalog.create_database("test_db", True)
+
+        pa_schema = pa.schema([('f0', pa.int32()), ('f1', pa.string())])
+        # Static overwrite (dynamic-partition-overwrite=false) so the overwrite
+        # is scoped to the explicit partition f0=1.
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            partition_keys=['f0'],
+            options={'dynamic-partition-overwrite': 'false'},
+        )
+        self.catalog.create_table('test_db.t', schema, False)
+        self.table = self.catalog.get_table('test_db.t')
+
+        # Seed base data: partition f0=1 is the overwrite target, f0=2 untouched.
+        self._append(pd.DataFrame({'f0': [1, 1, 2], 'f1': ['a', 'b', 'c']}))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _append(self, df):
+        """A normal (non-overwrite) append commit on a fresh write builder.
+
+        Used both to seed data and, during the test, as the "concurrent
+        writer" that advances the latest snapshot between retries.
+        """
+        wb = self.table.new_batch_write_builder()
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(df)
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
+    def test_full_scan_runs_once_not_once_per_retry(self):
+        K = 3  # force 3 conflicts; the 4th attempt wins
+
+        # Build the overwrite of partition f0=1 (do not commit yet).
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        # --- spies -----------------------------------------------------------
+        # scan2_conflict: full conflict-detection scan (this PR / #4286 makes it
+        #                 run once, then reuse + incremental on retries).
+        # incremental:    the incremental read used on retries (new path).
+        # scan1_delete:   full overwrite-DELETE scan (out of scope here; still
+        #                 once-per-attempt until #7894 is ported).
+        counts = {'scan1_delete': 0, 'scan2_conflict': 0, 'incremental': 0}
+        orig_scan1 = fsc._generate_overwrite_entries
+        orig_scan2 = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+
+        def spy_scan1(*a, **k):
+            counts['scan1_delete'] += 1
+            return orig_scan1(*a, **k)
+
+        def spy_scan2(*a, **k):
+            counts['scan2_conflict'] += 1
+            return orig_scan2(*a, **k)
+
+        def spy_incr(*a, **k):
+            counts['incremental'] += 1
+            return orig_incr(*a, **k)
+
+        fsc._generate_overwrite_entries = spy_scan1
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_scan2
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+
+        # --- inject K CAS conflicts ------------------------------------------
+        # Each forced failure first advances the latest snapshot via an append
+        # to an unrelated partition (f0=99), so retries face a genuinely newer
+        # snapshot (and thus a real incremental delta), then fails our CAS.
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [99], 'f1': [f'x{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        # --- run the overwrite commit ----------------------------------------
+        c.commit(messages)
+        c.close()
+
+        # Harness sanity: we really did force K conflicts and then converged.
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        print(f"\n[overwrite-conflict] K={K} conflicts -> "
+              f"scan2_conflict={counts['scan2_conflict']}, "
+              f"incremental={counts['incremental']}, "
+              f"scan1_delete={counts['scan1_delete']} (PR2 territory)")
+
+        # #4286: the full conflict-detection scan runs once; every retry reuses
+        # the previous base entries and only reads the incremental changes.
+        self.assertEqual(
+            counts['scan2_conflict'], 1,
+            f"read_all_entries_from_changed_partitions ran "
+            f"{counts['scan2_conflict']}x; should run once and read incremental "
+            f"on retry")
+        self.assertEqual(
+            counts['incremental'], K,
+            f"read_incremental_changes ran {counts['incremental']}x; should run "
+            f"once per retry (= K = {K})")
+
+        # Sanity: the overwrite still produced the correct table (f0=1 overwritten,
+        # f0=2 preserved, f0=99 appended by the simulated concurrent writer).
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits()).sort_values(
+            by=['f0', 'f1']).reset_index(drop=True)
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+        self.assertEqual(len(actual[actual['f0'] == 99]), K)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -293,6 +293,70 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertIn(None, incr_results)
         self.assertEqual(full_scans['n'], 2)
 
+    def test_incremental_merge_across_non_append_snapshot(self):
+        # A non-APPEND (OVERWRITE) snapshot lands between retries; merging its
+        # delta (ADD+DELETE) must still yield a base equal to a fresh full scan.
+        K = 2
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        captured = []
+        orig_check = fsc.conflict_detection.check_conflicts
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+
+        def spy_check(latest_snapshot, base_entries, delta_entries, *a, **k):
+            captured.append((latest_snapshot, list(base_entries), list(delta_entries)))
+            return orig_check(latest_snapshot, base_entries, delta_entries, *a, **k)
+
+        fsc.conflict_detection.check_conflicts = spy_check
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                # Concurrent OVERWRITE of the target partition -> a non-APPEND snapshot.
+                self._overwrite_target(f'z{cas["fails"]}')
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        # Across OVERWRITE snapshots, the merged base on the final attempt must
+        # still equal a fresh full scan.
+        last_snapshot, merged_base, last_delta = captured[-1]
+        full = orig_full(last_snapshot, last_delta)
+        self.assertEqual(
+            set(e.identifier() for e in merged_base),
+            set(e.identifier() for e in full),
+            "merged base must equal a full scan even across non-APPEND snapshots")
+
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+
+    def _overwrite_target(self, f1_val):
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': [f1_val]}))
+        c.commit(w.prepare_commit())
+        w.close()
+        c.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -153,6 +153,81 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
         self.assertEqual(len(actual[actual['f0'] == 99]), K)
 
+    def test_incremental_merge_when_concurrent_append_hits_target_partition(self):
+        # Concurrent appends hit the SAME partition being overwritten, so the
+        # incremental read is non-empty and must be merged into the reused base.
+        K = 3
+
+        wb = self.table.new_batch_write_builder().overwrite({'f0': 1})
+        w = wb.new_write()
+        c = wb.new_commit()
+        w.write_pandas(pd.DataFrame({'f0': [1], 'f1': ['new']}))
+        messages = w.prepare_commit()
+
+        fsc = c.file_store_commit
+
+        full_scans = {'n': 0}
+        incr_lengths = []
+        captured = []  # (latest_snapshot, base_entries, delta_entries) per check
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        orig_incr = fsc.commit_scanner.read_incremental_changes
+        orig_check = fsc.conflict_detection.check_conflicts
+
+        def spy_full(*a, **k):
+            full_scans['n'] += 1
+            return orig_full(*a, **k)
+
+        def spy_incr(*a, **k):
+            r = orig_incr(*a, **k)
+            incr_lengths.append(None if r is None else len(r))
+            return r
+
+        def spy_check(latest_snapshot, base_entries, delta_entries, *a, **k):
+            captured.append((latest_snapshot, list(base_entries), list(delta_entries)))
+            return orig_check(latest_snapshot, base_entries, delta_entries, *a, **k)
+
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
+        fsc.commit_scanner.read_incremental_changes = spy_incr
+        fsc.conflict_detection.check_conflicts = spy_check
+
+        orig_cas = fsc.snapshot_commit.commit
+        cas = {'fails': 0}
+
+        def patched_cas(snapshot, statistics):
+            if snapshot.commit_kind == "OVERWRITE" and cas['fails'] < K:
+                cas['fails'] += 1
+                self._append(pd.DataFrame({'f0': [1], 'f1': [f'y{cas["fails"]}']}))
+                return False
+            return orig_cas(snapshot, statistics)
+
+        fsc.snapshot_commit.commit = patched_cas
+
+        c.commit(messages)
+        c.close()
+
+        self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
+
+        # One full scan; each retry takes the incremental path with non-empty deltas.
+        self.assertEqual(full_scans['n'], 1)
+        self.assertEqual(len(incr_lengths), K)
+        self.assertTrue(all(incr_lengths),
+                        f"expected non-empty incremental on every retry, got {incr_lengths}")
+
+        # The incremental-merged base must equal a fresh full scan at that snapshot.
+        last_snapshot, merged_base, last_delta = captured[-1]
+        full = orig_full(last_snapshot, last_delta)
+        self.assertEqual(
+            set(e.identifier() for e in merged_base),
+            set(e.identifier() for e in full),
+            "incremental-merged base must equal a full scan of the target partition")
+
+        # Overwrite wins: f0=1 is just 'new', f0=2 untouched.
+        read_builder = self.table.new_read_builder()
+        actual = read_builder.new_read().to_pandas(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
+        self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_commit_conflict_test.py
@@ -15,23 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Regression test for overwrite-commit conflict retries.
+"""Regression test for conflict-detection scan reuse across commit retries.
 
-Reproduces the behaviour that makes a single OVERWRITE commit slow under
-concurrent writers: on every retry, pypaimon re-runs *two* full manifest
-scans of the changed partitions instead of reusing the previous attempt's
-work and reading only the incremental changes (as the Java side does).
+When a commit detects conflicts, it reads the base entries of the changed
+partitions from the latest snapshot. Previously every retry re-ran that full
+scan (``read_all_entries_from_changed_partitions``), making each retry as
+expensive as the first under concurrent writers. Now the base entries from the
+previous attempt are reused and only the incremental changes committed since are
+read (``read_incremental_changes``).
 
-The test deterministically forces ``K`` commit conflicts (each one advances
-the latest snapshot via an external append to an unrelated partition, then
-makes our CAS fail) and counts how many times the two full scans run:
-
-  * ``_generate_overwrite_entries``            (computes the DELETE set)
-  * ``read_all_entries_from_changed_partitions`` (feeds conflict detection)
-
-Current behaviour:  each is called ``K + 1`` times (once per attempt).
-Target behaviour:   each is called exactly once; retries read only the
-                    incremental delta.
+The test deterministically forces ``K`` conflicts, each advancing the latest
+snapshot with an append to an unrelated partition, and asserts the full scan
+runs once (not ``K + 1``) while the incremental read runs once per retry.
 """
 
 import os
@@ -71,10 +66,10 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def _append(self, df):
-        """A normal (non-overwrite) append commit on a fresh write builder.
+        """A normal append commit on a fresh write builder.
 
-        Used both to seed data and, during the test, as the "concurrent
-        writer" that advances the latest snapshot between retries.
+        Used both to seed data and, during the test, as the "concurrent writer"
+        that advances the latest snapshot between retries.
         """
         wb = self.table.new_batch_write_builder()
         w = wb.new_write()
@@ -84,7 +79,7 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         w.close()
         c.close()
 
-    def test_full_scan_runs_once_not_once_per_retry(self):
+    def test_conflict_scan_runs_once_not_once_per_retry(self):
         K = 3  # force 3 conflicts; the 4th attempt wins
 
         # Build the overwrite of partition f0=1 (do not commit yet).
@@ -96,37 +91,26 @@ class OverwriteCommitConflictTest(unittest.TestCase):
 
         fsc = c.file_store_commit
 
-        # --- spies -----------------------------------------------------------
-        # scan2_conflict: full conflict-detection scan (this PR / #4286 makes it
-        #                 run once, then reuse + incremental on retries).
-        # incremental:    the incremental read used on retries (new path).
-        # scan1_delete:   full overwrite-DELETE scan (out of scope here; still
-        #                 once-per-attempt until #7894 is ported).
-        counts = {'scan1_delete': 0, 'scan2_conflict': 0, 'incremental': 0}
-        orig_scan1 = fsc._generate_overwrite_entries
-        orig_scan2 = fsc.commit_scanner.read_all_entries_from_changed_partitions
+        # --- count the conflict-detection base scans -------------------------
+        counts = {'full_scan': 0, 'incremental': 0}
+        orig_full = fsc.commit_scanner.read_all_entries_from_changed_partitions
         orig_incr = fsc.commit_scanner.read_incremental_changes
 
-        def spy_scan1(*a, **k):
-            counts['scan1_delete'] += 1
-            return orig_scan1(*a, **k)
-
-        def spy_scan2(*a, **k):
-            counts['scan2_conflict'] += 1
-            return orig_scan2(*a, **k)
+        def spy_full(*a, **k):
+            counts['full_scan'] += 1
+            return orig_full(*a, **k)
 
         def spy_incr(*a, **k):
             counts['incremental'] += 1
             return orig_incr(*a, **k)
 
-        fsc._generate_overwrite_entries = spy_scan1
-        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_scan2
+        fsc.commit_scanner.read_all_entries_from_changed_partitions = spy_full
         fsc.commit_scanner.read_incremental_changes = spy_incr
 
         # --- inject K CAS conflicts ------------------------------------------
-        # Each forced failure first advances the latest snapshot via an append
-        # to an unrelated partition (f0=99), so retries face a genuinely newer
-        # snapshot (and thus a real incremental delta), then fails our CAS.
+        # Each forced failure first advances the latest snapshot via an append to
+        # an unrelated partition (f0=99), so retries face a genuinely newer
+        # snapshot (and a real incremental delta), then fails our CAS.
         orig_cas = fsc.snapshot_commit.commit
         cas = {'fails': 0}
 
@@ -147,28 +131,24 @@ class OverwriteCommitConflictTest(unittest.TestCase):
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
 
         print(f"\n[overwrite-conflict] K={K} conflicts -> "
-              f"scan2_conflict={counts['scan2_conflict']}, "
-              f"incremental={counts['incremental']}, "
-              f"scan1_delete={counts['scan1_delete']} (PR2 territory)")
+              f"full_scan={counts['full_scan']}, incremental={counts['incremental']} "
+              f"(target: full_scan=1, incremental=K)")
 
-        # #4286: the full conflict-detection scan runs once; every retry reuses
-        # the previous base entries and only reads the incremental changes.
+        # The full base scan runs once; every retry reuses the previous base and
+        # reads only the incremental changes since.
         self.assertEqual(
-            counts['scan2_conflict'], 1,
-            f"read_all_entries_from_changed_partitions ran "
-            f"{counts['scan2_conflict']}x; should run once and read incremental "
-            f"on retry")
+            counts['full_scan'], 1,
+            f"read_all_entries_from_changed_partitions ran {counts['full_scan']}x; "
+            f"should run once and read incremental on retry")
         self.assertEqual(
             counts['incremental'], K,
             f"read_incremental_changes ran {counts['incremental']}x; should run "
             f"once per retry (= K = {K})")
 
-        # Sanity: the overwrite still produced the correct table (f0=1 overwritten,
-        # f0=2 preserved, f0=99 appended by the simulated concurrent writer).
+        # Sanity: f0=1 overwritten, f0=2 preserved, f0=99 appended K times.
         read_builder = self.table.new_read_builder()
         actual = read_builder.new_read().to_pandas(
-            read_builder.new_scan().plan().splits()).sort_values(
-            by=['f0', 'f1']).reset_index(drop=True)
+            read_builder.new_scan().plan().splits())
         self.assertEqual(sorted(actual[actual['f0'] == 1]['f1'].tolist()), ['new'])
         self.assertEqual(sorted(actual[actual['f0'] == 2]['f1'].tolist()), ['c'])
         self.assertEqual(len(actual[actual['f0'] == 99]), K)

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -97,16 +97,21 @@ class CommitScanner:
         ).read_manifest_entries(delta_manifests)
 
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot: Snapshot,
-                                                             commit_entries: List[ManifestEntry]):
+                                                             commit_entries: List[ManifestEntry],
+                                                             partition_filter=None):
         """Like ``read_incremental_entries_from_changed_partitions`` but
         preserves DELETE entries (kind=1). The regular method funnels through
         ``read_entries_parallel`` which discards standalone DELETEs.
+
+        ``partition_filter`` may be passed to avoid rebuilding it per call;
+        built from ``commit_entries`` if None.
         """
         delta_manifests = self.manifest_list_manager.read_delta(snapshot)
         if not delta_manifests:
             return []
 
-        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        if partition_filter is None:
+            partition_filter = self._build_partition_filter_from_entries(commit_entries)
         mfm = ManifestFileManager(self.table)
         entries = []
         for mf in delta_manifests:
@@ -127,13 +132,18 @@ class CommitScanner:
         ``CommitScanner#readIncrementalChanges``.
         """
         snapshot_manager = self.table.snapshot_manager()
+        partition_filter = self._build_partition_filter_from_entries(commit_entries)
         entries = []
         for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
             snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
             if snapshot is None:
-                continue
+                # Skipping would silently drop concurrent changes; fail loudly.
+                raise RuntimeError(
+                    f"Snapshot #{snapshot_id} is missing while reading incremental "
+                    f"changes between #{from_snapshot.id} and #{to_snapshot.id}.")
             entries.extend(
-                self.read_incremental_raw_entries_from_changed_partitions(snapshot, commit_entries))
+                self.read_incremental_raw_entries_from_changed_partitions(
+                    snapshot, commit_entries, partition_filter))
         return entries
 
     def _build_partition_filter_from_entries(self, entries: List[ManifestEntry]):

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -99,12 +99,9 @@ class CommitScanner:
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot: Snapshot,
                                                              commit_entries: List[ManifestEntry],
                                                              partition_filter=None):
-        """Like ``read_incremental_entries_from_changed_partitions`` but
-        preserves DELETE entries (kind=1). The regular method funnels through
-        ``read_entries_parallel`` which discards standalone DELETEs.
-
-        ``partition_filter`` may be passed to avoid rebuilding it per call;
-        built from ``commit_entries`` if None.
+        """Like ``read_incremental_entries_from_changed_partitions`` but preserves
+        DELETE entries (kind=1). ``partition_filter`` may be passed to avoid
+        rebuilding it per call.
         """
         delta_manifests = self.manifest_list_manager.read_delta(snapshot)
         if not delta_manifests:
@@ -123,17 +120,10 @@ class CommitScanner:
 
     def read_incremental_changes(self, from_snapshot: Snapshot, to_snapshot: Snapshot,
                                  commit_entries: List[ManifestEntry]) -> Optional[List[ManifestEntry]]:
-        """Read delta entries (including DELETEs) for snapshots in the range
-        ``(from_snapshot, to_snapshot]``, filtered to the changed partitions.
-
-        Lets a commit retry reuse the base entries computed by the previous
-        attempt and only read what concurrent writers committed since, instead
-        of re-scanning the whole changed partitions. Mirrors Java
-        ``CommitScanner#readIncrementalChanges``.
-
-        Returns None if an intermediate snapshot is missing/expired, since the
-        reconstructed base would not be equivalent to ``to_snapshot``; the caller
-        should then fall back to a full scan.
+        """Delta entries (incl. DELETEs) in ``(from_snapshot, to_snapshot]``,
+        changed-partition filtered, so a retry can reuse the prior base and read
+        only the changes since. Returns None on a missing snapshot (caller then
+        full-scans). Mirrors Java ``CommitScanner#readIncrementalChanges``.
         """
         snapshot_manager = self.table.snapshot_manager()
         partition_filter = self._build_partition_filter_from_entries(commit_entries)

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -130,6 +130,10 @@ class CommitScanner:
         attempt and only read what concurrent writers committed since, instead
         of re-scanning the whole changed partitions. Mirrors Java
         ``CommitScanner#readIncrementalChanges``.
+
+        Returns None if an intermediate snapshot is missing/expired, since the
+        reconstructed base would not be equivalent to ``to_snapshot``; the caller
+        should then fall back to a full scan.
         """
         snapshot_manager = self.table.snapshot_manager()
         partition_filter = self._build_partition_filter_from_entries(commit_entries)
@@ -137,10 +141,7 @@ class CommitScanner:
         for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
             snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
             if snapshot is None:
-                # Skipping would silently drop concurrent changes; fail loudly.
-                raise RuntimeError(
-                    f"Snapshot #{snapshot_id} is missing while reading incremental "
-                    f"changes between #{from_snapshot.id} and #{to_snapshot.id}.")
+                return None
             entries.extend(
                 self.read_incremental_raw_entries_from_changed_partitions(
                     snapshot, commit_entries, partition_filter))

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -122,7 +122,7 @@ class CommitScanner:
         return entries
 
     def read_incremental_changes(self, from_snapshot: Snapshot, to_snapshot: Snapshot,
-                                 commit_entries: List[ManifestEntry]):
+                                 commit_entries: List[ManifestEntry]) -> Optional[List[ManifestEntry]]:
         """Read delta entries (including DELETEs) for snapshots in the range
         ``(from_snapshot, to_snapshot]``, filtered to the changed partitions.
 

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -116,6 +116,26 @@ class CommitScanner:
                 entries.append(entry)
         return entries
 
+    def read_incremental_changes(self, from_snapshot: Snapshot, to_snapshot: Snapshot,
+                                 commit_entries: List[ManifestEntry]):
+        """Read delta entries (including DELETEs) for snapshots in the range
+        ``(from_snapshot, to_snapshot]``, filtered to the changed partitions.
+
+        Lets a commit retry reuse the base entries computed by the previous
+        attempt and only read what concurrent writers committed since, instead
+        of re-scanning the whole changed partitions. Mirrors Java
+        ``CommitScanner#readIncrementalChanges``.
+        """
+        snapshot_manager = self.table.snapshot_manager()
+        entries = []
+        for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
+            snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is None:
+                continue
+            entries.extend(
+                self.read_incremental_raw_entries_from_changed_partitions(snapshot, commit_entries))
+        return entries
+
     def _build_partition_filter_from_entries(self, entries: List[ManifestEntry]):
         """Build a partition predicate that matches all partitions present in the given entries.
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -27,6 +27,7 @@ from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_file_merger import ManifestFileMerger
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.manifest.schema.file_entry import FileEntry
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
@@ -63,9 +64,15 @@ class SuccessResult(CommitResult):
 
 class RetryResult(CommitResult):
 
-    def __init__(self, latest_snapshot, exception: Optional[Exception] = None):
+    def __init__(self, latest_snapshot, exception: Optional[Exception] = None,
+                 base_data_files: Optional[List[ManifestEntry]] = None):
         self.latest_snapshot = latest_snapshot
         self.exception = exception
+        # Base entries of the changed partitions as of ``latest_snapshot``,
+        # computed during the failed attempt. Carried forward so the next
+        # attempt can reuse them and only read the incremental changes since
+        # then, instead of re-scanning the whole partition.
+        self.base_data_files = base_data_files
 
     def is_success(self) -> bool:
         return False
@@ -374,16 +381,34 @@ class FileStoreCommit:
         # process snapshot
         new_snapshot_id = latest_snapshot.id + 1 if latest_snapshot else 1
 
-        # Conflict detection: read base entries from latest snapshot, then check conflicts
+        # Conflict detection: build the base entries of the changed partitions, then
+        # check conflicts. On a retry we reuse the base entries computed by the previous
+        # attempt and only read the incremental changes committed since, instead of
+        # re-scanning the whole changed partitions every time (mirrors Java
+        # FileStoreCommitImpl conflict handling).
+        base_data_files = None
         if detect_conflicts and latest_snapshot is not None:
-            base_entries = self.commit_scanner.read_all_entries_from_changed_partitions(
-                latest_snapshot, commit_entries)
+            if (retry_result is not None
+                    and retry_result.latest_snapshot is not None
+                    and retry_result.base_data_files is not None):
+                base_data_files = list(retry_result.base_data_files)
+                incremental = self.commit_scanner.read_incremental_changes(
+                    retry_result.latest_snapshot, latest_snapshot, commit_entries)
+                if incremental:
+                    base_data_files.extend(incremental)
+                    base_data_files = FileEntry.merge_entries(base_data_files)
+            else:
+                base_data_files = self.commit_scanner.read_all_entries_from_changed_partitions(
+                    latest_snapshot, commit_entries)
+
             conflict_exception = self.conflict_detection.check_conflicts(
-                latest_snapshot, base_entries, commit_entries, commit_kind)
+                latest_snapshot, base_data_files, commit_entries, commit_kind)
 
             if conflict_exception is not None:
                 if allow_rollback and self.rollback is not None:
                     if self.rollback.try_to_rollback(latest_snapshot):
+                        # Rolled back: the table state changed, so the base entries are no
+                        # longer valid for reuse; do not carry them to the next attempt.
                         return RetryResult(latest_snapshot, conflict_exception)
                 raise conflict_exception
 
@@ -492,11 +517,11 @@ class FileStoreCommit:
                         commit_kind,
                         commit_time_s,
                     )
-                    return RetryResult(latest_snapshot, None)
+                    return RetryResult(latest_snapshot, None, base_data_files=base_data_files)
         except Exception as e:
             # Commit exception, not sure about the situation and should not clean up the files
             logger.warning("Retry commit for exception.", exc_info=True)
-            return RetryResult(latest_snapshot, e)
+            return RetryResult(latest_snapshot, e, base_data_files=base_data_files)
 
         logger.info(
             "Successfully commit snapshot %d to table %s by user %s "

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -385,16 +385,20 @@ class FileStoreCommit:
         # attempt's base + read only the incremental changes (mirrors Java).
         base_data_files = None
         if detect_conflicts and latest_snapshot is not None:
+            incremental = None
             if (retry_result is not None
                     and retry_result.latest_snapshot is not None
                     and retry_result.base_data_files is not None):
-                base_data_files = list(retry_result.base_data_files)
                 incremental = self.commit_scanner.read_incremental_changes(
                     retry_result.latest_snapshot, latest_snapshot, commit_entries)
+            if incremental is not None:
+                base_data_files = list(retry_result.base_data_files)
                 if incremental:
                     base_data_files.extend(incremental)
                     base_data_files = FileEntry.merge_entries(base_data_files)
             else:
+                # First attempt, or incremental could not be built (missing
+                # snapshot): scan the changed partitions in full.
                 base_data_files = self.commit_scanner.read_all_entries_from_changed_partitions(
                     latest_snapshot, commit_entries)
 

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -68,10 +68,8 @@ class RetryResult(CommitResult):
                  base_data_files: Optional[List[ManifestEntry]] = None):
         self.latest_snapshot = latest_snapshot
         self.exception = exception
-        # Base entries of the changed partitions as of ``latest_snapshot``,
-        # computed during the failed attempt. Carried forward so the next
-        # attempt can reuse them and only read the incremental changes since
-        # then, instead of re-scanning the whole partition.
+        # Base entries as of latest_snapshot, carried so the next attempt reuses
+        # them and reads only the incremental changes.
         self.base_data_files = base_data_files
 
     def is_success(self) -> bool:

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -381,11 +381,8 @@ class FileStoreCommit:
         # process snapshot
         new_snapshot_id = latest_snapshot.id + 1 if latest_snapshot else 1
 
-        # Conflict detection: build the base entries of the changed partitions, then
-        # check conflicts. On a retry we reuse the base entries computed by the previous
-        # attempt and only read the incremental changes committed since, instead of
-        # re-scanning the whole changed partitions every time (mirrors Java
-        # FileStoreCommitImpl conflict handling).
+        # Base entries for conflict detection. On retry, reuse the previous
+        # attempt's base + read only the incremental changes (mirrors Java).
         base_data_files = None
         if detect_conflicts and latest_snapshot is not None:
             if (retry_result is not None
@@ -407,9 +404,9 @@ class FileStoreCommit:
             if conflict_exception is not None:
                 if allow_rollback and self.rollback is not None:
                     if self.rollback.try_to_rollback(latest_snapshot):
-                        # Rolled back: the table state changed, so the base entries are no
-                        # longer valid for reuse; do not carry them to the next attempt.
-                        return RetryResult(latest_snapshot, conflict_exception)
+                        # Rolled back: base/snapshot no longer valid; next attempt
+                        # re-scans from scratch (matches Java RollbackRetryResult).
+                        return RetryResult(None, conflict_exception)
                 raise conflict_exception
 
         # Apply row tracking logic after conflict detection (matches Java ordering)


### PR DESCRIPTION

### Purpose

### Tests
