### PR TITLE
[core][spark] Use global index for data evolution update

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -282,7 +282,9 @@ public class DataEvolutionBatchScan implements DataTableScan {
             Optional<GlobalIndexResult> result = scanner.scan(filter);
             if (result.isPresent()) {
                 LOG.info("Scan table '{}' with global index.", table.name());
-                return Optional.of(result.get().or(scanner.unindexedRows(filter)));
+                GlobalIndexResult unindexedRows =
+                        scanner.unindexedRows(filter, options.globalIndexSearchMode());
+                return Optional.of(result.get().or(unindexedRows));
             }
             return Optional.empty();
         } catch (IOException e) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.globalindex;
 
-import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
@@ -74,30 +73,34 @@ public class GlobalIndexCoverage {
         }
     }
 
-    public List<Range> unindexedRanges(RowType rowType, @Nullable Predicate predicate) {
-        return unindexedRanges(collectFieldIds(rowType, predicate));
+    public List<Range> fullUnindexedRanges(RowType rowType, @Nullable Predicate predicate) {
+        return fullUnindexedRanges(collectFieldIds(rowType, predicate));
     }
 
-    public List<Range> unindexedRanges(int fieldId) {
-        return unindexedRanges(Collections.singleton(fieldId));
+    public List<Range> fullUnindexedRanges(int fieldId) {
+        return fullUnindexedRanges(Collections.singleton(fieldId));
     }
 
-    public List<Range> unindexedRanges(Collection<Integer> fieldIds) {
-        GlobalIndexSearchMode searchMode = table.coreOptions().globalIndexSearchMode();
-        if (searchMode == GlobalIndexSearchMode.FAST) {
+    public List<Range> fullUnindexedRanges(Collection<Integer> fieldIds) {
+        return unindexedRanges(fieldIds, dataRangesBySnapshotNextRowId());
+    }
+
+    public List<Range> detailUnindexedRanges(RowType rowType, @Nullable Predicate predicate) {
+        return detailUnindexedRanges(collectFieldIds(rowType, predicate));
+    }
+
+    public List<Range> detailUnindexedRanges(int fieldId) {
+        return detailUnindexedRanges(Collections.singleton(fieldId));
+    }
+
+    public List<Range> detailUnindexedRanges(Collection<Integer> fieldIds) {
+        return unindexedRanges(fieldIds, dataRangesByDataFiles());
+    }
+
+    private List<Range> unindexedRanges(Collection<Integer> fieldIds, List<Range> dataRanges) {
+        if (dataRanges.isEmpty()) {
             return Collections.emptyList();
         }
-        if (snapshot == null || snapshot.nextRowId() == null || snapshot.nextRowId() <= 0) {
-            return Collections.emptyList();
-        }
-
-        List<Range> dataRanges;
-        if (searchMode == GlobalIndexSearchMode.DETAIL) {
-            dataRanges = dataRangesByDataFiles();
-        } else {
-            dataRanges = Collections.singletonList(new Range(0, snapshot.nextRowId() - 1));
-        }
-
         List<Range> predicateIndexedRanges =
                 Range.sortAndMergeOverlap(indexedRanges(fieldIds), true);
         List<Range> unindexedRanges = new ArrayList<>();
@@ -124,7 +127,17 @@ public class GlobalIndexCoverage {
         return ranges == null ? Collections.emptyList() : Range.sortAndMergeOverlap(ranges, true);
     }
 
+    private List<Range> dataRangesBySnapshotNextRowId() {
+        if (snapshot == null || snapshot.nextRowId() == null || snapshot.nextRowId() <= 0) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(new Range(0, snapshot.nextRowId() - 1));
+    }
+
     private List<Range> dataRangesByDataFiles() {
+        if (snapshot == null || snapshot.nextRowId() == null || snapshot.nextRowId() <= 0) {
+            return Collections.emptyList();
+        }
         SnapshotReader snapshotReader =
                 table.newSnapshotReader()
                         .withPartitionFilter(partitionFilter)

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.globalindex;
 
+import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -33,6 +34,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -69,7 +71,6 @@ public class GlobalIndexScanner implements Closeable {
     private final GlobalIndexEvaluator globalIndexEvaluator;
     private final IndexPathFactory indexPathFactory;
     private final GlobalIndexCoverage coverage;
-    private final FileStoreTable table;
 
     private GlobalIndexScanner(
             FileStoreTable table,
@@ -80,7 +81,6 @@ public class GlobalIndexScanner implements Closeable {
             FileIO fileIO,
             IndexPathFactory indexPathFactory,
             Collection<IndexFileMeta> indexFiles) {
-        this.table = table;
         this.options = options;
         this.rowType = rowType;
         this.executor =
@@ -207,9 +207,20 @@ public class GlobalIndexScanner implements Closeable {
             @Nullable PartitionPredicate partitionFilter,
             @Nullable Predicate filter) {
         @Nullable Snapshot snapshot = tryTravelOrLatest(table);
+        return create(table, snapshot, partitionFilter, filter);
+    }
+
+    public static Optional<GlobalIndexScanner> create(
+            FileStoreTable table,
+            @Nullable Snapshot snapshot,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Predicate filter) {
+        PartitionPredicate resolvedPartitionFilter =
+                resolvePartitionFilter(table, partitionFilter, filter);
         List<IndexFileMeta> indexFiles =
                 table.store().newIndexFileHandler()
-                        .scan(snapshot, indexFileFilter(table, partitionFilter, filter)).stream()
+                        .scan(snapshot, indexFileFilter(table, resolvedPartitionFilter, filter))
+                        .stream()
                         .map(IndexManifestEntry::indexFile)
                         .collect(Collectors.toList());
         if (indexFiles.isEmpty()) {
@@ -219,12 +230,36 @@ public class GlobalIndexScanner implements Closeable {
                 new GlobalIndexScanner(
                         table,
                         snapshot,
-                        partitionFilter,
+                        resolvedPartitionFilter,
                         table.coreOptions().toConfiguration(),
                         table.rowType(),
                         table.fileIO(),
                         table.store().pathFactory().globalIndexFileFactory(),
                         indexFiles));
+    }
+
+    private static @Nullable PartitionPredicate resolvePartitionFilter(
+            FileStoreTable table,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Predicate filter) {
+        if (filter == null) {
+            return partitionFilter;
+        }
+
+        Pair<Optional<PartitionPredicate>, List<Predicate>> split =
+                PartitionPredicate.splitPartitionPredicatesAndDataPredicates(
+                        filter, table.rowType(), table.partitionKeys());
+        if (!split.getLeft().isPresent()) {
+            return partitionFilter;
+        }
+        if (partitionFilter == null) {
+            return split.getLeft().get();
+        }
+
+        List<PartitionPredicate> predicates = new ArrayList<>(2);
+        predicates.add(partitionFilter);
+        predicates.add(split.getLeft().get());
+        return PartitionPredicate.and(predicates);
     }
 
     private static Filter<IndexManifestEntry> indexFileFilter(
@@ -265,9 +300,31 @@ public class GlobalIndexScanner implements Closeable {
         return globalIndexEvaluator.evaluate(predicate);
     }
 
-    public GlobalIndexResult unindexedRows(Predicate predicate) {
+    public GlobalIndexResult unindexedRows(Predicate predicate, GlobalIndexSearchMode searchMode) {
+        switch (searchMode) {
+            case FAST:
+                return GlobalIndexResult.createEmpty();
+            case FULL:
+                return fullUnindexedRows(predicate);
+            case DETAIL:
+                return detailUnindexedRows(predicate);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported global index search mode: " + searchMode);
+        }
+    }
+
+    public GlobalIndexResult fullUnindexedRows(Predicate predicate) {
+        return unindexedRows(coverage.fullUnindexedRanges(rowType, predicate));
+    }
+
+    public GlobalIndexResult detailUnindexedRows(Predicate predicate) {
+        return unindexedRows(coverage.detailUnindexedRanges(rowType, predicate));
+    }
+
+    private GlobalIndexResult unindexedRows(List<Range> ranges) {
         RoaringNavigableMap64 rows = new RoaringNavigableMap64();
-        for (Range range : coverage.unindexedRanges(rowType, predicate)) {
+        for (Range range : ranges) {
             rows.addRange(range);
         }
         return GlobalIndexResult.create(rows);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
@@ -197,7 +197,9 @@ public abstract class AbstractVectorRead implements Serializable {
                 return null;
             }
             include.or(result.get().results());
-            include.or(scanner.unindexedRows(filter).results());
+            include.or(
+                    scanner.unindexedRows(filter, table.coreOptions().globalIndexSearchMode())
+                            .results());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.GlobalIndexCoverage;
 import org.apache.paimon.globalindex.GlobalIndexerFactory;
@@ -128,15 +129,30 @@ public class FullTextScanImpl implements FullTextScan {
         }
 
         if (!allIndexFiles.isEmpty()) {
-            List<Range> rawRowRanges =
-                    new GlobalIndexCoverage(table, snapshot, partitionFilter, allIndexFiles)
-                            .unindexedRanges(textColumnIds);
+            GlobalIndexCoverage coverage =
+                    new GlobalIndexCoverage(table, snapshot, partitionFilter, allIndexFiles);
+            List<Range> rawRowRanges = unindexedRanges(coverage, textColumnIds);
             if (!rawRowRanges.isEmpty()) {
                 splits.add(new RawFullTextSearchSplit(rawRowRanges));
             }
         }
 
         return () -> splits;
+    }
+
+    private List<Range> unindexedRanges(GlobalIndexCoverage coverage, Set<Integer> textColumnIds) {
+        GlobalIndexSearchMode searchMode = table.coreOptions().globalIndexSearchMode();
+        switch (searchMode) {
+            case FAST:
+                return Collections.emptyList();
+            case FULL:
+                return coverage.fullUnindexedRanges(textColumnIds);
+            case DETAIL:
+                return coverage.detailUnindexedRanges(textColumnIds);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported global index search mode: " + searchMode);
+        }
     }
 
     private static boolean supportsFullTextSearch(String indexType) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScanImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.globalindex.GlobalIndexCoverage;
 import org.apache.paimon.index.GlobalIndexMeta;
@@ -140,19 +141,21 @@ public class VectorScanImpl implements VectorScan {
         }
 
         List<Range> rawRowRanges =
-                new GlobalIndexCoverage(table, snapshot, partitionFilter, vectorIndexFiles)
-                        .unindexedRanges(vectorColumn.id());
+                unindexedRanges(
+                        new GlobalIndexCoverage(table, snapshot, partitionFilter, vectorIndexFiles),
+                        vectorColumn.id());
         if (filter != null) {
             rawRowRanges =
                     Range.sortAndMergeOverlap(
                             addAll(
                                     rawRowRanges,
-                                    new GlobalIndexCoverage(
+                                    unindexedRanges(
+                                            new GlobalIndexCoverage(
                                                     table,
                                                     snapshot,
                                                     partitionFilter,
-                                                    scalarIndexFiles(allIndexFiles))
-                                            .unindexedRanges(table.rowType(), filter)),
+                                                    scalarIndexFiles(allIndexFiles)),
+                                            filter)),
                             true);
         }
         if (!rawRowRanges.isEmpty()) {
@@ -173,6 +176,36 @@ public class VectorScanImpl implements VectorScan {
 
     private static boolean isPrimaryColumn(GlobalIndexMeta meta, int fieldId) {
         return meta.indexFieldId() == fieldId;
+    }
+
+    private List<Range> unindexedRanges(GlobalIndexCoverage coverage, int fieldId) {
+        GlobalIndexSearchMode searchMode = table.coreOptions().globalIndexSearchMode();
+        switch (searchMode) {
+            case FAST:
+                return Collections.emptyList();
+            case FULL:
+                return coverage.fullUnindexedRanges(fieldId);
+            case DETAIL:
+                return coverage.detailUnindexedRanges(fieldId);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported global index search mode: " + searchMode);
+        }
+    }
+
+    private List<Range> unindexedRanges(GlobalIndexCoverage coverage, Predicate predicate) {
+        GlobalIndexSearchMode searchMode = table.coreOptions().globalIndexSearchMode();
+        switch (searchMode) {
+            case FAST:
+                return Collections.emptyList();
+            case FULL:
+                return coverage.fullUnindexedRanges(table.rowType(), predicate);
+            case DETAIL:
+                return coverage.detailUnindexedRanges(table.rowType(), predicate);
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported global index search mode: " + searchMode);
+        }
     }
 
     private List<IndexFileMeta> scalarIndexFiles(List<IndexFileMeta> allIndexFiles) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -29,6 +29,7 @@ import org.apache.paimon.globalindex.sorted.SortedGlobalIndexBuilder;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -39,6 +40,7 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -188,9 +190,47 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
                 GlobalIndexScanner.create(table, PartitionPredicate.ALWAYS_TRUE, predicate).get()) {
             assertThat(scanner.scan(predicate).get().results().toRangeList())
                     .containsExactly(new Range(100L, 100L));
-            assertThat(scanner.unindexedRows(predicate).results().toRangeList())
+            assertThat(scanner.fullUnindexedRows(predicate).results().toRangeList())
                     .containsExactly(new Range(500L, 999L));
         }
+    }
+
+    @Test
+    public void testGlobalIndexScannerExtractsPartitionFilterFromFilter() throws Exception {
+        createPartitionedTable();
+        appendPartitionedRows();
+        createIndex("f1");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        PredicateBuilder builder = new PredicateBuilder(table.rowType());
+        Predicate valuePredicate = builder.equal(2, BinaryString.fromString("same"));
+        Predicate partitionAndValuePredicate =
+                PredicateBuilder.and(
+                        builder.equal(0, BinaryString.fromString("p0")), valuePredicate);
+
+        try (GlobalIndexScanner scanner =
+                GlobalIndexScanner.create(table, null, valuePredicate).get()) {
+            assertThat(scanner.scan(valuePredicate).get().results().getLongCardinality())
+                    .isEqualTo(2);
+        }
+
+        RoaringNavigableMap64 inferredPartitionRows;
+        try (GlobalIndexScanner scanner =
+                GlobalIndexScanner.create(table, null, partitionAndValuePredicate).get()) {
+            inferredPartitionRows = scanner.scan(partitionAndValuePredicate).get().results();
+        }
+
+        RoaringNavigableMap64 explicitPartitionRows;
+        try (GlobalIndexScanner scanner =
+                GlobalIndexScanner.create(
+                                table, partitionFilter(table, "p0"), partitionAndValuePredicate)
+                        .get()) {
+            explicitPartitionRows = scanner.scan(partitionAndValuePredicate).get().results();
+        }
+
+        assertThat(inferredPartitionRows.getLongCardinality()).isEqualTo(1);
+        assertThat(inferredPartitionRows.toRangeList())
+                .containsExactlyElementsOf(explicitPartitionRows.toRangeList());
     }
 
     @Test
@@ -366,6 +406,41 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
             }
             commit.commit(write.prepareCommit());
         }
+    }
+
+    private void createPartitionedTable() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("dt", DataTypes.STRING());
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.STRING());
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.partitionKeys(Collections.singletonList("dt"));
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+    }
+
+    private void appendPartitionedRows() throws Exception {
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(
+                    GenericRow.of(
+                            BinaryString.fromString("p0"), 0, BinaryString.fromString("same")));
+            write.write(
+                    GenericRow.of(
+                            BinaryString.fromString("p1"), 1, BinaryString.fromString("same")));
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private PartitionPredicate partitionFilter(FileStoreTable table, String partition) {
+        RowType partitionType = table.rowType().project("dt");
+        Predicate predicate =
+                PartitionPredicate.createPartitionPredicate(
+                        partitionType,
+                        Collections.singletonMap("dt", BinaryString.fromString(partition)));
+        return PartitionPredicate.fromPredicate(partitionType, predicate);
     }
 
     private RoaringNavigableMap64 globalIndexScan(FileStoreTable table, Predicate predicate)

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.Snapshot
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
+import org.apache.paimon.globalindex.GlobalIndexScanner
 import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
@@ -39,12 +40,25 @@ import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.types.DataTypeRoot.BLOB
 import org.apache.paimon.types.RowType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
+import org.apache.paimon.utils.{Range => RowIdRange}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{
+  Alias,
+  And,
+  Attribute,
+  AttributeReference,
+  EqualTo,
+  Expression,
+  ExprId,
+  Literal,
+  Or,
+  PythonUDF,
+  SubqueryExpression
+}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -118,23 +132,55 @@ case class MergeIntoPaimonDataEvolutionTable(
    *
    * without any extra shuffle, join, or sort.
    */
-  private lazy val isSelfMergeOnRowId: Boolean = {
-    if (!isPaimonTable(sourceTable)) {
-      false
-    } else if (!targetRelation.name.equals(PaimonRelation.getPaimonRelation(sourceTable).name)) {
-      false
+  private lazy val selfMergeOnRowIdFilter: Option[Expression] = {
+    def isTargetSource(plan: LogicalPlan): Boolean = {
+      isPaimonTable(plan) &&
+      targetRelation.name.equals(PaimonRelation.getPaimonRelation(plan).name)
+    }
+
+    val matchedOnRowId = matchedCondition match {
+      case EqualTo(left: AttributeReference, right: AttributeReference)
+          if left.name == ROW_ID_NAME && right.name == ROW_ID_NAME =>
+        true
+      case _ => false
+    }
+
+    if (!matchedOnRowId) {
+      None
     } else {
-      matchedCondition match {
-        case EqualTo(left: AttributeReference, right: AttributeReference)
-            if left.name == ROW_ID_NAME && right.name == ROW_ID_NAME =>
-          true
-        case _ => false
+      sourceTable match {
+        case Project(_, Filter(condition, child)) if isTargetSource(child) =>
+          Some(condition)
+        case _ if isTargetSource(sourceTable) =>
+          Some(TrueLiteral)
+        case _ =>
+          None
       }
     }
   }
 
+  private lazy val useSelfMergeOnRowIdShortcut: Boolean = {
+    selfMergeOnRowIdFilter.isDefined &&
+      notMatchedActions.isEmpty &&
+      notMatchedBySourceActions.isEmpty
+  }
+
+  private lazy val isUnfilteredSelfMergeOnRowId: Boolean = {
+    selfMergeOnRowIdFilter.contains(TrueLiteral)
+  }
+
+  private lazy val selfMergeOnRowIdFilterOutput: Seq[Attribute] = {
+    sourceTable match {
+      case Project(_, Filter(_, child)) =>
+        child.output ++ child.metadataOutput
+      case _ =>
+        sourceTable.output ++ sourceTable.metadataOutput
+    }
+  }
+
   assert(
-    !(isSelfMergeOnRowId && (notMatchedActions.nonEmpty || notMatchedBySourceActions.nonEmpty)),
+    !(selfMergeOnRowIdFilter.isDefined &&
+      (notMatchedActions.nonEmpty || notMatchedBySourceActions.nonEmpty)),
     "Self-Merge on _ROW_ID only supports WHEN MATCHED THEN UPDATE. WHEN NOT MATCHED and WHEN " +
       "NOT MATCHED BY SOURCE are not supported."
   )
@@ -155,6 +201,7 @@ case class MergeIntoPaimonDataEvolutionTable(
     val snapshotReader = table.newSnapshotReader()
     pushDownMergePartitionFilter(snapshotReader)
     val plan = snapshotReader.read()
+    val snapshot = Option(plan.snapshotId()).map(id => table.snapshotManager().snapshot(id)).orNull
     val tableSplits: Seq[DataSplit] = plan
       .splits()
       .asScala
@@ -208,6 +255,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       // step 1: find the related data splits, make it target file plan
       val dataSplits: Seq[DataSplit] = targetRelatedSplits(
         sparkSession,
+        snapshot,
         tableSplits,
         firstRowIds,
         firstRowIdToBlobFirstRowIds,
@@ -282,13 +330,14 @@ case class MergeIntoPaimonDataEvolutionTable(
 
   private def targetRelatedSplits(
       sparkSession: SparkSession,
+      snapshot: Snapshot,
       tableSplits: Seq[DataSplit],
       firstRowIds: immutable.IndexedSeq[Long],
       firstRowIdToBlobFirstRowIds: Map[Long, List[Long]],
       persistSourceDss: Option[Dataset[Row]]): Seq[DataSplit] = {
-    // Self-Merge shortcut:
-    // In Self-Merge mode, every row in the table may be updated, so we scan all splits.
-    if (isSelfMergeOnRowId) {
+    // Unfiltered self-merge shortcut:
+    // every row in the table may be updated, so we scan all splits.
+    if (isUnfilteredSelfMergeOnRowId) {
       return tableSplits
     }
 
@@ -299,28 +348,33 @@ case class MergeIntoPaimonDataEvolutionTable(
       return tableSplits
     }
 
-    val sourceDss = persistSourceDss.getOrElse(createDataset(sparkSession, sourceTable))
+    val firstRowIdsTouched = firstRowIdsTouchedByGlobalIndexFull(
+      snapshot,
+      tableSplits,
+      firstRowIdToBlobFirstRowIds).getOrElse {
+      val sourceDss = persistSourceDss.getOrElse(createDataset(sparkSession, sourceTable))
 
-    val firstRowIdsTouched = extractSourceRowIdMapping match {
-      case Some(sourceRowIdAttr) =>
-        // Shortcut: Directly get _FIRST_ROW_IDs from the source table.
-        findRelatedFirstRowIds(
-          sourceDss,
-          sparkSession,
-          firstRowIds,
-          firstRowIdToBlobFirstRowIds,
-          sourceRowIdAttr.name).toSet
+      extractSourceRowIdMapping match {
+        case Some(sourceRowIdAttr) =>
+          // Shortcut: Directly get _FIRST_ROW_IDs from the source table.
+          findRelatedFirstRowIds(
+            sourceDss,
+            sparkSession,
+            firstRowIds,
+            firstRowIdToBlobFirstRowIds,
+            sourceRowIdAttr.name).toSet
 
-      case None =>
-        // Perform the full join to find related _FIRST_ROW_IDs.
-        val targetDss = createDataset(sparkSession, targetRelation)
-        findRelatedFirstRowIds(
-          targetDss.alias("_left").join(sourceDss, toColumn(matchedCondition), "inner"),
-          sparkSession,
-          firstRowIds,
-          firstRowIdToBlobFirstRowIds,
-          "_left." + ROW_ID_NAME
-        ).toSet
+        case None =>
+          // Perform the full join to find related _FIRST_ROW_IDs.
+          val targetDss = createDataset(sparkSession, targetRelation)
+          findRelatedFirstRowIds(
+            targetDss.alias("_left").join(sourceDss, toColumn(matchedCondition), "inner"),
+            sparkSession,
+            firstRowIds,
+            firstRowIdToBlobFirstRowIds,
+            "_left." + ROW_ID_NAME
+          ).toSet
+      }
     }
 
     tableSplits
@@ -330,6 +384,73 @@ case class MergeIntoPaimonDataEvolutionTable(
             file => file.firstRowId() != null && firstRowIdsTouched.contains(file.firstRowId())))
       .filter(optional => optional.isPresent)
       .map(_.get())
+  }
+
+  private def firstRowIdsTouchedByGlobalIndexFull(
+      snapshot: Snapshot,
+      tableSplits: Seq[DataSplit],
+      firstRowIdToBlobFirstRowIds: Map[Long, List[Long]]): Option[Set[Long]] = {
+    if (!useSelfMergeOnRowIdShortcut || isUnfilteredSelfMergeOnRowId) {
+      return None
+    }
+
+    val predicate = convertConditionToPaimonPredicate(
+      selfMergeOnRowIdFilter.get,
+      selfMergeOnRowIdFilterOutput,
+      rowType,
+      ignorePartialFailure = true)
+    if (predicate.isEmpty) {
+      return None
+    }
+
+    val scanner = GlobalIndexScanner.create(table, snapshot, null, predicate.get)
+    if (!scanner.isPresent) {
+      return None
+    }
+
+    try {
+      val indexedRows = scanner.get().scan(predicate.get)
+      if (!indexedRows.isPresent) {
+        return None
+      }
+
+      val touchedRowRanges =
+        indexedRows.get().or(scanner.get().fullUnindexedRows(predicate.get)).results().toRangeList()
+      Some(firstRowIdsTouchedByRowRanges(
+        tableSplits,
+        touchedRowRanges.asScala,
+        firstRowIdToBlobFirstRowIds))
+    } finally {
+      scanner.get().close()
+    }
+  }
+
+  private def firstRowIdsTouchedByRowRanges(
+      tableSplits: Seq[DataSplit],
+      rowRanges: Seq[RowIdRange],
+      firstRowIdToBlobFirstRowIds: Map[Long, List[Long]]): Set[Long] = {
+    if (rowRanges.isEmpty) {
+      return Set.empty
+    }
+
+    def intersects(range: RowIdRange): Boolean = {
+      rowRanges.exists(_.hasIntersection(range))
+    }
+
+    tableSplits
+      .flatMap(_.dataFiles().asScala)
+      .filter(
+        file =>
+          file.firstRowId() != null &&
+            !isBlobFile(file.fileName()) &&
+            !isVectorStoreFile(file.fileName()) &&
+            intersects(file.nonNullRowIdRange()))
+      .flatMap {
+        file =>
+          val firstRowId = file.firstRowId().asInstanceOf[Long]
+          firstRowIdToBlobFirstRowIds.getOrElse(firstRowId, List(firstRowId))
+      }
+      .toSet
   }
 
   private def updateActionInvoke(
@@ -479,7 +600,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       }
     }
 
-    val toWrite = if (isSelfMergeOnRowId) {
+    val toWrite = if (useSelfMergeOnRowIdShortcut) {
       // Self-Merge shortcut:
       // - Scan the target table only (no source scan, no join), and read all columns required by
       //   merge condition and update expressions.
@@ -493,14 +614,10 @@ case class MergeIntoPaimonDataEvolutionTable(
           .map { case (_, attrs) => attrs.head }
           .toSeq
 
-      val neededNames: Set[String] = (allFields ++ metadataColumns).map(_.name).toSet
-      val allReadFieldsOnTarget: Seq[AttributeReference] =
-        targetAttrsDedup.filter(a => neededNames.exists(n => resolver(n, a.name)))
-      val readPlan = touchedFileTargetRelation.copy(output = allReadFieldsOnTarget)
-
-      // Build mapping: source exprId -> target attr (matched by column name).
+      // Build mapping from source attributes to target attributes. The fallback by name also
+      // covers attributes referenced by a source Filter but not emitted by the source Project.
+      val targetAttrs = targetRelation.output ++ targetRelation.metadataOutput
       val sourceToTarget = {
-        val targetAttrs = targetRelation.output ++ targetRelation.metadataOutput
         val sourceAttrs = sourceTable.output ++ sourceTable.metadataOutput
         sourceAttrs.flatMap {
           s => targetAttrs.find(t => resolver(t.name, s.name)).map(t => s.exprId -> t)
@@ -512,8 +629,29 @@ case class MergeIntoPaimonDataEvolutionTable(
           m: Map[ExprId, AttributeReference]): Expression = {
         expr.transform {
           case a: AttributeReference if m.contains(a.exprId) => m(a.exprId)
+          case a: AttributeReference =>
+            targetAttrs.find(t => resolver(t.name, a.name)).getOrElse(a)
         }
       }
+
+      def andCondition(left: Expression, right: Expression): Expression = {
+        if (left == TrueLiteral) {
+          right
+        } else if (right == TrueLiteral) {
+          left
+        } else {
+          And(left, right)
+        }
+      }
+
+      val selfMergeFilterOnTarget =
+        rewriteSourceToTarget(selfMergeOnRowIdFilter.get, sourceToTarget)
+
+      val neededNames: Set[String] =
+        (allFields ++ metadataColumns ++ extractFields(selfMergeFilterOnTarget)).map(_.name).toSet
+      val allReadFieldsOnTarget: Seq[AttributeReference] =
+        targetAttrsDedup.filter(a => neededNames.exists(n => resolver(n, a.name)))
+      val readPlan = touchedFileTargetRelation.copy(output = allReadFieldsOnTarget)
 
       val rawBlobModifiedByAction = realUpdateActions.map(modifiedRawBlobNames)
 
@@ -535,7 +673,7 @@ case class MergeIntoPaimonDataEvolutionTable(
             case (action, rawBlobModified) =>
               SparkShimLoader.shim
                 .mergeRowsKeepUpdate(
-                  action.condition.getOrElse(TrueLiteral),
+                  andCondition(selfMergeFilterOnTarget, action.condition.getOrElse(TrueLiteral)),
                   updateOutput(action, rawBlobModified))
                 .asInstanceOf[MergeRows.Instruction]
           } ++ Seq(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions.GlobalIndexColumnUpdateAction
 import org.apache.paimon.Snapshot
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
+import org.apache.paimon.globalindex.GlobalIndexScanner
 import org.apache.paimon.index.GlobalIndexMeta
 import org.apache.paimon.io.{CompactIncrement, DataIncrement}
 import org.apache.paimon.manifest.IndexManifestEntry
@@ -39,12 +40,13 @@ import org.apache.paimon.table.source.snapshot.SnapshotReader
 import org.apache.paimon.types.DataTypeRoot.BLOB
 import org.apache.paimon.types.RowType
 import org.apache.paimon.types.VectorType.isVectorStoreFile
+import org.apache.paimon.utils.{Range => RowIdRange}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.PaimonUtils._
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer.resolver
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, Attribute, AttributeReference, EqualTo, Expression, ExprId, Literal, Or, PythonUDF, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.{LeftAnti, LeftOuter}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -118,23 +120,55 @@ case class MergeIntoPaimonDataEvolutionTable(
    *
    * without any extra shuffle, join, or sort.
    */
-  private lazy val isSelfMergeOnRowId: Boolean = {
-    if (!isPaimonTable(sourceTable)) {
-      false
-    } else if (!targetRelation.name.equals(PaimonRelation.getPaimonRelation(sourceTable).name)) {
-      false
+  private lazy val selfMergeOnRowIdFilter: Option[Expression] = {
+    def isTargetSource(plan: LogicalPlan): Boolean = {
+      isPaimonTable(plan) &&
+      targetRelation.name.equals(PaimonRelation.getPaimonRelation(plan).name)
+    }
+
+    val matchedOnRowId = matchedCondition match {
+      case EqualTo(left: AttributeReference, right: AttributeReference)
+          if left.name == ROW_ID_NAME && right.name == ROW_ID_NAME =>
+        true
+      case _ => false
+    }
+
+    if (!matchedOnRowId) {
+      None
     } else {
-      matchedCondition match {
-        case EqualTo(left: AttributeReference, right: AttributeReference)
-            if left.name == ROW_ID_NAME && right.name == ROW_ID_NAME =>
-          true
-        case _ => false
+      sourceTable match {
+        case Project(_, Filter(condition, child)) if isTargetSource(child) =>
+          Some(condition)
+        case _ if isTargetSource(sourceTable) =>
+          Some(TrueLiteral)
+        case _ =>
+          None
       }
     }
   }
 
+  private lazy val useSelfMergeOnRowIdShortcut: Boolean = {
+    selfMergeOnRowIdFilter.isDefined &&
+    notMatchedActions.isEmpty &&
+    notMatchedBySourceActions.isEmpty
+  }
+
+  private lazy val isUnfilteredSelfMergeOnRowId: Boolean = {
+    selfMergeOnRowIdFilter.contains(TrueLiteral)
+  }
+
+  private lazy val selfMergeOnRowIdFilterOutput: Seq[Attribute] = {
+    sourceTable match {
+      case Project(_, Filter(_, child)) =>
+        child.output ++ child.metadataOutput
+      case _ =>
+        sourceTable.output ++ sourceTable.metadataOutput
+    }
+  }
+
   assert(
-    !(isSelfMergeOnRowId && (notMatchedActions.nonEmpty || notMatchedBySourceActions.nonEmpty)),
+    !(selfMergeOnRowIdFilter.isDefined &&
+      (notMatchedActions.nonEmpty || notMatchedBySourceActions.nonEmpty)),
     "Self-Merge on _ROW_ID only supports WHEN MATCHED THEN UPDATE. WHEN NOT MATCHED and WHEN " +
       "NOT MATCHED BY SOURCE are not supported."
   )
@@ -155,6 +189,7 @@ case class MergeIntoPaimonDataEvolutionTable(
     val snapshotReader = table.newSnapshotReader()
     pushDownMergePartitionFilter(snapshotReader)
     val plan = snapshotReader.read()
+    val snapshot = Option(plan.snapshotId()).map(id => table.snapshotManager().snapshot(id)).orNull
     val tableSplits: Seq[DataSplit] = plan
       .splits()
       .asScala
@@ -208,6 +243,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       // step 1: find the related data splits, make it target file plan
       val dataSplits: Seq[DataSplit] = targetRelatedSplits(
         sparkSession,
+        snapshot,
         tableSplits,
         firstRowIds,
         firstRowIdToBlobFirstRowIds,
@@ -281,13 +317,14 @@ case class MergeIntoPaimonDataEvolutionTable(
 
   private def targetRelatedSplits(
       sparkSession: SparkSession,
+      snapshot: Snapshot,
       tableSplits: Seq[DataSplit],
       firstRowIds: immutable.IndexedSeq[Long],
       firstRowIdToBlobFirstRowIds: Map[Long, List[Long]],
       persistSourceDss: Option[Dataset[Row]]): Seq[DataSplit] = {
-    // Self-Merge shortcut:
-    // In Self-Merge mode, every row in the table may be updated, so we scan all splits.
-    if (isSelfMergeOnRowId) {
+    // Unfiltered self-merge shortcut:
+    // every row in the table may be updated, so we scan all splits.
+    if (isUnfilteredSelfMergeOnRowId) {
       return tableSplits
     }
 
@@ -298,29 +335,33 @@ case class MergeIntoPaimonDataEvolutionTable(
       return tableSplits
     }
 
-    val sourceDss = persistSourceDss.getOrElse(createDataset(sparkSession, sourceTable))
+    val firstRowIdsTouched =
+      firstRowIdsTouchedByGlobalIndexFull(snapshot, tableSplits, firstRowIdToBlobFirstRowIds)
+        .getOrElse {
+          val sourceDss = persistSourceDss.getOrElse(createDataset(sparkSession, sourceTable))
 
-    val firstRowIdsTouched = extractSourceRowIdMapping match {
-      case Some(sourceRowIdAttr) =>
-        // Shortcut: Directly get _FIRST_ROW_IDs from the source table.
-        findRelatedFirstRowIds(
-          sourceDss,
-          sparkSession,
-          firstRowIds,
-          firstRowIdToBlobFirstRowIds,
-          sourceRowIdAttr.name).toSet
+          extractSourceRowIdMapping match {
+            case Some(sourceRowIdAttr) =>
+              // Shortcut: Directly get _FIRST_ROW_IDs from the source table.
+              findRelatedFirstRowIds(
+                sourceDss,
+                sparkSession,
+                firstRowIds,
+                firstRowIdToBlobFirstRowIds,
+                sourceRowIdAttr.name).toSet
 
-      case None =>
-        // Perform the full join to find related _FIRST_ROW_IDs.
-        val targetDss = createDataset(sparkSession, targetRelation)
-        findRelatedFirstRowIds(
-          targetDss.alias("_left").join(sourceDss, toColumn(matchedCondition), "inner"),
-          sparkSession,
-          firstRowIds,
-          firstRowIdToBlobFirstRowIds,
-          "_left." + ROW_ID_NAME
-        ).toSet
-    }
+            case None =>
+              // Perform the full join to find related _FIRST_ROW_IDs.
+              val targetDss = createDataset(sparkSession, targetRelation)
+              findRelatedFirstRowIds(
+                targetDss.alias("_left").join(sourceDss, toColumn(matchedCondition), "inner"),
+                sparkSession,
+                firstRowIds,
+                firstRowIdToBlobFirstRowIds,
+                "_left." + ROW_ID_NAME
+              ).toSet
+          }
+        }
 
     tableSplits
       .map(
@@ -329,6 +370,74 @@ case class MergeIntoPaimonDataEvolutionTable(
             file => file.firstRowId() != null && firstRowIdsTouched.contains(file.firstRowId())))
       .filter(optional => optional.isPresent)
       .map(_.get())
+  }
+
+  private def firstRowIdsTouchedByGlobalIndexFull(
+      snapshot: Snapshot,
+      tableSplits: Seq[DataSplit],
+      firstRowIdToBlobFirstRowIds: Map[Long, List[Long]]): Option[Set[Long]] = {
+    if (!useSelfMergeOnRowIdShortcut || isUnfilteredSelfMergeOnRowId) {
+      return None
+    }
+
+    val predicate = convertConditionToPaimonPredicate(
+      selfMergeOnRowIdFilter.get,
+      selfMergeOnRowIdFilterOutput,
+      rowType,
+      ignorePartialFailure = true)
+    if (predicate.isEmpty) {
+      return None
+    }
+
+    val scanner = GlobalIndexScanner.create(table, snapshot, null, predicate.get)
+    if (!scanner.isPresent) {
+      return None
+    }
+
+    try {
+      val indexedRows = scanner.get().scan(predicate.get)
+      if (!indexedRows.isPresent) {
+        return None
+      }
+
+      val touchedRowRanges =
+        indexedRows.get().or(scanner.get().fullUnindexedRows(predicate.get)).results().toRangeList()
+      Some(
+        firstRowIdsTouchedByRowRanges(
+          tableSplits,
+          touchedRowRanges.asScala,
+          firstRowIdToBlobFirstRowIds))
+    } finally {
+      scanner.get().close()
+    }
+  }
+
+  private def firstRowIdsTouchedByRowRanges(
+      tableSplits: Seq[DataSplit],
+      rowRanges: Seq[RowIdRange],
+      firstRowIdToBlobFirstRowIds: Map[Long, List[Long]]): Set[Long] = {
+    if (rowRanges.isEmpty) {
+      return Set.empty
+    }
+
+    def intersects(range: RowIdRange): Boolean = {
+      rowRanges.exists(_.hasIntersection(range))
+    }
+
+    tableSplits
+      .flatMap(_.dataFiles().asScala)
+      .filter(
+        file =>
+          file.firstRowId() != null &&
+            !isBlobFile(file.fileName()) &&
+            !isVectorStoreFile(file.fileName()) &&
+            intersects(file.nonNullRowIdRange()))
+      .flatMap {
+        file =>
+          val firstRowId = file.firstRowId().asInstanceOf[Long]
+          firstRowIdToBlobFirstRowIds.getOrElse(firstRowId, List(firstRowId))
+      }
+      .toSet
   }
 
   private def updateActionInvoke(
@@ -478,7 +587,7 @@ case class MergeIntoPaimonDataEvolutionTable(
       }
     }
 
-    val toWrite = if (isSelfMergeOnRowId) {
+    val toWrite = if (useSelfMergeOnRowIdShortcut) {
       // Self-Merge shortcut:
       // - Scan the target table only (no source scan, no join), and read all columns required by
       //   merge condition and update expressions.
@@ -492,14 +601,10 @@ case class MergeIntoPaimonDataEvolutionTable(
           .map { case (_, attrs) => attrs.head }
           .toSeq
 
-      val neededNames: Set[String] = (allFields ++ metadataColumns).map(_.name).toSet
-      val allReadFieldsOnTarget: Seq[AttributeReference] =
-        targetAttrsDedup.filter(a => neededNames.exists(n => resolver(n, a.name)))
-      val readPlan = touchedFileTargetRelation.copy(output = allReadFieldsOnTarget)
-
-      // Build mapping: source exprId -> target attr (matched by column name).
+      // Build mapping from source attributes to target attributes. The fallback by name also
+      // covers attributes referenced by a source Filter but not emitted by the source Project.
+      val targetAttrs = targetRelation.output ++ targetRelation.metadataOutput
       val sourceToTarget = {
-        val targetAttrs = targetRelation.output ++ targetRelation.metadataOutput
         val sourceAttrs = sourceTable.output ++ sourceTable.metadataOutput
         sourceAttrs.flatMap {
           s => targetAttrs.find(t => resolver(t.name, s.name)).map(t => s.exprId -> t)
@@ -511,8 +616,29 @@ case class MergeIntoPaimonDataEvolutionTable(
           m: Map[ExprId, AttributeReference]): Expression = {
         expr.transform {
           case a: AttributeReference if m.contains(a.exprId) => m(a.exprId)
+          case a: AttributeReference =>
+            targetAttrs.find(t => resolver(t.name, a.name)).getOrElse(a)
         }
       }
+
+      def andCondition(left: Expression, right: Expression): Expression = {
+        if (left == TrueLiteral) {
+          right
+        } else if (right == TrueLiteral) {
+          left
+        } else {
+          And(left, right)
+        }
+      }
+
+      val selfMergeFilterOnTarget =
+        rewriteSourceToTarget(selfMergeOnRowIdFilter.get, sourceToTarget)
+
+      val neededNames: Set[String] =
+        (allFields ++ metadataColumns ++ extractFields(selfMergeFilterOnTarget)).map(_.name).toSet
+      val allReadFieldsOnTarget: Seq[AttributeReference] =
+        targetAttrsDedup.filter(a => neededNames.exists(n => resolver(n, a.name)))
+      val readPlan = touchedFileTargetRelation.copy(output = allReadFieldsOnTarget)
 
       val rawBlobModifiedByAction = realUpdateActions.map(modifiedRawBlobNames)
 
@@ -534,7 +660,7 @@ case class MergeIntoPaimonDataEvolutionTable(
             case (action, rawBlobModified) =>
               SparkShimLoader.shim
                 .mergeRowsKeepUpdate(
-                  action.condition.getOrElse(TrueLiteral),
+                  andCondition(selfMergeFilterOnTarget, action.condition.getOrElse(TrueLiteral)),
                   updateOutput(action, rawBlobModified))
                 .asInstanceOf[MergeRows.Instruction]
           } ++ Seq(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.paimon.Utils
 import org.apache.spark.sql.util.QueryExecutionListener
 
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{Await, Future}
@@ -736,6 +737,104 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
           }
         }
       }
+  }
+
+  test("Data Evolution: update with filter uses row-id self-merge shortcut") {
+    withTable("T") {
+      sql("""
+            |CREATE TABLE T (id INT, name STRING, v INT)
+            |TBLPROPERTIES (
+            |  'bucket' = '-1',
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true')
+            |""".stripMargin)
+      sql("INSERT INTO T VALUES (1, 'name_1', 10)")
+      sql("INSERT INTO T VALUES (2, 'name_2', 20)")
+      sql("INSERT INTO T VALUES (3, 'name_3', 30)")
+      assert(
+        loadTable("T")
+          .newSnapshotReader()
+          .read()
+          .splits()
+          .asScala
+          .map(_.asInstanceOf[DataSplit].dataFiles().size())
+          .sum == 3)
+
+      val output =
+        sql(
+          "CALL sys.create_global_index(table => 'test.T', index_column => 'name', index_type => 'btree'," +
+            " options => 'btree-index.records-per-range=10')")
+          .collect()
+          .head
+      assert(output.getBoolean(0))
+
+      executeUpdateAndAssertSelfMergeShortcut(
+        "UPDATE T SET v = v + 1 WHERE name = 'name_2'",
+        expectedTargetResultedTableFiles = 1)
+      sql("INSERT INTO T VALUES (4, 'name_4', 40)")
+      executeUpdateAndAssertSelfMergeShortcut(
+        "UPDATE T SET v = v + 1 WHERE name = 'name_4'",
+        expectedTargetResultedTableFiles = 1)
+
+      checkAnswer(
+        sql("SELECT id, name, v FROM T ORDER BY id"),
+        Seq(Row(1, "name_1", 10), Row(2, "name_2", 21), Row(3, "name_3", 30), Row(4, "name_4", 41)))
+    }
+  }
+
+  private def executeUpdateAndAssertSelfMergeShortcut(
+      updateSql: String,
+      expectedTargetResultedTableFiles: Long): Unit = {
+    val sawMergeRows = new AtomicBoolean(false)
+    val sawJoinUnderMergeRows = new AtomicBoolean(false)
+    val targetResultedTableFiles = new java.util.concurrent.CopyOnWriteArrayList[Long]()
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        checkPlan(qe.analyzed)
+        collectTargetScanMetrics(qe)
+      }
+
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {
+        checkPlan(qe.analyzed)
+        collectTargetScanMetrics(qe)
+      }
+
+      private def checkPlan(plan: LogicalPlan): Unit = {
+        plan.collect {
+          case mergeRows: MergeRows =>
+            sawMergeRows.set(true)
+            if (mergeRows.child.collectFirst { case _: Join => true }.nonEmpty) {
+              sawJoinUnderMergeRows.set(true)
+            }
+        }
+      }
+
+      private def collectTargetScanMetrics(qe: QueryExecution): Unit = {
+        collect(qe.executedPlan) {
+          case scanExec: BatchScanExec if scanExec.scan.isInstanceOf[PaimonSplitScan] =>
+            val scan = scanExec.scan.asInstanceOf[PaimonSplitScan]
+            metric(scan.reportDriverMetrics(), RESULTED_TABLE_FILES)
+        }.foreach(resultedTableFile => targetResultedTableFiles.add(resultedTableFile))
+      }
+    }
+
+    spark.listenerManager.register(listener)
+    try {
+      sql(updateSql)
+      Utils.waitUntilEventEmpty(spark)
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+
+    assert(sawMergeRows.get(), "Expected UPDATE to execute through MergeRows.")
+    assert(
+      !sawJoinUnderMergeRows.get(),
+      "Expected filtered UPDATE to use the row-id self-merge shortcut without a source-target join.")
+    assert(
+      targetResultedTableFiles.asScala.contains(expectedTargetResultedTableFiles),
+      "Expected filtered UPDATE to scan only touched target files, but got resulted table files: " +
+        targetResultedTableFiles.asScala.mkString(", ")
+    )
   }
 
   private def executeMergeIntoAndAssertFilePruning(mergeSql: String, filePruning: Boolean): Unit = {


### PR DESCRIPTION
## Summary

Optimize Data Evolution UPDATE so filtered self-merge-on-row-id updates can use the global index to locate touched RowIDs and prune target files, while still falling back to full unindexed ranges for data written after index creation.

## Changes

- Add a Spark UPDATE shortcut for non-join self-merge-on-row-id plans that converts the filter to a Paimon predicate and uses `GlobalIndexScanner` to find touched target files.
- Make `GlobalIndexScanner` snapshot-aware for UPDATE and infer partition filters from the full predicate when callers pass `partitionFilter = null`.
- Refactor `GlobalIndexCoverage` to expose explicit full/detail unindexed range APIs without depending on `GlobalIndexSearchMode`; callers now choose the search mode outside coverage.
- Keep unindexed rows separate from indexed scan results, then combine them explicitly where full fallback is required.
- Add regression coverage for BTree unindexed fallback, partition filter inference, and the Spark UPDATE shortcut avoiding a join.

## Testing

- [x] `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=BtreeGlobalIndexTableTest test`
- [x] `mvn -pl paimon-spark/paimon-spark-common -am -Pspark3,fast-build -DskipTests compile`
- [x] `mvn -pl paimon-spark/paimon-spark-3.5 -am -Pspark3,fast-build -DfailIfNoTests=false -DwildcardSuites=org.apache.paimon.spark.sql.RowTrackingTest -Dtest=none test`

## Notes

Local Spark 4 compile was not completed because this machine is on Java 8 and `antlr4-maven-plugin:4.13.1` requires Java 11 bytecode.