### PR TITLE
[api] Avoid overflow in VectorType default size

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/types/VectorType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/VectorType.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.types;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.utils.MathUtils;
 import org.apache.paimon.utils.Preconditions;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -95,7 +96,7 @@ public class VectorType extends DataType {
 
     @Override
     public int defaultSize() {
-        return elementType.defaultSize() * length;
+        return MathUtils.multiplySafely(elementType.defaultSize(), length);
     }
 
     @Override

--- a/paimon-api/src/test/java/org/apache/paimon/types/VectorTypeTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/types/VectorTypeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link VectorType}. */
+class VectorTypeTest {
+
+    @Test
+    void testDefaultSize() {
+        assertThat(DataTypes.VECTOR(3, DataTypes.FLOAT()).defaultSize()).isEqualTo(12);
+        assertThat(DataTypes.VECTOR(2, DataTypes.DOUBLE()).defaultSize()).isEqualTo(16);
+    }
+
+    @Test
+    void testDefaultSizeOverflowReturnsMaxValue() {
+        assertThat(DataTypes.VECTOR(Integer.MAX_VALUE, DataTypes.FLOAT()).defaultSize())
+                .isEqualTo(Integer.MAX_VALUE);
+        assertThat(DataTypes.VECTOR(Integer.MAX_VALUE, DataTypes.DOUBLE()).defaultSize())
+                .isEqualTo(Integer.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
### Purpose

`VectorType.defaultSize()` previously multiplied the element default size by the vector length using int arithmetic. For very large vector lengths, this could overflow and return a negative size estimate.

This PR uses `MathUtils.multiplySafely` to cap overflow at `Integer.MAX_VALUE` and keep size estimation valid.

### Tests

  - `mvn -pl paimon-api -Pfast-build -Dtest=VectorTypeTest test`
  - `mvn -pl paimon-api -Pfast-build -DskipTests compile`
  - `mvn -pl paimon-api -Dtest=VectorTypeTest test`