### PR TITLE
[test]Fix resource leak in CompressUtils.gzipCompressFile

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/utils/CompressUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/CompressUtils.java
@@ -27,20 +27,14 @@ import java.util.zip.GZIPOutputStream;
 public class CompressUtils {
 
     public static void gzipCompressFile(String src, String dest) throws IOException {
-        FileInputStream fis = new FileInputStream(src);
-        FileOutputStream fos = new FileOutputStream(dest);
-        GZIPOutputStream gzipOs = new GZIPOutputStream(fos);
-        byte[] buffer = new byte[1024];
-        int bytesRead;
-        while (true) {
-            bytesRead = fis.read(buffer);
-            if (bytesRead == -1) {
-                fis.close();
-                gzipOs.close();
-                return;
+        try (FileInputStream fis = new FileInputStream(src);
+                FileOutputStream fos = new FileOutputStream(dest);
+                GZIPOutputStream gzipOs = new GZIPOutputStream(fos)) {
+            byte[] buffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = fis.read(buffer)) != -1) {
+                gzipOs.write(buffer, 0, bytesRead);
             }
-
-            gzipOs.write(buffer, 0, bytesRead);
         }
     }
 }


### PR DESCRIPTION
### Purpose

The original `CompressUtils.gzipCompressFile` implementation only closed
streams on the happy path. If an `IOException` was thrown after the streams
were opened, none of them would be closed, causing a resource leak.

- Rewrite using `try-with-resources` so `FileInputStream`, `FileOutputStream`,
  and `GZIPOutputStream` are always closed regardless of whether an exception
  occurs
- `CompressUtils` is kept in `paimon-core/src/main/java` because it is used by
  both `HiveCatalogFormatTableITCaseBase` (Hive IT) and `FormatTableTestBase`
  (Spark UT)

### Tests
GHA