### PR TITLE
[core] Support nested-key-null-strategy in FieldNestedUpdateAgg operator

### DIFF
--- a/docs/docs/primary-key-table/merge-engine/aggregation.mdx
+++ b/docs/docs/primary-key-table/merge-engine/aggregation.mdx
@@ -313,9 +313,7 @@ public static class BitmapContainsUDF extends ScalarFunction {
 
   Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
 
-  This option is optional. If it is not configured, the behavior is equivalent to using `merge`.
-
-   - `merge`: Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
+   - `merge` (default): Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
    - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
    - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
 

--- a/docs/docs/primary-key-table/merge-engine/aggregation.mdx
+++ b/docs/docs/primary-key-table/merge-engine/aggregation.mdx
@@ -311,6 +311,14 @@ public static class BitmapContainsUDF extends ScalarFunction {
 
   Use `fields.<field-name>.nested-key=pk0,pk1,...` to specify the primary keys of the nested table. If no keys, row will be appended to array\<row>.
 
+  Use `fields.<field-name>.nested-key-null-strategy=<merge|ignore|error>` to specify how rows are handled when the nested-key does not satisfy primary key semantics (e.g., primary key fields contain null values).
+
+  This option is optional. If it is not configured, the behavior is equivalent to using `merge`.
+
+   - `merge`: Merge rows even if the nested-key does not satisfy primary key semantics. This is the same behavior as when this option is not configured.
+   - `ignore`: Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics.
+   - `error`: Throw an exception if the nested-key contains null values, because primary key fields must not be null.
+
   Use `fields.<field-name>.nested-sequence-field=seq0,seq1,...` to control the update sequence of a nested table, you must configure `fields.<field-name>.nested-key` when using it.
 
   Use `fields.<field-name>.count-limit=<Integer>` to specify the maximum number of rows in the nested table. When no nested-key, it will select data

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -5056,11 +5056,8 @@ public class CoreOptions implements Serializable {
         }
     }
 
-    /**
-     * Strategy for handling rows whose nested-key contains null values.
-     */
+    /** Strategy for handling rows whose nested-key contains null values. */
     public enum NestedKeyNullStrategy implements DescribedEnum {
-
         MERGE(
                 "merge",
                 "Merge rows even if the nested-key contains null values, without enforcing primary key semantics."),

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -80,6 +80,8 @@ public class CoreOptions implements Serializable {
 
     public static final String NESTED_KEY = "nested-key";
 
+    public static final String NESTED_KEY_NULL_STRATEGY = "nested-key-null-strategy";
+
     public static final String NESTED_SEQUENCE_FIELD = "nested-sequence-field";
 
     public static final String COUNT_LIMIT = "count-limit";
@@ -2943,6 +2945,13 @@ public class CoreOptions implements Serializable {
         return Arrays.stream(keyString.split(",")).map(String::trim).collect(Collectors.toList());
     }
 
+    public NestedKeyNullStrategy fieldNestedUpdateAggNestedKeyNullStrategy(String fieldName) {
+        return options.get(
+                key(FIELDS_PREFIX + "." + fieldName + "." + NESTED_KEY_NULL_STRATEGY)
+                        .enumType(NestedKeyNullStrategy.class)
+                        .noDefaultValue());
+    }
+
     public List<String> fieldNestedUpdateAggNestedSequenceField(String fieldName) {
         String keyString =
                 options.get(
@@ -5044,6 +5053,42 @@ public class CoreOptions implements Serializable {
         @Override
         public InlineElement getDescription() {
             return text(description);
+        }
+    }
+
+    /**
+     * Strategy for handling rows whose nested-key contains null values.
+     */
+    public enum NestedKeyNullStrategy implements DescribedEnum {
+
+        MERGE(
+                "merge",
+                "Merge rows even if the nested-key contains null values, without enforcing primary key semantics."),
+
+        IGNORE(
+                "ignore",
+                "Ignore rows whose nested-key contains null values because they do not satisfy primary key semantics."),
+
+        ERROR(
+                "error",
+                "Throw an exception if the nested-key contains null values, because primary key fields must not be null.");
+
+        private final String value;
+        private final String description;
+
+        NestedKeyNullStrategy(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+
+        @Override
+        public String toString() {
+            return value;
         }
     }
 }

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2949,7 +2949,7 @@ public class CoreOptions implements Serializable {
         return options.get(
                 key(FIELDS_PREFIX + "." + fieldName + "." + NESTED_KEY_NULL_STRATEGY)
                         .enumType(NestedKeyNullStrategy.class)
-                        .noDefaultValue());
+                        .defaultValue(NestedKeyNullStrategy.MERGE));
     }
 
     public List<String> fieldNestedUpdateAggNestedSequenceField(String fieldName) {

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -189,14 +189,22 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
                     continue;
                 }
                 InternalRow row = acc.getRow(i, nestedFields);
-                map.put(keyProjection.apply(row).copy(), row);
+                BinaryRow key = keyProjection.apply(row).copy();
+                if (!applyNestedKeyNullStrategy(key)) {
+                    continue;
+                }
+                map.put(key, row);
             }
 
             for (int i = 0; i < retract.size(); i++) {
                 if (retract.isNullAt(i)) {
                     continue;
                 }
-                map.remove(keyProjection.apply(retract.getRow(i, nestedFields)));
+                BinaryRow key = keyProjection.apply(retract.getRow(i, nestedFields)).copy();
+                if (!applyNestedKeyNullStrategy(key)) {
+                    continue;
+                }
+                map.remove(key);
             }
 
             return new GenericArray(new ArrayList<>(map.values()).toArray());

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import static org.apache.paimon.codegen.CodeGenUtils.newProjection;
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordComparator;
 import static org.apache.paimon.codegen.CodeGenUtils.newRecordEqualiser;
-import static org.apache.paimon.options.ConfigOptions.key;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /**
@@ -83,24 +81,11 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
             this.elementEqualiser = null;
         }
 
-        checkArgument(
-                nestedKeyNullStrategy == null || this.keyProjection != null,
-                "Option 'fields.<field-name>.nested-key-null-strategy' requires "
-                        + "'fields.<field-name>.nested-key' to be configured.");
-
-        // Default to MERGE to preserve the previous behavior.
-        this.nestedKeyNullStrategy =
-                nestedKeyNullStrategy == null
-                        ? CoreOptions.NestedKeyNullStrategy.MERGE
-                        : nestedKeyNullStrategy;
+        this.nestedKeyNullStrategy = nestedKeyNullStrategy;
 
         // If nestedSequenceField is set, we need to compare sequence fields to determine
         // whether to update. Only update when the new sequence is greater than the old one.
         if (!nestedSequenceField.isEmpty()) {
-            checkArgument(
-                    this.keyProjection != null,
-                    "Option 'fields.<field-name>.nested-sequence-field' requires "
-                            + "'fields.<field-name>.nested-key' to be configured.");
             this.sequenceProjection = newProjection(nestedType, nestedSequenceField);
             this.hasSequenceField = true;
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldNestedUpdateAgg.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.mergetree.compact.aggregate;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.codegen.Projection;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.codegen.RecordEqualiser;
@@ -32,6 +33,7 @@ import org.apache.paimon.types.RowType;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -61,17 +63,14 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
     @Nullable private final RecordComparator sequenceComparator;
     private final boolean hasSequenceField;
 
+    private final CoreOptions.NestedKeyNullStrategy nestedKeyNullStrategy;
     private final int countLimit;
-
-    public FieldNestedUpdateAgg(
-            String name, ArrayType dataType, List<String> nestedKey, int countLimit) {
-        this(name, dataType, nestedKey, Collections.emptyList(), countLimit);
-    }
 
     public FieldNestedUpdateAgg(
             String name,
             ArrayType dataType,
             List<String> nestedKey,
+            CoreOptions.NestedKeyNullStrategy nestedKeyNullStrategy,
             List<String> nestedSequenceField,
             int countLimit) {
         super(name, dataType);
@@ -85,12 +84,24 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
             this.elementEqualiser = null;
         }
 
+        checkArgument(
+                nestedKeyNullStrategy == null || this.keyProjection != null,
+                "Option 'fields.<field-name>.nested-key-null-strategy' requires "
+                        + "'fields.<field-name>.nested-key' to be configured.");
+
+        // Default to MERGE to preserve the previous behavior.
+        this.nestedKeyNullStrategy =
+                nestedKeyNullStrategy == null
+                        ? CoreOptions.NestedKeyNullStrategy.MERGE
+                        : nestedKeyNullStrategy;
+
         // If nestedSequenceField is set, we need to compare sequence fields to determine
         // whether to update. Only update when the new sequence is greater than the old one.
         if (!nestedSequenceField.isEmpty()) {
             checkArgument(
                     this.keyProjection != null,
-                    "nested-sequence-field requires nested-key to be set.");
+                    "Option 'fields.<field-name>.nested-sequence-field' requires "
+                            + "'fields.<field-name>.nested-key' to be configured.");
             this.sequenceProjection = newProjection(nestedType, nestedSequenceField);
             this.hasSequenceField = true;
 
@@ -243,6 +254,11 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
 
             InternalRow row = array.getRow(i, nestedFields);
             BinaryRow key = keyProjection.apply(row).copy();
+
+            if (!applyNestedKeyNullStrategy(key)) {
+                continue;
+            }
+
             InternalRow existing = rows.get(key);
             if (existing != null) {
                 if (!hasSequenceField || compareSequence(row, existing) >= 0) {
@@ -251,6 +267,29 @@ public class FieldNestedUpdateAgg extends FieldAggregator {
             } else if (!limitNewKeys || rows.size() < countLimit) {
                 rows.put(key, row);
             }
+        }
+    }
+
+    private boolean applyNestedKeyNullStrategy(BinaryRow key) {
+        if (!key.anyNull()) {
+            // The nested-key satisfies primary key semantics.
+            return true;
+        }
+        switch (nestedKeyNullStrategy) {
+            case MERGE:
+                // Preserve the previous behavior.
+                return true;
+            case IGNORE:
+                return false;
+            case ERROR:
+                throw new IllegalArgumentException(
+                        "Nested key contains null values. Primary key fields must not be null.");
+            default:
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unsupported nested-key-null-strategy '%s'. Supported values are: %s.",
+                                nestedKeyNullStrategy,
+                                Arrays.toString(CoreOptions.NestedKeyNullStrategy.values())));
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
@@ -24,9 +24,10 @@ import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
-import java.util.Collections;
 import java.util.List;
 
+import static org.apache.paimon.CoreOptions.FIELDS_PREFIX;
+import static org.apache.paimon.CoreOptions.NESTED_KEY_NULL_STRATEGY;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Factory for #{@link FieldNestedUpdateAgg}. */
@@ -36,8 +37,17 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
 
     @Override
     public FieldNestedUpdateAgg create(DataType fieldType, CoreOptions options, String field) {
-        return createFieldNestedUpdateAgg(
-                fieldType,
+        String typeErrorMsg =
+                "Data type for nested table column must be 'Array<Row>' but was '%s'.";
+        checkArgument(fieldType instanceof ArrayType, typeErrorMsg, fieldType);
+        ArrayType arrayType = (ArrayType) fieldType;
+        checkArgument(arrayType.getElementType() instanceof RowType, typeErrorMsg, fieldType);
+
+        checkOptionDependencies(options, field);
+
+        return new FieldNestedUpdateAgg(
+                identifier(),
+                arrayType,
                 options.fieldNestedUpdateAggNestedKey(field),
                 options.fieldNestedUpdateAggNestedKeyNullStrategy(field),
                 options.fieldNestedUpdateAggNestedSequenceField(field),
@@ -49,32 +59,22 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
         return NAME;
     }
 
-    private FieldNestedUpdateAgg createFieldNestedUpdateAgg(
-            DataType fieldType,
-            List<String> nestedKey,
-            CoreOptions.NestedKeyNullStrategy nestedKeyNullStrategy,
-            List<String> nestedSequenceField,
-            int countLimit) {
-        if (nestedKey == null) {
-            nestedKey = Collections.emptyList();
-        }
+    private void checkOptionDependencies(CoreOptions options, String field) {
+        List<String> nestedKey = options.fieldNestedUpdateAggNestedKey(field);
 
-        if (nestedSequenceField == null) {
-            nestedSequenceField = Collections.emptyList();
-        }
+        boolean strategyConfigured =
+                options.toConfiguration()
+                        .containsKey(FIELDS_PREFIX + "." + field + "." + NESTED_KEY_NULL_STRATEGY);
 
-        String typeErrorMsg =
-                "Data type for nested table column must be 'Array<Row>' but was '%s'.";
-        checkArgument(fieldType instanceof ArrayType, typeErrorMsg, fieldType);
-        ArrayType arrayType = (ArrayType) fieldType;
-        checkArgument(arrayType.getElementType() instanceof RowType, typeErrorMsg, fieldType);
+        checkArgument(
+                !strategyConfigured || !nestedKey.isEmpty(),
+                "Option 'fields.<field-name>.nested-key-null-strategy' requires "
+                        + "'fields.<field-name>.nested-key' to be configured.");
 
-        return new FieldNestedUpdateAgg(
-                identifier(),
-                arrayType,
-                nestedKey,
-                nestedKeyNullStrategy,
-                nestedSequenceField,
-                countLimit);
+        checkArgument(
+                options.fieldNestedUpdateAggNestedSequenceField(field).isEmpty()
+                        || !nestedKey.isEmpty(),
+                "Option 'fields.<field-name>.nested-sequence-field' requires "
+                        + "'fields.<field-name>.nested-key' to be configured.");
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
@@ -70,6 +70,11 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
         checkArgument(arrayType.getElementType() instanceof RowType, typeErrorMsg, fieldType);
 
         return new FieldNestedUpdateAgg(
-                identifier(), arrayType, nestedKey, nestedKeyNullStrategy, nestedSequenceField, countLimit);
+                identifier(),
+                arrayType,
+                nestedKey,
+                nestedKeyNullStrategy,
+                nestedSequenceField,
+                countLimit);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/factory/FieldNestedUpdateAggFactory.java
@@ -39,6 +39,7 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
         return createFieldNestedUpdateAgg(
                 fieldType,
                 options.fieldNestedUpdateAggNestedKey(field),
+                options.fieldNestedUpdateAggNestedKeyNullStrategy(field),
                 options.fieldNestedUpdateAggNestedSequenceField(field),
                 options.fieldNestedUpdateAggCountLimit(field));
     }
@@ -51,6 +52,7 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
     private FieldNestedUpdateAgg createFieldNestedUpdateAgg(
             DataType fieldType,
             List<String> nestedKey,
+            CoreOptions.NestedKeyNullStrategy nestedKeyNullStrategy,
             List<String> nestedSequenceField,
             int countLimit) {
         if (nestedKey == null) {
@@ -68,6 +70,6 @@ public class FieldNestedUpdateAggFactory implements FieldAggregatorFactory {
         checkArgument(arrayType.getElementType() instanceof RowType, typeErrorMsg, fieldType);
 
         return new FieldNestedUpdateAgg(
-                identifier(), arrayType, nestedKey, nestedSequenceField, countLimit);
+                identifier(), arrayType, nestedKey, nestedKeyNullStrategy, nestedSequenceField, countLimit);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -734,7 +734,7 @@ public class FieldAggregatorTest {
                                         DataTypes.FIELD(1, "k1", DataTypes.INT()),
                                         DataTypes.FIELD(2, "v", DataTypes.STRING()))),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
@@ -775,7 +775,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Collections.emptyList(),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
@@ -800,6 +800,116 @@ public class FieldAggregatorTest {
     }
 
     @Test
+    public void testFieldNestedUpdateAggFactoryWithSequenceFieldPrerequisite() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () ->
+                                new FieldNestedUpdateAggFactory()
+                                        .create(
+                                                DataTypes.ARRAY(elementRowType),
+                                                CoreOptions.fromMap(
+                                                        ImmutableMap.of(
+                                                                "fields.fieldName.nested-sequence-field",
+                                                                "seq")),
+                                                "fieldName"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Option 'fields.<field-name>.nested-sequence-field' requires "
+                                + "'fields.<field-name>.nested-key' to be configured.");
+
+        FieldNestedUpdateAgg agg1 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(new HashMap<>()),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
+
+        FieldNestedUpdateAgg agg2 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of("fields.filedName.nested-key", "k0,k1")),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
+
+        FieldNestedUpdateAgg agg3 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of(
+                                                "fields.filedName.nested-key",
+                                                "k0,k1",
+                                                "fields.filedName.nested-sequence-field",
+                                                "seq")),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggFactoryWithNestedKeyNullStrategyPrerequisite() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () ->
+                                new FieldNestedUpdateAggFactory()
+                                        .create(
+                                                DataTypes.ARRAY(elementRowType),
+                                                CoreOptions.fromMap(
+                                                        ImmutableMap.of(
+                                                                "fields.fieldName.nested-key-null-strategy",
+                                                                "merge")),
+                                                "fieldName"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Option 'fields.<field-name>.nested-key-null-strategy' requires "
+                                + "'fields.<field-name>.nested-key' to be configured.");
+
+        FieldNestedUpdateAgg agg1 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(new HashMap<>()),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
+
+        FieldNestedUpdateAgg agg2 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of("fields.filedName.nested-key", "k0,k1")),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
+
+        FieldNestedUpdateAgg agg3 =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of(
+                                                "fields.filedName.nested-key",
+                                                "k0,k1",
+                                                "fields.filedName.nested-key-null-strategy",
+                                                "merge")),
+                                "fieldName");
+        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
+    }
+
+    @Test
     public void testFieldNestedAppendAggWithCountLimit() {
         DataType elementRowType =
                 DataTypes.ROW(
@@ -811,7 +921,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Collections.emptyList(),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         2);
 
@@ -848,7 +958,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Collections.emptyList(),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         2);
 
@@ -875,7 +985,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         2);
 
@@ -910,7 +1020,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         2);
 
@@ -944,7 +1054,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.singletonList("seq"),
                         Integer.MAX_VALUE);
 
@@ -996,7 +1106,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Arrays.asList("seq", "ts"),
                         Integer.MAX_VALUE);
 
@@ -1089,30 +1199,6 @@ public class FieldAggregatorTest {
     }
 
     @Test
-    public void testFieldNestedUpdateAggWithSequenceFieldWithoutNestedKey() {
-        DataType elementRowType =
-                DataTypes.ROW(
-                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
-                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
-                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
-                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
-
-        org.assertj.core.api.Assertions.assertThatThrownBy(
-                        () ->
-                                new FieldNestedUpdateAgg(
-                                        FieldNestedUpdateAggFactory.NAME,
-                                        DataTypes.ARRAY(elementRowType),
-                                        Collections.emptyList(),
-                                        null,
-                                        Collections.singletonList("seq"),
-                                        Integer.MAX_VALUE))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "Option 'fields.<field-name>.nested-sequence-field' requires "
-                                + "'fields.<field-name>.nested-key' to be configured.");
-    }
-
-    @Test
     public void testFieldNestedUpdateAggWithCountLimitWithSequenceFieldWithoutNestedKey() {
         DataType elementRowType =
                 DataTypes.ROW(
@@ -1124,13 +1210,16 @@ public class FieldAggregatorTest {
         // Verify that the same precondition check applies even when a count limit is specified
         org.assertj.core.api.Assertions.assertThatThrownBy(
                         () ->
-                                new FieldNestedUpdateAgg(
-                                        FieldNestedUpdateAggFactory.NAME,
-                                        DataTypes.ARRAY(elementRowType),
-                                        Collections.emptyList(),
-                                        null,
-                                        Collections.singletonList("seq"),
-                                        2))
+                                new FieldNestedUpdateAggFactory()
+                                        .create(
+                                                DataTypes.ARRAY(elementRowType),
+                                                CoreOptions.fromMap(
+                                                        ImmutableMap.of(
+                                                                "fields.fieldName.nested-sequence-field",
+                                                                "seq",
+                                                                "fields.fieldName.count-limit",
+                                                                "2")),
+                                                "fieldName"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                         "Option 'fields.<field-name>.nested-sequence-field' requires "
@@ -1151,7 +1240,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.singletonList("seq"),
                         2); // Enforce count limit = 2
 
@@ -1200,7 +1289,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.singletonList("seq"),
                         2);
 
@@ -1237,7 +1326,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.singletonList("seq"),
                         2);
 
@@ -1259,129 +1348,6 @@ public class FieldAggregatorTest {
     }
 
     @Test
-    public void testFieldNestedUpdateAggWithNestedKeyNullStrategyArgumentCheck() {
-        DataType elementRowType =
-                DataTypes.ROW(
-                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
-                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
-                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
-                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
-
-        // ============================================================
-        // 1. nested-key is not specified, but nested-key-null-strategy is provided
-        //    This should be rejected because strategy depends on nested-key.
-        // ============================================================
-        org.assertj.core.api.Assertions.assertThatThrownBy(
-                        () ->
-                                new FieldNestedUpdateAgg(
-                                        FieldNestedUpdateAggFactory.NAME,
-                                        DataTypes.ARRAY(elementRowType),
-                                        Collections.emptyList(),
-                                        CoreOptions.NestedKeyNullStrategy.MERGE,
-                                        Collections.emptyList(),
-                                        2))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "Option 'fields.<field-name>.nested-key-null-strategy' requires "
-                                + "'fields.<field-name>.nested-key' to be configured.");
-
-        // ============================================================
-        // 2. neither nested-key nor nested-key-null-strategy is specified
-        //    This is valid and should fall back to default behavior (MERGE).
-        // ============================================================
-        FieldNestedUpdateAgg agg1 =
-                new FieldNestedUpdateAgg(
-                        FieldNestedUpdateAggFactory.NAME,
-                        DataTypes.ARRAY(elementRowType),
-                        Collections.emptyList(),
-                        null,
-                        Collections.emptyList(),
-                        2);
-
-        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
-
-        // ============================================================
-        // 3. nested-key is specified but nested-key-null-strategy is not
-        //    This is valid and should use default strategy (MERGE).
-        // ============================================================
-        FieldNestedUpdateAgg agg2 =
-                new FieldNestedUpdateAgg(
-                        FieldNestedUpdateAggFactory.NAME,
-                        DataTypes.ARRAY(elementRowType),
-                        Collections.singletonList("k0"),
-                        null,
-                        Collections.emptyList(),
-                        2);
-
-        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
-
-        // ============================================================
-        // 4. both nested-key and nested-key-null-strategy are specified
-        //    This should be accepted and use the provided strategy.
-        // ============================================================
-        FieldNestedUpdateAgg agg3 =
-                new FieldNestedUpdateAgg(
-                        FieldNestedUpdateAggFactory.NAME,
-                        DataTypes.ARRAY(elementRowType),
-                        Collections.singletonList("k0"),
-                        CoreOptions.NestedKeyNullStrategy.MERGE,
-                        Collections.emptyList(),
-                        2);
-
-        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
-    }
-
-    @Test
-    public void testFieldNestedUpdateAggWithoutNestedKeyNullStrategy() {
-        DataType elementRowType =
-                DataTypes.ROW(
-                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
-                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
-                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
-                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
-
-        FieldNestedUpdateAgg agg =
-                new FieldNestedUpdateAgg(
-                        FieldNestedUpdateAggFactory.NAME,
-                        DataTypes.ARRAY(elementRowType),
-                        Arrays.asList("k0", "k1"),
-                        null, // Preserve the previous behavior.
-                        Collections.emptyList(),
-                        Integer.MAX_VALUE);
-
-        InternalArray accumulator;
-        InternalArray.ElementGetter elementGetter =
-                InternalArray.createElementGetter(elementRowType);
-
-        InternalRow current = row(0, 0, "A", 1);
-        accumulator = (InternalArray) agg.agg(null, singletonArray(current));
-        assertThat(unnest(accumulator, elementGetter))
-                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
-
-        current = row(0, 1, "B", 2);
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
-        assertThat(unnest(accumulator, elementGetter))
-                .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
-
-        current = row(0, null, "C", 3);
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
-        assertThat(unnest(accumulator, elementGetter))
-                .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2), row(0, null, "C", 3)));
-
-        current = row(null, null, "D", 4);
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
-        assertThat(unnest(accumulator, elementGetter))
-                .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                row(0, 0, "A", 1),
-                                row(0, 1, "B", 2),
-                                row(0, null, "C", 3),
-                                row(null, null, "D", 4)));
-    }
-
-    @Test
     public void testFieldNestedUpdateAggWhenNestedKeyNullUseMergeStrategy() {
         DataType elementRowType =
                 DataTypes.ROW(
@@ -1395,16 +1361,14 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.MERGE, // use merge strategy
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(elementRowType);
 
-        // ============================================================
-        // when the accumulator is empty
-        // ============================================================
+        // Empty accumulator.
         InternalArray accumulatorEmpty;
         InternalRow current = row(0, null, "C", 3);
 
@@ -1419,9 +1383,7 @@ public class FieldAggregatorTest {
         assertThat(unnest(accumulatorEmpty, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
 
-        // ============================================================
-        // when the accumulator is non-empty
-        // ============================================================
+        // Non-empty accumulator.
         InternalArray accumulator;
 
         current = row(0, 0, "A", 1);
@@ -1475,9 +1437,7 @@ public class FieldAggregatorTest {
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(elementRowType);
 
-        // ============================================================
-        // when the accumulator is empty
-        // ============================================================
+        // Empty accumulator.
         InternalArray accumulatorEmpty;
 
         // case 1: partially null nested key (some PK fields are null)
@@ -1488,9 +1448,7 @@ public class FieldAggregatorTest {
         accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(row(null, null, "D", 4)));
         assertThat(unnest(accumulatorEmpty, elementGetter)).isEmpty();
 
-        // ============================================================
-        // when the accumulator is non-empty
-        // ============================================================
+        // Non-empty accumulator.
         InternalArray accumulator;
 
         InternalRow current = row(0, 0, "A", 1);
@@ -1537,10 +1495,7 @@ public class FieldAggregatorTest {
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
-        // ============================================================
-        // when the accumulator is empty
-        // ============================================================
-
+        // Empty accumulator.
         // case 1: partially null nested key (some PK fields are null)
         assertThatThrownBy(() -> agg.agg(null, singletonArray(row(0, null, "C", 3))))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -1553,9 +1508,7 @@ public class FieldAggregatorTest {
                 .hasMessage(
                         "Nested key contains null values. Primary key fields must not be null.");
 
-        // ============================================================
-        // when the accumulator is non-empty
-        // ============================================================
+        // Non-empty accumulator.
         InternalArray accumulator;
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(elementRowType);
@@ -1756,10 +1709,7 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(1, 0, "B")));
         accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(1, 1, "C")));
 
-        // ============================================================
-        // Verify IGNORE behavior:
-        // rows with null nested keys in the accumulator should be ignored.
-        // ============================================================
+        // IGNORE behavior: rows with null nested keys in the accumulator should be ignored.
         FieldNestedUpdateAgg ignoreAgg =
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,
@@ -1777,10 +1727,7 @@ public class FieldAggregatorTest {
 
         assertThat(unnest(result, elementGetter)).containsExactly(row(1, 1, "C"));
 
-        // ============================================================
-        // Verify ERROR behavior:
-        // rows with null nested keys in the accumulator should throw exception.
-        // ============================================================
+        // ERROR behavior: rows with null nested keys in the accumulator should throw exception.
         FieldNestedUpdateAgg errorAgg =
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,
@@ -1791,7 +1738,6 @@ public class FieldAggregatorTest {
                         Integer.MAX_VALUE);
 
         final InternalArray acc = accumulator;
-
         assertThatThrownBy(() -> errorAgg.retract(acc, singletonArray(row(1, 0, "B"))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
@@ -1823,10 +1769,7 @@ public class FieldAggregatorTest {
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(elementRowType);
 
-        // ============================================================
-        // Verify IGNORE behavior:
-        // rows with null nested keys in the retract input should be ignored.
-        // ============================================================
+        // IGNORE behavior: rows with null nested keys in the retract input should be ignored.
         FieldNestedUpdateAgg ignoreAgg =
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,
@@ -1842,10 +1785,7 @@ public class FieldAggregatorTest {
         assertThat(unnest(result, elementGetter))
                 .containsExactlyInAnyOrder(row(0, 0, "A"), row(1, 1, "B"));
 
-        // ============================================================
-        // Verify ERROR behavior:
-        // rows with null nested keys in the retract input should throw exception.
-        // ============================================================
+        // ERROR behavior: rows with null nested keys in the retract input should throw exception.
         FieldNestedUpdateAgg errorAgg =
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -734,6 +734,8 @@ public class FieldAggregatorTest {
                                         DataTypes.FIELD(1, "k1", DataTypes.INT()),
                                         DataTypes.FIELD(2, "v", DataTypes.STRING()))),
                         Arrays.asList("k0", "k1"),
+                        null,
+                        Collections.emptyList(),
                         Integer.MAX_VALUE);
 
         InternalArray accumulator;
@@ -773,6 +775,8 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Collections.emptyList(),
+                        null,
+                        Collections.emptyList(),
                         Integer.MAX_VALUE);
 
         InternalArray accumulator = null;
@@ -806,6 +810,8 @@ public class FieldAggregatorTest {
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
+                        Collections.emptyList(),
+                        null,
                         Collections.emptyList(),
                         2);
 
@@ -842,6 +848,8 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Collections.emptyList(),
+                        null,
+                        Collections.emptyList(),
                         2);
 
         InternalArray.ElementGetter elementGetter =
@@ -867,6 +875,8 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
+                        Collections.emptyList(),
                         2);
 
         InternalArray accumulator = null;
@@ -900,6 +910,8 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
+                        Collections.emptyList(),
                         2);
 
         InternalArray.ElementGetter elementGetter =
@@ -932,6 +944,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
                         Collections.singletonList("seq"),
                         Integer.MAX_VALUE);
 
@@ -983,6 +996,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
                         Arrays.asList("seq", "ts"),
                         Integer.MAX_VALUE);
 
@@ -1089,10 +1103,12 @@ public class FieldAggregatorTest {
                                         FieldNestedUpdateAggFactory.NAME,
                                         DataTypes.ARRAY(elementRowType),
                                         Collections.emptyList(),
+                                        null,
                                         Collections.singletonList("seq"),
                                         Integer.MAX_VALUE))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("nested-sequence-field requires nested-key to be set.");
+                .hasMessage("Option 'fields.<field-name>.nested-sequence-field' requires "
+                        + "'fields.<field-name>.nested-key' to be configured.");
     }
 
     @Test
@@ -1111,10 +1127,13 @@ public class FieldAggregatorTest {
                                         FieldNestedUpdateAggFactory.NAME,
                                         DataTypes.ARRAY(elementRowType),
                                         Collections.emptyList(),
+                                        null,
                                         Collections.singletonList("seq"),
                                         2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("nested-sequence-field requires nested-key to be set.");
+                .hasMessage("Option 'fields.<field-name>.nested-sequence-field' requires " +
+                        "'fields.<field-name>.nested-key' to be configured."
+                );
     }
 
     @Test
@@ -1131,6 +1150,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
                         Collections.singletonList("seq"),
                         2); // Enforce count limit = 2
 
@@ -1179,6 +1199,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
                         Collections.singletonList("seq"),
                         2);
 
@@ -1215,6 +1236,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
+                        null,
                         Collections.singletonList("seq"),
                         2);
 
@@ -1233,6 +1255,506 @@ public class FieldAggregatorTest {
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
                         Arrays.asList(row(0, 1, "B_updated", 4), row(1, 2, "C", 3)));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWithNestedKeyNullStrategyArgumentCheck() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        // ============================================================
+        // 1. nested-key is not specified, but nested-key-null-strategy is provided
+        //    This should be rejected because strategy depends on nested-key.
+        // ============================================================
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () ->
+                                new FieldNestedUpdateAgg(
+                                        FieldNestedUpdateAggFactory.NAME,
+                                        DataTypes.ARRAY(elementRowType),
+                                        Collections.emptyList(),
+                                        CoreOptions.NestedKeyNullStrategy.MERGE,
+                                        Collections.emptyList(),
+                                        2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Option 'fields.<field-name>.nested-key-null-strategy' requires "
+                                + "'fields.<field-name>.nested-key' to be configured.");
+
+        // ============================================================
+        // 2. neither nested-key nor nested-key-null-strategy is specified
+        //    This is valid and should fall back to default behavior (MERGE).
+        // ============================================================
+        FieldNestedUpdateAgg agg1 =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Collections.emptyList(),
+                        null,
+                        Collections.emptyList(),
+                        2);
+
+        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
+
+        // ============================================================
+        // 3. nested-key is specified but nested-key-null-strategy is not
+        //    This is valid and should use default strategy (MERGE).
+        // ============================================================
+        FieldNestedUpdateAgg agg2 =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Collections.singletonList("k0"),
+                        null,
+                        Collections.emptyList(),
+                        2);
+
+        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
+
+        // ============================================================
+        // 4. both nested-key and nested-key-null-strategy are specified
+        //    This should be accepted and use the provided strategy.
+        // ============================================================
+        FieldNestedUpdateAgg agg3 =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Collections.singletonList("k0"),
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
+                        Collections.emptyList(),
+                        2);
+
+        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWithoutNestedKeyNullStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        null,  // Preserve the previous behavior.
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+
+        InternalArray accumulator;
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        InternalRow current = row(0, 0, "A", 1);
+        accumulator = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+        current = row(0, 1, "B", 2);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+
+        current = row(0, null, "C", 3);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2),
+                                row(0, null, "C", 3)
+                        ));
+
+        current = row(null, null, "D", 4);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2),
+                                row(0, null, "C", 3),
+                                row(null, null, "D", 4)
+                        ));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWhenNestedKeyNullUseMergeStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.MERGE,  // use merge strategy
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        // ============================================================
+        // when the accumulator is empty
+        // ============================================================
+        InternalArray accumulatorEmpty;
+        InternalRow current = row(0, null, "C", 3);
+
+        // case 1: partially null nested key (some PK fields are null)
+        accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulatorEmpty, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+        // case 2: fully null nested key (all PK fields are null)
+        current = row(null, null, "D", 4);
+        accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulatorEmpty, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+
+        // ============================================================
+        // when the accumulator is non-empty
+        // ============================================================
+        InternalArray accumulator;
+
+        current = row(0, 0, "A", 1);
+        accumulator = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+        current = row(0, 1, "B", 2);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+
+        // case 1: partially null nested key (some PK fields are null)
+        current = row(0, null, "C", 3);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2),
+                                row(0, null, "C", 3)
+                        ));
+
+        // case 2: fully null nested key (all PK fields are null)
+        current = row(null, null, "D", 4);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2),
+                                row(0, null, "C", 3),
+                                row(null, null, "D", 4)
+                        ));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWhenNestedKeyNullUseIgnoreStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.IGNORE,  // use ignore strategy
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+
+        // ============================================================
+        // when the accumulator is empty
+        // ============================================================
+        InternalArray accumulatorEmpty;
+
+        // case 1: partially null nested key (some PK fields are null)
+        accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(row(0, null, "C", 3)));
+        assertThat(unnest(accumulatorEmpty, elementGetter)).isEmpty();
+
+        // case 2: fully null nested key (all PK fields are null)
+        accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(row(null, null, "D", 4)));
+        assertThat(unnest(accumulatorEmpty, elementGetter)).isEmpty();
+
+
+        // ============================================================
+        // when the accumulator is non-empty
+        // ============================================================
+        InternalArray accumulator;
+
+        InternalRow current = row(0, 0, "A", 1);
+        accumulator = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+        current = row(0, 1, "B", 2);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+
+        // case 1: partially null nested key (some PK fields are null)
+        current = row(0, null, "C", 3);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2)
+                        ));
+
+        // case 2: fully null nested key (all PK fields are null)
+        current = row(null, null, "D", 4);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 0, "A", 1),
+                                row(0, 1, "B", 2)
+                        ));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWhenNestedKeyNullUseThrowErrorStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.ERROR,  // use error strategy
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+
+        // ============================================================
+        // when the accumulator is empty
+        // ============================================================
+
+        // case 1: partially null nested key (some PK fields are null)
+        assertThatThrownBy(() -> agg.agg(
+                null,
+                singletonArray(row(0, null, "C", 3))
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+        // case 2: fully null nested key (all PK fields are null)
+        assertThatThrownBy(() -> agg.agg(
+                null,
+                singletonArray(row(null, null, "D", 4))
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+
+        // ============================================================
+        // when the accumulator is non-empty
+        // ============================================================
+        InternalArray accumulator;
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        InternalRow current = row(0, 0, "A", 1);
+        accumulator = (InternalArray) agg.agg(null, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
+
+        current = row(0, 1, "B", 2);
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+
+        // case 1: partially null nested key (some PK fields are null)
+        InternalArray finalAccumulator1 = accumulator;
+        assertThatThrownBy(() -> agg.agg(
+                finalAccumulator1,
+                singletonArray(row(0, null, "C", 3))
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+
+        // case 2: fully null nested key (all PK fields are null)
+        InternalArray finalAccumulator2 = accumulator;
+        assertThatThrownBy(() -> agg.agg(
+                finalAccumulator2, singletonArray(row(null, null, "D", 4))
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseMergeStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.MERGE,  // use merge strategy
+                        Collections.singletonList("seq"),
+                        3);
+
+        InternalArray accumulator = null;
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 5)));
+
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B_updated", 4)));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 1, "B_updated", 4),
+                                row(null, 2, "NULL_2", 2),
+                                row(null, null, "NULL_NULL", 3)
+                                ));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseIgnoreStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+            FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.IGNORE,  // use ignore strategy
+                        Collections.singletonList("seq"),
+                        3);
+
+        InternalArray accumulator = null;
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 3)));
+
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B_updated", 4)));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 1, "B_updated", 4), row(1, 2, "C", 3)));
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(2, 3, "D", 5)));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 1, "B_updated", 4),
+                                row(1, 2, "C", 3),
+                                row(2, 3, "D", 5)
+                        ));
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseThrowErrorStrategy() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()),
+                        DataTypes.FIELD(3, "seq", DataTypes.INT()));
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.ERROR, // use error strategy
+                        Collections.singletonList("seq"),
+                        3);
+
+        InternalArray accumulator = null;
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
+
+        InternalArray finalAccumulator = accumulator;
+        assertThatThrownBy(() ->
+                agg.agg(finalAccumulator, singletonArray(row(null, 2, "NULL_2", 2)))
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+        assertThatThrownBy(() ->
+                agg.agg(finalAccumulator, singletonArray(row(null, null, "NULL_NULL", 3)))
+        )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 3)));
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B_updated", 4)));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(row(0, 1, "B_updated", 4), row(1, 2, "C", 3)));
+
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(2, 3, "D", 5)));
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(
+                                row(0, 1, "B_updated", 4),
+                                row(1, 2, "C", 3),
+                                row(2, 3, "D", 5)
+                        ));
     }
 
     private List<Object> unnest(InternalArray array, InternalArray.ElementGetter elementGetter) {

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -823,35 +823,31 @@ public class FieldAggregatorTest {
                         "Option 'fields.<field-name>.nested-sequence-field' requires "
                                 + "'fields.<field-name>.nested-key' to be configured.");
 
-        FieldNestedUpdateAgg agg1 =
-                new FieldNestedUpdateAggFactory()
-                        .create(
-                                DataTypes.ARRAY(elementRowType),
-                                CoreOptions.fromMap(new HashMap<>()),
-                                "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
-
-        FieldNestedUpdateAgg agg2 =
-                new FieldNestedUpdateAggFactory()
-                        .create(
-                                DataTypes.ARRAY(elementRowType),
-                                CoreOptions.fromMap(
-                                        ImmutableMap.of("fields.filedName.nested-key", "k0,k1")),
-                                "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
-
-        FieldNestedUpdateAgg agg3 =
+        FieldNestedUpdateAgg seqAgg =
                 new FieldNestedUpdateAggFactory()
                         .create(
                                 DataTypes.ARRAY(elementRowType),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
-                                                "fields.filedName.nested-key",
+                                                "fields.fieldName.nested-key",
                                                 "k0,k1",
-                                                "fields.filedName.nested-sequence-field",
+                                                "fields.fieldName.nested-sequence-field",
                                                 "seq")),
                                 "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        InternalArray accumulator = null;
+        accumulator = (InternalArray) seqAgg.agg(accumulator, singletonArray(row(0, 1, "A", 1)));
+        accumulator = (InternalArray) seqAgg.agg(accumulator, singletonArray(row(0, 1, "B", 2)));
+
+        assertThat(unnest(accumulator, elementGetter)).containsExactly(row(0, 1, "B", 2));
+
+        accumulator =
+                (InternalArray) seqAgg.agg(accumulator, singletonArray(row(0, 1, "b_Late", 1)));
+
+        assertThat(unnest(accumulator, elementGetter)).containsExactly(row(0, 1, "B", 2));
     }
 
     @Test
@@ -878,35 +874,68 @@ public class FieldAggregatorTest {
                         "Option 'fields.<field-name>.nested-key-null-strategy' requires "
                                 + "'fields.<field-name>.nested-key' to be configured.");
 
-        FieldNestedUpdateAgg agg1 =
-                new FieldNestedUpdateAggFactory()
-                        .create(
-                                DataTypes.ARRAY(elementRowType),
-                                CoreOptions.fromMap(new HashMap<>()),
-                                "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg1).isNotNull();
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
 
-        FieldNestedUpdateAgg agg2 =
-                new FieldNestedUpdateAggFactory()
-                        .create(
-                                DataTypes.ARRAY(elementRowType),
-                                CoreOptions.fromMap(
-                                        ImmutableMap.of("fields.filedName.nested-key", "k0,k1")),
-                                "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg2).isNotNull();
-
-        FieldNestedUpdateAgg agg3 =
+        // verify merge behavior
+        FieldNestedUpdateAgg mergeAgg =
                 new FieldNestedUpdateAggFactory()
                         .create(
                                 DataTypes.ARRAY(elementRowType),
                                 CoreOptions.fromMap(
                                         ImmutableMap.of(
-                                                "fields.filedName.nested-key",
+                                                "fields.fieldName.nested-key",
                                                 "k0,k1",
-                                                "fields.filedName.nested-key-null-strategy",
+                                                "fields.fieldName.nested-key-null-strategy",
                                                 "merge")),
                                 "fieldName");
-        org.assertj.core.api.Assertions.assertThat(agg3).isNotNull();
+
+        InternalArray mergeAccumulator = null;
+        mergeAccumulator =
+                (InternalArray)
+                        mergeAgg.agg(mergeAccumulator, singletonArray(row(0, null, "A", 1)));
+
+        assertThat(unnest(mergeAccumulator, elementGetter)).containsExactly(row(0, null, "A", 1));
+
+        // verify ignore behavior
+        FieldNestedUpdateAgg ignoreAgg =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of(
+                                                "fields.fieldName.nested-key",
+                                                "k0,k1",
+                                                "fields.fieldName.nested-key-null-strategy",
+                                                "ignore")),
+                                "fieldName");
+
+        InternalArray ignoreAccumulator = null;
+        ignoreAccumulator =
+                (InternalArray) ignoreAgg.agg(ignoreAccumulator, singletonArray(row(0, 1, "A", 1)));
+        ignoreAccumulator =
+                (InternalArray)
+                        ignoreAgg.agg(ignoreAccumulator, singletonArray(row(0, null, "B", 2)));
+
+        assertThat(unnest(ignoreAccumulator, elementGetter)).containsExactly(row(0, 1, "A", 1));
+
+        // verify error behavior
+        FieldNestedUpdateAgg errorAgg =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of(
+                                                "fields.fieldName.nested-key",
+                                                "k0,k1",
+                                                "fields.fieldName.nested-key-null-strategy",
+                                                "error")),
+                                "fieldName");
+
+        assertThatThrownBy(() -> errorAgg.agg(null, singletonArray(row(0, null, "B", 2))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
     }
 
     @Test
@@ -1224,6 +1253,31 @@ public class FieldAggregatorTest {
                 .hasMessage(
                         "Option 'fields.<field-name>.nested-sequence-field' requires "
                                 + "'fields.<field-name>.nested-key' to be configured.");
+
+        FieldNestedUpdateAgg agg =
+                new FieldNestedUpdateAggFactory()
+                        .create(
+                                DataTypes.ARRAY(elementRowType),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of(
+                                                "fields.fieldName.nested-key", "k0,k1",
+                                                "fields.fieldName.nested-sequence-field", "seq",
+                                                "fields.fieldName.count-limit", "2")),
+                                "fieldName");
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        InternalArray accumulator = null;
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "A", 1)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 2, "B", 2)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 3, "C", 3)));
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "A_Update", 4)));
+        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 2, "B_Late", 1)));
+
+        assertThat(unnest(accumulator, elementGetter))
+                .containsExactlyInAnyOrder(row(0, 1, "A_Update", 4), row(0, 2, "B", 2));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -1733,6 +1733,136 @@ public class FieldAggregatorTest {
                                 row(0, 1, "B_updated", 4), row(1, 2, "C", 3), row(2, 3, "D", 5)));
     }
 
+    @Test
+    public void testFieldNestedUpdateAggRetractWithNullNestedKeyInAccumulator() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()));
+
+        // Build an accumulator containing a null nested key.
+        FieldNestedUpdateAgg mergeAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray accumulator = null;
+        accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(0, null, "A")));
+        accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(1, 0, "B")));
+        accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(1, 1, "C")));
+
+        // ============================================================
+        // Verify IGNORE behavior:
+        // rows with null nested keys in the accumulator should be ignored.
+        // ============================================================
+        FieldNestedUpdateAgg ignoreAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.IGNORE,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray result =
+                (InternalArray) ignoreAgg.retract(accumulator, singletonArray(row(1, 0, "B")));
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        assertThat(unnest(result, elementGetter)).containsExactly(row(1, 1, "C"));
+
+        // ============================================================
+        // Verify ERROR behavior:
+        // rows with null nested keys in the accumulator should throw exception.
+        // ============================================================
+        FieldNestedUpdateAgg errorAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.ERROR,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        final InternalArray acc = accumulator;
+
+        assertThatThrownBy(() -> errorAgg.retract(acc, singletonArray(row(1, 0, "B"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
+    }
+
+    @Test
+    public void testFieldNestedUpdateAggRetractAppliesNestedKeyNullStrategyToRetractInput() {
+        DataType elementRowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "k0", DataTypes.INT()),
+                        DataTypes.FIELD(1, "k1", DataTypes.INT()),
+                        DataTypes.FIELD(2, "v", DataTypes.STRING()));
+
+        // Build an accumulator without null nested keys.
+        FieldNestedUpdateAgg mergeAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.MERGE,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray accumulator = null;
+        accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(0, 0, "A")));
+        accumulator = (InternalArray) mergeAgg.agg(accumulator, singletonArray(row(1, 1, "B")));
+
+        InternalArray.ElementGetter elementGetter =
+                InternalArray.createElementGetter(elementRowType);
+
+        // ============================================================
+        // Verify IGNORE behavior:
+        // rows with null nested keys in the retract input should be ignored.
+        // ============================================================
+        FieldNestedUpdateAgg ignoreAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.IGNORE,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        InternalArray result =
+                (InternalArray) ignoreAgg.retract(accumulator, singletonArray(row(0, null, "X")));
+
+        assertThat(unnest(result, elementGetter))
+                .containsExactlyInAnyOrder(row(0, 0, "A"), row(1, 1, "B"));
+
+        // ============================================================
+        // Verify ERROR behavior:
+        // rows with null nested keys in the retract input should throw exception.
+        // ============================================================
+        FieldNestedUpdateAgg errorAgg =
+                new FieldNestedUpdateAgg(
+                        FieldNestedUpdateAggFactory.NAME,
+                        DataTypes.ARRAY(elementRowType),
+                        Arrays.asList("k0", "k1"),
+                        CoreOptions.NestedKeyNullStrategy.ERROR,
+                        Collections.emptyList(),
+                        Integer.MAX_VALUE);
+
+        final InternalArray acc = accumulator;
+
+        assertThatThrownBy(() -> errorAgg.retract(acc, singletonArray(row(0, null, "X"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
+    }
+
     private List<Object> unnest(InternalArray array, InternalArray.ElementGetter elementGetter) {
         return IntStream.range(0, array.size())
                 .mapToObj(i -> elementGetter.getElementOrNull(array, i))

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -1734,7 +1734,7 @@ public class FieldAggregatorTest {
     }
 
     @Test
-    public void testFieldNestedUpdateAggRetractWithNullNestedKeyInAccumulator() {
+    public void testFieldNestedUpdateAggRetractAppliesNestedKeyNullStrategyToAccumulator() {
         DataType elementRowType =
                 DataTypes.ROW(
                         DataTypes.FIELD(0, "k0", DataTypes.INT()),

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -1107,8 +1107,9 @@ public class FieldAggregatorTest {
                                         Collections.singletonList("seq"),
                                         Integer.MAX_VALUE))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Option 'fields.<field-name>.nested-sequence-field' requires "
-                        + "'fields.<field-name>.nested-key' to be configured.");
+                .hasMessage(
+                        "Option 'fields.<field-name>.nested-sequence-field' requires "
+                                + "'fields.<field-name>.nested-key' to be configured.");
     }
 
     @Test
@@ -1131,9 +1132,9 @@ public class FieldAggregatorTest {
                                         Collections.singletonList("seq"),
                                         2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Option 'fields.<field-name>.nested-sequence-field' requires " +
-                        "'fields.<field-name>.nested-key' to be configured."
-                );
+                .hasMessage(
+                        "Option 'fields.<field-name>.nested-sequence-field' requires "
+                                + "'fields.<field-name>.nested-key' to be configured.");
     }
 
     @Test
@@ -1344,10 +1345,9 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        null,  // Preserve the previous behavior.
+                        null, // Preserve the previous behavior.
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
-
 
         InternalArray accumulator;
         InternalArray.ElementGetter elementGetter =
@@ -1368,11 +1368,7 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                row(0, 0, "A", 1),
-                                row(0, 1, "B", 2),
-                                row(0, null, "C", 3)
-                        ));
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2), row(0, null, "C", 3)));
 
         current = row(null, null, "D", 4);
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
@@ -1382,8 +1378,7 @@ public class FieldAggregatorTest {
                                 row(0, 0, "A", 1),
                                 row(0, 1, "B", 2),
                                 row(0, null, "C", 3),
-                                row(null, null, "D", 4)
-                        ));
+                                row(null, null, "D", 4)));
     }
 
     @Test
@@ -1400,7 +1395,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.MERGE,  // use merge strategy
+                        CoreOptions.NestedKeyNullStrategy.MERGE, // use merge strategy
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
@@ -1424,7 +1419,6 @@ public class FieldAggregatorTest {
         assertThat(unnest(accumulatorEmpty, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(Collections.singletonList(current));
 
-
         // ============================================================
         // when the accumulator is non-empty
         // ============================================================
@@ -1446,11 +1440,7 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                row(0, 0, "A", 1),
-                                row(0, 1, "B", 2),
-                                row(0, null, "C", 3)
-                        ));
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2), row(0, null, "C", 3)));
 
         // case 2: fully null nested key (all PK fields are null)
         current = row(null, null, "D", 4);
@@ -1461,8 +1451,7 @@ public class FieldAggregatorTest {
                                 row(0, 0, "A", 1),
                                 row(0, 1, "B", 2),
                                 row(0, null, "C", 3),
-                                row(null, null, "D", 4)
-                        ));
+                                row(null, null, "D", 4)));
     }
 
     @Test
@@ -1479,13 +1468,12 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.IGNORE,  // use ignore strategy
+                        CoreOptions.NestedKeyNullStrategy.IGNORE, // use ignore strategy
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
 
         InternalArray.ElementGetter elementGetter =
                 InternalArray.createElementGetter(elementRowType);
-
 
         // ============================================================
         // when the accumulator is empty
@@ -1499,7 +1487,6 @@ public class FieldAggregatorTest {
         // case 2: fully null nested key (all PK fields are null)
         accumulatorEmpty = (InternalArray) agg.agg(null, singletonArray(row(null, null, "D", 4)));
         assertThat(unnest(accumulatorEmpty, elementGetter)).isEmpty();
-
 
         // ============================================================
         // when the accumulator is non-empty
@@ -1522,20 +1509,14 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                row(0, 0, "A", 1),
-                                row(0, 1, "B", 2)
-                        ));
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
 
         // case 2: fully null nested key (all PK fields are null)
         current = row(null, null, "D", 4);
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(current));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
-                        Arrays.asList(
-                                row(0, 0, "A", 1),
-                                row(0, 1, "B", 2)
-                        ));
+                        Arrays.asList(row(0, 0, "A", 1), row(0, 1, "B", 2)));
     }
 
     @Test
@@ -1552,31 +1533,25 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.ERROR,  // use error strategy
+                        CoreOptions.NestedKeyNullStrategy.ERROR, // use error strategy
                         Collections.emptyList(),
                         Integer.MAX_VALUE);
-
 
         // ============================================================
         // when the accumulator is empty
         // ============================================================
 
         // case 1: partially null nested key (some PK fields are null)
-        assertThatThrownBy(() -> agg.agg(
-                null,
-                singletonArray(row(0, null, "C", 3))
-        ))
+        assertThatThrownBy(() -> agg.agg(null, singletonArray(row(0, null, "C", 3))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
         // case 2: fully null nested key (all PK fields are null)
-        assertThatThrownBy(() -> agg.agg(
-                null,
-                singletonArray(row(null, null, "D", 4))
-        ))
+        assertThatThrownBy(() -> agg.agg(null, singletonArray(row(null, null, "D", 4))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
-
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
         // ============================================================
         // when the accumulator is non-empty
@@ -1598,12 +1573,10 @@ public class FieldAggregatorTest {
 
         // case 1: partially null nested key (some PK fields are null)
         InternalArray finalAccumulator1 = accumulator;
-        assertThatThrownBy(() -> agg.agg(
-                finalAccumulator1,
-                singletonArray(row(0, null, "C", 3))
-        ))
+        assertThatThrownBy(() -> agg.agg(finalAccumulator1, singletonArray(row(0, null, "C", 3))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
@@ -1611,11 +1584,11 @@ public class FieldAggregatorTest {
 
         // case 2: fully null nested key (all PK fields are null)
         InternalArray finalAccumulator2 = accumulator;
-        assertThatThrownBy(() -> agg.agg(
-                finalAccumulator2, singletonArray(row(null, null, "D", 4))
-        ))
+        assertThatThrownBy(
+                        () -> agg.agg(finalAccumulator2, singletonArray(row(null, null, "D", 4))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
@@ -1636,7 +1609,7 @@ public class FieldAggregatorTest {
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.MERGE,  // use merge strategy
+                        CoreOptions.NestedKeyNullStrategy.MERGE, // use merge strategy
                         Collections.singletonList("seq"),
                         3);
 
@@ -1645,8 +1618,11 @@ public class FieldAggregatorTest {
                 InternalArray.createElementGetter(elementRowType);
 
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
+        accumulator =
+                (InternalArray)
+                        agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 5)));
 
         accumulator =
@@ -1656,8 +1632,7 @@ public class FieldAggregatorTest {
                         Arrays.asList(
                                 row(0, 1, "B_updated", 4),
                                 row(null, 2, "NULL_2", 2),
-                                row(null, null, "NULL_NULL", 3)
-                                ));
+                                row(null, null, "NULL_NULL", 3)));
     }
 
     @Test
@@ -1669,12 +1644,12 @@ public class FieldAggregatorTest {
                         DataTypes.FIELD(2, "v", DataTypes.STRING()),
                         DataTypes.FIELD(3, "seq", DataTypes.INT()));
 
-            FieldNestedUpdateAgg agg =
+        FieldNestedUpdateAgg agg =
                 new FieldNestedUpdateAgg(
                         FieldNestedUpdateAggFactory.NAME,
                         DataTypes.ARRAY(elementRowType),
                         Arrays.asList("k0", "k1"),
-                        CoreOptions.NestedKeyNullStrategy.IGNORE,  // use ignore strategy
+                        CoreOptions.NestedKeyNullStrategy.IGNORE, // use ignore strategy
                         Collections.singletonList("seq"),
                         3);
 
@@ -1683,8 +1658,11 @@ public class FieldAggregatorTest {
                 InternalArray.createElementGetter(elementRowType);
 
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(null, 2, "NULL_2", 2)));
+        accumulator =
+                (InternalArray)
+                        agg.agg(accumulator, singletonArray(row(null, null, "NULL_NULL", 3)));
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 3)));
 
         accumulator =
@@ -1697,10 +1675,7 @@ public class FieldAggregatorTest {
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
                         Arrays.asList(
-                                row(0, 1, "B_updated", 4),
-                                row(1, 2, "C", 3),
-                                row(2, 3, "D", 5)
-                        ));
+                                row(0, 1, "B_updated", 4), row(1, 2, "C", 3), row(2, 3, "D", 5)));
     }
 
     @Test
@@ -1728,21 +1703,25 @@ public class FieldAggregatorTest {
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B", 1)));
 
         InternalArray finalAccumulator = accumulator;
-        assertThatThrownBy(() ->
-                agg.agg(finalAccumulator, singletonArray(row(null, 2, "NULL_2", 2)))
-        )
+        assertThatThrownBy(
+                        () -> agg.agg(finalAccumulator, singletonArray(row(null, 2, "NULL_2", 2))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
-        assertThatThrownBy(() ->
-                agg.agg(finalAccumulator, singletonArray(row(null, null, "NULL_NULL", 3)))
-        )
+        assertThatThrownBy(
+                        () ->
+                                agg.agg(
+                                        finalAccumulator,
+                                        singletonArray(row(null, null, "NULL_NULL", 3))))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Nested key contains null values. Primary key fields must not be null.");
+                .hasMessage(
+                        "Nested key contains null values. Primary key fields must not be null.");
 
         accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(1, 2, "C", 3)));
 
-        accumulator = (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B_updated", 4)));
+        accumulator =
+                (InternalArray) agg.agg(accumulator, singletonArray(row(0, 1, "B_updated", 4)));
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
                         Arrays.asList(row(0, 1, "B_updated", 4), row(1, 2, "C", 3)));
@@ -1751,10 +1730,7 @@ public class FieldAggregatorTest {
         assertThat(unnest(accumulator, elementGetter))
                 .containsExactlyInAnyOrderElementsOf(
                         Arrays.asList(
-                                row(0, 1, "B_updated", 4),
-                                row(1, 2, "C", 3),
-                                row(2, 3, "D", 5)
-                        ));
+                                row(0, 1, "B_updated", 4), row(1, 2, "C", 3), row(2, 3, "D", 5)));
     }
 
     private List<Object> unnest(InternalArray array, InternalArray.ElementGetter elementGetter) {


### PR DESCRIPTION
### Purpose
[Feature] Add `fields.{fieldName}.nested-key-null-strategy` configuration for `nested_update` function  
[Feature] Support nested-key null handling strategies in FieldNestedUpdateAgg operator to control behavior when nested-key does not satisfy primary key semantics

Expected behavior when nested-key contains null values or does not satisfy primary key semantics:

In the following examples, `nested-key` is defined as `k0,k1`.

| **case**                     | **Input A**         | **Input B**      | **Current Behavior** | **Expected Behavior**         |
| ---------------------------- | ------------------- | ---------------- | -------------------- | ----------------------------- |
| Default behavior (no config) | [(0, null, "A", 1)] | [(0, 1, "B", 2)] | Merge                | Merge                         |
| MERGE strategy               | [(0, null, "A", 1)] | [(0, 1, "B", 2)] | Merge                | Merge                         |
| IGNORE strategy              | [(0, null, "A", 1)] | [(0, 1, "B", 2)] | Merge ❌              | Ignore invalid nested-key row |
| ERROR strategy               | [(0, null, "A", 1)] | [(0, 1, "B", 2)] | Merge ❌              | Throw exception               |

---
### Behavior Definition

- `merge`
  Merge rows even if nested-key does not satisfy primary key semantics.  
  This is equivalent to not configuring `nested-key-null-strategy`.

- `ignore`
  Ignore rows whose nested-key does not satisfy primary key semantics.

- `error`
  Throw an exception when nested-key does not satisfy primary key semantics.

---
### Tests
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggFactoryWithSequenceFieldPrerequisite
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggFactoryWithNestedKeyNullStrategyPrerequisite
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWhenNestedKeyNullUseMergeStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWhenNestedKeyNullUseIgnoreStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWhenNestedKeyNullUseThrowErrorStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseMergeStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseIgnoreStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggWithCountLimitWhenNestedKeyNullUseThrowErrorStrategy
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggRetractAppliesNestedKeyNullStrategyToAccumulator
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldNestedUpdateAggRetractAppliesNestedKeyNullStrategyToRetractInput
---

### API and Format
No Changes.

---

### Documentation
docs/docs/primary-key-table/merge-engine/aggregation.mdx
