### PR TITLE
[spark] prepare MAP selected-key pushdown read type

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.shredding;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/**
+ * Utils for marking a temporary read {@link RowType} field as selected-key MAP output. Uses
+ * description field in DataField to encode selected-key metadata.
+ *
+ * <p>Example: __PAIMON_MAP_SELECTED_KEYS:key1;key2
+ */
+public class MapSelectedKeysMetadataUtils {
+
+    public static final String METADATA_KEY = "__PAIMON_MAP_SELECTED_KEYS:";
+    public static final String KEY_DELIMITER = ";";
+
+    private MapSelectedKeysMetadataUtils() {}
+
+    public static String buildMapSelectedKeysMetadata(List<String> keys) {
+        List<String> normalizedKeys = normalizeKeys(keys);
+        return METADATA_KEY + String.join(KEY_DELIMITER, normalizedKeys);
+    }
+
+    public static boolean isMapSelectedKeysMetadata(@Nullable String description) {
+        return description != null && description.startsWith(METADATA_KEY);
+    }
+
+    public static boolean isMapSelectedKeysField(DataField field) {
+        return isMapSelectedKeysMetadata(field.description()) && field.type() instanceof RowType;
+    }
+
+    public static DataField withSelectedKeys(DataField field, DataType rowType, List<String> keys) {
+        checkArgument(rowType instanceof RowType, "Selected-key MAP read type must be ROW.");
+        return field.newType(rowType).newDescription(buildMapSelectedKeysMetadata(keys));
+    }
+
+    public static List<String> selectedKeys(String description) {
+        checkArgument(
+                isMapSelectedKeysMetadata(description),
+                "Invalid selected-key MAP metadata: %s",
+                description);
+        String encoded = description.substring(METADATA_KEY.length());
+
+        String[] parts = encoded.split(KEY_DELIMITER, -1);
+        List<String> keys = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            keys.add(part);
+        }
+        return keys;
+    }
+
+    private static List<String> normalizeKeys(List<String> keys) {
+        checkNotNull(keys, "Selected keys must not be null.");
+        checkArgument(!keys.isEmpty(), "Selected keys must not be empty.");
+
+        Set<String> seenKeys = new LinkedHashSet<>();
+        for (String key : keys) {
+            checkNotNull(key, "Selected key must not be null.");
+            checkArgument(
+                    !key.contains(KEY_DELIMITER),
+                    "Selected key must not contain '%s': %s",
+                    KEY_DELIMITER,
+                    key);
+            checkArgument(
+                    !key.startsWith(METADATA_KEY),
+                    "Selected key must not start with metadata prefix: %s",
+                    key);
+            checkArgument(!seenKeys.contains(key), "Selected key must not be duplicated: %s", key);
+            seenKeys.add(key);
+        }
+        return new ArrayList<>(seenKeys);
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtilsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.shredding;
+
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link MapSelectedKeysMetadataUtils}. */
+class MapSelectedKeysMetadataUtilsTest {
+
+    @Test
+    void testBuildAndParseMetadata() {
+        String metadata =
+                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                        Arrays.asList("key1", "key2"));
+
+        assertThat(metadata).isEqualTo("__PAIMON_MAP_SELECTED_KEYS:key1;key2");
+        assertThat(MapSelectedKeysMetadataUtils.isMapSelectedKeysMetadata(metadata)).isTrue();
+        assertThat(MapSelectedKeysMetadataUtils.selectedKeys(metadata))
+                .containsExactly("key1", "key2");
+    }
+
+    @Test
+    void testBuildAndParseMetadataWithEmptyKey() {
+        String metadata =
+                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                        Arrays.asList("key1", "", "key2"));
+
+        assertThat(metadata).isEqualTo("__PAIMON_MAP_SELECTED_KEYS:key1;;key2");
+        assertThat(MapSelectedKeysMetadataUtils.selectedKeys(metadata))
+                .containsExactly("key1", "", "key2");
+        assertThat(MapSelectedKeysMetadataUtils.selectedKeys("__PAIMON_MAP_SELECTED_KEYS:"))
+                .containsExactly("");
+    }
+
+    @Test
+    void testBuildMetadataRejectsDuplicateKeys() {
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                                        Arrays.asList("key1", "key2", "key1")))
+                .hasMessageContaining("Selected key must not be duplicated: key1");
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                                        Arrays.asList("key1", "", "")))
+                .hasMessageContaining("Selected key must not be duplicated");
+    }
+
+    @Test
+    void testWithSelectedKeys() {
+        DataField field =
+                DataTypes.FIELD(
+                        1,
+                        "attrs",
+                        DataTypes.MAP(DataTypes.STRING(), DataTypes.BIGINT()),
+                        "user comment");
+        RowType selectedType =
+                DataTypes.ROW(
+                        DataTypes.FIELD(0, "0", DataTypes.BIGINT()),
+                        DataTypes.FIELD(1, "1", DataTypes.BIGINT()));
+
+        DataField rewritten =
+                MapSelectedKeysMetadataUtils.withSelectedKeys(
+                        field, selectedType, Arrays.asList("key1", "key2"));
+
+        assertThat(rewritten.id()).isEqualTo(1);
+        assertThat(rewritten.name()).isEqualTo("attrs");
+        assertThat(rewritten.type()).isEqualTo(selectedType);
+        assertThat(rewritten.description()).isEqualTo("__PAIMON_MAP_SELECTED_KEYS:key1;key2");
+        assertThat(MapSelectedKeysMetadataUtils.isMapSelectedKeysField(rewritten)).isTrue();
+    }
+
+    @Test
+    void testErrors() {
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                                        Collections.emptyList()))
+                .hasMessageContaining("Selected keys must not be empty.");
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                                        Arrays.asList("key1", null)))
+                .hasMessageContaining("Selected key must not be null.");
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
+                                        Arrays.asList("key;1")))
+                .hasMessageContaining("Selected key must not contain ';'");
+        assertThatThrownBy(() -> MapSelectedKeysMetadataUtils.selectedKeys("invalid"))
+                .hasMessageContaining("Invalid selected-key MAP metadata");
+        assertThatThrownBy(
+                        () ->
+                                MapSelectedKeysMetadataUtils.withSelectedKeys(
+                                        DataTypes.FIELD(
+                                                1,
+                                                "attrs",
+                                                DataTypes.MAP(
+                                                        DataTypes.STRING(), DataTypes.BIGINT())),
+                                        DataTypes.BIGINT(),
+                                        Arrays.asList("key1")))
+                .hasMessageContaining("Selected-key MAP read type must be ROW.");
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/shredding/MapSelectedKeysMetadataUtilsTest.java
@@ -51,7 +51,8 @@ class MapSelectedKeysMetadataUtilsTest {
                 MapSelectedKeysMetadataUtils.buildMapSelectedKeysMetadata(
                         Arrays.asList("key1", "", "key2"));
 
-        assertThat(metadata).isEqualTo("__PAIMON_MAP_SELECTED_KEYS:key1;;key2");
+        String expectedMetadata = String.join(";", "__PAIMON_MAP_SELECTED_KEYS:key1", "", "key2");
+        assertThat(metadata).isEqualTo(expectedMetadata);
         assertThat(MapSelectedKeysMetadataUtils.selectedKeys(metadata))
                 .containsExactly("key1", "", "key2");
         assertThat(MapSelectedKeysMetadataUtils.selectedKeys("__PAIMON_MAP_SELECTED_KEYS:"))

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -36,6 +36,6 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
-    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[String, Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = true)
   extends PaimonBaseScan(table) {}

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -36,5 +36,6 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = true)
   extends PaimonBaseScan(table) {}

--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+object PushDownMapSelectedKeys extends PushDownMapSelectedKeysBase {
+
+  override protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation = {
+    DataSourceV2ScanRelation(relation.relation, scan, output)
+  }
+}

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -40,7 +40,7 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
-    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[String, Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table)
   with SupportsReportPartitioning {

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -40,6 +40,7 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table)
   with SupportsReportPartitioning {

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+object PushDownMapSelectedKeys extends PushDownMapSelectedKeysBase {
+
+  override protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation = {
+    DataSourceV2ScanRelation(relation.relation, scan, output, relation.keyGroupedPartitioning)
+  }
+}

--- a/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-3.4/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+object PushDownMapSelectedKeys extends PushDownMapSelectedKeysBase {
+
+  override protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation = {
+    DataSourceV2ScanRelation(
+      relation.relation,
+      scan,
+      output,
+      relation.keyGroupedPartitioning,
+      relation.ordering)
+  }
+}

--- a/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-3.5/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+object PushDownMapSelectedKeys extends PushDownMapSelectedKeysBase {
+
+  override protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation = {
+    DataSourceV2ScanRelation(
+      relation.relation,
+      scan,
+      output,
+      relation.keyGroupedPartitioning,
+      relation.ordering)
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -46,6 +46,7 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table)
   with SupportsReportPartitioning

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -46,7 +46,7 @@ case class PaimonScan(
     override val pushedHybridSearch: Option[HybridSearch] = None,
     override val pushedFullTextSearch: Option[FullTextSearch] = None,
     override val pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty,
-    override val pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty,
+    override val pushedMapSelectedKeys: Map[String, Seq[String]] = Map.empty,
     bucketedScanDisabled: Boolean = false)
   extends PaimonBaseScan(table)
   with SupportsReportPartitioning

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.{DataType, MapType, StringType, StructField, S
 import scala.collection.mutable
 
 /**
- * Pushes literal-key MAP access on MAP columns into Paimon scan read type.
+ * Pushes literal-key MAP access on shared-shredding MAP columns into Paimon scan read type.
  *
  * <p>Example: {@code SELECT id, attrs['key1'], attrs['key2'] FROM T} becomes a scan returning
  * {@code attrs} as {@code struct<0:valueType,1:valueType>} and a project reading struct fields.
@@ -187,7 +187,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
             layout match {
               case MapStorageLayout.SHARED_SHREDDING =>
                 access.path.length == 1
-              case _ => true
+              case _ => false
             }
           case _ => false
         }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -40,6 +40,13 @@ import scala.collection.mutable
  */
 object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
 
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan
+  }
+}
+
+abstract class PushDownMapSelectedKeysBase extends Rule[LogicalPlan] {
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transform {
     case project @ Project(projectList, relation: DataSourceV2ScanRelation) =>
       relation.scan match {
@@ -100,9 +107,14 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     val rewrittenScan = scan.copy(pushedMapSelectedKeys = pushedMapSelectedKeys)
     val rewrittenOutput =
       relation.output.map(attr => attrToRewritten.getOrElse(attr.exprId, attr))
-    val rewrittenRelation = relation.copy(scan = rewrittenScan, output = rewrittenOutput)
+    val rewrittenRelation = copyDataSourceV2ScanRelation(relation, rewrittenScan, rewrittenOutput)
     Some(project.copy(projectList = rewrittenProjectList, child = rewrittenRelation))
   }
+
+  protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation
 
   private def collectCandidates(
       projectList: Seq[NamedExpression],

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
-import org.apache.spark.sql.types.{DataType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
 
 import scala.collection.mutable
 
@@ -60,16 +60,19 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     }
 
     val outputByExprId = relation.output.map(a => a.exprId -> a).toMap
-    val selectedMaps = mutable.LinkedHashMap.empty[MapPath, SelectedMap]
+    val selectedMaps = mutable.LinkedHashMap.empty[ExprId, SelectedMap]
     candidates.foreach {
       candidate =>
         outputByExprId.get(candidate.rootExprId).foreach {
           root =>
-            val path = MapPath(root.exprId, candidate.path)
             val selectedMap =
               selectedMaps.getOrElseUpdate(
-                path,
-                SelectedMap(root, candidate.path, candidate.mapType, mutable.ArrayBuffer.empty))
+                root.exprId,
+                SelectedMap(
+                  root,
+                  candidate.fieldName,
+                  candidate.mapType,
+                  mutable.ArrayBuffer.empty))
             if (!selectedMap.keys.contains(candidate.key)) {
               selectedMap.keys.append(candidate.key)
             }
@@ -79,24 +82,20 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
       return None
     }
 
-    val selectedByPath = selectedMaps.toMap
-    val selectedByRoot = selectedMaps.values.toSeq.groupBy(_.root.exprId)
-    val attrToRewritten = selectedByRoot.map {
-      case (exprId, selections) =>
-        val root = selections.head.root
-        exprId -> root
-          .withDataType(rewriteSparkType(root.dataType, root.name, selections))
-          .asInstanceOf[AttributeReference]
+    val selectedByExprId = selectedMaps.toMap
+    val attrToRewritten = selectedByExprId.map {
+      case (exprId, selected) =>
+        exprId -> selected.root.withDataType(selected.structType).asInstanceOf[AttributeReference]
     }
 
-    val rewriteState = RewriteState(selectedByPath, attrToRewritten)
+    val rewriteState = RewriteState(selectedByExprId, attrToRewritten)
     val rewrittenProjectList = projectList.map(rewriteExpression(_, rewriteState))
     if (rewriteState.failed) {
       return None
     }
 
     val pushedMapSelectedKeys = scan.pushedMapSelectedKeys ++ selectedMaps.values.map {
-      selected => selected.path.head -> selected.keys.toSeq
+      selected => selected.fieldName -> selected.keys.toSeq
     }.toMap
     val rewrittenScan = scan.copy(pushedMapSelectedKeys = pushedMapSelectedKeys)
     val rewrittenOutput =
@@ -114,7 +113,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
         expr.foreach {
           case mapKeyValueAccess(access) if canPushDown(scan, access) =>
             candidates.append(
-              MapKeyCandidate(access.root.exprId, access.path, access.mapType, access.key))
+              MapKeyCandidate(access.root.exprId, access.fieldName, access.mapType, access.key))
           case _ =>
         }
     }
@@ -127,14 +126,14 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     expression match {
       case alias: Alias =>
         alias.child match {
-          case mapKeyValueAccess(access) if state.selectedByPath.contains(access.mapPath) =>
+          case mapKeyValueAccess(access) if state.selectedByExprId.contains(access.root.exprId) =>
             rewriteMapKeyAccess(access, state) match {
               case Some(rewritten) =>
                 alias.withNewChildren(Seq(rewritten)).asInstanceOf[NamedExpression]
               case None => expression
             }
           case _ =>
-            if (hasSelectedPathReference(alias, state)) {
+            if (hasSelectedMapReference(alias, state)) {
               state.failed = true
             }
             expression
@@ -143,7 +142,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
         state.failed = true
         expression
       case _ =>
-        if (hasSelectedPathReference(expression, state)) {
+        if (hasSelectedMapReference(expression, state)) {
           state.failed = true
         }
         expression
@@ -151,22 +150,20 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
   }
 
   private def rewriteMapKeyAccess(access: MapKeyAccess, state: RewriteState): Option[Expression] = {
-    val selected = state.selectedByPath(access.mapPath)
+    val selected = state.selectedByExprId(access.root.exprId)
     val ordinal = selected.keys.indexOf(access.key)
     if (ordinal < 0) {
       state.failed = true
       None
     } else {
-      buildPathExpression(state.attrToRewritten(access.root.exprId), access.path).map {
-        selectedMapRow => GetStructField(selectedMapRow, ordinal, Some(access.key))
-      }
+      Some(GetStructField(state.attrToRewritten(access.root.exprId), ordinal, Some(access.key)))
     }
   }
 
-  private def hasSelectedPathReference(expression: Expression, state: RewriteState): Boolean = {
+  private def hasSelectedMapReference(expression: Expression, state: RewriteState): Boolean = {
     var found = false
     expression.foreach {
-      case mapFieldReference(access) if state.selectedByPath.contains(access.mapPath) =>
+      case mapFieldReference(access) if state.selectedByExprId.contains(access.root.exprId) =>
         found = true
       case _ =>
     }
@@ -174,15 +171,15 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
   }
 
   private def canPushDown(scan: PaimonScan, access: MapKeyAccess): Boolean = {
-    if (access.path.length != 1 || !canEncodeKey(access.key)) {
+    if (!canEncodeKey(access.key)) {
       return false
     }
 
     access.mapType match {
       case MapType(StringType, _, _) =>
-        fieldType(scan.table.rowType(), access.path.head) match {
+        fieldType(scan.table.rowType(), access.fieldName) match {
           case Some(mapType: org.apache.paimon.types.MapType) if isStringKeyMap(mapType) =>
-            CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.path.head) ==
+            CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.fieldName) ==
               MapStorageLayout.SHARED_SHREDDING
           case _ => false
         }
@@ -216,8 +213,13 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
 
   private object mapFieldReference {
     def unapply(expression: Expression): Option[MapKeyAccess] = {
-      toFieldPath(expression).collect {
-        case (root, path, mapType: MapType) => MapKeyAccess(root, path, mapType, "")
+      expression match {
+        case attr: Attribute =>
+          attr.dataType match {
+            case mapType: MapType => Some(MapKeyAccess(attr, attr.name, mapType, ""))
+            case _ => None
+          }
+        case _ => None
       }
     }
   }
@@ -231,20 +233,6 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     }
   }
 
-  private def toFieldPath(expression: Expression): Option[(Attribute, Seq[String], DataType)] = {
-    expression match {
-      case attr: Attribute => Some((attr, Seq(attr.name), attr.dataType))
-      case GetStructField(child, ordinal, name) =>
-        toFieldPath(child).flatMap {
-          case (root, path, childType: StructType) if ordinal < childType.fields.length =>
-            val field = childType.fields(ordinal)
-            Some((root, path :+ name.getOrElse(field.name), field.dataType))
-          case _ => None
-        }
-      case _ => None
-    }
-  }
-
   private def fieldType(
       rowType: org.apache.paimon.types.RowType,
       fieldName: String): Option[org.apache.paimon.types.DataType] = {
@@ -255,41 +243,17 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     }
   }
 
-  private def rewriteSparkType(
-      dataType: DataType,
-      fieldName: String,
-      selections: Seq[SelectedMap]): DataType = {
-    selections.find(_.path == Seq(fieldName)) match {
-      case Some(selected) => selected.structType
-      case None => dataType
-    }
-  }
-
-  private def buildPathExpression(
-      root: AttributeReference,
-      path: Seq[String]): Option[Expression] = {
-    if (path == Seq(root.name)) Some(root) else None
-  }
-
   private case class MapKeyCandidate(
       rootExprId: ExprId,
-      path: Seq[String],
+      fieldName: String,
       mapType: MapType,
       key: String)
 
-  private case class MapPath(rootExprId: ExprId, path: Seq[String])
-
-  private case class MapKeyAccess(
-      root: Attribute,
-      path: Seq[String],
-      mapType: MapType,
-      key: String) {
-    def mapPath: MapPath = MapPath(root.exprId, path)
-  }
+  private case class MapKeyAccess(root: Attribute, fieldName: String, mapType: MapType, key: String)
 
   private case class SelectedMap(
       root: Attribute,
-      path: Seq[String],
+      fieldName: String,
       mapType: MapType,
       keys: mutable.ArrayBuffer[String]) {
     def structType: StructType = {
@@ -302,12 +266,12 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
   }
 
   private case class RewriteState(
-      selectedByPath: Map[MapPath, SelectedMap],
+      selectedByExprId: Map[ExprId, SelectedMap],
       attrToRewritten: Map[ExprId, AttributeReference]) {
     var failed: Boolean = false
 
     def hasRootSelection(exprId: ExprId): Boolean = {
-      selectedByPath.keys.exists(_.rootExprId == exprId)
+      selectedByExprId.contains(exprId)
     }
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -20,6 +20,7 @@ package org.apache.paimon.spark.catalyst.optimizer
 
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.CoreOptions.MapStorageLayout
+import org.apache.paimon.data.shredding.MapSelectedKeysMetadataUtils
 import org.apache.paimon.data.shredding.MapSharedShreddingUtils
 import org.apache.paimon.spark.PaimonScan
 
@@ -173,6 +174,10 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
   }
 
   private def canPushDown(scan: PaimonScan, access: MapKeyAccess): Boolean = {
+    if (!canEncodeKey(access.key)) {
+      return false
+    }
+
     access.mapType match {
       case MapType(StringType, _, _) =>
         fieldType(scan.table.rowType(), access.path) match {
@@ -181,18 +186,18 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
               CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.path.head)
             layout match {
               case MapStorageLayout.SHARED_SHREDDING =>
-                if (access.path.length != 1) {
-                  throw new UnsupportedOperationException(
-                    s"Nested shared-shredding MAP selected-key pushdown is not supported: " +
-                      s"${access.path.mkString(".")}.")
-                }
-                true
+                access.path.length == 1
               case _ => true
             }
           case _ => false
         }
       case _ => false
     }
+  }
+
+  private def canEncodeKey(key: String): Boolean = {
+    !key.contains(MapSelectedKeysMetadataUtils.KEY_DELIMITER) &&
+    !key.startsWith(MapSelectedKeysMetadataUtils.METADATA_KEY)
   }
 
   private def isStringKeyMap(mapType: org.apache.paimon.types.MapType): Boolean = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.CoreOptions
+import org.apache.paimon.CoreOptions.MapStorageLayout
+import org.apache.paimon.data.shredding.MapSharedShreddingUtils
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, ExprId, GetMapValue, GetStructField, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.types.{DataType, MapType, StringType, StructField, StructType}
+
+import scala.collection.mutable
+
+/**
+ * Pushes literal-key MAP access on MAP columns into Paimon scan read type.
+ *
+ * <p>Example: {@code SELECT id, attrs['key1'], attrs['key2'] FROM T} becomes a scan returning
+ * {@code attrs} as {@code struct<0:valueType,1:valueType>} and a project reading struct fields.
+ */
+object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transform {
+    case project @ Project(projectList, relation: DataSourceV2ScanRelation) =>
+      relation.scan match {
+        case scan: PaimonScan =>
+          rewriteProject(project, projectList, relation, scan).getOrElse(project)
+        case _ => project
+      }
+  }
+
+  private def rewriteProject(
+      project: Project,
+      projectList: Seq[NamedExpression],
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan): Option[LogicalPlan] = {
+    val candidates = collectCandidates(projectList, scan)
+    if (candidates.isEmpty) {
+      return None
+    }
+
+    val outputByExprId = relation.output.map(a => a.exprId -> a).toMap
+    val selectedMaps = mutable.LinkedHashMap.empty[MapPath, SelectedMap]
+    candidates.foreach {
+      candidate =>
+        outputByExprId.get(candidate.rootExprId).foreach {
+          root =>
+            val path = MapPath(root.exprId, candidate.path)
+            val selectedMap =
+              selectedMaps.getOrElseUpdate(
+                path,
+                SelectedMap(root, candidate.path, candidate.mapType, mutable.ArrayBuffer.empty))
+            if (!selectedMap.keys.contains(candidate.key)) {
+              selectedMap.keys.append(candidate.key)
+            }
+        }
+    }
+    if (selectedMaps.isEmpty) {
+      return None
+    }
+
+    val selectedByPath = selectedMaps.toMap
+    val selectedByRoot = selectedMaps.values.toSeq.groupBy(_.root.exprId)
+    val attrToRewritten = selectedByRoot.map {
+      case (exprId, selections) =>
+        val root = selections.head.root
+        exprId -> root
+          .withDataType(rewriteSparkType(root.dataType, root.name, selections))
+          .asInstanceOf[AttributeReference]
+    }
+
+    val rewriteState = RewriteState(selectedByPath, attrToRewritten)
+    val rewrittenProjectList = projectList.map(rewriteExpression(_, rewriteState))
+    if (rewriteState.failed) {
+      return None
+    }
+
+    val pushedMapSelectedKeys = scan.pushedMapSelectedKeys ++ selectedMaps.values.map {
+      selected => selected.path -> selected.keys.toSeq
+    }.toMap
+    val rewrittenScan = scan.copy(pushedMapSelectedKeys = pushedMapSelectedKeys)
+    val rewrittenOutput =
+      relation.output.map(attr => attrToRewritten.getOrElse(attr.exprId, attr))
+    val rewrittenRelation = relation.copy(scan = rewrittenScan, output = rewrittenOutput)
+    Some(project.copy(projectList = rewrittenProjectList, child = rewrittenRelation))
+  }
+
+  private def collectCandidates(
+      projectList: Seq[NamedExpression],
+      scan: PaimonScan): Seq[MapKeyCandidate] = {
+    val candidates = mutable.ArrayBuffer.empty[MapKeyCandidate]
+    projectList.foreach {
+      expr =>
+        expr.foreach {
+          case mapKeyValueAccess(access) if canPushDown(scan, access) =>
+            candidates.append(
+              MapKeyCandidate(access.root.exprId, access.path, access.mapType, access.key))
+          case _ =>
+        }
+    }
+    candidates
+  }
+
+  private def rewriteExpression(
+      expression: NamedExpression,
+      state: RewriteState): NamedExpression = {
+    expression match {
+      case alias: Alias =>
+        alias.child match {
+          case mapKeyValueAccess(access) if state.selectedByPath.contains(access.mapPath) =>
+            rewriteMapKeyAccess(access, state) match {
+              case Some(rewritten) =>
+                alias.withNewChildren(Seq(rewritten)).asInstanceOf[NamedExpression]
+              case None => expression
+            }
+          case _ =>
+            if (hasSelectedPathReference(alias, state)) {
+              state.failed = true
+            }
+            expression
+        }
+      case attr: Attribute if state.hasRootSelection(attr.exprId) =>
+        state.failed = true
+        expression
+      case _ =>
+        if (hasSelectedPathReference(expression, state)) {
+          state.failed = true
+        }
+        expression
+    }
+  }
+
+  private def rewriteMapKeyAccess(access: MapKeyAccess, state: RewriteState): Option[Expression] = {
+    val selected = state.selectedByPath(access.mapPath)
+    val ordinal = selected.keys.indexOf(access.key)
+    if (ordinal < 0) {
+      state.failed = true
+      None
+    } else {
+      buildPathExpression(state.attrToRewritten(access.root.exprId), access.path).map {
+        selectedMapRow => GetStructField(selectedMapRow, ordinal, Some(access.key))
+      }
+    }
+  }
+
+  private def hasSelectedPathReference(expression: Expression, state: RewriteState): Boolean = {
+    var found = false
+    expression.foreach {
+      case mapFieldReference(access) if state.selectedByPath.contains(access.mapPath) =>
+        found = true
+      case _ =>
+    }
+    found
+  }
+
+  private def canPushDown(scan: PaimonScan, access: MapKeyAccess): Boolean = {
+    access.mapType match {
+      case MapType(StringType, _, _) =>
+        fieldType(scan.table.rowType(), access.path) match {
+          case Some(mapType: org.apache.paimon.types.MapType) if isStringKeyMap(mapType) =>
+            val layout =
+              CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.path.head)
+            layout match {
+              case MapStorageLayout.SHARED_SHREDDING =>
+                if (access.path.length != 1) {
+                  throw new UnsupportedOperationException(
+                    s"Nested shared-shredding MAP selected-key pushdown is not supported: " +
+                      s"${access.path.mkString(".")}.")
+                }
+                true
+              case _ => true
+            }
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+
+  private def isStringKeyMap(mapType: org.apache.paimon.types.MapType): Boolean = {
+    MapSharedShreddingUtils.isShreddingKeyMap(mapType)
+  }
+
+  private object mapKeyValueAccess {
+    def unapply(expression: Expression): Option[MapKeyAccess] = {
+      expression match {
+        case GetMapValue(mapFieldReference(access), StringLiteral(key)) =>
+          Some(access.copy(key = key))
+        case e if e.prettyName == "element_at" && e.children.length == 2 =>
+          (e.children.head, e.children(1)) match {
+            case (mapFieldReference(access), StringLiteral(key)) => Some(access.copy(key = key))
+            case _ => None
+          }
+        case _ => None
+      }
+    }
+  }
+
+  private object mapFieldReference {
+    def unapply(expression: Expression): Option[MapKeyAccess] = {
+      toFieldPath(expression).collect {
+        case (root, path, mapType: MapType) => MapKeyAccess(root, path, mapType, "")
+      }
+    }
+  }
+
+  private object StringLiteral {
+    def unapply(expression: Expression): Option[String] = {
+      expression match {
+        case Literal(value, StringType) if value != null => Some(value.toString)
+        case _ => None
+      }
+    }
+  }
+
+  private def toFieldPath(expression: Expression): Option[(Attribute, Seq[String], DataType)] = {
+    expression match {
+      case attr: Attribute => Some((attr, Seq(attr.name), attr.dataType))
+      case GetStructField(child, ordinal, name) =>
+        toFieldPath(child).flatMap {
+          case (root, path, childType: StructType) if ordinal < childType.fields.length =>
+            val field = childType.fields(ordinal)
+            Some((root, path :+ name.getOrElse(field.name), field.dataType))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  private def fieldType(
+      rowType: org.apache.paimon.types.RowType,
+      path: Seq[String]): Option[org.apache.paimon.types.DataType] = {
+    if (path.isEmpty || !rowType.containsField(path.head)) {
+      None
+    } else if (path.length == 1) {
+      Some(rowType.getField(path.head).`type`())
+    } else {
+      rowType.getField(path.head).`type`() match {
+        case nested: org.apache.paimon.types.RowType => fieldType(nested, path.tail)
+        case _ => None
+      }
+    }
+  }
+
+  private def rewriteSparkType(
+      dataType: DataType,
+      fieldName: String,
+      selections: Seq[SelectedMap]): DataType = {
+    selections.find(_.path == Seq(fieldName)) match {
+      case Some(selected) => selected.structType
+      case None =>
+        dataType match {
+          case struct: StructType =>
+            StructType(struct.fields.map {
+              field =>
+                val nestedSelections =
+                  selections.filter(s => s.path.length > 1 && s.path(1) == field.name)
+                if (nestedSelections.isEmpty) {
+                  field
+                } else {
+                  field.copy(
+                    dataType = rewriteSparkType(
+                      field.dataType,
+                      field.name,
+                      nestedSelections.map(s => s.copy(path = s.path.tail))))
+                }
+            })
+          case other => other
+        }
+    }
+  }
+
+  private def buildPathExpression(
+      root: AttributeReference,
+      path: Seq[String]): Option[Expression] = {
+    if (path.isEmpty || path.head != root.name) {
+      None
+    } else {
+      path.tail
+        .foldLeft(Option((root: Expression, root.dataType))) {
+          case (Some((current, struct: StructType)), name) =>
+            struct.fields.zipWithIndex.find(_._1.name == name).map {
+              case (field, ordinal) =>
+                ((GetStructField(current, ordinal, Some(name)): Expression), field.dataType)
+            }
+          case _ => None
+        }
+        .map(_._1)
+    }
+  }
+
+  private case class MapKeyCandidate(
+      rootExprId: ExprId,
+      path: Seq[String],
+      mapType: MapType,
+      key: String)
+
+  private case class MapPath(rootExprId: ExprId, path: Seq[String])
+
+  private case class MapKeyAccess(
+      root: Attribute,
+      path: Seq[String],
+      mapType: MapType,
+      key: String) {
+    def mapPath: MapPath = MapPath(root.exprId, path)
+  }
+
+  private case class SelectedMap(
+      root: Attribute,
+      path: Seq[String],
+      mapType: MapType,
+      keys: mutable.ArrayBuffer[String]) {
+    def structType: StructType = {
+      val MapType(_, valueType, _) = mapType
+      StructType(keys.zipWithIndex.map {
+        case (_, ordinal) =>
+          StructField(ordinal.toString, valueType, nullable = true)
+      })
+    }
+  }
+
+  private case class RewriteState(
+      selectedByPath: Map[MapPath, SelectedMap],
+      attrToRewritten: Map[ExprId, AttributeReference]) {
+    var failed: Boolean = false
+
+    def hasRootSelection(exprId: ExprId): Boolean = {
+      selectedByPath.keys.exists(_.rootExprId == exprId)
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -117,7 +117,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
           case _ =>
         }
     }
-    candidates
+    candidates.toSeq
   }
 
   private def rewriteExpression(
@@ -333,7 +333,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
       StructType(keys.zipWithIndex.map {
         case (_, ordinal) =>
           StructField(ordinal.toString, valueType, nullable = true)
-      })
+      }.toSeq)
     }
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -96,7 +96,7 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
     }
 
     val pushedMapSelectedKeys = scan.pushedMapSelectedKeys ++ selectedMaps.values.map {
-      selected => selected.path -> selected.keys.toSeq
+      selected => selected.path.head -> selected.keys.toSeq
     }.toMap
     val rewrittenScan = scan.copy(pushedMapSelectedKeys = pushedMapSelectedKeys)
     val rewrittenOutput =
@@ -174,21 +174,16 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
   }
 
   private def canPushDown(scan: PaimonScan, access: MapKeyAccess): Boolean = {
-    if (!canEncodeKey(access.key)) {
+    if (access.path.length != 1 || !canEncodeKey(access.key)) {
       return false
     }
 
     access.mapType match {
       case MapType(StringType, _, _) =>
-        fieldType(scan.table.rowType(), access.path) match {
+        fieldType(scan.table.rowType(), access.path.head) match {
           case Some(mapType: org.apache.paimon.types.MapType) if isStringKeyMap(mapType) =>
-            val layout =
-              CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.path.head)
-            layout match {
-              case MapStorageLayout.SHARED_SHREDDING =>
-                access.path.length == 1
-              case _ => false
-            }
+            CoreOptions.fromMap(scan.table.options()).mapStorageLayout(access.path.head) ==
+              MapStorageLayout.SHARED_SHREDDING
           case _ => false
         }
       case _ => false
@@ -252,16 +247,11 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
 
   private def fieldType(
       rowType: org.apache.paimon.types.RowType,
-      path: Seq[String]): Option[org.apache.paimon.types.DataType] = {
-    if (path.isEmpty || !rowType.containsField(path.head)) {
+      fieldName: String): Option[org.apache.paimon.types.DataType] = {
+    if (!rowType.containsField(fieldName)) {
       None
-    } else if (path.length == 1) {
-      Some(rowType.getField(path.head).`type`())
     } else {
-      rowType.getField(path.head).`type`() match {
-        case nested: org.apache.paimon.types.RowType => fieldType(nested, path.tail)
-        case _ => None
-      }
+      Some(rowType.getField(fieldName).`type`())
     }
   }
 
@@ -271,45 +261,14 @@ object PushDownMapSelectedKeys extends Rule[LogicalPlan] {
       selections: Seq[SelectedMap]): DataType = {
     selections.find(_.path == Seq(fieldName)) match {
       case Some(selected) => selected.structType
-      case None =>
-        dataType match {
-          case struct: StructType =>
-            StructType(struct.fields.map {
-              field =>
-                val nestedSelections =
-                  selections.filter(s => s.path.length > 1 && s.path(1) == field.name)
-                if (nestedSelections.isEmpty) {
-                  field
-                } else {
-                  field.copy(
-                    dataType = rewriteSparkType(
-                      field.dataType,
-                      field.name,
-                      nestedSelections.map(s => s.copy(path = s.path.tail))))
-                }
-            })
-          case other => other
-        }
+      case None => dataType
     }
   }
 
   private def buildPathExpression(
       root: AttributeReference,
       path: Seq[String]): Option[Expression] = {
-    if (path.isEmpty || path.head != root.name) {
-      None
-    } else {
-      path.tail
-        .foldLeft(Option((root: Expression, root.dataType))) {
-          case (Some((current, struct: StructType)), name) =>
-            struct.fields.zipWithIndex.find(_._1.name == name).map {
-              case (field, ordinal) =>
-                ((GetStructField(current, ordinal, Some(name)): Expression), field.dataType)
-            }
-          case _ => None
-        }
-        .map(_._1)
-    }
+    if (path == Seq(root.name)) Some(root) else None
   }
 
   private case class MapKeyCandidate(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/extensions/PaimonSparkSessionExtensions.scala
@@ -101,6 +101,8 @@ class PaimonSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     // optimization rules
     extensions.injectOptimizerRule(spark => ReplacePaimonFunctions(spark))
     extensions.injectOptimizerRule(_ => OptimizeMetadataOnlyDeleteFromPaimonTable)
+    // TODO: Enable MAP selected-key pushdown after core reader supports
+    // __PAIMON_MAP_SELECTED_KEYS read type.
     extensions.injectOptimizerRule(_ => MergePaimonScalarSubqueries)
     extensions.injectOptimizerRule(_ => PushDownLateralVectorSearchFilter)
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -54,6 +54,7 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   def pushedHybridSearch: Option[HybridSearch] = None
   def pushedFullTextSearch: Option[FullTextSearch] = None
   def pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty
+  def pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty
 
   // Runtime push down
   val pushedRuntimePartitionFilters: ListBuffer[PartitionPredicate] = ListBuffer.empty
@@ -80,7 +81,10 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
     }
   }
 
-  /** Pruned read RowType, with variant fields rewritten if variant pushdown was accepted. */
+  /**
+   * Pruned read RowType, with variant fields rewritten if variant pushdown was accepted, with
+   * accepted nested field pushdowns rewritten.
+   */
   private[paimon] val (readTableRowType, metadataFields) = {
     requiredSchema.fields.foreach(f => checkMetadataColumn(f.name))
     val (_requiredTableFields, _metadataFields) =
@@ -90,7 +94,10 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
     val withVariants =
       if (pushedVariantExtractions.isEmpty) pruned
       else VariantPushDownUtils.rewriteRowType(pruned, pushedVariantExtractions)
-    (withVariants, _metadataFields)
+    val withMapSelectedKeys =
+      if (pushedMapSelectedKeys.isEmpty) withVariants
+      else MapSelectedKeysPushDownUtils.rewriteRowType(withVariants, pushedMapSelectedKeys)
+    (withMapSelectedKeys, _metadataFields)
   }
 
   private def checkMetadataColumn(fieldName: String): Unit = {
@@ -198,6 +205,13 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
           .describeRewrittenRowType(readTableRowType)
           .map(s => s", PushedVariants: [$s]")
           .getOrElse("")
+    val pushedMapSelectedKeysStr =
+      if (pushedMapSelectedKeys.isEmpty) ""
+      else
+        MapSelectedKeysPushDownUtils
+          .describeRewrittenRowType(readTableRowType)
+          .map(s => s", PushedMapSelectedKeys: [$s]")
+          .getOrElse("")
     s"${getClass.getSimpleName}: [${table.name}]" +
       pushedPartitionFiltersStr +
       pushedRuntimePartitionFiltersStr +
@@ -207,6 +221,7 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
       pushedVectorSearch.map(vs => s", VectorSearch: [$vs]").getOrElse("") +
       pushedHybridSearch.map(hs => s", HybridSearch: [$hs]").getOrElse("") +
       pushedFullTextSearch.map(fts => s", FullTextSearch: [$fts]").getOrElse("") +
-      pushedVariantsStr
+      pushedVariantsStr +
+      pushedMapSelectedKeysStr
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BaseScan.scala
@@ -54,7 +54,7 @@ trait BaseScan extends Scan with SupportsReportStatistics with Logging {
   def pushedHybridSearch: Option[HybridSearch] = None
   def pushedFullTextSearch: Option[FullTextSearch] = None
   def pushedVariantExtractions: Map[Seq[String], Seq[VariantExtractionInfo]] = Map.empty
-  def pushedMapSelectedKeys: Map[Seq[String], Seq[String]] = Map.empty
+  def pushedMapSelectedKeys: Map[String, Seq[String]] = Map.empty
 
   // Runtime push down
   val pushedRuntimePartitionFilters: ListBuffer[PartitionPredicate] = ListBuffer.empty

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtils.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read
+
+import org.apache.paimon.data.shredding.MapSelectedKeysMetadataUtils
+import org.apache.paimon.types.{DataField, MapType, RowType}
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/** MAP selected-key pushdown business logic. */
+object MapSelectedKeysPushDownUtils {
+
+  /** Replace accepted MAP fields with selected-key ROW fields in the temporary read type. */
+  def rewriteRowType(rt: RowType, accepted: Map[Seq[String], Seq[String]]): RowType =
+    rewriteRowType(rt, accepted, Vector.empty)
+
+  private def rewriteRowType(
+      rt: RowType,
+      accepted: Map[Seq[String], Seq[String]],
+      prefix: Seq[String]): RowType = {
+    val newFields = rt.getFields.asScala.map(f => rewriteField(f, accepted, prefix)).asJava
+    new RowType(rt.isNullable, newFields)
+  }
+
+  private def rewriteField(
+      field: DataField,
+      accepted: Map[Seq[String], Seq[String]],
+      prefix: Seq[String]): DataField = {
+    val path = prefix :+ field.name()
+    accepted.get(path) match {
+      case Some(keys) =>
+        field.`type`() match {
+          case mapType: MapType =>
+            val selectedFields = keys.zipWithIndex.map {
+              case (_, ordinal) =>
+                new DataField(ordinal, ordinal.toString, mapType.getValueType.copy(true))
+            }.asJava
+            MapSelectedKeysMetadataUtils.withSelectedKeys(
+              field,
+              new RowType(field.`type`().isNullable, selectedFields),
+              keys.asJava)
+          case _ => field
+        }
+      case None =>
+        field.`type`() match {
+          case nested: RowType => field.newType(rewriteRowType(nested, accepted, path))
+          case _ => field
+        }
+    }
+  }
+
+  /** "col=[key1,key2], nested.col=[key1]" rendering for `Scan.description()`. */
+  def describeRewrittenRowType(rt: RowType): Option[String] = {
+    val parts = mutable.ArrayBuffer.empty[String]
+    collectSelectedKeys(rt, Vector.empty, parts)
+    if (parts.isEmpty) None else Some(parts.mkString(", "))
+  }
+
+  private def collectSelectedKeys(
+      rt: RowType,
+      prefix: Seq[String],
+      out: mutable.ArrayBuffer[String]): Unit = {
+    rt.getFields.asScala.foreach {
+      field =>
+        val path = prefix :+ field.name()
+        if (MapSelectedKeysMetadataUtils.isMapSelectedKeysField(field)) {
+          val keys = MapSelectedKeysMetadataUtils.selectedKeys(field.description()).asScala
+          out.append(s"${path.mkString(".")}=[${keys.mkString(",")}]")
+        } else {
+          field.`type`() match {
+            case child: RowType => collectSelectedKeys(child, path, out)
+            case _ =>
+          }
+        }
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtils.scala
@@ -24,27 +24,17 @@ import org.apache.paimon.types.{DataField, MapType, RowType}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-/** MAP selected-key pushdown business logic. */
+/** Shared-shredding MAP selected-key pushdown business logic. */
 object MapSelectedKeysPushDownUtils {
 
-  /** Replace accepted MAP fields with selected-key ROW fields in the temporary read type. */
-  def rewriteRowType(rt: RowType, accepted: Map[Seq[String], Seq[String]]): RowType =
-    rewriteRowType(rt, accepted, Vector.empty)
-
-  private def rewriteRowType(
-      rt: RowType,
-      accepted: Map[Seq[String], Seq[String]],
-      prefix: Seq[String]): RowType = {
-    val newFields = rt.getFields.asScala.map(f => rewriteField(f, accepted, prefix)).asJava
+  /** Replace accepted top-level MAP fields with selected-key ROW fields in the read type. */
+  def rewriteRowType(rt: RowType, accepted: Map[String, Seq[String]]): RowType = {
+    val newFields = rt.getFields.asScala.map(f => rewriteField(f, accepted)).asJava
     new RowType(rt.isNullable, newFields)
   }
 
-  private def rewriteField(
-      field: DataField,
-      accepted: Map[Seq[String], Seq[String]],
-      prefix: Seq[String]): DataField = {
-    val path = prefix :+ field.name()
-    accepted.get(path) match {
+  private def rewriteField(field: DataField, accepted: Map[String, Seq[String]]): DataField = {
+    accepted.get(field.name()) match {
       case Some(keys) =>
         field.`type`() match {
           case mapType: MapType =>
@@ -58,36 +48,23 @@ object MapSelectedKeysPushDownUtils {
               keys.asJava)
           case _ => field
         }
-      case None =>
-        field.`type`() match {
-          case nested: RowType => field.newType(rewriteRowType(nested, accepted, path))
-          case _ => field
-        }
+      case None => field
     }
   }
 
-  /** "col=[key1,key2], nested.col=[key1]" rendering for `Scan.description()`. */
+  /** "col=[key1,key2]" rendering for `Scan.description()`. */
   def describeRewrittenRowType(rt: RowType): Option[String] = {
     val parts = mutable.ArrayBuffer.empty[String]
-    collectSelectedKeys(rt, Vector.empty, parts)
+    collectSelectedKeys(rt, parts)
     if (parts.isEmpty) None else Some(parts.mkString(", "))
   }
 
-  private def collectSelectedKeys(
-      rt: RowType,
-      prefix: Seq[String],
-      out: mutable.ArrayBuffer[String]): Unit = {
+  private def collectSelectedKeys(rt: RowType, out: mutable.ArrayBuffer[String]): Unit = {
     rt.getFields.asScala.foreach {
       field =>
-        val path = prefix :+ field.name()
         if (MapSelectedKeysMetadataUtils.isMapSelectedKeysField(field)) {
           val keys = MapSelectedKeysMetadataUtils.selectedKeys(field.description()).asScala
-          out.append(s"${path.mkString(".")}=[${keys.mkString(",")}]")
-        } else {
-          field.`type`() match {
-            case child: RowType => collectSelectedKeys(child, path, out)
-            case _ =>
-          }
+          out.append(s"${field.name()}=[${keys.mkString(",")}]")
         }
     }
   }

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtilsTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtilsTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read
+
+import org.apache.paimon.data.shredding.MapSelectedKeysMetadataUtils
+import org.apache.paimon.types.{DataTypes, MapType, RowType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+/** Tests for {@link MapSelectedKeysPushDownUtils}. */
+class MapSelectedKeysPushDownUtilsTest extends AnyFunSuite {
+
+  test("rewrite map field with selected keys") {
+    val rowType = DataTypes.ROW(
+      DataTypes.FIELD(0, "id", DataTypes.INT()),
+      DataTypes.FIELD(1, "attrs", DataTypes.MAP(DataTypes.STRING(), DataTypes.BIGINT().notNull())),
+      DataTypes.FIELD(2, "tags", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))
+    )
+
+    val rewritten = MapSelectedKeysPushDownUtils.rewriteRowType(
+      rowType,
+      Map(Seq("attrs") -> Seq("key1", "key2"))
+    )
+
+    assert(rewritten.getField("id").`type`() == DataTypes.INT())
+    assert(rewritten.getField("tags").`type`().isInstanceOf[MapType])
+
+    val attrs = rewritten.getField("attrs")
+    assert(attrs.description() == "__PAIMON_MAP_SELECTED_KEYS:key1;key2")
+    assert(MapSelectedKeysMetadataUtils.isMapSelectedKeysField(attrs))
+    assert(
+      MapSelectedKeysMetadataUtils.selectedKeys(attrs.description()).asScala == Seq("key1", "key2"))
+
+    val attrsRowType = attrs.`type`().asInstanceOf[RowType]
+    assert(attrsRowType.getFieldNames.asScala == Seq("0", "1"))
+    assert(attrsRowType.getField("0").`type`() == DataTypes.BIGINT())
+    assert(attrsRowType.getField("1").`type`() == DataTypes.BIGINT())
+    assert(attrsRowType.getField("0").`type`().isNullable)
+    assert(attrsRowType.getField("1").`type`().isNullable)
+  }
+
+  test("rewrite nested map field with selected keys") {
+    val nestedType = DataTypes.ROW(
+      DataTypes.FIELD(2, "name", DataTypes.STRING()),
+      DataTypes.FIELD(3, "attrs", DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()))
+    )
+    val rowType = DataTypes.ROW(
+      DataTypes.FIELD(0, "id", DataTypes.INT()),
+      DataTypes.FIELD(1, "profile", nestedType)
+    )
+
+    val rewritten = MapSelectedKeysPushDownUtils.rewriteRowType(
+      rowType,
+      Map(Seq("profile", "attrs") -> Seq("key1", "key2"))
+    )
+
+    val profile = rewritten.getField("profile").`type`().asInstanceOf[RowType]
+    assert(profile.getField("name").`type`() == DataTypes.STRING())
+
+    val attrs = profile.getField("attrs")
+    assert(attrs.description() == "__PAIMON_MAP_SELECTED_KEYS:key1;key2")
+    assert(
+      MapSelectedKeysMetadataUtils.selectedKeys(attrs.description()).asScala == Seq("key1", "key2"))
+
+    val attrsRowType = attrs.`type`().asInstanceOf[RowType]
+    assert(attrsRowType.getFieldNames.asScala == Seq("0", "1"))
+    assert(attrsRowType.getField("0").`type`() == DataTypes.DOUBLE())
+    assert(attrsRowType.getField("1").`type`() == DataTypes.DOUBLE())
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtilsTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/read/MapSelectedKeysPushDownUtilsTest.scala
@@ -37,7 +37,7 @@ class MapSelectedKeysPushDownUtilsTest extends AnyFunSuite {
 
     val rewritten = MapSelectedKeysPushDownUtils.rewriteRowType(
       rowType,
-      Map(Seq("attrs") -> Seq("key1", "key2"))
+      Map("attrs" -> Seq("key1", "key2"))
     )
 
     assert(rewritten.getField("id").`type`() == DataTypes.INT())
@@ -57,7 +57,7 @@ class MapSelectedKeysPushDownUtilsTest extends AnyFunSuite {
     assert(attrsRowType.getField("1").`type`().isNullable)
   }
 
-  test("rewrite nested map field with selected keys") {
+  test("ignore nested map field with selected keys") {
     val nestedType = DataTypes.ROW(
       DataTypes.FIELD(2, "name", DataTypes.STRING()),
       DataTypes.FIELD(3, "attrs", DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()))
@@ -69,20 +69,12 @@ class MapSelectedKeysPushDownUtilsTest extends AnyFunSuite {
 
     val rewritten = MapSelectedKeysPushDownUtils.rewriteRowType(
       rowType,
-      Map(Seq("profile", "attrs") -> Seq("key1", "key2"))
+      Map("profile.attrs" -> Seq("key1", "key2"))
     )
 
     val profile = rewritten.getField("profile").`type`().asInstanceOf[RowType]
     assert(profile.getField("name").`type`() == DataTypes.STRING())
-
-    val attrs = profile.getField("attrs")
-    assert(attrs.description() == "__PAIMON_MAP_SELECTED_KEYS:key1;key2")
-    assert(
-      MapSelectedKeysMetadataUtils.selectedKeys(attrs.description()).asScala == Seq("key1", "key2"))
-
-    val attrsRowType = attrs.`type`().asInstanceOf[RowType]
-    assert(attrsRowType.getFieldNames.asScala == Seq("0", "1"))
-    assert(attrsRowType.getField("0").`type`() == DataTypes.DOUBLE())
-    assert(attrsRowType.getField("1").`type`() == DataTypes.DOUBLE())
+    assert(profile.getField("attrs").description() == null)
+    assert(profile.getField("attrs").`type`().isInstanceOf[MapType])
   }
 }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
@@ -120,9 +120,27 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase with Expre
     }
   }
 
-  test("Paimon Optimization: map selected-key pushdown skips metadata-unsafe keys") {
+  test("Paimon Optimization: map selected-key pushdown only supports shared-shredding map") {
     withTable("T") {
       spark.sql("CREATE TABLE T (id INT, attrs MAP<STRING, BIGINT>)")
+
+      val normalMapScan = mapSelectedKeysPaimonScan("SELECT attrs['key1'] FROM T")
+      Assertions.assertTrue(normalMapScan.pushedMapSelectedKeys.isEmpty)
+    }
+
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, attrs MAP<STRING, BIGINT>)
+                  |TBLPROPERTIES (
+                  |  'fields.attrs.map.storage-layout' = 'shared-shredding'
+                  |)
+                  |""".stripMargin)
+
+      val sharedShreddingMapScan =
+        mapSelectedKeysPaimonScan("SELECT attrs['key1'], attrs['key2'] FROM T")
+      Assertions.assertEquals(
+        Map(Seq("attrs") -> Seq("key1", "key2")),
+        sharedShreddingMapScan.pushedMapSelectedKeys)
 
       val delimiterKeyScan = mapSelectedKeysPaimonScan("SELECT attrs['a;b'] FROM T")
       Assertions.assertTrue(delimiterKeyScan.pushedMapSelectedKeys.isEmpty)

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
@@ -129,6 +129,13 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase with Expre
     }
 
     withTable("T") {
+      spark.sql("CREATE TABLE T (id INT, profile STRUCT<attrs: MAP<STRING, BIGINT>>)")
+
+      val nestedMapScan = mapSelectedKeysPaimonScan("SELECT profile.attrs['key1'] FROM T")
+      Assertions.assertTrue(nestedMapScan.pushedMapSelectedKeys.isEmpty)
+    }
+
+    withTable("T") {
       spark.sql("""
                   |CREATE TABLE T (id INT, attrs MAP<STRING, BIGINT>)
                   |TBLPROPERTIES (
@@ -139,7 +146,7 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase with Expre
       val sharedShreddingMapScan =
         mapSelectedKeysPaimonScan("SELECT attrs['key1'], attrs['key2'] FROM T")
       Assertions.assertEquals(
-        Map(Seq("attrs") -> Seq("key1", "key2")),
+        Map("attrs" -> Seq("key1", "key2")),
         sharedShreddingMapScan.pushedMapSelectedKeys)
 
       val delimiterKeyScan = mapSelectedKeysPaimonScan("SELECT attrs['a;b'] FROM T")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonOptimizationTestBase.scala
@@ -19,9 +19,10 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.Snapshot.CommitKind
-import org.apache.paimon.spark.PaimonSparkTestBase
+import org.apache.paimon.spark.{PaimonScan, PaimonSparkTestBase}
 import org.apache.paimon.spark.catalyst.analysis.expressions.ExpressionHelper
 import org.apache.paimon.spark.catalyst.optimizer.MergePaimonScalarSubqueries
+import org.apache.paimon.spark.catalyst.optimizer.PushDownMapSelectedKeys
 import org.apache.paimon.spark.execution.TruncatePaimonTableWithFilterExec
 
 import org.apache.spark.sql.{DataFrame, PaimonUtils, Row}
@@ -29,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, CreateNamedStruct, 
 import org.apache.spark.sql.catalyst.plans.logical.{CTERelationDef, LogicalPlan, OneRowRelation, WithCTE}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.execution.CommandResultExec
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.functions._
 import org.junit.jupiter.api.Assertions
 
@@ -115,6 +117,19 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase with Expre
       // topN
       val sqlText2 = "SELECT id FROM T ORDER BY id ASC NULLS LAST LIMIT 5"
       Assertions.assertEquals(getPaimonScan(sqlText2), getPaimonScan(sqlText2))
+    }
+  }
+
+  test("Paimon Optimization: map selected-key pushdown skips metadata-unsafe keys") {
+    withTable("T") {
+      spark.sql("CREATE TABLE T (id INT, attrs MAP<STRING, BIGINT>)")
+
+      val delimiterKeyScan = mapSelectedKeysPaimonScan("SELECT attrs['a;b'] FROM T")
+      Assertions.assertTrue(delimiterKeyScan.pushedMapSelectedKeys.isEmpty)
+
+      val metadataPrefixKeyScan =
+        mapSelectedKeysPaimonScan("SELECT attrs['__PAIMON_MAP_SELECTED_KEYS:key1'] FROM T")
+      Assertions.assertTrue(metadataPrefixKeyScan.pushedMapSelectedKeys.isEmpty)
     }
   }
 
@@ -232,6 +247,12 @@ abstract class PaimonOptimizationTestBase extends PaimonSparkTestBase with Expre
   }
 
   def extractorExpression(cteIndex: Int, output: Seq[Attribute], fieldIndex: Int): NamedExpression
+
+  private def mapSelectedKeysPaimonScan(sqlText: String): PaimonScan = {
+    PushDownMapSelectedKeys(sql(sqlText).queryExecution.optimizedPlan).collectFirst {
+      case relation: DataSourceV2ScanRelation => relation.scan.asInstanceOf[PaimonScan]
+    }.get
+  }
 
   def checkTruncatePaimonTable(df: DataFrame): Unit = {
     val plan = df.queryExecution.executedPlan.asInstanceOf[CommandResultExec].commandPhysicalPlan

--- a/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
+++ b/paimon-spark/paimon-spark4-common/src/main/scala/org/apache/paimon/spark/catalyst/optimizer/PushDownMapSelectedKeys.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.catalyst.optimizer
+
+import org.apache.paimon.spark.PaimonScan
+
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+object PushDownMapSelectedKeys extends PushDownMapSelectedKeysBase {
+
+  override protected def copyDataSourceV2ScanRelation(
+      relation: DataSourceV2ScanRelation,
+      scan: PaimonScan,
+      output: Seq[AttributeReference]): DataSourceV2ScanRelation = {
+    DataSourceV2ScanRelation(
+      relation.relation,
+      scan,
+      output,
+      relation.keyGroupedPartitioning,
+      relation.ordering)
+  }
+}


### PR DESCRIPTION
### Purpose
This PR introduces the preliminary Spark-side and metadata infrastructure for MAP selected-key pushdown.
The target use case is to allow upper engines, such as Spark, to describe a read schema like:

`SELECT
  id,
  attrs['key1'] AS key1_value,
  attrs['key2'] AS key2_value
FROM T;`

as a temporary Paimon read type where the MAP field is rewritten to a ROW field, and the selected MAP keys are recorded in DataField.description:

`__PAIMON_MAP_SELECTED_KEYS:key1;key2`

This metadata is only intended to exist in the temporary scan/read schema. It must not be persisted into table schema or catalog schema.

#### Explicitly out of scope
This PR does not enable the full read path yet. The following parts are intentionally left for a follow-up PR for #8392 is not merged:
- FormatReaderMapping support for consuming __PAIMON_MAP_SELECTED_KEYS.
- Core reader support for reading a MAP field as a rewritten ROW field.
- Shared-shredding MAP reader support for selected-key recall.
- End-to-end SQL execution for attrs['key1'] / element_at(attrs, 'key1') selected-key pushdown.
Because the reader/core side is not implemented in this PR, the optimizer rule is not registered in PaimonSparkSessionExtensions.

### Tests
MAP selected-key metadata construction and parsing.
Empty key handling.
Duplicate selected-key validation.
Spark read type rewrite behavior for selected MAP keys.