### PR TITLE
[common][python] Use roaring bitmap for row ranges

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/BitmapRowRangeIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BitmapRowRangeIndex.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+/** Row range index backed by a row-id bitmap. */
+class BitmapRowRangeIndex extends RowRangeIndex {
+
+    private final RoaringNavigableMap64 rowIds;
+
+    BitmapRowRangeIndex(RoaringNavigableMap64 rowIds) {
+        this.rowIds = rowIds;
+    }
+
+    @Override
+    public boolean intersects(long start, long end) {
+        return rowIds.intersects(new Range(start, end));
+    }
+
+    @Override
+    public boolean contains(Range range) {
+        return rowIds.containsRange(range);
+    }
+
+    @Override
+    public boolean containsExactly(Range range) {
+        if (!rowIds.containsRange(range)) {
+            return false;
+        }
+
+        boolean leftOpen = range.from == Long.MIN_VALUE || !rowIds.contains(range.from - 1);
+        boolean rightOpen = range.to == Long.MAX_VALUE || !rowIds.contains(range.to + 1);
+        return leftOpen && rightOpen;
+    }
+
+    @Override
+    public void forEachIntersectedRange(long start, long end, LongRangeConsumer consumer) {
+        rowIds.forEachIntersectedRange(start, end, consumer);
+    }
+
+    @Override
+    void forEachRange(LongRangeConsumer consumer) {
+        rowIds.forEachIntersectedRange(0, Long.MAX_VALUE, consumer);
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/LongRangeConsumer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/LongRangeConsumer.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+/** Consumer for an inclusive long range. */
+@FunctionalInterface
+public interface LongRangeConsumer {
+
+    void accept(long from, long to);
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RangeListRowRangeIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RangeListRowRangeIndex.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.List;
+
+/** Row range index backed by a sorted range list. */
+class RangeListRowRangeIndex extends RowRangeIndex {
+
+    private final List<Range> ranges;
+    private final RoaringNavigableMap64 rowIds;
+
+    RangeListRowRangeIndex(List<Range> ranges) {
+        this.ranges = ranges;
+        this.rowIds = RoaringNavigableMap64.fromRanges(ranges);
+    }
+
+    @Override
+    public boolean intersects(long start, long end) {
+        return rowIds.intersects(new Range(start, end));
+    }
+
+    @Override
+    public boolean contains(Range range) {
+        return RowRangeIndexUtils.contains(ranges, range);
+    }
+
+    @Override
+    public boolean containsExactly(Range range) {
+        int candidate = RowRangeIndexUtils.lowerBoundByStart(ranges, range.from);
+        if (candidate >= ranges.size()) {
+            return false;
+        }
+
+        Range candidateRange = ranges.get(candidate);
+        return candidateRange.from == range.from && candidateRange.to == range.to;
+    }
+
+    @Override
+    public void forEachIntersectedRange(long start, long end, LongRangeConsumer consumer) {
+        if (start > end) {
+            return;
+        }
+
+        int left = RowRangeIndexUtils.lowerBoundByEnd(ranges, start);
+        if (left >= ranges.size()) {
+            return;
+        }
+
+        int right = RowRangeIndexUtils.lowerBoundByEnd(ranges, end);
+        if (right >= ranges.size()) {
+            right = ranges.size() - 1;
+        }
+
+        if (ranges.get(left).from > end) {
+            return;
+        }
+
+        Range from = ranges.get(left);
+        consumer.accept(Math.max(start, from.from), Math.min(end, from.to));
+
+        for (int i = left + 1; i < right; i++) {
+            Range range = ranges.get(i);
+            consumer.accept(range.from, range.to);
+        }
+
+        if (right != left) {
+            Range to = ranges.get(right);
+            if (to.from <= end) {
+                consumer.accept(Math.max(start, to.from), Math.min(end, to.to));
+            }
+        }
+    }
+
+    @Override
+    void forEachRange(LongRangeConsumer consumer) {
+        for (Range range : ranges) {
+            consumer.accept(range.from, range.to);
+        }
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RoaringNavigableMap64.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RoaringNavigableMap64.java
@@ -26,6 +26,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -47,6 +48,14 @@ public class RoaringNavigableMap64 implements Iterable<Long>, Serializable {
 
     public void addRange(Range range) {
         roaring64NavigableMap.addRange(range.from, range.to + 1);
+    }
+
+    public boolean intersects(Range range) {
+        return rangeCardinality(range.from, range.to) > 0;
+    }
+
+    public boolean containsRange(Range range) {
+        return rangeCardinality(range.from, range.to) == range.count();
     }
 
     public boolean contains(long x) {
@@ -89,6 +98,91 @@ public class RoaringNavigableMap64 implements Iterable<Long>, Serializable {
         return roaring64NavigableMap.iterator();
     }
 
+    public List<Range> intersectedRanges(long start, long end) {
+        List<Range> ranges = new ArrayList<>();
+        forEachIntersectedRange(start, end, (from, to) -> ranges.add(new Range(from, to)));
+        return Range.mergeSortedAsPossible(ranges);
+    }
+
+    public void forEachIntersectedRange(long start, long end, LongRangeConsumer consumer) {
+        if (start > end) {
+            return;
+        }
+
+        MergingRangeConsumer mergingConsumer = new MergingRangeConsumer(consumer);
+        collectIntersectedRanges(start, end, mergingConsumer);
+        mergingConsumer.flush();
+    }
+
+    private void collectIntersectedRanges(long start, long end, LongRangeConsumer consumer) {
+        long cardinality = rangeCardinality(start, end);
+        if (cardinality == 0) {
+            return;
+        }
+
+        if (cardinality == end - start + 1) {
+            consumer.accept(start, end);
+            return;
+        }
+
+        if (start == end) {
+            consumer.accept(start, end);
+            return;
+        }
+
+        long mid = start + (end - start) / 2;
+        collectIntersectedRanges(start, mid, consumer);
+        collectIntersectedRanges(mid + 1, end, consumer);
+    }
+
+    private static class MergingRangeConsumer implements LongRangeConsumer {
+
+        private final LongRangeConsumer wrapped;
+        private boolean hasRange;
+        private long from;
+        private long to;
+
+        private MergingRangeConsumer(LongRangeConsumer wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public void accept(long from, long to) {
+            if (!hasRange) {
+                this.hasRange = true;
+                this.from = from;
+                this.to = to;
+                return;
+            }
+
+            if (from <= this.to || (this.to != Long.MAX_VALUE && from == this.to + 1)) {
+                this.to = Math.max(this.to, to);
+                return;
+            }
+
+            flush();
+            this.hasRange = true;
+            this.from = from;
+            this.to = to;
+        }
+
+        private void flush() {
+            if (hasRange) {
+                wrapped.accept(from, to);
+                hasRange = false;
+            }
+        }
+    }
+
+    private synchronized long rangeCardinality(long start, long end) {
+        if (start > end || roaring64NavigableMap.isEmpty()) {
+            return 0;
+        }
+
+        long beforeStart = start <= 0 ? 0 : roaring64NavigableMap.rankLong(start - 1);
+        return roaring64NavigableMap.rankLong(end) - beforeStart;
+    }
+
     public static RoaringNavigableMap64 and(RoaringNavigableMap64 x1, RoaringNavigableMap64 x2) {
         Roaring64NavigableMap result = new Roaring64NavigableMap();
         result.or(x1.roaring64NavigableMap);
@@ -101,6 +195,15 @@ public class RoaringNavigableMap64 implements Iterable<Long>, Serializable {
         result.or(x1.roaring64NavigableMap);
         result.or(x2.roaring64NavigableMap);
         return new RoaringNavigableMap64(result);
+    }
+
+    public static RoaringNavigableMap64 fromRanges(List<Range> ranges) {
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        for (Range range : ranges) {
+            result.addRange(range);
+        }
+        result.runOptimize();
+        return result;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowRangeIndex.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowRangeIndex.java
@@ -19,28 +19,12 @@
 package org.apache.paimon.utils;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Index for row ranges. */
-public class RowRangeIndex {
-
-    private final List<Range> ranges;
-    private final long[] starts;
-    private final long[] ends;
-
-    private RowRangeIndex(List<Range> ranges) {
-        this.ranges = ranges;
-        this.starts = new long[ranges.size()];
-        this.ends = new long[ranges.size()];
-        for (int i = 0; i < ranges.size(); i++) {
-            Range range = ranges.get(i);
-            starts[i] = range.from;
-            ends[i] = range.to;
-        }
-    }
+public abstract class RowRangeIndex {
 
     public static RowRangeIndex create(List<Range> ranges) {
         return create(ranges, true);
@@ -48,76 +32,38 @@ public class RowRangeIndex {
 
     public static RowRangeIndex create(List<Range> ranges, boolean mergeAdjacent) {
         checkArgument(ranges != null, "Ranges cannot be null");
-        return new RowRangeIndex(Range.sortAndMergeOverlap(ranges, mergeAdjacent));
+        return new RangeListRowRangeIndex(Range.sortAndMergeOverlap(ranges, mergeAdjacent));
     }
 
-    public List<Range> ranges() {
-        return Collections.unmodifiableList(ranges);
+    public static RowRangeIndex fromBitmap(RoaringNavigableMap64 rowIds) {
+        checkArgument(rowIds != null, "Row IDs cannot be null");
+        return new BitmapRowRangeIndex(rowIds);
     }
 
-    public boolean intersects(long start, long end) {
-        int candidate = lowerBound(ends, start);
-        return candidate < starts.length && starts[candidate] <= end;
+    public RowRangeIndex intersect(RowRangeIndex other) {
+        checkArgument(other != null, "Other row range index cannot be null");
+
+        List<Range> ranges = new ArrayList<>();
+        other.forEachRange(
+                (start, end) ->
+                        forEachIntersectedRange(
+                                start, end, (from, to) -> ranges.add(new Range(from, to))));
+        return create(ranges);
     }
 
-    public boolean contains(Range range) {
-        int candidate = lowerBound(ends, range.from);
-        return candidate < starts.length
-                && starts[candidate] <= range.from
-                && ends[candidate] >= range.to;
+    public List<Range> toRangeList() {
+        List<Range> ranges = new ArrayList<>();
+        forEachRange((from, to) -> ranges.add(new Range(from, to)));
+        return ranges;
     }
 
-    public boolean containsExactly(Range range) {
-        int candidate = lowerBound(starts, range.from);
-        return candidate < starts.length
-                && starts[candidate] == range.from
-                && ends[candidate] == range.to;
-    }
+    public abstract boolean intersects(long start, long end);
 
-    public List<Range> intersectedRanges(long start, long end) {
-        int left = lowerBound(ends, start);
-        if (left >= ranges.size()) {
-            return Collections.emptyList();
-        }
+    public abstract boolean contains(Range range);
 
-        int right = lowerBound(ends, end);
-        if (right >= ranges.size()) {
-            right = ranges.size() - 1;
-        }
+    public abstract boolean containsExactly(Range range);
 
-        if (starts[left] > end) {
-            return Collections.emptyList();
-        }
+    public abstract void forEachIntersectedRange(long start, long end, LongRangeConsumer consumer);
 
-        List<Range> expected = new ArrayList<>();
-        Range from = ranges.get(left);
-        expected.add(new Range(Math.max(start, from.from), Math.min(end, from.to)));
-
-        int length = right - left - 1;
-        if (length > 0) {
-            expected.addAll(ranges.subList(left + 1, left + 1 + length));
-        }
-
-        if (right != left) {
-            Range to = ranges.get(right);
-            if (to.from <= end) {
-                expected.add(new Range(Math.max(start, to.from), Math.min(end, to.to)));
-            }
-        }
-        return expected;
-    }
-
-    private static int lowerBound(long[] sorted, long target) {
-        int left = 0;
-        int right = sorted.length;
-        while (left < right) {
-            int mid = left + (right - left) / 2;
-            if (sorted[mid] < target) {
-                left = mid + 1;
-            } else {
-                right = mid;
-            }
-        }
-        return left;
-    }
+    abstract void forEachRange(LongRangeConsumer consumer);
 }

--- a/paimon-common/src/main/java/org/apache/paimon/utils/RowRangeIndexUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/RowRangeIndexUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import java.util.List;
+
+/** Utilities for row range index implementations. */
+class RowRangeIndexUtils {
+
+    private RowRangeIndexUtils() {}
+
+    static boolean contains(List<Range> ranges, Range range) {
+        int candidate = lowerBoundByEnd(ranges, range.from);
+        if (candidate >= ranges.size()) {
+            return false;
+        }
+
+        Range candidateRange = ranges.get(candidate);
+        return candidateRange.from <= range.from && candidateRange.to >= range.to;
+    }
+
+    static int lowerBoundByStart(List<Range> sorted, long target) {
+        int left = 0;
+        int right = sorted.size();
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+            if (sorted.get(mid).from < target) {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        return left;
+    }
+
+    static int lowerBoundByEnd(List<Range> sorted, long target) {
+        int left = 0;
+        int right = sorted.size();
+        while (left < right) {
+            int mid = left + (right - left) / 2;
+            if (sorted.get(mid).to < target) {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        return left;
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RoaringNavigableMap64Test.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RoaringNavigableMap64Test.java
@@ -21,6 +21,7 @@ package org.apache.paimon.utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,5 +108,57 @@ public class RoaringNavigableMap64Test {
         assertThat(values).hasSize(101);
         assertThat(values.get(0)).isEqualTo(start);
         assertThat(values.get(100)).isEqualTo(end);
+    }
+
+    @Test
+    public void testRangePredicates() {
+        RoaringNavigableMap64 bitmap =
+                RoaringNavigableMap64.fromRanges(
+                        Arrays.asList(new Range(0, 9), new Range(20, 29), new Range(40, 45)));
+
+        assertThat(bitmap.intersects(new Range(5, 5))).isTrue();
+        assertThat(bitmap.intersects(new Range(10, 19))).isFalse();
+        assertThat(bitmap.intersects(new Range(29, 40))).isTrue();
+        assertThat(bitmap.intersects(new Range(30, 39))).isFalse();
+
+        assertThat(bitmap.containsRange(new Range(0, 9))).isTrue();
+        assertThat(bitmap.containsRange(new Range(2, 8))).isTrue();
+        assertThat(bitmap.containsRange(new Range(9, 20))).isFalse();
+        assertThat(bitmap.containsRange(new Range(10, 19))).isFalse();
+        assertThat(bitmap.containsRange(new Range(40, 45))).isTrue();
+    }
+
+    @Test
+    public void testIntersectedRanges() {
+        RoaringNavigableMap64 bitmap =
+                RoaringNavigableMap64.fromRanges(
+                        Arrays.asList(new Range(0, 9), new Range(20, 29), new Range(40, 45)));
+        bitmap.add(35);
+        bitmap.add(37);
+
+        assertThat(bitmap.intersectedRanges(5, 42))
+                .containsExactly(
+                        new Range(5, 9),
+                        new Range(20, 29),
+                        new Range(35, 35),
+                        new Range(37, 37),
+                        new Range(40, 42));
+        assertThat(bitmap.intersectedRanges(10, 19)).isEmpty();
+    }
+
+    @Test
+    public void testLargeIntersectedRanges() {
+        long start = Integer.MAX_VALUE + 100L;
+        RoaringNavigableMap64 bitmap =
+                RoaringNavigableMap64.fromRanges(
+                        Arrays.asList(
+                                new Range(start, start + 99), new Range(start + 200, start + 299)));
+
+        assertThat(bitmap.intersects(new Range(start + 50, start + 60))).isTrue();
+        assertThat(bitmap.containsRange(new Range(start + 20, start + 80))).isTrue();
+        assertThat(bitmap.containsRange(new Range(start + 100, start + 199))).isFalse();
+        assertThat(bitmap.intersectedRanges(start + 95, start + 205))
+                .containsExactly(
+                        new Range(start + 95, start + 99), new Range(start + 200, start + 205));
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/RowRangeIndexTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/RowRangeIndexTest.java
@@ -20,7 +20,9 @@ package org.apache.paimon.utils;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,5 +39,79 @@ class RowRangeIndexTest {
         assertThat(index.contains(new Range(50, 120))).isTrue();
         assertThat(index.contains(new Range(150, 199))).isFalse();
         assertThat(index.contains(new Range(100, 200))).isFalse();
+    }
+
+    @Test
+    void testContainsExactlyKeepsRangeBoundaries() {
+        RowRangeIndex merged =
+                RowRangeIndex.create(Arrays.asList(new Range(0, 99), new Range(100, 149)));
+        assertThat(merged.contains(new Range(0, 149))).isTrue();
+        assertThat(merged.containsExactly(new Range(0, 149))).isTrue();
+        assertThat(merged.containsExactly(new Range(0, 99))).isFalse();
+
+        RowRangeIndex notMerged =
+                RowRangeIndex.create(Arrays.asList(new Range(0, 99), new Range(100, 149)), false);
+        assertThat(notMerged.contains(new Range(0, 149))).isFalse();
+        assertThat(notMerged.contains(new Range(0, 99))).isTrue();
+        assertThat(notMerged.containsExactly(new Range(0, 149))).isFalse();
+        assertThat(notMerged.containsExactly(new Range(0, 99))).isTrue();
+        assertThat(notMerged.containsExactly(new Range(100, 149))).isTrue();
+    }
+
+    @Test
+    void testIntersectsAndIntersectedRanges() {
+        RowRangeIndex index =
+                RowRangeIndex.create(
+                        Arrays.asList(new Range(0, 9), new Range(20, 29), new Range(40, 45)));
+
+        assertThat(index.intersects(5, 15)).isTrue();
+        assertThat(index.intersects(10, 19)).isFalse();
+        assertThat(collectIntersections(index, 5, 42))
+                .containsExactly(new Range(5, 9), new Range(20, 29), new Range(40, 42));
+        assertThat(collectIntersections(index, 10, 19)).isEmpty();
+        assertThat(
+                        index.intersect(RowRangeIndex.create(Arrays.asList(new Range(5, 42))))
+                                .toRangeList())
+                .containsExactly(new Range(5, 9), new Range(20, 29), new Range(40, 42));
+    }
+
+    @Test
+    void testBitmapBackedIndex() {
+        RoaringNavigableMap64 rowIds =
+                RoaringNavigableMap64.fromRanges(
+                        Arrays.asList(new Range(0, 9), new Range(20, 29), new Range(40, 45)));
+        rowIds.add(35);
+        rowIds.add(37);
+
+        RowRangeIndex index = RowRangeIndex.fromBitmap(rowIds);
+
+        assertThat(index.intersects(5, 15)).isTrue();
+        assertThat(index.intersects(10, 19)).isFalse();
+        assertThat(collectIntersections(index, 5, 42))
+                .containsExactly(
+                        new Range(5, 9),
+                        new Range(20, 29),
+                        new Range(35, 35),
+                        new Range(37, 37),
+                        new Range(40, 42));
+        assertThat(index.containsExactly(new Range(20, 29))).isTrue();
+        assertThat(index.containsExactly(new Range(40, 44))).isFalse();
+        assertThat(collectIntersections(index, 34, 38))
+                .containsExactly(new Range(35, 35), new Range(37, 37));
+        assertThat(
+                        index.intersect(RowRangeIndex.create(Arrays.asList(new Range(5, 42))))
+                                .toRangeList())
+                .containsExactly(
+                        new Range(5, 9),
+                        new Range(20, 29),
+                        new Range(35, 35),
+                        new Range(37, 37),
+                        new Range(40, 42));
+    }
+
+    private static List<Range> collectIntersections(RowRangeIndex index, long start, long end) {
+        List<Range> ranges = new ArrayList<>();
+        index.forEachIntersectedRange(start, end, (from, to) -> ranges.add(new Range(from, to)));
+        return ranges;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.table.SpecialFields.ROW_ID;
 import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequentialReturn;
@@ -244,7 +245,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
             Optional<GlobalIndexResult> indexResult = evalGlobalIndex();
             if (indexResult.isPresent()) {
                 GlobalIndexResult result = indexResult.get();
-                rowRangeIndex = RowRangeIndex.create(result.results().toRangeList());
+                rowRangeIndex = RowRangeIndex.fromBitmap(result.results());
                 if (result instanceof ScoredGlobalIndexResult) {
                     scoreGetter = ((ScoredGlobalIndexResult) result).scoreGetter();
                 }
@@ -308,12 +309,10 @@ public class DataEvolutionBatchScan implements DataTableScan {
             DataSplit dataSplit, final RowRangeIndex rowRangeIndex, ScoreGetter scoreGetter) {
         List<DataFileMeta> files = dataSplit.dataFiles();
 
-        List<Range> expected = new ArrayList<>();
-        for (DataFileMeta file : files) {
-            Range fileRange = file.nonNullRowIdRange();
-            expected.addAll(rowRangeIndex.intersectedRanges(fileRange.from, fileRange.to));
-        }
-        expected = Range.sortAndMergeOverlap(expected, true);
+        List<Range> fileRanges =
+                files.stream().map(DataFileMeta::nonNullRowIdRange).collect(Collectors.toList());
+        List<Range> expected =
+                rowRangeIndex.intersect(RowRangeIndex.create(fileRanges)).toRangeList();
         if (expected.isEmpty()) {
             long min = files.stream().mapToLong(f -> f.nonNullRowIdRange().from).min().orElse(-1L);
             long max = files.stream().mapToLong(f -> f.nonNullRowIdRange().to).max().orElse(-1L);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
@@ -48,6 +48,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
+import org.apache.paimon.utils.RowRangeIndex;
 
 import javax.annotation.Nullable;
 
@@ -307,11 +308,7 @@ public abstract class AbstractVectorRead implements Serializable {
             return result;
         }
         ScoredGlobalIndexResult candidates = result.topK(indexedSearchLimit(indexType));
-        return readRawSearch(
-                candidates.results().toRangeList(),
-                candidates.results(),
-                globalIndexer,
-                queryVector);
+        return readRawSearch(candidates.results(), null, globalIndexer, queryVector);
     }
 
     protected String vectorIndexType(List<IndexVectorSearchSplit> splits) {
@@ -367,19 +364,53 @@ public abstract class AbstractVectorRead implements Serializable {
             @Nullable RoaringNavigableMap64 preFilter,
             String metric,
             float[] queryVector) {
-        RowType readType = SpecialFields.rowTypeWithRowId(table.rowType());
         if (preFilter != null) {
-            rawRowRanges =
-                    Range.and(
-                            Range.sortAndMergeOverlap(rawRowRanges, true),
-                            Range.sortAndMergeOverlap(preFilter.toRangeList(), true));
+            RoaringNavigableMap64 rawRows = bitmapOf(rawRowRanges);
+            rawRows.and(preFilter);
+            return readRawSearch(rawRows, null, metric, queryVector);
         }
+
+        RowType readType = SpecialFields.rowTypeWithRowId(table.rowType());
         if (rawRowRanges.isEmpty()) {
             return ScoredGlobalIndexResult.createEmpty();
         }
 
         TableScan.Plan plan =
                 newRawReadBuilder(readType, false).withRowRanges(rawRowRanges).newScan().plan();
+        return readRawSearch(plan, readType, metric, queryVector);
+    }
+
+    protected ScoredGlobalIndexResult readRawSearch(
+            RoaringNavigableMap64 rawRows,
+            @Nullable RoaringNavigableMap64 preFilter,
+            @Nullable GlobalIndexer globalIndexer,
+            float[] queryVector) {
+        return readRawSearch(rawRows, preFilter, rawSearchMetric(globalIndexer), queryVector);
+    }
+
+    protected ScoredGlobalIndexResult readRawSearch(
+            RoaringNavigableMap64 rawRows,
+            @Nullable RoaringNavigableMap64 preFilter,
+            String metric,
+            float[] queryVector) {
+        if (preFilter != null) {
+            rawRows = RoaringNavigableMap64.and(rawRows, preFilter);
+        }
+        if (rawRows.isEmpty()) {
+            return ScoredGlobalIndexResult.createEmpty();
+        }
+
+        RowType readType = SpecialFields.rowTypeWithRowId(table.rowType());
+        TableScan.Plan plan =
+                newRawReadBuilder(readType, false)
+                        .withRowRangeIndex(RowRangeIndex.fromBitmap(rawRows))
+                        .newScan()
+                        .plan();
+        return readRawSearch(plan, readType, metric, queryVector);
+    }
+
+    private ScoredGlobalIndexResult readRawSearch(
+            TableScan.Plan plan, RowType readType, String metric, float[] queryVector) {
         ReadBuilder readBuilder = newRawReadBuilder(readType, true);
         RoaringNavigableMap64 resultBitmap = new RoaringNavigableMap64();
         Map<Long, Float> scoreMap = new HashMap<>();

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import org.junit.jupiter.api.Test;
@@ -83,9 +84,12 @@ public class DataEvolutionBatchScanTest {
             }
 
             List<Range> rowRanges = Range.sortAndMergeOverlap(candidateRanges, true);
+            RowRangeIndex rowRangeIndex =
+                    round % 2 == 0
+                            ? RowRangeIndex.create(rowRanges)
+                            : RowRangeIndex.fromBitmap(RoaringNavigableMap64.fromRanges(rowRanges));
             List<Split> indexedSplits =
-                    DataEvolutionBatchScan.wrapToIndexSplits(
-                                    splits, RowRangeIndex.create(rowRanges), null)
+                    DataEvolutionBatchScan.wrapToIndexSplits(splits, rowRangeIndex, null)
                             .splits();
 
             assertThat(indexedSplits).hasSize(splits.size());

--- a/paimon-python/pypaimon/globalindex/global_index_result.py
+++ b/paimon-python/pypaimon/globalindex/global_index_result.py
@@ -69,17 +69,12 @@ class GlobalIndexResult(ABC):
     @staticmethod
     def from_range(range_: Range) -> 'GlobalIndexResult':
         """Returns a new GlobalIndexResult from Range."""
-        result = RoaringBitmap64()
-        result.add_range(range_.from_, range_.to)
-        return SimpleGlobalIndexResult(result)
+        return SimpleGlobalIndexResult(RoaringBitmap64.from_ranges([range_]))
 
     @staticmethod
     def from_ranges(ranges: List[Range]) -> 'GlobalIndexResult':
         """Returns a new GlobalIndexResult from multiple Ranges."""
-        result = RoaringBitmap64()
-        for r in ranges:
-            result.add_range(r.from_, r.to)
-        return SimpleGlobalIndexResult(result)
+        return SimpleGlobalIndexResult(RoaringBitmap64.from_ranges(ranges))
 
 
 class SimpleGlobalIndexResult(GlobalIndexResult):

--- a/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
+++ b/paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py
@@ -18,12 +18,13 @@
 from collections import defaultdict
 from typing import List, Optional, Tuple
 
-from pypaimon.globalindex.indexed_split import IndexedSplit
-from pypaimon.utils.range import Range
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.manifest.schema.manifest_entry import ManifestEntry
+from pypaimon.globalindex.indexed_split import IndexedSplit
 from pypaimon.read.scanner.split_generator import AbstractSplitGenerator
 from pypaimon.read.split import DataSplit, Split
+from pypaimon.utils.range import Range
+from pypaimon.utils.row_range_index import RowRangeIndex
 
 
 class DataEvolutionSplitGenerator(AbstractSplitGenerator):
@@ -38,11 +39,20 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
         open_file_cost: int,
         deletion_files_map=None,
         row_ranges: Optional[List] = None,
-        score_getter=None
+        score_getter=None,
+        row_bitmap=None,
+        row_range_index=None
     ):
         super().__init__(table, target_split_size, open_file_cost, deletion_files_map)
         self.row_ranges = row_ranges
         self.score_getter = score_getter
+        self.row_bitmap = row_bitmap
+        self.row_range_index = row_range_index
+        if self.row_range_index is None:
+            if row_bitmap is not None:
+                self.row_range_index = RowRangeIndex.from_bitmap(row_bitmap)
+            elif row_ranges is not None:
+                self.row_range_index = RowRangeIndex.create(row_ranges)
 
     def create_splits(self, file_entries: List[ManifestEntry]) -> List[Split]:
         """
@@ -100,15 +110,18 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 flatten_packed_files, packed_files, sorted_entries_list
             )
 
-        # merge slice_row_ranges and self.row_ranges
-        if slice_row_ranges is None:
-            slice_row_ranges = self.row_ranges
-        elif self.row_ranges is not None:
-            slice_row_ranges = Range.and_(slice_row_ranges, self.row_ranges)
+        effective_row_range_index = self.row_range_index
+        if slice_row_ranges is not None:
+            if effective_row_range_index is not None:
+                effective_row_range_index = effective_row_range_index.intersect(
+                    RowRangeIndex.create(slice_row_ranges))
+            else:
+                effective_row_range_index = RowRangeIndex.create(slice_row_ranges)
 
         # Wrap splits with IndexedSplit for slice-based filtering or row_ranges
-        if slice_row_ranges:
-            splits = self._wrap_to_indexed_splits(splits, slice_row_ranges)
+        if effective_row_range_index is not None:
+            splits = self._wrap_to_indexed_splits(
+                splits, row_range_index=effective_row_range_index)
 
         return splits
 
@@ -317,13 +330,25 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
 
         return list(range_to_files.values())
 
-    def _wrap_to_indexed_splits(self, splits: List[Split], row_ranges: List[Range]) -> List[Split]:
+    def _wrap_to_indexed_splits(
+            self,
+            splits: List[Split],
+            row_ranges: Optional[List[Range]] = None,
+            row_bitmap=None,
+            row_range_index=None) -> List[Split]:
         """
         Wrap splits with IndexedSplit for row range filtering.
         """
+        if row_range_index is None:
+            if row_bitmap is not None:
+                row_range_index = RowRangeIndex.from_bitmap(row_bitmap)
+            elif row_ranges is not None:
+                row_range_index = RowRangeIndex.create(row_ranges)
+        if row_range_index is None:
+            return splits
+
         indexed_splits = []
         for split in splits:
-            # Calculate file ranges for this split
             file_ranges = [file.row_id_range() for file in split.files]
 
             if not file_ranges:
@@ -331,11 +356,8 @@ class DataEvolutionSplitGenerator(AbstractSplitGenerator):
                 indexed_splits.append(split)
                 continue
 
-            # Merge file ranges
-            file_ranges = Range.merge_sorted_as_possible(file_ranges)
-
-            # Intersect with row_ranges from global index
-            expected = Range.and_(file_ranges, row_ranges)
+            expected = row_range_index.intersect(
+                RowRangeIndex.create(file_ranges)).to_range_list()
 
             if not expected:
                 # No intersection, skip this split

--- a/paimon-python/pypaimon/read/scanner/file_scanner.py
+++ b/paimon-python/pypaimon/read/scanner/file_scanner.py
@@ -102,7 +102,18 @@ def _row_ranges_from_predicate(predicate: Optional[Predicate]) -> Optional[List]
     return visit(predicate)
 
 
-def _build_early_row_range_filter(row_ranges):
+def _to_row_range_index(row_ranges=None, row_bitmap=None, row_range_index=None):
+    if row_range_index is not None:
+        return row_range_index
+    from pypaimon.utils.row_range_index import RowRangeIndex
+    if row_bitmap is not None:
+        return RowRangeIndex.from_bitmap(row_bitmap)
+    if row_ranges is not None:
+        return RowRangeIndex.create(row_ranges)
+    return None
+
+
+def _build_early_row_range_filter(row_ranges, row_bitmap=None, row_range_index=None):
     """Skip entries whose row-id range doesn't intersect ``row_ranges``.
 
     Runs on the raw fastavro record (OrderedDict) before the expensive
@@ -113,10 +124,11 @@ def _build_early_row_range_filter(row_ranges):
     Safe for DELETE entries because ADD and DELETE for the same file
     share the same ``_FIRST_ROW_ID``.
     """
-    if row_ranges is None or not row_ranges:
+    row_range_index = _to_row_range_index(row_ranges, row_bitmap, row_range_index)
+    if row_range_index is None:
         return None
-
-    from pypaimon.utils.range import Range
+    if row_range_index.is_empty():
+        return lambda record: False
 
     def _filter(record):
         file_dict = record.get('_FILE')
@@ -130,10 +142,7 @@ def _build_early_row_range_filter(row_ranges):
             return True
         file_start = int(first_row_id)
         file_end = file_start + int(row_count) - 1
-        for r in row_ranges:
-            if Range.intersect(file_start, file_end, r.from_, r.to):
-                return True
-        return False
+        return row_range_index.intersects(file_start, file_end)
 
     return _filter
 
@@ -153,44 +162,45 @@ def _filter_manifest_files_by_row_ranges(
     Returns:
         Filtered list of manifest files
     """
-    from pypaimon.utils.range import Range
+    from pypaimon.utils.row_range_index import RowRangeIndex
+    return _filter_manifest_files_by_row_range_index(
+        manifest_files, RowRangeIndex.create(row_ranges))
+
+
+def _filter_manifest_files_by_row_bitmap(
+        manifest_files: List[ManifestFileMeta],
+        row_bitmap) -> List[ManifestFileMeta]:
+    from pypaimon.utils.row_range_index import RowRangeIndex
+    return _filter_manifest_files_by_row_range_index(
+        manifest_files, RowRangeIndex.from_bitmap(row_bitmap))
+
+
+def _filter_manifest_files_by_row_range_index(
+        manifest_files: List[ManifestFileMeta],
+        row_range_index) -> List[ManifestFileMeta]:
+    if row_range_index.is_empty():
+        return []
 
     filtered_files = []
     for manifest in manifest_files:
         min_row_id = manifest.min_row_id
         max_row_id = manifest.max_row_id
-
-        # If min_row_id or max_row_id is None, we cannot filter, keep the file
         if min_row_id is None or max_row_id is None:
             filtered_files.append(manifest)
             continue
-
-        # Check if manifest row range overlaps with any of the expected row ranges
-        manifest_row_range = Range(min_row_id, max_row_id)
-        should_keep = False
-
-        for expected_range in row_ranges:
-            # Check if ranges intersect
-            intersect = Range.intersect(
-                manifest_row_range.from_,
-                manifest_row_range.to,
-                expected_range.from_,
-                expected_range.to)
-            if intersect:
-                should_keep = True
-                break
-
-        if should_keep:
+        if row_range_index.intersects(min_row_id, max_row_id):
             filtered_files.append(manifest)
-
     return filtered_files
 
 
 def _filter_manifest_entries_by_row_ranges(
         entries: List[ManifestEntry],
-        row_ranges: List) -> List[ManifestEntry]:
+        row_ranges: List,
+        row_bitmap=None,
+        row_range_index=None) -> List[ManifestEntry]:
 
-    if not row_ranges:
+    row_range_index = _to_row_range_index(row_ranges, row_bitmap, row_range_index)
+    if row_range_index is None or row_range_index.is_empty():
         return []
 
     filtered = []
@@ -200,10 +210,8 @@ def _filter_manifest_entries_by_row_ranges(
             filtered.append(entry)
             continue
         file_range = entry.file.row_id_range()
-        for r in row_ranges:
-            if file_range.overlaps(r):
-                filtered.append(entry)
-                break
+        if row_range_index.intersects(file_range.from_, file_range.to):
+            filtered.append(entry)
     return filtered
 
 
@@ -361,6 +369,7 @@ class FileScanner:
 
     def _create_data_evolution_split_generator(self):
         row_ranges = None
+        row_range_index = None
         score_getter = None
         # Fetch snapshot once and share with global index evaluation to avoid
         # a duplicate /snapshot REST round-trip (#7513).
@@ -371,21 +380,28 @@ class FileScanner:
         global_index_result = self._global_index_result if self._global_index_result is not None \
             else self._eval_global_index(snapshot)
         if global_index_result is not None:
-            row_ranges = global_index_result.results().to_range_list()
+            from pypaimon.utils.row_range_index import RowRangeIndex
+            row_range_index = RowRangeIndex.from_bitmap(global_index_result.results())
             if isinstance(global_index_result, ScoredGlobalIndexResult):
                 score_getter = global_index_result.score_getter()
-        if row_ranges is None and self.predicate is not None:
+        if row_range_index is None and self.predicate is not None:
             row_ranges = _row_ranges_from_predicate(self.predicate)
+            if row_ranges is not None:
+                from pypaimon.utils.row_range_index import RowRangeIndex
+                row_range_index = RowRangeIndex.create(row_ranges)
 
         # Filter manifest files by row ranges if available
-        if row_ranges is not None:
-            manifest_files = _filter_manifest_files_by_row_ranges(manifest_files, row_ranges)
+        if row_range_index is not None:
+            manifest_files = _filter_manifest_files_by_row_range_index(
+                manifest_files, row_range_index)
 
-        entries = self.read_manifest_entries(manifest_files, row_ranges=row_ranges)
+        entries = self.read_manifest_entries(
+            manifest_files, row_ranges=row_ranges, row_range_index=row_range_index)
 
         # Redundant when early_record_filter ran; kept for explain mode and as safety net.
-        if row_ranges is not None:
-            entries = _filter_manifest_entries_by_row_ranges(entries, row_ranges)
+        if row_range_index is not None:
+            entries = _filter_manifest_entries_by_row_ranges(
+                entries, row_ranges, row_range_index=row_range_index)
 
         return entries, DataEvolutionSplitGenerator(
             self.table,
@@ -393,7 +409,8 @@ class FileScanner:
             self.open_file_cost,
             self._deletion_files_map(entries),
             row_ranges,
-            score_getter
+            score_getter,
+            row_range_index=row_range_index
         )
 
     def plan_files(self) -> List[ManifestEntry]:
@@ -433,7 +450,9 @@ class FileScanner:
             return None
 
     def read_manifest_entries(self, manifest_files: List[ManifestFileMeta],
-                              row_ranges=None) -> List[ManifestEntry]:
+                              row_ranges=None,
+                              row_bitmap=None,
+                              row_range_index=None) -> List[ManifestEntry]:
         max_workers = self.table.options.scan_manifest_parallelism(os.cpu_count() or 8)
         if self.scan_stats is not None:
             self.scan_stats.manifest_files_total += len(manifest_files)
@@ -452,7 +471,7 @@ class FileScanner:
         # Disable both early filters in explain mode (scan_stats) so all entries
         # flow through _filter_manifest_entry for accurate funnel counting.
         early_row_filter = None if self.scan_stats is not None \
-            else _build_early_row_range_filter(row_ranges)
+            else _build_early_row_range_filter(row_ranges, row_bitmap, row_range_index)
         partition_filter = None if self.scan_stats is not None \
             else self.partition_key_predicate
         return self.manifest_file_manager.read_entries_parallel(

--- a/paimon-python/pypaimon/table/source/vector_search_read.py
+++ b/paimon-python/pypaimon/table/source/vector_search_read.py
@@ -221,10 +221,8 @@ class AbstractVectorSearchReadImpl:
     def _read_raw_search(self, raw_row_ranges, pre_filter, query_vector, index_type=None):
         raw_row_ranges = Range.sort_and_merge_overlap(raw_row_ranges, True)
         if pre_filter is not None:
-            raw_row_ranges = Range.and_(
-                raw_row_ranges,
-                Range.sort_and_merge_overlap(pre_filter.to_range_list(), True),
-            )
+            raw_rows = RoaringBitmap64.and_(_bitmap_of_ranges(raw_row_ranges), pre_filter)
+            return self._read_raw_bitmap_search(raw_rows, query_vector, index_type)
         if not raw_row_ranges:
             return DictBasedScoredIndexResult({})
 
@@ -241,6 +239,43 @@ class AbstractVectorSearchReadImpl:
         read_builder = read_builder.with_projection(projection)
         plan = read_builder.new_scan().with_global_index_result(
             GlobalIndexResult.from_ranges(raw_row_ranges)).plan()
+        table = read_builder.new_read().to_arrow(plan.splits())
+        if table is None or table.num_rows == 0:
+            return DictBasedScoredIndexResult({})
+
+        row_ids = table.column(SpecialFields.ROW_ID.name).to_pylist()
+        vectors = table.column(self._vector_column.name).to_pylist()
+        metric = _raw_search_metric(
+            self._table, self._vector_column, self._options, index_type)
+        scores = {}
+        for row_id, stored in zip(row_ids, vectors):
+            if stored is None:
+                continue
+            stored_vector = _to_vector_list(stored)
+            if len(stored_vector) != len(query_vector):
+                raise ValueError(
+                    "Query vector dimension mismatch: expected %d, got %d"
+                    % (len(stored_vector), len(query_vector)))
+            scores[row_id] = _compute_score(query_vector, stored_vector, metric)
+        return DictBasedScoredIndexResult(scores).top_k(self._limit)
+
+    def _read_raw_bitmap_search(self, raw_rows, query_vector, index_type=None):
+        if raw_rows.is_empty():
+            return DictBasedScoredIndexResult({})
+
+        read_builder = self._table.new_read_builder()
+        if self._partition_filter is not None:
+            read_builder = read_builder.with_partition_filter(
+                self._partition_filter)
+        if self._filter is not None:
+            read_builder = read_builder.with_filter(self._filter)
+        from pypaimon.table.special_fields import SpecialFields
+        projection = [f.name for f in self._table.fields]
+        if SpecialFields.ROW_ID.name not in projection:
+            projection.append(SpecialFields.ROW_ID.name)
+        read_builder = read_builder.with_projection(projection)
+        plan = read_builder.new_scan().with_global_index_result(
+            GlobalIndexResult.create(raw_rows)).plan()
         table = read_builder.new_read().to_arrow(plan.splits())
         if table is None or table.num_rows == 0:
             return DictBasedScoredIndexResult({})
@@ -294,12 +329,8 @@ class AbstractVectorSearchReadImpl:
                 result.results().is_empty()):
             return result
         candidates = result.top_k(self._indexed_search_limit(index_type))
-        return self._read_raw_search(
-            candidates.results().to_range_list(),
-            candidates.results(),
-            query_vector,
-            index_type,
-        )
+        return self._read_raw_bitmap_search(
+            candidates.results(), query_vector, index_type)
 
     def _configured_refine_factor(self, index_type):
         value = _configured_refine_factor(

--- a/paimon-python/pypaimon/tests/data_evolution_test.py
+++ b/paimon-python/pypaimon/tests/data_evolution_test.py
@@ -1140,6 +1140,61 @@ class DataEvolutionTest(unittest.TestCase):
         filtered = _filter_manifest_entries_by_row_ranges(entries, row_ranges)
         self.assertEqual(filtered, [], "empty row_ranges must return no entries, not all entries")
 
+    def test_filter_manifest_entries_by_row_range_index(self):
+        from pypaimon.read.scanner.file_scanner import _filter_manifest_entries_by_row_ranges
+        from pypaimon.utils.range import Range
+        from pypaimon.utils.roaring_bitmap import RoaringBitmap64
+        from pypaimon.utils.row_range_index import RowRangeIndex
+
+        entry_0 = SimpleNamespace(
+            file=SimpleNamespace(
+                first_row_id=0,
+                row_count=10,
+                row_id_range=lambda: Range(0, 9)))
+        entry_1 = SimpleNamespace(
+            file=SimpleNamespace(
+                first_row_id=20,
+                row_count=10,
+                row_id_range=lambda: Range(20, 29)))
+        bitmap = RoaringBitmap64.from_ranges([Range(5, 6), Range(22, 24)])
+        row_range_index = RowRangeIndex.from_bitmap(bitmap)
+
+        filtered = _filter_manifest_entries_by_row_ranges(
+            [entry_0, entry_1], None, row_range_index=row_range_index)
+
+        self.assertEqual(filtered, [entry_0, entry_1])
+
+    def test_wrap_to_indexed_splits_by_row_range_index(self):
+        from pypaimon.globalindex.indexed_split import IndexedSplit
+        from pypaimon.read.scanner.data_evolution_split_generator import (
+            DataEvolutionSplitGenerator,
+        )
+        from pypaimon.utils.range import Range
+        from pypaimon.utils.roaring_bitmap import RoaringBitmap64
+        from pypaimon.utils.row_range_index import RowRangeIndex
+
+        table = SimpleNamespace(options=SimpleNamespace(options={}))
+        row_range_index = RowRangeIndex.from_bitmap(
+            RoaringBitmap64.from_ranges([Range(5, 6), Range(22, 24)]))
+        generator = DataEvolutionSplitGenerator(
+            table,
+            target_split_size=1024,
+            open_file_cost=1,
+            row_range_index=row_range_index)
+        split = SimpleNamespace(files=[
+            SimpleNamespace(row_id_range=lambda: Range(0, 9)),
+            SimpleNamespace(row_id_range=lambda: Range(20, 29)),
+        ])
+
+        result = generator._wrap_to_indexed_splits(
+            [split], row_range_index=generator.row_range_index)
+
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], IndexedSplit)
+        self.assertEqual(
+            result[0].row_ranges(),
+            [Range(5, 6), Range(22, 24)])
+
     def test_more_data(self):
         simple_pa_schema = pa.schema([
             ('f0', pa.int32()),

--- a/paimon-python/pypaimon/tests/roaring_bitmap_test.py
+++ b/paimon-python/pypaimon/tests/roaring_bitmap_test.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from pypaimon.utils.range import Range
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
+
+
+class RoaringBitmap64Test(unittest.TestCase):
+
+    def test_range_predicates(self):
+        bitmap = RoaringBitmap64.from_ranges([
+            Range(0, 9),
+            Range(20, 29),
+            Range(40, 45),
+        ])
+
+        self.assertTrue(bitmap.intersects(Range(5, 5)))
+        self.assertFalse(bitmap.intersects(Range(10, 19)))
+        self.assertTrue(bitmap.intersects(Range(29, 40)))
+        self.assertFalse(bitmap.intersects(Range(30, 39)))
+
+        self.assertTrue(bitmap.contains_range(Range(0, 9)))
+        self.assertTrue(bitmap.contains_range(Range(2, 8)))
+        self.assertFalse(bitmap.contains_range(Range(9, 20)))
+        self.assertFalse(bitmap.contains_range(Range(10, 19)))
+        self.assertTrue(bitmap.contains_range(Range(40, 45)))
+
+    def test_intersected_ranges(self):
+        bitmap = RoaringBitmap64.from_ranges([
+            Range(0, 9),
+            Range(20, 29),
+            Range(40, 45),
+        ])
+        bitmap.add(35)
+        bitmap.add(37)
+
+        self.assertEqual(
+            [
+                Range(5, 9),
+                Range(20, 29),
+                Range(35, 35),
+                Range(37, 37),
+                Range(40, 42),
+            ],
+            bitmap.intersected_ranges(5, 42))
+        self.assertEqual([], bitmap.intersected_ranges(10, 19))
+
+    def test_large_intersected_ranges(self):
+        start = 2 ** 31 + 100
+        bitmap = RoaringBitmap64.from_ranges([
+            Range(start, start + 9),
+            Range(start + 20, start + 24),
+        ])
+
+        self.assertTrue(bitmap.contains_range(Range(start, start + 9)))
+        self.assertFalse(bitmap.contains_range(Range(start + 5, start + 20)))
+        self.assertEqual(
+            [Range(start + 8, start + 9), Range(start + 20, start + 22)],
+            bitmap.intersected_ranges(start + 8, start + 22))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/row_range_index_test.py
+++ b/paimon-python/pypaimon/tests/row_range_index_test.py
@@ -1,0 +1,122 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from pypaimon.utils.range import Range
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
+from pypaimon.utils.row_range_index import RowRangeIndex
+
+
+class RowRangeIndexTest(unittest.TestCase):
+
+    def test_range_list_contains(self):
+        index = RowRangeIndex.create([
+            Range(0, 99),
+            Range(100, 149),
+            Range(200, 299),
+        ])
+
+        self.assertTrue(index.contains(Range(0, 149)))
+        self.assertTrue(index.contains(Range(50, 120)))
+        self.assertFalse(index.contains(Range(150, 199)))
+        self.assertFalse(index.contains(Range(100, 200)))
+
+    def test_range_list_intersections(self):
+        index = RowRangeIndex.create([
+            Range(0, 9),
+            Range(20, 29),
+            Range(40, 45),
+        ])
+
+        self.assertTrue(index.intersects(5, 15))
+        self.assertFalse(index.intersects(10, 19))
+        self.assertEqual(
+            [Range(5, 9), Range(20, 29), Range(40, 42)],
+            _collect_intersections(index, 5, 42))
+        self.assertEqual([], _collect_intersections(index, 10, 19))
+        self.assertEqual(
+            [Range(5, 9), Range(20, 29), Range(40, 42)],
+            index.intersect(RowRangeIndex.create([Range(5, 42)])).to_range_list())
+
+    def test_contains_exactly_keeps_range_boundaries(self):
+        merged = RowRangeIndex.create([Range(0, 99), Range(100, 149)])
+        self.assertTrue(merged.contains(Range(0, 149)))
+        self.assertTrue(merged.contains_exactly(Range(0, 149)))
+        self.assertFalse(merged.contains_exactly(Range(0, 99)))
+
+        not_merged = RowRangeIndex.create(
+            [Range(0, 99), Range(100, 149)], merge_adjacent=False)
+        self.assertFalse(not_merged.contains(Range(0, 149)))
+        self.assertTrue(not_merged.contains(Range(0, 99)))
+        self.assertFalse(not_merged.contains_exactly(Range(0, 149)))
+        self.assertTrue(not_merged.contains_exactly(Range(0, 99)))
+        self.assertTrue(not_merged.contains_exactly(Range(100, 149)))
+
+    def test_bitmap_backed_index_avoids_range_list_on_bounded_operations(self):
+        row_ids = RoaringBitmap64.from_ranges([
+            Range(0, 9),
+            Range(20, 29),
+            Range(40, 45),
+        ])
+        row_ids.add(35)
+        row_ids.add(37)
+
+        original_to_range_list = row_ids.to_range_list
+
+        def fail_to_range_list():
+            raise AssertionError("unexpected full bitmap to range-list conversion")
+
+        row_ids.to_range_list = fail_to_range_list
+        index = RowRangeIndex.from_bitmap(row_ids)
+
+        self.assertTrue(index.intersects(5, 15))
+        self.assertFalse(index.intersects(10, 19))
+        self.assertEqual(
+            [
+                Range(5, 9),
+                Range(20, 29),
+                Range(35, 35),
+                Range(37, 37),
+                Range(40, 42),
+            ],
+            _collect_intersections(index, 5, 42))
+        self.assertTrue(index.contains(Range(20, 29)))
+        self.assertFalse(index.contains(Range(20, 30)))
+        self.assertTrue(index.contains_exactly(Range(35, 35)))
+        self.assertFalse(index.contains_exactly(Range(20, 28)))
+        self.assertEqual(
+            [
+                Range(5, 9),
+                Range(20, 29),
+                Range(35, 35),
+                Range(37, 37),
+                Range(40, 42),
+            ],
+            index.intersect(RowRangeIndex.create([Range(5, 42)])).to_range_list())
+        row_ids.to_range_list = original_to_range_list
+
+
+def _collect_intersections(index, start, end):
+    ranges = []
+    index.for_each_intersected_range(
+        start, end, lambda from_, to: ranges.append(Range(from_, to)))
+    return ranges
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/paimon-python/pypaimon/tests/write/conflict_detection_test.py
+++ b/paimon-python/pypaimon/tests/write/conflict_detection_test.py
@@ -145,10 +145,21 @@ class TestCheckRowIdExistence(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Row ID existence conflict", str(result))
 
-    def test_no_conflict_when_blob_file_range_is_covered_by_multiple_files(self):
+    def test_conflict_when_blob_file_range_is_covered_by_adjacent_files(self):
         detection = self._make_detection()
         base = [
             _make_entry("f1", kind=0, first_row_id=0, row_count=50),
+            _make_entry("f2", kind=0, first_row_id=50, row_count=50),
+        ]
+        delta = [_make_entry("p1.blob", kind=0, first_row_id=25, row_count=50)]
+        result = detection.check_row_id_existence(base, delta, next_row_id=200)
+        self.assertIsNotNone(result)
+        self.assertIn("Row ID existence conflict", str(result))
+
+    def test_no_conflict_when_blob_file_range_is_covered_by_overlapping_files(self):
+        detection = self._make_detection()
+        base = [
+            _make_entry("f1", kind=0, first_row_id=0, row_count=60),
             _make_entry("f2", kind=0, first_row_id=50, row_count=50),
         ]
         delta = [_make_entry("p1.blob", kind=0, first_row_id=25, row_count=50)]

--- a/paimon-python/pypaimon/utils/roaring_bitmap.py
+++ b/paimon-python/pypaimon/utils/roaring_bitmap.py
@@ -42,6 +42,14 @@ class RoaringBitmap64:
         """Add a range of values [from_, to] to the bitmap."""
         self._data.add_range(from_, to + 1)
 
+    def intersects(self, range_) -> bool:
+        """Check if the bitmap intersects with the given Range."""
+        return self._range_cardinality(range_.from_, range_.to) > 0
+
+    def contains_range(self, range_) -> bool:
+        """Check if the bitmap contains every value in the given Range."""
+        return self._range_cardinality(range_.from_, range_.to) == range_.count()
+
     def contains(self, value: int) -> bool:
         """Check if the bitmap contains the given value."""
         return value in self._data
@@ -104,6 +112,60 @@ class RoaringBitmap64:
 
         return ranges
 
+    def intersected_ranges(self, start: int, end: int) -> list:
+        """
+        Return contiguous bitmap ranges intersecting [start, end].
+        """
+        from pypaimon.utils.range import Range
+
+        ranges = []
+        self.for_each_intersected_range(
+            start, end, lambda from_, to: ranges.append(Range(from_, to)))
+        return Range.merge_sorted_as_possible(ranges)
+
+    def for_each_intersected_range(self, start: int, end: int, consumer) -> None:
+        """
+        Visit contiguous bitmap ranges intersecting [start, end].
+        """
+        if start > end:
+            return
+
+        merging_consumer = _MergingRangeConsumer(consumer)
+        self._collect_intersected_ranges(start, end, merging_consumer.accept)
+        merging_consumer.flush()
+
+    def _collect_intersected_ranges(self, start: int, end: int, consumer) -> None:
+        cardinality = self._range_cardinality(start, end)
+        if cardinality == 0:
+            return
+
+        if cardinality == end - start + 1:
+            consumer(start, end)
+            return
+
+        if start == end:
+            consumer(start, end)
+            return
+
+        mid = start + (end - start) // 2
+        self._collect_intersected_ranges(start, mid, consumer)
+        self._collect_intersected_ranges(mid + 1, end, consumer)
+
+    def _range_cardinality(self, start: int, end: int) -> int:
+        if start > end or self.is_empty() or end < 0:
+            return 0
+        start = max(start, 0)
+        return self._data.range_cardinality(start, end + 1)
+
+    @staticmethod
+    def from_ranges(ranges: list) -> 'RoaringBitmap64':
+        """Return a bitmap containing all values in the given ranges."""
+        result = RoaringBitmap64()
+        for r in ranges:
+            result.add_range(r.from_, r.to)
+        result._data.run_optimize()
+        return result
+
     @staticmethod
     def and_(a: 'RoaringBitmap64', b: 'RoaringBitmap64') -> 'RoaringBitmap64':
         """Return the intersection of two bitmaps."""
@@ -149,6 +211,36 @@ class RoaringBitmap64:
         if len(values) <= 10:
             return f"RoaringBitmap64({values})"
         return f"RoaringBitmap64({len(values)} elements)"
+
+
+class _MergingRangeConsumer:
+
+    def __init__(self, consumer):
+        self._consumer = consumer
+        self._has_range = False
+        self._from = None
+        self._to = None
+
+    def accept(self, from_, to):
+        if not self._has_range:
+            self._has_range = True
+            self._from = from_
+            self._to = to
+            return
+
+        if from_ <= self._to + 1:
+            self._to = max(self._to, to)
+            return
+
+        self.flush()
+        self._has_range = True
+        self._from = from_
+        self._to = to
+
+    def flush(self):
+        if self._has_range:
+            self._consumer(self._from, self._to)
+            self._has_range = False
 
 
 class RoaringBitmap:

--- a/paimon-python/pypaimon/utils/row_range_index.py
+++ b/paimon-python/pypaimon/utils/row_range_index.py
@@ -1,0 +1,193 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+
+from pypaimon.utils.range import Range
+from pypaimon.utils.roaring_bitmap import RoaringBitmap64
+
+
+class RowRangeIndex(ABC):
+
+    @staticmethod
+    def create(ranges, merge_adjacent=True):
+        if ranges is None:
+            raise ValueError("Ranges cannot be None")
+        return _RangeListRowRangeIndex(
+            Range.sort_and_merge_overlap(ranges, True, merge_adjacent))
+
+    @staticmethod
+    def from_bitmap(row_ids):
+        if row_ids is None:
+            raise ValueError("Row IDs cannot be None")
+        return _BitmapRowRangeIndex(row_ids)
+
+    def intersect(self, other):
+        if other is None:
+            raise ValueError("Other row range index cannot be None")
+
+        ranges = []
+        other._for_each_range(
+            lambda start, end: self.for_each_intersected_range(
+                start, end, lambda from_, to: ranges.append(Range(from_, to))))
+        return RowRangeIndex.create(ranges)
+
+    def to_range_list(self):
+        ranges = []
+        self._for_each_range(lambda from_, to: ranges.append(Range(from_, to)))
+        return ranges
+
+    @abstractmethod
+    def is_empty(self):
+        pass
+
+    @abstractmethod
+    def intersects(self, start, end):
+        pass
+
+    @abstractmethod
+    def contains(self, range_):
+        pass
+
+    @abstractmethod
+    def contains_exactly(self, range_):
+        pass
+
+    @abstractmethod
+    def for_each_intersected_range(self, start, end, consumer):
+        pass
+
+    @abstractmethod
+    def _for_each_range(self, consumer):
+        pass
+
+
+class _RangeListRowRangeIndex(RowRangeIndex):
+
+    def __init__(self, ranges):
+        self._ranges = ranges
+        self._row_ids = RoaringBitmap64.from_ranges(ranges)
+
+    def is_empty(self):
+        return len(self._ranges) == 0
+
+    def intersects(self, start, end):
+        return self._row_ids.intersects(Range(start, end))
+
+    def contains(self, range_):
+        return _contains(self._ranges, range_)
+
+    def contains_exactly(self, range_):
+        candidate = _lower_bound_by_start(self._ranges, range_.from_)
+        if candidate >= len(self._ranges):
+            return False
+
+        candidate_range = self._ranges[candidate]
+        return candidate_range.from_ == range_.from_ and candidate_range.to == range_.to
+
+    def for_each_intersected_range(self, start, end, consumer):
+        if start > end:
+            return
+
+        left = _lower_bound_by_end(self._ranges, start)
+        if left >= len(self._ranges):
+            return
+
+        right = _lower_bound_by_end(self._ranges, end)
+        if right >= len(self._ranges):
+            right = len(self._ranges) - 1
+
+        if self._ranges[left].from_ > end:
+            return
+
+        from_range = self._ranges[left]
+        consumer(max(start, from_range.from_), min(end, from_range.to))
+
+        for i in range(left + 1, right):
+            range_ = self._ranges[i]
+            consumer(range_.from_, range_.to)
+
+        if right != left:
+            to_range = self._ranges[right]
+            if to_range.from_ <= end:
+                consumer(max(start, to_range.from_), min(end, to_range.to))
+
+    def _for_each_range(self, consumer):
+        for range_ in self._ranges:
+            consumer(range_.from_, range_.to)
+
+
+class _BitmapRowRangeIndex(RowRangeIndex):
+
+    def __init__(self, row_ids):
+        self._row_ids = row_ids
+
+    def is_empty(self):
+        return self._row_ids.is_empty()
+
+    def intersects(self, start, end):
+        return self._row_ids.intersects(Range(start, end))
+
+    def contains(self, range_):
+        return self._row_ids.contains_range(range_)
+
+    def contains_exactly(self, range_):
+        if not self._row_ids.contains_range(range_):
+            return False
+
+        left_open = range_.from_ <= 0 or not self._row_ids.contains(range_.from_ - 1)
+        right_open = not self._row_ids.contains(range_.to + 1)
+        return left_open and right_open
+
+    def for_each_intersected_range(self, start, end, consumer):
+        self._row_ids.for_each_intersected_range(start, end, consumer)
+
+    def _for_each_range(self, consumer):
+        self._row_ids.for_each_intersected_range(0, (1 << 63) - 1, consumer)
+
+
+def _contains(ranges, target):
+    candidate = _lower_bound_by_end(ranges, target.from_)
+    if candidate >= len(ranges):
+        return False
+
+    candidate_range = ranges[candidate]
+    return candidate_range.from_ <= target.from_ and candidate_range.to >= target.to
+
+
+def _lower_bound_by_start(ranges, target):
+    left = 0
+    right = len(ranges)
+    while left < right:
+        mid = left + (right - left) // 2
+        if ranges[mid].from_ < target:
+            left = mid + 1
+        else:
+            right = mid
+    return left
+
+
+def _lower_bound_by_end(ranges, target):
+    left = 0
+    right = len(ranges)
+    while left < right:
+        mid = left + (right - left) // 2
+        if ranges[mid].to < target:
+            left = mid + 1
+        else:
+            right = mid
+    return left

--- a/paimon-python/pypaimon/write/commit/conflict_detection.py
+++ b/paimon-python/pypaimon/write/commit/conflict_detection.py
@@ -28,6 +28,7 @@ from pypaimon.manifest.schema.file_entry import FileEntry
 from pypaimon.table.special_fields import SpecialFields
 from pypaimon.utils.range import Range
 from pypaimon.utils.range_helper import RangeHelper
+from pypaimon.utils.row_range_index import RowRangeIndex
 from pypaimon.write.commit.commit_scanner import CommitScanner
 
 
@@ -318,8 +319,8 @@ class ConflictDetection:
                 key = (tuple(entry.partition.values), entry.bucket)
                 data_ranges.setdefault(key, []).append(row_range)
 
-        data_ranges = {
-            key: Range.sort_and_merge_overlap(ranges, True, True)
+        row_range_indexes = {
+            key: RowRangeIndex.create(ranges)
             for key, ranges in data_ranges.items()
         }
 
@@ -330,7 +331,8 @@ class ConflictDetection:
                 global_index.row_range_end,
             )
             key = (tuple(index_entry.partition.values), index_entry.bucket)
-            if index_range.exclude(data_ranges.get(key, [])):
+            row_range_index = row_range_indexes.get(key)
+            if row_range_index is None or not row_range_index.contains(index_range):
                 return RuntimeError(
                     "Global index row ID existence conflict: index file '{}' "
                     "references row range {}, but this range is not fully "
@@ -399,31 +401,30 @@ class ConflictDetection:
         if not files_to_check:
             return None
 
-        existing_index = set()
         existing_ranges = {}
         for base in base_entries:
             if base.file.first_row_id is not None:
-                existing_index.add((
-                    base.partition, base.bucket,
-                    base.file.first_row_id, base.file.row_count))
                 if not DataFileMeta.is_blob_file(base.file.file_name):
                     existing_ranges.setdefault((base.partition, base.bucket), []).append(
                         base.file.row_id_range())
 
-        existing_ranges = {
-            key: Range.sort_and_merge_overlap(ranges, True, True)
+        existing_range_indexes = {
+            key: RowRangeIndex.create(ranges, merge_adjacent=False)
             for key, ranges in existing_ranges.items()
         }
 
         for entry in files_to_check:
-            if DataFileMeta.is_blob_file(entry.file.file_name):
-                base_ranges = existing_ranges.get((entry.partition, entry.bucket), [])
-                if not entry.file.row_id_range().exclude(base_ranges):
-                    continue
-
-            key = (entry.partition, entry.bucket,
-                   entry.file.first_row_id, entry.file.row_count)
-            if key not in existing_index:
+            row_range = entry.file.row_id_range()
+            row_range_index = existing_range_indexes.get((entry.partition, entry.bucket))
+            exists = (
+                row_range_index is not None
+                and (
+                    row_range_index.contains(row_range)
+                    if DataFileMeta.is_blob_file(entry.file.file_name)
+                    else row_range_index.contains_exactly(row_range)
+                )
+            )
+            if not exists:
                 return RuntimeError(
                     "Row ID existence conflict: file '{}' references "
                     "firstRowId={}, rowCount={} in bucket {}, "


### PR DESCRIPTION
## Summary

Abstracts row-range filtering behind `RowRangeIndex` while preserving the existing row-ranges entry points. Java now has a `RowRangeIndex` abstraction with range-list and bitmap-backed implementations; Python mirrors the same shape with `RowRangeIndex.create(...)` and `RowRangeIndex.from_bitmap(...)`.

`RowRangeIndex` no longer exposes `ranges()` and no longer returns `List<Range>` from `intersectedRanges`. The bounded intersection API is visitor-based (`forEachIntersectedRange` / `for_each_intersected_range`), and index-level intersection is expressed as `intersect(RowRangeIndex other)`. Callers that truly need a list use the terminal conversion `toRangeList()` / `to_range_list()` at the boundary.

Bitmap results from global index and vector-search paths stay bitmap-backed through manifest filtering, split wrapping, and rerank reads. `DataEvolutionBatchScan.wrap` now builds a row-range index for split file ranges, intersects it with the pushed row-range index, and only converts the final result to `List<Range>` for `IndexedSplit`.

## Changes

- Add range predicates, bounded streamed intersection, and from-ranges construction to Java/Python roaring bitmap helpers.
- Refactor Java `RowRangeIndex` into an abstraction with `RangeListRowRangeIndex` and `BitmapRowRangeIndex` implementations.
- Remove `RowRangeIndex.ranges()` and replace `RowRangeIndex.intersectedRanges(...)` with `forEachIntersectedRange(...)`.
- Add `RowRangeIndex.intersect(...)` and terminal `toRangeList()` / `to_range_list()` conversion.
- Add Python `pypaimon.utils.row_range_index` with matching range-list and bitmap-backed implementations.
- Route Java data-evolution scan and vector raw-search/rerank paths through bitmap-backed row range indexes.
- Route Python `FileScanner`, `DataEvolutionSplitGenerator`, vector search read, and conflict detection through the row range index abstraction.
- Keep compatibility entry points for existing `List<Range>` / `row_ranges` callers, while adding bitmap/index-backed paths.
- Add tests covering bitmap-backed bounded operations without full range-list conversion, index-level intersection, streamed split wrapping, large row ids, and conflict-detection boundary semantics.

## Testing

- [x] `mvn -pl paimon-common -DskipTests spotless:check`
- [x] `mvn -pl paimon-common -Pfast-build -Dtest=RowRangeIndexTest,RoaringNavigableMap64Test test`
- [x] `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=DataEvolutionBatchScanTest,SortedGlobalIndexBuilderSplitTest,ConflictDetectionTest,DataEvolutionFileStoreScanTest test`
- [x] `python -m compileall -q paimon-python/pypaimon/utils/row_range_index.py paimon-python/pypaimon/read/scanner/data_evolution_split_generator.py paimon-python/pypaimon/tests/row_range_index_test.py`
- [x] `python -m pytest paimon-python/pypaimon/tests/row_range_index_test.py paimon-python/pypaimon/tests/data_evolution_test.py::DataEvolutionTest::test_wrap_to_indexed_splits_by_row_range_index -q`
- [x] `python -m pytest paimon-python/pypaimon/tests/roaring_bitmap_test.py paimon-python/pypaimon/tests/row_range_index_test.py paimon-python/pypaimon/tests/data_evolution_test.py::DataEvolutionTest::test_filter_manifest_entries_by_row_ranges paimon-python/pypaimon/tests/data_evolution_test.py::DataEvolutionTest::test_filter_manifest_entries_by_row_range_index paimon-python/pypaimon/tests/data_evolution_test.py::DataEvolutionTest::test_wrap_to_indexed_splits_by_row_range_index paimon-python/pypaimon/tests/write/conflict_detection_test.py paimon-python/pypaimon/tests/global_index_test.py paimon-python/pypaimon/tests/global_index_build_test.py paimon-python/pypaimon/tests/range_test.py paimon-python/pypaimon/tests/vector_search_filter_test.py::VectorSearchFilterTest::test_refine_factor_reranks_index_candidates_with_raw_vectors paimon-python/pypaimon/tests/vector_search_filter_test.py::VectorSearchFilterTest::test_refine_factor_one_reranks_without_expanding_candidates paimon-python/pypaimon/tests/vector_search_filter_test.py::VectorSearchManySplitsTest::test_raw_search_uses_partition_filter_and_index_type_metric -q`
- [x] `git diff --check`