### PR TITLE
[python] Support delete in data evolution APIs

### DIFF
--- a/docs/docs/pypaimon/data-evolution.md
+++ b/docs/docs/pypaimon/data-evolution.md
@@ -144,6 +144,52 @@ commit.commit(messages)
 commit.close()
 ```
 
+## Delete Rows
+
+Use `delete_by_predicate` for SQL-like `DELETE ... WHERE ...` operations.
+For row-level deletes, the target table must enable deletion vectors in
+addition to the [Prerequisites](#prerequisites):
+
+- **`deletion-vectors.enabled`**: `true`
+
+Deletes are written as deletion-vector index updates. If the predicate only
+references partition columns, PyPaimon uses a partition overwrite/drop path
+instead of scanning `_ROW_ID` values; that partition-only fast path does not
+require deletion vectors.
+
+```python
+schema = Schema.from_pyarrow_schema(
+    pa_schema,
+    options={
+        'row-tracking.enabled': 'true',
+        'data-evolution.enabled': 'true',
+        'deletion-vectors.enabled': 'true',
+    },
+)
+catalog.create_table('default.users_delete', schema, False)
+table = catalog.get_table('default.users_delete')
+
+# ... write initial data ...
+
+write_builder = table.new_batch_write_builder()
+table_update = write_builder.new_update()
+table_commit = write_builder.new_commit()
+
+# DELETE FROM users_delete WHERE age >= 35
+predicate = table_update.new_predicate_builder().greater_or_equal('age', 35)
+messages = table_update.delete_by_predicate(predicate)
+table_commit.commit(messages)
+table_commit.close()
+```
+
+If you already have `_ROW_ID` values, use `delete_by_row_id` to write deletion
+vectors directly:
+
+```python
+messages = table_update.delete_by_row_id([0, 2, 4])
+table_commit.commit(messages)
+```
+
 ## Filter by _ROW_ID
 
 Requires the same [Prerequisites](#prerequisites) (row-tracking and data-evolution enabled). On such tables you can filter by `_ROW_ID` to prune files at scan time. Supported: `equal('_ROW_ID', id)`, `is_in('_ROW_ID', [id1, ...])`, `between('_ROW_ID', low, high)`.
@@ -284,21 +330,23 @@ table_commit.close()
 
 ## Merge Into
 
-Use `merge_into` when your source data should update matched target rows and
-optionally insert rows that do not match, similar to SQL `MERGE INTO`.
+Use `merge_into` when your source data should update or delete matched target
+rows and optionally insert rows that do not match, similar to SQL `MERGE INTO`.
 `merge_into` is exposed from `TableUpdate`, so it follows the same
 commit-message lifecycle as other PyPaimon update APIs. The PyPaimon
 implementation runs in a single process and materializes the rows it needs
 locally.
 
-Matched rows are updated by `_ROW_ID` internally. Only the columns touched by
-the matched clauses are rewritten. `merge_into` derives the update columns from
-the `WhenMatched` clauses; `with_update_type` is not needed.
+Matched rows are updated by `_ROW_ID` internally, or deleted through deletion
+vectors for delete clauses. Only the columns touched by update clauses are
+rewritten. `merge_into` derives the update columns from the `WhenMatched`
+clauses; `with_update_type` is not needed.
 
 **Requirements**
 
 - The target table must have `data-evolution.enabled = true` and
   `row-tracking.enabled = true`.
+- Matched delete clauses require `deletion-vectors.enabled = true`.
 - `source` must be a `pyarrow.Table`, `pandas.DataFrame`, or another PyPaimon
   table object.
 - `on` can be a list of same-named key columns, or `{target_col: source_col}`
@@ -354,7 +402,7 @@ table_commit = write_builder.new_commit()
 messages = table_update.merge_into(
     source,
     on=['id'],
-    when_matched=[WhenMatched(update='*')],
+    when_matched=[WhenMatched.update('*')],
     when_not_matched=[WhenNotMatched(insert='*')],
 )
 table_commit.commit(messages)
@@ -377,7 +425,7 @@ messages = table_update.merge_into(
     source,
     on={'id': 'source_id'},
     when_matched=[
-        WhenMatched(update={
+        WhenMatched.update({
             'age': source_col('new_age'),
             'name': target_col('name'),
         }),
@@ -401,8 +449,21 @@ Install the extra before using conditions: `pip install pypaimon[sql]`.
 messages = table_update.merge_into(
     source,
     on=['id'],
-    when_matched=[WhenMatched(update='*', condition='s.age > t.age')],
+    when_matched=[WhenMatched.update('*', condition='s.age > t.age')],
     when_not_matched=[WhenNotMatched(insert='*', condition='s.age > 18')],
+)
+```
+
+Use `WhenMatched.delete()` to delete matched rows:
+
+```python
+messages = table_update.merge_into(
+    source,
+    on=['id'],
+    when_matched=[
+        WhenMatched.delete(condition='s.deleted = TRUE'),
+        WhenMatched.update('*'),
+    ],
 )
 ```
 
@@ -411,6 +472,8 @@ messages = table_update.merge_into(
 - Multiple clauses are evaluated in order; the first matching condition wins.
 - Matched clauses cannot update partition key columns, because cross-partition
   row movement is not implemented.
+- Matched delete clauses use deletion vectors, so the target table must enable
+  `deletion-vectors.enabled`.
 - Blob columns can be updated and inserted by `merge_into`. With `update="*"`
   or `insert="*"`, the source must include the corresponding blob columns.
   If an insert mapping omits a blob column, that column is written as `NULL`.
@@ -535,6 +598,8 @@ The API mapping is:
 | `write.prepare_commit()` | `write.prepare_commit(commit_identifier)` |
 | `update.update_by_arrow_with_row_id(table)` | `update.update_by_arrow_with_row_id(table, commit_identifier)` |
 | `update.update_by_predicate(predicate, assignments)` | `update.update_by_predicate(predicate, assignments, commit_identifier)` |
+| `update.delete_by_predicate(predicate)` | `update.delete_by_predicate(predicate, commit_identifier)` |
+| `update.delete_by_row_id(row_ids)` | `update.delete_by_row_id(row_ids, commit_identifier)` |
 | `update.upsert_by_arrow_with_key(table, keys)` | `update.upsert_by_arrow_with_key(table, keys, commit_identifier)` |
 | `update.merge_into(source, on=..., when_matched=..., when_not_matched=...)` | `update.merge_into(source, on=..., when_matched=..., when_not_matched=..., commit_identifier=...)` |
 | `commit.commit(messages)` | `commit.commit(messages, commit_identifier)` |

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -201,18 +201,30 @@ docs.update(
 )
 ```
 
+## Delete
+
+`delete` removes rows matched by a SQL-like predicate. It uses the same
+predicate syntax as `scan().where(...)` and `update(...)`. Multimodal tables
+enable deletion vectors by default; on partitioned tables, a predicate that
+references only partition columns uses the partition drop path.
+
+```python
+docs.delete(where="id = 2")
+```
+
 ## Merge
 
-Use `merge` for idempotent ingestion. The builder delegates to Paimon's local
-`MERGE INTO` implementation.
+Use `merge` for idempotent ingestion and matched-row deletes. The builder
+delegates to Paimon's local `MERGE INTO` implementation.
 
 `execute` takes the source rows for the merge. It accepts the same input formats
 as `add`, including `pyarrow.Table`, `pyarrow.RecordBatch`, a list of
 dictionaries, a dictionary of arrays, or a pandas DataFrame. A list of
 dictionaries is convenient for small batches. `when_matched_update()` updates
 the columns present in the source data and leaves omitted target columns
-unchanged. `when_not_matched_insert()` inserts the columns present in the source
-data and fills omitted target columns with null.
+unchanged. `when_matched_delete()` deletes matched rows.
+`when_not_matched_insert()` inserts the columns present in the source data and
+fills omitted target columns with null.
 
 ```python
 from pypaimon.multimodal import source_col
@@ -232,9 +244,26 @@ docs.merge("id") \
     ])
 ```
 
-Clause predicates use `where`. Refer to source rows with `source.<column>` and
-target rows with `target.<column>`. Install `pypaimon[sql]` when using merge
-clause predicates.
+Use `when_matched_delete()` for matched rows that should be removed:
+
+```python
+docs.merge("id") \
+    .when_matched_delete(where="source.deleted = TRUE") \
+    .when_matched_update() \
+    .execute([
+        {
+            "id": 2,
+            "content": "Updated text",
+            "embedding": [0.7, 0.8, 0.9],
+            "category": "docs",
+            "deleted": True,
+        }
+    ])
+```
+
+Clause predicates use `where` for update and delete clauses. Refer to source
+rows with `source.<column>` and target rows with `target.<column>`. Install
+`pypaimon[sql]` when using merge clause predicates.
 
 When source and target key names differ, pass a mapping from target column to
 source column:

--- a/docs/docs/pypaimon/ray-data.md
+++ b/docs/docs/pypaimon/ray-data.md
@@ -341,10 +341,13 @@ table_write.write_ray(ray_dataset)
 
 ## Merge Into
 
-`merge_into` updates (and optionally inserts) rows of a **data-evolution** table
-from a source, like SQL `MERGE INTO`. Matched rows are updated in place by
-`_ROW_ID`; only the touched columns are rewritten. Requires `ray >= 2.50` and a
-target table with `'data-evolution.enabled'` and `'row-tracking.enabled'` set.
+`merge_into` updates or deletes matched rows and optionally inserts unmatched
+rows of a **data-evolution** table from a source, like SQL `MERGE INTO`.
+Matched rows are updated in place by `_ROW_ID`; only the touched columns are
+rewritten. Matched delete clauses are written through deletion vectors.
+Requires `ray >= 2.50` and a target table with `'data-evolution.enabled'` and
+`'row-tracking.enabled'` set. If you use matched delete clauses, the target
+must also enable `'deletion-vectors.enabled'`.
 
 ```python
 from pypaimon.ray import merge_into, WhenMatched, WhenNotMatched
@@ -354,7 +357,7 @@ metrics = merge_into(
     source=ray_dataset,          # ray.data.Dataset / pa.Table / pandas / table-name str
     catalog_options={"warehouse": "/path/to/warehouse"},
     on=["id"],                   # or {"target_col": "source_col"} for renamed keys
-    when_matched=[WhenMatched(update="*")],
+    when_matched=[WhenMatched.update("*")],
     when_not_matched=[WhenNotMatched(insert="*")],             # optional
 )
 print(metrics)   # {"num_matched": 3, "num_inserted": 2, "num_unchanged": 0}
@@ -368,8 +371,23 @@ merge_into(
     source=source_ds,
     catalog_options=catalog_options,
     on=["id"],
-    when_matched=[WhenMatched(update="*", condition="s.age > t.age")],
+    when_matched=[WhenMatched.update("*", condition="s.age > t.age")],
     when_not_matched=[WhenNotMatched(insert="*", condition="s.age > 18")],
+)
+```
+
+Use `WhenMatched.delete()` to delete matched rows:
+
+```python
+merge_into(
+    target="db.table",
+    source=source_ds,
+    catalog_options=catalog_options,
+    on=["id"],
+    when_matched=[
+        WhenMatched.delete(condition="s.deleted = TRUE"),
+        WhenMatched.update("*"),
+    ],
 )
 ```
 
@@ -378,13 +396,16 @@ column prefixes. `WhenNotMatched` conditions may only reference source
 columns (`s.*`). Condition evaluation uses DataFusion through the PyPaimon SQL
 extra. Install the extra before using conditions: `pip install pypaimon[sql]`.
 
-- `update` / `insert`: `"*"` updates/inserts all columns from source,
-  including blob columns.
+- `update` / `delete` / `insert`: `WhenMatched.update(...)` updates matched
+  rows, `WhenMatched.delete()` deletes matched rows, and
+  `WhenNotMatched(insert=...)` inserts unmatched rows. `"*"` updates/inserts
+  all columns from source, including blob columns.
   A mapping selects specific columns:
   ```python
   from pypaimon.ray import source_col, target_col, lit
 
-  WhenMatched(update={"age": source_col("age"), "name": target_col("name")})
+  WhenMatched.update({"age": source_col("age"), "name": target_col("name")})
+  WhenMatched.delete()
   WhenNotMatched(insert={"id": source_col("id"), "status": lit("new")})
   ```
   `"s.<col>"` / `"t.<col>"` shorthands also work (`t.*` only in update).
@@ -394,8 +415,8 @@ extra. Install the extra before using conditions: `pip install pypaimon[sql]`.
 - Multiple clauses are evaluated in order; the first matching condition wins:
   ```python
   when_matched=[
-      WhenMatched(update="*", condition="s.ts > t.ts"),
-      WhenMatched(update="*"),  # fallback for unmatched rows
+      WhenMatched.update("*", condition="s.ts > t.ts"),
+      WhenMatched.update("*"),  # fallback for unmatched rows
   ]
   ```
 
@@ -407,21 +428,22 @@ extra. Install the extra before using conditions: `pip install pypaimon[sql]`.
 - `num_partitions`: shuffle parallelism for the join and the write; defaults to
   `max(1, cluster_cpus * 2)`. Raise it for large merges on big clusters.
 - `ray_remote_args`: Ray remote options applied to the merge's map/group
-  tasks (update transform, group write, insert transform).
+  tasks (update/delete transform, group write, insert transform).
 - `concurrency`: scheduling for the insert sink.
 
 **Returns:** `{"num_matched", "num_inserted", "num_unchanged"}`. `num_matched`
-counts the rows actually updated (after condition filtering). `num_unchanged`
-is `0` in the current implementation.
+counts the rows actually updated or deleted (after condition filtering).
+`num_unchanged` is `0` in the current implementation.
 
 For an end-to-end feature update workflow on Blob tables, see
 [Distributed Feature Backfill with Ray](../learn-paimon/scenario-guide#distributed-feature-backfill-with-ray).
 
 **Notes:**
-- Partition key columns cannot be updated by matched clauses. If the target
-  table is partitioned, `merge_into` raises an error when `when_matched` is
-  specified, because cross-partition row movement is not implemented.
+- Partition key columns cannot be updated by matched update clauses, because
+  cross-partition row movement is not implemented. Matched delete clauses and
+  matched updates of non-partition columns work on partitioned tables.
   Not-matched inserts into partitioned tables work normally.
+- Matched delete clauses require `deletion-vectors.enabled = true`.
 - Blob columns can be updated and inserted by `merge_into`. With `update="*"`
   or `insert="*"`, the source must include the corresponding blob columns.
   If an insert mapping omits a blob column, that column is written as `NULL`.

--- a/paimon-python/pypaimon/multimodal/table.py
+++ b/paimon-python/pypaimon/multimodal/table.py
@@ -122,6 +122,19 @@ class MultimodalTable:
             table_commit.close()
         return self
 
+    def delete(self, where):
+        query = self.scan().where(where)
+        predicate = query._predicate
+        write_builder = self.raw_table.new_batch_write_builder()
+        table_update = write_builder.new_update()
+        table_commit = write_builder.new_commit()
+        try:
+            messages = table_update.delete_by_predicate(predicate)
+            table_commit.commit(messages)
+        finally:
+            table_commit.close()
+        return self
+
     def merge(self, on):
         return _MergeBuilder(self, on)
 
@@ -251,8 +264,15 @@ class _MergeBuilder:
 
     def when_matched_update(self, values=None, where: Optional[str] = None):
         self._when_matched.append(
-            WhenMatched(
-                update=_ALL_SOURCE_COLUMNS if values is None else values,
+            WhenMatched.update(
+                _ALL_SOURCE_COLUMNS if values is None else values,
+                condition=_normalize_merge_where(where),
+            ))
+        return self
+
+    def when_matched_delete(self, where: Optional[str] = None):
+        self._when_matched.append(
+            WhenMatched.delete(
                 condition=_normalize_merge_where(where),
             ))
         return self
@@ -391,10 +411,14 @@ def _resolve_merge_clauses(
     source_names = set(source_table.column_names)
     return (
         [
-            WhenMatched(
-                update=_resolve_merge_set_spec(
-                    clause.update, target_names, source_names, on_map),
-                condition=clause.condition,
+            (
+                WhenMatched.delete(condition=clause.condition)
+                if clause.delete
+                else WhenMatched.update(
+                    _resolve_merge_set_spec(
+                        clause.update, target_names, source_names, on_map),
+                    condition=clause.condition,
+                )
             )
             for clause in when_matched
         ],

--- a/paimon-python/pypaimon/ray/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_into.py
@@ -25,9 +25,12 @@ import pyarrow as pa
 
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.ray.data_evolution_merge_join import (
+    build_matched_delete_ds,
     build_matched_update_ds,
     build_not_matched_insert_ds,
+    build_self_merge_delete_ds,
     build_self_merge_update_ds,
+    distributed_delete_apply,
     distributed_update_apply,
     distributed_write_collect_msgs,
 )
@@ -79,13 +82,13 @@ def merge_into(
     )
     base_snapshot = table.snapshot_manager().get_latest_snapshot()
 
-    update_ds, insert_ds, update_cols_union = _build_datasets(
+    update_ds, delete_ds, insert_ds, update_cols_union = _build_datasets(
         target, source_ds, matched_specs, not_matched_specs,
         ctx, base_snapshot, num_partitions, ray_remote_args,
     )
 
     return _execute_and_commit(
-        table, update_ds, insert_ds, update_cols_union,
+        table, update_ds, delete_ds, insert_ds, update_cols_union,
         base_snapshot, num_partitions,
         ray_remote_args, concurrency,
     )
@@ -119,19 +122,31 @@ def _prepare(target, source, catalog_options, when_matched, when_not_matched, on
         raise ValueError(
             f"merge_into requires 'row-tracking.enabled' = 'true' on '{target}'."
         )
+    if any(c.delete for c in when_matched) and not (
+        table.options.deletion_vectors_enabled(False)
+    ):
+        raise ValueError(
+            f"merge_into DELETE requires 'deletion-vectors.enabled' = "
+            f"'true' on '{target}'."
+        )
 
     full_target_field_names = list(table.field_names)
     settable_field_names = list(full_target_field_names)
     on_map = dict(zip(target_on_cols, source_on_cols))
-    matched_specs = [
-        _NormalizedClause(
-            spec=_normalize_set_spec(
+    matched_specs = []
+    for c in when_matched:
+        spec = {}
+        if not c.delete:
+            spec = _normalize_set_spec(
                 c.update, settable_field_names, on_map,
-            ),
-            condition=c.condition,
+            )
+        matched_specs.append(
+            _NormalizedClause(
+                spec=spec,
+                condition=c.condition,
+                delete=c.delete,
+            )
         )
-        for c in when_matched
-    ]
     if matched_specs and table.partition_keys:
         partition_set = set(table.partition_keys)
         for clause in matched_specs:
@@ -260,6 +275,7 @@ def _build_datasets(
     base_snapshot_id = base_snapshot.id if base_snapshot is not None else None
 
     update_ds = None
+    delete_ds = None
     insert_ds = None
     update_cols_union: List[str] = []
 
@@ -278,7 +294,17 @@ def _build_datasets(
                     snapshot_id=base_snapshot_id,
                     ray_remote_args=ray_remote_args,
                 )
-        return update_ds, insert_ds, update_cols_union
+            if any(c.delete for c in matched_specs):
+                delete_ds = build_self_merge_delete_ds(
+                    target_identifier=target,
+                    clauses=matched_specs,
+                    target_field_names=ctx.full_target_field_names,
+                    catalog_options=ctx.catalog_options,
+                    resolve_target_projection=_resolve_target_projection,
+                    snapshot_id=base_snapshot_id,
+                    ray_remote_args=ray_remote_args,
+                )
+        return update_ds, delete_ds, insert_ds, update_cols_union
 
     # Mirror Spark: matched/not-matched run as two independent joins
     # (inner / left_anti). One unified left_outer join would force
@@ -295,6 +321,20 @@ def _build_datasets(
                 target_field_names=ctx.settable_field_names,
                 target_pa_schema=ctx.update_pa_schema,
                 update_cols=update_cols_union,
+                catalog_options=ctx.catalog_options,
+                num_partitions=num_partitions,
+                resolve_target_projection=_resolve_target_projection,
+                snapshot_id=base_snapshot_id,
+                ray_remote_args=ray_remote_args,
+            )
+        if any(c.delete for c in matched_specs):
+            delete_ds = build_matched_delete_ds(
+                target_identifier=target,
+                source_ds=source_ds,
+                target_on=ctx.target_on_cols,
+                source_on=ctx.source_on_cols,
+                clauses=matched_specs,
+                target_field_names=ctx.settable_field_names,
                 catalog_options=ctx.catalog_options,
                 num_partitions=num_partitions,
                 resolve_target_projection=_resolve_target_projection,
@@ -318,19 +358,22 @@ def _build_datasets(
             ray_remote_args=ray_remote_args,
         )
 
-    return update_ds, insert_ds, update_cols_union
+    return update_ds, delete_ds, insert_ds, update_cols_union
 
 
 def _execute_and_commit(
-    table, update_ds, insert_ds, update_cols_union,
+    table, update_ds, delete_ds, insert_ds, update_cols_union,
     base_snapshot, num_partitions,
     ray_remote_args, concurrency,
 ):
+    collect_action_row_ids = update_ds is not None and delete_ds is not None
+
     update_msgs: list = []
     num_updated = 0
+    update_row_ids = []
     if update_ds is not None:
         try:
-            update_msgs, num_updated = distributed_update_apply(
+            update_msgs, num_updated, update_row_ids = distributed_update_apply(
                 update_ds, table, update_cols_union,
                 num_partitions=num_partitions,
                 ray_remote_args=ray_remote_args,
@@ -338,11 +381,33 @@ def _execute_and_commit(
                     base_snapshot.id
                     if base_snapshot is not None else None
                 ),
+                collect_row_ids=collect_action_row_ids,
             )
         except Exception as e:
             _reraise_inner(e)
 
-    all_msgs: list = list(update_msgs)
+    delete_msgs: list = []
+    num_deleted = 0
+    delete_row_ids = []
+    if delete_ds is not None:
+        try:
+            delete_msgs, num_deleted, delete_row_ids = distributed_delete_apply(
+                delete_ds, table,
+                num_partitions=num_partitions,
+                ray_remote_args=ray_remote_args,
+                base_snapshot_id=(
+                    base_snapshot.id
+                    if base_snapshot is not None else None
+                ),
+                collect_row_ids=collect_action_row_ids,
+            )
+        except Exception as e:
+            _reraise_inner(e)
+
+    if collect_action_row_ids:
+        _validate_disjoint_action_row_ids(update_row_ids, delete_row_ids)
+
+    all_msgs: list = list(update_msgs) + list(delete_msgs)
     num_inserted = 0
     if insert_ds is not None:
         try:
@@ -365,9 +430,9 @@ def _execute_and_commit(
         tc.commit(all_msgs)
         tc.close()
 
-    # num_matched = rows that passed the condition and were updated
+    # num_matched = rows that passed a matched condition and changed
     return {
-        "num_matched": num_updated,
+        "num_matched": num_updated + num_deleted,
         "num_inserted": num_inserted,
         "num_unchanged": 0,
     }
@@ -418,6 +483,17 @@ def _reraise_inner(err: BaseException) -> None:
     if inner is err:
         raise err
     raise inner from err
+
+
+def _validate_disjoint_action_row_ids(update_row_ids, delete_row_ids) -> None:
+    seen = set()
+    for row_id in list(update_row_ids) + list(delete_row_ids):
+        if row_id in seen:
+            raise ValueError(
+                "MERGE matched multiple source rows to the same target "
+                "_ROW_ID. Deduplicate the source before merging."
+            )
+        seen.add(row_id)
 
 
 def _union_update_cols(clauses: List[_NormalizedClause]) -> List[str]:

--- a/paimon-python/pypaimon/ray/data_evolution_merge_join.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_join.py
@@ -23,8 +23,10 @@ import pyarrow as pa
 from pypaimon.ray.data_evolution_merge_transform import (
     SourceColumnRef,
     _NormalizedClause,
+    build_delete_schema,
     build_update_schema,
     cast_to_schema,
+    vectorized_delete_transform,
     vectorized_insert_transform,
     vectorized_matched_transform,
 )
@@ -60,16 +62,16 @@ def _build_matched_transform(
             rewritten = remap_source_on_keys(
                 rewrite_condition(clause.condition), on_map,
             )
-        prepared_clauses.append((clause.spec, rewritten))
+        prepared_clauses.append((clause.spec, rewritten, clause.delete))
 
     _filter_batch = None
-    if any(r is not None for _, r in prepared_clauses):
+    if any(r is not None for _, r, _ in prepared_clauses):
         from pypaimon.ray.merge_condition import filter_batch as _filter_batch
 
     def _transform(batch: pa.Table) -> pa.Table:
         remaining = batch
         parts = []
-        for spec, rewritten in prepared_clauses:
+        for spec, rewritten, is_delete in prepared_clauses:
             if remaining.num_rows == 0:
                 break
             if rewritten is not None:
@@ -80,11 +82,12 @@ def _build_matched_transform(
                 matched = remaining
             if matched.num_rows == 0:
                 continue
-            parts.append(vectorized_matched_transform(
-                matched, spec, on_pairs,
-                update_cols, row_id_name,
-                update_schema,
-            ))
+            if not is_delete:
+                parts.append(vectorized_matched_transform(
+                    matched, spec, on_pairs,
+                    update_cols, row_id_name,
+                    update_schema,
+                ))
             if rewritten is not None and matched.num_rows < remaining.num_rows:
                 not_cond = f"COALESCE(NOT ({rewritten}), TRUE)"
                 remaining = _filter_batch(
@@ -94,6 +97,60 @@ def _build_matched_transform(
                 remaining = remaining.slice(0, 0)
         if not parts:
             return update_schema.empty_table()
+        return pa.concat_tables(parts)
+
+    return _transform
+
+
+def _build_matched_delete_transform(
+    clauses: List[_NormalizedClause],
+    on_map: Dict[str, str],
+    row_id_name: str,
+    delete_schema: pa.Schema,
+):
+    prepared_clauses = []
+    for clause in clauses:
+        rewritten = None
+        if clause.condition is not None:
+            from pypaimon.ray.merge_condition import (
+                remap_source_on_keys, rewrite_condition,
+            )
+            rewritten = remap_source_on_keys(
+                rewrite_condition(clause.condition), on_map,
+            )
+        prepared_clauses.append((rewritten, clause.delete))
+
+    _filter_batch = None
+    if any(r is not None for r, _ in prepared_clauses):
+        from pypaimon.ray.merge_condition import filter_batch as _filter_batch
+
+    def _transform(batch: pa.Table) -> pa.Table:
+        remaining = batch
+        parts = []
+        for rewritten, is_delete in prepared_clauses:
+            if remaining.num_rows == 0:
+                break
+            if rewritten is not None:
+                matched = _filter_batch(
+                    remaining, rewritten, _pre_rewritten=True,
+                )
+            else:
+                matched = remaining
+            if matched.num_rows > 0 and is_delete:
+                parts.append(
+                    vectorized_delete_transform(
+                        matched, row_id_name, delete_schema,
+                    )
+                )
+            if rewritten is not None and matched.num_rows < remaining.num_rows:
+                not_cond = f"COALESCE(NOT ({rewritten}), TRUE)"
+                remaining = _filter_batch(
+                    remaining, not_cond, _pre_rewritten=True,
+                )
+            else:
+                remaining = remaining.slice(0, 0)
+        if not parts:
+            return delete_schema.empty_table()
         return pa.concat_tables(parts)
 
     return _transform
@@ -173,6 +230,72 @@ def build_self_merge_update_ds(
     return aliased.map_batches(_transform, **_map_kwargs(ray_remote_args))
 
 
+def build_self_merge_delete_ds(
+    *,
+    target_identifier: str,
+    clauses: List[_NormalizedClause],
+    target_field_names: Sequence[str],
+    catalog_options: Dict[str, str],
+    resolve_target_projection,
+    snapshot_id: Optional[int] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+) -> Tuple:
+    from pypaimon.ray.ray_paimon import read_paimon
+    from pypaimon.table.special_fields import SpecialFields
+
+    row_id_name = SpecialFields.ROW_ID.name
+    needed_cols = set(resolve_target_projection(
+        clauses, [row_id_name], [], target_field_names,
+    ))
+    target_set = set(target_field_names)
+    for clause in clauses:
+        if clause.condition is not None:
+            from pypaimon.ray.merge_condition import extract_columns
+            for ref in extract_columns(clause.condition):
+                prefix, col = ref.split(".", 1)
+                if prefix == "s" and col in target_set:
+                    needed_cols.add(col)
+    projection = [row_id_name] + [
+        c for c in target_field_names if c in needed_cols
+    ]
+
+    target_ds = read_paimon(
+        target_identifier, catalog_options,
+        projection=projection, snapshot_id=snapshot_id,
+    )
+    delete_schema = build_delete_schema(row_id_name)
+
+    orig_names = target_ds.schema().names
+    target_renamed = target_ds.rename_columns(
+        {c: f"t.{c}" for c in orig_names}
+    )
+
+    def _add_source_aliases(batch: pa.Table) -> pa.Table:
+        columns = list(batch.columns)
+        names = list(batch.schema.names)
+        for orig in orig_names:
+            if orig == row_id_name:
+                continue
+            t_col_name = f"t.{orig}"
+            if t_col_name in names:
+                idx = names.index(t_col_name)
+                columns.append(columns[idx])
+                names.append(f"s.{orig}")
+        return pa.table(columns, names=names)
+
+    aliased = target_renamed.map_batches(
+        _add_source_aliases, **_map_kwargs(ray_remote_args),
+    )
+
+    _transform = _build_matched_delete_transform(
+        clauses,
+        on_map={row_id_name: row_id_name},
+        row_id_name=row_id_name,
+        delete_schema=delete_schema,
+    )
+    return aliased.map_batches(_transform, **_map_kwargs(ray_remote_args))
+
+
 def build_matched_update_ds(
     *,
     target_identifier: str,
@@ -231,6 +354,63 @@ def build_matched_update_ds(
     return joined.map_batches(_transform, **_map_kwargs(ray_remote_args))
 
 
+def build_matched_delete_ds(
+    *,
+    target_identifier: str,
+    source_ds,
+    target_on: Sequence[str],
+    source_on: Sequence[str],
+    clauses: List[_NormalizedClause],
+    target_field_names: Sequence[str],
+    catalog_options: Dict[str, str],
+    num_partitions: int,
+    resolve_target_projection,
+    snapshot_id: Optional[int] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+) -> Tuple:
+    from pypaimon.ray.ray_paimon import read_paimon
+    from pypaimon.table.special_fields import SpecialFields
+
+    row_id_name = SpecialFields.ROW_ID.name
+    needed_cols = resolve_target_projection(
+        clauses,
+        target_on,
+        [],
+        target_field_names,
+    )
+    projection = [row_id_name] + [c for c in needed_cols if c != row_id_name]
+
+    target_ds = read_paimon(
+        target_identifier, catalog_options,
+        projection=projection, snapshot_id=snapshot_id,
+    )
+    delete_schema = build_delete_schema(row_id_name)
+
+    target_renamed = target_ds.rename_columns(
+        {c: f"t.{c}" for c in target_ds.schema().names}
+    )
+    source_cols = list(source_ds.schema().names)
+    source_renamed = source_ds.rename_columns(
+        {c: f"s.{c}" for c in source_cols}
+    )
+
+    joined = target_renamed.join(
+        source_renamed,
+        join_type="inner",
+        num_partitions=num_partitions,
+        on=tuple(f"t.{c}" for c in target_on),
+        right_on=tuple(f"s.{c}" for c in source_on),
+    )
+
+    _transform = _build_matched_delete_transform(
+        clauses,
+        on_map=dict(zip(source_on, target_on)),
+        row_id_name=row_id_name,
+        delete_schema=delete_schema,
+    )
+    return joined.map_batches(_transform, **_map_kwargs(ray_remote_args))
+
+
 def distributed_update_apply(
     update_ds,
     table,
@@ -239,7 +419,8 @@ def distributed_update_apply(
     num_partitions: int,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     base_snapshot_id: Optional[int] = None,
-) -> Tuple[list, int]:
+    collect_row_ids: bool = False,
+) -> Tuple[list, int, list]:
     import numpy as np
     import pickle
     import uuid
@@ -267,7 +448,7 @@ def distributed_update_apply(
     )
     sorted_first_row_ids = list(planner.first_row_ids)
     if not sorted_first_row_ids:
-        return [], 0
+        return [], 0, []
 
     # Pin commit-time conflict check to the snapshot the join was built on,
     # so concurrent commits between read and planner are detected.
@@ -338,6 +519,7 @@ def distributed_update_apply(
             return pa.Table.from_pydict({
                 "msgs_blob": pa.array([], type=pa.binary()),
                 "n_updated": pa.array([], type=pa.int64()),
+                "row_ids_blob": pa.array([], type=pa.binary()),
             })
 
         if (
@@ -351,6 +533,10 @@ def distributed_update_apply(
             )
 
         for_update = group.drop_columns([frid_col])
+        row_ids = (
+            for_update.column(row_id_name).to_pylist()
+            if collect_row_ids else []
+        )
         worker = TableUpdateByRowId(
             captured_table,
             "_merge_into_shard_" + uuid.uuid4().hex[:8],
@@ -362,6 +548,9 @@ def distributed_update_apply(
             "msgs_blob": [pickle.dumps(msgs)],
             "n_updated": pa.array(
                 [for_update.num_rows], type=pa.int64()
+            ),
+            "row_ids_blob": pa.array(
+                [pickle.dumps(row_ids)], type=pa.binary()
             ),
         })
 
@@ -375,12 +564,158 @@ def distributed_update_apply(
 
     all_msgs: list = []
     num_updated = 0
+    action_row_ids = []
     for batch in msgs_ds.iter_batches(batch_format="pyarrow"):
         for blob in batch.column("msgs_blob").to_pylist():
             all_msgs.extend(pickle.loads(blob))
         for n in batch.column("n_updated").to_pylist():
             num_updated += n
-    return all_msgs, num_updated
+        if collect_row_ids:
+            for blob in batch.column("row_ids_blob").to_pylist():
+                action_row_ids.extend(pickle.loads(blob))
+    return all_msgs, num_updated, action_row_ids
+
+
+def distributed_delete_apply(
+    delete_ds,
+    table,
+    *,
+    num_partitions: int,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+    base_snapshot_id: Optional[int] = None,
+    collect_row_ids: bool = False,
+) -> Tuple[list, int, list]:
+    import base64
+    import numpy as np
+    import pickle
+
+    import pyarrow.compute as pc
+    import ray
+
+    from pypaimon.common.options.core_options import CoreOptions
+    from pypaimon.table.special_fields import SpecialFields
+    from pypaimon.write.table_delete import TableDeleteByRowId
+
+    row_id_name = SpecialFields.ROW_ID.name
+    scan_table = (
+        table.copy({CoreOptions.SCAN_SNAPSHOT_ID.key(): str(base_snapshot_id)})
+        if base_snapshot_id is not None else table
+    )
+
+    planner = TableDeleteByRowId(scan_table)
+    anchor_info = planner._snapshot_anchor_ranges()
+    if not anchor_info.anchors:
+        return [], 0, []
+
+    precomputed_info_ref = ray.put(anchor_info)
+
+    starts = np.asarray(
+        [a.row_range.from_ for a in anchor_info.anchors], dtype=np.int64
+    )
+    ends = np.asarray(
+        [a.row_range.to for a in anchor_info.anchors], dtype=np.int64
+    )
+
+    def _group_key(anchor) -> str:
+        partition_blob = base64.b64encode(
+            pickle.dumps(tuple(anchor.partition.values))
+        ).decode("ascii")
+        return f"{anchor.bucket}:{partition_blob}"
+
+    group_keys = [_group_key(a) for a in anchor_info.anchors]
+    unique_group_count = len(set(group_keys))
+    group_col = "_DELETE_GROUP_KEY"
+    valid_ranges = [
+        f"[{a.row_range.from_}, {a.row_range.to}]"
+        for a in anchor_info.anchors
+    ]
+
+    def _assign_group(batch: pa.Table) -> pa.Table:
+        if batch.num_rows == 0:
+            return batch.append_column(
+                group_col, pa.array([], type=pa.string())
+            )
+        rid_col = batch.column(row_id_name)
+        if rid_col.null_count:
+            raise ValueError(
+                "_ROW_ID is null; planner snapshot is stale "
+                "or matched rows come from a different table."
+            )
+        rids = rid_col.to_numpy(zero_copy_only=False)
+        idx = np.searchsorted(starts, rids, side="right") - 1
+        safe_idx = np.clip(idx, 0, len(starts) - 1)
+        in_range = (
+            (idx >= 0)
+            & (idx < len(starts))
+            & (rids >= starts[safe_idx])
+            & (rids <= ends[safe_idx])
+        )
+        if not in_range.all():
+            bad = rids[~in_range][0]
+            raise ValueError(
+                f"_ROW_ID {bad} does not belong to any valid range "
+                f"{valid_ranges}; planner snapshot is stale or matched "
+                f"rows come from a different table."
+            )
+        return batch.append_column(
+            group_col,
+            pa.array([group_keys[i] for i in safe_idx], type=pa.string()),
+        )
+
+    map_kwargs = _map_kwargs(ray_remote_args)
+    with_group = delete_ds.map_batches(_assign_group, **map_kwargs)
+    captured_table = scan_table
+
+    def _apply_group(group: pa.Table) -> pa.Table:
+        if group.num_rows == 0:
+            return pa.Table.from_pydict({
+                "msgs_blob": pa.array([], type=pa.binary()),
+                "n_deleted": pa.array([], type=pa.int64()),
+                "row_ids_blob": pa.array([], type=pa.binary()),
+            })
+
+        if (
+            pc.count_distinct(group.column(row_id_name)).as_py()
+            != group.num_rows
+        ):
+            raise ValueError(
+                "MERGE matched multiple source rows to the same "
+                "target _ROW_ID. Deduplicate the source before "
+                "merging."
+            )
+
+        row_ids = group.column(row_id_name).to_pylist()
+        worker = TableDeleteByRowId(
+            captured_table,
+            _precomputed_anchor_ranges=ray.get(precomputed_info_ref),
+        )
+        msgs = worker.delete(row_ids)
+        return pa.Table.from_pydict({
+            "msgs_blob": pa.array([pickle.dumps(msgs)], type=pa.binary()),
+            "n_deleted": pa.array([len(row_ids)], type=pa.int64()),
+            "row_ids_blob": pa.array(
+                [pickle.dumps(row_ids if collect_row_ids else [])],
+                type=pa.binary(),
+            ),
+        })
+
+    group_partitions = max(1, min(unique_group_count, num_partitions))
+    msgs_ds = with_group.groupby(
+        group_col, num_partitions=group_partitions
+    ).map_groups(_apply_group, **map_kwargs)
+
+    all_msgs: list = []
+    num_deleted = 0
+    action_row_ids = []
+    for batch in msgs_ds.iter_batches(batch_format="pyarrow"):
+        for blob in batch.column("msgs_blob").to_pylist():
+            all_msgs.extend(pickle.loads(blob))
+        for n in batch.column("n_deleted").to_pylist():
+            num_deleted += n
+        if collect_row_ids:
+            for blob in batch.column("row_ids_blob").to_pylist():
+                action_row_ids.extend(pickle.loads(blob))
+    return all_msgs, num_deleted, action_row_ids
 
 
 def build_not_matched_insert_ds(

--- a/paimon-python/pypaimon/ray/data_evolution_merge_transform.py
+++ b/paimon-python/pypaimon/ray/data_evolution_merge_transform.py
@@ -52,10 +52,33 @@ def lit(value: Any) -> LiteralValue:
     return LiteralValue(value)
 
 
-@dataclass
 class WhenMatched:
-    update: SetSpec
-    condition: Optional[str] = None
+    def __init__(
+            self,
+            action: str,
+            *,
+            update: Optional[SetSpec] = None,
+            condition: Optional[str] = None):
+        if action not in ("update", "delete"):
+            raise ValueError("WhenMatched action must be 'update' or 'delete'.")
+        if action == "update" and update is None:
+            raise ValueError("WhenMatched.update requires an update spec.")
+        if action == "delete" and update is not None:
+            raise ValueError("WhenMatched.delete must not specify update.")
+        self.update = update
+        self.condition = condition
+        self.delete = action == "delete"
+
+    @classmethod
+    def update(
+            cls,
+            update: SetSpec = "*",
+            condition: Optional[str] = None):
+        return cls("update", update=update, condition=condition)
+
+    @classmethod
+    def delete(cls, condition: Optional[str] = None):
+        return cls("delete", condition=condition)
 
 
 @dataclass
@@ -68,6 +91,7 @@ class WhenNotMatched:
 class _NormalizedClause:
     spec: Dict[str, Any]
     condition: Optional[str] = None
+    delete: bool = False
 
 
 def vectorized_matched_transform(
@@ -91,6 +115,16 @@ def vectorized_matched_transform(
         else:
             arrays.append(batch.column(f"t.{col}"))
     return pa.Table.from_arrays(arrays, schema=update_schema)
+
+
+def vectorized_delete_transform(
+    batch: pa.Table,
+    row_id_name: str,
+    delete_schema: pa.Schema,
+) -> pa.Table:
+    return pa.Table.from_arrays(
+        [batch.column(f"t.{row_id_name}")], schema=delete_schema
+    )
 
 
 def vectorized_insert_transform(
@@ -127,6 +161,10 @@ def build_update_schema(
         [pa.field(row_id_name, pa.int64(), nullable=False)]
         + [target_pa_schema.field(col) for col in update_cols]
     )
+
+
+def build_delete_schema(row_id_name: str) -> pa.Schema:
+    return pa.schema([pa.field(row_id_name, pa.int64(), nullable=False)])
 
 
 def _resolve_spec_array(

--- a/paimon-python/pypaimon/table/data_evolution_merge_into.py
+++ b/paimon-python/pypaimon/table/data_evolution_merge_into.py
@@ -32,13 +32,17 @@ from pypaimon.ray.data_evolution_merge_into import (
     _union_update_cols,
     _validate_source_has_target_cols,
 )
-from pypaimon.ray.data_evolution_merge_join import _build_matched_transform
+from pypaimon.ray.data_evolution_merge_join import (
+    _build_matched_delete_transform,
+    _build_matched_transform,
+)
 from pypaimon.ray.data_evolution_merge_transform import (
     OnSpec,
     SourceColumnRef,
     WhenMatched,
     WhenNotMatched,
     _NormalizedClause,
+    build_delete_schema,
     build_update_schema,
     cast_to_schema,
     lit,
@@ -50,6 +54,7 @@ from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.write.commit_message import CommitMessage
 from pypaimon.write.table_write import BatchTableWrite, StreamTableWrite
+from pypaimon.write.table_delete import TableDeleteByRowId
 from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 
 __all__ = [
@@ -97,7 +102,7 @@ def merge_into(
         on,
     )
 
-    update_table, insert_table, update_cols_union = _build_tables(
+    update_table, delete_table, insert_table, update_cols_union = _build_tables(
         target_table,
         source_table,
         matched_specs,
@@ -109,6 +114,7 @@ def merge_into(
     return _prepare_commit_messages(
         target_table,
         update_table,
+        delete_table,
         insert_table,
         update_cols_union,
         base_snapshot,
@@ -147,22 +153,34 @@ def _prepare(
         raise ValueError(
             "merge_into requires 'row-tracking.enabled' = 'true' on target table."
         )
+    if any(c.delete for c in when_matched) and not (
+        target_table.options.deletion_vectors_enabled(False)
+    ):
+        raise ValueError(
+            "merge_into DELETE requires 'deletion-vectors.enabled' = "
+            "'true' on target table."
+        )
 
     full_target_field_names = list(target_table.field_names)
     settable_field_names = list(full_target_field_names)
     on_map = dict(zip(target_on_cols, source_on_cols))
 
-    matched_specs = [
-        _NormalizedClause(
-            spec=_normalize_set_spec(
+    matched_specs = []
+    for c in when_matched:
+        spec = {}
+        if not c.delete:
+            spec = _normalize_set_spec(
                 c.update,
                 settable_field_names,
                 on_map,
-            ),
-            condition=c.condition,
+            )
+        matched_specs.append(
+            _NormalizedClause(
+                spec=spec,
+                condition=c.condition,
+                delete=c.delete,
+            )
         )
-        for c in when_matched
-    ]
     if matched_specs and target_table.partition_keys:
         partition_set = set(target_table.partition_keys)
         for clause in matched_specs:
@@ -283,6 +301,7 @@ def _build_tables(
 ):
     base_snapshot_id = base_snapshot.id if base_snapshot is not None else None
     update_table = None
+    delete_table = None
     insert_table = None
     update_cols_union: List[str] = []
 
@@ -297,7 +316,14 @@ def _build_tables(
                     update_cols_union,
                     base_snapshot_id,
                 )
-        return update_table, insert_table, update_cols_union
+            if any(c.delete for c in matched_specs):
+                delete_table = _build_self_merge_delete_table(
+                    target_table,
+                    matched_specs,
+                    ctx,
+                    base_snapshot_id,
+                )
+        return update_table, delete_table, insert_table, update_cols_union
 
     if matched_specs and base_snapshot is not None:
         update_cols_union = _union_update_cols(matched_specs)
@@ -308,6 +334,14 @@ def _build_tables(
                 matched_specs,
                 ctx,
                 update_cols_union,
+                base_snapshot_id,
+            )
+        if any(c.delete for c in matched_specs):
+            delete_table = _build_matched_delete_table(
+                target_table,
+                source_table,
+                matched_specs,
+                ctx,
                 base_snapshot_id,
             )
 
@@ -321,7 +355,7 @@ def _build_tables(
             target_empty=base_snapshot is None,
         )
 
-    return update_table, insert_table, update_cols_union
+    return update_table, delete_table, insert_table, update_cols_union
 
 
 def _build_self_merge_update_table(
@@ -380,6 +414,53 @@ def _build_self_merge_update_table(
     return transform(aliased)
 
 
+def _build_self_merge_delete_table(
+    target_table,
+    clauses: List[_NormalizedClause],
+    ctx: _PrepareCtx,
+    snapshot_id: Optional[int],
+) -> pa.Table:
+    row_id_name = SpecialFields.ROW_ID.name
+    needed_cols = set(
+        _resolve_target_projection(
+            clauses,
+            [row_id_name],
+            [],
+            ctx.full_target_field_names,
+        )
+    )
+    target_set = set(ctx.full_target_field_names)
+    for clause in clauses:
+        if clause.condition is not None:
+            from pypaimon.ray.merge_condition import extract_columns
+
+            for ref in extract_columns(clause.condition):
+                prefix, col = ref.split(".", 1)
+                if prefix == "s" and col in target_set:
+                    needed_cols.add(col)
+    projection = [row_id_name] + [
+        c for c in ctx.full_target_field_names if c in needed_cols
+    ]
+
+    target = _read_table(target_table, projection=projection, snapshot_id=snapshot_id)
+    delete_schema = build_delete_schema(row_id_name)
+    if target.num_rows == 0:
+        return delete_schema.empty_table()
+
+    orig_names = list(target.schema.names)
+    target_renamed = _rename_with_prefix(target, "t.")
+    aliased = _add_self_merge_source_aliases(
+        target_renamed, orig_names, row_id_name
+    )
+    transform = _build_matched_delete_transform(
+        clauses,
+        on_map={row_id_name: row_id_name},
+        row_id_name=row_id_name,
+        delete_schema=delete_schema,
+    )
+    return transform(aliased)
+
+
 def _build_matched_update_table(
     target_table,
     source_table: pa.Table,
@@ -418,6 +499,43 @@ def _build_matched_update_table(
         update_cols=list(update_cols),
         row_id_name=row_id_name,
         update_schema=update_schema,
+    )
+    return transform(joined)
+
+
+def _build_matched_delete_table(
+    target_table,
+    source_table: pa.Table,
+    clauses: List[_NormalizedClause],
+    ctx: _PrepareCtx,
+    snapshot_id: Optional[int],
+) -> pa.Table:
+    row_id_name = SpecialFields.ROW_ID.name
+    needed_cols = _resolve_target_projection(
+        clauses,
+        ctx.target_on_cols,
+        [],
+        ctx.settable_field_names,
+    )
+    projection = [row_id_name] + [c for c in needed_cols if c != row_id_name]
+    target = _read_table(target_table, projection=projection, snapshot_id=snapshot_id)
+    delete_schema = build_delete_schema(row_id_name)
+    if target.num_rows == 0 or source_table.num_rows == 0:
+        return delete_schema.empty_table()
+
+    target_renamed = _rename_with_prefix(target, "t.")
+    source_renamed = _rename_with_prefix(source_table, "s.")
+    joined = target_renamed.join(
+        source_renamed,
+        keys=["t.{}".format(c) for c in ctx.target_on_cols],
+        right_keys=["s.{}".format(c) for c in ctx.source_on_cols],
+        join_type="inner",
+    )
+    transform = _build_matched_delete_transform(
+        clauses,
+        on_map=dict(zip(ctx.source_on_cols, ctx.target_on_cols)),
+        row_id_name=row_id_name,
+        delete_schema=delete_schema,
     )
     return transform(joined)
 
@@ -462,6 +580,7 @@ def _build_not_matched_insert_table(
 def _prepare_commit_messages(
     table,
     update_table: Optional[pa.Table],
+    delete_table: Optional[pa.Table],
     insert_table: Optional[pa.Table],
     update_cols_union: Sequence[str],
     base_snapshot,
@@ -469,8 +588,9 @@ def _prepare_commit_messages(
     commit_identifier: int,
 ) -> List[CommitMessage]:
     all_msgs: list = []
+    _validate_unique_action_row_ids(update_table, delete_table)
+
     if update_table is not None and update_table.num_rows > 0:
-        _validate_unique_row_ids(update_table)
         update_snapshot_table = _copy_at_snapshot(
             table, base_snapshot.id if base_snapshot is not None else None
         )
@@ -483,6 +603,17 @@ def _prepare_commit_messages(
             update_table, list(update_cols_union)
         )
         all_msgs.extend(update_msgs)
+
+    if delete_table is not None and delete_table.num_rows > 0:
+        delete_snapshot_table = _copy_at_snapshot(
+            table, base_snapshot.id if base_snapshot is not None else None
+        )
+        deleter = TableDeleteByRowId(delete_snapshot_table)
+        row_id_name = SpecialFields.ROW_ID.name
+        delete_msgs = deleter.delete(
+            delete_table.column(row_id_name).to_pylist()
+        )
+        all_msgs.extend(delete_msgs)
 
     if insert_table is not None and insert_table.num_rows > 0:
         writer = _new_table_write(table, commit_user, commit_identifier)
@@ -612,12 +743,22 @@ def _validate_source_on_cols(source_table: pa.Table, on: Sequence[str]) -> None:
         )
 
 
-def _validate_unique_row_ids(update_table: pa.Table) -> None:
+def _validate_unique_action_row_ids(
+    update_table: Optional[pa.Table],
+    delete_table: Optional[pa.Table],
+) -> None:
+    chunks = []
+    total_rows = 0
     row_id_name = SpecialFields.ROW_ID.name
-    if (
-        pc.count_distinct(update_table.column(row_id_name)).as_py()
-        != update_table.num_rows
-    ):
+    for table in (update_table, delete_table):
+        if table is None or table.num_rows == 0:
+            continue
+        total_rows += table.num_rows
+        chunks.extend(table.column(row_id_name).chunks)
+    if not chunks:
+        return
+    row_ids = pa.chunked_array(chunks)
+    if pc.count_distinct(row_ids).as_py() != total_rows:
         raise ValueError(
             "MERGE matched multiple source rows to the same target _ROW_ID. "
             "Deduplicate the source before merging."

--- a/paimon-python/pypaimon/tests/global_index_build_test.py
+++ b/paimon-python/pypaimon/tests/global_index_build_test.py
@@ -30,6 +30,7 @@ from pypaimon.globalindex.build_plan import (
     split_by_global_index_shard as _split_by_global_index_shard,
     split_one_by_contiguous_row_range as _split_one_by_contiguous_row_range,
 )
+from pypaimon.globalindex.create_global_index import GlobalIndexBuilder
 from pypaimon.globalindex.key_serializer import create_serializer
 from pypaimon.globalindex.tantivy.tantivy_full_text_global_index_reader import (
     TANTIVY_FULLTEXT_IDENTIFIER,
@@ -416,6 +417,54 @@ class GlobalIndexBuildTest(
         index_table = index_read_builder.new_read().to_arrow(
             index_read_builder.new_scan().plan().splits())
         self.assertEqual(0, index_table.num_rows)
+
+    def test_stale_global_index_commit_conflicts_when_data_files_removed(self):
+        table = self._create_table()
+        self._write_arrow(table, pa.table(
+            {
+                'id': [1, 2, 3, 4],
+                'name': ['a', 'b', 'c', 'd'],
+                'age': [10, 20, 30, 40],
+                'city': ['x', 'y', 'z', 'w'],
+            },
+            schema=self.pa_schema,
+        ))
+
+        messages = GlobalIndexBuilder(
+            table,
+            'id',
+            options={'sorted-index.records-per-range': '2'},
+        ).build()
+        self.assertGreater(sum(len(message.index_adds) for message in messages), 0)
+
+        overwrite_wb = table.new_batch_write_builder().overwrite({})
+        overwrite_write = overwrite_wb.new_write()
+        overwrite_commit = overwrite_wb.new_commit()
+        overwrite_write.write_arrow(pa.table(
+            {
+                'id': [5, 6],
+                'name': ['e', 'f'],
+                'age': [50, 60],
+                'city': ['new1', 'new2'],
+            },
+            schema=self.pa_schema,
+        ))
+        overwrite_commit.commit(overwrite_write.prepare_commit())
+        overwrite_write.close()
+        overwrite_commit.close()
+
+        stale_commit = table.new_batch_write_builder().new_commit()
+        with self.assertRaises(RuntimeError) as ctx:
+            stale_commit.commit(messages)
+        stale_commit.close()
+        self.assertIn(
+            'Global index row ID existence conflict',
+            str(ctx.exception),
+        )
+        self.assertEqual(
+            [],
+            IndexFileHandler(table).scan(table.snapshot_manager().get_latest_snapshot()),
+        )
 
     def test_create_bitmap_global_index_from_python(self):
         table = self._create_table()

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -306,6 +306,33 @@ class MultimodalTableTest(unittest.TestCase):
             rows,
         )
 
+    def test_delete_by_filter(self):
+        users = self.conn.create_table(
+            "users",
+            data=[
+                {"id": 1, "name": "Alice", "age": 30},
+                {"id": 2, "name": "Bob", "age": 25},
+                {"id": 3, "name": "Carol", "age": 40},
+            ],
+            schema=_schema({
+                "id": pa.int32(),
+                "name": pa.string(),
+                "age": pa.int32(),
+            }),
+            options=_PARQUET_OPTIONS,
+        )
+
+        users.delete(where="id = 2")
+
+        rows = sorted(users.scan().to_list(), key=lambda r: r["id"])
+        self.assertEqual(
+            [
+                {"id": 1, "name": "Alice", "age": 30},
+                {"id": 3, "name": "Carol", "age": 40},
+            ],
+            rows,
+        )
+
     def test_merge_updates_matches_and_inserts_new_rows(self):
         users = self.conn.create_table(
             "users",
@@ -335,6 +362,37 @@ class MultimodalTableTest(unittest.TestCase):
                 {"id": 1, "name": "Alice", "age": 30},
                 {"id": 2, "name": "Bob_v2", "age": 26},
                 {"id": 3, "name": "Carol", "age": 40},
+            ],
+            rows,
+        )
+
+    def test_merge_deletes_matched_rows(self):
+        users = self.conn.create_table(
+            "users",
+            data=[
+                {"id": 1, "name": "Alice", "age": 30},
+                {"id": 2, "name": "Bob", "age": 25},
+                {"id": 3, "name": "Carol", "age": 40},
+            ],
+            schema=_schema({
+                "id": pa.int32(),
+                "name": pa.string(),
+                "age": pa.int32(),
+            }),
+            options=_PARQUET_OPTIONS,
+        )
+
+        users.merge("id") \
+            .when_matched_delete() \
+            .execute([
+                {"id": 2},
+                {"id": 3},
+            ])
+
+        rows = sorted(users.scan().to_list(), key=lambda r: r["id"])
+        self.assertEqual(
+            [
+                {"id": 1, "name": "Alice", "age": 30},
             ],
             rows,
         )
@@ -464,6 +522,62 @@ class MultimodalTableTest(unittest.TestCase):
             calls["matched"][0].condition,
         )
         self.assertEqual("s.age > 0", calls["not_matched"][0].condition)
+        self.assertEqual([], calls["messages"])
+
+    def test_merge_delete_where_uses_source_and_target_aliases(self):
+        users = self.conn.create_table(
+            "users",
+            schema=_schema({
+                "id": pa.int32(),
+                "name": pa.string(),
+                "age": pa.int32(),
+            }),
+            options=_PARQUET_OPTIONS,
+        )
+
+        calls = {}
+
+        class FakeUpdate:
+            def merge_into(
+                    self,
+                    source,
+                    on,
+                    when_matched=None,
+                    when_not_matched=None):
+                calls["matched"] = list(when_matched or [])
+                return []
+
+        class FakeCommit:
+            def commit(self, messages):
+                calls["messages"] = messages
+
+            def close(self):
+                pass
+
+        class FakeWriteBuilder:
+            def new_update(self):
+                return FakeUpdate()
+
+            def new_commit(self):
+                return FakeCommit()
+
+        users.raw_table.new_batch_write_builder = lambda: FakeWriteBuilder()
+
+        (
+            users.merge("id")
+            .when_matched_delete(
+                where="source.age < target.age and source.name != 'target.name'",
+            )
+            .execute([
+                {"id": 1, "name": "Alice", "age": 29},
+            ])
+        )
+
+        self.assertTrue(calls["matched"][0].delete)
+        self.assertEqual(
+            "s.age < t.age and s.name != 'target.name'",
+            calls["matched"][0].condition,
+        )
         self.assertEqual([], calls["messages"])
 
     def test_merge_validates_on_columns(self):

--- a/paimon-python/pypaimon/tests/overwrite_changes_cache_test.py
+++ b/paimon-python/pypaimon/tests/overwrite_changes_cache_test.py
@@ -86,8 +86,8 @@ class OverwriteChangesCacheTest(unittest.TestCase):
 
         # --- count provider full scans and delta probes (class-level spies) ---
         counts = {'full_scan': 0, 'probe': 0}
-        orig_full = OverwriteChangesProvider._full_scan
-        orig_probe = OverwriteChangesProvider._read_delta_entries
+        orig_full = OverwriteChangesProvider._full_scan_manifest_entries
+        orig_probe = OverwriteChangesProvider._read_delta_manifest_entries
 
         def spy_full(self, *a, **k):
             counts['full_scan'] += 1
@@ -111,14 +111,14 @@ class OverwriteChangesCacheTest(unittest.TestCase):
             return orig_cas(snapshot, statistics)
 
         fsc.snapshot_commit.commit = patched_cas
-        OverwriteChangesProvider._full_scan = spy_full
-        OverwriteChangesProvider._read_delta_entries = spy_probe
+        OverwriteChangesProvider._full_scan_manifest_entries = spy_full
+        OverwriteChangesProvider._read_delta_manifest_entries = spy_probe
         try:
             c.commit(messages)
             c.close()
         finally:
-            OverwriteChangesProvider._full_scan = orig_full
-            OverwriteChangesProvider._read_delta_entries = orig_probe
+            OverwriteChangesProvider._full_scan_manifest_entries = orig_full
+            OverwriteChangesProvider._read_delta_manifest_entries = orig_probe
 
         # Harness sanity: we really did force K conflicts and then converged.
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
@@ -160,8 +160,8 @@ class OverwriteChangesCacheTest(unittest.TestCase):
         fsc = c.file_store_commit
 
         counts = {'full_scan': 0, 'probe': 0}
-        orig_full = OverwriteChangesProvider._full_scan
-        orig_probe = OverwriteChangesProvider._read_delta_entries
+        orig_full = OverwriteChangesProvider._full_scan_manifest_entries
+        orig_probe = OverwriteChangesProvider._read_delta_manifest_entries
 
         def spy_full(self, *a, **k):
             counts['full_scan'] += 1
@@ -182,14 +182,14 @@ class OverwriteChangesCacheTest(unittest.TestCase):
             return orig_cas(snapshot, statistics)
 
         fsc.snapshot_commit.commit = patched_cas
-        OverwriteChangesProvider._full_scan = spy_full
-        OverwriteChangesProvider._read_delta_entries = spy_probe
+        OverwriteChangesProvider._full_scan_manifest_entries = spy_full
+        OverwriteChangesProvider._read_delta_manifest_entries = spy_probe
         try:
             c.commit(messages)
             c.close()
         finally:
-            OverwriteChangesProvider._full_scan = orig_full
-            OverwriteChangesProvider._read_delta_entries = orig_probe
+            OverwriteChangesProvider._full_scan_manifest_entries = orig_full
+            OverwriteChangesProvider._read_delta_manifest_entries = orig_probe
 
         self.assertEqual(cas['fails'], K, "expected exactly K forced conflicts")
 

--- a/paimon-python/pypaimon/tests/partition_predicate_test.py
+++ b/paimon-python/pypaimon/tests/partition_predicate_test.py
@@ -19,6 +19,9 @@ import unittest
 from unittest.mock import Mock, patch
 
 from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.manifest.schema.manifest_file_meta import ManifestFileMeta
 from pypaimon.manifest.schema.simple_stats import SimpleStats
@@ -93,6 +96,15 @@ def _manifest_entry(partition_values):
         bucket=0,
         total_buckets=1,
         file=Mock(),
+    )
+
+
+def _index_manifest_entry(partition_values, index_type):
+    return IndexManifestEntry(
+        kind=0,
+        partition=GenericRow(partition_values, PARTITION_FIELDS),
+        bucket=0,
+        index_file=IndexFileMeta(index_type, 'index-file', 1, 0),
     )
 
 
@@ -305,6 +317,19 @@ class TestCommitScannerPartitionPredicate(unittest.TestCase):
         self.assertTrue(pred.test(GenericRow(['2024-01-15', 'us-east-1'], PARTITION_FIELDS)))
         self.assertTrue(pred.test(GenericRow(['2024-01-16', 'us-west-2'], PARTITION_FIELDS)))
         self.assertFalse(pred.test(GenericRow(['2024-01-17', 'eu-west-1'], PARTITION_FIELDS)))
+
+    def test_filter_includes_deletion_vector_index_partitions(self):
+        scanner = self._scanner()
+        pred = scanner._build_partition_filter_from_changes(
+            [],
+            [_index_manifest_entry(
+                ['2024-01-15', 'us-east-1'],
+                IndexManifestFile.DELETION_VECTORS_INDEX,
+            )],
+        )
+
+        self.assertTrue(pred.test(GenericRow(['2024-01-15', 'us-east-1'], PARTITION_FIELDS)))
+        self.assertFalse(pred.test(GenericRow(['2024-01-16', 'us-west-2'], PARTITION_FIELDS)))
 
     def test_filter_handles_null_partition_values(self):
         scanner = self._scanner()

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -1861,9 +1861,9 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             on=['id'],
             when_matched=[
                 WhenMatched.update({'name': 's.name'},
-                            condition='s.age > 50'),
+                                   condition='s.age > 50'),
                 WhenMatched.update({'age': 's.age'},
-                            condition='s.age > 10'),
+                                   condition='s.age > 10'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )

--- a/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_evolution_merge_into_test.py
@@ -133,7 +133,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         ) as mock_read_paimon:
             m._prepare(
                 target, source, self.catalog_options,
-                [WhenMatched(update='*')], [], ['id'],
+                [WhenMatched.update('*')], [], ['id'],
             )
 
         mock_read_paimon.assert_called_once_with(
@@ -162,8 +162,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 catalog_options=self.catalog_options,
                 on=['id'],
                 when_matched=[
-                    WhenMatched(update='*'),
-                    WhenMatched(update={'age': 's.age'}, condition='s.age > 10'),
+                    WhenMatched.update('*'),
+                    WhenMatched.update({'age': 's.age'}, condition='s.age > 10'),
                 ],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
@@ -195,7 +195,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched.update('*')],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('data-evolution.enabled', str(ctx.exception))
@@ -208,7 +208,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched.update('*')],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('row-tracking.enabled', str(ctx.exception))
@@ -225,7 +225,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=bad_source,
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched.update('*')],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn("'id'", str(ctx.exception))
@@ -257,7 +257,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 catalog_options=self.catalog_options,
                 on=['id'],
                 when_matched=[
-                    WhenMatched(update='*', condition='s.nonexistent > 0')
+                    WhenMatched.update('*', condition='s.nonexistent > 0')
                 ],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
@@ -274,7 +274,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 catalog_options=self.catalog_options,
                 on=['id'],
                 when_matched=[
-                    WhenMatched(update='*', condition='s.age > t.nonexistent')
+                    WhenMatched.update('*', condition='s.age > t.nonexistent')
                 ],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
@@ -308,7 +308,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -316,6 +316,46 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
         self.assertEqual(out['id'], [1, 2, 3])
         self.assertEqual(out['name'], ['a', 'b2', 'c2'])
         self.assertEqual(out['age'], [10, 22, 33])
+
+    def test_matched_delete(self):
+        options = dict(self.de_options)
+        options['deletion-vectors.enabled'] = 'true'
+        target = self._create_table(options=options)
+        self._write(
+            target,
+            pa.Table.from_pydict(
+                {
+                    'id': pa.array([1, 2, 3], type=pa.int32()),
+                    'name': ['a', 'b', 'c'],
+                    'age': pa.array([10, 20, 30], type=pa.int32()),
+                },
+                schema=self.pa_schema,
+            ),
+        )
+
+        metrics = merge_into(
+            target=target,
+            source=pa.Table.from_pydict(
+                {
+                    'id': pa.array([2, 3], type=pa.int32()),
+                    'name': ['ignored', 'ignored'],
+                    'age': pa.array([99, 99], type=pa.int32()),
+                },
+                schema=self.pa_schema,
+            ),
+            catalog_options=self.catalog_options,
+            on=['id'],
+            when_matched=[WhenMatched.delete()],
+            num_partitions=_TEST_NUM_PARTITIONS,
+        )
+
+        self.assertEqual(metrics, {
+            'num_matched': 2, 'num_inserted': 0, 'num_unchanged': 0,
+        })
+        out = self._read_sorted(target)
+        self.assertEqual(out['id'], [1])
+        self.assertEqual(out['name'], ['a'])
+        self.assertEqual(out['age'], [10])
 
     def test_not_matched_insert_appends_unmatched(self):
         target = self._create_table()
@@ -382,7 +422,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             when_not_matched=[WhenNotMatched(insert='*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -428,7 +468,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on={'id': 'uid'},
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             when_not_matched=[WhenNotMatched(insert='*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -495,7 +535,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=source,
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched.update('*')],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn("multiple source rows", str(ctx.exception))
@@ -537,7 +577,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             ),
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             when_not_matched=[WhenNotMatched(insert='*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -653,7 +693,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update={'feature': source_col('new_feature')})
+                WhenMatched.update({'feature': source_col('new_feature')})
             ],
             num_partitions=num_partitions,
         )
@@ -733,7 +773,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update={'feature': source_col('new_feature')})
+                WhenMatched.update({'feature': source_col('new_feature')})
             ],
             num_partitions=num_partitions,
         )
@@ -776,7 +816,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             when_not_matched=[WhenNotMatched(insert='*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -802,7 +842,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -849,7 +889,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={'name': source_col('name')})],
+            when_matched=[WhenMatched.update({'name': source_col('name')})],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -866,7 +906,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=source,
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={'pt': source_col('pt')})],
+                when_matched=[WhenMatched.update({'pt': source_col('pt')})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('partition', str(ctx.exception))
@@ -937,7 +977,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*', condition='s.age > t.age + 10')],
+            when_matched=[WhenMatched.update('*', condition='s.age > t.age + 10')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -975,7 +1015,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*', condition='s.id >= 2')],
+            when_matched=[WhenMatched.update('*', condition='s.id >= 2')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -1053,7 +1093,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*', condition='s.age > t.age')],
+            when_matched=[WhenMatched.update('*', condition='s.age > t.age')],
             when_not_matched=[
                 WhenNotMatched(insert='*', condition='s.age > 10')
             ],
@@ -1096,7 +1136,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update='*', condition='s.age > t.age')],
+            when_matched=[WhenMatched.update('*', condition='s.age > t.age')],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -1135,7 +1175,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update='*', condition='s.age > t.age')
+                WhenMatched.update('*', condition='s.age > t.age')
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -1173,7 +1213,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={'age': 's.age'})],
+            when_matched=[WhenMatched.update({'age': 's.age'})],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -1238,7 +1278,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={'name': 'updated'})],
+            when_matched=[WhenMatched.update({'name': 'updated'})],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -1254,7 +1294,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={'nonexistent': 's.id'})],
+                when_matched=[WhenMatched.update({'nonexistent': 's.id'})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('nonexistent', str(ctx.exception))
@@ -1267,7 +1307,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={'name': 't.nme'})],
+                when_matched=[WhenMatched.update({'name': 't.nme'})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('nme', str(ctx.exception))
@@ -1280,7 +1320,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={})],
+                when_matched=[WhenMatched.update({})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
 
@@ -1327,7 +1367,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={'age': 's.age', 'name': 't.name'})],
+            when_matched=[WhenMatched.update({'age': 's.age', 'name': 't.name'})],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
 
@@ -1343,7 +1383,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=self._source(),
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={'name': lambda r: r})],
+                when_matched=[WhenMatched.update({'name': lambda r: r})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
 
@@ -1359,7 +1399,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=source,
                 catalog_options=self.catalog_options,
                 on=['id'],
-                when_matched=[WhenMatched(update={'name': 's.name'})],
+                when_matched=[WhenMatched.update({'name': 's.name'})],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
         self.assertIn('name', str(ctx.exception))
@@ -1458,7 +1498,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on={'id': 'uid'},
-            when_matched=[WhenMatched(update={
+            when_matched=[WhenMatched.update({
                 'age': source_col('id'),
             })],
             num_partitions=_TEST_NUM_PARTITIONS,
@@ -1489,7 +1529,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=source,
                 catalog_options=self.catalog_options,
                 on={'id': 'uid'},
-                when_matched=[WhenMatched(update={
+                when_matched=[WhenMatched.update({
                     'id': source_col('id'),
                 })],
                 num_partitions=_TEST_NUM_PARTITIONS,
@@ -1524,7 +1564,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={
+            when_matched=[WhenMatched.update({
                 'name': lit('s.active'),
             })],
             num_partitions=_TEST_NUM_PARTITIONS,
@@ -1562,7 +1602,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={
+            when_matched=[WhenMatched.update({
                 'age': source_col('age'),
             })],
             num_partitions=_TEST_NUM_PARTITIONS,
@@ -1600,7 +1640,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=source,
             catalog_options=self.catalog_options,
             on=['id'],
-            when_matched=[WhenMatched(update={
+            when_matched=[WhenMatched.update({
                 'age': source_col('age'),
                 'name': target_col('name'),
             })],
@@ -1641,8 +1681,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update='*', condition='s.age > 80'),
-                WhenMatched(update='*'),
+                WhenMatched.update('*', condition='s.age > 80'),
+                WhenMatched.update('*'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -1710,8 +1750,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update='*', condition='s.age > 40'),
-                WhenMatched(update='*'),
+                WhenMatched.update('*', condition='s.age > 40'),
+                WhenMatched.update('*'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -1780,8 +1820,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update='*', condition='s.age > 50'),
-                WhenMatched(update='*', condition='s.age > 30'),
+                WhenMatched.update('*', condition='s.age > 50'),
+                WhenMatched.update('*', condition='s.age > 30'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -1820,9 +1860,9 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update={'name': 's.name'},
+                WhenMatched.update({'name': 's.name'},
                             condition='s.age > 50'),
-                WhenMatched(update={'age': 's.age'},
+                WhenMatched.update({'age': 's.age'},
                             condition='s.age > 10'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
@@ -1862,8 +1902,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['id'],
             when_matched=[
-                WhenMatched(update='*', condition='s.age > 50'),
-                WhenMatched(update='*', condition='s.age > 80'),
+                WhenMatched.update('*', condition='s.age > 50'),
+                WhenMatched.update('*', condition='s.age > 80'),
             ],
             num_partitions=_TEST_NUM_PARTITIONS,
         )
@@ -1903,8 +1943,48 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 catalog_options=self.catalog_options,
                 on=['id'],
                 when_matched=[
-                    WhenMatched(update='*', condition='s.age > 80'),
-                    WhenMatched(update='*', condition='s.age > 30'),
+                    WhenMatched.update('*', condition='s.age > 80'),
+                    WhenMatched.update('*', condition='s.age > 30'),
+                ],
+                num_partitions=_TEST_NUM_PARTITIONS,
+            )
+        self.assertIn('multiple source rows', str(ctx.exception))
+
+    @unittest.skipIf(_SKIP_CONDITION, _SKIP_REASON)
+    def test_multi_clause_duplicate_update_delete_raises(self):
+        options = dict(self.de_options)
+        options['deletion-vectors.enabled'] = 'true'
+        target = self._create_table(options=options)
+        self._write(
+            target,
+            pa.Table.from_pydict(
+                {
+                    'id': pa.array([1], type=pa.int32()),
+                    'name': ['a'],
+                    'age': pa.array([10], type=pa.int32()),
+                },
+                schema=self.pa_schema,
+            ),
+        )
+
+        source = pa.Table.from_pydict(
+            {
+                'id': pa.array([1, 1], type=pa.int32()),
+                'name': ['x', 'y'],
+                'age': pa.array([99, 5], type=pa.int32()),
+            },
+            schema=self.pa_schema,
+        )
+
+        with self.assertRaises(Exception) as ctx:
+            merge_into(
+                target=target,
+                source=source,
+                catalog_options=self.catalog_options,
+                on=['id'],
+                when_matched=[
+                    WhenMatched.update('*', condition='s.age > 50'),
+                    WhenMatched.delete(condition='s.age < 10'),
                 ],
                 num_partitions=_TEST_NUM_PARTITIONS,
             )
@@ -1929,7 +2009,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(update={'age': lit(99)})],
+            when_matched=[WhenMatched.update({'age': lit(99)})],
         )
 
         self.assertEqual(result['num_matched'], 3)
@@ -1956,7 +2036,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(update='*')],
+            when_matched=[WhenMatched.update('*')],
         )
 
         self.assertEqual(result['num_matched'], 3)
@@ -1985,7 +2065,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(update={'age': lit(99)}, condition='t.age > 15')],
+            when_matched=[WhenMatched.update({'age': lit(99)}, condition='t.age > 15')],
         )
 
         self.assertEqual(result['num_matched'], 2)
@@ -2012,8 +2092,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(
-                update={'name': lit('updated')},
+            when_matched=[WhenMatched.update(
+                {'name': lit('updated')},
                 condition='s.age > 15',
             )],
         )
@@ -2033,7 +2113,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
                 source=target,
                 catalog_options=self.catalog_options,
                 on=['_ROW_ID'],
-                when_matched=[WhenMatched(update='*')],
+                when_matched=[WhenMatched.update('*')],
                 when_not_matched=[WhenNotMatched(insert='*')],
             )
         self.assertIn('Self-merge', str(ctx.exception))
@@ -2057,7 +2137,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(update={'name': lit('updated')})],
+            when_matched=[WhenMatched.update({'name': lit('updated')})],
         )
 
         self.assertEqual(result['num_matched'], 2)
@@ -2084,7 +2164,7 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             source=target,
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
-            when_matched=[WhenMatched(update={'name': source_col('_ROW_ID')})],
+            when_matched=[WhenMatched.update({'name': source_col('_ROW_ID')})],
         )
 
         self.assertEqual(result['num_matched'], 2)
@@ -2113,8 +2193,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
             when_matched=[
-                WhenMatched(
-                    update={'age': lit(99)},
+                WhenMatched.update(
+                    {'age': lit(99)},
                     condition='s._ROW_ID >= 0',
                 ),
             ],
@@ -2145,8 +2225,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
             when_matched=[
-                WhenMatched(
-                    update={'age': lit(99)},
+                WhenMatched.update(
+                    {'age': lit(99)},
                     condition='t._ROW_ID >= 0',
                 ),
             ],
@@ -2177,9 +2257,9 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
             when_matched=[
-                WhenMatched(update={'name': lit('old')}, condition='s.age <= 10'),
-                WhenMatched(update={'name': lit('young')}, condition='s.age <= 20'),
-                WhenMatched(update={'name': lit('senior')}),
+                WhenMatched.update({'name': lit('old')}, condition='s.age <= 10'),
+                WhenMatched.update({'name': lit('young')}, condition='s.age <= 20'),
+                WhenMatched.update({'name': lit('senior')}),
             ],
         )
 
@@ -2217,8 +2297,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
             when_matched=[
-                WhenMatched(
-                    update={'name': lit('updated')},
+                WhenMatched.update(
+                    {'name': lit('updated')},
                     condition='s.picture IS NULL',
                 ),
             ],
@@ -2257,8 +2337,8 @@ class RayDataEvolutionMergeIntoTest(unittest.TestCase):
             catalog_options=self.catalog_options,
             on=['_ROW_ID'],
             when_matched=[
-                WhenMatched(
-                    update={'name': lit('x')},
+                WhenMatched.update(
+                    {'name': lit('x')},
                     condition='t.picture IS NOT NULL',
                 ),
             ],

--- a/paimon-python/pypaimon/tests/table_merge_into_test.py
+++ b/paimon-python/pypaimon/tests/table_merge_into_test.py
@@ -17,6 +17,7 @@
 ################################################################################
 
 import unittest
+from unittest.mock import patch
 
 import pyarrow as pa
 
@@ -68,6 +69,51 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
         commit.close()
         return msgs
 
+    def test_when_matched_action_constructors(self):
+        update = WhenMatched.update(
+            {"age": source_col("age")},
+            condition="s.age > t.age",
+        )
+        delete = WhenMatched.delete(condition="s.deleted = TRUE")
+
+        self.assertEqual({"age": source_col("age")}, update.update)
+        self.assertEqual("s.age > t.age", update.condition)
+        self.assertFalse(update.delete)
+        self.assertIsNone(delete.update)
+        self.assertEqual("s.deleted = TRUE", delete.condition)
+        self.assertTrue(delete.delete)
+
+    def test_ray_merge_rejects_mixed_update_delete_duplicate_row_ids(self):
+        import pypaimon.ray.data_evolution_merge_into as ray_merge
+
+        with self.assertRaisesRegex(ValueError, "multiple source rows"):
+            ray_merge._validate_disjoint_action_row_ids([7], [7])
+
+    def test_ray_execute_validates_mixed_update_delete_duplicate_row_ids(self):
+        import pypaimon.ray.data_evolution_merge_into as ray_merge
+
+        with patch.object(
+                ray_merge,
+                "distributed_update_apply",
+                return_value=([], 1, [7])
+        ), patch.object(
+                ray_merge,
+                "distributed_delete_apply",
+                return_value=([], 1, [7])
+        ):
+            with self.assertRaisesRegex(ValueError, "multiple source rows"):
+                ray_merge._execute_and_commit(
+                    table=object(),
+                    update_ds=object(),
+                    delete_ds=object(),
+                    insert_ds=None,
+                    update_cols_union=["age"],
+                    base_snapshot=None,
+                    num_partitions=1,
+                    ray_remote_args=None,
+                    concurrency=None,
+                )
+
     def test_table_merge_into_updates_and_inserts(self):
         target = self._create_table()
         self._write_arrow(target, pa.Table.from_pydict({
@@ -88,7 +134,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target,
             source,
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             when_not_matched=[WhenNotMatched(insert="*")],
         )
 
@@ -150,7 +196,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             source,
             on={"id": "source_id"},
             when_matched=[
-                WhenMatched(update={
+                WhenMatched.update({
                     "name": source_col("new_name"),
                     "age": source_col("new_age"),
                     "city": source_col("new_city"),
@@ -197,7 +243,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
                     target,
                     source,
                     on=["id"],
-                    when_matched=[WhenMatched(update={"name": assignment})],
+                    when_matched=[WhenMatched.update({"name": assignment})],
                 )
 
                 self.assertEqual([], msgs)
@@ -231,7 +277,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target,
             source,
             on=["id"],
-            when_matched=[WhenMatched(update={"name": source_col("name")})],
+            when_matched=[WhenMatched.update({"name": source_col("name")})],
         )
 
         self.assertTrue(msgs)
@@ -257,7 +303,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target.new_batch_write_builder().new_update().merge_into(
                 source,
                 on=["id"],
-                when_matched=[WhenMatched(update={"name.first": lit("A")})],
+                when_matched=[WhenMatched.update({"name.first": lit("A")})],
             )
 
     def test_table_merge_into_rejects_partition_column_update(self):
@@ -279,7 +325,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target.new_batch_write_builder().new_update().merge_into(
                 source,
                 on=["id"],
-                when_matched=[WhenMatched(update={"city": source_col("city")})],
+                when_matched=[WhenMatched.update({"city": source_col("city")})],
             )
 
     def test_table_merge_into_preserves_row_ids_for_matched_rows(self):
@@ -301,7 +347,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
                 "city": ["LA2", "SF"],
             }, schema=self.pa_schema),
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             when_not_matched=[WhenNotMatched(insert="*")],
         )
 
@@ -309,6 +355,40 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
         self.assertEqual(row_ids_before[1], row_ids_after[1])
         self.assertEqual(row_ids_before[2], row_ids_after[2])
         self.assertGreater(row_ids_after[3], max(row_ids_before.values()))
+
+    def test_table_merge_into_delete_matched_rows(self):
+        options = dict(self.table_options)
+        options["deletion-vectors.enabled"] = "true"
+        target = self._create_table(options=options)
+        self._write_arrow(target, pa.Table.from_pydict({
+            "id": pa.array([1, 2, 3], type=pa.int32()),
+            "name": ["Alice", "Bob", "Charlie"],
+            "age": pa.array([25, 30, 35], type=pa.int32()),
+            "city": ["NYC", "LA", "Chicago"],
+        }, schema=self.pa_schema))
+
+        msgs = self._merge_and_commit(
+            target,
+            pa.Table.from_pydict({
+                "id": pa.array([2, 3], type=pa.int32()),
+                "name": ["ignored", "ignored"],
+                "age": pa.array([99, 99], type=pa.int32()),
+                "city": ["ignored", "ignored"],
+            }, schema=self.pa_schema),
+            on=["id"],
+            when_matched=[WhenMatched.delete()],
+        )
+
+        self.assertEqual(1, sum(len(m.index_adds) for m in msgs))
+        self.assertEqual(
+            {
+                "id": [1],
+                "name": ["Alice"],
+                "age": [25],
+                "city": ["NYC"],
+            },
+            self._read_sorted(target),
+        )
 
     def test_table_merge_into_second_round_updates_first_round_insert(self):
         target = self._create_table()
@@ -341,7 +421,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
                 "city": ["LA2"],
             }, schema=self.pa_schema),
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
         )
 
         self.assertEqual(
@@ -375,7 +455,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target,
             source,
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             when_not_matched=[WhenNotMatched(insert="*")],
         )
 
@@ -415,7 +495,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
                 ),
             }, schema=blob_schema),
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             when_not_matched=[WhenNotMatched(insert="*")],
         )
 
@@ -486,8 +566,8 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             source,
             on=["id"],
             when_matched=[
-                WhenMatched(update={"age": lit(99)}, condition="s.age > t.age"),
-                WhenMatched(update={"name": lit("kept")}),
+                WhenMatched.update({"age": lit(99)}, condition="s.age > t.age"),
+                WhenMatched.update({"name": lit("kept")}),
             ],
             when_not_matched=[
                 WhenNotMatched(insert="*", condition="s.age > 45"),
@@ -525,7 +605,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target.new_batch_write_builder().new_update().merge_into(
                 source,
                 on=["id"],
-                when_matched=[WhenMatched(update={"age": "s.age"})],
+                when_matched=[WhenMatched.update({"age": "s.age"})],
             )
 
     def test_table_merge_into_self_merge_by_row_id(self):
@@ -541,7 +621,7 @@ class TableMergeIntoTest(BatchModeMixin, DataEvolutionTestBase, unittest.TestCas
             target,
             target,
             on=["_ROW_ID"],
-            when_matched=[WhenMatched(update={"name": lit("updated")})],
+            when_matched=[WhenMatched.update({"name": lit("updated")})],
         )
 
         self.assertTrue(msgs)
@@ -575,7 +655,7 @@ class StreamTableMergeIntoTest(StreamModeMixin, DataEvolutionTestBase, unittest.
         msgs = wb.new_update().merge_into(
             source,
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             when_not_matched=[WhenNotMatched(insert="*")],
             commit_identifier=cid,
         )
@@ -632,7 +712,7 @@ class StreamTableMergeIntoTest(StreamModeMixin, DataEvolutionTestBase, unittest.
                 "city": ["LA2"],
             }, schema=self.pa_schema),
             on=["id"],
-            when_matched=[WhenMatched(update="*")],
+            when_matched=[WhenMatched.update("*")],
             commit_identifier=cid2,
         )
         commit.commit(msgs2, cid2)

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -560,6 +560,32 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
 
         self.assertIn('deletion-vectors.enabled', str(ctx.exception))
 
+    def test_concurrent_row_level_deletes_conflict_on_same_dv_file(self):
+        table = self._create_seeded_deletion_vector_table()
+        pb = table.new_read_builder().new_predicate_builder()
+
+        first_wb = self._make_write_builder(table)
+        first_update = first_wb.new_update()
+        first_cid = self._next_commit_id()
+        first_msgs = self._apply_delete_by_predicate(
+            first_update,
+            pb.equal('id', 1),
+            first_cid,
+        )
+
+        self._do_delete_by_predicate(table, pb.equal('id', 2))
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 3, 4, 5], result['id'].to_pylist())
+
+        first_commit = first_wb.new_commit()
+        with self.assertRaises(RuntimeError) as ctx:
+            self._apply_commit(first_commit, first_msgs, first_cid)
+        first_commit.close()
+        self.assertIn('Deletion vector index conflict', str(ctx.exception))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 3, 4, 5], result['id'].to_pylist())
+
     def test_delete_by_partition_predicate_drops_partition_without_dv(self):
         table = self._create_seeded_table(partition_keys=['city'])
         pb = table.new_read_builder().new_predicate_builder()

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -54,11 +54,17 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             self, table_update, predicate, assignments, cid):
         raise NotImplementedError
 
+    def _apply_delete_by_predicate(self, table_update, predicate, cid):
+        raise NotImplementedError
+
+    def _apply_delete_by_row_id(self, table_update, row_ids, cid):
+        raise NotImplementedError
+
     # ------------------------------------------------------------------
     # Helpers built on the primitives
     # ------------------------------------------------------------------
 
-    def _create_seeded_table(self, partition_keys=None):
+    def _create_seeded_table(self, partition_keys=None, options=None):
         """Create the canonical 5-row / 2-file table used by most tests.
 
         Layout (row_id → row):
@@ -68,7 +74,10 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
             3: (4, David,   40, Houston)
             4: (5, Eve,     45, Phoenix)
         """
-        table = self._create_table(partition_keys=partition_keys)
+        table = self._create_table(
+            partition_keys=partition_keys,
+            options=options,
+        )
         self._write_arrow(table, pa.Table.from_pydict({
             'id': [1, 2],
             'name': ['Alice', 'Bob'],
@@ -139,6 +148,35 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         self._apply_commit(tc, msgs, cid)
         tc.close()
         return msgs
+
+    def _do_delete_by_predicate(self, table, predicate):
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete_by_predicate(tu, predicate, cid)
+        tc = wb.new_commit()
+        self._apply_commit(tc, msgs, cid)
+        tc.close()
+        return msgs
+
+    def _do_delete_by_row_id(self, table, row_ids):
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete_by_row_id(tu, row_ids, cid)
+        tc = wb.new_commit()
+        self._apply_commit(tc, msgs, cid)
+        tc.close()
+        return msgs
+
+    def _create_seeded_deletion_vector_table(self, partition_keys=None):
+        options = dict(self.table_options)
+        options['deletion-vectors.enabled'] = 'true'
+        table = self._create_seeded_table(
+            partition_keys=partition_keys,
+            options=options,
+        )
+        return table
 
     # ==================================================================
     # Shared tests (run under both batch and stream modes)
@@ -480,6 +518,112 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
                 {'city': 'LA'},
             )
         self.assertIn('partition column', str(ctx.exception))
+
+    def test_delete_by_predicate(self):
+        table = self._create_seeded_deletion_vector_table()
+        pb = table.new_read_builder().new_predicate_builder()
+
+        msgs = self._do_delete_by_predicate(
+            table,
+            pb.greater_or_equal('age', 35),
+        )
+
+        self.assertEqual(1, sum(len(m.index_adds) for m in msgs))
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 2], result['id'].to_pylist())
+        self.assertEqual(['Alice', 'Bob'], result['name'].to_pylist())
+
+    def test_delete_by_predicate_requires_deletion_vectors(self):
+        table = self._create_seeded_table()
+        pb = table.new_read_builder().new_predicate_builder()
+
+        with self.assertRaises(ValueError) as ctx:
+            self._do_delete_by_predicate(table, pb.equal('id', 1))
+
+        self.assertIn('deletion-vectors.enabled', str(ctx.exception))
+
+    def test_delete_by_row_id(self):
+        table = self._create_seeded_deletion_vector_table()
+
+        msgs = self._do_delete_by_row_id(table, [0, 2, 4])
+
+        self.assertEqual(1, sum(len(m.index_adds) for m in msgs))
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([2, 4], result['id'].to_pylist())
+        self.assertEqual(['Bob', 'David'], result['name'].to_pylist())
+
+    def test_delete_by_row_id_requires_deletion_vectors(self):
+        table = self._create_seeded_table()
+
+        with self.assertRaises(ValueError) as ctx:
+            self._do_delete_by_row_id(table, [0])
+
+        self.assertIn('deletion-vectors.enabled', str(ctx.exception))
+
+    def test_delete_by_partition_predicate_drops_partition_without_dv(self):
+        table = self._create_seeded_table(partition_keys=['city'])
+        pb = table.new_read_builder().new_predicate_builder()
+
+        msgs = self._do_delete_by_predicate(table, pb.equal('city', 'LA'))
+
+        self.assertGreater(sum(len(m.deleted_files) for m in msgs), 0)
+        self.assertEqual(0, sum(len(m.index_adds) for m in msgs))
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 3, 4, 5], result['id'].to_pylist())
+        self.assertEqual(
+            ['NYC', 'Chicago', 'Houston', 'Phoenix'],
+            result['city'].to_pylist(),
+        )
+
+    def test_delete_by_partition_predicate_deletes_matching_indexes(self):
+        table = self._create_seeded_deletion_vector_table(partition_keys=['city'])
+        pb = table.new_read_builder().new_predicate_builder()
+
+        self._do_delete_by_predicate(table, pb.equal('id', 2))
+        msgs = self._do_delete_by_predicate(table, pb.equal('city', 'LA'))
+
+        self.assertGreater(sum(len(m.deleted_files) for m in msgs), 0)
+        self.assertGreater(sum(len(m.index_deletes) for m in msgs), 0)
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 3, 4, 5], result['id'].to_pylist())
+        self.assertEqual(
+            ['NYC', 'Chicago', 'Houston', 'Phoenix'],
+            result['city'].to_pylist(),
+        )
+
+    def test_delete_by_partition_predicate_conflicts_when_partition_changes(self):
+        table = self._create_seeded_table(partition_keys=['city'])
+        wb = self._make_write_builder(table)
+        tu = wb.new_update()
+        pb = tu.new_predicate_builder()
+        cid = self._next_commit_id()
+        msgs = self._apply_delete_by_predicate(tu, pb.equal('city', 'LA'), cid)
+
+        self._write_arrow(table, pa.Table.from_pydict({
+            'id': [6],
+            'name': ['Frank'],
+            'age': [28],
+            'city': ['LA'],
+        }, schema=self.pa_schema))
+
+        tc = wb.new_commit()
+        with self.assertRaises(RuntimeError) as ctx:
+            self._apply_commit(tc, msgs, cid)
+        tc.close()
+        self.assertIn('Overwrite conflict', str(ctx.exception))
+
+    def test_delete_by_mixed_partition_predicate_still_requires_dv(self):
+        table = self._create_seeded_table(partition_keys=['city'])
+        pb = table.new_read_builder().new_predicate_builder()
+        predicate = pb.and_predicates([
+            pb.equal('city', 'LA'),
+            pb.equal('age', 30),
+        ])
+
+        with self.assertRaises(ValueError) as ctx:
+            self._do_delete_by_predicate(table, predicate)
+
+        self.assertIn('deletion-vectors.enabled', str(ctx.exception))
 
     def test_update_multiple_columns(self):
         """Update ``age`` + ``city`` together; other columns are untouched."""
@@ -1037,6 +1181,12 @@ class _BatchModeMixin(BatchModeMixin):
             self, table_update, predicate, assignments, cid):
         return table_update.update_by_predicate(predicate, assignments)
 
+    def _apply_delete_by_predicate(self, table_update, predicate, cid):
+        return table_update.delete_by_predicate(predicate)
+
+    def _apply_delete_by_row_id(self, table_update, row_ids, cid):
+        return table_update.delete_by_row_id(row_ids)
+
 
 class _StreamModeMixin(StreamModeMixin):
     def _apply_update(self, table_update, data, cid):
@@ -1049,6 +1199,12 @@ class _StreamModeMixin(StreamModeMixin):
             assignments,
             cid,
         )
+
+    def _apply_delete_by_predicate(self, table_update, predicate, cid):
+        return table_update.delete_by_predicate(predicate, cid)
+
+    def _apply_delete_by_row_id(self, table_update, row_ids, cid):
+        return table_update.delete_by_row_id(row_ids, cid)
 
 
 # ======================================================================

--- a/paimon-python/pypaimon/tests/table_update_test.py
+++ b/paimon-python/pypaimon/tests/table_update_test.py
@@ -586,6 +586,41 @@ class _TableUpdateTestBase(DataEvolutionTestBase):
         result = self._read_all(table).sort_by('id')
         self.assertEqual([1, 3, 4, 5], result['id'].to_pylist())
 
+    def test_row_level_delete_conflicts_when_target_file_removed(self):
+        table = self._create_seeded_deletion_vector_table(partition_keys=['city'])
+        pb = table.new_read_builder().new_predicate_builder()
+
+        first_wb = self._make_write_builder(table)
+        first_update = first_wb.new_update()
+        first_cid = self._next_commit_id()
+        first_msgs = self._apply_delete_by_predicate(
+            first_update,
+            pb.equal('id', 2),
+            first_cid,
+        )
+
+        overwrite_wb = table.new_batch_write_builder().overwrite({'city': 'LA'})
+        overwrite_write = overwrite_wb.new_write()
+        overwrite_commit = overwrite_wb.new_commit()
+        overwrite_write.write_arrow(pa.Table.from_pydict({
+            'id': [6],
+            'name': ['Frank'],
+            'age': [28],
+            'city': ['LA'],
+        }, schema=self.pa_schema))
+        overwrite_commit.commit(overwrite_write.prepare_commit())
+        overwrite_write.close()
+        overwrite_commit.close()
+
+        first_commit = first_wb.new_commit()
+        with self.assertRaises(RuntimeError) as ctx:
+            self._apply_commit(first_commit, first_msgs, first_cid)
+        first_commit.close()
+        self.assertIn('Deletion vector index conflict', str(ctx.exception))
+
+        result = self._read_all(table).sort_by('id')
+        self.assertEqual([1, 3, 4, 5, 6], result['id'].to_pylist())
+
     def test_delete_by_partition_predicate_drops_partition_without_dv(self):
         table = self._create_seeded_table(partition_keys=['city'])
         pb = table.new_read_builder().new_predicate_builder()

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -19,6 +19,9 @@ import unittest
 from dataclasses import dataclass
 from typing import List
 
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
 from pypaimon.schema.data_types import AtomicType, DataField
@@ -203,6 +206,52 @@ class TestCheckRowIdExistence(unittest.TestCase):
         delta = [_make_entry("p1", kind=0, first_row_id=0, row_count=100)]
         self.assertIsNone(
             detection.check_row_id_existence(base, delta, next_row_id=None))
+
+
+class TestOverwriteConflictDetection(unittest.TestCase):
+
+    def _make_detection(self):
+        return ConflictDetection(
+            data_evolution_enabled=True,
+            snapshot_manager=None,
+            manifest_list_manager=None,
+            table=None,
+            commit_scanner=None,
+        )
+
+    def test_deleted_files_trigger_overwrite_commit(self):
+        detection = self._make_detection()
+        entries = [
+            _make_entry("f1", kind=0),
+            _make_entry("f2", kind=1),
+        ]
+        self.assertTrue(detection.should_be_overwrite_commit(entries, []))
+
+    def test_deletion_vector_index_files_trigger_overwrite_commit(self):
+        detection = self._make_detection()
+        index_entry = IndexManifestEntry(
+            kind=0,
+            partition=_EMPTY_PARTITION,
+            bucket=0,
+            index_file=IndexFileMeta(
+                index_type=IndexManifestFile.DELETION_VECTORS_INDEX,
+                file_name="dv",
+                file_size=1,
+                row_count=1,
+            ),
+        )
+        self.assertTrue(detection.should_be_overwrite_commit([], [index_entry]))
+
+    def test_delete_entry_missing_from_base_conflicts(self):
+        detection = self._make_detection()
+        result = detection.check_conflicts(
+            latest_snapshot=None,
+            base_entries=[],
+            delta_entries=[_make_entry("missing", kind=1)],
+            commit_kind="OVERWRITE",
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("File deletion conflicts", str(result))
 
 
 class _FakeSnapshot:

--- a/paimon-python/pypaimon/write/commit/commit_scanner.py
+++ b/paimon-python/pypaimon/write/commit/commit_scanner.py
@@ -21,6 +21,7 @@ Manifest entries scanner for commit operations.
 from typing import Optional, List
 
 from pypaimon.common.predicate_builder import PredicateBuilder
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.manifest_file_manager import ManifestFileManager
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
@@ -44,8 +45,10 @@ class CommitScanner:
         self.table = table
         self.manifest_list_manager = manifest_list_manager
 
-    def read_all_entries_from_changed_partitions(self, latest_snapshot: Optional[Snapshot],
-                                                 commit_entries: List[ManifestEntry]):
+    def read_all_entries_from_changed_partitions(self,
+                                                 latest_snapshot: Optional[Snapshot],
+                                                 commit_entries: List[ManifestEntry],
+                                                 index_entries=None):
         """Read all entries from the latest snapshot for partitions that are changed.
 
         Builds a partition predicate from delta entries and passes it to FileScanner,
@@ -63,15 +66,18 @@ class CommitScanner:
         if latest_snapshot is None:
             return []
 
-        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        partition_filter = self._build_partition_filter_from_changes(
+            commit_entries, index_entries)
 
         all_manifests = self.manifest_list_manager.read_all(latest_snapshot)
         return FileScanner(
             self.table, lambda: ([], None), partition_predicate=partition_filter
         ).read_manifest_entries(all_manifests)
 
-    def read_incremental_entries_from_changed_partitions(self, snapshot: Snapshot,
-                                                         commit_entries: List[ManifestEntry]):
+    def read_incremental_entries_from_changed_partitions(self,
+                                                         snapshot: Snapshot,
+                                                         commit_entries: List[ManifestEntry],
+                                                         index_entries=None):
         """Read incremental manifest entries from a snapshot's delta manifest list.
 
         Builds a partition predicate from delta entries and passes it to FileScanner,
@@ -90,7 +96,8 @@ class CommitScanner:
         if not delta_manifests:
             return []
 
-        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        partition_filter = self._build_partition_filter_from_changes(
+            commit_entries, index_entries)
 
         return FileScanner(
             self.table, lambda: ([], None), partition_predicate=partition_filter
@@ -98,7 +105,8 @@ class CommitScanner:
 
     def read_incremental_raw_entries_from_changed_partitions(self, snapshot: Snapshot,
                                                              commit_entries: List[ManifestEntry],
-                                                             partition_filter=None):
+                                                             partition_filter=None,
+                                                             index_entries=None):
         """Like ``read_incremental_entries_from_changed_partitions`` but preserves
         DELETE entries (kind=1). ``partition_filter`` may be passed to avoid
         rebuilding it per call.
@@ -108,7 +116,8 @@ class CommitScanner:
             return []
 
         if partition_filter is None:
-            partition_filter = self._build_partition_filter_from_entries(commit_entries)
+            partition_filter = self._build_partition_filter_from_changes(
+                commit_entries, index_entries)
         mfm = ManifestFileManager(self.table)
         entries = []
         for mf in delta_manifests:
@@ -118,15 +127,19 @@ class CommitScanner:
                 entries.append(entry)
         return entries
 
-    def read_incremental_changes(self, from_snapshot: Snapshot, to_snapshot: Snapshot,
-                                 commit_entries: List[ManifestEntry]) -> Optional[List[ManifestEntry]]:
+    def read_incremental_changes(self,
+                                 from_snapshot: Snapshot,
+                                 to_snapshot: Snapshot,
+                                 commit_entries: List[ManifestEntry],
+                                 index_entries=None) -> Optional[List[ManifestEntry]]:
         """Delta entries (incl. DELETEs) in ``(from_snapshot, to_snapshot]``,
         changed-partition filtered, so a retry can reuse the prior base and read
         only the changes since. Returns None on a missing snapshot (caller then
         full-scans). Mirrors Java ``CommitScanner#readIncrementalChanges``.
         """
         snapshot_manager = self.table.snapshot_manager()
-        partition_filter = self._build_partition_filter_from_entries(commit_entries)
+        partition_filter = self._build_partition_filter_from_changes(
+            commit_entries, index_entries)
         entries = []
         for snapshot_id in range(from_snapshot.id + 1, to_snapshot.id + 1):
             snapshot = snapshot_manager.get_snapshot_by_id(snapshot_id)
@@ -138,10 +151,15 @@ class CommitScanner:
         return entries
 
     def _build_partition_filter_from_entries(self, entries: List[ManifestEntry]):
+        return self._build_partition_filter_from_changes(entries)
+
+    def _build_partition_filter_from_changes(self, entries, index_entries=None):
         """Build a partition predicate that matches all partitions present in the given entries.
 
         Args:
             entries: List of ManifestEntry whose partitions should be matched.
+            index_entries: Optional index manifest entries whose partitions
+                should be matched.
 
         Returns:
             A Predicate matching any of the changed partitions, or None if
@@ -152,8 +170,11 @@ class CommitScanner:
             return None
 
         changed_partitions = set()
-        for entry in entries:
+        for entry in entries or []:
             changed_partitions.add(tuple(entry.partition.values))
+        for entry in index_entries or []:
+            if self._index_entry_changes_partition(entry):
+                changed_partitions.add(tuple(entry.partition.values))
 
         if not changed_partitions:
             return None
@@ -170,3 +191,8 @@ class CommitScanner:
             partition_predicates.append(predicate_builder.and_predicates(sub_predicates))
 
         return predicate_builder.or_predicates(partition_predicates)
+
+    @staticmethod
+    def _index_entry_changes_partition(entry):
+        return (entry.index_file.index_type == IndexManifestFile.DELETION_VECTORS_INDEX
+                or entry.index_file.global_index_meta is not None)

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -22,6 +22,7 @@ Conflict detection for commit operations.
 import bisect
 
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.file_entry import FileEntry
 from pypaimon.table.special_fields import SpecialFields
@@ -160,20 +161,43 @@ class ConflictDetection:
         self._row_id_check_from_snapshot = None
         self.commit_scanner = commit_scanner
 
-    def should_be_overwrite_commit(self):
+    def should_be_overwrite_commit(self, append_file_entries=None, append_index_files=None):
+        for entry in append_file_entries or []:
+            if entry.kind == 1:
+                return True
+        for entry in append_index_files or []:
+            if entry.index_file.index_type == IndexManifestFile.DELETION_VECTORS_INDEX:
+                return True
         return False
 
     def has_row_id_check_from_snapshot(self):
         return self._row_id_check_from_snapshot is not None
 
     def check_conflicts(self, latest_snapshot, base_entries, delta_entries, commit_kind):
-        all_entries = list(base_entries) + list(delta_entries)
+        try:
+            FileEntry.merge_entries(delta_entries)
+        except Exception as e:
+            return RuntimeError(
+                "File deletion conflicts detected! Give up committing. " + str(e))
 
+        all_entries = list(base_entries) + list(delta_entries)
         try:
             merged_entries = FileEntry.merge_entries(all_entries)
         except Exception as e:
             return RuntimeError(
                 "File deletion conflicts detected! Give up committing. " + str(e))
+
+        for entry in merged_entries:
+            if entry.kind == 1:
+                return RuntimeError(
+                    "File deletion conflicts detected! Give up committing. "
+                    "Trying to delete file {} which is not previously added.".format(
+                        entry.file.file_name))
+
+        conflict = self.check_overwrite_from_snapshot(
+            latest_snapshot, delta_entries, commit_kind)
+        if conflict is not None:
+            return conflict
 
         if commit_kind != "COMPACT":
             next_row_id = latest_snapshot.next_row_id if latest_snapshot else None
@@ -187,6 +211,41 @@ class ConflictDetection:
             return conflict
 
         return self.check_row_id_from_snapshot(latest_snapshot, delta_entries)
+
+    def check_overwrite_from_snapshot(self, latest_snapshot, delta_entries, commit_kind):
+        if commit_kind != "OVERWRITE":
+            return None
+        if self._row_id_check_from_snapshot is None:
+            return None
+        if latest_snapshot is None or latest_snapshot.id <= self._row_id_check_from_snapshot:
+            return None
+        if not any(entry.kind == 1 for entry in delta_entries):
+            return None
+
+        check_snapshot = self.snapshot_manager.get_snapshot_by_id(
+            self._row_id_check_from_snapshot)
+        if check_snapshot is None:
+            return RuntimeError(
+                "Overwrite conflict detected: base snapshot {} cannot be found.".format(
+                    self._row_id_check_from_snapshot))
+
+        for snapshot_id in range(
+                self._row_id_check_from_snapshot + 1,
+                latest_snapshot.id + 1):
+            snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot is None:
+                return RuntimeError(
+                    "Overwrite conflict detected: snapshot {} cannot be found.".format(
+                        snapshot_id))
+            incremental_entries = (
+                self.commit_scanner.read_incremental_raw_entries_from_changed_partitions(
+                    snapshot, delta_entries))
+            if incremental_entries:
+                return RuntimeError(
+                    "Overwrite conflict detected: target partitions were modified "
+                    "after snapshot {}.".format(self._row_id_check_from_snapshot))
+
+        return None
 
     def check_row_id_existence(self, base_entries, delta_entries, next_row_id=None):
         if not self.data_evolution_enabled:

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -173,7 +173,13 @@ class ConflictDetection:
     def has_row_id_check_from_snapshot(self):
         return self._row_id_check_from_snapshot is not None
 
-    def check_conflicts(self, latest_snapshot, base_entries, delta_entries, commit_kind):
+    def check_conflicts(
+            self,
+            latest_snapshot,
+            base_entries,
+            delta_entries,
+            commit_kind,
+            delta_index_entries=None):
         try:
             FileEntry.merge_entries(delta_entries)
         except Exception as e:
@@ -199,6 +205,11 @@ class ConflictDetection:
         if conflict is not None:
             return conflict
 
+        conflict = self.check_deletion_vector_index_conflicts(
+            latest_snapshot, delta_index_entries)
+        if conflict is not None:
+            return conflict
+
         if commit_kind != "COMPACT":
             next_row_id = latest_snapshot.next_row_id if latest_snapshot else None
             conflict = self.check_row_id_existence(
@@ -211,6 +222,54 @@ class ConflictDetection:
             return conflict
 
         return self.check_row_id_from_snapshot(latest_snapshot, delta_entries)
+
+    def check_deletion_vector_index_conflicts(self, latest_snapshot, delta_index_entries=None):
+        dv_entries = [
+            entry for entry in (delta_index_entries or [])
+            if entry.index_file.index_type == IndexManifestFile.DELETION_VECTORS_INDEX
+        ]
+        if not dv_entries:
+            return None
+
+        delete_entries = [entry for entry in dv_entries if entry.kind == 1]
+        add_entries = [entry for entry in dv_entries if entry.kind == 0]
+        delete_names = {entry.index_file.file_name for entry in delete_entries}
+
+        current_entries = []
+        if latest_snapshot is not None and latest_snapshot.index_manifest is not None:
+            current_entries = [
+                entry for entry in IndexManifestFile(self.table).read(
+                    latest_snapshot.index_manifest)
+                if entry.kind == 0
+                and entry.index_file.index_type == IndexManifestFile.DELETION_VECTORS_INDEX
+            ]
+
+        current_names = {entry.index_file.file_name for entry in current_entries}
+        for delete in delete_entries:
+            if delete.index_file.file_name not in current_names:
+                return RuntimeError(
+                    "Deletion vector index conflict detected: index file {} "
+                    "is not present in the latest snapshot.".format(
+                        delete.index_file.file_name))
+
+        affected_files = []
+        for add in add_entries:
+            for data_file_name in (add.index_file.dv_ranges or {}):
+                affected_files.append((add.partition, add.bucket, data_file_name))
+
+        for partition, bucket, data_file_name in affected_files:
+            for current in current_entries:
+                if current.index_file.file_name in delete_names:
+                    continue
+                if current.partition != partition or current.bucket != bucket:
+                    continue
+                if data_file_name in (current.index_file.dv_ranges or {}):
+                    return RuntimeError(
+                        "Deletion vector index conflict detected: data file {} "
+                        "already has a newer deletion vector index file {}.".format(
+                            data_file_name, current.index_file.file_name))
+
+        return None
 
     def check_overwrite_from_snapshot(self, latest_snapshot, delta_entries, commit_kind):
         if commit_kind != "OVERWRITE":

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -206,7 +206,7 @@ class ConflictDetection:
             return conflict
 
         conflict = self.check_deletion_vector_index_conflicts(
-            latest_snapshot, delta_index_entries)
+            latest_snapshot, delta_index_entries, base_entries, delta_entries)
         if conflict is not None:
             return conflict
 
@@ -223,7 +223,11 @@ class ConflictDetection:
 
         return self.check_row_id_from_snapshot(latest_snapshot, delta_entries)
 
-    def check_deletion_vector_index_conflicts(self, latest_snapshot, delta_index_entries=None):
+    def check_deletion_vector_index_conflicts(self,
+                                              latest_snapshot,
+                                              delta_index_entries=None,
+                                              base_entries=None,
+                                              delta_entries=None):
         dv_entries = [
             entry for entry in (delta_index_entries or [])
             if entry.index_file.index_type == IndexManifestFile.DELETION_VECTORS_INDEX
@@ -252,24 +256,43 @@ class ConflictDetection:
                     "is not present in the latest snapshot.".format(
                         delete.index_file.file_name))
 
+        existing_data_files = {
+            (tuple(entry.partition.values), entry.bucket, entry.file.file_name)
+            for entry in list(base_entries or []) + list(delta_entries or [])
+            if entry.kind == 0
+        }
         affected_files = []
         for add in add_entries:
-            for data_file_name in (add.index_file.dv_ranges or {}):
+            for data_file_name in self._deletion_vector_data_file_names(add.index_file):
                 affected_files.append((add.partition, add.bucket, data_file_name))
 
         for partition, bucket, data_file_name in affected_files:
+            data_file_key = (tuple(partition.values), bucket, data_file_name)
+            if data_file_key not in existing_data_files:
+                return RuntimeError(
+                    "Deletion vector index conflict detected: data file {} "
+                    "is not present in the latest snapshot.".format(
+                        data_file_name))
+
             for current in current_entries:
                 if current.index_file.file_name in delete_names:
                     continue
                 if current.partition != partition or current.bucket != bucket:
                     continue
-                if data_file_name in (current.index_file.dv_ranges or {}):
+                if data_file_name in self._deletion_vector_data_file_names(current.index_file):
                     return RuntimeError(
                         "Deletion vector index conflict detected: data file {} "
                         "already has a newer deletion vector index file {}.".format(
                             data_file_name, current.index_file.file_name))
 
         return None
+
+    @staticmethod
+    def _deletion_vector_data_file_names(index_file):
+        return [
+            meta.data_file_name
+            for meta in (index_file.dv_ranges or {}).values()
+        ]
 
     def check_overwrite_from_snapshot(self, latest_snapshot, delta_entries, commit_kind):
         if commit_kind != "OVERWRITE":

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -173,6 +173,10 @@ class ConflictDetection:
     def has_row_id_check_from_snapshot(self):
         return self._row_id_check_from_snapshot is not None
 
+    @staticmethod
+    def has_global_index_additions(index_entries=None):
+        return bool(ConflictDetection.global_index_file_additions(index_entries))
+
     def check_conflicts(
             self,
             latest_snapshot,
@@ -218,6 +222,11 @@ class ConflictDetection:
                 return conflict
 
         conflict = self.check_row_id_range_conflicts(commit_kind, merged_entries)
+        if conflict is not None:
+            return conflict
+
+        conflict = self.check_global_index_row_id_existence(
+            base_entries, delta_index_entries)
         if conflict is not None:
             return conflict
 
@@ -292,6 +301,50 @@ class ConflictDetection:
         return [
             meta.data_file_name
             for meta in (index_file.dv_ranges or {}).values()
+        ]
+
+    def check_global_index_row_id_existence(self, base_entries, delta_index_entries=None):
+        if not self.data_evolution_enabled:
+            return None
+
+        indexes_to_check = self.global_index_file_additions(delta_index_entries)
+        if not indexes_to_check:
+            return None
+
+        data_ranges = {}
+        for entry in base_entries or []:
+            row_range = entry.file.row_id_range()
+            if entry.kind == 0 and row_range is not None:
+                key = (tuple(entry.partition.values), entry.bucket)
+                data_ranges.setdefault(key, []).append(row_range)
+
+        data_ranges = {
+            key: Range.sort_and_merge_overlap(ranges, True, True)
+            for key, ranges in data_ranges.items()
+        }
+
+        for index_entry in indexes_to_check:
+            global_index = index_entry.index_file.global_index_meta
+            index_range = Range(
+                global_index.row_range_start,
+                global_index.row_range_end,
+            )
+            key = (tuple(index_entry.partition.values), index_entry.bucket)
+            if index_range.exclude(data_ranges.get(key, [])):
+                return RuntimeError(
+                    "Global index row ID existence conflict: index file '{}' "
+                    "references row range {}, but this range is not fully "
+                    "covered by current data files. The referenced row IDs "
+                    "may have been reassigned or removed by a concurrent "
+                    "commit.".format(index_entry.index_file.file_name, index_range))
+
+        return None
+
+    @staticmethod
+    def global_index_file_additions(index_entries=None):
+        return [
+            entry for entry in (index_entries or [])
+            if entry.kind == 0 and entry.index_file.global_index_meta is not None
         ]
 
     def check_overwrite_from_snapshot(self, latest_snapshot, delta_entries, commit_kind):

--- a/paimon-python/pypaimon/write/commit/overwrite_changes_provider.py
+++ b/paimon-python/pypaimon/write/commit/overwrite_changes_provider.py
@@ -57,27 +57,27 @@ class OverwriteChangesProvider:
             return self._build_result([])
 
         if self._cached_snapshot is None:
-            self._cached_entries = self._full_scan(latest_snapshot)
+            self._cached_entries = self._full_scan_manifest_entries(latest_snapshot)
             self._cached_snapshot = latest_snapshot
         elif self._cached_snapshot.id > latest_snapshot.id:
             raise RuntimeError(
                 f"Cached snapshot id {self._cached_snapshot.id} is greater than "
                 f"latest snapshot id {latest_snapshot.id}")
         elif self._cached_snapshot.id < latest_snapshot.id:
-            if not self._advance_cache(latest_snapshot):
-                self._cached_entries = self._full_scan(latest_snapshot)
+            if not self._update_cache(latest_snapshot):
+                self._cached_entries = self._full_scan_manifest_entries(latest_snapshot)
             self._cached_snapshot = latest_snapshot
         # cached_snapshot.id == latest_snapshot.id -> reuse cache as-is
 
         return self._build_result(self._cached_entries)
 
-    def _full_scan(self, latest_snapshot: Snapshot) -> List[ManifestEntry]:
+    def _full_scan_manifest_entries(self, latest_snapshot: Snapshot) -> List[ManifestEntry]:
         self.full_scan_count += 1
         return (FileScanner(self.table, lambda: ([], None),
                             partition_predicate=self.partition_filter)
                 .read_manifest_entries(self.manifest_list_manager.read_all(latest_snapshot)))
 
-    def _advance_cache(self, latest_snapshot: Snapshot) -> bool:
+    def _update_cache(self, latest_snapshot: Snapshot) -> bool:
         pending_entries = []
         applied_count = 0
         manifest_file_manager = ManifestFileManager(self.table)
@@ -87,7 +87,7 @@ class OverwriteChangesProvider:
                 snapshot = self.snapshot_manager.get_snapshot_by_id(snapshot_id)
                 if snapshot is None:
                     return False
-                entries = self._read_delta_entries(snapshot, manifest_file_manager)
+                entries = self._read_delta_manifest_entries(snapshot, manifest_file_manager)
                 if entries:
                     pending_entries.extend(entries)
                     applied_count += 1
@@ -100,7 +100,7 @@ class OverwriteChangesProvider:
             return False
         return True
 
-    def _read_delta_entries(
+    def _read_delta_manifest_entries(
             self, snapshot: Snapshot,
             manifest_file_manager: ManifestFileManager) -> List[ManifestEntry]:
         delta_manifests = self.manifest_list_manager.read_delta(snapshot)

--- a/paimon-python/pypaimon/write/commit_message.py
+++ b/paimon-python/pypaimon/write/commit_message.py
@@ -30,6 +30,7 @@ class CommitMessage:
     bucket: int
     new_files: List[DataFileMeta]
     check_from_snapshot: Optional[int] = -1
+    deleted_files: List[DataFileMeta] = field(default_factory=list)
     index_adds: List['IndexManifestEntry'] = field(default_factory=list)
     index_deletes: List['IndexManifestEntry'] = field(default_factory=list)
     changelog_files: List[DataFileMeta] = field(default_factory=list)
@@ -37,6 +38,7 @@ class CommitMessage:
     def is_empty(self):
         return (
             not self.new_files
+            and not self.deleted_files
             and not self.index_adds
             and not self.index_deletes
             and not self.changelog_files

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -381,6 +381,7 @@ class FileStoreCommit:
         new_index_manifest = None
         # process snapshot
         new_snapshot_id = latest_snapshot.id + 1 if latest_snapshot else 1
+        index_entries = (index_deletes or []) + (index_adds or [])
 
         # Base entries for conflict detection. On retry, reuse the previous
         # attempt's base + read only the incremental changes (mirrors Java).
@@ -391,7 +392,10 @@ class FileStoreCommit:
                     and retry_result.latest_snapshot is not None
                     and retry_result.base_data_files is not None):
                 incremental = self.commit_scanner.read_incremental_changes(
-                    retry_result.latest_snapshot, latest_snapshot, commit_entries)
+                    retry_result.latest_snapshot,
+                    latest_snapshot,
+                    commit_entries,
+                    index_entries)
             if incremental is not None:
                 base_data_files = list(retry_result.base_data_files)
                 if incremental:
@@ -401,14 +405,14 @@ class FileStoreCommit:
                 # First attempt, or incremental could not be built (missing
                 # snapshot): scan the changed partitions in full.
                 base_data_files = self.commit_scanner.read_all_entries_from_changed_partitions(
-                    latest_snapshot, commit_entries)
+                    latest_snapshot, commit_entries, index_entries)
 
             conflict_exception = self.conflict_detection.check_conflicts(
                 latest_snapshot,
                 base_data_files,
                 commit_entries,
                 commit_kind,
-                (index_deletes or []) + (index_adds or []),
+                index_entries,
             )
 
             if conflict_exception is not None:

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -404,7 +404,12 @@ class FileStoreCommit:
                     latest_snapshot, commit_entries)
 
             conflict_exception = self.conflict_detection.check_conflicts(
-                latest_snapshot, base_data_files, commit_entries, commit_kind)
+                latest_snapshot,
+                base_data_files,
+                commit_entries,
+                commit_kind,
+                (index_deletes or []) + (index_adds or []),
+            )
 
             if conflict_exception is not None:
                 if allow_rollback and self.rollback is not None:

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -183,6 +183,8 @@ class FileStoreCommit:
         if self.conflict_detection.has_row_id_check_from_snapshot():
             detect_conflicts = True
             allow_rollback = True
+        if self.conflict_detection.has_global_index_additions(index_adds):
+            detect_conflicts = True
 
         self._try_commit(commit_kind=commit_kind,
                          commit_identifier=commit_identifier,

--- a/paimon-python/pypaimon/write/file_store_commit.py
+++ b/paimon-python/pypaimon/write/file_store_commit.py
@@ -139,17 +139,7 @@ class FileStoreCommit:
             self.table.identifier,
             len(commit_messages),
         )
-        commit_entries = []
-        for msg in commit_messages:
-            partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
-            for file in msg.new_files:
-                commit_entries.append(ManifestEntry(
-                    kind=0,
-                    partition=partition,
-                    bucket=msg.bucket,
-                    total_buckets=self.table.total_buckets,
-                    file=file
-                ))
+        commit_entries = self._collect_manifest_entries(commit_messages)
         changelog_entries = self._collect_changelog_entries(commit_messages)
 
         logger.info("Finished collecting changes, including: %d entries, %d changelog entries",
@@ -185,7 +175,8 @@ class FileStoreCommit:
         commit_kind = "APPEND"
         detect_conflicts = False
         allow_rollback = False
-        if self.conflict_detection.should_be_overwrite_commit():
+        if self.conflict_detection.should_be_overwrite_commit(
+                commit_entries, index_adds + index_deletes):
             commit_kind = "OVERWRITE"
             detect_conflicts = True
             allow_rollback = True
@@ -267,6 +258,12 @@ class FileStoreCommit:
             raise RuntimeError("Failed to build partition filter for drop_partitions.")
 
         partition_filter = predicate_builder.or_predicates(partition_predicates)
+
+        self.drop_by_partition_filter(partition_filter, commit_identifier)
+
+    def drop_by_partition_filter(self, partition_filter, commit_identifier: int) -> None:
+        if partition_filter is None:
+            raise RuntimeError("Failed to build partition filter.")
 
         provider = self._overwrite_changes_provider(partition_filter, [])
         self._try_commit(
@@ -469,9 +466,7 @@ class FileStoreCommit:
                     delta_record_count -= entry.file.row_count
 
             total_record_count += delta_record_count
-            index_manifest = None
-            if latest_snapshot and commit_kind == "APPEND":
-                index_manifest = latest_snapshot.index_manifest
+            index_manifest = latest_snapshot.index_manifest if latest_snapshot else None
             if index_deletes or index_adds:
                 from pypaimon.manifest.index_manifest_file import IndexManifestFile
                 previous_index_manifest = index_manifest
@@ -652,6 +647,28 @@ class FileStoreCommit:
                     file=file
                 ))
         return changelog_entries
+
+    def _collect_manifest_entries(self, commit_messages: List[CommitMessage]) -> List[ManifestEntry]:
+        commit_entries = []
+        for msg in commit_messages:
+            partition = GenericRow(list(msg.partition), self.table.partition_keys_fields)
+            for file in msg.new_files:
+                commit_entries.append(ManifestEntry(
+                    kind=0,
+                    partition=partition,
+                    bucket=msg.bucket,
+                    total_buckets=self.table.total_buckets,
+                    file=file,
+                ))
+            for file in msg.deleted_files:
+                commit_entries.append(ManifestEntry(
+                    kind=1,
+                    partition=partition,
+                    bucket=msg.bucket,
+                    total_buckets=self.table.total_buckets,
+                    file=file,
+                ))
+        return commit_entries
 
     def _clean_up_reuse_tmp_manifests(
             self,

--- a/paimon-python/pypaimon/write/table_delete.py
+++ b/paimon-python/pypaimon/write/table_delete.py
@@ -1,0 +1,328 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import uuid
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+from pypaimon.deletionvectors.bitmap_deletion_vector import BitmapDeletionVector
+from pypaimon.deletionvectors.deletion_vector import DeletionVector
+from pypaimon.index.deletion_vector_meta import DeletionVectorMeta
+from pypaimon.index.index_file_meta import IndexFileMeta
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
+from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.read.scanner.data_evolution_split_generator import (
+    DataEvolutionSplitGenerator,
+)
+from pypaimon.table.row.generic_row import GenericRow
+from pypaimon.table.source.deletion_file import DeletionFile
+from pypaimon.utils.data_evolution_utils import retrieve_anchor_file
+from pypaimon.utils.file_store_path_factory import FileStorePathFactory
+from pypaimon.utils.range import Range
+from pypaimon.write.commit_message import CommitMessage
+
+
+_ADD = 0
+_DELETE = 1
+_DV_INDEX_VERSION = 1
+
+
+@dataclass(frozen=True)
+class _AnchorRange:
+    row_range: Range
+    partition: GenericRow
+    bucket: int
+    anchor_file: DataFileMeta
+
+
+@dataclass(frozen=True)
+class _AnchorRangesInfo:
+    snapshot_id: int
+    anchors: List[_AnchorRange]
+
+
+class TableDeleteByRowId:
+    """Write data-evolution deletes as deletion-vector index updates."""
+
+    def __init__(
+            self,
+            table,
+            _precomputed_anchor_ranges: Optional[_AnchorRangesInfo] = None,
+    ):
+        from pypaimon.table.file_store_table import FileStoreTable
+
+        self.table: FileStoreTable = table
+        self.file_io = table.file_io
+        self._precomputed_anchor_ranges = _precomputed_anchor_ranges
+
+    def _snapshot_anchor_ranges(self) -> _AnchorRangesInfo:
+        snapshot_id, anchors = self._scan_anchor_ranges()
+        return _AnchorRangesInfo(snapshot_id=snapshot_id, anchors=anchors)
+
+    def delete(self, row_ids: Sequence[int]) -> List[CommitMessage]:
+        self._validate_delete()
+
+        deduplicated = self._deduplicate_row_ids(row_ids)
+        if not deduplicated:
+            return []
+
+        snapshot_id, anchors = self._load_anchor_ranges()
+        targets = self._group_delete_targets(deduplicated, anchors)
+
+        commit_messages = []
+        for (partition, bucket), file_positions in targets.items():
+            message = self._build_commit_message(
+                partition,
+                bucket,
+                file_positions,
+                snapshot_id,
+            )
+            if message is not None:
+                commit_messages.append(message)
+        return commit_messages
+
+    def _validate_delete(self):
+        if not self.table.options.data_evolution_enabled():
+            raise ValueError(
+                "delete requires 'data-evolution.enabled' = 'true'."
+            )
+        if not self.table.options.row_tracking_enabled():
+            raise ValueError(
+                "delete requires 'row-tracking.enabled' = 'true'."
+            )
+        if not self.table.options.deletion_vectors_enabled(False):
+            raise ValueError(
+                "delete requires 'deletion-vectors.enabled' = 'true'."
+            )
+
+    @staticmethod
+    def _deduplicate_row_ids(row_ids: Sequence[int]) -> List[int]:
+        result = []
+        seen = set()
+        for row_id in row_ids:
+            if row_id is None:
+                raise ValueError("_ROW_ID value must not be null.")
+            row_id = int(row_id)
+            if row_id not in seen:
+                result.append(row_id)
+                seen.add(row_id)
+        return result
+
+    def _load_anchor_ranges(self) -> Tuple[int, List[_AnchorRange]]:
+        if self._precomputed_anchor_ranges is not None:
+            return (
+                self._precomputed_anchor_ranges.snapshot_id,
+                self._precomputed_anchor_ranges.anchors,
+            )
+        return self._scan_anchor_ranges()
+
+    def _scan_anchor_ranges(self) -> Tuple[int, List[_AnchorRange]]:
+        plan = self.table.new_read_builder().new_scan().plan()
+        snapshot_id = plan.snapshot_id if plan.snapshot_id is not None else -1
+        anchors = []
+
+        for split in plan.splits():
+            files = [
+                file
+                for file in split.files
+                if file.row_id_range() is not None
+            ]
+            for group in DataEvolutionSplitGenerator._split_by_row_id(files):
+                anchor = retrieve_anchor_file(group)
+                anchors.append(
+                    _AnchorRange(
+                        row_range=anchor.row_id_range(),
+                        partition=split.partition,
+                        bucket=split.bucket,
+                        anchor_file=anchor,
+                    )
+                )
+
+        anchors.sort(key=lambda item: item.row_range.from_)
+        return snapshot_id, anchors
+
+    def _group_delete_targets(
+            self,
+            row_ids: Sequence[int],
+            anchors: List[_AnchorRange],
+    ) -> Dict[Tuple[Tuple, int], Dict[str, Set[int]]]:
+        starts = [anchor.row_range.from_ for anchor in anchors]
+        targets: Dict[Tuple[Tuple, int], Dict[str, Set[int]]] = {}
+
+        for row_id in row_ids:
+            index = bisect_right(starts, row_id) - 1
+            if index < 0 or not anchors[index].row_range.contains(row_id):
+                raise ValueError(
+                    f"Row ID {row_id} does not belong to any valid range "
+                    f"{[f'[{a.row_range.from_}, {a.row_range.to}]' for a in anchors]}"
+                )
+
+            anchor = anchors[index]
+            partition_tuple = tuple(anchor.partition.values)
+            key = (partition_tuple, anchor.bucket)
+            file_positions = targets.setdefault(key, {})
+            positions = file_positions.setdefault(anchor.anchor_file.file_name, set())
+            positions.add(row_id - anchor.row_range.from_)
+
+        return targets
+
+    def _build_commit_message(
+            self,
+            partition: Tuple,
+            bucket: int,
+            file_positions: Dict[str, Set[int]],
+            snapshot_id: int,
+    ) -> Optional[CommitMessage]:
+        partition_row = GenericRow(list(partition), self.table.partition_keys_fields)
+        old_entries, deletion_vectors = self._read_existing_deletion_vectors(
+            partition_row,
+            bucket,
+            snapshot_id,
+        )
+
+        changed = False
+        for file_name, positions in file_positions.items():
+            deletion_vector = deletion_vectors.setdefault(
+                file_name,
+                BitmapDeletionVector(),
+            )
+            for position in positions:
+                changed = deletion_vector.checked_delete(position) or changed
+
+        if not changed:
+            return None
+
+        new_entry = self._write_deletion_vector_index(
+            partition_row,
+            bucket,
+            deletion_vectors,
+        )
+        delete_entries = [
+            IndexManifestEntry(
+                kind=_DELETE,
+                partition=entry.partition,
+                bucket=entry.bucket,
+                index_file=entry.index_file,
+            )
+            for entry in old_entries
+        ]
+        return CommitMessage(
+            partition=partition,
+            bucket=bucket,
+            new_files=[],
+            check_from_snapshot=snapshot_id,
+            index_adds=[new_entry],
+            index_deletes=delete_entries,
+        )
+
+    def _read_existing_deletion_vectors(
+            self,
+            partition: GenericRow,
+            bucket: int,
+            snapshot_id: int,
+    ) -> Tuple[List[IndexManifestEntry], Dict[str, DeletionVector]]:
+        snapshot_manager = self.table.snapshot_manager()
+        snapshot = (
+            snapshot_manager.get_snapshot_by_id(snapshot_id)
+            if snapshot_id >= 0 else snapshot_manager.get_latest_snapshot()
+        )
+        if snapshot is None or not snapshot.index_manifest:
+            return [], {}
+
+        index_manifest_file = IndexManifestFile(self.table)
+        entries = []
+        deletion_vectors: Dict[str, DeletionVector] = {}
+        for entry in index_manifest_file.read(snapshot.index_manifest):
+            if entry.kind != _ADD:
+                continue
+            if entry.index_file.index_type != IndexManifestFile.DELETION_VECTORS_INDEX:
+                continue
+            if entry.bucket != bucket or entry.partition != partition:
+                continue
+
+            entries.append(entry)
+            if not entry.index_file.dv_ranges:
+                continue
+
+            dv_path = self._index_file_path(entry.index_file)
+            for data_file_name, meta in entry.index_file.dv_ranges.items():
+                deletion_file = DeletionFile(
+                    dv_index_path=dv_path,
+                    offset=meta.offset,
+                    length=meta.length,
+                    cardinality=meta.cardinality,
+                )
+                deletion_vectors[data_file_name] = DeletionVector.read(
+                    self.file_io,
+                    deletion_file,
+                )
+
+        return entries, deletion_vectors
+
+    def _write_deletion_vector_index(
+            self,
+            partition: GenericRow,
+            bucket: int,
+            deletion_vectors: Dict[str, DeletionVector],
+    ) -> IndexManifestEntry:
+        file_name = f"{FileStorePathFactory.INDEX_PREFIX}{uuid.uuid4()}-1"
+        path = f"{self.table.path_factory().index_path()}/{file_name}"
+
+        position = 1
+        dv_ranges = {}
+        chunks = [bytes([_DV_INDEX_VERSION])]
+        for data_file_name in sorted(deletion_vectors):
+            deletion_vector = deletion_vectors[data_file_name]
+            serialized = deletion_vector.serialize()
+            bitmap_length = int.from_bytes(serialized[:4], byteorder="big")
+            dv_ranges[data_file_name] = DeletionVectorMeta(
+                data_file_name=data_file_name,
+                offset=position,
+                length=bitmap_length,
+                cardinality=deletion_vector.get_cardinality(),
+            )
+            chunks.append(serialized)
+            position += len(serialized)
+
+        data = b"".join(chunks)
+        try:
+            with self.file_io.new_output_stream(path) as output_stream:
+                output_stream.write(data)
+        except Exception:
+            self.file_io.delete_quietly(path)
+            raise
+
+        index_file = IndexFileMeta(
+            index_type=IndexManifestFile.DELETION_VECTORS_INDEX,
+            file_name=file_name,
+            file_size=len(data),
+            row_count=len(dv_ranges),
+            dv_ranges=dv_ranges,
+        )
+        return IndexManifestEntry(
+            kind=_ADD,
+            partition=partition,
+            bucket=bucket,
+            index_file=index_file,
+        )
+
+    def _index_file_path(self, index_file: IndexFileMeta) -> str:
+        if index_file.external_path:
+            return index_file.external_path
+        return f"{self.table.path_factory().index_path()}/{index_file.file_name}"

--- a/paimon-python/pypaimon/write/table_update.py
+++ b/paimon-python/pypaimon/write/table_update.py
@@ -30,13 +30,18 @@ from pypaimon.common.options.core_options import (
 from pypaimon.common.predicate import Predicate
 from pypaimon.common.predicate_builder import PredicateBuilder
 from pypaimon.globalindex import Range
+from pypaimon.manifest.index_manifest_entry import IndexManifestEntry
+from pypaimon.manifest.index_manifest_file import IndexManifestFile
+from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
+from pypaimon.read.scanner.file_scanner import FileScanner
 from pypaimon.read.split import DataSplit
 from pypaimon.schema.data_types import PyarrowFieldParser
 from pypaimon.snapshot.snapshot import BATCH_COMMIT_IDENTIFIER
 from pypaimon.snapshot.time_travel_util import SCAN_KEYS, TimeTravelUtil
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.write.commit_message import CommitMessage
+from pypaimon.write.table_delete import TableDeleteByRowId
 from pypaimon.write.table_update_by_row_id import TableUpdateByRowId
 from pypaimon.write.table_upsert_by_key import TableUpsertByKey
 from pypaimon.write.writer.data_writer import DataWriter
@@ -335,6 +340,148 @@ class TableUpdate:
             array = array.cast(data_type)
         return array
 
+    def _delete_by_predicate(
+            self,
+            predicate: Optional[Predicate],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        partition_filter = self._partition_only_delete_filter(predicate)
+        if partition_filter is not None:
+            return self._delete_by_partition_filter(partition_filter)
+
+        row_ids = self._matched_delete_row_ids(predicate)
+        return TableDeleteByRowId(self.table).delete(row_ids)
+
+    def _delete_by_partition_filter(
+            self, partition_filter: Predicate) -> List[CommitMessage]:
+        snapshot = self.table.snapshot_manager().get_latest_snapshot()
+        if snapshot is None:
+            return []
+
+        messages = {}
+        manifest_list_manager = ManifestListManager(self.table)
+        data_entries = FileScanner(
+            self.table,
+            lambda: ([], None),
+            partition_predicate=partition_filter,
+        ).read_manifest_entries(manifest_list_manager.read_all(snapshot))
+
+        for entry in data_entries:
+            message = self._partition_delete_message(
+                messages,
+                tuple(entry.partition.values),
+                entry.bucket,
+                snapshot.id,
+            )
+            message.deleted_files.append(entry.file)
+
+        for entry in self._partition_index_entries(snapshot, partition_filter):
+            message = self._partition_delete_message(
+                messages,
+                tuple(entry.partition.values),
+                entry.bucket,
+                snapshot.id,
+            )
+            message.index_deletes.append(IndexManifestEntry(
+                kind=1,
+                partition=entry.partition,
+                bucket=entry.bucket,
+                index_file=entry.index_file,
+            ))
+
+        return [message for message in messages.values() if not message.is_empty()]
+
+    @staticmethod
+    def _partition_delete_message(messages, partition, bucket, snapshot_id):
+        key = (partition, bucket)
+        if key not in messages:
+            messages[key] = CommitMessage(
+                partition=partition,
+                bucket=bucket,
+                new_files=[],
+                check_from_snapshot=snapshot_id,
+            )
+        return messages[key]
+
+    def _partition_index_entries(self, snapshot, partition_filter: Predicate):
+        if snapshot.index_manifest is None:
+            return []
+        return [
+            entry for entry in IndexManifestFile(self.table).read(
+                snapshot.index_manifest)
+            if partition_filter.test(entry.partition)
+        ]
+
+    def _delete_by_row_id(
+            self,
+            row_ids: Sequence[int],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        return TableDeleteByRowId(self.table).delete(list(row_ids))
+
+    def _partition_only_delete_filter(
+            self, predicate: Optional[Predicate]) -> Optional[Predicate]:
+        if predicate is None or not self.table.partition_keys:
+            return None
+        predicate_fields = self._predicate_fields(predicate)
+        if not predicate_fields:
+            return None
+        partition_keys = set(self.table.partition_keys)
+        if not predicate_fields.issubset(partition_keys):
+            return None
+        partition_index = {
+            name: index for index, name in enumerate(self.table.partition_keys)
+        }
+        return self._rewrite_predicate_to_partition_indices(
+            predicate, partition_index
+        )
+
+    def _rewrite_predicate_to_partition_indices(
+            self,
+            predicate: Predicate,
+            partition_index: Mapping[str, int],
+    ) -> Predicate:
+        if predicate.method in ('and', 'or'):
+            return predicate.new_literals([
+                self._rewrite_predicate_to_partition_indices(
+                    child, partition_index,
+                )
+                for child in (predicate.literals or [])
+            ])
+        if predicate.field not in partition_index:
+            raise ValueError(
+                "Partition delete predicate references non-partition "
+                f"field '{predicate.field}'."
+            )
+        return predicate.new_index(partition_index[predicate.field])
+
+    @staticmethod
+    def _predicate_fields(predicate: Predicate) -> set:
+        if predicate.field is not None:
+            return {predicate.field}
+        fields = set()
+        for child in predicate.literals or []:
+            fields.update(TableUpdate._predicate_fields(child))
+        return fields
+
+    def _matched_delete_row_ids(
+            self, predicate: Optional[Predicate]) -> List[int]:
+        scan_table = self._matched_update_scan_table()
+        read_builder = scan_table.new_read_builder()
+        if predicate is not None:
+            read_builder.with_filter(predicate)
+            read_builder.with_projection(
+                list(scan_table.field_names) + [SpecialFields.ROW_ID.name]
+            )
+        else:
+            read_builder.with_projection([SpecialFields.ROW_ID.name])
+
+        splits = read_builder.new_scan().plan().splits()
+        matched = read_builder.new_read().to_arrow(splits)
+        if matched.num_rows == 0:
+            return []
+        return matched[SpecialFields.ROW_ID.name].to_pylist()
+
 
 class BatchTableUpdate(TableUpdate):
     """Batch-mode table update; commit messages always use
@@ -361,6 +508,17 @@ class BatchTableUpdate(TableUpdate):
         return self._update_by_predicate(
             predicate, assignments, BATCH_COMMIT_IDENTIFIER
         )
+
+    def delete_by_predicate(
+            self,
+            predicate: Optional[Predicate],
+    ) -> List[CommitMessage]:
+        """Delete rows matching ``predicate`` using deletion vectors."""
+        return self._delete_by_predicate(predicate, BATCH_COMMIT_IDENTIFIER)
+
+    def delete_by_row_id(self, row_ids: Sequence[int]) -> List[CommitMessage]:
+        """Delete rows by ``_ROW_ID`` using deletion vectors."""
+        return self._delete_by_row_id(row_ids, BATCH_COMMIT_IDENTIFIER)
 
     def merge_into(
             self,
@@ -414,6 +572,24 @@ class StreamTableUpdate(TableUpdate):
         return self._update_by_predicate(
             predicate, assignments, commit_identifier
         )
+
+    def delete_by_predicate(
+            self,
+            predicate: Optional[Predicate],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        """Delete rows matching ``predicate`` using deletion vectors,
+        tagging the produced commit messages with ``commit_identifier``."""
+        return self._delete_by_predicate(predicate, commit_identifier)
+
+    def delete_by_row_id(
+            self,
+            row_ids: Sequence[int],
+            commit_identifier: int,
+    ) -> List[CommitMessage]:
+        """Delete rows by ``_ROW_ID`` using deletion vectors,
+        tagging the produced commit messages with ``commit_identifier``."""
+        return self._delete_by_row_id(row_ids, commit_identifier)
 
     def merge_into(
             self,


### PR DESCRIPTION
## Summary

This PR adds DELETE support to PyPaimon data-evolution APIs and wires delete branches into table, multimodal, and Ray MERGE INTO flows. It also changes partition-only DELETE to emit file-level `deleted_files` commit messages, including matching index deletes, so the commit path uses overwrite-style conflict detection instead of a partition-filter shortcut.

## Changes

- Add `delete_by_predicate` and `delete_by_row_id` support for data-evolution tables using deletion vectors.
- Support `WhenMatched.delete()` alongside `WhenMatched.update()` in table MERGE INTO, multimodal MERGE, and Ray MERGE INTO.
- Replace the internal partition-delete commit-message shortcut with `deleted_files` manifest deletes and matching `index_deletes`.
- Trigger overwrite-style conflict detection for table DELETE entries and deletion-vector index changes, including stale partition detection for partition-only DELETE.
- Split Ray merge update/delete branches so row-id actions are validated and committed separately.
- Update PyPaimon docs for data evolution, multimodal APIs, and Ray data APIs.

## Testing

- [x] `python -m pytest paimon-python/pypaimon/tests/table_update_test.py paimon-python/pypaimon/tests/data_evolution_deletion_vector_test.py paimon-python/pypaimon/tests/table_merge_into_test.py paimon-python/pypaimon/tests/multimodal_table_test.py paimon-python/pypaimon/tests/partition_predicate_test.py paimon-python/pypaimon/tests/overwrite_changes_cache_test.py -q`
- [x] `python -m pytest paimon-python/pypaimon/tests/file_store_commit_test.py paimon-python/pypaimon/tests/table_commit_test.py paimon-python/pypaimon/tests/write/changelog_producer_test.py -q`
- [x] `PYTHONPATH=paimon-python python -m pytest paimon-python/pypaimon/tests/write/conflict_detection_test.py -q`
- [x] `python -m py_compile paimon-python/pypaimon/write/commit_message.py paimon-python/pypaimon/write/file_store_commit.py paimon-python/pypaimon/write/table_update.py paimon-python/pypaimon/write/commit/conflict_detection.py paimon-python/pypaimon/write/commit/overwrite_changes_provider.py paimon-python/pypaimon/ray/data_evolution_merge_into.py paimon-python/pypaimon/ray/data_evolution_merge_join.py paimon-python/pypaimon/ray/data_evolution_merge_transform.py`
- [x] `git diff --check`

## Notes

Ray e2e tests were not run locally because the environment does not have the `ray` Python package installed (`ModuleNotFoundError: No module named 'ray'`).
