### PR TITLE
[spark] Fix column pruning for lateral vector search query vector

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
@@ -232,16 +232,18 @@ object PaimonTableValuedFunctions {
             "LATERAL vector_search only supports deterministic subquery predicates " +
               "convertible to Paimon predicates on searched-table columns.")
         }
+        val stripOuterRef: Expression => Expression =
+          _.transform { case OuterReference(a) => a.toAttribute }
         val lateralVectorSearch =
           LateralVectorSearch(
             left,
             relation.innerTable,
             relation.columnName,
-            relation.queryVectorExpr,
+            stripOuterRef(relation.queryVectorExpr),
             relation.limit,
             relation.options,
             vectorSearchOutput,
-            projectList,
+            projectList.map(stripOuterRef),
             projectOutput,
             searchFilters
           )

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -39,7 +39,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ResolvedNamespace, ResolvedTable}
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, GenericInternalRow, JoinedRow, OuterReference, PredicateHelper, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, Expression, GenericInternalRow, JoinedRow, PredicateHelper, UnsafeProjection}
 import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, DescribeRelation, LogicalPlan, ReplaceTable, ReplaceTableAsSelect, ShowCreateTable}
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.connector.catalog.{Identifier, PaimonLookupCatalog, TableCatalog}
@@ -277,18 +277,9 @@ case class LateralVectorSearchExec(
   override protected def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions {
       outerRows =>
-        val strippedQueryExpr = queryVectorExpr.transform {
-          case OuterReference(namedExpression) => namedExpression.toAttribute
-        }
-        val queryVectorProjection = UnsafeProjection.create(Seq(strippedQueryExpr), child.output)
-        val strippedProjectList = projectList.map {
-          project =>
-            project.transform {
-              case OuterReference(namedExpression) => namedExpression.toAttribute
-            }
-        }
+        val queryVectorProjection = UnsafeProjection.create(Seq(queryVectorExpr), child.output)
         val rightProjection =
-          UnsafeProjection.create(strippedProjectList, child.output ++ vectorSearchOutput)
+          UnsafeProjection.create(projectList, child.output ++ vectorSearchOutput)
         val joinedRow = new JoinedRow
         val readerTracker = new LateralVectorSearchReaderTracker
         Option(TaskContext.get())
@@ -301,7 +292,7 @@ case class LateralVectorSearchExec(
             val searchBatch = ArrayBuffer[LateralVectorSearchQuery]()
             outerRowBatch.foreach {
               outerRow =>
-                toFloatArray(queryVectorProjection(outerRow).get(0, strippedQueryExpr.dataType))
+                toFloatArray(queryVectorProjection(outerRow).get(0, queryVectorExpr.dataType))
                   .foreach(
                     queryVector => searchBatch += LateralVectorSearchQuery(outerRow, queryVector))
             }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -167,6 +167,25 @@ class TableValuedFunctionsTest extends PaimonHiveTestBase {
         lateralVectorSearchesWithSubqueryFilter.head.searchFilters.nonEmpty,
         optimizedPlanWithSubqueryFilter.toString)
 
+      val optimizedPlanWithoutQueryVector = spark
+        .sql("""
+               |SELECT q.gid AS query_gid, r.gid AS result_gid
+               |FROM vector_search_source AS q,
+               |LATERAL (
+               |  SELECT gid
+               |  FROM vector_search('vector_search_source', 'embs', q.embs, 5)
+               |) AS r
+               |""".stripMargin)
+        .queryExecution
+        .optimizedPlan
+      val lateralVectorSearchesWithoutQueryVector =
+        optimizedPlanWithoutQueryVector.collect { case lvs: LateralVectorSearch => lvs }
+      assert(
+        lateralVectorSearchesWithoutQueryVector.size == 1,
+        "Query vector column not in outer SELECT should not break lateral vector search: " +
+          optimizedPlanWithoutQueryVector.toString
+      )
+
       val constantVectorPlan = spark
         .sql("""
                |SELECT gid


### PR DESCRIPTION
## Summary
  - Strip `OuterReference` from `queryVectorExpr` and `projectList` when creating `LateralVectorSearch`, so that the default `references` computation sees the query vector column and
  column pruning does not remove it from the left plan
  - This also removes redundant `OuterReference` stripping in the physical execution

  ## Test plan
  - [x] `TableValuedFunctionsTest` — added test case for lateral vector search without query vector column in outer SELECT