### PR TITLE
[python] Use parquet by default for multimodal table

### DIFF
--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -215,7 +215,7 @@ class CoreOptions:
     FILE_FORMAT: ConfigOption[str] = (
         ConfigOptions.key("file.format")
         .string_type()
-        .default_value(FILE_FORMAT_ORC)
+        .default_value(FILE_FORMAT_PARQUET)
         .with_description("Specify the message format of data files.")
     )
 

--- a/paimon-python/pypaimon/multimodal/connection.py
+++ b/paimon-python/pypaimon/multimodal/connection.py
@@ -33,7 +33,6 @@ _DEFAULT_OPTIONS = {
     "data-evolution.enabled": "true",
     "deletion-vectors.enabled": "true",
     "blob-as-descriptor": "true",
-    "file.format": "vortex",
     "global-index.search-mode": "full",
     "vector.file.format": "vortex",
 }

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -111,7 +111,6 @@ class MultimodalTableTest(unittest.TestCase):
         self.assertEqual("true", options["deletion-vectors.enabled"])
         self.assertEqual("true", options["blob-as-descriptor"])
         self.assertNotIn("data-evolution.row-sidecar.enabled", options)
-        self.assertEqual("vortex", options["file.format"])
         self.assertEqual("full", options["global-index.search-mode"])
         self.assertEqual("vortex", options["vector.file.format"])
         self.assertEqual("default.docs", self.conn.get_table("docs").identifier)


### PR DESCRIPTION
Parquet has a wide ecosystem and better compression ratio, so it seems not worth using Vortex for the sake of efficiency.