### PR TITLE
[orc] Ensure batch size is at least 1

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/OrcReaderFactory.java
@@ -158,7 +158,8 @@ public class OrcReaderFactory implements FormatReaderFactory {
         final Pool<OrcReaderBatch> pool = new Pool<>(numBatches);
 
         for (int i = 0; i < numBatches; i++) {
-            final VectorizedRowBatch orcBatch = createBatchWrapper(schema, batchSize / numBatches);
+            final VectorizedRowBatch orcBatch =
+                    createBatchWrapper(schema, Math.max(1, batchSize / numBatches));
             final OrcReaderBatch batch =
                     createReaderBatch(filePath, orcBatch, pool.recycler(), fileIO);
             pool.add(batch);


### PR DESCRIPTION
### Purpose

```sql
set spark.paimon.read.batch-size=1;
```

```java
java.io.IOException: java.lang.ArrayIndexOutOfBoundsException: 0
at org.apache.paimon.utils.AsyncRecordReader.checkException(AsyncRecordReader.java:102)
at org.apache.paimon.utils.AsyncRecordReader.readBatch(AsyncRecordReader.java:82)
at org.apache.paimon.mergetree.compact.ConcatRecordReader.readBatch(ConcatRecordReader.java:66)
at org.apache.paimon.mergetree.compact.LoserTree$LeafIterator.advanceIfAvailable(LoserTree.java:315)
at org.apache.paimon.mergetree.compact.LoserTree.initializeIfNeeded(LoserTree.java:87)
at org.apache.paimon.mergetree.compact.SortMergeReaderWithLoserTree.readBatch(SortMergeReaderWithLoserTree.java:71)
at org.apache.paimon.mergetree.DropDeleteReader.readBatch(DropDeleteReader.java:44)
at org.apache.paimon.reader.RecordReader$1.readBatch(RecordReader.java:173)
at org.apache.paimon.reader.RecordReader$1.readBatch(RecordReader.java:173)
at org.apache.paimon.table.source.KeyValueTableRead$1.readBatch(KeyValueTableRead.java:136)
at org.apache.paimon.spark.PaimonRecordReaderIterator.readBatch(PaimonRecordReaderIterator.scala:89)
at org.apache.paimon.spark.PaimonRecordReaderIterator.(PaimonRecordReaderIterator.scala:40)
at org.apache.paimon.spark.PaimonPartitionReader.readSplit(PaimonPartitionReader.scala:104)
at org.apache.paimon.spark.PaimonPartitionReader.(PaimonPartitionReader.scala:46)
at org.apache.paimon.spark.PaimonPartitionReaderFactory.createReader(PaimonPartitionReaderFactory.scala:37)
at org.apache.spark.sql.execution.datasources.v2.DataSourceRDD.compute(DataSourceRDD.scala:64)
```

### Tests
