### PR TITLE
[core] enable data-evolution compaction with deletion vectors rewrite

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -64,7 +64,6 @@ public class DataEvolutionCompactCoordinator {
     private static final int FILES_BATCH = 100_000;
     private static final int BLOB_COMPACT_MIN_FILE_NUM = 2;
 
-    private final boolean deletionVectorsEnabled;
     private final CompactScanner scanner;
     private final CompactPlanner planner;
 
@@ -79,12 +78,6 @@ public class DataEvolutionCompactCoordinator {
             boolean compactBlob,
             boolean compactVector) {
         CoreOptions options = table.coreOptions();
-        this.deletionVectorsEnabled = options.deletionVectorsEnabled();
-        if (deletionVectorsEnabled) {
-            this.scanner = null;
-            this.planner = null;
-            return;
-        }
 
         long targetFileSize = options.targetFileSize(false);
         long openFileCost = options.splitOpenFileCost();
@@ -117,10 +110,6 @@ public class DataEvolutionCompactCoordinator {
     }
 
     public List<DataEvolutionCompactTask> plan() {
-        if (deletionVectorsEnabled) {
-            throw new EndOfScanException();
-        }
-
         // scan files in snapshot
         List<ManifestEntry> entries = scanner.scan();
         if (!entries.isEmpty()) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.deletionvectors.Bitmap64DeletionVector;
+import org.apache.paimon.deletionvectors.BitmapDeletionVector;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.deletionvectors.append.AppendDeleteFileMaintainer;
+import org.apache.paimon.deletionvectors.append.BaseAppendDeleteFileMaintainer;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RangeHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
+import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.checkContiguousRowRange;
+import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
+import static org.apache.paimon.utils.Preconditions.checkState;
+
+/**
+ * Rewrites deletion vectors for non-materialized data-evolution compaction.
+ *
+ * <p>Compaction tasks rewrite data files without applying deletion vectors. This class consumes all
+ * compaction messages before commit, moves old anchor-file DVs to new compacted files, and returns
+ * index-only compact messages for the rewritten DV index files.
+ *
+ * <p>Unlike append compaction, data-evolution compaction does not pack compact tasks by deletion
+ * vector index files. Data-evolution compaction is batch-oriented, and packing by DV may create a
+ * huge compact task when many files contain only a few deleted rows. This is especially risky when
+ * blob compaction is involved. Instead, compact tasks are planned normally and DVs are rewritten
+ * centrally from compact commit messages. This is acceptable because most DVs only need to be
+ * renamed to the new anchor file and are not fully rewritten.
+ */
+public class DataEvolutionCompactDeletionVectorRewriter {
+
+    private final FileStoreTable table;
+
+    public DataEvolutionCompactDeletionVectorRewriter(FileStoreTable table) {
+        this.table = table;
+    }
+
+    public List<CommitMessage> rewriteDeletionVectors(List<CommitMessage> messages) {
+        if (!table.coreOptions().deletionVectorsEnabled() || messages.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        Map<BinaryRow, AppendDeleteFileMaintainer> maintainerByParts =
+                collectMaintainers(snapshot, messages);
+        if (maintainerByParts.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<CommitMessage> result = new ArrayList<>();
+        for (Map.Entry<BinaryRow, AppendDeleteFileMaintainer> entry :
+                maintainerByParts.entrySet()) {
+            List<IndexManifestEntry> indexChanges = entry.getValue().persist();
+            if (!indexChanges.isEmpty()) {
+                result.add(toCommitMessage(entry.getKey(), indexChanges));
+            }
+        }
+        return result;
+    }
+
+    private Map<BinaryRow, AppendDeleteFileMaintainer> collectMaintainers(
+            Snapshot snapshot, List<CommitMessage> messages) {
+        Map<BinaryRow, AppendDeleteFileMaintainer> result = new LinkedHashMap<>();
+        RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
+
+        for (CommitMessage message : messages) {
+            CommitMessageImpl commitMessage = (CommitMessageImpl) message;
+            CompactIncrement compactIncrement = commitMessage.compactIncrement();
+            checkNoCompactIndexChanges(compactIncrement);
+
+            checkState(
+                    commitMessage.bucket() == UNAWARE_BUCKET
+                            && commitMessage.totalBuckets() == null,
+                    "Data evolution compaction should only produce unaware-bucket commit "
+                            + "messages, but got bucket %s and total buckets %s.",
+                    commitMessage.bucket(),
+                    commitMessage.totalBuckets());
+
+            List<DataFileMeta> before = normalFiles(compactIncrement.compactBefore());
+            List<DataFileMeta> after = normalFiles(compactIncrement.compactAfter());
+
+            // Skip blob tasks
+            if (before.isEmpty() && after.isEmpty()) {
+                continue;
+            }
+
+            checkState(
+                    after.size() == 1,
+                    "Only one normal file should be generated by a single compact task.");
+            Range beforeRange = checkContiguousRowRange(before);
+            Range afterRange = after.get(0).nonNullRowIdRange();
+            checkState(
+                    beforeRange.equals(afterRange),
+                    "Non-materialized data evolution compaction should keep the same row-id "
+                            + "range, but compact before range is %s and compact after range is %s.",
+                    beforeRange,
+                    afterRange);
+
+            AppendDeleteFileMaintainer maintainer =
+                    result.computeIfAbsent(
+                            commitMessage.partition(),
+                            ignored ->
+                                    BaseAppendDeleteFileMaintainer.forUnawareAppend(
+                                            table.store().newIndexFileHandler(),
+                                            snapshot,
+                                            commitMessage.partition()));
+            DeletionVector merged = newDeletionVector();
+
+            // Merge all old DeletionVectors, should consider row range offset of each sub dv
+            for (List<DataFileMeta> previousRowGroup : rangeHelper.mergeOverlappingRanges(before)) {
+                DataFileMeta oldAnchor = retrieveAnchorFile(previousRowGroup, file -> file);
+                moveDeletionVector(
+                        maintainer,
+                        merged,
+                        oldAnchor.fileName(),
+                        oldAnchor.nonNullRowIdRange(),
+                        afterRange);
+            }
+            if (!merged.isEmpty()) {
+                maintainer.notifyNewDeletionVector(after.get(0).fileName(), merged);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * 'Move' the deletion vectors of old anchor files to the new anchor file. This may merge
+     * several deletion vectors into one if row-level compaction is triggered,
+     */
+    private void moveDeletionVector(
+            AppendDeleteFileMaintainer maintainer,
+            DeletionVector merged,
+            String oldFileName,
+            Range oldRange,
+            Range newRange) {
+        DeletionVector old = maintainer.getDeletionVector(oldFileName);
+        if (old == null || old.isEmpty()) {
+            return;
+        }
+
+        // Fast path for renaming deletion vectors only
+        if (oldRange.equals(newRange)) {
+            merged.merge(old);
+        } else {
+            old.forEachDeletedPosition(
+                    position -> {
+                        long absolutePosition = oldRange.from + position;
+                        long newPosition = absolutePosition - newRange.from;
+                        checkState(
+                                newPosition >= 0 && newPosition < newRange.count(),
+                                "Cannot move deletion position %s from old range %s to new range %s.",
+                                absolutePosition,
+                                oldRange,
+                                newRange);
+                        merged.delete(newPosition);
+                    });
+        }
+        maintainer.notifyRemovedDeletionVector(oldFileName);
+    }
+
+    private List<DataFileMeta> normalFiles(List<DataFileMeta> files) {
+        return files.stream().filter(this::isNormalFile).collect(Collectors.toList());
+    }
+
+    private boolean isNormalFile(DataFileMeta fileMeta) {
+        return !isBlobFile(fileMeta.fileName()) && !isVectorStoreFile(fileMeta.fileName());
+    }
+
+    private DeletionVector newDeletionVector() {
+        return table.coreOptions().deletionVectorBitmap64()
+                ? new Bitmap64DeletionVector()
+                : new BitmapDeletionVector();
+    }
+
+    private CommitMessage toCommitMessage(
+            BinaryRow partition, List<IndexManifestEntry> indexChanges) {
+        List<IndexFileMeta> newIndexFiles = new ArrayList<>();
+        List<IndexFileMeta> deletedIndexFiles = new ArrayList<>();
+        for (IndexManifestEntry entry : indexChanges) {
+            if (entry.kind() == FileKind.ADD) {
+                newIndexFiles.add(entry.indexFile());
+            } else {
+                deletedIndexFiles.add(entry.indexFile());
+            }
+        }
+
+        return new CommitMessageImpl(
+                partition,
+                UNAWARE_BUCKET,
+                null,
+                DataIncrement.emptyIncrement(),
+                new CompactIncrement(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        newIndexFiles,
+                        deletedIndexFiles));
+    }
+
+    private void checkNoCompactIndexChanges(CompactIncrement compactIncrement) {
+        checkState(
+                compactIncrement.newIndexFiles().isEmpty()
+                        && compactIncrement.deletedIndexFiles().isEmpty(),
+                "Data evolution compaction should not produce index changes before deletion vector rewrite, "
+                        + "but got new index files %s and deleted index files %s.",
+                compactIncrement.newIndexFiles(),
+                compactIncrement.deletedIndexFiles());
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -65,6 +65,7 @@ import static java.util.Comparator.comparingLong;
 import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
 import static org.apache.paimon.types.VectorType.fieldNamesInVectorFile;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.checkContiguousRowRange;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Data evolution table compaction task. */
@@ -97,9 +98,6 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
     public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
         CoreOptions options = table.coreOptions();
-        checkArgument(
-                !options.deletionVectorsEnabled(),
-                "Data evolution compaction does not support deletion vectors.");
 
         if (blobTask) {
             return doCompactBlobFiles(table, commitUser);
@@ -180,12 +178,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         compactAfter.add(dataFileMeta);
 
         CompactIncrement compactIncrement =
-                new CompactIncrement(
-                        compactBefore,
-                        compactAfter,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList());
+                new CompactIncrement(compactBefore, compactAfter, Collections.emptyList());
         return new CommitMessageImpl(
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
@@ -247,12 +240,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         checkSameRowRange(sortedCompactBefore, compactAfter);
 
         CompactIncrement compactIncrement =
-                new CompactIncrement(
-                        sortedCompactBefore,
-                        compactAfter,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList());
+                new CompactIncrement(sortedCompactBefore, compactAfter, Collections.emptyList());
         return new CommitMessageImpl(
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
@@ -327,19 +315,6 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                 "Field %s in latest schema is not a blob file field.",
                 field.name());
         return field;
-    }
-
-    private Range checkContiguousRowRange(List<DataFileMeta> files) {
-        checkArgument(!files.isEmpty(), "%s should not be empty.", "Blob compact files");
-        List<Range> ranges =
-                files.stream().map(DataFileMeta::nonNullRowIdRange).collect(Collectors.toList());
-        List<Range> merged = Range.sortAndMergeOverlap(ranges, true);
-        checkArgument(
-                merged.size() == 1,
-                "%s should have a contiguous row range, but got %s.",
-                "Blob compact files",
-                merged);
-        return merged.get(0);
     }
 
     private void checkSameRowRange(

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -22,10 +22,13 @@ import org.apache.paimon.io.DataFileMeta;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Util class for Deletion Vectors. */
@@ -60,5 +63,19 @@ public class DataEvolutionUtils {
                 anchor != null,
                 "Data-evolution deletion vectors should have a normal anchor file in each row range group.");
         return anchor;
+    }
+
+    /** Check files row ranges. */
+    public static Range checkContiguousRowRange(List<DataFileMeta> files) {
+        checkArgument(!files.isEmpty(), "%s should not be empty.", "Data evolution compact files");
+        List<Range> ranges =
+                files.stream().map(DataFileMeta::nonNullRowIdRange).collect(Collectors.toList());
+        List<Range> merged = Range.sortAndMergeOverlap(ranges, true);
+        checkArgument(
+                merged.size() == 1,
+                "%s should have a contiguous row range, but got %s.",
+                "Data evolution compact files",
+                merged);
+        return merged.get(0);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -34,7 +34,6 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.FileStoreTable;
-import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
@@ -57,7 +56,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongFunction;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -554,40 +552,6 @@ public class DataEvolutionCompactCoordinatorTest {
         assertThat(tasks.get(0).partition()).isEqualTo(partitionB);
         assertThat(tasks.get(0).compactBefore().stream().map(DataFileMeta::fileName))
                 .containsExactly(b1.file().fileName(), b2.file().fileName());
-    }
-
-    @Test
-    public void testPlanEndsScanWhenDeletionVectorsEnabled() {
-        Options options = new Options();
-        options.set(CoreOptions.DATA_EVOLUTION_ENABLED, true);
-        options.set(CoreOptions.DELETION_VECTORS_ENABLED, true);
-        FileStoreTable table = mock(FileStoreTable.class);
-        when(table.coreOptions()).thenReturn(new CoreOptions(options));
-
-        DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
-
-        assertThatThrownBy(coordinator::plan).isInstanceOf(EndOfScanException.class);
-    }
-
-    @Test
-    public void testCompactTaskRejectsDeletionVectorEnabledTable() {
-        Options options = new Options();
-        options.set(CoreOptions.DELETION_VECTORS_ENABLED, true);
-        FileStoreTable table = mock(FileStoreTable.class);
-        when(table.coreOptions()).thenReturn(new CoreOptions(options));
-
-        DataEvolutionCompactTask task =
-                new DataEvolutionCompactTask(
-                        BinaryRow.EMPTY_ROW,
-                        Collections.singletonList(
-                                createDataFileMeta("file1.parquet", 0L, 100L, 0, 1024)),
-                        false);
-
-        assertThatThrownBy(() -> task.doCompact(table, "user"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(
-                        "Data evolution compaction does not support deletion vectors.");
     }
 
     private ManifestEntry makeEntry(

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -19,6 +19,9 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BlobData;
@@ -29,6 +32,7 @@ import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.deletionvectors.append.BaseAppendDeleteFileMaintainer;
 import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.index.DeletionVectorMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
@@ -46,6 +50,7 @@ import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DeletionFile;
+import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
@@ -66,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
 import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
@@ -238,6 +244,142 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                         "9|name-9|base-9|9");
     }
 
+    @Test
+    public void testCompactRewritesDeletionVectors() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(table, DEFAULT_DV_SPECS);
+        List<String> oldAnchorFiles = new ArrayList<>(anchorFilesByRange(table).values());
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        assertRegularFileRowRanges(
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList()),
+                Collections.singletonList(FULL_RANGE));
+        assertRowsAndProjections(table, "updated");
+
+        DataSplit fullRangeSplit = planDataSplit(table, FULL_RANGE);
+        assertDeletionFileRanges(fullRangeSplit, FULL_RANGE);
+        assertThat(fullRangeSplit.mergedRowCount()).hasValue(10L);
+        String newAnchorFile = anchorFilesByRange(table).get(FULL_RANGE);
+        List<String> liveDeletionVectorDataFileNames = liveDeletionVectorDataFileNames(table);
+        assertThat(liveDeletionVectorDataFileNames).containsExactly(newAnchorFile);
+        assertThat(liveDeletionVectorDataFileNames).doesNotContainAnyElementsOf(oldAnchorFiles);
+    }
+
+    @Test
+    public void testCompactRenamesDeletionVectorForSameRowRange() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(table, Collections.singletonList(new DvSpec(FIRST_RANGE, 1, 4)));
+        String oldAnchorFile = anchorFilesByRange(table).get(FIRST_RANGE);
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(CoreOptions.TARGET_FILE_SIZE.key(), "1 B");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        assertRegularFileRowRanges(
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList()),
+                Arrays.asList(new Range(0, 4), new Range(5, 9), new Range(10, 14)));
+        assertThat(readRows(table.newReadBuilder()))
+                .containsExactlyElementsOf(expectedRowsExcluding("updated", FULL_RANGE, 1, 4));
+
+        DataSplit firstRangeSplit = planDataSplit(table, FIRST_RANGE);
+        assertDeletionFileRanges(firstRangeSplit, FIRST_RANGE);
+        assertThat(firstRangeSplit.mergedRowCount()).hasValue(3L);
+        String newAnchorFile = anchorFilesByRange(table).get(FIRST_RANGE);
+        assertThat(newAnchorFile).isNotEqualTo(oldAnchorFile);
+        assertThat(liveDeletionVectorDataFileNames(table)).containsExactly(newAnchorFile);
+    }
+
+    @Test
+    public void testCompactRewritesOnlyExistingDeletionVectors() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(table, Collections.singletonList(new DvSpec(new Range(5, 9), 6)));
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        assertRegularFileRowRanges(
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList()),
+                Collections.singletonList(FULL_RANGE));
+        assertThat(readRows(table.newReadBuilder()))
+                .containsExactlyElementsOf(expectedRowsExcluding("updated", FULL_RANGE, 6));
+
+        DataSplit fullRangeSplit = planDataSplit(table, FULL_RANGE);
+        assertDeletionFileRanges(fullRangeSplit, FULL_RANGE);
+        assertThat(fullRangeSplit.mergedRowCount()).hasValue(14L);
+        assertThat(liveDeletionVectorDataFileNames(table))
+                .containsExactly(anchorFilesByRange(table).get(FULL_RANGE));
+    }
+
+    @Test
+    public void testCompactWithoutDeletionVectors() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        assertRegularFileRowRanges(
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList()),
+                Collections.singletonList(FULL_RANGE));
+        assertThat(readRows(table.newReadBuilder()))
+                .containsExactlyElementsOf(expectedRowsExcluding("updated", FULL_RANGE));
+
+        DataSplit fullRangeSplit = planDataSplit(table, FULL_RANGE);
+        assertDeletionFileRanges(fullRangeSplit);
+        assertThat(fullRangeSplit.mergedRowCount()).hasValue(15L);
+        assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+    }
+
+    @Test
+    public void testBlobCompactKeepsDeletionVectors() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        commitDeletionVectors(table, DEFAULT_DV_SPECS);
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "128 MB");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), true);
+
+        table = getTableDefault();
+        assertRowsAndProjections(table, "base");
+        assertFirstBlobFileRowRanges(table, Arrays.asList(new Range(0, 4), new Range(5, 9)), 3);
+        assertDeletionFileRanges(
+                planDataSplit(table, FULL_RANGE),
+                new Range(0, 4),
+                new Range(5, 9),
+                new Range(10, 14));
+    }
+
     @Override
     protected Schema schemaDefault() {
         Schema.Builder schemaBuilder = Schema.newBuilder();
@@ -286,6 +428,27 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                 commit.commit(commitables);
             }
         }
+    }
+
+    private void compactDataEvolutionTable(FileStoreTable table, boolean compactBlob)
+            throws Exception {
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(table, compactBlob, false);
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        try {
+            while (true) {
+                for (DataEvolutionCompactTask task : coordinator.plan()) {
+                    commitMessages.add(task.doCompact(table, "test-compact"));
+                }
+            }
+        } catch (EndOfScanException ignored) {
+        }
+        assertThat(commitMessages).isNotEmpty();
+
+        commitMessages.addAll(
+                new DataEvolutionCompactDeletionVectorRewriter(table)
+                        .rewriteDeletionVectors(commitMessages));
+        commitDefault(commitMessages);
     }
 
     private void commitDeletionVectors(FileStoreTable table, List<DvSpec> deletionVectorSpecs)
@@ -346,6 +509,17 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
     private static void assertReadMatrix(FileStoreTable table, String structuredValuePrefix)
             throws Exception {
+        assertRowsAndProjections(table, structuredValuePrefix);
+
+        DataSplit fullRangeSplit = planDataSplit(table, FULL_RANGE);
+        assertDeletionFileRanges(
+                fullRangeSplit, new Range(0, 4), new Range(5, 9), new Range(10, 14));
+        assertThat(fullRangeSplit.mergedRowCount()).hasValue(10L);
+        assertThat(planDataSplit(table, FIRST_RANGE).mergedRowCount()).hasValue(3L);
+    }
+
+    private static void assertRowsAndProjections(FileStoreTable table, String structuredValuePrefix)
+            throws Exception {
         List<String> expectedRows = expectedRows(structuredValuePrefix, FULL_RANGE);
         List<String> expectedFirstRangeRows = expectedRows(structuredValuePrefix, FIRST_RANGE);
         List<String> expectedProjectedStrings =
@@ -390,16 +564,15 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                                         .withProjection(new int[] {3})
                                         .withRowRanges(Collections.singletonList(FULL_RANGE))))
                 .containsExactlyElementsOf(expectedBlobValues);
-
-        DataSplit fullRangeSplit = planDataSplit(table, FULL_RANGE);
-        assertDeletionFileRanges(
-                fullRangeSplit, new Range(0, 4), new Range(5, 9), new Range(10, 14));
-        assertThat(fullRangeSplit.mergedRowCount()).hasValue(10L);
-        assertThat(planDataSplit(table, FIRST_RANGE).mergedRowCount()).hasValue(3L);
     }
 
     private static void assertDeletionFileRanges(DataSplit split, Range... expectedRanges) {
-        List<DeletionFile> deletionFiles = split.deletionFiles().orElse(Collections.emptyList());
+        if (!split.deletionFiles().isPresent()) {
+            assertThat(expectedRanges).isEmpty();
+            return;
+        }
+
+        List<DeletionFile> deletionFiles = split.deletionFiles().get();
         assertThat(deletionFiles).hasSize(split.dataFiles().size());
 
         Map<Range, DeletionFile> actual = new HashMap<>();
@@ -421,6 +594,17 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         List<String> rows = new ArrayList<>();
         for (int rowId = (int) range.from; rowId <= range.to; rowId++) {
             if (!isDeletedByDefaultDv(rowId)) {
+                rows.add(expectedRow(structuredValuePrefix, rowId));
+            }
+        }
+        return rows;
+    }
+
+    private static List<String> expectedRowsExcluding(
+            String structuredValuePrefix, Range range, long... deletedRowIds) {
+        List<String> rows = new ArrayList<>();
+        for (int rowId = (int) range.from; rowId <= range.to; rowId++) {
+            if (!isDeleted(rowId, deletedRowIds)) {
                 rows.add(expectedRow(structuredValuePrefix, rowId));
             }
         }
@@ -459,6 +643,15 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         return false;
     }
 
+    private static boolean isDeleted(int rowId, long... deletedRowIds) {
+        for (long deletedRowId : deletedRowIds) {
+            if (deletedRowId == rowId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static String expectedRow(String structuredValuePrefix, int rowId) {
         return rowId + "|name-" + rowId + "|" + structuredValuePrefix + "-" + rowId + "|" + rowId;
     }
@@ -479,6 +672,23 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         TableScan.Plan plan = readBuilder.newScan().plan();
         assertThat(plan.splits()).hasSize(1);
         return toDataSplit(plan.splits().get(0));
+    }
+
+    private static List<String> liveDeletionVectorDataFileNames(FileStoreTable table) {
+        List<String> result = new ArrayList<>();
+        for (IndexManifestEntry entry :
+                table.store()
+                        .newIndexFileHandler()
+                        .scan(table.latestSnapshot().get(), DELETION_VECTORS_INDEX)) {
+            Map<String, DeletionVectorMeta> dvRanges = entry.indexFile().dvRanges();
+            if (dvRanges != null) {
+                for (DeletionVectorMeta meta : dvRanges.values()) {
+                    result.add(meta.dataFileName());
+                }
+            }
+        }
+        Collections.sort(result);
+        return result;
     }
 
     private static List<String> readRows(ReadBuilder readBuilder, TableScan.Plan plan)

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.sink;
+
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Operator to rewrite deletion vectors for data-evolution compaction before committing. */
+public class DataEvolutionCompactDeletionVectorOperator
+        extends PrepareCommitOperator<Committable, Committable> {
+
+    private final FileStoreTable table;
+    private final List<Committable> committables;
+
+    private DataEvolutionCompactDeletionVectorOperator(
+            StreamOperatorParameters<Committable> parameters, FileStoreTable table) {
+        super(parameters, Options.fromMap(table.options()));
+        this.table = table;
+        this.committables = new ArrayList<>();
+    }
+
+    @Override
+    public void processElement(StreamRecord<Committable> element) {
+        committables.add(element.getValue());
+    }
+
+    @Override
+    protected List<Committable> prepareCommit(boolean waitCompaction, long checkpointId)
+            throws IOException {
+        List<Committable> toCommit = new ArrayList<>(committables);
+        committables.clear();
+        if (toCommit.isEmpty()) {
+            return toCommit;
+        }
+
+        List<CommitMessage> messages = new ArrayList<>(toCommit.size());
+        for (Committable committable : toCommit) {
+            messages.add(committable.commitMessage());
+        }
+        for (CommitMessage message :
+                new DataEvolutionCompactDeletionVectorRewriter(table)
+                        .rewriteDeletionVectors(messages)) {
+            toCommit.add(new Committable(toCommit.get(0).checkpointId(), message));
+        }
+        return toCommit;
+    }
+
+    /** {@link StreamOperatorFactory} of {@link DataEvolutionCompactDeletionVectorOperator}. */
+    public static class Factory extends PrepareCommitOperator.Factory<Committable, Committable> {
+
+        private final FileStoreTable table;
+
+        public Factory(FileStoreTable table) {
+            super(Options.fromMap(table.options()));
+            this.table = table;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends StreamOperator<Committable>> T createStreamOperator(
+                StreamOperatorParameters<Committable> parameters) {
+            return (T) new DataEvolutionCompactDeletionVectorOperator(parameters, table);
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return DataEvolutionCompactDeletionVectorOperator.class;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionTableCompactSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionTableCompactSink.java
@@ -43,6 +43,22 @@ public class DataEvolutionTableCompactSink extends FlinkSink<DataEvolutionCompac
     }
 
     @Override
+    public DataStreamSink<?> sinkFrom(
+            DataStream<DataEvolutionCompactTask> input, String initialCommitUser) {
+        DataStream<Committable> written = doWrite(input, initialCommitUser, null);
+        if (table.coreOptions().deletionVectorsEnabled()) {
+            written =
+                    written.transform(
+                                    "Data Evolution Compact Deletion Vector Rewriter : "
+                                            + table.name(),
+                                    new CommittableTypeInfo(),
+                                    new DataEvolutionCompactDeletionVectorOperator.Factory(table))
+                            .forceNonParallel();
+        }
+        return doCommit(written, initialCommitUser);
+    }
+
+    @Override
     protected OneInputStreamOperatorFactory<DataEvolutionCompactTask, Committable>
             createWriteOperatorFactory(StoreSinkWrite.Provider writeProvider, String commitUser) {
         return new DataEvolutionCompactionWorkerOperator.Factory(table, commitUser);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -24,6 +24,7 @@ import org.apache.paimon.append.AppendCompactCoordinator;
 import org.apache.paimon.append.AppendCompactTask;
 import org.apache.paimon.append.cluster.IncrementalClusterManager;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTaskSerializer;
 import org.apache.paimon.compact.CompactUnit;
@@ -579,6 +580,9 @@ public class CompactProcedure extends BaseProcedure {
                                 messageSerializerser.deserialize(
                                         messageSerializerser.getVersion(), serializedMessage));
                     }
+                    messages.addAll(
+                            new DataEvolutionCompactDeletionVectorRewriter(table)
+                                    .rewriteDeletionVectors(messages));
                     commit.commit(messages);
                 } catch (Exception e) {
                     throw new RuntimeException("Deserialize commit message failed", e);


### PR DESCRIPTION
### Purpose
Parts of https://github.com/apache/paimon/issues/8322

This PR enables data-evolution compaction **WITHOUT** materializing deletion vectors. This is useful if only very small portion of data is deleted and user just want to merge small files.

Note that materializing deletion vectors is very 'heavy', we need to:
1. force rewrite all columns, including blobs and vectors
2. reassign row ids
3. invalidate all global indices.

So we introduce this more light weight compaction. The core change:
1. After generating all commit messages, we check if any anchor file with existing DVs is compacted, if so, we rewrite the corresponding DVs to new anchor files.
### Tests
See `DataEvolutionDeletionVectorTest`