### PR TITLE
[flink] add lineage-use-catalog-key-as-identifier option for table apis for jdbc metastore

### DIFF
--- a/docs/generated/flink_catalog_configuration.html
+++ b/docs/generated/flink_catalog_configuration.html
@@ -38,5 +38,11 @@ under the License.
             <td>Boolean</td>
             <td>If true, creating table in default database is not allowed. Default is false.</td>
         </tr>
+        <tr>
+            <td><h5>lineage-use-catalog-key-as-identifier</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to use the 'catalog-key' as the catalog identifier in the lineage dataset name (i.e., catalog_key.db_name.table_name) when using a JDBC metastore. If false, the internal Flink catalog name is used instead.</td>
+        </tr>
     </tbody>
 </table>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkCatalogOptions.java
@@ -36,4 +36,13 @@ public class FlinkCatalogOptions {
                     .defaultValue(false)
                     .withDescription(
                             "If true, creating table in default database is not allowed. Default is false.");
+
+    public static final ConfigOption<Boolean> LINEAGE_USE_CATALOG_KEY =
+            ConfigOptions.key("lineage-use-catalog-key-as-identifier")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to use the 'catalog-key' as the catalog identifier in the lineage dataset name "
+                                    + "(i.e., catalog_key.db_name.table_name) when using a JDBC metastore. "
+                                    + "If false, the internal Flink catalog name is used instead.");
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lineage/LineageUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lineage/LineageUtils.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.flink.FlinkCatalogOptions;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.iceberg.IcebergOptions;
 import org.apache.paimon.jdbc.JdbcCatalogFactory;
@@ -138,23 +139,26 @@ public class LineageUtils {
 
     @VisibleForTesting
     static String resolveNameByMetastore(Table table, @Nullable String defaultName) {
-        if (defaultName != null) {
-            return defaultName;
-        }
-
         CatalogContext ctx = catalogContext(table);
         if (ctx != null) {
             Options catalogOptions = ctx.options();
-            // If jdbc metastore is used, use catalog-key as the catalog identifier.
-            if (JdbcCatalogFactory.IDENTIFIER.equals(
-                    catalogOptions.get(CatalogOptions.METASTORE))) {
+            // Use catalog-key as the identifier when explicitly opted-in via config,
+            // or when no explicit name is provided (DataStream API path).
+            boolean useCatalogKey =
+                    defaultName == null
+                            || catalogOptions.get(FlinkCatalogOptions.LINEAGE_USE_CATALOG_KEY);
+            if (useCatalogKey
+                    && JdbcCatalogFactory.IDENTIFIER.equals(
+                            catalogOptions.get(CatalogOptions.METASTORE))) {
                 String catalogKeyValue = catalogOptions.get(JdbcCatalogOptions.CATALOG_KEY);
                 if (!StringUtils.isNullOrWhitespaceOnly(catalogKeyValue)) {
                     return catalogKeyValue + "." + table.fullName();
                 }
             }
         }
-        return DEFAULT_CATALOG_IDENTIFIER + "." + table.fullName();
+        return defaultName != null
+                ? defaultName
+                : DEFAULT_CATALOG_IDENTIFIER + "." + table.fullName();
     }
 
     /**

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lineage/LineageUtilsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lineage/LineageUtilsTest.java
@@ -189,6 +189,31 @@ class LineageUtilsTest {
     }
 
     @Test
+    void testResolveNameByMetastoreUsesCatalogKeyWhenFlagEnabled() throws Exception {
+        Map<String, String> catalogOptions = new HashMap<>();
+        catalogOptions.put("metastore", "jdbc");
+        catalogOptions.put("catalog-key", "jdbc-warehouse");
+        catalogOptions.put("lineage-use-catalog-key-as-identifier", "true");
+        FileStoreTable table = createTableWithCatalogOptions(catalogOptions);
+
+        // With flag enabled, catalog-key overrides even when explicit name is provided
+        assertThat(LineageUtils.resolveNameByMetastore(table, "my_catalog.db.src"))
+                .isEqualTo("jdbc-warehouse." + table.fullName());
+    }
+
+    @Test
+    void testResolveNameByMetastoreKeepsCatalogNameWhenFlagDisabled() throws Exception {
+        Map<String, String> catalogOptions = new HashMap<>();
+        catalogOptions.put("metastore", "jdbc");
+        catalogOptions.put("catalog-key", "jdbc-warehouse");
+        FileStoreTable table = createTableWithCatalogOptions(catalogOptions);
+
+        // With flag disabled (default), Flink catalog name is preserved
+        assertThat(LineageUtils.resolveNameByMetastore(table, "my_catalog.db.src"))
+                .isEqualTo("my_catalog.db.src");
+    }
+
+    @Test
     void testDataStreamSourceLineageVertexUsesCatalogKey() throws Exception {
         Map<String, String> catalogOptions = new HashMap<>();
         catalogOptions.put("metastore", "jdbc");


### PR DESCRIPTION
### Purpose
Follow up to: https://github.com/apache/paimon/pull/8001#discussion_r3485025467

Flink catalog names used in `tableIdentifier.asSummaryString()` are arbitrary per-job the same physical table can appear under different lineage dataset names depending on how the job registers its catalog. This becomes especially problematic in organizations with multiple teams, where different teams can end up using different catalog names for the same Paimon table, resulting in fragmented lineage graphs.

This PR adds `lineage-use-catalog-key-as-identifier`, a Flink catalog option that allows users to opt-in to using `catalog-key` as the catalog identifier in lineage dataset names. `catalog-key` is a more stable cross-job identifier that users explicitly configure. This is particularly valuable when the same database and table exist across different JDBC catalogs the `catalog-key` disambiguates them consistently across all jobs regardless of how each job names its catalog.

**Note**: This PR change depends on a Flink change: https://issues.apache.org/jira/browse/FLINK-39935 (PR: https://github.com/apache/flink/pull/28439) with out this Flink will continue using catalog name.

### Tests
- Added unit tests for this
- Manually tested this scenario e2e and it works as expected.
