### PR TITLE
[docs] Update release 1.4 docs version to 1.4.2

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,7 +34,7 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "1.4.1"
+  Version = "1.4.2"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version


### PR DESCRIPTION
Update the release 1.4 documentation version from 1.4.1 to 1.4.2 so the published docs page shows the latest patch release.\n\nTests: Not run; documentation configuration only.