### PR TITLE
[core] Use full table name in file store

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -81,7 +81,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                             tableSchema.logicalPartitionType(),
                             tableSchema.logicalBucketKeyType(),
                             tableSchema.logicalRowType().notNull(),
-                            name(),
+                            fullName(),
                             catalogEnvironment);
         }
         return lazyStore;

--- a/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/PrimaryKeyFileStoreTable.java
@@ -97,7 +97,7 @@ public class PrimaryKeyFileStoreTable extends AbstractFileStoreTable {
                             rowType,
                             extractor,
                             mfFactory,
-                            name(),
+                            fullName(),
                             catalogEnvironment);
         }
         return lazyStore;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonV2Write.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonV2Write.scala
@@ -53,13 +53,13 @@ class PaimonV2Write(
 
   override def requiredDistribution(): Distribution = {
     val distribution = writeRequirement.distribution
-    logInfo(s"Requesting $distribution as write distribution for table ${table.name()}")
+    logInfo(s"Requesting $distribution as write distribution for table ${table.fullName()}")
     distribution
   }
 
   override def requiredOrdering(): Array[SortOrder] = {
     val ordering = writeRequirement.ordering
-    logInfo(s"Requesting ${ordering.mkString(",")} as write ordering for table ${table.name()}")
+    logInfo(s"Requesting ${ordering.mkString(",")} as write ordering for table ${table.fullName()}")
     ordering
   }
 


### PR DESCRIPTION
### Purpose
Make logs more readable by using fully qualified table names instead of short table names.
### Tests
Not needed, because this change only updates log messages to use fully qualified table names and does not affect write behavior or data processing.