### PR TITLE
[spark] skip table lookup for meta-columns-only vector search since r…

### DIFF
--- a/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-3.2/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark
 
+import org.apache.paimon.spark.read.{PaimonLocalScan, VectorSearchResultUtils}
 import org.apache.paimon.table.InnerTable
 
 import org.apache.spark.sql.connector.read.Scan
@@ -33,6 +34,21 @@ class PaimonScanBuilder(val table: InnerTable) extends PaimonBaseScanBuilder {
       case ftst: org.apache.paimon.table.FullTextSearchTable =>
         (ftst.origin(), None, None, Option(ftst.fullTextSearch()))
       case _ => (table, pushedVectorSearch, None, pushedFullTextSearch)
+    }
+    if (
+      vectorSearch.isDefined &&
+      VectorSearchResultUtils.isVectorSearchMetaOnly(requiredSchema.fieldNames.toSeq)
+    ) {
+      val result = PaimonBaseScan.evalVectorSearch(
+        actualTable,
+        vectorSearch.get,
+        pushedPartitionFilters,
+        pushedDataFilters)
+      return PaimonLocalScan(
+        VectorSearchResultUtils.toRows(result, requiredSchema),
+        requiredSchema,
+        actualTable,
+        pushedPartitionFilters)
     }
     PaimonScan(
       actualTable,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScan.scala
@@ -21,7 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.globalindex.GlobalIndexResult
 import org.apache.paimon.partition.PartitionPredicate
-import org.apache.paimon.predicate.PredicateBuilder
+import org.apache.paimon.predicate.{Predicate, PredicateBuilder, VectorSearch}
 import org.apache.paimon.spark.metric.SparkMetricRegistry
 import org.apache.paimon.spark.read.{BaseScan, BatchReadTagCleanupListener, PaimonSupportsRuntimeFiltering, SparkHybridSearchBuilderImpl, SparkVectorSearchBuilderImpl}
 import org.apache.paimon.spark.sources.PaimonMicroBatchStream
@@ -83,25 +83,11 @@ abstract class PaimonBaseScan(table: InnerTable)
   }
 
   private def evalVectorSearch(): GlobalIndexResult = {
-    val vectorSearch = pushedVectorSearch.get
-    val vectorSearchBuilder =
-      if (CoreOptions.fromMap(table.options).vectorSearchDistributeEnabled()) {
-        new SparkVectorSearchBuilderImpl(table)
-      } else {
-        table.newVectorSearchBuilder()
-      }
-    val vectorBuilder = vectorSearchBuilder
-      .withVector(vectorSearch.vector())
-      .withVectorColumn(vectorSearch.fieldName())
-      .withLimit(vectorSearch.limit())
-      .withOptions(vectorSearch.options())
-    if (pushedPartitionFilters.nonEmpty) {
-      vectorBuilder.withPartitionFilter(PartitionPredicate.and(pushedPartitionFilters.asJava))
-    }
-    if (pushedDataFilters.nonEmpty) {
-      vectorBuilder.withFilter(PredicateBuilder.and(pushedDataFilters.asJava))
-    }
-    vectorBuilder.newVectorRead().read(vectorBuilder.newVectorScan().scan())
+    PaimonBaseScan.evalVectorSearch(
+      table,
+      pushedVectorSearch.get,
+      pushedPartitionFilters,
+      pushedDataFilters)
   }
 
   private def evalHybridSearch(): GlobalIndexResult = {
@@ -180,5 +166,33 @@ abstract class PaimonBaseScan(table: InnerTable)
         }
       case _ =>
     }
+  }
+}
+
+object PaimonBaseScan {
+
+  private[spark] def evalVectorSearch(
+      table: InnerTable,
+      vectorSearch: VectorSearch,
+      pushedPartitionFilters: Seq[PartitionPredicate],
+      pushedDataFilters: Seq[Predicate]): GlobalIndexResult = {
+    val vectorSearchBuilder =
+      if (CoreOptions.fromMap(table.options).vectorSearchDistributeEnabled()) {
+        new SparkVectorSearchBuilderImpl(table)
+      } else {
+        table.newVectorSearchBuilder()
+      }
+    val vectorBuilder = vectorSearchBuilder
+      .withVector(vectorSearch.vector())
+      .withVectorColumn(vectorSearch.fieldName())
+      .withLimit(vectorSearch.limit())
+      .withOptions(vectorSearch.options())
+    if (pushedPartitionFilters.nonEmpty) {
+      vectorBuilder.withPartitionFilter(PartitionPredicate.and(pushedPartitionFilters.asJava))
+    }
+    if (pushedDataFilters.nonEmpty) {
+      vectorBuilder.withFilter(PredicateBuilder.and(pushedDataFilters.asJava))
+    }
+    vectorBuilder.newVectorRead().read(vectorBuilder.newVectorScan().scan())
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
@@ -23,7 +23,7 @@ import org.apache.paimon.fs.Path
 import org.apache.paimon.globalindex.IndexedSplitRecordReader
 import org.apache.paimon.reader.{FileRecordIterator, RecordReader, ScoreRecordIterator}
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.spark.schema.PaimonMetadataColumn.{PARTITION_AND_BUCKET_META_COLUMNS, PATH_AND_INDEX_META_COLUMNS, ROW_ID_COLUMN, SEARCH_SCORE_COLUMN}
+import org.apache.paimon.spark.schema.PaimonMetadataColumn.{PARTITION_AND_BUCKET_META_COLUMNS, PATH_AND_INDEX_META_COLUMNS, VECTOR_SEARCH_META_COLUMN_NAMES}
 import org.apache.paimon.table.source.{DataSplit, Split}
 import org.apache.paimon.utils.{CloseableIterator, Preconditions}
 
@@ -50,11 +50,11 @@ case class PaimonRecordReaderIterator(
   private val needPathAndIndexMetadata =
     metadataColumns.exists(c => PATH_AND_INDEX_META_COLUMNS.contains(c.name))
   private val needVectorSearchMetadata = reader.isInstanceOf[IndexedSplitRecordReader] &&
-    metadataColumns.exists(c => c.name == ROW_ID_COLUMN || c.name == SEARCH_SCORE_COLUMN)
+    metadataColumns.exists(c => VECTOR_SEARCH_META_COLUMN_NAMES.contains(c.name))
 
   Preconditions.checkArgument(
     !needVectorSearchMetadata ||
-      metadataColumns.forall(c => c.name == ROW_ID_COLUMN || c.name == SEARCH_SCORE_COLUMN))
+      metadataColumns.forall(c => VECTOR_SEARCH_META_COLUMN_NAMES.contains(c.name)))
 
   private val metadataRow: GenericRow =
     GenericRow.of(Array.fill(metadataColumns.size)(null.asInstanceOf[AnyRef]): _*)

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScanBuilder.scala
@@ -22,7 +22,7 @@ import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate._
 import org.apache.paimon.predicate.SortValue.{NullOrdering, SortDirection}
 import org.apache.paimon.spark.aggregate.AggregatePushDownUtils.tryPushdownAggregation
-import org.apache.paimon.spark.read.{PaimonLocalScan, PaimonSupportsPushDownVariantExtractions}
+import org.apache.paimon.spark.read.{PaimonLocalScan, PaimonSupportsPushDownVariantExtractions, VectorSearchResultUtils}
 import org.apache.paimon.table.{FileStoreTable, InnerTable}
 
 import org.apache.spark.sql.connector.expressions
@@ -137,6 +137,22 @@ class PaimonScanBuilder(val table: InnerTable)
           case ftst: org.apache.paimon.table.FullTextSearchTable =>
             (ftst.origin(), None, None, Option(ftst.fullTextSearch()))
           case _ => (table, pushedVectorSearch, None, pushedFullTextSearch)
+        }
+
+        if (
+          vectorSearch.isDefined &&
+          VectorSearchResultUtils.isVectorSearchMetaOnly(requiredSchema.fieldNames.toSeq)
+        ) {
+          val result = PaimonBaseScan.evalVectorSearch(
+            actualTable,
+            vectorSearch.get,
+            pushedPartitionFilters,
+            pushedDataFilters)
+          return PaimonLocalScan(
+            VectorSearchResultUtils.toRows(result, requiredSchema),
+            requiredSchema,
+            actualTable,
+            pushedPartitionFilters)
         }
 
         PaimonScan(

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/plans/logical/PaimonTableValuedFunctions.scala
@@ -846,7 +846,7 @@ case class DynamicVectorSearchRelation(
 
   private lazy val outputWithMetaFields: Seq[Attribute] =
     relationOutput ++
-      Seq(PaimonMetadataColumn.ROW_ID.toAttribute, PaimonMetadataColumn.SEARCH_SCORE.toAttribute)
+      PaimonMetadataColumn.VECTOR_SEARCH_META_COLUMNS.map(_.toAttribute)
 
   override def output: Seq[Attribute] = outputWithMetaFields
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -28,6 +28,7 @@ import org.apache.paimon.spark.catalog.{SparkBaseCatalog, SupportView}
 import org.apache.paimon.spark.catalyst.analysis.ResolvedPaimonView
 import org.apache.paimon.spark.catalyst.plans.logical.{CopyIntoLocationCommand, CopyIntoLocationSource, CopyIntoTableCommand, CreateOrReplaceTagCommand, CreatePaimonView, DeleteTagCommand, DropPaimonView, LateralVectorSearch, PaimonCallCommand, PaimonDropPartitions, PaimonTableValuedFunctions, RenameTagCommand, ResolvedIdentifier, ShowPaimonViews, ShowTagsCommand, TruncatePaimonTableWithFilter}
 import org.apache.paimon.spark.data.SparkInternalRow
+import org.apache.paimon.spark.read.VectorSearchResultUtils
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.table.{InnerTable, SpecialFields, Table}
 import org.apache.paimon.table.source.{BatchVectorSearchBuilder, InnerTableScan, ReadBuilder, VectorScan}
@@ -360,6 +361,8 @@ case class LateralVectorSearchExec(
       scoreMetadataColumns,
       sparkRow,
       rowIdOrdinal = resultRowType.getFieldIndex(SpecialFields.ROW_ID.name()),
+      metaColumnsOnly =
+        VectorSearchResultUtils.isVectorSearchMetaOnly(vectorSearchOutput.map(_.name)),
       projectionInputOrdinals = vectorSearchOutput.map {
         attr =>
           if (attr.name == PaimonMetadataColumn.SEARCH_SCORE_COLUMN) {
@@ -431,6 +434,9 @@ case class LateralVectorSearchExec(
       s"Batch vector search returned ${globalIndexResults.size} results for ${queries.size} " +
         "query vectors. The result count must match the query count."
     )
+    if (context.metaColumnsOnly) {
+      return searchMetaColumns(queries, globalIndexResults, context)
+    }
     val rowIdToMatches = createRowIdToMatches(queries, globalIndexResults)
     val batchGlobalIndexResult = createBatchGlobalIndexResult(globalIndexResults)
     val scan = context.readBuilder
@@ -463,6 +469,30 @@ case class LateralVectorSearchExec(
             }
           }
         }.flatMap(identity)
+    }
+  }
+
+  private def searchMetaColumns(
+      queries: Seq[LateralVectorSearchQuery],
+      globalIndexResults: Seq[GlobalIndexResult],
+      context: LateralVectorSearchContext): Iterator[(InternalRow, InternalRow)] = {
+    queries.zip(globalIndexResults).iterator.flatMap {
+      case (query, result) =>
+        val scoreGetter = result match {
+          case scored: ScoredGlobalIndexResult => Some(scored.scoreGetter())
+          case _ => None
+        }
+        result.results().iterator().asScala.map {
+          rowId =>
+            val values = vectorSearchOutput
+              .map(attr => VectorSearchResultUtils.valueOf(attr.name, rowId, scoreGetter))
+              .toArray
+            val projectedRow = context.rightProjection(
+              new JoinedRow(
+                query.outerRow,
+                new GenericInternalRow(values.asInstanceOf[Array[Any]])))
+            (query.outerRow, projectedRow)
+        }
     }
   }
 
@@ -574,6 +604,7 @@ case class LateralVectorSearchExec(
       scoreMetadataColumns: Seq[PaimonMetadataColumn],
       sparkRow: SparkInternalRow,
       rowIdOrdinal: Int,
+      metaColumnsOnly: Boolean,
       projectionInputOrdinals: Seq[Int],
       rightProjection: UnsafeProjection,
       batchSize: Int,

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/VectorSearchResultUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/VectorSearchResultUtils.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.read
+
+import org.apache.paimon.globalindex.{GlobalIndexResult, ScoredGlobalIndexResult}
+import org.apache.paimon.spark.catalyst.plans.logical.DynamicVectorSearchRelation
+import org.apache.paimon.spark.schema.PaimonMetadataColumn
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.types.StructType
+
+import scala.collection.JavaConverters._
+
+/** Utilities for returning vector search results without reading table rows. */
+object VectorSearchResultUtils {
+
+  def isVectorSearchMetaOnly(fieldNames: Seq[String]): Boolean = {
+    fieldNames.nonEmpty && fieldNames.forall(
+      PaimonMetadataColumn.VECTOR_SEARCH_META_COLUMN_NAMES.contains)
+  }
+
+  def toRows(result: GlobalIndexResult, requiredSchema: StructType): Array[InternalRow] = {
+    val fieldNames = requiredSchema.fieldNames
+    val scoreGetter = result match {
+      case scored: ScoredGlobalIndexResult => Some(scored.scoreGetter())
+      case _ => None
+    }
+    result
+      .results()
+      .iterator()
+      .asScala
+      .map {
+        rowId =>
+          new GenericInternalRow(
+            fieldNames.map(valueOf(_, rowId, scoreGetter)).asInstanceOf[Array[Any]])
+      }
+      .toArray
+  }
+
+  def valueOf(
+      fieldName: String,
+      rowId: Long,
+      scoreGetter: Option[org.apache.paimon.globalindex.ScoreGetter]): Any = {
+    fieldName match {
+      case PaimonMetadataColumn.ROW_ID_COLUMN => rowId
+      case PaimonMetadataColumn.SEARCH_SCORE_COLUMN =>
+        scoreGetter.map(_.score(rowId)).getOrElse(Float.NaN)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Field $fieldName cannot be returned directly from vector search result.")
+    }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/schema/PaimonMetadataColumn.scala
@@ -61,6 +61,7 @@ object PaimonMetadataColumn {
   val PATH_AND_INDEX_META_COLUMNS: Seq[String] = Seq(FILE_PATH_COLUMN, ROW_INDEX_COLUMN)
   val PARTITION_AND_BUCKET_META_COLUMNS: Seq[String] = Seq(PARTITION_COLUMN, BUCKET_COLUMN)
   val ROW_TRACKING_META_COLUMNS: Seq[String] = Seq(ROW_ID_COLUMN, SEQUENCE_NUMBER_COLUMN)
+  val VECTOR_SEARCH_META_COLUMN_NAMES: Seq[String] = Seq(ROW_ID_COLUMN, SEARCH_SCORE_COLUMN)
 
   val SUPPORTED_METADATA_COLUMNS: Seq[String] = Seq(
     ROW_INDEX_COLUMN,
@@ -91,6 +92,8 @@ object PaimonMetadataColumn {
       preserveOnUpdate = false)
   val SEARCH_SCORE: PaimonMetadataColumn =
     PaimonMetadataColumn(Integer.MAX_VALUE - 106, SEARCH_SCORE_COLUMN, FloatType)
+
+  val VECTOR_SEARCH_META_COLUMNS: Seq[PaimonMetadataColumn] = Seq(ROW_ID, SEARCH_SCORE)
 
   def dvMetaCols: Seq[PaimonMetadataColumn] = Seq(FILE_PATH, ROW_INDEX)
 

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
@@ -195,6 +195,21 @@ public class SparkMultimodalITCase {
                                                         .equals(row.getLong(3))))
                 .isTrue();
 
+        // **vector search with metadata columns only */
+        String vectorSearchWithMetadataColumnsOnlySql =
+                "select _row_id AS _row_id, __paimon_search_score "
+                        + "from vector_search('my_db1.vector_test', 'embs', array(1.0f, 2.0f, 3.0f, 4.0f), 5) "
+                        + "where date = '20260420'";
+        df = spark.sql(vectorSearchWithMetadataColumnsOnlySql);
+        assertThat(df.columns()).hasSize(2);
+        assertThat(df.columns()).contains("_row_id", "__paimon_search_score");
+        rows = df.collectAsList();
+        assertThat(rows).hasSize(5);
+        assertThat(rows.stream().allMatch(row -> !row.isNullAt(0) && !row.isNullAt(1))).isTrue();
+        assertThat(rows.stream().allMatch(row -> baseRowIds.containsValue(row.getLong(0))))
+                .isTrue();
+        assertThat(rows.stream().map(row -> row.getLong(0)).collect(Collectors.toSet())).hasSize(5);
+
         // **vector search with score */
         String vectorSearchSql =
                 "select gid, sid,  embs, __paimon_search_score "
@@ -256,6 +271,32 @@ public class SparkMultimodalITCase {
                 .containsEntry(6L, 5L)
                 .containsEntry(7L, 5L)
                 .containsEntry(8L, 5L);
+
+        // ** lateral vector search with metadata columns only in subquery */
+        rows =
+                spark.sql(
+                                "SELECT q.gid AS query_gid, "
+                                        + "r._row_id AS result_row_id, "
+                                        + "r.__paimon_search_score AS result_score "
+                                        + "FROM my_db1.vector_test AS q, "
+                                        + "LATERAL (SELECT _row_id, __paimon_search_score "
+                                        + "FROM vector_search('my_db1.vector_test', 'embs', q.embs, 5)) AS r "
+                                        + "WHERE q.`date` = '20260420';")
+                        .collectAsList();
+        assertThat(rows).hasSize(40);
+        assertThat(rows.stream().allMatch(row -> !row.isNullAt(0) && !row.isNullAt(1))).isTrue();
+        assertThat(rows.stream().allMatch(row -> baseRowIds.containsValue(row.getLong(1))))
+                .isTrue();
+        Map<Long, java.util.Set<Long>> rowIdsPerQueryGid =
+                rows.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        row -> row.getLong(0),
+                                        Collectors.mapping(
+                                                row -> row.getLong(1), Collectors.toSet())));
+        assertThat(rowIdsPerQueryGid).hasSize(8);
+        assertThat(rowIdsPerQueryGid.values().stream().allMatch(rowIds -> rowIds.size() == 5))
+                .isTrue();
         spark.close();
 
         spark = builder.getOrCreate();


### PR DESCRIPTION
…ow ids and scores are already available from the index result

### Purpose
Purpose: Skip table lookup for meta-columns-only vector search since row ids and scores are already available from the index result
Linked issue: https://github.com/apache/paimon/issues/8484

### Tests
Add vector search with meta-columns-only in org.apache.paimon.spark.SparkMultimodalITCase#testVector