### PR TITLE
[core] bump ORC to 1.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@ under the License.
         <testcontainers.version>1.19.1</testcontainers.version>
         <iceberg.version>1.6.1</iceberg.version>
         <parquet.version>1.16.0</parquet.version>
-        <orc.version>1.9.2</orc.version>
+        <orc.version>1.9.8</orc.version>
         <protobuf-java.version>3.19.6</protobuf-java.version>
         <roaringbitmap.version>1.2.1</roaringbitmap.version>
         <arrow.version>15.0.0</arrow.version>


### PR DESCRIPTION
### Purpose

https://orc.apache.org/news/2024/11/14/ORC-1.9.5/

https://orc.apache.org/news/2025/07/04/ORC-1.9.7/

https://orc.apache.org/news/2026/01/08/ORC-1.9.8/

### Tests

GHA
