### PR TITLE
[core][spark] Add statistics sidecar for NDV sketches

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/ThetaSketch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/ThetaSketch.java
@@ -19,20 +19,32 @@
 package org.apache.paimon.utils;
 
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.data.Decimal;
 
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.theta.UpdateSketch;
 
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+
 /** A compressed bitmap for 32-bit integer. */
 public class ThetaSketch {
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     public static byte[] union(byte[] sketchBytes1, byte[] sketchBytes2) {
         Union union = Sketches.setOperationBuilder().buildUnion();
         union.union(Memory.wrap(sketchBytes1));
         union.union(Memory.wrap(sketchBytes2));
         return union.getResult().toByteArray();
+    }
+
+    public static double estimate(byte[] sketchBytes) {
+        return Sketches.wrapSketch(Memory.wrap(sketchBytes)).getEstimate();
     }
 
     @VisibleForTesting
@@ -42,5 +54,42 @@ public class ThetaSketch {
             updateSketch.update(value);
         }
         return updateSketch.compact().toByteArray();
+    }
+
+    /** Incremental Theta sketch builder. Null values are ignored. */
+    public static class Builder {
+
+        private final UpdateSketch updateSketch;
+
+        private Builder() {
+            this.updateSketch = UpdateSketch.builder().build();
+        }
+
+        public void update(Object value) {
+            if (value == null) {
+                return;
+            }
+
+            if (value instanceof byte[]) {
+                updateSketch.update((byte[]) value);
+            } else if (value instanceof Byte
+                    || value instanceof Short
+                    || value instanceof Integer
+                    || value instanceof Long) {
+                updateSketch.update(((Number) value).longValue());
+            } else if (value instanceof Float || value instanceof Double) {
+                updateSketch.update(((Number) value).doubleValue());
+            } else if (value instanceof BigDecimal) {
+                updateSketch.update(((BigDecimal) value).toPlainString());
+            } else if (value instanceof Decimal) {
+                updateSketch.update(((Decimal) value).toBigDecimal().toPlainString());
+            } else {
+                updateSketch.update(value.toString().getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        public byte[] toByteArray() {
+            return updateSketch.compact().toByteArray();
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/AbstractFileStore.java
@@ -55,6 +55,7 @@ import org.apache.paimon.partition.PartitionValuesTimeExpireStrategy;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.stats.StatisticsSidecarFile;
 import org.apache.paimon.stats.StatsFile;
 import org.apache.paimon.stats.StatsFileHandler;
 import org.apache.paimon.table.BucketMode;
@@ -249,7 +250,8 @@ abstract class AbstractFileStore<T> implements FileStore<T> {
         return new StatsFileHandler(
                 snapshotManager(),
                 schemaManager,
-                new StatsFile(fileIO, pathFactory().statsFileFactory()));
+                new StatsFile(fileIO, pathFactory().statsFileFactory()),
+                new StatisticsSidecarFile(fileIO, pathFactory().statsSidecarFileFactory()));
     }
 
     protected ManifestsReader newManifestsReader() {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/LocalOrphanFilesClean.java
@@ -159,12 +159,17 @@ public class LocalOrphanFilesClean extends OrphanFilesClean {
     private void collectWithoutDataFile(
             String branch, Consumer<String> usedFileConsumer, Consumer<String> manifestConsumer)
             throws IOException {
+        Set<String> readStatisticsFiles = ConcurrentHashMap.newKeySet();
         randomlyOnlyExecute(
                 executor,
                 snapshot -> {
                     try {
                         collectWithoutDataFile(
-                                branch, snapshot, usedFileConsumer, manifestConsumer);
+                                branch,
+                                snapshot,
+                                usedFileConsumer,
+                                manifestConsumer,
+                                readStatisticsFiles);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/OrphanFilesClean.java
@@ -29,6 +29,8 @@ import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.manifest.ManifestList;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.stats.Statistics;
+import org.apache.paimon.stats.StatisticsBlobMetadata;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.utils.ChangelogManager;
 import org.apache.paimon.utils.DateTimeUtils;
@@ -251,6 +253,17 @@ public abstract class OrphanFilesClean implements Serializable {
             Consumer<String> usedFileConsumer,
             Consumer<String> manifestConsumer)
             throws IOException {
+        collectWithoutDataFile(
+                branch, snapshot, usedFileConsumer, manifestConsumer, new HashSet<>());
+    }
+
+    protected void collectWithoutDataFile(
+            String branch,
+            Snapshot snapshot,
+            Consumer<String> usedFileConsumer,
+            Consumer<String> manifestConsumer,
+            Set<String> readStatisticsFiles)
+            throws IOException {
         Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer =
                 fileAndFlag -> {
                     if (fileAndFlag.getRight()) {
@@ -258,13 +271,24 @@ public abstract class OrphanFilesClean implements Serializable {
                     }
                     usedFileConsumer.accept(fileAndFlag.getLeft());
                 };
-        collectWithoutDataFileWithManifestFlag(branch, snapshot, usedFileWithFlagConsumer);
+        collectWithoutDataFileWithManifestFlag(
+                branch, snapshot, usedFileWithFlagConsumer, readStatisticsFiles);
     }
 
     protected void collectWithoutDataFileWithManifestFlag(
             String branch,
             Snapshot snapshot,
             Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer)
+            throws IOException {
+        collectWithoutDataFileWithManifestFlag(
+                branch, snapshot, usedFileWithFlagConsumer, new HashSet<>());
+    }
+
+    protected void collectWithoutDataFileWithManifestFlag(
+            String branch,
+            Snapshot snapshot,
+            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
+            Set<String> readStatisticsFiles)
             throws IOException {
         FileStoreTable branchTable = table.switchToBranch(branch);
         ManifestList manifestList = branchTable.store().manifestListFactory().create();
@@ -317,7 +341,36 @@ public abstract class OrphanFilesClean implements Serializable {
 
         // statistic file
         if (snapshot.statistics() != null) {
-            usedFileWithFlagConsumer.accept(Pair.of(snapshot.statistics(), false));
+            collectStatisticsFiles(
+                    branchTable,
+                    snapshot.statistics(),
+                    usedFileWithFlagConsumer,
+                    readStatisticsFiles);
+        }
+    }
+
+    private void collectStatisticsFiles(
+            FileStoreTable branchTable,
+            String statistics,
+            Consumer<Pair<String, Boolean>> usedFileWithFlagConsumer,
+            Set<String> readStatisticsFiles)
+            throws IOException {
+        usedFileWithFlagConsumer.accept(Pair.of(statistics, false));
+        if (!readStatisticsFiles.add(statistics)) {
+            return;
+        }
+
+        Path statisticsPath =
+                branchTable.store().pathFactory().statsFileFactory().toPath(statistics);
+        Statistics stats =
+                retryReadingFiles(
+                        () -> Statistics.fromJson(fileIO.readFileUtf8(statisticsPath)), null);
+        if (stats == null) {
+            return;
+        }
+
+        for (StatisticsBlobMetadata metadata : stats.blobMetadata()) {
+            usedFileWithFlagConsumer.accept(Pair.of(metadata.fileLocation(), false));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/stats/Statistics.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/Statistics.java
@@ -35,7 +35,9 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
@@ -48,6 +50,7 @@ import java.util.stream.Collectors;
  *   <li>mergedRecordCount: the total number of records after merge
  *   <li>mergedRecordSize: the size of the mergedRecordCount in bytes
  *   <li>colStats: column stats map
+ *   <li>blobMetadata: metadata of statistics blobs stored in sidecar files
  * </ul>
  */
 @Experimental
@@ -61,6 +64,7 @@ public class Statistics {
     private static final String FIELD_MERGED_RECORD_COUNT = "mergedRecordCount";
     private static final String FIELD_MERGED_RECORD_SIZE = "mergedRecordSize";
     private static final String FIELD_COL_STATS = "colStats";
+    private static final String FIELD_BLOB_METADATA = "blobMetadata";
 
     @JsonProperty(FIELD_SNAPSHOT_ID)
     private final long snapshotId;
@@ -79,22 +83,50 @@ public class Statistics {
     @JsonProperty(FIELD_COL_STATS)
     private final Map<String, ColStats<?>> colStats;
 
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(FIELD_BLOB_METADATA)
+    private final List<StatisticsBlobMetadata> blobMetadata;
+
     @JsonCreator
     public Statistics(
             @JsonProperty(FIELD_SNAPSHOT_ID) long snapshotId,
             @JsonProperty(FIELD_SCHEMA_ID) long schemaId,
             @JsonProperty(FIELD_MERGED_RECORD_COUNT) @Nullable Long mergedRecordCount,
             @JsonProperty(FIELD_MERGED_RECORD_SIZE) @Nullable Long mergedRecordSize,
-            @JsonProperty(FIELD_COL_STATS) Map<String, ColStats<?>> colStats) {
+            @JsonProperty(FIELD_COL_STATS) Map<String, ColStats<?>> colStats,
+            @JsonProperty(FIELD_BLOB_METADATA) @Nullable
+                    List<StatisticsBlobMetadata> blobMetadata) {
         this.snapshotId = snapshotId;
         this.schemaId = schemaId;
         this.mergedRecordCount = mergedRecordCount;
         this.mergedRecordSize = mergedRecordSize;
         this.colStats = colStats;
+        this.blobMetadata =
+                blobMetadata == null
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(blobMetadata));
     }
 
     public Statistics(
-            long snapshotId, long schemaId, Long mergedRecordCount, Long mergedRecordSize) {
+            long snapshotId,
+            long schemaId,
+            @Nullable Long mergedRecordCount,
+            @Nullable Long mergedRecordSize,
+            Map<String, ColStats<?>> colStats) {
+        this(
+                snapshotId,
+                schemaId,
+                mergedRecordCount,
+                mergedRecordSize,
+                colStats,
+                Collections.emptyList());
+    }
+
+    public Statistics(
+            long snapshotId,
+            long schemaId,
+            @Nullable Long mergedRecordCount,
+            @Nullable Long mergedRecordSize) {
         this(snapshotId, schemaId, mergedRecordCount, mergedRecordSize, Collections.emptyMap());
     }
 
@@ -116,6 +148,10 @@ public class Statistics {
 
     public Map<String, ColStats<?>> colStats() {
         return colStats;
+    }
+
+    public List<StatisticsBlobMetadata> blobMetadata() {
+        return blobMetadata;
     }
 
     public void serializeFieldsToString(TableSchema schema) {
@@ -190,12 +226,14 @@ public class Statistics {
                 && schemaId == stats.schemaId
                 && Objects.equals(mergedRecordCount, stats.mergedRecordCount)
                 && Objects.equals(mergedRecordSize, stats.mergedRecordSize)
-                && Objects.equals(colStats, stats.colStats);
+                && Objects.equals(colStats, stats.colStats)
+                && Objects.equals(blobMetadata, stats.blobMetadata);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotId, schemaId, mergedRecordCount, mergedRecordSize, colStats);
+        return Objects.hash(
+                snapshotId, schemaId, mergedRecordCount, mergedRecordSize, colStats, blobMetadata);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsBlob.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsBlob.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.annotation.Experimental;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Statistics blob payload and the metadata needed to describe it after writing. */
+@Experimental
+public class StatisticsBlob {
+
+    private final String type;
+    private final List<Integer> fieldIds;
+    @Nullable private final Long snapshotId;
+    @Nullable private final Long sequenceNumber;
+    private final Map<String, String> properties;
+    private final byte[] payload;
+
+    public StatisticsBlob(
+            String type,
+            @Nullable List<Integer> fieldIds,
+            @Nullable Long snapshotId,
+            @Nullable Long sequenceNumber,
+            @Nullable Map<String, String> properties,
+            byte[] payload) {
+        this.type = checkNotNull(type, "type must not be null");
+        this.fieldIds =
+                fieldIds == null
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(fieldIds));
+        this.snapshotId = snapshotId;
+        this.sequenceNumber = sequenceNumber;
+        this.properties =
+                properties == null
+                        ? Collections.emptyMap()
+                        : Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+        this.payload =
+                Arrays.copyOf(checkNotNull(payload, "payload must not be null"), payload.length);
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public List<Integer> fieldIds() {
+        return fieldIds;
+    }
+
+    @Nullable
+    public Long snapshotId() {
+        return snapshotId;
+    }
+
+    @Nullable
+    public Long sequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public Map<String, String> properties() {
+        return properties;
+    }
+
+    public byte[] payload() {
+        return Arrays.copyOf(payload, payload.length);
+    }
+
+    StatisticsBlobMetadata toMetadata(String fileLocation, long offset, long length) {
+        return new StatisticsBlobMetadata(
+                type,
+                fieldIds,
+                snapshotId,
+                sequenceNumber,
+                properties,
+                fileLocation,
+                offset,
+                length);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsBlobMetadata.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsBlobMetadata.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.OptionalUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/** Metadata of a statistics blob stored in a sidecar file. */
+@Experimental
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StatisticsBlobMetadata {
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_FIELD_IDS = "fieldIds";
+    private static final String FIELD_SNAPSHOT_ID = "snapshotId";
+    private static final String FIELD_SEQUENCE_NUMBER = "sequenceNumber";
+    private static final String FIELD_PROPERTIES = "properties";
+    private static final String FIELD_FILE_LOCATION = "fileLocation";
+    private static final String FIELD_OFFSET = "offset";
+    private static final String FIELD_LENGTH = "length";
+
+    @JsonProperty(FIELD_TYPE)
+    private final String type;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(FIELD_FIELD_IDS)
+    private final List<Integer> fieldIds;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_SNAPSHOT_ID)
+    private final @Nullable Long snapshotId;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_SEQUENCE_NUMBER)
+    private final @Nullable Long sequenceNumber;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonProperty(FIELD_PROPERTIES)
+    private final Map<String, String> properties;
+
+    @JsonProperty(FIELD_FILE_LOCATION)
+    private final String fileLocation;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_OFFSET)
+    private final @Nullable Long offset;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_LENGTH)
+    private final @Nullable Long length;
+
+    @JsonCreator
+    public StatisticsBlobMetadata(
+            @JsonProperty(FIELD_TYPE) String type,
+            @JsonProperty(FIELD_FIELD_IDS) @Nullable List<Integer> fieldIds,
+            @JsonProperty(FIELD_SNAPSHOT_ID) @Nullable Long snapshotId,
+            @JsonProperty(FIELD_SEQUENCE_NUMBER) @Nullable Long sequenceNumber,
+            @JsonProperty(FIELD_PROPERTIES) @Nullable Map<String, String> properties,
+            @JsonProperty(FIELD_FILE_LOCATION) String fileLocation,
+            @JsonProperty(FIELD_OFFSET) @Nullable Long offset,
+            @JsonProperty(FIELD_LENGTH) @Nullable Long length) {
+        this.type = requireField(type, FIELD_TYPE);
+        this.fieldIds =
+                fieldIds == null
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(fieldIds));
+        this.snapshotId = snapshotId;
+        this.sequenceNumber = sequenceNumber;
+        this.properties =
+                properties == null
+                        ? Collections.emptyMap()
+                        : Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+        this.fileLocation = requireField(fileLocation, FIELD_FILE_LOCATION);
+        this.offset = offset;
+        this.length = length;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public List<Integer> fieldIds() {
+        return fieldIds;
+    }
+
+    public OptionalLong snapshotId() {
+        return OptionalUtils.ofNullable(snapshotId);
+    }
+
+    public OptionalLong sequenceNumber() {
+        return OptionalUtils.ofNullable(sequenceNumber);
+    }
+
+    public Map<String, String> properties() {
+        return properties;
+    }
+
+    public String fileLocation() {
+        return fileLocation;
+    }
+
+    public OptionalLong offset() {
+        return OptionalUtils.ofNullable(offset);
+    }
+
+    public OptionalLong length() {
+        return OptionalUtils.ofNullable(length);
+    }
+
+    public String toJson() {
+        return JsonSerdeUtil.toJson(this);
+    }
+
+    public static StatisticsBlobMetadata fromJson(String json) {
+        return JsonSerdeUtil.fromJson(json, StatisticsBlobMetadata.class);
+    }
+
+    private static String requireField(@Nullable String value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Missing required field '%s' in statistics blob metadata.", field));
+        }
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StatisticsBlobMetadata that = (StatisticsBlobMetadata) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(fieldIds, that.fieldIds)
+                && Objects.equals(snapshotId, that.snapshotId)
+                && Objects.equals(sequenceNumber, that.sequenceNumber)
+                && Objects.equals(properties, that.properties)
+                && Objects.equals(fileLocation, that.fileLocation)
+                && Objects.equals(offset, that.offset)
+                && Objects.equals(length, that.length);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                type,
+                fieldIds,
+                snapshotId,
+                sequenceNumber,
+                properties,
+                fileLocation,
+                offset,
+                length);
+    }
+
+    @Override
+    public String toString() {
+        return JsonSerdeUtil.toJson(this);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsNdvSketch.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsNdvSketch.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.utils.ThetaSketch;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Utilities for NDV statistics stored as Apache DataSketches Theta sketches. */
+@Experimental
+public class StatisticsNdvSketch {
+
+    /**
+     * Paimon-specific blob type. The payload is an Apache DataSketches compact Theta sketch, but
+     * the sidecar container is Paimon's own statistics sidecar format, not an Iceberg Puffin file.
+     */
+    public static final String THETA_SKETCH_BLOB_TYPE = "paimon-ndv-theta-sketch-v1";
+
+    public static final String PROPERTY_NDV = "ndv";
+
+    private StatisticsNdvSketch() {}
+
+    public static StatisticsBlob toBlob(
+            int fieldId,
+            @Nullable Long snapshotId,
+            @Nullable Long sequenceNumber,
+            byte[] thetaSketchBytes) {
+        return toBlob(
+                Collections.singletonList(fieldId), snapshotId, sequenceNumber, thetaSketchBytes);
+    }
+
+    public static StatisticsBlob toBlob(
+            List<Integer> fieldIds,
+            @Nullable Long snapshotId,
+            @Nullable Long sequenceNumber,
+            byte[] thetaSketchBytes) {
+        Map<String, String> properties = new LinkedHashMap<>();
+        // Cache the estimate in metadata so readers do not need to open the payload for NDV.
+        properties.put(PROPERTY_NDV, Double.toString(estimate(thetaSketchBytes)));
+        return new StatisticsBlob(
+                THETA_SKETCH_BLOB_TYPE,
+                fieldIds,
+                snapshotId,
+                sequenceNumber,
+                properties,
+                thetaSketchBytes);
+    }
+
+    public static byte[] union(byte[] sketchBytes1, byte[] sketchBytes2) {
+        return ThetaSketch.union(sketchBytes1, sketchBytes2);
+    }
+
+    public static double estimate(byte[] thetaSketchBytes) {
+        return ThetaSketch.estimate(thetaSketchBytes);
+    }
+
+    public static double ndv(StatisticsBlobMetadata metadata) {
+        checkArgument(
+                THETA_SKETCH_BLOB_TYPE.equals(metadata.type()),
+                "Unsupported NDV sketch blob type %s.",
+                metadata.type());
+        String ndv = metadata.properties().get(PROPERTY_NDV);
+        checkArgument(
+                ndv != null, "NDV sketch blob metadata must contain property '%s'.", PROPERTY_NDV);
+        return Double.parseDouble(ndv);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsSidecarFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatisticsSidecarFile.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.annotation.Experimental;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.memory.BytesUtils;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.StreamUtils;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Sidecar file for statistics blobs. */
+@Experimental
+public class StatisticsSidecarFile {
+
+    private static final int VERSION = 1;
+    private static final int MAGIC_NUMBER = 0x53544331;
+    private static final byte[] MAGIC_NUMBER_BYTES = StreamUtils.intToLittleEndian(MAGIC_NUMBER);
+    private static final int FOOTER_LENGTH_BYTES = Integer.BYTES;
+    private static final int MAGIC_NUMBER_LENGTH = Integer.BYTES;
+    private static final int MIN_FILE_LENGTH = FOOTER_LENGTH_BYTES + MAGIC_NUMBER_LENGTH;
+
+    private final FileIO fileIO;
+    private final PathFactory pathFactory;
+
+    public StatisticsSidecarFile(FileIO fileIO, PathFactory pathFactory) {
+        this.fileIO = fileIO;
+        this.pathFactory = pathFactory;
+    }
+
+    /**
+     * Write statistics blobs to one sidecar file.
+     *
+     * @return metadata for the written blobs
+     */
+    public List<StatisticsBlobMetadata> write(List<StatisticsBlob> blobs) {
+        checkNotNull(blobs, "blobs must not be null");
+        checkArgument(!blobs.isEmpty(), "Statistics sidecar file must contain at least one blob.");
+
+        Path path = pathFactory.newPath();
+        List<StatisticsBlobMetadata> metadata = new ArrayList<>(blobs.size());
+        try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
+            for (StatisticsBlob blob : blobs) {
+                long offset = out.getPos();
+                byte[] payload = blob.payload();
+                out.write(payload);
+                metadata.add(blob.toMetadata(path.getName(), offset, payload.length));
+            }
+
+            byte[] footer =
+                    JsonSerdeUtil.toFlatJson(new Footer(VERSION, metadata))
+                            .getBytes(StandardCharsets.UTF_8);
+            out.write(footer);
+            out.write(StreamUtils.intToLittleEndian(footer.length));
+            out.write(MAGIC_NUMBER_BYTES);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write statistics sidecar file: " + path, e);
+        }
+        return metadata;
+    }
+
+    /** Read the metadata footer from a sidecar file. */
+    public List<StatisticsBlobMetadata> readMetadata(String fileName) {
+        Path path = pathFactory.toPath(fileName);
+        try (SeekableInputStream in = fileIO.newInputStream(path)) {
+            long fileLength = fileIO.getFileStatus(path).getLen();
+            checkArgument(
+                    fileLength >= MIN_FILE_LENGTH,
+                    "Statistics sidecar file %s is too small.",
+                    path);
+
+            byte[] footerHandle = new byte[MIN_FILE_LENGTH];
+            in.seek(fileLength - MIN_FILE_LENGTH);
+            IOUtils.readFully(in, footerHandle);
+
+            int footerLength = BytesUtils.getInt(footerHandle, 0);
+            int magicNumber = BytesUtils.getInt(footerHandle, FOOTER_LENGTH_BYTES);
+            checkArgument(
+                    magicNumber == MAGIC_NUMBER,
+                    "Statistics sidecar file %s has invalid magic number.",
+                    path);
+            checkArgument(
+                    footerLength >= 0 && footerLength <= fileLength - MIN_FILE_LENGTH,
+                    "Statistics sidecar file %s has invalid footer length.",
+                    path);
+
+            byte[] footerBytes = new byte[footerLength];
+            in.seek(fileLength - MIN_FILE_LENGTH - footerLength);
+            IOUtils.readFully(in, footerBytes);
+            Footer footer =
+                    JsonSerdeUtil.fromJson(
+                            new String(footerBytes, StandardCharsets.UTF_8), Footer.class);
+            checkArgument(
+                    footer.version() == VERSION,
+                    "Unsupported statistics sidecar file version %s.",
+                    footer.version());
+            return footer.blobs();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read statistics sidecar file: " + path, e);
+        }
+    }
+
+    /** Read a statistics blob payload described by the metadata. */
+    public byte[] read(StatisticsBlobMetadata metadata) {
+        checkNotNull(metadata, "metadata must not be null");
+        checkArgument(
+                metadata.offset().isPresent() && metadata.length().isPresent(),
+                "Statistics blob metadata must contain offset and length.");
+
+        long offset = metadata.offset().getAsLong();
+        long length = metadata.length().getAsLong();
+        checkArgument(length <= Integer.MAX_VALUE, "Statistics blob is too large to read.");
+        checkArgument(offset >= 0 && length >= 0, "Invalid statistics blob range.");
+
+        Path path = pathFactory.toPath(metadata.fileLocation());
+        try (SeekableInputStream in = fileIO.newInputStream(path)) {
+            long fileLength = fileIO.getFileStatus(path).getLen();
+            checkArgument(
+                    offset <= fileLength && length <= fileLength - offset,
+                    "Statistics blob range exceeds sidecar file length: %s.",
+                    metadata);
+            byte[] payload = new byte[(int) length];
+            in.seek(offset);
+            IOUtils.readFully(in, payload);
+            return payload;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read statistics blob: " + metadata, e);
+        }
+    }
+
+    public void delete(String fileName) {
+        fileIO.deleteQuietly(pathFactory.toPath(fileName));
+    }
+
+    public boolean exists(String fileName) {
+        try {
+            return fileIO.exists(pathFactory.toPath(fileName));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Footer {
+
+        private static final String FIELD_VERSION = "version";
+        private static final String FIELD_BLOBS = "blobs";
+
+        @JsonProperty(FIELD_VERSION)
+        private final int version;
+
+        @JsonProperty(FIELD_BLOBS)
+        private final List<StatisticsBlobMetadata> blobs;
+
+        @JsonCreator
+        private Footer(
+                @JsonProperty(FIELD_VERSION) int version,
+                @JsonProperty(FIELD_BLOBS) @Nullable List<StatisticsBlobMetadata> blobs) {
+            this.version = version;
+            this.blobs =
+                    blobs == null
+                            ? Collections.emptyList()
+                            : Collections.unmodifiableList(new ArrayList<>(blobs));
+        }
+
+        private int version() {
+            return version;
+        }
+
+        private List<StatisticsBlobMetadata> blobs() {
+            return blobs;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/stats/StatsFileHandler.java
@@ -22,20 +22,40 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.utils.SnapshotManager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /** Handler of StatsFile. */
 public class StatsFileHandler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(StatsFileHandler.class);
+
     private final SnapshotManager snapshotManager;
     private final SchemaManager schemaManager;
     private final StatsFile statsFile;
+    @Nullable private final StatisticsSidecarFile sidecarFile;
 
     public StatsFileHandler(
             SnapshotManager snapshotManager, SchemaManager schemaManager, StatsFile statsFile) {
+        this(snapshotManager, schemaManager, statsFile, null);
+    }
+
+    public StatsFileHandler(
+            SnapshotManager snapshotManager,
+            SchemaManager schemaManager,
+            StatsFile statsFile,
+            @Nullable StatisticsSidecarFile sidecarFile) {
         this.snapshotManager = snapshotManager;
         this.schemaManager = schemaManager;
         this.statsFile = statsFile;
+        this.sidecarFile = sidecarFile;
     }
 
     /**
@@ -77,15 +97,61 @@ public class StatsFileHandler {
         return stats;
     }
 
+    public List<StatisticsBlobMetadata> writeSidecar(List<StatisticsBlob> blobs) {
+        return sidecarFile().write(blobs);
+    }
+
+    public List<StatisticsBlobMetadata> readSidecarMetadata(String fileName) {
+        return sidecarFile().readMetadata(fileName);
+    }
+
+    public byte[] readSidecar(StatisticsBlobMetadata metadata) {
+        return sidecarFile().read(metadata);
+    }
+
     /** Delete stats of the specified snapshot. */
     public void deleteStats(long snapshotId) {
         Snapshot snapshot = snapshotManager.snapshot(snapshotId);
         if (snapshot.statistics() != null) {
-            statsFile.delete(snapshot.statistics());
+            deleteStats(snapshot.statistics());
         }
     }
 
     public void deleteStats(String statistic) {
+        deleteSidecarFiles(statistic);
         statsFile.delete(statistic);
+    }
+
+    private void deleteSidecarFiles(String statistic) {
+        if (sidecarFile == null) {
+            return;
+        }
+
+        Statistics stats;
+        try {
+            stats = statsFile.read(statistic);
+        } catch (RuntimeException e) {
+            LOG.debug(
+                    "Failed to read statistics file {} before deletion. "
+                            + "Skipping statistics sidecar file cleanup.",
+                    statistic,
+                    e);
+            return;
+        }
+
+        Set<String> sidecarFileNames = new HashSet<>();
+        for (StatisticsBlobMetadata metadata : stats.blobMetadata()) {
+            sidecarFileNames.add(metadata.fileLocation());
+        }
+        for (String sidecarFileName : sidecarFileNames) {
+            sidecarFile.delete(sidecarFileName);
+        }
+    }
+
+    private StatisticsSidecarFile sidecarFile() {
+        if (sidecarFile == null) {
+            throw new IllegalStateException("Statistics sidecar file is not configured.");
+        }
+        return sidecarFile;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/FileStorePathFactory.java
@@ -60,6 +60,7 @@ public class FileStorePathFactory {
 
     public static final String STATISTICS_PATH = "statistics";
     public static final String STATISTICS_PREFIX = "stat-";
+    public static final String STATISTICS_SIDECAR_PREFIX = "stat-sidecar-";
 
     public static final String BUCKET_PATH_PREFIX = "bucket-";
 
@@ -362,6 +363,21 @@ public class FileStorePathFactory {
             @Override
             public Path newPath() {
                 return toPath(STATISTICS_PREFIX + uuid + "-" + statsFileCount.getAndIncrement());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(statisticsPath(), fileName);
+            }
+        };
+    }
+
+    public PathFactory statsSidecarFileFactory() {
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return toPath(
+                        STATISTICS_SIDECAR_PREFIX + uuid + "-" + statsFileCount.getAndIncrement());
             }
 
             @Override

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsBlobMetadataTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsBlobMetadataTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link StatisticsBlobMetadata}. */
+public class StatisticsBlobMetadataTest {
+
+    @Test
+    public void testJsonRoundTrip() {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("ndv", "1024");
+        properties.put("sketch", "theta");
+
+        StatisticsBlobMetadata metadata =
+                new StatisticsBlobMetadata(
+                        "paimon-ndv-theta-sketch-v1",
+                        Arrays.asList(1, 3),
+                        10L,
+                        20L,
+                        properties,
+                        "statistics/stats-00001.bin",
+                        128L,
+                        4096L);
+
+        String json = metadata.toJson();
+        assertThat(json).contains("\"type\"", "\"fieldIds\"", "\"fileLocation\"");
+
+        StatisticsBlobMetadata parsed = StatisticsBlobMetadata.fromJson(json);
+        assertThat(parsed).isEqualTo(metadata);
+        assertThat(parsed.fieldIds()).containsExactly(1, 3);
+        assertThat(parsed.snapshotId()).hasValue(10L);
+        assertThat(parsed.sequenceNumber()).hasValue(20L);
+        assertThat(parsed.properties())
+                .containsEntry("ndv", "1024")
+                .containsEntry("sketch", "theta");
+        assertThat(parsed.offset()).hasValue(128L);
+        assertThat(parsed.length()).hasValue(4096L);
+    }
+
+    @Test
+    public void testOptionalFieldsAndUnknownFields() {
+        String json =
+                "{\n"
+                        + "  \"type\" : \"table-row-count-v1\",\n"
+                        + "  \"fileLocation\" : \"statistics/stats-00002.bin\",\n"
+                        + "  \"unknown\" : \"ignored\"\n"
+                        + "}";
+
+        StatisticsBlobMetadata metadata = StatisticsBlobMetadata.fromJson(json);
+        assertThat(metadata.type()).isEqualTo("table-row-count-v1");
+        assertThat(metadata.fieldIds()).isEmpty();
+        assertThat(metadata.snapshotId().isPresent()).isFalse();
+        assertThat(metadata.sequenceNumber().isPresent()).isFalse();
+        assertThat(metadata.properties()).isEmpty();
+        assertThat(metadata.fileLocation()).isEqualTo("statistics/stats-00002.bin");
+        assertThat(metadata.offset().isPresent()).isFalse();
+        assertThat(metadata.length().isPresent()).isFalse();
+
+        String roundTripJson = metadata.toJson();
+        assertThat(roundTripJson).doesNotContain("\"fieldIds\"", "\"properties\"");
+        assertThat(StatisticsBlobMetadata.fromJson(roundTripJson)).isEqualTo(metadata);
+    }
+
+    @Test
+    public void testMissingRequiredFields() {
+        assertThatThrownBy(
+                        () ->
+                                StatisticsBlobMetadata.fromJson(
+                                        "{\n"
+                                                + "  \"fileLocation\" : \"statistics/stats-00002.bin\"\n"
+                                                + "}"))
+                .hasMessageContaining("Missing required field 'type'");
+
+        assertThatThrownBy(
+                        () ->
+                                StatisticsBlobMetadata.fromJson(
+                                        "{\n" + "  \"type\" : \"table-row-count-v1\"\n" + "}"))
+                .hasMessageContaining("Missing required field 'fileLocation'");
+    }
+
+    @Test
+    public void testCollectionDefensiveCopy() {
+        List<Integer> fieldIds = new ArrayList<>(Arrays.asList(1, 3));
+
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("ndv", "1024");
+
+        StatisticsBlobMetadata metadata =
+                new StatisticsBlobMetadata(
+                        "paimon-ndv-theta-sketch-v1",
+                        fieldIds,
+                        10L,
+                        20L,
+                        properties,
+                        "statistics/stats-00001.bin",
+                        128L,
+                        4096L);
+
+        fieldIds.set(0, 2);
+        fieldIds.add(4);
+        properties.put("sketch", "theta");
+
+        assertThat(metadata.fieldIds()).containsExactly(1, 3);
+        assertThat(metadata.properties()).containsOnlyKeys("ndv");
+        assertThatThrownBy(() -> metadata.fieldIds().add(4))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> metadata.properties().put("new-key", "new-value"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsNdvSketchTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsNdvSketchTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.PathFactory;
+import org.apache.paimon.utils.ThetaSketch;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+/** Test for {@link StatisticsNdvSketch}. */
+public class StatisticsNdvSketchTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    public void testMergeableNdvSketchBlobRoundTrip() {
+        byte[] left = ThetaSketch.sketchOf(1, 2, 3);
+        byte[] right = ThetaSketch.sketchOf(3, 4, 5);
+        byte[] union = StatisticsNdvSketch.union(left, right);
+
+        assertThat(StatisticsNdvSketch.estimate(union)).isCloseTo(5.0, offset(0.001));
+
+        StatisticsBlob blob = StatisticsNdvSketch.toBlob(1, 10L, 20L, union);
+        StatisticsSidecarFile sidecarFile =
+                new StatisticsSidecarFile(LocalFileIO.create(), pathFactory());
+        List<StatisticsBlobMetadata> metadata = sidecarFile.write(Collections.singletonList(blob));
+
+        StatisticsBlobMetadata ndvMetadata = metadata.get(0);
+        assertThat(ndvMetadata.type()).isEqualTo(StatisticsNdvSketch.THETA_SKETCH_BLOB_TYPE);
+        assertThat(ndvMetadata.fieldIds()).containsExactly(1);
+        assertThat(StatisticsNdvSketch.ndv(ndvMetadata)).isCloseTo(5.0, offset(0.001));
+
+        byte[] payload = sidecarFile.read(ndvMetadata);
+        assertThat(StatisticsNdvSketch.estimate(payload)).isCloseTo(5.0, offset(0.001));
+    }
+
+    private PathFactory pathFactory() {
+        Path dir = new Path(tempPath.toUri());
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return new Path(dir, UUID.randomUUID().toString());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(dir, fileName);
+            }
+        };
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsSidecarFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsSidecarFileTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.PathFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link StatisticsSidecarFile}. */
+public class StatisticsSidecarFileTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    public void testWriteAndReadMultipleBlobs() {
+        StatisticsSidecarFile sidecarFile =
+                new StatisticsSidecarFile(
+                        LocalFileIO.create(),
+                        pathFactory(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX));
+
+        Map<String, String> firstProperties = new LinkedHashMap<>();
+        firstProperties.put("name", "first");
+
+        StatisticsBlob first =
+                new StatisticsBlob(
+                        "test-type-a",
+                        Collections.singletonList(1),
+                        10L,
+                        20L,
+                        firstProperties,
+                        "first-payload".getBytes(StandardCharsets.UTF_8));
+        StatisticsBlob second =
+                new StatisticsBlob(
+                        "test-type-b",
+                        Arrays.asList(2, 3),
+                        10L,
+                        21L,
+                        Collections.emptyMap(),
+                        "second-payload".getBytes(StandardCharsets.UTF_8));
+
+        List<StatisticsBlobMetadata> writtenMetadata =
+                sidecarFile.write(Arrays.asList(first, second));
+
+        assertThat(writtenMetadata).hasSize(2);
+        assertThat(writtenMetadata.get(0).fileLocation())
+                .startsWith(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX);
+        assertThat(writtenMetadata.get(0).fileLocation())
+                .isEqualTo(writtenMetadata.get(1).fileLocation());
+        assertThat(sidecarFile.exists(writtenMetadata.get(0).fileLocation())).isTrue();
+        assertThat(writtenMetadata.get(0).offset()).hasValue(0L);
+        assertThat(writtenMetadata.get(0).length()).hasValue((long) first.payload().length);
+        assertThat(writtenMetadata.get(1).offset()).hasValue((long) first.payload().length);
+        assertThat(writtenMetadata.get(1).length()).hasValue((long) second.payload().length);
+
+        assertThat(sidecarFile.read(writtenMetadata.get(0))).containsExactly(first.payload());
+        assertThat(sidecarFile.read(writtenMetadata.get(1))).containsExactly(second.payload());
+        assertThat(sidecarFile.readMetadata(writtenMetadata.get(0).fileLocation()))
+                .isEqualTo(writtenMetadata);
+
+        sidecarFile.delete(writtenMetadata.get(0).fileLocation());
+        assertThat(sidecarFile.exists(writtenMetadata.get(0).fileLocation())).isFalse();
+    }
+
+    @Test
+    public void testStatsFileHandlerDeletesSidecarFiles() {
+        PathFactory statsPathFactory = pathFactory("stat-");
+        PathFactory sidecarPathFactory =
+                pathFactory(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX);
+        LocalFileIO fileIO = LocalFileIO.create();
+        StatsFile statsFile = new StatsFile(fileIO, statsPathFactory);
+        StatisticsSidecarFile sidecarFile = new StatisticsSidecarFile(fileIO, sidecarPathFactory);
+        StatsFileHandler statsFileHandler =
+                new StatsFileHandler(null, null, statsFile, sidecarFile);
+
+        List<StatisticsBlobMetadata> blobMetadata =
+                statsFileHandler.writeSidecar(
+                        Collections.singletonList(
+                                new StatisticsBlob(
+                                        "test-type",
+                                        Collections.singletonList(1),
+                                        10L,
+                                        20L,
+                                        Collections.emptyMap(),
+                                        "payload".getBytes(StandardCharsets.UTF_8))));
+        Statistics stats =
+                new Statistics(10L, 0L, 100L, 1000L, Collections.emptyMap(), blobMetadata);
+        String statsFileName = statsFile.write(stats);
+
+        assertThat(statsFile.exists(statsFileName)).isTrue();
+        assertThat(sidecarFile.exists(blobMetadata.get(0).fileLocation())).isTrue();
+        assertThat(blobMetadata.get(0).fileLocation())
+                .startsWith(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX);
+        assertThat(statsFileHandler.readSidecar(blobMetadata.get(0)))
+                .containsExactly("payload".getBytes(StandardCharsets.UTF_8));
+
+        statsFileHandler.deleteStats(statsFileName);
+
+        assertThat(statsFile.exists(statsFileName)).isFalse();
+        assertThat(sidecarFile.exists(blobMetadata.get(0).fileLocation())).isFalse();
+    }
+
+    @Test
+    public void testRejectEmptyBlobs() {
+        StatisticsSidecarFile sidecarFile =
+                new StatisticsSidecarFile(
+                        LocalFileIO.create(),
+                        pathFactory(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX));
+
+        assertThatThrownBy(() -> sidecarFile.write(Collections.emptyList()))
+                .hasMessageContaining("must contain at least one blob");
+    }
+
+    @Test
+    public void testRejectOutOfRangeBlobMetadata() {
+        StatisticsSidecarFile sidecarFile =
+                new StatisticsSidecarFile(
+                        LocalFileIO.create(),
+                        pathFactory(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX));
+        StatisticsBlob blob =
+                new StatisticsBlob(
+                        "test-type",
+                        Collections.singletonList(1),
+                        10L,
+                        20L,
+                        Collections.emptyMap(),
+                        "payload".getBytes(StandardCharsets.UTF_8));
+
+        StatisticsBlobMetadata metadata = sidecarFile.write(Collections.singletonList(blob)).get(0);
+        StatisticsBlobMetadata outOfRangeMetadata =
+                new StatisticsBlobMetadata(
+                        metadata.type(),
+                        metadata.fieldIds(),
+                        metadata.snapshotId().getAsLong(),
+                        metadata.sequenceNumber().getAsLong(),
+                        metadata.properties(),
+                        metadata.fileLocation(),
+                        metadata.offset().getAsLong(),
+                        1024L);
+
+        assertThatThrownBy(() -> sidecarFile.read(outOfRangeMetadata))
+                .hasMessageContaining("range exceeds sidecar file length");
+    }
+
+    private PathFactory pathFactory(String prefix) {
+        Path dir = new Path(tempPath.toUri());
+        return new PathFactory() {
+            @Override
+            public Path newPath() {
+                return new Path(dir, prefix + UUID.randomUUID());
+            }
+
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(dir, fileName);
+            }
+        };
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/stats/StatisticsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.stats;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link Statistics}. */
+public class StatisticsTest {
+
+    @Test
+    public void testJsonRoundTripWithBlobMetadata() {
+        StatisticsBlobMetadata blobMetadata =
+                new StatisticsBlobMetadata(
+                        "paimon-ndv-theta-sketch-v1",
+                        Collections.singletonList(1),
+                        10L,
+                        20L,
+                        Collections.singletonMap("ndv", "5.0"),
+                        "stat-00001",
+                        0L,
+                        128L);
+        Statistics statistics =
+                new Statistics(
+                        10L,
+                        0L,
+                        100L,
+                        1000L,
+                        Collections.emptyMap(),
+                        Collections.singletonList(blobMetadata));
+
+        String json = statistics.toJson();
+        assertThat(json).contains("\"blobMetadata\"");
+        assertThat(Statistics.fromJson(json)).isEqualTo(statistics);
+    }
+
+    @Test
+    public void testReadJsonWithoutBlobMetadata() {
+        String json =
+                "{\n"
+                        + "  \"snapshotId\" : 10,\n"
+                        + "  \"schemaId\" : 0,\n"
+                        + "  \"mergedRecordCount\" : 100,\n"
+                        + "  \"mergedRecordSize\" : 1000,\n"
+                        + "  \"colStats\" : { }\n"
+                        + "}";
+
+        Statistics statistics = Statistics.fromJson(json);
+        assertThat(statistics.blobMetadata()).isEmpty();
+        assertThat(statistics.toJson()).doesNotContain("\"blobMetadata\"");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/FileStorePathFactoryTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.paimon.CoreOptions.PARTITION_DEFAULT_NAME;
+import static org.apache.paimon.utils.FileStorePathFactory.STATISTICS_SIDECAR_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileStorePathFactory}. */
@@ -75,6 +76,16 @@ public class FileStorePathFactoryTest {
         assertThat(dataFilePathFactory.newPath("my-data-file-name").toString())
                 .startsWith(
                         new Path(tempDir.toString() + "/bucket-123/my-data-file-name").toString());
+    }
+
+    @Test
+    public void testStatisticsSidecarPath() {
+        FileStorePathFactory pathFactory = createNonPartFactory(new Path(tempDir.toString()));
+
+        Path sidecarPath = pathFactory.statsSidecarFileFactory().newPath();
+
+        assertThat(sidecarPath.getParent()).isEqualTo(new Path(tempDir.toString() + "/statistics"));
+        assertThat(sidecarPath.getName()).startsWith(STATISTICS_SIDECAR_PREFIX);
     }
 
     @Test

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -67,6 +67,13 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "If true, v2 write will be used. Currently, only HASH_FIXED and BUCKET_UNAWARE bucket modes are supported. Will fall back to v1 write for other bucket modes. Currently, Spark V2 write does not support TableCapability.STREAMING_WRITE.");
 
+    public static final ConfigOption<Boolean> ANALYZE_NDV_SKETCH_ENABLED =
+            key("analyze.ndv-sketch.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, ANALYZE TABLE ... COMPUTE STATISTICS FOR COLUMNS writes NDV Theta sketches to Paimon statistics sidecar files.");
+
     public static final ConfigOption<Integer> MAX_FILES_PER_TRIGGER =
             key("read.stream.maxFilesPerTrigger")
                     .intType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/PaimonAnalyzeTableColumnCommand.scala
@@ -18,19 +18,24 @@
 
 package org.apache.paimon.spark.commands
 
+import org.apache.paimon.Snapshot
 import org.apache.paimon.schema.TableSchema
 import org.apache.paimon.spark.SparkTable
 import org.apache.paimon.spark.leafnode.PaimonLeafRunnableCommand
-import org.apache.paimon.stats.{ColStats, Statistics}
+import org.apache.paimon.spark.util.OptionUtils
+import org.apache.paimon.stats.{ColStats, Statistics, StatisticsBlob, StatisticsBlobMetadata, StatisticsNdvSketch}
 import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.utils.Preconditions.checkState
+import org.apache.paimon.utils.ThetaSketch
 
 import org.apache.spark.sql.{PaimonStatsUtils, Row, SparkSession}
+import org.apache.spark.sql.PaimonUtils.createDataset
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.ColumnStat
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.paimon.shims.SparkShimLoader
 import org.apache.spark.sql.types.{DataType, Decimal, DecimalType, TimestampType}
 
 import java.util
@@ -80,12 +85,21 @@ case class PaimonAnalyzeTableColumnCommand(
       colStatsMap.put(attr.name, toPaimonColStats(attr, stats, tableSchema))
     }
 
+    val blobMetadata = writeNdvSketchSidecarIfNeeded(
+      sparkSession,
+      relation,
+      attributes,
+      currentSnapshot,
+      tableSchema)
+
     val stats = new Statistics(
       currentSnapshot.id(),
       currentSnapshot.schemaId(),
       mergedRecordCount,
       mergedRecordSize,
-      colStatsMap)
+      colStatsMap,
+      blobMetadata
+    )
 
     // commit stats
     val commit = table.newBatchWriteBuilder().newCommit()
@@ -145,6 +159,67 @@ case class PaimonAnalyzeTableColumnCommand(
           )
       }
       .getOrElse(throw new RuntimeException(s"Column ${attribute.name} is not found in schema."))
+  }
+
+  private def writeNdvSketchSidecarIfNeeded(
+      sparkSession: SparkSession,
+      relation: DataSourceV2Relation,
+      attributes: Seq[Attribute],
+      currentSnapshot: Snapshot,
+      tableSchema: TableSchema): util.List[StatisticsBlobMetadata] = {
+    if (!OptionUtils.analyzeNdvSketchEnabled() || attributes.isEmpty) {
+      return java.util.Collections.emptyList()
+    }
+
+    // This optional path intentionally runs a second scan after Spark column-stat computation.
+    // Keeping it behind a default-off flag avoids changing ANALYZE cost for existing users while
+    // the sidecar format is still experimental.
+    val sketches = computeNdvSketches(sparkSession, relation, attributes)
+    val fieldsByName = tableSchema.fields.asScala.map(field => field.name() -> field).toMap
+    val blobs = new util.ArrayList[StatisticsBlob]()
+    attributes.foreach {
+      attr =>
+        val field = fieldsByName.getOrElse(
+          attr.name,
+          throw new RuntimeException(s"Column ${attr.name} is not found in schema."))
+        blobs.add(
+          StatisticsNdvSketch.toBlob(field.id(), currentSnapshot.id(), null, sketches(attr)))
+    }
+    table.store().newStatsFileHandler().writeSidecar(blobs)
+  }
+
+  private def computeNdvSketches(
+      sparkSession: SparkSession,
+      relation: DataSourceV2Relation,
+      attributes: Seq[Attribute]): Map[Attribute, Array[Byte]] = {
+    val selected = createDataset(sparkSession, relation)
+      .select(attributes.map(SparkShimLoader.shim.classicApi.column): _*)
+    val partitionSketches = selected.rdd
+      .mapPartitions {
+        rows =>
+          val builders = Array.fill(attributes.size)(ThetaSketch.builder())
+          rows.foreach {
+            row =>
+              var index = 0
+              while (index < builders.length) {
+                builders(index).update(row.get(index))
+                index += 1
+              }
+          }
+          Iterator(builders.map(_.toByteArray))
+      }
+      .collect()
+
+    val merged = Array.fill(attributes.size)(ThetaSketch.builder().toByteArray)
+    partitionSketches.foreach {
+      sketches =>
+        var index = 0
+        while (index < sketches.length) {
+          merged(index) = StatisticsNdvSketch.union(merged(index), sketches(index))
+          index += 1
+        }
+    }
+    attributes.zip(merged).toMap
   }
 
   /**

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -110,6 +110,10 @@ object OptionUtils extends SQLConfHelper with Logging {
     getOptionString(SparkConnectorOptions.MERGE_SCHEMA).toBoolean
   }
 
+  def analyzeNdvSketchEnabled(): Boolean = {
+    getOptionString(SparkConnectorOptions.ANALYZE_NDV_SKETCH_ENABLED).toBoolean
+  }
+
   def writeMergeSchemaExplicitCastEnabled(): Boolean = {
     getOptionString(SparkConnectorOptions.EXPLICIT_CAST).toBoolean
   }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/AnalyzeTableTestBase.scala
@@ -21,8 +21,9 @@ package org.apache.paimon.spark.sql
 import org.apache.paimon.data.Decimal
 import org.apache.paimon.fs.{FileIO, Path}
 import org.apache.paimon.spark.PaimonSparkTestBase
-import org.apache.paimon.stats.ColStats
+import org.apache.paimon.stats.{ColStats, StatisticsNdvSketch}
 import org.apache.paimon.utils.DateTimeUtils
+import org.apache.paimon.utils.FileStorePathFactory
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
@@ -31,6 +32,8 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions
 
 import java.util.UUID
+
+import scala.collection.JavaConverters._
 
 abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
 
@@ -358,6 +361,46 @@ abstract class AnalyzeTableTestBase extends PaimonSparkTestBase {
     checkAnswer(
       spark.sql(s"SELECT * from T ORDER BY id"),
       Row("1", "a", 1, 1) :: Row("2", "aaa", 1, 2) :: Nil)
+  }
+
+  test("Paimon analyze: write NDV sketch sidecar when enabled") {
+    spark.sql(s"""
+                 |CREATE TABLE T (id INT, name STRING, l LONG)
+                 |USING PAIMON
+                 |""".stripMargin)
+
+    spark.sql(s"INSERT INTO T VALUES (1, 'a', 1), (2, 'a', 2), (2, 'b', 3), (null, 'b', 4)")
+
+    spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS id, name")
+    Assertions.assertTrue(loadTable("T").statistics().get().blobMetadata().isEmpty)
+
+    withSparkSQLConf("spark.paimon.analyze.ndv-sketch.enabled" -> "true") {
+      spark.sql(s"ANALYZE TABLE T COMPUTE STATISTICS FOR COLUMNS id, name")
+    }
+
+    val table = loadTable("T")
+    val stats = table.statistics().get()
+    val metadata = stats.blobMetadata()
+    Assertions.assertEquals(2, metadata.size())
+    metadata.asScala.foreach(
+      blob =>
+        Assertions.assertTrue(
+          blob.fileLocation().startsWith(FileStorePathFactory.STATISTICS_SIDECAR_PREFIX)))
+
+    val metadataByFieldId = metadata.asScala.map(blob => blob.fieldIds().get(0) -> blob).toMap
+    val statsFileHandler = table.store().newStatsFileHandler()
+
+    val idSketch = statsFileHandler.readSidecar(metadataByFieldId(0))
+    Assertions.assertEquals(2.0, StatisticsNdvSketch.estimate(idSketch), 0.001)
+    Assertions.assertEquals(
+      stats.colStats().get("id").distinctCount().getAsLong,
+      Math.round(StatisticsNdvSketch.ndv(metadataByFieldId(0))))
+
+    val nameSketch = statsFileHandler.readSidecar(metadataByFieldId(1))
+    Assertions.assertEquals(2.0, StatisticsNdvSketch.estimate(nameSketch), 0.001)
+    Assertions.assertEquals(
+      stats.colStats().get("name").distinctCount().getAsLong,
+      Math.round(StatisticsNdvSketch.ndv(metadataByFieldId(1))))
   }
 
   test("Paimon analyze: statistics expire and clean") {


### PR DESCRIPTION
### Purpose

For #8381.

This PR implements a core + Spark statistics sidecar vertical slice for mergeable NDV sketches.

It adds:

- `StatisticsBlobMetadata` for typed blob references, field ids, optional snapshot / sequence numbers, properties, sidecar file location, offset, and length.
- `StatisticsBlob` and `StatisticsSidecarFile` to write multiple statistics blob payloads into one sidecar file and read them back by metadata.
- `Statistics.blobMetadata` JSON serialization with backward-compatible reads when the field is absent.
- `StatsFileHandler` sidecar read/write APIs and sidecar cleanup when deleting statistics files.
- orphan file cleanup protection for sidecar files referenced by live statistics files.
- `FileStorePathFactory.statsSidecarFileFactory()` and the `stat-sidecar-` prefix, so binary sidecars are distinguishable from JSON statistics files under the statistics directory.
- `StatisticsNdvSketch` for Paimon-specific `paimon-ndv-theta-sketch-v1` blobs. The payload is an Apache DataSketches compact Theta sketch, while the container is Paimon's own statistics sidecar format.
- Spark `ANALYZE TABLE ... COMPUTE STATISTICS FOR COLUMNS` sidecar production behind `spark.paimon.analyze.ndv-sketch.enabled` (default: false). When enabled, Spark writes one NDV sketch blob per analyzed column and attaches the sidecar metadata to the committed `Statistics` file.

Existing scalar column statistics remain unchanged; the sidecar metadata is additional optional statistics metadata.

### Tests

CI
