### PR TITLE
[spark] Add legacy timestamp mapping option

### DIFF
--- a/docs/generated/spark_connector_configuration.html
+++ b/docs/generated/spark_connector_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>legacy-timestamp-mapping.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, map Paimon TIMESTAMP to Spark TIMESTAMP instead of TIMESTAMP_NTZ.</td>
+        </tr>
+        <tr>
             <td><h5>read.allow.fullScan</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -32,6 +32,13 @@ public class SparkConnectorOptions {
                     .withDescription(
                             "Whether to verify SparkSession is initialized with required configurations.");
 
+    public static final ConfigOption<Boolean> LEGACY_TIMESTAMP_MAPPING =
+            key("legacy-timestamp-mapping.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If true, map Paimon TIMESTAMP to Spark TIMESTAMP instead of TIMESTAMP_NTZ.");
+
     public static final ConfigOption<Boolean> MERGE_SCHEMA =
             key("write.merge-schema")
                     .booleanType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/OptionUtils.scala
@@ -126,6 +126,10 @@ object OptionUtils extends SQLConfHelper with Logging {
     getOptionString(SparkConnectorOptions.DATA_EVOLUTION_UPDATE_CONFLICT_RETRY_WAIT_MS).toLong
   }
 
+  def legacyTimestampMappingEnabled(): Boolean = {
+    getOptionString(SparkConnectorOptions.LEGACY_TIMESTAMP_MAPPING).toBoolean
+  }
+
   def v1FunctionEnabled(): Boolean = {
     getOptionString(SparkCatalogOptions.V1FUNCTION_ENABLED).toBoolean
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/shim/TypeUtils.scala
@@ -18,7 +18,11 @@
 
 package org.apache.paimon.spark.util.shim
 
+import org.apache.paimon.spark.util.OptionUtils
+
 object TypeUtils {
 
-  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = false
+  def treatPaimonTimestampTypeAsSparkTimestampType(): Boolean = {
+    OptionUtils.legacyTimestampMappingEnabled()
+  }
 }

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkLegacyTimestampMappingTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/SparkLegacyTimestampMappingTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark;
+
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.paimon.spark.SparkTypeUtils.fromPaimonRowType;
+import static org.apache.paimon.spark.SparkTypeUtils.toPaimonType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for legacy timestamp mapping. */
+public class SparkLegacyTimestampMappingTest {
+
+    private static final String LEGACY_TIMESTAMP_MAPPING_KEY =
+            "spark.paimon.legacy-timestamp-mapping.enabled";
+
+    @Test
+    public void testLegacyTimestampMapping() {
+        RowType paimonType = RowType.builder().field("ts", DataTypes.TIMESTAMP()).build();
+
+        assertThat(fromPaimonRowType(paimonType).apply("ts").dataType())
+                .isEqualTo(org.apache.spark.sql.types.DataTypes.TimestampNTZType);
+
+        withSQLConf(
+                LEGACY_TIMESTAMP_MAPPING_KEY,
+                "true",
+                () -> {
+                    StructType sparkType = fromPaimonRowType(paimonType);
+                    assertThat(sparkType.apply("ts").dataType())
+                            .isEqualTo(org.apache.spark.sql.types.DataTypes.TimestampType);
+                    assertThat(toPaimonType(sparkType)).isEqualTo(paimonType);
+                });
+    }
+
+    private static void withSQLConf(String key, String value, Runnable test) {
+        SQLConf conf = SQLConf.get();
+        boolean contains = conf.contains(key);
+        String originalValue = contains ? conf.getConfString(key) : null;
+        conf.setConfString(key, value);
+        try {
+            test.run();
+        } finally {
+            if (contains) {
+                conf.setConfString(key, originalValue);
+            } else {
+                conf.unsetConf(key);
+            }
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -25,6 +25,7 @@ import org.apache.paimon.types.DataTypes
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionsException
+import org.apache.spark.sql.types.TimestampType
 import org.junit.jupiter.api.Assertions
 
 import java.sql.{Date, Timestamp}
@@ -647,6 +648,40 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
                 }
               }
             }
+        }
+    }
+  }
+
+  test("Paimon DDL: legacy timestamp mapping") {
+    assume(gteqSpark3_4)
+
+    Seq("orc", "parquet").foreach {
+      format =>
+        withSparkSQLConf("spark.paimon.legacy-timestamp-mapping.enabled" -> "true") {
+          withTimeZone("Asia/Shanghai") {
+            withTable("paimon_tbl") {
+              sql(s"""
+                     |CREATE TABLE paimon_tbl (reported_time timestamp)
+                     |USING paimon
+                     |TBLPROPERTIES ('file.format'='$format')
+                     |""".stripMargin)
+
+              sql("INSERT INTO paimon_tbl VALUES (timestamp'2026-06-30 23:47:51')")
+
+              Assertions.assertEquals(
+                TimestampType,
+                spark.table("paimon_tbl").schema("reported_time").dataType)
+              checkAnswer(
+                sql("""
+                      |SELECT from_unixtime(
+                      |  unix_timestamp(reported_time) + 24 * 3600,
+                      |  'yyyy-MM-dd HH:mm:ss'
+                      |) FROM paimon_tbl
+                      |""".stripMargin),
+                Row("2026-07-01 23:47:51") :: Nil
+              )
+            }
+          }
         }
     }
   }


### PR DESCRIPTION
### Purpose

Add `spark.paimon.legacy-timestamp-mapping.enabled` for Spark 3.4+ users who need to expose Paimon `TIMESTAMP` as Spark `TIMESTAMP` instead of `TIMESTAMP_NTZ`. The option is disabled by default, so existing Spark 3.4+ behavior is unchanged.

When enabled, Paimon reuses the existing legacy timestamp conversion path. This helps workloads migrating from Spark 3.3 keep expressions such as `unix_timestamp(ts)` followed by `from_unixtime(...)` consistent with their previous behavior.

### Tests

CI