### PR TITLE
[Flink] Fix class loading for built-in functions

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -1484,11 +1484,6 @@ public class FlinkCatalog extends AbstractCatalog {
 
     @Override
     public final boolean functionExists(ObjectPath functionPath) throws CatalogException {
-        if (isSystemNamespace(functionPath.getDatabaseName())
-                && BuiltInFunctions.FUNCTIONS.containsKey(functionPath.getObjectName())) {
-            return true;
-        }
-
         try {
             return catalog.listFunctions(functionPath.getDatabaseName())
                     .contains(functionPath.getObjectName());

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalog.java
@@ -257,6 +257,10 @@ public class FlinkCatalog extends AbstractCatalog {
                     context == null
                             ? Thread.currentThread().getContextClassLoader()
                             : context.getClassLoader();
+            // the built-in functions are bundled in Paimon connector
+            if (BuiltInFunctions.FUNCTIONS.containsKey(functionName)) {
+                classLoader = FlinkCatalog.class.getClassLoader();
+            }
             UserDefinedFunction function =
                     UserDefinedFunctionHelper.instantiateFunction(
                             classLoader, new Configuration(), functionName, catalogFunction);
@@ -1480,6 +1484,11 @@ public class FlinkCatalog extends AbstractCatalog {
 
     @Override
     public final boolean functionExists(ObjectPath functionPath) throws CatalogException {
+        if (isSystemNamespace(functionPath.getDatabaseName())
+                && BuiltInFunctions.FUNCTIONS.containsKey(functionPath.getObjectName())) {
+            return true;
+        }
+
         try {
             return catalog.listFunctions(functionPath.getDatabaseName())
                     .contains(functionPath.getObjectName());


### PR DESCRIPTION
### Purpose
When calling built-in functions at Aliyun VVP, it throws exceptions like:
```
Caused by: java.lang.ClassNotFoundException: org.apache.paimon.flink.function.PathToDescriptor
	at java.base/java.net.URLClassLoader.findClassInternal(URLClassLoader.java:491)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:455)
	at org.apache.flink.util.CompressionSerializer.findClass(CompressionSerializer.java:53)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:626)
	at org.apache.flink.util.FlinkUserCodeClassLoader.loadClassWithoutExceptionHandling(FlinkUserCodeClassLoader.java:72)
	at org.apache.flink.util.CompressionSerializer.loadClassWithoutExceptionHandling(CompressionSerializer.java:74)
	at org.apache.flink.util.ChildFirstClassLoader.loadClassWithoutExceptionHandling(ChildFirstClassLoader.java:74)
	at org.apache.flink.util.FlinkUserCodeClassLoader.loadClass(FlinkUserCodeClassLoader.java:51)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:558)
	at org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader.loadClass(FlinkUserCodeClassLoaders.java:196)
	at org.apache.flink.table.functions.UserDefinedFunctionHelper.instantiateFunction(UserDefinedFunctionHelper.java:224)
	... 36 more
```

### Tests
