### PR TITLE
[core][spark] Fix RTAS reads after incompatible nested type replace

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -1029,6 +1029,19 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
             boolean resetSnapshotStateForRtasAppend =
                     isRtasAppendAfterTruncate(latestSnapshot, commitKind);
+            System.out.println(
+                    "[DEBUG][FileStoreCommitImpl] commitKind="
+                            + commitKind
+                            + ", operation="
+                            + operation
+                            + ", latestSnapshotId="
+                            + (latestSnapshot == null ? null : latestSnapshot.id())
+                            + ", latestSnapshotKind="
+                            + (latestSnapshot == null ? null : latestSnapshot.commitKind())
+                            + ", latestSnapshotOperation="
+                            + (latestSnapshot == null ? null : latestSnapshot.operation())
+                            + ", resetSnapshotStateForRtasAppend="
+                            + resetSnapshotStateForRtasAppend);
             if (resetSnapshotStateForRtasAppend) {
                 mergeBeforeManifests = emptyList();
                 mergeAfterManifests = emptyList();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -849,9 +849,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 null);
     }
 
-    private boolean isRtasAppendAfterTruncate(
-            @Nullable Snapshot latestSnapshot, CommitKind commitKind) {
-        if (latestSnapshot == null || operation == null || commitKind != CommitKind.APPEND) {
+    private boolean isRtasAfterTruncate(@Nullable Snapshot latestSnapshot, CommitKind commitKind) {
+        if (latestSnapshot == null || operation == null) {
             return false;
         }
 
@@ -1027,22 +1026,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 oldIndexManifest = latestSnapshot.indexManifest();
             }
 
-            boolean resetSnapshotStateForRtasAppend =
-                    isRtasAppendAfterTruncate(latestSnapshot, commitKind);
-            System.out.println(
-                    "[DEBUG][FileStoreCommitImpl] commitKind="
-                            + commitKind
-                            + ", operation="
-                            + operation
-                            + ", latestSnapshotId="
-                            + (latestSnapshot == null ? null : latestSnapshot.id())
-                            + ", latestSnapshotKind="
-                            + (latestSnapshot == null ? null : latestSnapshot.commitKind())
-                            + ", latestSnapshotOperation="
-                            + (latestSnapshot == null ? null : latestSnapshot.operation())
-                            + ", resetSnapshotStateForRtasAppend="
-                            + resetSnapshotStateForRtasAppend);
-            if (resetSnapshotStateForRtasAppend) {
+            boolean resetSnapshotStateForRtas = isRtasAfterTruncate(latestSnapshot, commitKind);
+            if (resetSnapshotStateForRtas) {
                 mergeBeforeManifests = emptyList();
                 mergeAfterManifests = emptyList();
                 oldIndexManifest = null;
@@ -1112,7 +1097,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String statsFileName = null;
             if (newStatsFileName != null) {
                 statsFileName = newStatsFileName;
-            } else if (latestSnapshot != null && !resetSnapshotStateForRtasAppend) {
+            } else if (latestSnapshot != null && !resetSnapshotStateForRtas) {
                 Optional<Statistics> previousStatistic = statsFileHandler.readStats(latestSnapshot);
                 if (previousStatistic.isPresent()) {
                     if (previousStatistic.get().schemaId() != latestSchemaId) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -849,6 +849,17 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 null);
     }
 
+    private boolean isRtasAppendAfterTruncate(
+            @Nullable Snapshot latestSnapshot, CommitKind commitKind) {
+        if (latestSnapshot == null || operation == null || commitKind != CommitKind.APPEND) {
+            return false;
+        }
+
+        return latestSnapshot.operation() == Snapshot.Operation.TRUNCATE
+                && (operation == Snapshot.Operation.REPLACE_TABLE_AS_SELECT
+                        || operation == Snapshot.Operation.CREATE_OR_REPLACE_TABLE_AS_SELECT);
+    }
+
     @VisibleForTesting
     CommitResult tryCommitOnce(
             @Nullable RetryCommitResult retryResult,
@@ -1016,23 +1027,30 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 oldIndexManifest = latestSnapshot.indexManifest();
             }
 
-            // try to merge old manifest files to create base manifest list
-            ManifestMergeReuse manifestMergeReuse =
-                    tryReuseManifestMergeResult(retryResult, mergeBeforeManifests);
-            skipManifestMergeOnRetry = manifestMergeReuse == null && retryResult != null;
-            if (manifestMergeReuse != null) {
-                mergeBeforeManifests = manifestMergeReuse.preservedManifests;
-                mergeAfterManifests = manifestMergeReuse.mergeAfterManifests;
-            } else if (skipManifestMergeOnRetry) {
-                mergeAfterManifests = mergeBeforeManifests;
+            boolean resetSnapshotStateForRtasAppend =
+                    isRtasAppendAfterTruncate(latestSnapshot, commitKind);
+            if (resetSnapshotStateForRtasAppend) {
+                mergeBeforeManifests = emptyList();
+                mergeAfterManifests = emptyList();
+                oldIndexManifest = null;
             } else {
-                mergeAfterManifests =
-                        ManifestFileMerger.merge(
-                                mergeBeforeManifests,
-                                manifestFile,
-                                partitionType,
-                                options,
-                                ioManager);
+                ManifestMergeReuse manifestMergeReuse =
+                        tryReuseManifestMergeResult(retryResult, mergeBeforeManifests);
+                skipManifestMergeOnRetry = manifestMergeReuse == null && retryResult != null;
+                if (manifestMergeReuse != null) {
+                    mergeBeforeManifests = manifestMergeReuse.preservedManifests;
+                    mergeAfterManifests = manifestMergeReuse.mergeAfterManifests;
+                } else if (skipManifestMergeOnRetry) {
+                    mergeAfterManifests = mergeBeforeManifests;
+                } else {
+                    mergeAfterManifests =
+                            ManifestFileMerger.merge(
+                                    mergeBeforeManifests,
+                                    manifestFile,
+                                    partitionType,
+                                    options,
+                                    ioManager);
+                }
             }
             baseManifestList = manifestList.write(mergeAfterManifests);
 
@@ -1081,7 +1099,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
             String statsFileName = null;
             if (newStatsFileName != null) {
                 statsFileName = newStatsFileName;
-            } else if (latestSnapshot != null) {
+            } else if (latestSnapshot != null && !resetSnapshotStateForRtasAppend) {
                 Optional<Statistics> previousStatistic = statsFileHandler.readStats(latestSnapshot);
                 if (previousStatistic.isPresent()) {
                     if (previousStatistic.get().schemaId() != latestSchemaId) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -1133,6 +1133,51 @@ public class FileStoreCommitTest {
     }
 
     @Test
+    public void testRtasAppendAfterTruncateResetsInheritedIndexAndStats() throws Exception {
+        TestFileStore store = createStore(false, 1, CoreOptions.ChangelogProducer.NONE);
+        BinaryRow partition = gen.getPartition(gen.next());
+
+        store.commitData(generateDataList(1), s -> partition, kv -> 0);
+        try (FileStoreCommitImpl commit = store.newCommit()) {
+            commit.commit(indexCommittable(partition, "stale-index", 0, 0), false);
+        }
+
+        Snapshot latestSnapshot = checkNotNull(store.snapshotManager().latestSnapshot());
+        HashMap<String, ColStats<?>> fakeColStatsMap = new HashMap<>();
+        fakeColStatsMap.put("orderId", ColStats.newColStats(3, 1L, 1L, 1L, 0L, 8L, 8L));
+        Statistics fakeStats =
+                new Statistics(
+                        latestSnapshot.id(), latestSnapshot.schemaId(), 1L, 100L, fakeColStatsMap);
+        try (FileStoreCommitImpl commit = store.newCommit()) {
+            commit.commitStatistics(fakeStats, Long.MAX_VALUE);
+        }
+
+        try (FileStoreCommitImpl truncateCommit = store.newCommit()) {
+            truncateCommit.withOperation(Snapshot.Operation.TRUNCATE);
+            truncateCommit.truncateTable(1L);
+        }
+
+        List<KeyValue> replacement = generateDataList(1);
+        store.commitDataImpl(
+                replacement,
+                s -> partition,
+                kv -> 0,
+                false,
+                null,
+                null,
+                Collections.emptyList(),
+                (commit, committable) -> {
+                    commit.withOperation(Snapshot.Operation.REPLACE_TABLE_AS_SELECT);
+                    commit.commit(committable, false);
+                });
+
+        Snapshot rtasSnapshot = checkNotNull(store.snapshotManager().latestSnapshot());
+        assertThat(rtasSnapshot.operation()).isEqualTo(Snapshot.Operation.REPLACE_TABLE_AS_SELECT);
+        assertThat(rtasSnapshot.indexManifest()).isNull();
+        assertThat(rtasSnapshot.statistics()).isNull();
+    }
+
+    @Test
     public void testDropStatsForOverwrite() throws Exception {
         TestFileStore store = createStore(false);
         store.options().toConfiguration().set(CoreOptions.MANIFEST_DELETE_FILE_DROP_STATS, true);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonBatchWriteBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonBatchWriteBase.scala
@@ -118,8 +118,6 @@ abstract class PaimonBatchWriteBase(
     batchTableCommit.withMetricRegistry(metricRegistry)
     val operation = operationType.getOrElse(
       if (overwritePartitions.isDefined) Snapshot.Operation.OVERWRITE else Snapshot.Operation.WRITE)
-    println(
-      s"[DEBUG][PaimonBatchWriteBase] table=${table.name()} operation=$operation overwritePartitions=${overwritePartitions.isDefined} messages=${messages.length}")
     batchTableCommit.withOperation(operation)
     val addCommitMessage = WriteTaskResult.merge(messages)
     val deletedCommitMessage = copyOnWriteScan match {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonBatchWriteBase.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/PaimonBatchWriteBase.scala
@@ -118,6 +118,8 @@ abstract class PaimonBatchWriteBase(
     batchTableCommit.withMetricRegistry(metricRegistry)
     val operation = operationType.getOrElse(
       if (overwritePartitions.isDefined) Snapshot.Operation.OVERWRITE else Snapshot.Operation.WRITE)
+    println(
+      s"[DEBUG][PaimonBatchWriteBase] table=${table.name()} operation=$operation overwritePartitions=${overwritePartitions.isDefined} messages=${messages.length}")
     batchTableCommit.withOperation(operation)
     val addCommitMessage = WriteTaskResult.merge(messages)
     val deletedCommitMessage = copyOnWriteScan match {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -406,6 +406,63 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test(
+    "Paimon DDL: CREATE OR REPLACE TABLE AS SELECT reads latest rows after incompatible nested type replace") {
+    assume(gteqSpark3_4)
+    withTable("src", "t") {
+      sql("""
+            |CREATE TABLE src (
+            |  id BIGINT,
+            |  payload DOUBLE,
+            |  name_a STRING,
+            |  name_b STRING
+            |)
+            |USING paimon
+            |TBLPROPERTIES ('bucket' = '-1')
+            |""".stripMargin)
+      sql("""
+            |INSERT INTO src VALUES
+            |  (1, 1.1D, 'a', 'x'),
+            |  (2, 2.2D, 'b', 'y')
+            |""".stripMargin)
+
+      sql("""
+            |CREATE TABLE t
+            |USING paimon
+            |TBLPROPERTIES ('bucket' = '-1')
+            |AS SELECT * FROM src
+            |""".stripMargin)
+
+      sql("""
+            |CREATE OR REPLACE TABLE t
+            |USING paimon
+            |TBLPROPERTIES ('bucket' = '-1')
+            |AS
+            |SELECT
+            |  id,
+            |  named_struct(
+            |    'items_before', array(name_a),
+            |    'items_after', array(name_b)
+            |  ) AS payload,
+            |  name_a,
+            |  name_b
+            |FROM src
+            |""".stripMargin)
+
+      Assertions.assertEquals("struct", spark.table("t").schema("payload").dataType.typeName)
+
+      checkAnswer(
+        sql("""
+              |SELECT id, payload.items_before, payload.items_after, name_a, name_b
+              |FROM t
+              |WHERE name_a = 'a'
+              |LIMIT 1
+              |""".stripMargin),
+        Row(1L, Seq("a"), Seq("x"), "a", "x") :: Nil
+      )
+    }
+  }
+
   test("Paimon DDL: REPLACE TABLE supports incompatible schema and preserves old snapshots") {
     assume(gteqSpark3_4)
     withTable("t") {


### PR DESCRIPTION
### Purpose

Fix `CREATE OR REPLACE TABLE ... AS SELECT` after an incompatible nested type replace.

The issue happens in the two-snapshot RTAS flow:
1. a truncate snapshot clears the old visible files
2. the following RTAS append snapshot writes the new result

Without extra handling, the RTAS append snapshot can still inherit stale snapshot state from the truncate snapshot. This is especially problematic for incompatible schema replacement, where latest-table reads may observe old metadata/state that should not survive the replace.

This change:
- adds a Spark SQL regression in `DDLTestBase` that reproduces the incompatible nested-type RTAS read failure
- resets inherited manifest state for the RTAS append-after-truncate path
- also clears inherited index manifest and statistics metadata in that path
- adds a focused core unit test to verify the index/statistics reset behavior

### Tests

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -Dtest=FileStoreCommitTest#testRtasAppendAfterTruncateResetsInheritedIndexAndStats test`
- `mvn -pl paimon-spark/paimon-spark-3.5 -Pspark3,fast-build -DfailIfNoTests=false -DwildcardSuites=org.apache.paimon.spark.sql.DDLTest -Dtest=none test`
- `mvn -Pspark3 spotless:apply`
