### PR TITLE
[docs] fix typo in migration from hive document

### DIFF
--- a/docs/docs/migration/migration-from-hive.mdx
+++ b/docs/docs/migration/migration-from-hive.mdx
@@ -115,7 +115,7 @@ CALL sys.migrate_database(
 ```bash
 <FLINK_HOME>/bin/flink run \
 /path/to/paimon-flink-action-@@VERSION@@.jar \
-migrate_databse \
+migrate_database \
 --warehouse <warehouse-path> \
 --source_type hive \
 --database <database> \


### PR DESCRIPTION
### Purpose
[docs] fix typo in migration from hive document
### Tests
