### PR TITLE
[vector] Fix partition filter handling in vector search

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
@@ -24,11 +24,15 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.Pair;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicate;
+import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
@@ -52,20 +56,39 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public BatchVectorSearchBuilder withPartitionFilter(PartitionPredicate partitionFilter) {
-        this.partitionFilter = partitionFilter;
+        addPartitionFilter(partitionFilter);
         return this;
     }
 
     @Override
     public BatchVectorSearchBuilder withFilter(Predicate predicate) {
-        if (this.filter == null) {
-            this.filter = predicate;
-        } else {
-            this.filter = PredicateBuilder.and(this.filter, predicate);
+        Pair<Optional<PartitionPredicate>, List<Predicate>> pair =
+                splitPartitionPredicatesAndDataPredicates(
+                        predicate, table.rowType(), table.partitionKeys());
+        if (pair.getLeft().isPresent()) {
+            addPartitionFilter(pair.getLeft().get());
         }
-        splitPartitionPredicate(predicate, table.rowType(), table.partitionKeys())
-                .ifPresent(value -> this.partitionFilter = value);
+        if (!pair.getRight().isEmpty()) {
+            Predicate dataFilter = PredicateBuilder.and(pair.getRight());
+            if (this.filter == null) {
+                this.filter = dataFilter;
+            } else {
+                this.filter = PredicateBuilder.and(this.filter, dataFilter);
+            }
+        }
         return this;
+    }
+
+    private void addPartitionFilter(PartitionPredicate partitionFilter) {
+        if (partitionFilter == null) {
+            return;
+        }
+        if (this.partitionFilter == null) {
+            this.partitionFilter = partitionFilter;
+        } else {
+            this.partitionFilter =
+                    PartitionPredicate.and(Arrays.asList(this.partitionFilter, partitionFilter));
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -24,11 +24,15 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.Pair;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicate;
+import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /** Implementation for {@link VectorSearchBuilder}. */
@@ -51,20 +55,39 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
 
     @Override
     public VectorSearchBuilder withPartitionFilter(PartitionPredicate partitionFilter) {
-        this.partitionFilter = partitionFilter;
+        addPartitionFilter(partitionFilter);
         return this;
     }
 
     @Override
     public VectorSearchBuilder withFilter(Predicate predicate) {
-        if (this.filter == null) {
-            this.filter = predicate;
-        } else {
-            this.filter = PredicateBuilder.and(this.filter, predicate);
+        Pair<Optional<PartitionPredicate>, List<Predicate>> pair =
+                splitPartitionPredicatesAndDataPredicates(
+                        predicate, table.rowType(), table.partitionKeys());
+        if (pair.getLeft().isPresent()) {
+            addPartitionFilter(pair.getLeft().get());
         }
-        splitPartitionPredicate(predicate, table.rowType(), table.partitionKeys())
-                .ifPresent(value -> this.partitionFilter = value);
+        if (!pair.getRight().isEmpty()) {
+            Predicate dataFilter = PredicateBuilder.and(pair.getRight());
+            if (this.filter == null) {
+                this.filter = dataFilter;
+            } else {
+                this.filter = PredicateBuilder.and(this.filter, dataFilter);
+            }
+        }
         return this;
+    }
+
+    private void addPartitionFilter(PartitionPredicate partitionFilter) {
+        if (partitionFilter == null) {
+            return;
+        }
+        if (this.partitionFilter == null) {
+            this.partitionFilter = partitionFilter;
+        } else {
+            this.partitionFilter =
+                    PartitionPredicate.and(Arrays.asList(this.partitionFilter, partitionFilter));
+        }
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -680,6 +680,129 @@ public class VectorSearchBuilderTest extends TableTestBase {
     }
 
     @Test
+    public void testVectorSearchPartitionFilterAndExtractedFilterAreConjunctive() throws Exception {
+        catalog.createTable(
+                identifier("partitioned_filter_table"),
+                withVectorSchemaOptions(
+                                Schema.newBuilder()
+                                        .column("pt", DataTypes.INT())
+                                        .column("id", DataTypes.INT())
+                                        .column(VECTOR_FIELD_NAME, new ArrayType(DataTypes.FLOAT()))
+                                        .partitionKeys("pt"))
+                        .build(),
+                false);
+        FileStoreTable table = getTable(identifier("partitioned_filter_table"));
+
+        float[][] pt1Vectors = {{1.0f, 0.0f}, {0.95f, 0.1f}};
+        float[][] pt2Vectors = {{0.0f, 1.0f}, {0.1f, 0.95f}};
+
+        writePartitionedVectors(table, 1, pt1Vectors);
+        writePartitionedVectors(table, 2, pt2Vectors);
+
+        RowType partitionType = RowType.of(DataTypes.INT());
+        InternalRowSerializer serializer = new InternalRowSerializer(partitionType);
+        BinaryRow partition1 = serializer.toBinaryRow(GenericRow.of(1)).copy();
+        BinaryRow partition2 = serializer.toBinaryRow(GenericRow.of(2)).copy();
+
+        buildAndCommitPartitionedIndex(table, pt1Vectors, partition1, new Range(0, 1));
+        buildAndCommitPartitionedIndex(table, pt2Vectors, partition2, new Range(2, 3));
+
+        PartitionPredicate partitionFilter =
+                PartitionPredicate.fromMultiple(
+                        partitionType, Collections.singletonList(partition1));
+        Predicate matchingPartitionFilter = new PredicateBuilder(table.rowType()).equal(0, 1);
+        Predicate extractedPartitionFilter = new PredicateBuilder(table.rowType()).equal(0, 2);
+
+        VectorScan.Plan plan =
+                table.newVectorSearchBuilder()
+                        .withPartitionFilter(partitionFilter)
+                        .withFilter(extractedPartitionFilter)
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(plan.splits()).isEmpty();
+
+        VectorScan.Plan reverseOrderPlan =
+                table.newVectorSearchBuilder()
+                        .withFilter(extractedPartitionFilter)
+                        .withPartitionFilter(partitionFilter)
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(reverseOrderPlan.splits()).isEmpty();
+
+        VectorScan.Plan batchPlan =
+                table.newBatchVectorSearchBuilder()
+                        .withPartitionFilter(partitionFilter)
+                        .withFilter(extractedPartitionFilter)
+                        .withVectors(new float[][] {new float[] {1.0f, 0.0f}})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(batchPlan.splits()).isEmpty();
+
+        VectorScan.Plan reverseOrderBatchPlan =
+                table.newBatchVectorSearchBuilder()
+                        .withFilter(extractedPartitionFilter)
+                        .withPartitionFilter(partitionFilter)
+                        .withVectors(new float[][] {new float[] {1.0f, 0.0f}})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(reverseOrderBatchPlan.splits()).isEmpty();
+
+        GlobalIndexResult matchingResult =
+                table.newVectorSearchBuilder()
+                        .withFilter(matchingPartitionFilter)
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .executeLocal();
+        assertResultRowsBetween(matchingResult, 0, 1);
+
+        GlobalIndexResult matchingResultWithPartitionFilter =
+                table.newVectorSearchBuilder()
+                        .withPartitionFilter(partitionFilter)
+                        .withFilter(matchingPartitionFilter)
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .executeLocal();
+        assertResultRowsBetween(matchingResultWithPartitionFilter, 0, 1);
+
+        List<GlobalIndexResult> matchingBatchResults =
+                table.newBatchVectorSearchBuilder()
+                        .withFilter(matchingPartitionFilter)
+                        .withVectors(new float[][] {new float[] {1.0f, 0.0f}})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .executeBatchLocal();
+        assertThat(matchingBatchResults).hasSize(1);
+        assertResultRowsBetween(matchingBatchResults.get(0), 0, 1);
+
+        List<GlobalIndexResult> matchingBatchResultsWithPartitionFilter =
+                table.newBatchVectorSearchBuilder()
+                        .withPartitionFilter(partitionFilter)
+                        .withFilter(matchingPartitionFilter)
+                        .withVectors(new float[][] {new float[] {1.0f, 0.0f}})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .executeBatchLocal();
+        assertThat(matchingBatchResultsWithPartitionFilter).hasSize(1);
+        assertResultRowsBetween(matchingBatchResultsWithPartitionFilter.get(0), 0, 1);
+    }
+
+    @Test
     public void testScanPartialRangeIntersection() throws Exception {
         catalog.createTable(
                 identifier("full_search_partial_scalar_table"),
@@ -1161,6 +1284,13 @@ public class VectorSearchBuilderTest extends TableTestBase {
             reader.forEachRemaining(row -> ids.add(row.getInt(0)));
         }
         return ids;
+    }
+
+    private void assertResultRowsBetween(GlobalIndexResult result, long start, long end) {
+        assertThat(result.results().isEmpty()).isFalse();
+        for (long rowId : result.results()) {
+            assertThat(rowId).isBetween(start, end);
+        }
     }
 
     private void buildAndCommitIndex(FileStoreTable table, float[][] vectors) throws Exception {


### PR DESCRIPTION
### Purpose

Fix partition filter handling in vector search builders.

Previously, `withFilter` extracted partition predicates but still kept the full predicate in the scalar filter. For partition-only filters, indexed vector reads could incorrectly enter the scalar pre-filter path and return empty results when no scalar index files existed. In addition, explicit `withPartitionFilter` calls and partition predicates extracted from `withFilter` could overwrite each other instead of behaving as a stable intersection.

### Tests

  - `mvn -pl paimon-core -Dtest=VectorSearchBuilderTest test`