### PR TITLE
[spark] Cover overwrite lookup compaction by default

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkWriteITCase.java
@@ -646,7 +646,7 @@ public class SparkWriteITCase {
     @Test
     public void testInsertOverwriteDoesNotProduceLookupChangelogFiles() throws Exception {
         spark.sql(
-                "CREATE TABLE T (a INT, b INT, c STRING) TBLPROPERTIES ('primary-key'='a', 'bucket' = '1', 'changelog-producer' = 'lookup', 'compaction.force-up-level-0' = 'true', 'file.format' = 'avro', 'file.compression' = 'null', 'manifest.compression' = 'null')");
+                "CREATE TABLE T (a INT, b INT, c STRING) TBLPROPERTIES ('primary-key'='a', 'bucket' = '1', 'changelog-producer' = 'lookup', 'file.format' = 'avro', 'file.compression' = 'null', 'manifest.compression' = 'null')");
 
         FileStoreTable table = getTable("T");
         Path bucketPath = new Path(table.location(), "bucket-0");


### PR DESCRIPTION
### Purpose

This cherry-picks the remaining regression-test coverage from the internal fix for overwrite lookup L0 compaction.

On current `master`, the production-code part of that internal patch is already covered by `e01147795c [core] Fix bug that overwrite does not create remote lookup file (#8333)`: `MergeTreeCompactManagerFactory#createCompactStrategy` now uses `options.needLookup()` directly, so overwrite writes no longer disable lookup L0 compaction through `ignorePreviousFiles`. The current code path is:

- `MergeTreeCompactManagerFactory#create(..., boolean ignorePreviousFiles)` still receives the overwrite flag for changelog suppression.
- `createCompactStrategy(options, restoreFiles)` is independent of `ignorePreviousFiles`.
- when `options.needLookup()` is true, it returns `ForceUpLevel0Compaction`.

Therefore the only remaining diff from the internal patch on latest `master` is the Spark regression test change: the test no longer sets `compaction.force-up-level-0=true`, so it verifies the default lookup overwrite compaction behavior.

### Tests

- `git diff --check HEAD^ HEAD`
- Not run: `mvn -s ~/.m2/apache-community.xml -pl paimon-spark/paimon-spark-ut -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=org.apache.paimon.spark.SparkWriteITCase -Dtest=none test` because `mvn` is not installed in the local shell (`zsh:1: command not found: mvn`).