### PR TITLE
[python][ray] Integrate Ray for distributed multimodal table reads

### DIFF
--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -383,6 +383,70 @@ Notes:
   few large reads); scattered point reads coalesce less.
 - Blob reads are available only on `scan()`, not on the `search()` queries.
 
+### Distributed BLOB processing with Ray
+
+For larger offline jobs, `scan().to_ray()` reads scalar columns plus BLOB
+Descriptors as a Ray Dataset, and `map_with_blobs` fetches BLOB bytes on Ray
+workers before calling your UDF.
+
+```python
+import ray
+import pyarrow as pa
+import pypaimon.multimodal as pm
+from pypaimon.ray import map_with_blobs
+
+ray.init(num_cpus=8)
+
+conn = pm.connect(
+    database="default",
+    options={"warehouse": "file:///tmp/warehouse"},
+)
+docs = conn.get_table("docs")
+
+ids = ["a", "b", "c"]
+in_clause = ", ".join(f"'{i}'" for i in ids)
+
+scalar_cols = ["id", "category"]
+blob_cols = ["image"]
+
+
+def process_batch(scalar_batch, blobs):
+    # scalar_batch is a pyarrow.Table with non-BLOB columns.
+    # blobs is dict[str, list[bytes | None]].
+    images = blobs["image"]
+
+    # Decode, infer, write samples, or train here. Return a small result.
+    return pa.table({"rows": [scalar_batch.num_rows]})
+
+
+# Most jobs can leave concurrency / override_num_blocks unset; Ray chooses them.
+ds = (
+    docs.scan()
+    .where(f"id IN ({in_clause})")
+    .select(scalar_cols + blob_cols)
+    .to_ray()
+)
+
+# Most jobs can also start with the default parallelism and batch_size.
+result_ds = map_with_blobs(ds, blob_cols, process_batch)
+```
+
+`process_batch` must return a Ray-compatible batch, such as a small
+`pyarrow.Table`. For side-effect-only jobs, return an empty table rather than
+`None`. Avoid returning raw BLOB bytes, which would materialize large payloads
+in Ray's object store.
+
+Optional tuning parameters:
+
+- `to_ray(concurrency=...)` limits concurrent Ray read tasks. By default, Ray
+  decides based on available resources.
+- `to_ray(override_num_blocks=...)` controls Ray Dataset block count. Most jobs
+  do not need to set it manually.
+- `map_with_blobs(parallelism=...)` controls the per-Ray-task BLOB fetch threads.
+  It is not the number of Ray workers.
+- `map_with_blobs(batch_size=...)` controls rows per UDF call. Reduce it when
+  individual BLOBs are large or worker memory is tight.
+
 ## Row IDs
 
 Multimodal tables enable `row-tracking.enabled` by default, so each row has a

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -393,7 +393,6 @@ workers before calling your UDF.
 import ray
 import pyarrow as pa
 import pypaimon.multimodal as pm
-from pypaimon.ray import map_with_blobs
 
 ray.init(num_cpus=8)
 
@@ -427,16 +426,20 @@ ds = (
     .to_ray()
 )
 
+# Optional Ray transforms are fine as long as BLOB descriptor columns remain.
+# ds = ds.filter(lambda row: row["category"] == "lake")
+# ds = ds.repartition(32)
+
 # Most jobs can also start with the default parallelism and batch_size.
-result_ds = map_with_blobs(ds, blob_cols, process_batch)
+result_ds = docs.map_with_blobs(ds, blob_cols, process_batch)
 ```
 
 `process_batch` must return a Ray-compatible batch, such as a small
 `pyarrow.Table`. For side-effect-only jobs, return an empty table rather than
 `None`. Avoid returning raw BLOB bytes, which would materialize large payloads
-in Ray's object store. Call `map_with_blobs` directly on the Dataset returned by
-`to_ray()`; if intermediate Ray transforms drop Dataset metadata, pass `file_io`
-and `all_blob_columns` explicitly.
+in Ray's object store. Use `MultimodalTable.map_with_blobs(...)` when applying
+Ray transforms between `to_ray()` and BLOB processing; the table supplies the
+BLOB read context.
 
 Optional tuning parameters:
 

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -385,9 +385,8 @@ Notes:
 
 ### Distributed BLOB processing with Ray
 
-For larger offline jobs, `scan().to_ray()` reads scalar columns plus BLOB
-Descriptors as a Ray Dataset, and `map_with_blobs` fetches BLOB bytes on Ray
-workers before calling your UDF.
+For larger jobs, read descriptors with `to_ray()`, then fetch and process BLOB
+bytes on Ray workers with `map_with_blobs`.
 
 ```python
 import ray
@@ -396,29 +395,21 @@ import pypaimon.multimodal as pm
 
 ray.init(num_cpus=8)
 
-conn = pm.connect(
-    database="default",
-    options={"warehouse": "file:///tmp/warehouse"},
-)
+conn = pm.connect(database="default", options={"warehouse": "file:///tmp/warehouse"})
 docs = conn.get_table("docs")
 
 ids = ["a", "b", "c"]
-in_clause = ", ".join(f"'{i}'" for i in ids)
-
 scalar_cols = ["id", "category"]
 blob_cols = ["image"]
+in_clause = ", ".join(f"'{i}'" for i in ids)
 
 
 def process_batch(scalar_batch, blobs):
-    # scalar_batch is a pyarrow.Table with non-BLOB columns.
-    # blobs is dict[str, list[bytes | None]].
     images = blobs["image"]
-
-    # Decode, infer, write samples, or train here. Return a small result.
+    # Decode, infer, write samples, or train here.
     return pa.table({"rows": [scalar_batch.num_rows]})
 
 
-# Most jobs can leave concurrency / override_num_blocks unset; Ray chooses them.
 ds = (
     docs.scan()
     .where(f"id IN ({in_clause})")
@@ -426,32 +417,19 @@ ds = (
     .to_ray()
 )
 
-# Optional Ray transforms are fine as long as BLOB descriptor columns remain.
+# Optional Ray transforms are fine if BLOB descriptor columns remain.
 # ds = ds.filter(lambda row: row["category"] == "lake")
-# ds = ds.repartition(32)
 
-# Multiple BLOB tables: map each source separately.
-# Most jobs can also start with the default parallelism and batch_size.
 result_ds = docs.map_with_blobs(ds, blob_cols, process_batch)
 ```
 
-`process_batch` must return a Ray-compatible batch, such as a small
-`pyarrow.Table`. For side-effect-only jobs, return an empty table rather than
-`None`. Avoid returning raw BLOB bytes, which would materialize large payloads
-in Ray's object store. Use `MultimodalTable.map_with_blobs(...)` when applying
-Ray transforms between `to_ray()` and BLOB processing; the table supplies the
-BLOB read context.
+Notes:
 
-Optional tuning parameters:
-
-- `to_ray(concurrency=...)` limits concurrent Ray read tasks. By default, Ray
-  decides based on available resources.
-- `to_ray(override_num_blocks=...)` controls Ray Dataset block count. Most jobs
-  do not need to set it manually.
-- `map_with_blobs(parallelism=...)` controls the per-Ray-task BLOB fetch threads.
-  It is not the number of Ray workers.
-- `map_with_blobs(batch_size=...)` controls rows per UDF call. Reduce it when
-  individual BLOBs are large or worker memory is tight.
+- `process_batch` must return a small Ray-compatible batch; return an empty
+  `pyarrow.Table` for side-effect-only jobs.
+- Avoid returning raw BLOB bytes, which would materialize payloads in Ray's
+  object store.
+- Tune `to_ray(...)` and `map_with_blobs(...)` parameters only when needed.
 
 ## Row IDs
 

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -434,7 +434,9 @@ result_ds = map_with_blobs(ds, blob_cols, process_batch)
 `process_batch` must return a Ray-compatible batch, such as a small
 `pyarrow.Table`. For side-effect-only jobs, return an empty table rather than
 `None`. Avoid returning raw BLOB bytes, which would materialize large payloads
-in Ray's object store.
+in Ray's object store. Call `map_with_blobs` directly on the Dataset returned by
+`to_ray()`; if intermediate Ray transforms drop Dataset metadata, pass `file_io`
+and `all_blob_columns` explicitly.
 
 Optional tuning parameters:
 

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -430,7 +430,7 @@ ds = (
 # ds = ds.filter(lambda row: row["category"] == "lake")
 # ds = ds.repartition(32)
 
-# For multiple BLOB tables, process each BLOB source with its own table context.
+# Multiple BLOB tables: map each source separately.
 # Most jobs can also start with the default parallelism and batch_size.
 result_ds = docs.map_with_blobs(ds, blob_cols, process_batch)
 ```

--- a/docs/docs/pypaimon/multimodal-api.mdx
+++ b/docs/docs/pypaimon/multimodal-api.mdx
@@ -430,6 +430,7 @@ ds = (
 # ds = ds.filter(lambda row: row["category"] == "lake")
 # ds = ds.repartition(32)
 
+# For multiple BLOB tables, process each BLOB source with its own table context.
 # Most jobs can also start with the default parallelism and batch_size.
 result_ds = docs.map_with_blobs(ds, blob_cols, process_batch)
 ```

--- a/paimon-python/pypaimon/multimodal/blob_read.py
+++ b/paimon-python/pypaimon/multimodal/blob_read.py
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Shared helpers for materialising multimodal BLOB descriptor columns."""
+
+
+def fetch_blob_bodies(file_io, data, blob_cols, parallelism):
+    """Fetch BLOB payload bytes for descriptor/inline/null cells.
+
+    ``data`` is a ``dict`` mapping each BLOB column name to row-aligned cells.
+    Each cell may be serialized ``BlobDescriptor`` bytes, inline payload bytes,
+    or ``None``. Returned values preserve row order and are grouped per column.
+    """
+    from pypaimon.table.row.blob import BlobDescriptor, BlobViewStruct
+
+    ranges = []
+    inline = {}
+    index = 0
+    for col in blob_cols:
+        for value in data[col]:
+            if value is None:
+                ranges.append(None)
+            else:
+                raw = bytes(value)
+                if BlobViewStruct.is_blob_view_struct(raw):
+                    raise ValueError(
+                        "read_blobs does not support unresolved blob-view columns; "
+                        "read such a column on its own, or enable blob-view resolution.")
+                if BlobDescriptor.is_blob_descriptor(raw):
+                    descriptor = BlobDescriptor.deserialize(raw)
+                    ranges.append((descriptor.uri, descriptor.offset, descriptor.length))
+                else:
+                    ranges.append(None)
+                    inline[index] = raw
+            index += 1
+
+    fetched = file_io.read_ranges_coalesced(ranges, parallelism)
+    for index, raw in inline.items():
+        fetched[index] = raw
+
+    bodies = {}
+    offset = 0
+    for col in blob_cols:
+        count = len(data[col])
+        bodies[col] = fetched[offset:offset + count]
+        offset += count
+    return bodies

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -114,9 +114,8 @@ class ScanQuery:
             **read_args):
         """Read this scan as a Ray Dataset.
 
-        BLOB columns are read as serialized descriptors, so callers can run
-        :func:`pypaimon.ray.map_with_blobs` on the returned Dataset to read payload
-        bytes and process them on Ray workers.
+        BLOB columns are read as serialized descriptors. Use
+        ``table.map_with_blobs(...)`` to fetch payload bytes on Ray workers.
         """
         if self._result_factory is not None:
             raise TypeError("to_ray is only supported on scan(), not search queries.")

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -135,6 +135,7 @@ class ScanQuery:
                 fn_kwargs={"columns": visible_columns},
                 batch_format="pyarrow")
         setattr(ds, "_paimon_blob_file_io", file_io)
+        setattr(ds, "_paimon_blob_columns", self._all_blob_columns())
         return ds
 
     def read_blobs(
@@ -203,11 +204,15 @@ class ScanQuery:
         if projection is None:
             return read_builder, read_table.file_io, None
         internal_column_names = [field.name for field in read_builder.read_type()]
-        internal_columns = set(internal_column_names)
-        visible_columns = [name for name in projection if name in internal_columns]
+        visible_columns = self._projected_output_columns(read_table, projection)
         if visible_columns == internal_column_names:
             visible_columns = None
         return read_builder, read_table.file_io, visible_columns
+
+    @staticmethod
+    def _projected_output_columns(table, projection):
+        builder = table.new_read_builder().with_projection(projection)
+        return [field.name for field in builder.read_type()]
 
     def _blob_descriptor_read_builder(self, blob_cols: List[str]):
         """Blob-as-descriptor read builder with this query's filter/projection/limit;

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -115,7 +115,7 @@ class ScanQuery:
         """Read this scan as a Ray Dataset.
 
         BLOB columns are read as serialized descriptors, so callers can run
-        :func:`pypaimon.ray.map_blobs` on the returned Dataset to read payload
+        :func:`pypaimon.ray.map_with_blobs` on the returned Dataset to read payload
         bytes and process them on Ray workers.
         """
         if self._result_factory is not None:

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -15,12 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pyarrow as pa
 
 from pypaimon.common.where_parser import parse_where_clause
+from pypaimon.multimodal.blob_read import fetch_blob_bodies
 from pypaimon.table.special_fields import SpecialFields
+
+
+def _select_arrow_columns(batch, columns):
+    return batch.select(columns)
 
 
 class ScanQuery:
@@ -100,6 +105,38 @@ class ScanQuery:
     def to_list(self) -> List[dict]:
         return self.to_arrow().to_pylist()
 
+    def to_ray(
+            self,
+            *,
+            ray_remote_args: Optional[Dict[str, Any]] = None,
+            concurrency: Optional[int] = None,
+            override_num_blocks: Optional[int] = None,
+            **read_args):
+        """Read this scan as a Ray Dataset.
+
+        BLOB columns are read as serialized descriptors, so callers can run
+        :func:`pypaimon.ray.read_blobs` on the returned Dataset to materialise
+        payload bytes on Ray workers.
+        """
+        if self._result_factory is not None:
+            raise TypeError("to_ray is only supported on scan(), not search queries.")
+
+        read_builder, file_io, visible_columns = self._blob_descriptor_query_read_builder()
+        plan = read_builder.new_scan().plan()
+        ds = read_builder.new_read().to_ray(
+            plan.splits(),
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+            override_num_blocks=override_num_blocks,
+            **read_args)
+        if visible_columns is not None:
+            ds = ds.map_batches(
+                _select_arrow_columns,
+                fn_kwargs={"columns": visible_columns},
+                batch_format="pyarrow")
+        setattr(ds, "_paimon_blob_file_io", file_io)
+        return ds
+
     def read_blobs(
             self, columns=None, *, parallelism: int = 64
     ) -> Tuple[pa.Table, Dict[str, List[Optional[bytes]]]]:
@@ -146,6 +183,32 @@ class ScanQuery:
             if hasattr(reader, "close"):
                 reader.close()
 
+    def _blob_descriptor_query_read_builder(self):
+        from pypaimon.common.options.core_options import CoreOptions
+        read_table = self._table.copy({
+            CoreOptions.BLOB_AS_DESCRIPTOR.key(): "true"
+        })
+        read_builder = read_table.new_read_builder()
+        if self._predicate is not None:
+            read_builder = read_builder.with_filter(self._predicate)
+        projection = self._effective_projection()
+        if projection is not None:
+            internal_projection = list(projection)
+            for name in self._predicate_fields():
+                if name not in internal_projection:
+                    internal_projection.append(name)
+            read_builder = read_builder.with_projection(internal_projection)
+        if self._limit is not None:
+            read_builder = read_builder.with_limit(self._limit)
+        if projection is None:
+            return read_builder, read_table.file_io, None
+        internal_column_names = [field.name for field in read_builder.read_type()]
+        internal_columns = set(internal_column_names)
+        visible_columns = [name for name in projection if name in internal_columns]
+        if visible_columns == internal_column_names:
+            visible_columns = None
+        return read_builder, read_table.file_io, visible_columns
+
     def _blob_descriptor_read_builder(self, blob_cols: List[str]):
         """Blob-as-descriptor read builder with this query's filter/projection/limit;
         returns ``(read_builder, file_io)``."""
@@ -172,37 +235,7 @@ class ScanQuery:
         # ``FileIO.get(uri, catalog_options)`` off the raw options (no merged token),
         # failing with "endpoint should be non-empty" / "Init credential failed" unless
         # the caller also passes fs.oss.* -- which users should not have to.
-        from pypaimon.table.row.blob import BlobDescriptor, BlobViewStruct
-        ranges = []
-        inline = {}  # cell index -> blob stored inline (returned as-is, no ranged read)
-        i = 0
-        for col in blob_cols:
-            for value in data[col]:
-                if value is None:
-                    ranges.append(None)
-                else:
-                    raw = bytes(value)
-                    if BlobViewStruct.is_blob_view_struct(raw):
-                        raise ValueError(
-                            "read_blobs does not support unresolved blob-view columns; "
-                            "read such a column on its own, or enable blob-view resolution.")
-                    if BlobDescriptor.is_blob_descriptor(raw):
-                        d = BlobDescriptor.deserialize(raw)
-                        ranges.append((d.uri, d.offset, d.length))
-                    else:  # blob stored inline: the bytes are the payload
-                        ranges.append(None)
-                        inline[i] = raw
-                i += 1
-        fetched = file_io.read_ranges_coalesced(ranges, parallelism)
-        for idx, raw in inline.items():
-            fetched[idx] = raw
-        bodies = {}
-        offset = 0
-        for col in blob_cols:
-            n = len(data[col])
-            bodies[col] = fetched[offset:offset + n]
-            offset += n
-        return bodies
+        return fetch_blob_bodies(file_io, data, blob_cols, parallelism)
 
     def _all_blob_columns(self) -> List[str]:
         return [
@@ -299,6 +332,9 @@ class _PreFilterQuery(ScanQuery):
 
     def stream_blobs(self, *args, **kwargs):
         raise TypeError("stream_blobs is only supported on scan(), not search queries.")
+
+    def to_ray(self, *args, **kwargs):
+        raise TypeError("to_ray is only supported on scan(), not search queries.")
 
 
 class VectorQuery(_PreFilterQuery):

--- a/paimon-python/pypaimon/multimodal/query.py
+++ b/paimon-python/pypaimon/multimodal/query.py
@@ -115,8 +115,8 @@ class ScanQuery:
         """Read this scan as a Ray Dataset.
 
         BLOB columns are read as serialized descriptors, so callers can run
-        :func:`pypaimon.ray.read_blobs` on the returned Dataset to materialise
-        payload bytes on Ray workers.
+        :func:`pypaimon.ray.map_blobs` on the returned Dataset to read payload
+        bytes and process them on Ray workers.
         """
         if self._result_factory is not None:
             raise TypeError("to_ray is only supported on scan(), not search queries.")

--- a/paimon-python/pypaimon/multimodal/table.py
+++ b/paimon-python/pypaimon/multimodal/table.py
@@ -157,6 +157,18 @@ class MultimodalTable:
     def merge(self, on):
         return _MergeBuilder(self, on)
 
+    def map_with_blobs(self, dataset, columns, fn, **kwargs):
+        from pypaimon.ray import map_with_blobs
+
+        return map_with_blobs(
+            dataset,
+            columns,
+            fn,
+            file_io=self.raw_table.file_io,
+            all_blob_columns=_blob_columns(self.raw_table),
+            **kwargs,
+        )
+
     def scan(
             self,
             *,
@@ -355,6 +367,13 @@ class _MergeBuilder:
             when_not_matched=self._when_not_matched,
             operation="merge",
         )
+
+
+def _blob_columns(table):
+    return tuple(
+        field.name for field in table.fields
+        if getattr(field.type, "type", None) == "BLOB"
+    )
 
 
 def _to_arrow_table(data, target_schema=None):

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pypaimon.ray.ray_paimon import read_paimon, write_paimon
+from pypaimon.ray.ray_paimon import read_blobs, read_paimon, write_paimon
 from pypaimon.ray.bucket_join import bucket_join
 from pypaimon.ray.data_evolution_merge_into import (
     WhenMatched,
@@ -30,6 +30,7 @@ from pypaimon.ray.data_evolution_merge_transform import (
 
 __all__ = [
     "read_paimon",
+    "read_blobs",
     "write_paimon",
     "bucket_join",
     "merge_into",

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pypaimon.ray.ray_paimon import map_blobs, read_paimon, write_paimon
+from pypaimon.ray.ray_paimon import map_with_blobs, read_paimon, write_paimon
 from pypaimon.ray.bucket_join import bucket_join
 from pypaimon.ray.data_evolution_merge_into import (
     WhenMatched,
@@ -30,7 +30,7 @@ from pypaimon.ray.data_evolution_merge_transform import (
 
 __all__ = [
     "read_paimon",
-    "map_blobs",
+    "map_with_blobs",
     "write_paimon",
     "bucket_join",
     "merge_into",

--- a/paimon-python/pypaimon/ray/__init__.py
+++ b/paimon-python/pypaimon/ray/__init__.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pypaimon.ray.ray_paimon import read_blobs, read_paimon, write_paimon
+from pypaimon.ray.ray_paimon import map_blobs, read_paimon, write_paimon
 from pypaimon.ray.bucket_join import bucket_join
 from pypaimon.ray.data_evolution_merge_into import (
     WhenMatched,
@@ -30,7 +30,7 @@ from pypaimon.ray.data_evolution_merge_transform import (
 
 __all__ = [
     "read_paimon",
-    "read_blobs",
+    "map_blobs",
     "write_paimon",
     "bucket_join",
     "merge_into",

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -143,6 +143,7 @@ def read_blobs(
     *,
     file_io=None,
     parallelism: int = 64,
+    batch_size: Optional[int] = 1024,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     **map_args,
 ) -> "ray.data.Dataset":
@@ -153,7 +154,9 @@ def read_blobs(
     table. The returned Dataset has the same schema shape, with the requested
     BLOB columns replaced by payload bytes. Work runs inside Ray ``map_batches``
     tasks, so descriptor batches stay distributed instead of being collected on
-    the driver.
+    the driver. ``batch_size`` bounds how many rows are materialised by one
+    worker task, which avoids very large Ray blocks turning into large in-memory
+    payload batches.
     """
     _require_ray_data()
 
@@ -165,6 +168,8 @@ def read_blobs(
         raise ValueError("columns must contain at least one BLOB column")
     if parallelism < 1:
         raise ValueError("parallelism must be at least 1, got {}".format(parallelism))
+    if batch_size is not None and batch_size < 1:
+        raise ValueError("batch_size must be at least 1, got {}".format(batch_size))
 
     resolved_file_io = file_io
     if resolved_file_io is None:
@@ -176,6 +181,8 @@ def read_blobs(
 
     kwargs = dict(map_args)
     kwargs.setdefault("batch_format", "pyarrow")
+    if batch_size is not None:
+        kwargs.setdefault("batch_size", batch_size)
     if ray_remote_args is not None:
         kwargs.update(ray_remote_args)
 

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -177,7 +177,7 @@ def read_blobs(
     kwargs = dict(map_args)
     kwargs.setdefault("batch_format", "pyarrow")
     if ray_remote_args is not None:
-        kwargs["ray_remote_args"] = ray_remote_args
+        kwargs.update(ray_remote_args)
 
     return dataset.map_batches(
         _read_blob_batch,

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -238,10 +238,18 @@ def _map_blob_batch(
         raise ValueError("BLOB column(s) not found in Ray Dataset: {}".format(
             ", ".join(missing)))
 
-    bodies = fetch_blob_bodies(
-        file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
     all_blob = set(all_blob_cols)
     scalar_cols = [name for name in batch.schema.names if name not in all_blob]
+    unknown = _unknown_blob_descriptor_columns(batch, scalar_cols)
+    if unknown:
+        raise ValueError(
+            "Column {!r} holds BLOB descriptors this table does not own "
+            "(likely from a joined BLOB table). Fetch it with its own "
+            "table.map_with_blobs() in a separate pass, or drop it before "
+            "mapping.".format(unknown[0]))
+
+    bodies = fetch_blob_bodies(
+        file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
     result = fn(batch.select(scalar_cols), bodies, **fn_kwargs)
     if result is None:
         raise ValueError(
@@ -249,6 +257,26 @@ def _map_blob_batch(
             "pyarrow.Table. For side-effect-only processing, return an empty "
             "pyarrow.Table instead of None.")
     return result
+
+
+def _unknown_blob_descriptor_columns(batch, scalar_cols):
+    return [
+        name for name in scalar_cols
+        if _looks_like_blob_descriptor(batch.column(name))]
+
+
+def _looks_like_blob_descriptor(column):
+    import pyarrow as pa
+    from pypaimon.table.row.blob import BlobDescriptor
+
+    if not (pa.types.is_binary(column.type) or pa.types.is_large_binary(column.type)):
+        return False
+    chunks = getattr(column, "chunks", None) or [column]
+    for chunk in chunks:
+        for value in chunk:
+            if value.is_valid:
+                return BlobDescriptor.is_blob_descriptor(value.as_py())
+    return False
 
 
 def write_paimon(

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -137,6 +137,79 @@ def read_paimon(
     return ds
 
 
+def read_blobs(
+    dataset: "ray.data.Dataset",
+    columns,
+    *,
+    file_io=None,
+    parallelism: int = 64,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+    **map_args,
+) -> "ray.data.Dataset":
+    """Materialise serialized BlobDescriptor columns in a Ray Dataset.
+
+    The input Dataset is expected to contain BLOB columns read as serialized
+    descriptor bytes, e.g. from ``table.scan().to_ray(...)`` on a multimodal
+    table. The returned Dataset has the same schema shape, with the requested
+    BLOB columns replaced by payload bytes. Work runs inside Ray ``map_batches``
+    tasks, so descriptor batches stay distributed instead of being collected on
+    the driver.
+    """
+    _require_ray_data()
+
+    if isinstance(columns, str):
+        blob_cols = [columns]
+    else:
+        blob_cols = list(dict.fromkeys(columns))
+    if not blob_cols:
+        raise ValueError("columns must contain at least one BLOB column")
+    if parallelism < 1:
+        raise ValueError("parallelism must be at least 1, got {}".format(parallelism))
+
+    resolved_file_io = file_io
+    if resolved_file_io is None:
+        resolved_file_io = getattr(dataset, "_paimon_blob_file_io", None)
+    if resolved_file_io is None:
+        raise ValueError(
+            "read_blobs requires a FileIO. Use table.scan().to_ray(...) on a "
+            "multimodal table, or pass file_io= explicitly.")
+
+    kwargs = dict(map_args)
+    kwargs.setdefault("batch_format", "pyarrow")
+    if ray_remote_args is not None:
+        kwargs["ray_remote_args"] = ray_remote_args
+
+    return dataset.map_batches(
+        _read_blob_batch,
+        fn_kwargs={
+            "file_io": resolved_file_io,
+            "blob_cols": blob_cols,
+            "parallelism": parallelism,
+        },
+        **kwargs)
+
+
+def _read_blob_batch(batch, file_io, blob_cols, parallelism):
+    import pyarrow as pa
+    from pypaimon.multimodal.blob_read import fetch_blob_bodies
+
+    missing = [name for name in blob_cols if name not in batch.schema.names]
+    if missing:
+        raise ValueError("BLOB column(s) not found in Ray Dataset: {}".format(
+            ", ".join(missing)))
+
+    bodies = fetch_blob_bodies(file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
+    arrays = []
+    fields = []
+    for field in batch.schema:
+        if field.name in bodies:
+            arrays.append(pa.array(bodies[field.name], type=pa.large_binary()))
+            fields.append(pa.field(field.name, pa.large_binary(), nullable=field.nullable))
+        else:
+            arrays.append(batch.column(field.name))
+            fields.append(field)
+    return pa.Table.from_arrays(arrays, schema=pa.schema(fields))
+
 def write_paimon(
     dataset: "ray.data.Dataset",
     table_identifier: str,

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -27,7 +27,7 @@ Usage::
 """
 
 import importlib
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from pypaimon.common.predicate import Predicate
 
@@ -137,29 +137,45 @@ def read_paimon(
     return ds
 
 
-def read_blobs(
+def map_blobs(
     dataset: "ray.data.Dataset",
     columns,
+    fn: Callable,
     *,
     file_io=None,
     parallelism: int = 64,
     batch_size: Optional[int] = 1024,
+    fn_kwargs: Optional[Dict[str, Any]] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     **map_args,
 ) -> "ray.data.Dataset":
-    """Materialise serialized BlobDescriptor columns in a Ray Dataset.
+    """Read BLOB payloads on Ray workers and apply a batch function.
 
     The input Dataset is expected to contain BLOB columns read as serialized
     descriptor bytes, e.g. from ``table.scan().to_ray(...)`` on a multimodal
-    table. The returned Dataset has the same schema shape, with the requested
-    BLOB columns replaced by payload bytes. Work runs inside Ray ``map_batches``
-    tasks, so descriptor batches stay distributed instead of being collected on
-    the driver. ``batch_size`` bounds how many rows are materialised by one
-    worker task, which avoids very large Ray blocks turning into large in-memory
-    payload batches.
+    table. For each Ray batch, the requested BLOB columns are fetched as
+    row-aligned ``bytes`` lists and passed to ``fn`` together with the scalar
+    columns::
+
+        fn(scalar_batch, blobs, **fn_kwargs)
+
+    ``scalar_batch`` is a ``pyarrow.Table`` with non-BLOB columns. ``blobs`` is
+    a ``dict`` mapping each requested BLOB column to ``List[bytes | None]``.
+    The return value of ``fn`` becomes the output Ray Dataset. Large jobs should
+    return a small ``pyarrow.Table`` with processed results, such as embeddings
+    or output paths, instead of returning raw BLOB bytes. For side-effect-only
+    processing, return an empty ``pyarrow.Table`` rather than ``None``.
+
+    ``file_io`` is resolved from the Dataset created by
+    ``table.scan().to_ray(...)`` by default. ``ray_remote_args`` and
+    ``**map_args`` are forwarded to ``ray.data.Dataset.map_batches``; use them
+    for Ray execution options such as CPU resources, retries, and concurrency.
+    ``batch_format`` is always ``"pyarrow"``.
     """
     _require_ray_data()
 
+    if not callable(fn):
+        raise ValueError("fn must be callable")
     if isinstance(columns, str):
         blob_cols = [columns]
     else:
@@ -176,28 +192,33 @@ def read_blobs(
         resolved_file_io = getattr(dataset, "_paimon_blob_file_io", None)
     if resolved_file_io is None:
         raise ValueError(
-            "read_blobs requires a FileIO. Use table.scan().to_ray(...) on a "
+            "map_blobs requires a FileIO. Use table.scan().to_ray(...) on a "
             "multimodal table, or pass file_io= explicitly.")
 
+    batch_format = map_args.pop("batch_format", "pyarrow")
+    if batch_format != "pyarrow":
+        raise ValueError("map_blobs requires batch_format='pyarrow'")
+
     kwargs = dict(map_args)
-    kwargs.setdefault("batch_format", "pyarrow")
+    kwargs["batch_format"] = "pyarrow"
     if batch_size is not None:
         kwargs.setdefault("batch_size", batch_size)
     if ray_remote_args is not None:
         kwargs.update(ray_remote_args)
 
     return dataset.map_batches(
-        _read_blob_batch,
+        _map_blob_batch,
         fn_kwargs={
             "file_io": resolved_file_io,
             "blob_cols": blob_cols,
             "parallelism": parallelism,
+            "fn": fn,
+            "fn_kwargs": dict(fn_kwargs or {}),
         },
         **kwargs)
 
 
-def _read_blob_batch(batch, file_io, blob_cols, parallelism):
-    import pyarrow as pa
+def _map_blob_batch(batch, file_io, blob_cols, parallelism, fn, fn_kwargs):
     from pypaimon.multimodal.blob_read import fetch_blob_bodies
 
     missing = [name for name in blob_cols if name not in batch.schema.names]
@@ -205,17 +226,17 @@ def _read_blob_batch(batch, file_io, blob_cols, parallelism):
         raise ValueError("BLOB column(s) not found in Ray Dataset: {}".format(
             ", ".join(missing)))
 
-    bodies = fetch_blob_bodies(file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
-    arrays = []
-    fields = []
-    for field in batch.schema:
-        if field.name in bodies:
-            arrays.append(pa.array(bodies[field.name], type=pa.large_binary()))
-            fields.append(pa.field(field.name, pa.large_binary(), nullable=field.nullable))
-        else:
-            arrays.append(batch.column(field.name))
-            fields.append(field)
-    return pa.Table.from_arrays(arrays, schema=pa.schema(fields))
+    bodies = fetch_blob_bodies(
+        file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
+    scalar_cols = [name for name in batch.schema.names if name not in blob_cols]
+    result = fn(batch.select(scalar_cols), bodies, **fn_kwargs)
+    if result is None:
+        raise ValueError(
+            "map_blobs UDF must return a Ray-compatible batch, such as a "
+            "pyarrow.Table. For side-effect-only processing, return an empty "
+            "pyarrow.Table instead of None.")
+    return result
+
 
 def write_paimon(
     dataset: "ray.data.Dataset",

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -137,7 +137,7 @@ def read_paimon(
     return ds
 
 
-def map_blobs(
+def map_with_blobs(
     dataset: "ray.data.Dataset",
     columns,
     fn: Callable,
@@ -177,12 +177,12 @@ def map_blobs(
         resolved_file_io = getattr(dataset, "_paimon_blob_file_io", None)
     if resolved_file_io is None:
         raise ValueError(
-            "map_blobs requires a FileIO. Use table.scan().to_ray() or "
+            "map_with_blobs requires a FileIO. Use table.scan().to_ray() or "
             "pass file_io= explicitly.")
 
     batch_format = map_args.pop("batch_format", "pyarrow")
     if batch_format != "pyarrow":
-        raise ValueError("map_blobs requires batch_format='pyarrow'")
+        raise ValueError("map_with_blobs requires batch_format='pyarrow'")
 
     kwargs = dict(map_args)
     kwargs["batch_format"] = "pyarrow"
@@ -192,7 +192,12 @@ def map_blobs(
         _set_map_batches_remote_args(dataset, kwargs, ray_remote_args)
 
     all_blob_cols = getattr(dataset, "_paimon_blob_columns", None)
-    if all_blob_cols is None:
+    if all_blob_cols is not None:
+        all_blob = set(all_blob_cols)
+        invalid = [name for name in blob_cols if name not in all_blob]
+        if invalid:
+            raise ValueError("Column {!r} is not a BLOB column.".format(invalid[0]))
+    else:
         all_blob_cols = blob_cols
 
     return dataset.map_batches(
@@ -234,7 +239,7 @@ def _map_blob_batch(
     result = fn(batch.select(scalar_cols), bodies, **fn_kwargs)
     if result is None:
         raise ValueError(
-            "map_blobs UDF must return a Ray-compatible batch, such as a "
+            "map_with_blobs UDF must return a Ray-compatible batch, such as a "
             "pyarrow.Table. For side-effect-only processing, return an empty "
             "pyarrow.Table instead of None.")
     return result

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -149,28 +149,13 @@ def map_blobs(
     ray_remote_args: Optional[Dict[str, Any]] = None,
     **map_args,
 ) -> "ray.data.Dataset":
-    """Read BLOB payloads on Ray workers and apply a batch function.
+    """Fetch BLOB payloads in Ray batches and call ``fn``.
 
-    The input Dataset is expected to contain BLOB columns read as serialized
-    descriptor bytes, e.g. from ``table.scan().to_ray(...)`` on a multimodal
-    table. For each Ray batch, the requested BLOB columns are fetched as
-    row-aligned ``bytes`` lists and passed to ``fn`` together with the scalar
-    columns::
-
-        fn(scalar_batch, blobs, **fn_kwargs)
-
-    ``scalar_batch`` is a ``pyarrow.Table`` with non-BLOB columns. ``blobs`` is
-    a ``dict`` mapping each requested BLOB column to ``List[bytes | None]``.
-    The return value of ``fn`` becomes the output Ray Dataset. Large jobs should
-    return a small ``pyarrow.Table`` with processed results, such as embeddings
-    or output paths, instead of returning raw BLOB bytes. For side-effect-only
-    processing, return an empty ``pyarrow.Table`` rather than ``None``.
-
-    ``file_io`` is resolved from the Dataset created by
-    ``table.scan().to_ray(...)`` by default. ``ray_remote_args`` and
-    ``**map_args`` are forwarded to ``ray.data.Dataset.map_batches``; use them
-    for Ray execution options such as CPU resources, retries, and concurrency.
-    ``batch_format`` is always ``"pyarrow"``.
+    ``fn(scalar_batch, blobs, **fn_kwargs)`` receives a ``pyarrow.Table`` of
+    non-BLOB columns and a row-aligned ``dict`` of BLOB bytes. Return a small
+    Ray-compatible batch; for side-effect-only work, return an empty
+    ``pyarrow.Table`` instead of ``None``. Tune ``batch_size`` for BLOB size and
+    worker memory.
     """
     _require_ray_data()
 
@@ -192,8 +177,8 @@ def map_blobs(
         resolved_file_io = getattr(dataset, "_paimon_blob_file_io", None)
     if resolved_file_io is None:
         raise ValueError(
-            "map_blobs requires a FileIO. Use table.scan().to_ray(...) on a "
-            "multimodal table, or pass file_io= explicitly.")
+            "map_blobs requires a FileIO. Use table.scan().to_ray() or "
+            "pass file_io= explicitly.")
 
     batch_format = map_args.pop("batch_format", "pyarrow")
     if batch_format != "pyarrow":
@@ -204,13 +189,18 @@ def map_blobs(
     if batch_size is not None:
         kwargs.setdefault("batch_size", batch_size)
     if ray_remote_args is not None:
-        kwargs.update(ray_remote_args)
+        _set_map_batches_remote_args(dataset, kwargs, ray_remote_args)
+
+    all_blob_cols = getattr(dataset, "_paimon_blob_columns", None)
+    if all_blob_cols is None:
+        all_blob_cols = blob_cols
 
     return dataset.map_batches(
         _map_blob_batch,
         fn_kwargs={
             "file_io": resolved_file_io,
             "blob_cols": blob_cols,
+            "all_blob_cols": list(all_blob_cols),
             "parallelism": parallelism,
             "fn": fn,
             "fn_kwargs": dict(fn_kwargs or {}),
@@ -218,7 +208,18 @@ def map_blobs(
         **kwargs)
 
 
-def _map_blob_batch(batch, file_io, blob_cols, parallelism, fn, fn_kwargs):
+def _set_map_batches_remote_args(dataset, kwargs, ray_remote_args):
+    import inspect
+
+    param = inspect.signature(dataset.map_batches).parameters.get("ray_remote_args")
+    if param is not None and param.kind != inspect.Parameter.VAR_KEYWORD:
+        kwargs["ray_remote_args"] = ray_remote_args
+    else:
+        kwargs.update(ray_remote_args)
+
+
+def _map_blob_batch(
+        batch, file_io, blob_cols, all_blob_cols, parallelism, fn, fn_kwargs):
     from pypaimon.multimodal.blob_read import fetch_blob_bodies
 
     missing = [name for name in blob_cols if name not in batch.schema.names]
@@ -228,7 +229,8 @@ def _map_blob_batch(batch, file_io, blob_cols, parallelism, fn, fn_kwargs):
 
     bodies = fetch_blob_bodies(
         file_io, batch.select(blob_cols).to_pydict(), blob_cols, parallelism)
-    scalar_cols = [name for name in batch.schema.names if name not in blob_cols]
+    all_blob = set(all_blob_cols)
+    scalar_cols = [name for name in batch.schema.names if name not in all_blob]
     result = fn(batch.select(scalar_cols), bodies, **fn_kwargs)
     if result is None:
         raise ValueError(

--- a/paimon-python/pypaimon/ray/ray_paimon.py
+++ b/paimon-python/pypaimon/ray/ray_paimon.py
@@ -143,6 +143,7 @@ def map_with_blobs(
     fn: Callable,
     *,
     file_io=None,
+    all_blob_columns=None,
     parallelism: int = 64,
     batch_size: Optional[int] = 1024,
     fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -154,8 +155,9 @@ def map_with_blobs(
     ``fn(scalar_batch, blobs, **fn_kwargs)`` receives a ``pyarrow.Table`` of
     non-BLOB columns and a row-aligned ``dict`` of BLOB bytes. Return a small
     Ray-compatible batch; for side-effect-only work, return an empty
-    ``pyarrow.Table`` instead of ``None``. Tune ``batch_size`` for BLOB size and
-    worker memory.
+    ``pyarrow.Table`` instead of ``None``. Call this directly on
+    ``scan().to_ray()`` output, or pass ``file_io`` and ``all_blob_columns``.
+    Tune ``batch_size`` for BLOB size and worker memory.
     """
     _require_ray_data()
 
@@ -191,14 +193,18 @@ def map_with_blobs(
     if ray_remote_args is not None:
         _set_map_batches_remote_args(dataset, kwargs, ray_remote_args)
 
-    all_blob_cols = getattr(dataset, "_paimon_blob_columns", None)
-    if all_blob_cols is not None:
-        all_blob = set(all_blob_cols)
-        invalid = [name for name in blob_cols if name not in all_blob]
-        if invalid:
-            raise ValueError("Column {!r} is not a BLOB column.".format(invalid[0]))
-    else:
-        all_blob_cols = blob_cols
+    all_blob_cols = all_blob_columns
+    if all_blob_cols is None:
+        all_blob_cols = getattr(dataset, "_paimon_blob_columns", None)
+    if all_blob_cols is None:
+        raise ValueError(
+            "map_with_blobs requires all_blob_columns when Dataset lacks "
+            "BLOB metadata.")
+
+    all_blob = set(all_blob_cols)
+    invalid = [name for name in blob_cols if name not in all_blob]
+    if invalid:
+        raise ValueError("Column {!r} is not a BLOB column.".format(invalid[0]))
 
     return dataset.map_batches(
         _map_blob_batch,

--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -238,6 +238,7 @@ class RayDatasource(Datasource):
             metadata = BlockMetadata(**metadata_kwargs)
 
             read_fn = partial(get_read_task, chunk_splits)
+            read_fn.__name__ = "read_paimon_table"
             read_task_kwargs = {
                 'read_fn': read_fn,
                 'metadata': metadata,

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1079,6 +1079,70 @@ class MultimodalTableTest(unittest.TestCase):
             if started_ray:
                 ray.shutdown()
 
+    @unittest.skipIf(ray is None, "ray is not installed")
+    def test_scan_to_ray_map_with_blobs_guards(self):
+        started_ray = False
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+            started_ray = True
+        obs = self.conn.create_table(
+            "ray_obs_guards",
+            schema=_schema({
+                "clip": pa.string(),
+                "idx": pa.int32(),
+                "image": pa.large_binary(),
+            }),
+            options=_PARQUET_OPTIONS,
+            partitioned=["clip"],
+        )
+        obs.add([{"clip": "c1", "idx": 0, "image": b"img-0"}])
+
+        def return_none(scalar, blobs):
+            return None
+
+        try:
+            from pypaimon.ray import map_with_blobs
+
+            ds = (
+                obs.scan()
+                .where("clip = 'c1'")
+                .select(["idx", "image"])
+                .to_ray(concurrency=1, override_num_blocks=1)
+            )
+
+            with self.assertRaisesRegex(ValueError, "all_blob_columns"):
+                map_with_blobs(
+                    ray.data.from_arrow(pa.table({"image": [b"inline"]})),
+                    ["image"],
+                    lambda scalar, blobs: pa.table({"rows": [scalar.num_rows]}),
+                    file_io=obs.raw_table.file_io,
+                )
+
+            with self.assertRaisesRegex(Exception, "must return"):
+                obs.map_with_blobs(
+                    ds,
+                    ["image"],
+                    return_none,
+                    batch_size=1,
+                ).take_all()
+
+            empty_ds = (
+                obs.scan()
+                .where("clip = 'none'")
+                .select(["idx", "image"])
+                .to_ray(concurrency=1, override_num_blocks=1)
+            )
+            result = obs.map_with_blobs(
+                empty_ds,
+                ["image"],
+                lambda scalar, blobs: pa.table({"rows": [scalar.num_rows]}),
+                batch_size=1,
+            )
+            self.assertEqual([], result.take_all())
+        finally:
+            if started_ray:
+                ray.shutdown()
+
     def test_scan_to_ray_nested_projection_output_names(self):
         obs = self.conn.create_table(
             "ray_nested_obs",

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1021,7 +1021,7 @@ class MultimodalTableTest(unittest.TestCase):
                 .select(["idx", "image", "audio"])
                 .to_ray(concurrency=1, override_num_blocks=1)
             )
-            ds = read_blobs(ds, ["image", "audio"], parallelism=2)
+            ds = read_blobs(ds, ["image", "audio"], parallelism=2, batch_size=1)
             rows = sorted(ds.to_pandas().to_dict("records"), key=lambda row: row["idx"])
 
             self.assertEqual(

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1032,26 +1032,22 @@ class MultimodalTableTest(unittest.TestCase):
                 .select(["idx", "image", "audio"])
                 .to_ray(concurrency=1, override_num_blocks=1)
             )
-            with self.assertRaisesRegex(ValueError, "not a BLOB column"):
-                map_with_blobs(ds, ["idx"], collect_batch)
+            ds = ds.filter(lambda row: row["idx"] >= 0)
 
-            blob_columns = getattr(ds, "_paimon_blob_columns")
-            delattr(ds, "_paimon_blob_columns")
-            try:
-                with self.assertRaisesRegex(ValueError, "all_blob_columns"):
-                    map_with_blobs(ds, ["image"], collect_batch)
-                result = map_with_blobs(
-                    ds,
-                    ["image"],
-                    collect_batch,
-                    all_blob_columns=["image", "audio"],
-                    parallelism=2,
-                    batch_size=1,
-                    fn_kwargs={"prefix": b"got-"},
-                    ray_remote_args={"num_cpus": 1},
-                )
-            finally:
-                setattr(ds, "_paimon_blob_columns", blob_columns)
+            with self.assertRaisesRegex(ValueError, "not a BLOB column"):
+                obs.map_with_blobs(ds, ["idx"], collect_batch)
+            with self.assertRaisesRegex(ValueError, "FileIO"):
+                map_with_blobs(ds, ["image"], collect_batch)
+
+            result = obs.map_with_blobs(
+                ds,
+                ["image"],
+                collect_batch,
+                parallelism=2,
+                batch_size=1,
+                fn_kwargs={"prefix": b"got-"},
+                ray_remote_args={"num_cpus": 1},
+            )
             rows = sorted(result.to_pandas().to_dict("records"), key=lambda row: row["idx"])
 
             self.assertEqual(

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -990,7 +990,7 @@ class MultimodalTableTest(unittest.TestCase):
             [], list(obs.scan().where("clip = 'none'").stream_blobs("image")))
 
     @unittest.skipIf(ray is None, "ray is not installed")
-    def test_scan_to_ray_read_blobs(self):
+    def test_scan_to_ray_map_blobs(self):
         started_ray = False
         if not ray.is_initialized():
             ray.init(ignore_reinit_error=True, num_cpus=2)
@@ -1012,8 +1012,16 @@ class MultimodalTableTest(unittest.TestCase):
             {"clip": "c2", "idx": 0, "image": b"img-x", "audio": b"aud-x"},
         ])
 
+        def collect_batch(scalar, blobs, prefix):
+            self.assertIsInstance(scalar, pa.Table)
+            idxs = scalar.column("idx").to_pylist()
+            rows = []
+            for idx, image, audio in zip(idxs, blobs["image"], blobs["audio"]):
+                rows.append({"idx": idx, "image": prefix + image, "audio": audio})
+            return pa.Table.from_pylist(rows)
+
         try:
-            from pypaimon.ray import read_blobs
+            from pypaimon.ray import map_blobs
 
             ds = (
                 obs.scan()
@@ -1021,13 +1029,21 @@ class MultimodalTableTest(unittest.TestCase):
                 .select(["idx", "image", "audio"])
                 .to_ray(concurrency=1, override_num_blocks=1)
             )
-            ds = read_blobs(ds, ["image", "audio"], parallelism=2, batch_size=1)
-            rows = sorted(ds.to_pandas().to_dict("records"), key=lambda row: row["idx"])
+            result = map_blobs(
+                ds,
+                ["image", "audio"],
+                collect_batch,
+                parallelism=2,
+                batch_size=1,
+                fn_kwargs={"prefix": b"got-"},
+                ray_remote_args={"num_cpus": 1},
+            )
+            rows = sorted(result.to_pandas().to_dict("records"), key=lambda row: row["idx"])
 
             self.assertEqual(
                 [
-                    {"idx": 0, "image": b"img-0", "audio": b"aud-0"},
-                    {"idx": 1, "image": b"img-1", "audio": b"aud-1"},
+                    {"idx": 0, "image": b"got-img-0", "audio": b"aud-0"},
+                    {"idx": 1, "image": b"got-img-1", "audio": b"aud-1"},
                 ],
                 rows,
             )

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -30,6 +30,11 @@ from pypaimon import Schema as PaimonSchema
 from pypaimon.globalindex.global_index_result import GlobalIndexResult
 from pypaimon.utils.range import Range
 
+try:
+    import ray
+except ImportError:
+    ray = None
+
 
 _PARQUET_OPTIONS = {
     "row-tracking.enabled": "true",
@@ -983,6 +988,52 @@ class MultimodalTableTest(unittest.TestCase):
         # empty result streams nothing
         self.assertEqual(
             [], list(obs.scan().where("clip = 'none'").stream_blobs("image")))
+
+    @unittest.skipIf(ray is None, "ray is not installed")
+    def test_scan_to_ray_read_blobs(self):
+        started_ray = False
+        if not ray.is_initialized():
+            ray.init(ignore_reinit_error=True, num_cpus=2)
+            started_ray = True
+        obs = self.conn.create_table(
+            "ray_obs",
+            schema=_schema({
+                "clip": pa.string(),
+                "idx": pa.int32(),
+                "image": pa.large_binary(),
+                "audio": pa.large_binary(),
+            }),
+            options=_PARQUET_OPTIONS,
+            partitioned=["clip"],
+        )
+        obs.add([
+            {"clip": "c1", "idx": 0, "image": b"img-0", "audio": b"aud-0"},
+            {"clip": "c1", "idx": 1, "image": b"img-1", "audio": b"aud-1"},
+            {"clip": "c2", "idx": 0, "image": b"img-x", "audio": b"aud-x"},
+        ])
+
+        try:
+            from pypaimon.ray import read_blobs
+
+            ds = (
+                obs.scan()
+                .where("clip = 'c1'")
+                .select(["idx", "image", "audio"])
+                .to_ray(concurrency=1, override_num_blocks=1)
+            )
+            ds = read_blobs(ds, ["image", "audio"], parallelism=2)
+            rows = sorted(ds.to_pandas().to_dict("records"), key=lambda row: row["idx"])
+
+            self.assertEqual(
+                [
+                    {"idx": 0, "image": b"img-0", "audio": b"aud-0"},
+                    {"idx": 1, "image": b"img-1", "audio": b"aud-1"},
+                ],
+                rows,
+            )
+        finally:
+            if started_ray:
+                ray.shutdown()
 
     def test_fetch_bodies_decodes_descriptor_inline_and_null(self):
         # Cells may be descriptor bytes (incl. -1 read-to-EOF), inline bytes, or null.

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -990,7 +990,7 @@ class MultimodalTableTest(unittest.TestCase):
             [], list(obs.scan().where("clip = 'none'").stream_blobs("image")))
 
     @unittest.skipIf(ray is None, "ray is not installed")
-    def test_scan_to_ray_map_blobs(self):
+    def test_scan_to_ray_map_with_blobs(self):
         started_ray = False
         if not ray.is_initialized():
             ray.init(ignore_reinit_error=True, num_cpus=2)
@@ -1013,8 +1013,8 @@ class MultimodalTableTest(unittest.TestCase):
         ])
 
         def collect_batch(scalar, blobs, prefix):
-            self.assertIsInstance(scalar, pa.Table)
-            self.assertEqual(["idx"], scalar.column_names)
+            assert isinstance(scalar, pa.Table)
+            assert ["idx"] == scalar.column_names
             idxs = scalar.column("idx").to_pylist()
             rows = []
             for idx, image in zip(idxs, blobs["image"]):
@@ -1022,7 +1022,7 @@ class MultimodalTableTest(unittest.TestCase):
             return pa.Table.from_pylist(rows)
 
         try:
-            from pypaimon.ray import map_blobs
+            from pypaimon.ray import map_with_blobs
 
             ds = (
                 obs.scan()
@@ -1030,7 +1030,10 @@ class MultimodalTableTest(unittest.TestCase):
                 .select(["idx", "image", "audio"])
                 .to_ray(concurrency=1, override_num_blocks=1)
             )
-            result = map_blobs(
+            with self.assertRaisesRegex(ValueError, "not a BLOB column"):
+                map_with_blobs(ds, ["idx"], collect_batch)
+
+            result = map_with_blobs(
                 ds,
                 ["image"],
                 collect_batch,

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1033,15 +1033,23 @@ class MultimodalTableTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "not a BLOB column"):
                 map_with_blobs(ds, ["idx"], collect_batch)
 
-            result = map_with_blobs(
-                ds,
-                ["image"],
-                collect_batch,
-                parallelism=2,
-                batch_size=1,
-                fn_kwargs={"prefix": b"got-"},
-                ray_remote_args={"num_cpus": 1},
-            )
+            blob_columns = getattr(ds, "_paimon_blob_columns")
+            delattr(ds, "_paimon_blob_columns")
+            try:
+                with self.assertRaisesRegex(ValueError, "all_blob_columns"):
+                    map_with_blobs(ds, ["image"], collect_batch)
+                result = map_with_blobs(
+                    ds,
+                    ["image"],
+                    collect_batch,
+                    all_blob_columns=["image", "audio"],
+                    parallelism=2,
+                    batch_size=1,
+                    fn_kwargs={"prefix": b"got-"},
+                    ray_remote_args={"num_cpus": 1},
+                )
+            finally:
+                setattr(ds, "_paimon_blob_columns", blob_columns)
             rows = sorted(result.to_pandas().to_dict("records"), key=lambda row: row["idx"])
 
             self.assertEqual(

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1014,10 +1014,11 @@ class MultimodalTableTest(unittest.TestCase):
 
         def collect_batch(scalar, blobs, prefix):
             self.assertIsInstance(scalar, pa.Table)
+            self.assertEqual(["idx"], scalar.column_names)
             idxs = scalar.column("idx").to_pylist()
             rows = []
-            for idx, image, audio in zip(idxs, blobs["image"], blobs["audio"]):
-                rows.append({"idx": idx, "image": prefix + image, "audio": audio})
+            for idx, image in zip(idxs, blobs["image"]):
+                rows.append({"idx": idx, "image": prefix + image})
             return pa.Table.from_pylist(rows)
 
         try:
@@ -1031,7 +1032,7 @@ class MultimodalTableTest(unittest.TestCase):
             )
             result = map_blobs(
                 ds,
-                ["image", "audio"],
+                ["image"],
                 collect_batch,
                 parallelism=2,
                 batch_size=1,
@@ -1042,14 +1043,35 @@ class MultimodalTableTest(unittest.TestCase):
 
             self.assertEqual(
                 [
-                    {"idx": 0, "image": b"got-img-0", "audio": b"aud-0"},
-                    {"idx": 1, "image": b"got-img-1", "audio": b"aud-1"},
+                    {"idx": 0, "image": b"got-img-0"},
+                    {"idx": 1, "image": b"got-img-1"},
                 ],
                 rows,
             )
         finally:
             if started_ray:
                 ray.shutdown()
+
+    def test_scan_to_ray_nested_projection_output_names(self):
+        obs = self.conn.create_table(
+            "ray_nested_obs",
+            schema=_schema({
+                "id": pa.int32(),
+                "tag": pa.string(),
+                "payload": pa.struct([("a", pa.int64()), ("b", pa.string())]),
+                "image": pa.large_binary(),
+            }),
+            options=_PARQUET_OPTIONS,
+        )
+
+        _, _, visible_columns = (
+            obs.scan()
+            .where("tag = 'keep'")
+            .select(["id", "payload.a"])
+            ._blob_descriptor_query_read_builder()
+        )
+
+        self.assertEqual(["id", "payload_a"], visible_columns)
 
     def test_fetch_bodies_decodes_descriptor_inline_and_null(self):
         # Cells may be descriptor bytes (incl. -1 read-to-EOF), inline bytes, or null.

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -950,6 +950,8 @@ class MultimodalTableTest(unittest.TestCase):
             t.search([1.0, 0.0, 0.0], column="emb").read_blobs("img")
         with self.assertRaisesRegex(TypeError, "only supported on scan"):
             t.search([1.0, 0.0, 0.0], column="emb").stream_blobs("img")
+        with self.assertRaisesRegex(TypeError, "only supported on scan"):
+            t.search([1.0, 0.0, 0.0], column="emb").to_ray()
 
     def test_scan_stream_blobs(self):
         obs = self.conn.create_table(

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -1039,6 +1039,24 @@ class MultimodalTableTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "FileIO"):
                 map_with_blobs(ds, ["image"], collect_batch)
 
+            from pypaimon.table.row.blob import BlobDescriptor
+
+            descriptor = BlobDescriptor("oss://bucket/blob", 0, 1).serialize()
+            foreign_ds = ray.data.from_arrow(pa.table({
+                "idx": [0],
+                "image": [descriptor],
+                "foreign_blob": [descriptor],
+            }))
+            with self.assertRaisesRegex(Exception, "does not own"):
+                map_with_blobs(
+                    foreign_ds,
+                    ["image"],
+                    collect_batch,
+                    file_io=obs.raw_table.file_io,
+                    all_blob_columns=["image"],
+                    batch_size=1,
+                ).take_all()
+
             result = obs.map_with_blobs(
                 ds,
                 ["image"],


### PR DESCRIPTION
  ### Purpose

  Multimodal tables define a very simple API for reading data, but it only runs in local mode. This PR adds two small
  Ray APIs to distribute multimodal table reads:

  - **`scan().to_ray()`** — read filtered rows as a `ray.data.Dataset`; BLOB columns come back as lightweight descriptors, not payloads.
  - **`pypaimon.ray.map_blobs(ds, blob_cols, fn, parallelism=, batch_size=)`** — fetch BLOB bytes on the workers and hand `(scalar_batch, blobs)` to `fn`, so payloads are consumed in-place, never materialised on the driver.

  ```python
  ds = table.scan().where(...).select(cols).to_ray(concurrency=8)
  result = map_blobs(ds, blob_cols, process, parallelism=16, batch_size=512)
  ```

  ### Tests

`MultimodalToRayTest`
