### PR TITLE
[core] Ignore blank values in FieldListaggAgg operator.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.BinaryStringUtils;
+import org.apache.paimon.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -50,21 +51,14 @@ public class FieldListaggAgg extends FieldAggregator {
 
     @Override
     public Object agg(Object accumulator, Object inputField) {
-        if (accumulator == null || inputField == null) {
-            return accumulator == null ? inputField : accumulator;
+        if (inputField == null || StringUtils.isBlank(inputField.toString())) {
+            return accumulator;
         }
         // ordered by type root definition
 
-        BinaryString mergeFieldSD = (BinaryString) accumulator;
+        BinaryString mergeFieldSD =
+                accumulator != null ? (BinaryString) accumulator : BinaryString.EMPTY_UTF8;
         BinaryString inFieldSD = (BinaryString) inputField;
-
-        if (inFieldSD.getSizeInBytes() <= 0) {
-            return mergeFieldSD;
-        }
-
-        if (mergeFieldSD.getSizeInBytes() <= 0) {
-            return inFieldSD;
-        }
 
         if (distinct) {
             BinaryString[] accumulatorTokens =
@@ -75,15 +69,19 @@ public class FieldListaggAgg extends FieldAggregator {
             }
 
             List<BinaryString> result = new ArrayList<>();
-            result.add(mergeFieldSD);
+            if (mergeFieldSD.getSizeInBytes() > 0) {
+                result.add(mergeFieldSD);
+            }
             for (BinaryString str :
                     splitByWholeSeparatorPreserveAllTokens(inFieldSD, delimiterBinaryString)) {
-                if (str.getSizeInBytes() == 0 || existingTokens.contains(str)) {
+                if (StringUtils.isBlank(str.toString()) || existingTokens.contains(str)) {
                     continue;
                 }
 
                 existingTokens.add(str);
-                result.add(delimiterBinaryString);
+                if (!result.isEmpty()) {
+                    result.add(delimiterBinaryString);
+                }
                 result.add(str);
             }
 

--- a/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
+++ b/paimon-core/src/main/java/org/apache/paimon/mergetree/compact/aggregate/FieldListaggAgg.java
@@ -56,8 +56,11 @@ public class FieldListaggAgg extends FieldAggregator {
         }
         // ordered by type root definition
 
-        BinaryString mergeFieldSD =
-                accumulator != null ? (BinaryString) accumulator : BinaryString.EMPTY_UTF8;
+        if (accumulator == null || StringUtils.isBlank(accumulator.toString())) {
+            return inputField;
+        }
+
+        BinaryString mergeFieldSD = (BinaryString) accumulator;
         BinaryString inFieldSD = (BinaryString) inputField;
 
         if (distinct) {
@@ -69,9 +72,7 @@ public class FieldListaggAgg extends FieldAggregator {
             }
 
             List<BinaryString> result = new ArrayList<>();
-            if (mergeFieldSD.getSizeInBytes() > 0) {
-                result.add(mergeFieldSD);
-            }
+            result.add(mergeFieldSD);
             for (BinaryString str :
                     splitByWholeSeparatorPreserveAllTokens(inFieldSD, delimiterBinaryString)) {
                 if (StringUtils.isBlank(str.toString()) || existingTokens.contains(str)) {
@@ -79,9 +80,7 @@ public class FieldListaggAgg extends FieldAggregator {
                 }
 
                 existingTokens.add(str);
-                if (!result.isEmpty()) {
-                    result.add(delimiterBinaryString);
-                }
+                result.add(delimiterBinaryString);
                 result.add(str);
             }
 

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -480,6 +480,24 @@ public class FieldAggregatorTest {
     }
 
     @Test
+    public void testFieldListAggFirstNonBlankValueWithoutLeadingDelimiter() {
+        FieldListaggAgg fieldListaggAgg =
+                new FieldListaggAggFactory()
+                        .create(
+                                new VarCharType(VarCharType.MAX_LENGTH),
+                                new CoreOptions(new HashMap<>()),
+                                "fieldName");
+
+        BinaryString accumulator = null;
+        accumulator = (BinaryString) fieldListaggAgg.agg(accumulator, BinaryString.fromString(" "));
+        accumulator =
+                (BinaryString)
+                        fieldListaggAgg.agg(accumulator, BinaryString.fromString("first line"));
+
+        assertThat(accumulator.toString()).isEqualTo("first line");
+    }
+
+    @Test
     public void testFieldMaxAgg() {
         FieldMaxAgg fieldMaxAgg = new FieldMaxAggFactory().create(new IntType(), null, null);
         Integer accumulator = 1;

--- a/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/mergetree/compact/aggregate/FieldAggregatorTest.java
@@ -412,6 +412,74 @@ public class FieldAggregatorTest {
     }
 
     @Test
+    public void testFieldListAggWithDefaultDelimiterIgnoringBlankValues() {
+        FieldListaggAgg fieldListaggAgg =
+                new FieldListaggAggFactory()
+                        .create(
+                                new VarCharType(VarCharType.MAX_LENGTH),
+                                new CoreOptions(new HashMap<>()),
+                                "fieldName");
+        BinaryString result =
+                Stream.of(
+                                BinaryString.fromString("user1"),
+                                BinaryString.fromString(""),
+                                BinaryString.fromString(" "),
+                                BinaryString.fromString("   "),
+                                BinaryString.fromString("\t"),
+                                BinaryString.fromString("\n"),
+                                BinaryString.fromString("\r"),
+                                BinaryString.fromString("\r\n"),
+                                BinaryString.fromString(" \t\n "),
+                                BinaryString.fromString(" \t\n\r\n \u3000 "),
+                                BinaryString.fromString("user2"),
+                                BinaryString.fromString("\u3000"),
+                                BinaryString.fromString("\u2000"))
+                        .sequential()
+                        .reduce((l, r) -> (BinaryString) fieldListaggAgg.agg(l, r))
+                        .orElse(null);
+
+        assertNotNull(result);
+        assertThat(result.toString()).isEqualTo("user1,user2");
+    }
+
+    @Test
+    public void testFieldListAggWithDefaultDelimiterAndDistinctIgnoringBlankValues() {
+        FieldListaggAgg fieldListaggAgg =
+                new FieldListaggAggFactory()
+                        .create(
+                                new VarCharType(VarCharType.MAX_LENGTH),
+                                CoreOptions.fromMap(
+                                        ImmutableMap.of("fields.fieldName.distinct", "true")),
+                                "fieldName");
+
+        BinaryString result =
+                Stream.of(
+                                BinaryString.fromString("user1"),
+                                BinaryString.fromString("user2"),
+                                BinaryString.fromString("user1"),
+                                BinaryString.fromString("user3"),
+                                BinaryString.fromString(""),
+                                BinaryString.fromString(" "),
+                                BinaryString.fromString("   "),
+                                BinaryString.fromString("\t"),
+                                BinaryString.fromString("\n"),
+                                BinaryString.fromString("\r"),
+                                BinaryString.fromString("\r\n"),
+                                BinaryString.fromString(" \t\n "),
+                                BinaryString.fromString(" \t\n\r\n \u3000 "),
+                                BinaryString.fromString("user2"),
+                                BinaryString.fromString("user3"),
+                                BinaryString.fromString("\u3000"),
+                                BinaryString.fromString("\u2000"))
+                        .sequential()
+                        .reduce((l, r) -> (BinaryString) fieldListaggAgg.agg(l, r))
+                        .orElse(null);
+
+        assertNotNull(result);
+        assertEquals("user1,user2,user3", result.toString());
+    }
+
+    @Test
     public void testFieldMaxAgg() {
         FieldMaxAgg fieldMaxAgg = new FieldMaxAggFactory().create(new IntType(), null, null);
         Integer accumulator = 1;


### PR DESCRIPTION
### Purpose
[Fix] Ignore blank input values when using field.{fieldName}.aggregate-function=listagg

Expected behavior

| Case | Input A | Input B | Current Output | Expected Output |
|------|---------|---------|----------------|-----------------|
| listagg | `'user1,user2,user3'` | `''` (empty string) | `'user1,user2,user3,'` ❌ | `'user1,user2,user3'` |
| listagg | `'user1,user2,user3'` | `' '` (space) | `'user1,user2,user3, '` ❌ | `'user1,user2,user3'` |
| listagg | `'user1,user2,user3'` | `'\t'` (tab) | `'user1,user2,user3,\t'` ❌ | `'user1,user2,user3'` |
| listagg | `'user1,user2,user3'` | `'\n'` (newline) | `'user1,user2,user3,\n'` ❌ | `'user1,user2,user3'` |
| listagg | `'user1,user2,user3'` | `'\r'` (carriage return) | `'user1,user2,user3,\r'` ❌ | `'user1,user2,user3'` |
| listagg | `'   '` (whitespace only) | `'user1,user2,user3'` | `'   ,user1,user2,user3'` ❌ | `'user1,user2,user3'` |

Blank values are determined using `org.apache.paimon.utils.StringUtils.StringUtils.isBlank(...)`.

### Tests
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldListAggWithDefaultDelimiterIgnoringBlankValues
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldListAggWithDefaultDelimiterAndDistinctIgnoringBlankValues
- org.apache.paimon.mergetree.compact.aggregate.FieldAggregatorTest#testFieldListAggFirstNonBlankValueWithoutLeadingDelimiter
