### PR TITLE
[core] supports materializing deletions for data-evolution compaction

### DIFF
--- a/docs/docs/multimodal-table/data-evolution.mdx
+++ b/docs/docs/multimodal-table/data-evolution.mdx
@@ -227,7 +227,11 @@ together with row tracking and Data Evolution:
 Deleting rows with deletion vectors does not physically remove the original
 data immediately. If a table has many deleted rows, run compaction to
 materialize the deletions; otherwise, the deleted data still consumes storage
-space and may reduce read efficiency.
+space and may reduce read efficiency. Set
+`data-evolution.compaction.materialize-deletions=true` for compaction to rewrite
+all column files in the compacted range, remove the materialized deletion
+vectors, and make the remaining rows use new row IDs. This also drops global
+indexes for the affected partitions because row IDs change.
 
 :::
 
@@ -243,6 +247,15 @@ Spark SQL supports `DELETE FROM` for Data Evolution tables:
 
 ```sql
 DELETE FROM target_table WHERE id = 1;
+```
+
+To physically remove deleted rows during compaction:
+
+```sql
+CALL sys.compact(
+    table => 'target_table',
+    options => 'data-evolution.compaction.materialize-deletions=true'
+);
 ```
 
 Spark SQL also supports delete actions in `MERGE INTO`:

--- a/docs/docs/multimodal-table/data-evolution.mdx
+++ b/docs/docs/multimodal-table/data-evolution.mdx
@@ -228,10 +228,11 @@ Deleting rows with deletion vectors does not physically remove the original
 data immediately. If a table has many deleted rows, run compaction to
 materialize the deletions; otherwise, the deleted data still consumes storage
 space and may reduce read efficiency. Set
-`data-evolution.compaction.reassign-row-id-and-materialize-deletions=true` for
-compaction to rewrite all column files in the compacted range, reassign row IDs,
-and remove the materialized deletion vectors. This also drops global indexes for
-the affected partitions because row IDs change.
+`data-evolution.compaction.rewrite-row-ids=true` for compaction to rewrite all
+column files in the compacted range, physically apply deletion vectors, and
+reassign row IDs. Enable this only when callers do not rely on stable `_ROW_ID`;
+this invalidates row-id based references and drops global indexes for affected
+partitions.
 
 :::
 
@@ -254,7 +255,7 @@ To physically remove deleted rows during compaction:
 ```sql
 CALL sys.compact(
     table => 'target_table',
-    options => 'data-evolution.compaction.reassign-row-id-and-materialize-deletions=true'
+    options => 'data-evolution.compaction.rewrite-row-ids=true'
 );
 ```
 

--- a/docs/docs/multimodal-table/data-evolution.mdx
+++ b/docs/docs/multimodal-table/data-evolution.mdx
@@ -228,10 +228,10 @@ Deleting rows with deletion vectors does not physically remove the original
 data immediately. If a table has many deleted rows, run compaction to
 materialize the deletions; otherwise, the deleted data still consumes storage
 space and may reduce read efficiency. Set
-`data-evolution.compaction.materialize-deletions=true` for compaction to rewrite
-all column files in the compacted range, remove the materialized deletion
-vectors, and make the remaining rows use new row IDs. This also drops global
-indexes for the affected partitions because row IDs change.
+`data-evolution.compaction.reassign-row-id-and-materialize-deletions=true` for
+compaction to rewrite all column files in the compacted range, reassign row IDs,
+and remove the materialized deletion vectors. This also drops global indexes for
+the affected partitions because row IDs change.
 
 :::
 
@@ -254,7 +254,7 @@ To physically remove deleted rows during compaction:
 ```sql
 CALL sys.compact(
     table => 'target_table',
-    options => 'data-evolution.compaction.materialize-deletions=true'
+    options => 'data-evolution.compaction.reassign-row-id-and-materialize-deletions=true'
 );
 ```
 

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -465,10 +465,10 @@ under the License.
             <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
         </tr>
         <tr>
-            <td><h5>data-evolution.compaction.reassign-row-id-and-materialize-deletions</h5></td>
+            <td><h5>data-evolution.compaction.rewrite-row-ids</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to reassign row IDs and physically apply deletions during compaction. For data-evolution tables, enabling this triggers full-column compaction (including blobs and vectors), row-id reassignment, and global index invalidation. Set to true only when physical deletion is required. If the goal is merely to merge small files with a low deletion ratio, keep this disabled.</td>
+            <td>Whether data-evolution compaction may rewrite row IDs while physically applying deletion vectors. Enable only when callers do not rely on stable _ROW_ID; this invalidates row-id based references and drops global indexes for affected partitions.</td>
         </tr>
         <tr>
             <td><h5>data-evolution.enabled</h5></td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -465,6 +465,12 @@ under the License.
             <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
         </tr>
         <tr>
+            <td><h5>data-evolution.compaction.materialize-deletions</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to physically apply deletions during compaction. For data-evolution tables, enabling this triggers full-column compaction (including blobs and vectors), row-id reassignment, and global index invalidation. Set to true only when physical deletion is required. If the goal is merely to merge small files with a low deletion ratio, keep this disabled.</td>
+        </tr>
+        <tr>
             <td><h5>data-evolution.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -1272,6 +1278,12 @@ This config option does not affect the default filesystem metastore.</td>
             <td>End condition "watermark" for bounded streaming mode. Stream reading will end when a larger watermark snapshot is encountered.</td>
         </tr>
         <tr>
+            <td><h5>scan.bucket</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Specify a single bucket to scan. This option filters manifest entries and only plans splits for the given bucket. It is only supported for fixed-bucket primary key tables (bucket &gt; 0). It cannot be used with postpone bucket tables.</td>
+        </tr>
+        <tr>
             <td><h5>scan.creation-time-millis</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>
@@ -1324,12 +1336,6 @@ This config option does not affect the default filesystem metastore.</td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The parallelism of scanning manifest files, default value is the size of cpu processor. Note: Scale-up this parameter will increase memory usage while scanning manifest files. We can consider downsize it when we encounter an out of memory exception while scanning</td>
-        </tr>
-        <tr>
-            <td><h5>scan.bucket</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>Specify a single bucket to scan. This option filters manifest entries and only plans splits for the given bucket. It is only supported for fixed-bucket primary key tables (bucket &gt; 0). It cannot be used with postpone bucket tables.</td>
         </tr>
         <tr>
             <td><h5>scan.max-splits-per-task</h5></td>

--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -465,10 +465,10 @@ under the License.
             <td>The TTL in rocksdb index for cross partition upsert (primary keys not contain all partition fields), this can avoid maintaining too many indexes and lead to worse and worse performance, but please note that this may also cause data duplication.</td>
         </tr>
         <tr>
-            <td><h5>data-evolution.compaction.materialize-deletions</h5></td>
+            <td><h5>data-evolution.compaction.reassign-row-id-and-materialize-deletions</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to physically apply deletions during compaction. For data-evolution tables, enabling this triggers full-column compaction (including blobs and vectors), row-id reassignment, and global index invalidation. Set to true only when physical deletion is required. If the goal is merely to merge small files with a low deletion ratio, keep this disabled.</td>
+            <td>Whether to reassign row IDs and physically apply deletions during compaction. For data-evolution tables, enabling this triggers full-column compaction (including blobs and vectors), row-id reassignment, and global index invalidation. Set to true only when physical deletion is required. If the goal is merely to merge small files with a low deletion ratio, keep this disabled.</td>
         </tr>
         <tr>
             <td><h5>data-evolution.enabled</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2427,18 +2427,14 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to persist source when process merge into action on data evolution table.");
 
-    public static final ConfigOption<Boolean>
-            DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS =
-                    key("data-evolution.compaction.reassign-row-id-and-materialize-deletions")
-                            .booleanType()
-                            .defaultValue(false)
-                            .withDescription(
-                                    "Whether to reassign row IDs and physically apply deletions during compaction. "
-                                            + "For data-evolution tables, "
-                                            + "enabling this triggers full-column compaction (including blobs and vectors), "
-                                            + "row-id reassignment, and global index invalidation. "
-                                            + "Set to true only when physical deletion is required. "
-                                            + "If the goal is merely to merge small files with a low deletion ratio, keep this disabled.");
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS =
+            key("data-evolution.compaction.rewrite-row-ids")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether data-evolution compaction may rewrite row IDs while physically applying deletion vectors. "
+                                    + "Enable only when callers do not rely on stable _ROW_ID; "
+                                    + "this invalidates row-id based references and drops global indexes for affected partitions.");
 
     public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
             key("blob-compaction.enabled")
@@ -3940,8 +3936,8 @@ public class CoreOptions implements Serializable {
         return options.get(DELETION_VECTOR_BITMAP64);
     }
 
-    public boolean dataEvolutionCompactionReassignRowIdAndMaterializeDeletions() {
-        return options.get(DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS);
+    public boolean dataEvolutionCompactionRewriteRowIds() {
+        return options.get(DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS);
     }
 
     public FileIndexOptions indexColumnsOptions() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2427,6 +2427,17 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to persist source when process merge into action on data evolution table.");
 
+    public static final ConfigOption<Boolean> DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS =
+            key("data-evolution.compaction.materialize-deletions")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to physically apply deletions during compaction. For data-evolution tables, "
+                                    + "enabling this triggers full-column compaction (including blobs and vectors), "
+                                    + "row-id reassignment, and global index invalidation. "
+                                    + "Set to true only when physical deletion is required. "
+                                    + "If the goal is merely to merge small files with a low deletion ratio, keep this disabled.");
+
     public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
             key("blob-compaction.enabled")
                     .booleanType()
@@ -3925,6 +3936,10 @@ public class CoreOptions implements Serializable {
 
     public boolean deletionVectorBitmap64() {
         return options.get(DELETION_VECTOR_BITMAP64);
+    }
+
+    public boolean dataEvolutionCompactionMaterializeDeletions() {
+        return options.get(DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS);
     }
 
     public FileIndexOptions indexColumnsOptions() {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2427,16 +2427,18 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Whether to persist source when process merge into action on data evolution table.");
 
-    public static final ConfigOption<Boolean> DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS =
-            key("data-evolution.compaction.materialize-deletions")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Whether to physically apply deletions during compaction. For data-evolution tables, "
-                                    + "enabling this triggers full-column compaction (including blobs and vectors), "
-                                    + "row-id reassignment, and global index invalidation. "
-                                    + "Set to true only when physical deletion is required. "
-                                    + "If the goal is merely to merge small files with a low deletion ratio, keep this disabled.");
+    public static final ConfigOption<Boolean>
+            DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS =
+                    key("data-evolution.compaction.reassign-row-id-and-materialize-deletions")
+                            .booleanType()
+                            .defaultValue(false)
+                            .withDescription(
+                                    "Whether to reassign row IDs and physically apply deletions during compaction. "
+                                            + "For data-evolution tables, "
+                                            + "enabling this triggers full-column compaction (including blobs and vectors), "
+                                            + "row-id reassignment, and global index invalidation. "
+                                            + "Set to true only when physical deletion is required. "
+                                            + "If the goal is merely to merge small files with a low deletion ratio, keep this disabled.");
 
     public static final ConfigOption<Boolean> BLOB_COMPACTION_ENABLED =
             key("blob-compaction.enabled")
@@ -3938,8 +3940,8 @@ public class CoreOptions implements Serializable {
         return options.get(DELETION_VECTOR_BITMAP64);
     }
 
-    public boolean dataEvolutionCompactionMaterializeDeletions() {
-        return options.get(DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS);
+    public boolean dataEvolutionCompactionReassignRowIdAndMaterializeDeletions() {
+        return options.get(DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS);
     }
 
     public FileIndexOptions indexColumnsOptions() {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionBlobCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionBlobCompactTask.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.AppendOnlyFileStore;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fileindex.FileIndexOptions;
+import org.apache.paimon.format.blob.BlobFileFormat;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.io.FileWriter;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.io.RowDataFileWriter;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.statistics.NoneSimpleColStatsCollector;
+import org.apache.paimon.statistics.SimpleColStatsCollector;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.LongCounter;
+import org.apache.paimon.utils.Range;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.checkContiguousRowRange;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Compacts dedicated blob files of a data evolution table. */
+public class DataEvolutionBlobCompactTask extends DataEvolutionCompactTask {
+
+    public DataEvolutionBlobCompactTask(BinaryRow partition, List<DataFileMeta> files) {
+        super(partition, files);
+    }
+
+    @Override
+    public TaskType type() {
+        return TaskType.BLOB;
+    }
+
+    @Override
+    public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
+        CoreOptions options = table.coreOptions();
+        List<DataFileMeta> sortedCompactBefore = sortedByFirstRowId(compactBefore);
+        DataField blobField = blobField(table, options, sortedCompactBefore);
+        Range compactBeforeRange = checkContiguousRowRange(sortedCompactBefore);
+        checkArgument(
+                sortedCompactBefore.size() > 1,
+                "Blob compaction task %s should contain at least two files to compact.",
+                this);
+
+        RowType blobWriteType = new RowType(Collections.singletonList(blobField));
+
+        FileStoreTable readTable = table.copy(BLOB_COMPACT_READ_OPTIONS);
+        AppendOnlyFileStore store = (AppendOnlyFileStore) readTable.store();
+        DataFilePathFactory pathFactory =
+                store.pathFactory().createDataFilePathFactory(partition, 0);
+
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withPartition(partition)
+                        .withBucket(0)
+                        .withDataFiles(sortedCompactBefore)
+                        .withBucketPath(pathFactory.parent().toString())
+                        .rawConvertible(false)
+                        .build();
+        RecordReader<InternalRow> reader =
+                store.newDataEvolutionRead().withReadType(blobWriteType).createReader(dataSplit);
+        FileWriter<InternalRow, DataFileMeta> writer =
+                createBlobFileWriter(table, options, blobWriteType, blobField.name(), pathFactory);
+
+        try {
+            reader.forEachRemaining(
+                    row -> {
+                        try {
+                            writer.write(row);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+            writer.close();
+        } catch (Exception e) {
+            writer.abort();
+            throw e;
+        }
+
+        DataFileMeta compactedFile =
+                writer.result()
+                        .assignFirstRowId(compactBeforeRange.from)
+                        .assignSequenceNumber(
+                                minSequenceId(sortedCompactBefore),
+                                maxSequenceId(sortedCompactBefore));
+        compactAfter.add(compactedFile);
+        checkArgument(compactAfter.size() == 1, "Blob file compaction should produce one file.");
+        checkSameRowRange("Blob compact files", sortedCompactBefore, compactAfter);
+
+        return commitMessage(sortedCompactBefore, compactAfter);
+    }
+
+    private FileWriter<InternalRow, DataFileMeta> createBlobFileWriter(
+            FileStoreTable table,
+            CoreOptions options,
+            RowType blobWriteType,
+            String blobFieldName,
+            DataFilePathFactory pathFactory) {
+        BlobFileFormat blobFileFormat = new BlobFileFormat();
+        return new RowDataFileWriter(
+                table.fileIO(),
+                RollingFileWriter.createFileWriterContext(
+                        blobFileFormat,
+                        blobWriteType,
+                        new SimpleColStatsCollector.Factory[] {NoneSimpleColStatsCollector::new},
+                        "none"),
+                pathFactory.newBlobPath(),
+                blobWriteType,
+                table.schema().id(),
+                () -> new LongCounter(0),
+                new FileIndexOptions(),
+                FileSource.COMPACT,
+                false,
+                options.statsDenseStore(),
+                pathFactory.isExternalPath(),
+                Collections.singletonList(blobFieldName));
+    }
+
+    private DataField blobField(
+            FileStoreTable table, CoreOptions options, List<DataFileMeta> files) {
+        Integer blobFieldId = null;
+        Map<Long, RowType> schemaCache = new HashMap<>();
+        for (DataFileMeta file : files) {
+            checkArgument(
+                    file.writeCols() != null && file.writeCols().size() == 1,
+                    "Blob file %s should contain exactly one write column.",
+                    file);
+            RowType fileRowType =
+                    schemaCache.computeIfAbsent(
+                            file.schemaId(),
+                            schemaId -> table.schemaManager().schema(schemaId).logicalRowType());
+            int currentFieldId = fileRowType.getField(file.writeCols().get(0)).id();
+            if (blobFieldId == null) {
+                blobFieldId = currentFieldId;
+            } else {
+                checkArgument(
+                        blobFieldId == currentFieldId,
+                        "Blob compact before files %s should contain the same field.",
+                        files);
+            }
+        }
+
+        checkArgument(blobFieldId != null, "Blob compaction task should not be empty.");
+        checkArgument(
+                table.rowType().containsField(blobFieldId),
+                "Cannot find blob field id %s in latest schema for compaction task %s.",
+                blobFieldId,
+                this);
+        DataField field = table.rowType().getField(blobFieldId);
+        Set<String> blobFieldNames =
+                fieldNamesInBlobFile(table.rowType(), options.blobInlineField());
+        checkArgument(
+                blobFieldNames.contains(field.name()),
+                "Field %s in latest schema is not a blob file field.",
+                field.name());
+        return field;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -62,7 +62,6 @@ import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
 import static org.apache.paimon.types.DataTypeRoot.BLOB;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
-import static org.apache.paimon.utils.DataEvolutionUtils.toDeletionFiles;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Compact coordinator to compact data evolution table. */
@@ -544,7 +543,7 @@ public class DataEvolutionCompactCoordinator {
             List<IndexFileMeta> indexFiles =
                     indexFileHandler.scan(
                             snapshot, DELETION_VECTORS_INDEX, partition, UNAWARE_BUCKET);
-            return toDeletionFiles(indexFileHandler, partition, UNAWARE_BUCKET, indexFiles);
+            return indexFileHandler.dvIndex(partition, UNAWARE_BUCKET).toDeletionFiles(indexFiles);
         }
 
         private List<List<DataFileMeta>> blobFileGroupsToCompact(List<DataFileMeta> blobFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -22,12 +22,15 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.manifest.ManifestFileMeta;
 import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.DeletionFile;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
@@ -52,10 +55,14 @@ import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparingLong;
+import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.manifest.ManifestFileMeta.allContainsRowId;
+import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
 import static org.apache.paimon.types.DataTypeRoot.BLOB;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
+import static org.apache.paimon.utils.DataEvolutionUtils.toDeletionFiles;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Compact coordinator to compact data evolution table. */
@@ -88,10 +95,16 @@ public class DataEvolutionCompactCoordinator {
                 new CompactScanner(
                         table.newSnapshotReader().withPartitionFilter(partitionPredicate),
                         table.store().newScan().withPartitionFilter(partitionPredicate));
+        boolean materializeDeletions =
+                options.deletionVectorsEnabled()
+                        && options.dataEvolutionCompactionMaterializeDeletions();
         this.planner =
                 new CompactPlanner(
                         compactBlob,
                         compactVector,
+                        materializeDeletions,
+                        table.store().newIndexFileHandler(),
+                        scanner.snapshot(),
                         targetFileSize,
                         options.blobTargetFileSize(),
                         openFileCost,
@@ -124,11 +137,12 @@ public class DataEvolutionCompactCoordinator {
     static class CompactScanner {
 
         private final FileStoreScan scan;
+        private final Snapshot snapshot;
         private final Queue<List<ManifestFileMeta>> metas;
 
         private CompactScanner(SnapshotReader snapshotReader, FileStoreScan scan) {
             this.scan = scan;
-            Snapshot snapshot = snapshotReader.snapshotManager().latestSnapshot();
+            this.snapshot = snapshotReader.snapshotManager().latestSnapshot();
 
             List<ManifestFileMeta> manifestFileMetas =
                     snapshotReader.manifestsReader().read(snapshot, ScanMode.ALL).filteredManifests;
@@ -156,6 +170,10 @@ public class DataEvolutionCompactCoordinator {
             }
             return result;
         }
+
+        Snapshot snapshot() {
+            return snapshot;
+        }
     }
 
     /** Generate compaction tasks. */
@@ -163,6 +181,9 @@ public class DataEvolutionCompactCoordinator {
 
         private final boolean compactBlob;
         private final boolean compactVector;
+        private final boolean materializeDeletions;
+        @Nullable private final IndexFileHandler indexFileHandler;
+        @Nullable private final Snapshot snapshot;
         private final long targetFileSize;
         private final long blobTargetFileSize;
         private final long openFileCost;
@@ -180,6 +201,9 @@ public class DataEvolutionCompactCoordinator {
             this(
                     compactBlob,
                     compactVector,
+                    false,
+                    null,
+                    null,
                     targetFileSize,
                     targetFileSize,
                     openFileCost,
@@ -194,6 +218,9 @@ public class DataEvolutionCompactCoordinator {
         CompactPlanner(
                 boolean compactBlob,
                 boolean compactVector,
+                boolean materializeDeletions,
+                @Nullable IndexFileHandler indexFileHandler,
+                @Nullable Snapshot snapshot,
                 long targetFileSize,
                 long blobTargetFileSize,
                 long openFileCost,
@@ -202,6 +229,9 @@ public class DataEvolutionCompactCoordinator {
                 @Nullable Set<Integer> currentBlobFieldIds) {
             this.compactBlob = compactBlob;
             this.compactVector = compactVector;
+            this.materializeDeletions = materializeDeletions;
+            this.indexFileHandler = indexFileHandler;
+            this.snapshot = snapshot;
             this.targetFileSize = targetFileSize;
             this.blobTargetFileSize = blobTargetFileSize;
             this.openFileCost = openFileCost;
@@ -225,6 +255,7 @@ public class DataEvolutionCompactCoordinator {
                     partitionedFiles.entrySet()) {
                 BinaryRow partition = partitionFiles.getKey();
                 List<DataFileMeta> files = partitionFiles.getValue();
+                Map<String, DeletionFile> deletionFiles = deletionFiles(partition);
                 RangeHelper<DataFileMeta> rangeHelper =
                         new RangeHelper<>(
                                 f ->
@@ -254,7 +285,7 @@ public class DataEvolutionCompactCoordinator {
                         }
                     }
 
-                    if (compactBlob) {
+                    if (compactBlob || materializeDeletions) {
                         // associate blob files to data files
                         for (DataFileMeta blobFile : blobFiles) {
                             Long key = treeMap.floorKey(blobFile.nonNullFirstRowId());
@@ -272,7 +303,7 @@ public class DataEvolutionCompactCoordinator {
                             }
                         }
                     }
-                    if (compactVector) {
+                    if (compactVector || materializeDeletions) {
                         // associate vector-store files to data files
                         for (DataFileMeta vectorStoreFile : vectorStoreFiles) {
                             Long key = treeMap.floorKey(vectorStoreFile.nonNullFirstRowId());
@@ -296,53 +327,54 @@ public class DataEvolutionCompactCoordinator {
                             new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
                     List<List<DataFileMeta>> groupedFiles =
                             rangeHelper2.mergeOverlappingRanges(dataFiles);
-                    List<DataFileMeta> waitCompactFiles = new ArrayList<>();
 
-                    long weightSum = 0L;
+                    CompactBin compactBin = new CompactBin(targetFileSize);
                     for (List<DataFileMeta> fileGroup : groupedFiles) {
                         checkArgument(
                                 rangeHelper.areAllRangesSame(fileGroup),
                                 "Data files %s should be all row id ranges same.",
                                 dataFiles);
-                        long currentGroupWeight =
-                                fileGroup.stream()
-                                        .mapToLong(d -> Math.max(d.fileSize(), openFileCost))
-                                        .sum();
-                        if (currentGroupWeight > targetFileSize) {
+                        DataFileMeta anchor = retrieveAnchorFile(fileGroup, file -> file);
+                        DeletionFile anchorDeletionFile =
+                                materializeDeletions ? deletionFiles.get(anchor.fileName()) : null;
+
+                        // use remaining records num ratio to estimate real file size
+                        // of each normal file
+                        long groupWeight = groupWeight(fileGroup, anchor, anchorDeletionFile);
+                        if (groupWeight > targetFileSize) {
+                            tasks.addAll(
+                                    triggerTask(
+                                            compactBin.drain(),
+                                            partition,
+                                            dataFileToBlobFiles,
+                                            dataFileToVectorStoreFiles));
                             // compact current file group to merge field files
                             tasks.addAll(
                                     triggerTask(
-                                            fileGroup,
+                                            compactBin(
+                                                    fileGroup,
+                                                    anchor.fileName(),
+                                                    anchorDeletionFile,
+                                                    groupWeight),
                                             partition,
                                             dataFileToBlobFiles,
                                             dataFileToVectorStoreFiles));
-                            // compact wait compact files
-                            tasks.addAll(
-                                    triggerTask(
-                                            waitCompactFiles,
-                                            partition,
-                                            dataFileToBlobFiles,
-                                            dataFileToVectorStoreFiles));
-                            waitCompactFiles = new ArrayList<>();
-                            weightSum = 0;
                         } else {
-                            weightSum += currentGroupWeight;
-                            waitCompactFiles.addAll(fileGroup);
-                            if (weightSum > targetFileSize) {
+                            compactBin.add(
+                                    fileGroup, anchor.fileName(), anchorDeletionFile, groupWeight);
+                            if (compactBin.enoughContent()) {
                                 tasks.addAll(
                                         triggerTask(
-                                                waitCompactFiles,
+                                                compactBin.drain(),
                                                 partition,
                                                 dataFileToBlobFiles,
                                                 dataFileToVectorStoreFiles));
-                                waitCompactFiles = new ArrayList<>();
-                                weightSum = 0L;
                             }
                         }
                     }
                     tasks.addAll(
                             triggerTask(
-                                    waitCompactFiles,
+                                    compactBin.drain(),
                                     partition,
                                     dataFileToBlobFiles,
                                     dataFileToVectorStoreFiles));
@@ -352,6 +384,28 @@ public class DataEvolutionCompactCoordinator {
         }
 
         private List<DataEvolutionCompactTask> triggerTask(
+                CompactBin compactBin,
+                BinaryRow partition,
+                Map<DataFileMeta, List<DataFileMeta>> dataFileToBlobFiles,
+                Map<DataFileMeta, List<DataFileMeta>> dataFileToVectorStoreFiles) {
+            if (compactBin.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            List<DataFileMeta> dataFiles = compactBin.files();
+            if (compactBin.materializeDeletion()) {
+                return triggerMaterializeTask(
+                        dataFiles,
+                        compactBin.anchorDeletionFiles(),
+                        partition,
+                        dataFileToBlobFiles,
+                        dataFileToVectorStoreFiles);
+            }
+            return triggerNonMaterializeTask(
+                    dataFiles, partition, dataFileToBlobFiles, dataFileToVectorStoreFiles);
+        }
+
+        private List<DataEvolutionCompactTask> triggerNonMaterializeTask(
                 List<DataFileMeta> dataFiles,
                 BinaryRow partition,
                 Map<DataFileMeta, List<DataFileMeta>> dataFileToBlobFiles,
@@ -359,7 +413,7 @@ public class DataEvolutionCompactCoordinator {
             List<DataEvolutionCompactTask> tasks = new ArrayList<>();
             boolean triggerNormalFile = dataFiles.size() >= compactMinFileNum;
             if (triggerNormalFile) {
-                tasks.add(new DataEvolutionCompactTask(partition, dataFiles, false));
+                tasks.add(new DataEvolutionNormalCompactTask(partition, dataFiles));
             }
 
             if (compactBlob) {
@@ -372,8 +426,7 @@ public class DataEvolutionCompactCoordinator {
                     }
                     for (List<DataFileMeta> blobFilesToCompact :
                             blobFileGroupsToCompact(blobFiles)) {
-                        tasks.add(
-                                new DataEvolutionCompactTask(partition, blobFilesToCompact, true));
+                        tasks.add(new DataEvolutionBlobCompactTask(partition, blobFilesToCompact));
                     }
                 } else {
                     for (DataFileMeta dataFile : dataFiles) {
@@ -382,8 +435,8 @@ public class DataEvolutionCompactCoordinator {
                                         dataFileToBlobFiles.getOrDefault(
                                                 dataFile, Collections.emptyList()))) {
                             tasks.add(
-                                    new DataEvolutionCompactTask(
-                                            partition, blobFilesToCompact, true));
+                                    new DataEvolutionBlobCompactTask(
+                                            partition, blobFilesToCompact));
                         }
                     }
                 }
@@ -398,7 +451,7 @@ public class DataEvolutionCompactCoordinator {
                                         dataFile, Collections.emptyList()));
                     }
                     if (vectorStoreFiles.size() >= compactMinFileNum) {
-                        tasks.add(new DataEvolutionCompactTask(partition, vectorStoreFiles, false));
+                        tasks.add(new DataEvolutionNormalCompactTask(partition, vectorStoreFiles));
                     }
                 } else {
                     for (DataFileMeta dataFile : dataFiles) {
@@ -407,13 +460,81 @@ public class DataEvolutionCompactCoordinator {
                                         dataFile, Collections.emptyList());
                         if (vectorStoreFiles.size() >= compactMinFileNum) {
                             tasks.add(
-                                    new DataEvolutionCompactTask(
-                                            partition, vectorStoreFiles, false));
+                                    new DataEvolutionNormalCompactTask(
+                                            partition, vectorStoreFiles));
                         }
                     }
                 }
             }
             return tasks;
+        }
+
+        private List<DataEvolutionCompactTask> triggerMaterializeTask(
+                List<DataFileMeta> dataFiles,
+                Map<String, DeletionFile> deletionFiles,
+                BinaryRow partition,
+                Map<DataFileMeta, List<DataFileMeta>> dataFileToBlobFiles,
+                Map<DataFileMeta, List<DataFileMeta>> dataFileToVectorStoreFiles) {
+            List<DataFileMeta> taskFiles = new ArrayList<>(dataFiles);
+            for (DataFileMeta dataFile : dataFiles) {
+                taskFiles.addAll(
+                        dataFileToBlobFiles.getOrDefault(dataFile, Collections.emptyList()));
+                List<DataFileMeta> vectorStoreFiles =
+                        dataFileToVectorStoreFiles.getOrDefault(dataFile, Collections.emptyList());
+                checkArgument(
+                        vectorStoreFiles.isEmpty(),
+                        "Materializing deletion vectors for vector-store files is not supported.");
+            }
+
+            List<DeletionFile> taskDeletionFiles = new ArrayList<>(taskFiles.size());
+            for (DataFileMeta taskFile : taskFiles) {
+                taskDeletionFiles.add(deletionFiles.get(taskFile.fileName()));
+            }
+            return Collections.singletonList(
+                    new DataEvolutionMaterializeDeletionCompactTask(
+                            partition, taskFiles, taskDeletionFiles));
+        }
+
+        private CompactBin compactBin(
+                List<DataFileMeta> files,
+                String anchorFileName,
+                @Nullable DeletionFile anchorDeletionFile,
+                long groupWeight) {
+            CompactBin bin = new CompactBin(targetFileSize);
+            bin.add(files, anchorFileName, anchorDeletionFile, groupWeight);
+            return bin;
+        }
+
+        private long groupWeight(
+                List<DataFileMeta> files,
+                DataFileMeta anchor,
+                @Nullable DeletionFile anchorDeletionFile) {
+            double remainingRatio = remainingRatio(anchor, anchorDeletionFile);
+            long weight = 0L;
+            for (DataFileMeta file : files) {
+                weight +=
+                        Math.max((long) Math.ceil(file.fileSize() * remainingRatio), openFileCost);
+            }
+            return weight;
+        }
+
+        private double remainingRatio(DataFileMeta file, DeletionFile deletionFile) {
+            Long cardinality = deletionFile == null ? null : deletionFile.cardinality();
+            if (cardinality == null || file.rowCount() <= 0) {
+                return 1D;
+            }
+            long visibleRows = Math.max(0L, file.rowCount() - cardinality);
+            return ((double) visibleRows) / file.rowCount();
+        }
+
+        private Map<String, DeletionFile> deletionFiles(BinaryRow partition) {
+            if (!materializeDeletions || snapshot == null || indexFileHandler == null) {
+                return Collections.emptyMap();
+            }
+            List<IndexFileMeta> indexFiles =
+                    indexFileHandler.scan(
+                            snapshot, DELETION_VECTORS_INDEX, partition, UNAWARE_BUCKET);
+            return toDeletionFiles(indexFileHandler, partition, UNAWARE_BUCKET, indexFiles);
         }
 
         private List<List<DataFileMeta>> blobFileGroupsToCompact(List<DataFileMeta> blobFiles) {
@@ -514,6 +635,62 @@ public class DataEvolutionCompactCoordinator {
                     blobFile);
             RowType rowType = schemaFetcher.apply(blobFile.schemaId());
             return rowType.getField(blobFile.writeCols().get(0)).id();
+        }
+    }
+
+    private static class CompactBin {
+
+        private final List<DataFileMeta> files = new ArrayList<>();
+        private final Map<String, DeletionFile> anchorDeletionFiles = new HashMap<>();
+        private final long targetFileSize;
+
+        private long weight = 0L;
+
+        CompactBin(long targetFileSize) {
+            this.targetFileSize = targetFileSize;
+        }
+
+        private void add(
+                List<DataFileMeta> files,
+                String anchorFileName,
+                @Nullable DeletionFile anchorDeletionFile,
+                long weight) {
+            this.files.addAll(files);
+            this.weight += weight;
+            if (anchorDeletionFile != null) {
+                this.anchorDeletionFiles.put(anchorFileName, anchorDeletionFile);
+            }
+        }
+
+        private boolean isEmpty() {
+            return files.isEmpty();
+        }
+
+        private boolean materializeDeletion() {
+            return !anchorDeletionFiles.isEmpty();
+        }
+
+        private List<DataFileMeta> files() {
+            return files;
+        }
+
+        private Map<String, DeletionFile> anchorDeletionFiles() {
+            return anchorDeletionFiles;
+        }
+
+        private boolean enoughContent() {
+            return weight > targetFileSize;
+        }
+
+        private CompactBin drain() {
+            CompactBin result = new CompactBin(targetFileSize);
+            result.files.addAll(files);
+            result.anchorDeletionFiles.putAll(anchorDeletionFiles);
+            result.weight = weight;
+            files.clear();
+            anchorDeletionFiles.clear();
+            weight = 0L;
+            return result;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -96,14 +96,13 @@ public class DataEvolutionCompactCoordinator {
                         table.newSnapshotReader().withPartitionFilter(partitionPredicate),
                         table.store().newScan().withPartitionFilter(partitionPredicate),
                         snapshot);
-        boolean reassignRowIdAndMaterializeDeletions =
-                options.deletionVectorsEnabled()
-                        && options.dataEvolutionCompactionReassignRowIdAndMaterializeDeletions();
+        boolean rewriteRowIds =
+                options.deletionVectorsEnabled() && options.dataEvolutionCompactionRewriteRowIds();
         this.planner =
                 new CompactPlanner(
                         compactBlob,
                         compactVector,
-                        reassignRowIdAndMaterializeDeletions,
+                        rewriteRowIds,
                         table.store().newIndexFileHandler(),
                         scanner.snapshot(),
                         targetFileSize,

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -75,15 +75,16 @@ public class DataEvolutionCompactCoordinator {
     private final CompactPlanner planner;
 
     public DataEvolutionCompactCoordinator(
-            FileStoreTable table, boolean compactBlob, boolean compactVector) {
-        this(table, null, compactBlob, compactVector);
+            FileStoreTable table, boolean compactBlob, boolean compactVector, Snapshot snapshot) {
+        this(table, null, compactBlob, compactVector, snapshot);
     }
 
     public DataEvolutionCompactCoordinator(
             FileStoreTable table,
             @Nullable PartitionPredicate partitionPredicate,
             boolean compactBlob,
-            boolean compactVector) {
+            boolean compactVector,
+            Snapshot snapshot) {
         CoreOptions options = table.coreOptions();
 
         long targetFileSize = options.targetFileSize(false);
@@ -94,7 +95,8 @@ public class DataEvolutionCompactCoordinator {
         this.scanner =
                 new CompactScanner(
                         table.newSnapshotReader().withPartitionFilter(partitionPredicate),
-                        table.store().newScan().withPartitionFilter(partitionPredicate));
+                        table.store().newScan().withPartitionFilter(partitionPredicate),
+                        snapshot);
         boolean materializeDeletions =
                 options.deletionVectorsEnabled()
                         && options.dataEvolutionCompactionMaterializeDeletions();
@@ -133,6 +135,10 @@ public class DataEvolutionCompactCoordinator {
         return Collections.emptyList();
     }
 
+    public Snapshot snapshot() {
+        return scanner.snapshot();
+    }
+
     /** Scanner to generate sorted ManifestEntries. */
     static class CompactScanner {
 
@@ -140,12 +146,16 @@ public class DataEvolutionCompactCoordinator {
         private final Snapshot snapshot;
         private final Queue<List<ManifestFileMeta>> metas;
 
-        private CompactScanner(SnapshotReader snapshotReader, FileStoreScan scan) {
+        private CompactScanner(
+                SnapshotReader snapshotReader, FileStoreScan scan, Snapshot snapshot) {
             this.scan = scan;
-            this.snapshot = snapshotReader.snapshotManager().latestSnapshot();
+            this.snapshot = snapshot;
 
             List<ManifestFileMeta> manifestFileMetas =
-                    snapshotReader.manifestsReader().read(snapshot, ScanMode.ALL).filteredManifests;
+                    snapshotReader
+                            .manifestsReader()
+                            .read(this.snapshot, ScanMode.ALL)
+                            .filteredManifests;
 
             if (allContainsRowId(manifestFileMetas)) {
                 RangeHelper<ManifestFileMeta> rangeHelper =

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinator.java
@@ -97,14 +97,14 @@ public class DataEvolutionCompactCoordinator {
                         table.newSnapshotReader().withPartitionFilter(partitionPredicate),
                         table.store().newScan().withPartitionFilter(partitionPredicate),
                         snapshot);
-        boolean materializeDeletions =
+        boolean reassignRowIdAndMaterializeDeletions =
                 options.deletionVectorsEnabled()
-                        && options.dataEvolutionCompactionMaterializeDeletions();
+                        && options.dataEvolutionCompactionReassignRowIdAndMaterializeDeletions();
         this.planner =
                 new CompactPlanner(
                         compactBlob,
                         compactVector,
-                        materializeDeletions,
+                        reassignRowIdAndMaterializeDeletions,
                         table.store().newIndexFileHandler(),
                         scanner.snapshot(),
                         targetFileSize,

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
@@ -117,8 +117,21 @@ public class DataEvolutionCompactDeletionVectorRewriter {
             List<DataFileMeta> before = normalFiles(compactIncrement.compactBefore());
             List<DataFileMeta> after = normalFiles(compactIncrement.compactAfter());
 
-            // Skip blob tasks
+            // Skip blob-only tasks and index-only commit messages.
             if (before.isEmpty() && after.isEmpty()) {
+                continue;
+            }
+
+            AppendDeleteFileMaintainer maintainer =
+                    result.computeIfAbsent(
+                            commitMessage.partition(),
+                            ignored ->
+                                    BaseAppendDeleteFileMaintainer.forUnawareAppend(
+                                            table.store().newIndexFileHandler(),
+                                            snapshot,
+                                            commitMessage.partition()));
+            if (isMaterialized(compactIncrement)) {
+                removeMaterializedDeletionVectors(maintainer, rangeHelper, before);
                 continue;
             }
 
@@ -133,15 +146,6 @@ public class DataEvolutionCompactDeletionVectorRewriter {
                             + "range, but compact before range is %s and compact after range is %s.",
                     beforeRange,
                     afterRange);
-
-            AppendDeleteFileMaintainer maintainer =
-                    result.computeIfAbsent(
-                            commitMessage.partition(),
-                            ignored ->
-                                    BaseAppendDeleteFileMaintainer.forUnawareAppend(
-                                            table.store().newIndexFileHandler(),
-                                            snapshot,
-                                            commitMessage.partition()));
             DeletionVector merged = newDeletionVector();
 
             // Merge all old DeletionVectors, should consider row range offset of each sub dv
@@ -159,6 +163,24 @@ public class DataEvolutionCompactDeletionVectorRewriter {
             }
         }
         return result;
+    }
+
+    private void removeMaterializedDeletionVectors(
+            AppendDeleteFileMaintainer maintainer,
+            RangeHelper<DataFileMeta> rangeHelper,
+            List<DataFileMeta> before) {
+        for (List<DataFileMeta> previousRowGroup : rangeHelper.mergeOverlappingRanges(before)) {
+            DataFileMeta oldAnchor = retrieveAnchorFile(previousRowGroup, file -> file);
+            maintainer.notifyRemovedDeletionVector(oldAnchor.fileName());
+        }
+    }
+
+    private boolean isMaterialized(CompactIncrement compactIncrement) {
+        List<DataFileMeta> before = normalFiles(compactIncrement.compactBefore());
+        if (before.isEmpty()) {
+            return false;
+        }
+        return compactIncrement.compactAfter().stream().allMatch(file -> file.firstRowId() == null);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactDeletionVectorRewriter.java
@@ -68,9 +68,11 @@ import static org.apache.paimon.utils.Preconditions.checkState;
 public class DataEvolutionCompactDeletionVectorRewriter {
 
     private final FileStoreTable table;
+    private final Snapshot snapshot;
 
-    public DataEvolutionCompactDeletionVectorRewriter(FileStoreTable table) {
+    public DataEvolutionCompactDeletionVectorRewriter(FileStoreTable table, Snapshot snapshot) {
         this.table = table;
+        this.snapshot = snapshot;
     }
 
     public List<CommitMessage> rewriteDeletionVectors(List<CommitMessage> messages) {
@@ -78,7 +80,6 @@ public class DataEvolutionCompactDeletionVectorRewriter {
             return Collections.emptyList();
         }
 
-        Snapshot snapshot = table.snapshotManager().latestSnapshot();
         Map<BinaryRow, AppendDeleteFileMaintainer> maintainerByParts =
                 collectMaintainers(snapshot, messages);
         if (maintainerByParts.isEmpty()) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
@@ -46,19 +46,16 @@ import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 class DataEvolutionCompactGlobalIndexDropper {
 
     private final FileStoreTable table;
+    private final Snapshot snapshot;
 
-    DataEvolutionCompactGlobalIndexDropper(FileStoreTable table) {
+    DataEvolutionCompactGlobalIndexDropper(FileStoreTable table, Snapshot snapshot) {
         this.table = table;
+        this.snapshot = snapshot;
     }
 
     List<CommitMessage> dropGlobalIndexes(List<CommitMessage> messages) {
         Set<BinaryRow> partitions = materializedPartitions(messages);
         if (partitions.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Snapshot snapshot = table.snapshotManager().latestSnapshot();
-        if (snapshot == null) {
             return Collections.emptyList();
         }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactGlobalIndexDropper.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.utils.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+
+/** Drops partition-level global indexes invalidated by materialized data-evolution compaction. */
+class DataEvolutionCompactGlobalIndexDropper {
+
+    private final FileStoreTable table;
+
+    DataEvolutionCompactGlobalIndexDropper(FileStoreTable table) {
+        this.table = table;
+    }
+
+    List<CommitMessage> dropGlobalIndexes(List<CommitMessage> messages) {
+        Set<BinaryRow> partitions = materializedPartitions(messages);
+        if (partitions.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        if (snapshot == null) {
+            return Collections.emptyList();
+        }
+
+        Map<Pair<BinaryRow, Integer>, List<IndexFileMeta>> deletedIndexes = new LinkedHashMap<>();
+        for (IndexManifestEntry entry :
+                table.store()
+                        .newIndexFileHandler()
+                        .scan(
+                                snapshot,
+                                e ->
+                                        partitions.contains(e.partition())
+                                                && e.indexFile().globalIndexMeta() != null)) {
+            deletedIndexes
+                    .computeIfAbsent(
+                            Pair.of(entry.partition(), entry.bucket()), k -> new ArrayList<>())
+                    .add(entry.indexFile());
+        }
+
+        List<CommitMessage> result = new ArrayList<>();
+        for (Map.Entry<Pair<BinaryRow, Integer>, List<IndexFileMeta>> entry :
+                deletedIndexes.entrySet()) {
+            result.add(
+                    toCommitMessage(
+                            entry.getKey().getLeft(), entry.getKey().getRight(), entry.getValue()));
+        }
+        return result;
+    }
+
+    private Set<BinaryRow> materializedPartitions(List<CommitMessage> messages) {
+        Set<BinaryRow> result = new LinkedHashSet<>();
+        for (CommitMessage message : messages) {
+            CommitMessageImpl commitMessage = (CommitMessageImpl) message;
+            CompactIncrement compactIncrement = commitMessage.compactIncrement();
+            if (normalFiles(compactIncrement.compactBefore()).isEmpty()) {
+                continue;
+            }
+            // only involve partitions with deletions materialization
+            if (compactIncrement.compactAfter().stream()
+                    .allMatch(file -> file.firstRowId() == null)) {
+                result.add(commitMessage.partition());
+            }
+        }
+        return result;
+    }
+
+    private List<DataFileMeta> normalFiles(List<DataFileMeta> files) {
+        return files.stream()
+                .filter(file -> !isBlobFile(file.fileName()) && !isVectorStoreFile(file.fileName()))
+                .collect(Collectors.toList());
+    }
+
+    private CommitMessage toCommitMessage(
+            BinaryRow partition, int bucket, List<IndexFileMeta> deletedIndexFiles) {
+        return new CommitMessageImpl(
+                partition,
+                bucket,
+                null,
+                DataIncrement.emptyIncrement(),
+                new CompactIncrement(
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        deletedIndexFiles));
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTask.java
@@ -18,39 +18,15 @@
 
 package org.apache.paimon.append.dataevolution;
 
-import org.apache.paimon.AppendOnlyFileStore;
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.append.AppendCompactTask;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.fileindex.FileIndexOptions;
-import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.io.DataIncrement;
-import org.apache.paimon.io.FileWriter;
-import org.apache.paimon.io.RollingFileWriter;
-import org.apache.paimon.io.RowDataFileWriter;
-import org.apache.paimon.manifest.FileSource;
-import org.apache.paimon.operation.AppendFileStoreWrite;
-import org.apache.paimon.reader.RecordReader;
-import org.apache.paimon.statistics.NoneSimpleColStatsCollector;
-import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
-import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.types.DataField;
-import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.FileStorePathFactory;
-import org.apache.paimon.utils.LongCounter;
 import org.apache.paimon.utils.Range;
-import org.apache.paimon.utils.RecordWriter;
-import org.apache.paimon.utils.SetUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,24 +34,28 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.Comparator.comparingLong;
-import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
-import static org.apache.paimon.types.VectorType.fieldNamesInVectorFile;
-import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.checkContiguousRowRange;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Data evolution table compaction task. */
-public class DataEvolutionCompactTask extends AppendCompactTask {
+/** Base class for data evolution table compaction tasks. */
+public abstract class DataEvolutionCompactTask {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionCompactTask.class);
-
-    private static final Map<String, String> DYNAMIC_WRITE_OPTIONS = dynamicWriteOptions();
-    private static final Map<String, String> BLOB_COMPACT_READ_OPTIONS =
+    protected static final Map<String, String> DYNAMIC_WRITE_OPTIONS = dynamicWriteOptions();
+    protected static final Map<String, String> BLOB_COMPACT_READ_OPTIONS =
             Collections.singletonMap(CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true");
+
+    protected final BinaryRow partition;
+    protected final List<DataFileMeta> compactBefore;
+    protected final List<DataFileMeta> compactAfter;
+
+    protected DataEvolutionCompactTask(BinaryRow partition, List<DataFileMeta> files) {
+        checkArgument(files != null);
+        this.partition = partition;
+        this.compactBefore = new ArrayList<>(files);
+        this.compactAfter = new ArrayList<>();
+    }
 
     private static Map<String, String> dynamicWriteOptions() {
         Map<String, String> options = new HashMap<>();
@@ -84,253 +64,53 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         return Collections.unmodifiableMap(options);
     }
 
-    private final boolean blobTask;
-
-    public DataEvolutionCompactTask(
-            BinaryRow partition, List<DataFileMeta> files, boolean blobTask) {
-        super(partition, files);
-        this.blobTask = blobTask;
+    public BinaryRow partition() {
+        return partition;
     }
 
-    public boolean isBlobTask() {
-        return blobTask;
+    public List<DataFileMeta> compactBefore() {
+        return compactBefore;
     }
 
-    public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
-        CoreOptions options = table.coreOptions();
+    public List<DataFileMeta> compactAfter() {
+        return compactAfter;
+    }
 
-        if (blobTask) {
-            return doCompactBlobFiles(table, commitUser);
-        }
-        if (isVectorStoreFile(compactBefore.get(0).fileName())) {
-            // TODO: support vector-store file compaction
-            throw new UnsupportedOperationException("Vector-store task is not supported");
-        }
+    public abstract TaskType type();
 
-        Set<String> fieldsInDedicatedFile =
-                SetUtils.union(
-                        fieldNamesInBlobFile(table.rowType(), options.blobInlineField()),
-                        fieldNamesInVectorFile(table.rowType(), options.withVectorFormat()));
+    public abstract CommitMessage doCompact(FileStoreTable table, String commitUser)
+            throws Exception;
 
-        table = table.copy(DYNAMIC_WRITE_OPTIONS);
-        long firstRowId = compactBefore.get(0).nonNullFirstRowId();
-
-        RowType readWriteType =
-                new RowType(
-                        table.rowType().getFields().stream()
-                                .filter(f -> !fieldsInDedicatedFile.contains(f.name()))
-                                .collect(Collectors.toList()));
-        FileStorePathFactory pathFactory = table.store().pathFactory();
-        AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
-
-        DataSplit dataSplit =
-                DataSplit.builder()
-                        .withPartition(partition)
-                        .withBucket(0)
-                        .withDataFiles(compactBefore)
-                        .withBucketPath(pathFactory.bucketPath(partition, 0).toString())
-                        .rawConvertible(false)
-                        .build();
-        RecordReader<InternalRow> reader =
-                store.newDataEvolutionRead().withReadType(readWriteType).createReader(dataSplit);
-        AppendFileStoreWrite storeWrite = (AppendFileStoreWrite) store.newWrite(commitUser);
-        storeWrite.withWriteType(readWriteType);
-        RecordWriter<InternalRow> writer = storeWrite.createWriter(partition, 0);
-
-        reader.forEachRemaining(
-                row -> {
-                    try {
-                        writer.write(row);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-
-        List<DataFileMeta> writeResult = writer.prepareCommit(false).newFilesIncrement().newFiles();
-        checkArgument(
-                writeResult.size() == 1, "Data evolution compaction should produce one file.");
-
-        try {
-            writer.close();
-            storeWrite.close();
-        } catch (Exception e) {
-            LOG.warn("Failed to close reader and writer.", e);
-        }
-
-        DataFileMeta dataFileMeta = writeResult.get(0).assignFirstRowId(firstRowId);
-        long minSequenceId =
-                compactBefore.stream()
-                        .mapToLong(DataFileMeta::minSequenceNumber)
-                        .min()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Cannot get min sequence id from compact before files."));
-        long maxSequenceId =
-                compactBefore.stream()
-                        .mapToLong(DataFileMeta::maxSequenceNumber)
-                        .max()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Cannot get max sequence id from compact before files."));
-        dataFileMeta = dataFileMeta.assignSequenceNumber(minSequenceId, maxSequenceId);
-        compactAfter.add(dataFileMeta);
-
+    protected CommitMessage commitMessage(
+            List<DataFileMeta> compactBefore, List<DataFileMeta> compactAfter) {
         CompactIncrement compactIncrement =
                 new CompactIncrement(compactBefore, compactAfter, Collections.emptyList());
         return new CommitMessageImpl(
                 partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
     }
 
-    private CommitMessage doCompactBlobFiles(FileStoreTable table, String commitUser)
-            throws Exception {
-        CoreOptions options = table.coreOptions();
-        List<DataFileMeta> sortedCompactBefore = sortedByFirstRowId(compactBefore);
-        DataField blobField = blobField(table, options, sortedCompactBefore);
-        Range compactBeforeRange = checkContiguousRowRange(sortedCompactBefore);
-        checkArgument(
-                sortedCompactBefore.size() > 1,
-                "Blob compaction task %s should contain at least two files to compact.",
-                this);
-
-        RowType blobWriteType = new RowType(Collections.singletonList(blobField));
-
-        FileStoreTable readTable = table.copy(BLOB_COMPACT_READ_OPTIONS);
-        AppendOnlyFileStore store = (AppendOnlyFileStore) readTable.store();
-        DataFilePathFactory pathFactory =
-                store.pathFactory().createDataFilePathFactory(partition, 0);
-
-        DataSplit dataSplit =
-                DataSplit.builder()
-                        .withPartition(partition)
-                        .withBucket(0)
-                        .withDataFiles(sortedCompactBefore)
-                        .withBucketPath(pathFactory.parent().toString())
-                        .rawConvertible(false)
-                        .build();
-        RecordReader<InternalRow> reader =
-                store.newDataEvolutionRead().withReadType(blobWriteType).createReader(dataSplit);
-        FileWriter<InternalRow, DataFileMeta> writer =
-                createBlobFileWriter(table, options, blobWriteType, blobField.name(), pathFactory);
-
-        try {
-            reader.forEachRemaining(
-                    row -> {
-                        try {
-                            writer.write(row);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }
-                    });
-            writer.close();
-        } catch (Exception e) {
-            writer.abort();
-            throw e;
-        }
-
-        long minSequenceId = minSequenceId(sortedCompactBefore);
-        long maxSequenceId = maxSequenceId(sortedCompactBefore);
-        DataFileMeta compactedFile =
-                writer.result()
-                        .assignFirstRowId(compactBeforeRange.from)
-                        .assignSequenceNumber(minSequenceId, maxSequenceId);
-        compactAfter.add(compactedFile);
-        checkArgument(compactAfter.size() == 1, "Blob file compaction should produce one file.");
-        checkSameRowRange(sortedCompactBefore, compactAfter);
-
-        CompactIncrement compactIncrement =
-                new CompactIncrement(sortedCompactBefore, compactAfter, Collections.emptyList());
-        return new CommitMessageImpl(
-                partition, 0, null, DataIncrement.emptyIncrement(), compactIncrement);
-    }
-
-    private FileWriter<InternalRow, DataFileMeta> createBlobFileWriter(
-            FileStoreTable table,
-            CoreOptions options,
-            RowType blobWriteType,
-            String blobFieldName,
-            DataFilePathFactory pathFactory) {
-        BlobFileFormat blobFileFormat = new BlobFileFormat();
-        return new RowDataFileWriter(
-                table.fileIO(),
-                RollingFileWriter.createFileWriterContext(
-                        blobFileFormat,
-                        blobWriteType,
-                        new SimpleColStatsCollector.Factory[] {NoneSimpleColStatsCollector::new},
-                        "none"),
-                pathFactory.newBlobPath(),
-                blobWriteType,
-                table.schema().id(),
-                () -> new LongCounter(0),
-                new FileIndexOptions(),
-                FileSource.COMPACT,
-                false,
-                options.statsDenseStore(),
-                pathFactory.isExternalPath(),
-                Collections.singletonList(blobFieldName));
-    }
-
-    private List<DataFileMeta> sortedByFirstRowId(List<DataFileMeta> files) {
+    protected List<DataFileMeta> sortedByFirstRowId(List<DataFileMeta> files) {
         List<DataFileMeta> sorted = new ArrayList<>(files);
         sorted.sort(comparingLong(DataFileMeta::nonNullFirstRowId));
         return sorted;
     }
 
-    private DataField blobField(
-            FileStoreTable table, CoreOptions options, List<DataFileMeta> files) {
-        Integer blobFieldId = null;
-        Map<Long, RowType> schemaCache = new HashMap<>();
-        for (DataFileMeta file : files) {
-            checkArgument(
-                    file.writeCols() != null && file.writeCols().size() == 1,
-                    "Blob file %s should contain exactly one write column.",
-                    file);
-            RowType fileRowType =
-                    schemaCache.computeIfAbsent(
-                            file.schemaId(),
-                            schemaId -> table.schemaManager().schema(schemaId).logicalRowType());
-            int currentFieldId = fileRowType.getField(file.writeCols().get(0)).id();
-            if (blobFieldId == null) {
-                blobFieldId = currentFieldId;
-            } else {
-                checkArgument(
-                        blobFieldId == currentFieldId,
-                        "Blob compact before files %s should contain the same field.",
-                        files);
-            }
-        }
-
-        checkArgument(blobFieldId != null, "Blob compaction task should not be empty.");
-        checkArgument(
-                table.rowType().containsField(blobFieldId),
-                "Cannot find blob field id %s in latest schema for compaction task %s.",
-                blobFieldId,
-                this);
-        DataField field = table.rowType().getField(blobFieldId);
-        Set<String> blobFieldNames =
-                fieldNamesInBlobFile(table.rowType(), options.blobInlineField());
-        checkArgument(
-                blobFieldNames.contains(field.name()),
-                "Field %s in latest schema is not a blob file field.",
-                field.name());
-        return field;
-    }
-
-    private void checkSameRowRange(
-            List<DataFileMeta> compactBefore, List<DataFileMeta> compactAfter) {
+    protected void checkSameRowRange(
+            String fileDescription,
+            List<DataFileMeta> compactBefore,
+            List<DataFileMeta> compactAfter) {
         Range beforeRange = checkContiguousRowRange(compactBefore);
         Range afterRange = checkContiguousRowRange(compactAfter);
         checkArgument(
                 beforeRange.equals(afterRange),
                 "%s compact after files should have the same row range as compact before files, "
                         + "before range is %s, but after range is %s.",
-                "Blob compact files",
+                fileDescription,
                 beforeRange,
                 afterRange);
     }
 
-    private long minSequenceId(List<DataFileMeta> files) {
+    protected long minSequenceId(List<DataFileMeta> files) {
         return files.stream()
                 .mapToLong(DataFileMeta::minSequenceNumber)
                 .min()
@@ -340,7 +120,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
                                         "Cannot get min sequence id from compact before files."));
     }
 
-    private long maxSequenceId(List<DataFileMeta> files) {
+    protected long maxSequenceId(List<DataFileMeta> files) {
         return files.stream()
                 .mapToLong(DataFileMeta::maxSequenceNumber)
                 .max()
@@ -352,7 +132,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
 
     @Override
     public int hashCode() {
-        return Objects.hash(partition, compactBefore, compactAfter, blobTask);
+        return Objects.hash(partition, compactBefore, compactAfter);
     }
 
     @Override
@@ -365,8 +145,7 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
         }
 
         DataEvolutionCompactTask that = (DataEvolutionCompactTask) o;
-        return blobTask == that.blobTask
-                && Objects.equals(partition, that.partition)
+        return Objects.equals(partition, that.partition)
                 && Objects.equals(compactBefore, that.compactBefore)
                 && Objects.equals(compactAfter, that.compactAfter);
     }
@@ -374,11 +153,34 @@ public class DataEvolutionCompactTask extends AppendCompactTask {
     @Override
     public String toString() {
         return String.format(
-                "DataEvolutionCompactTask {"
-                        + "partition = %s, "
-                        + "compactBefore = %s, "
-                        + "compactAfter = %s, "
-                        + "blobTask = %s}",
-                partition, compactBefore, compactAfter, blobTask);
+                "%s {partition = %s, compactBefore = %s, compactAfter = %s}",
+                getClass().getSimpleName(), partition, compactBefore, compactAfter);
+    }
+
+    /** Type of data evolution compaction task. */
+    public enum TaskType {
+        NORMAL(0),
+        BLOB(1),
+        MATERIALIZE_DELETION(2);
+
+        private final int code;
+
+        TaskType(int code) {
+            this.code = code;
+        }
+
+        public int code() {
+            return code;
+        }
+
+        public static TaskType fromCode(int code) {
+            for (TaskType type : values()) {
+                if (type.code == code) {
+                    return type;
+                }
+            }
+            throw new UnsupportedOperationException(
+                    "Unsupported data evolution compact task type code: " + code);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTaskSerializer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactTaskSerializer.java
@@ -18,12 +18,15 @@
 
 package org.apache.paimon.append.dataevolution;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.serializer.VersionedSerializer;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
 import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
+import org.apache.paimon.table.source.DeletionFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,7 +40,7 @@ import static org.apache.paimon.utils.SerializationUtils.serializeBinaryRow;
 public class DataEvolutionCompactTaskSerializer
         implements VersionedSerializer<DataEvolutionCompactTask> {
 
-    private static final int CURRENT_VERSION = 1;
+    private static final int CURRENT_VERSION = 2;
 
     private final DataFileMetaSerializer dataFileSerializer;
 
@@ -69,14 +72,18 @@ public class DataEvolutionCompactTaskSerializer
     private void serialize(DataEvolutionCompactTask task, DataOutputView view) throws IOException {
         serializeBinaryRow(task.partition(), view);
         dataFileSerializer.serializeList(task.compactBefore(), view);
-        view.writeBoolean(task.isBlobTask());
+        view.writeInt(task.type().code());
+        if (task.type() == DataEvolutionCompactTask.TaskType.MATERIALIZE_DELETION) {
+            DeletionFile.serializeList(
+                    view, ((DataEvolutionMaterializeDeletionCompactTask) task).deletionFiles());
+        }
     }
 
     @Override
     public DataEvolutionCompactTask deserialize(int version, byte[] serialized) throws IOException {
         checkVersion(version);
         DataInputDeserializer view = new DataInputDeserializer(serialized);
-        return deserialize(view);
+        return deserialize(version, view);
     }
 
     public List<DataEvolutionCompactTask> deserializeList(int version, DataInputView view)
@@ -85,7 +92,7 @@ public class DataEvolutionCompactTaskSerializer
         int length = view.readInt();
         List<DataEvolutionCompactTask> list = new ArrayList<>(length);
         for (int i = 0; i < length; i++) {
-            list.add(deserialize(view));
+            list.add(deserialize(version, view));
         }
         return list;
     }
@@ -102,10 +109,24 @@ public class DataEvolutionCompactTaskSerializer
         }
     }
 
-    private DataEvolutionCompactTask deserialize(DataInputView view) throws IOException {
-        return new DataEvolutionCompactTask(
-                deserializeBinaryRow(view),
-                dataFileSerializer.deserializeList(view),
-                view.readBoolean());
+    private DataEvolutionCompactTask deserialize(int version, DataInputView view)
+            throws IOException {
+        BinaryRow partition = deserializeBinaryRow(view);
+        List<DataFileMeta> files = dataFileSerializer.deserializeList(view);
+        DataEvolutionCompactTask.TaskType type =
+                DataEvolutionCompactTask.TaskType.fromCode(view.readInt());
+        switch (type) {
+            case NORMAL:
+                return new DataEvolutionNormalCompactTask(partition, files);
+            case BLOB:
+                return new DataEvolutionBlobCompactTask(partition, files);
+            case MATERIALIZE_DELETION:
+                return new DataEvolutionMaterializeDeletionCompactTask(
+                        partition,
+                        files,
+                        DeletionFile.deserializeList(view, DeletionFile::deserialize));
+            default:
+                throw new UnsupportedOperationException("Unsupported compact task type: " + type);
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactionCommitPreparation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactionCommitPreparation.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.append.dataevolution;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 
@@ -28,18 +29,21 @@ import java.util.List;
 public class DataEvolutionCompactionCommitPreparation {
 
     private final FileStoreTable table;
+    private final Snapshot snapshot;
 
-    public DataEvolutionCompactionCommitPreparation(FileStoreTable table) {
+    public DataEvolutionCompactionCommitPreparation(FileStoreTable table, Snapshot snapshot) {
         this.table = table;
+        this.snapshot = snapshot;
     }
 
     public List<CommitMessage> prepare(List<CommitMessage> messages) {
         List<CommitMessage> result = new ArrayList<>();
         result.addAll(
-                new DataEvolutionCompactDeletionVectorRewriter(table)
+                new DataEvolutionCompactDeletionVectorRewriter(table, snapshot)
                         .rewriteDeletionVectors(messages));
         result.addAll(
-                new DataEvolutionCompactGlobalIndexDropper(table).dropGlobalIndexes(messages));
+                new DataEvolutionCompactGlobalIndexDropper(table, snapshot)
+                        .dropGlobalIndexes(messages));
         return result;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactionCommitPreparation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactionCommitPreparation.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Prepares extra commit messages for data-evolution compaction before committing. */
+public class DataEvolutionCompactionCommitPreparation {
+
+    private final FileStoreTable table;
+
+    public DataEvolutionCompactionCommitPreparation(FileStoreTable table) {
+        this.table = table;
+    }
+
+    public List<CommitMessage> prepare(List<CommitMessage> messages) {
+        List<CommitMessage> result = new ArrayList<>();
+        result.addAll(
+                new DataEvolutionCompactDeletionVectorRewriter(table)
+                        .rewriteDeletionVectors(messages));
+        result.addAll(
+                new DataEvolutionCompactGlobalIndexDropper(table).dropGlobalIndexes(messages));
+        return result;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionMaterializeDeletionCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionMaterializeDeletionCompactTask.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.AppendOnlyFileStore;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.operation.AppendFileStoreWrite;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.DeletionFile;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.RecordWriter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Physically applies deletion vectors while compacting a data evolution row-id range. */
+public class DataEvolutionMaterializeDeletionCompactTask extends DataEvolutionCompactTask {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DataEvolutionMaterializeDeletionCompactTask.class);
+
+    private final List<DeletionFile> deletionFiles;
+
+    public DataEvolutionMaterializeDeletionCompactTask(
+            BinaryRow partition, List<DataFileMeta> files, List<DeletionFile> deletionFiles) {
+        super(partition, files);
+        checkArgument(
+                deletionFiles != null && deletionFiles.size() == files.size(),
+                "Materialize deletion compact task should have deletion files aligned with data files.");
+        this.deletionFiles = new ArrayList<>(deletionFiles);
+    }
+
+    public List<DeletionFile> deletionFiles() {
+        return deletionFiles;
+    }
+
+    @Override
+    public TaskType type() {
+        return TaskType.MATERIALIZE_DELETION;
+    }
+
+    @Override
+    public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
+        if (compactBefore.stream().anyMatch(file -> isVectorStoreFile(file.fileName()))) {
+            // TODO: support vector-store file compaction
+            throw new UnsupportedOperationException("Vector-store task is not supported");
+        }
+
+        table = table.copy(DYNAMIC_WRITE_OPTIONS);
+        FileStorePathFactory pathFactory = table.store().pathFactory();
+        AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
+
+        // build DataSplit with deletion vectors
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withPartition(partition)
+                        .withBucket(0)
+                        .withDataFiles(compactBefore)
+                        .withDataDeletionFiles(deletionFiles)
+                        .withBucketPath(pathFactory.bucketPath(partition, 0).toString())
+                        .rawConvertible(false)
+                        .build();
+        RecordReader<InternalRow> reader =
+                store.newDataEvolutionRead().withReadType(table.rowType()).createReader(dataSplit);
+        AppendFileStoreWrite storeWrite = (AppendFileStoreWrite) store.newWrite(commitUser);
+        storeWrite.withWriteType(table.rowType());
+        RecordWriter<InternalRow> writer = storeWrite.createWriter(partition, 0);
+
+        try {
+            reader.forEachRemaining(
+                    row -> {
+                        try {
+                            writer.write(row);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+
+            compactAfter.addAll(writer.prepareCommit(false).newFilesIncrement().newFiles());
+        } finally {
+            writer.close();
+            storeWrite.close();
+        }
+
+        return commitMessage(compactBefore, compactAfter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), deletionFiles);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o)
+                && Objects.equals(
+                        deletionFiles,
+                        ((DataEvolutionMaterializeDeletionCompactTask) o).deletionFiles);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionNormalCompactTask.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionNormalCompactTask.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.append.dataevolution;
+
+import org.apache.paimon.AppendOnlyFileStore;
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.operation.AppendFileStoreWrite;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+import org.apache.paimon.utils.RecordWriter;
+import org.apache.paimon.utils.SetUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.paimon.types.BlobType.fieldNamesInBlobFile;
+import static org.apache.paimon.types.VectorType.fieldNamesInVectorFile;
+import static org.apache.paimon.types.VectorType.isVectorStoreFile;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Compacts normal structured files of a data evolution table. */
+public class DataEvolutionNormalCompactTask extends DataEvolutionCompactTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionNormalCompactTask.class);
+
+    public DataEvolutionNormalCompactTask(BinaryRow partition, List<DataFileMeta> files) {
+        super(partition, files);
+    }
+
+    @Override
+    public TaskType type() {
+        return TaskType.NORMAL;
+    }
+
+    @Override
+    public CommitMessage doCompact(FileStoreTable table, String commitUser) throws Exception {
+        CoreOptions options = table.coreOptions();
+
+        if (isVectorStoreFile(compactBefore.get(0).fileName())) {
+            // TODO: support vector-store file compaction
+            throw new UnsupportedOperationException("Vector-store task is not supported");
+        }
+
+        Set<String> fieldsInDedicatedFile =
+                SetUtils.union(
+                        fieldNamesInBlobFile(table.rowType(), options.blobInlineField()),
+                        fieldNamesInVectorFile(table.rowType(), options.withVectorFormat()));
+
+        table = table.copy(DYNAMIC_WRITE_OPTIONS);
+        long firstRowId = compactBefore.get(0).nonNullFirstRowId();
+
+        RowType readWriteType =
+                new RowType(
+                        table.rowType().getFields().stream()
+                                .filter(f -> !fieldsInDedicatedFile.contains(f.name()))
+                                .collect(Collectors.toList()));
+        FileStorePathFactory pathFactory = table.store().pathFactory();
+        AppendOnlyFileStore store = (AppendOnlyFileStore) table.store();
+
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withPartition(partition)
+                        .withBucket(0)
+                        .withDataFiles(compactBefore)
+                        .withBucketPath(pathFactory.bucketPath(partition, 0).toString())
+                        .rawConvertible(false)
+                        .build();
+        RecordReader<InternalRow> reader =
+                store.newDataEvolutionRead().withReadType(readWriteType).createReader(dataSplit);
+        AppendFileStoreWrite storeWrite = (AppendFileStoreWrite) store.newWrite(commitUser);
+        storeWrite.withWriteType(readWriteType);
+        RecordWriter<InternalRow> writer = storeWrite.createWriter(partition, 0);
+
+        reader.forEachRemaining(
+                row -> {
+                    try {
+                        writer.write(row);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        List<DataFileMeta> writeResult = writer.prepareCommit(false).newFilesIncrement().newFiles();
+        checkArgument(
+                writeResult.size() == 1, "Data evolution compaction should produce one file.");
+
+        try {
+            writer.close();
+            storeWrite.close();
+        } catch (Exception e) {
+            LOG.warn("Failed to close reader and writer.", e);
+        }
+
+        DataFileMeta dataFileMeta = writeResult.get(0).assignFirstRowId(firstRowId);
+        dataFileMeta =
+                dataFileMeta.assignSequenceNumber(
+                        minSequenceId(compactBefore), maxSequenceId(compactBefore));
+        compactAfter.add(dataFileMeta);
+
+        return commitMessage(compactBefore, compactAfter);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/deletionvectors/DeletionVectorsIndexFile.java
@@ -102,6 +102,27 @@ public class DeletionVectorsIndexFile extends IndexFile {
         return deletionVectors;
     }
 
+    /** Converts deletion-vector index file metas to data-file deletion file metadata. */
+    public Map<String, DeletionFile> toDeletionFiles(List<IndexFileMeta> fileMetas) {
+        Map<String, DeletionFile> deletionFiles = new HashMap<>();
+        for (IndexFileMeta indexFile : fileMetas) {
+            LinkedHashMap<String, DeletionVectorMeta> dvRanges = indexFile.dvRanges();
+            String dvFilePath = path(indexFile).toString();
+            if (dvRanges != null && !dvRanges.isEmpty()) {
+                for (DeletionVectorMeta dvMeta : dvRanges.values()) {
+                    deletionFiles.put(
+                            dvMeta.dataFileName(),
+                            new DeletionFile(
+                                    dvFilePath,
+                                    dvMeta.offset(),
+                                    dvMeta.length(),
+                                    dvMeta.cardinality()));
+                }
+            }
+        }
+        return deletionFiles;
+    }
+
     /** Reads deletion vectors from a list of DeletionFile which belong to a same index file. */
     public Map<String, DeletionVector> readDeletionVector(
             Map<String, DeletionFile> dataFileToDeletionFiles) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -24,7 +24,6 @@ import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.index.DeletionVectorMeta;
 import org.apache.paimon.index.IndexFileHandler;
@@ -83,6 +82,7 @@ import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETIO
 import static org.apache.paimon.operation.FileStoreScan.Plan.groupByPartFiles;
 import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
 import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates;
+import static org.apache.paimon.utils.DataEvolutionUtils.toDeletionFiles;
 
 /** Implementation of {@link SnapshotReader}. */
 public class SnapshotReaderImpl implements SnapshotReader {
@@ -679,7 +679,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
                     Pair<BinaryRow, Integer> partitionBucket = entry;
                     if (remainingBuckets.contains(entry)) {
                         Map<String, DeletionFile> deletionFiles =
-                                toDeletionFiles(partitionBucket, indexFileMetas);
+                                toDeletionFiles(
+                                        indexFileHandler,
+                                        partitionBucket.getLeft(),
+                                        partitionBucket.getRight(),
+                                        indexFileMetas);
                         result.put(partitionBucket, deletionFiles);
                         if (dvMetaCache != null) {
                             dvMetaCache.put(
@@ -694,7 +698,12 @@ public class SnapshotReaderImpl implements SnapshotReader {
                                 partitionBucket.getLeft(),
                                 partitionBucket.getRight(),
                                 deletionFileNumber(indexFileMetas),
-                                () -> toDeletionFiles(partitionBucket, indexFileMetas));
+                                () ->
+                                        toDeletionFiles(
+                                                indexFileHandler,
+                                                partitionBucket.getLeft(),
+                                                partitionBucket.getRight(),
+                                                indexFileMetas));
                     }
                 });
         return result;
@@ -709,29 +718,6 @@ public class SnapshotReaderImpl implements SnapshotReader {
             }
         }
         return count;
-    }
-
-    private Map<String, DeletionFile> toDeletionFiles(
-            Pair<BinaryRow, Integer> partitionBucket, List<IndexFileMeta> fileMetas) {
-        Map<String, DeletionFile> deletionFiles = new HashMap<>();
-        DeletionVectorsIndexFile dvIndex =
-                indexFileHandler.dvIndex(partitionBucket.getLeft(), partitionBucket.getRight());
-        for (IndexFileMeta indexFile : fileMetas) {
-            LinkedHashMap<String, DeletionVectorMeta> dvRanges = indexFile.dvRanges();
-            String dvFilePath = dvIndex.path(indexFile).toString();
-            if (dvRanges != null && !dvRanges.isEmpty()) {
-                for (DeletionVectorMeta dvMeta : dvRanges.values()) {
-                    deletionFiles.put(
-                            dvMeta.dataFileName(),
-                            new DeletionFile(
-                                    dvFilePath,
-                                    dvMeta.offset(),
-                                    dvMeta.length(),
-                                    dvMeta.cardinality()));
-                }
-            }
-        }
-        return deletionFiles;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/snapshot/SnapshotReaderImpl.java
@@ -82,7 +82,6 @@ import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETIO
 import static org.apache.paimon.operation.FileStoreScan.Plan.groupByPartFiles;
 import static org.apache.paimon.partition.PartitionPredicate.createPartitionPredicate;
 import static org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates;
-import static org.apache.paimon.utils.DataEvolutionUtils.toDeletionFiles;
 
 /** Implementation of {@link SnapshotReader}. */
 public class SnapshotReaderImpl implements SnapshotReader {
@@ -679,11 +678,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
                     Pair<BinaryRow, Integer> partitionBucket = entry;
                     if (remainingBuckets.contains(entry)) {
                         Map<String, DeletionFile> deletionFiles =
-                                toDeletionFiles(
-                                        indexFileHandler,
-                                        partitionBucket.getLeft(),
-                                        partitionBucket.getRight(),
-                                        indexFileMetas);
+                                indexFileHandler
+                                        .dvIndex(
+                                                partitionBucket.getLeft(),
+                                                partitionBucket.getRight())
+                                        .toDeletionFiles(indexFileMetas);
                         result.put(partitionBucket, deletionFiles);
                         if (dvMetaCache != null) {
                             dvMetaCache.put(
@@ -699,11 +698,11 @@ public class SnapshotReaderImpl implements SnapshotReader {
                                 partitionBucket.getRight(),
                                 deletionFileNumber(indexFileMetas),
                                 () ->
-                                        toDeletionFiles(
-                                                indexFileHandler,
-                                                partitionBucket.getLeft(),
-                                                partitionBucket.getRight(),
-                                                indexFileMetas));
+                                        indexFileHandler
+                                                .dvIndex(
+                                                        partitionBucket.getLeft(),
+                                                        partitionBucket.getRight())
+                                                .toDeletionFiles(indexFileMetas));
                     }
                 });
         return result;

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -18,20 +18,11 @@
 
 package org.apache.paimon.utils;
 
-import org.apache.paimon.data.BinaryRow;
-import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
-import org.apache.paimon.index.DeletionVectorMeta;
-import org.apache.paimon.index.IndexFileHandler;
-import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.table.source.DeletionFile;
 
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,7 +31,7 @@ import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
-/** Util class for Deletion Vectors. */
+/** Util class for data evolution. */
 public class DataEvolutionUtils {
 
     /**
@@ -86,31 +77,5 @@ public class DataEvolutionUtils {
                 "Data evolution compact files",
                 merged);
         return merged.get(0);
-    }
-
-    /** Convert deletion-vector index file metas to anchor-file deletion file metadata. */
-    public static Map<String, DeletionFile> toDeletionFiles(
-            IndexFileHandler indexFileHandler,
-            BinaryRow partition,
-            int bucket,
-            List<IndexFileMeta> fileMetas) {
-        Map<String, DeletionFile> deletionFiles = new HashMap<>();
-        DeletionVectorsIndexFile dvIndex = indexFileHandler.dvIndex(partition, bucket);
-        for (IndexFileMeta indexFile : fileMetas) {
-            LinkedHashMap<String, DeletionVectorMeta> dvRanges = indexFile.dvRanges();
-            String dvFilePath = dvIndex.path(indexFile).toString();
-            if (dvRanges != null && !dvRanges.isEmpty()) {
-                for (DeletionVectorMeta dvMeta : dvRanges.values()) {
-                    deletionFiles.put(
-                            dvMeta.dataFileName(),
-                            new DeletionFile(
-                                    dvFilePath,
-                                    dvMeta.offset(),
-                                    dvMeta.length(),
-                                    dvMeta.cardinality()));
-                }
-            }
-        }
-        return deletionFiles;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/DataEvolutionUtils.java
@@ -18,11 +18,20 @@
 
 package org.apache.paimon.utils;
 
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
+import org.apache.paimon.index.DeletionVectorMeta;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.table.source.DeletionFile;
 
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -77,5 +86,31 @@ public class DataEvolutionUtils {
                 "Data evolution compact files",
                 merged);
         return merged.get(0);
+    }
+
+    /** Convert deletion-vector index file metas to anchor-file deletion file metadata. */
+    public static Map<String, DeletionFile> toDeletionFiles(
+            IndexFileHandler indexFileHandler,
+            BinaryRow partition,
+            int bucket,
+            List<IndexFileMeta> fileMetas) {
+        Map<String, DeletionFile> deletionFiles = new HashMap<>();
+        DeletionVectorsIndexFile dvIndex = indexFileHandler.dvIndex(partition, bucket);
+        for (IndexFileMeta indexFile : fileMetas) {
+            LinkedHashMap<String, DeletionVectorMeta> dvRanges = indexFile.dvRanges();
+            String dvFilePath = dvIndex.path(indexFile).toString();
+            if (dvRanges != null && !dvRanges.isEmpty()) {
+                for (DeletionVectorMeta dvMeta : dvRanges.values()) {
+                    deletionFiles.put(
+                            dvMeta.dataFileName(),
+                            new DeletionFile(
+                                    dvFilePath,
+                                    dvMeta.offset(),
+                                    dvMeta.length(),
+                                    dvMeta.cardinality()));
+                }
+            }
+        }
+        return deletionFiles;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -1180,7 +1180,7 @@ public class JavaPyE2ETest {
         table = (FileStoreTable) catalog.getTable(identifier);
         org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator coordinator =
                 new org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator(
-                        table, false, false);
+                        table, false, false, table.latestSnapshot().get());
         List<org.apache.paimon.append.dataevolution.DataEvolutionCompactTask> tasks =
                 coordinator.plan();
         assertThat(tasks.size()).isGreaterThan(0);
@@ -1831,7 +1831,8 @@ public class JavaPyE2ETest {
     private void doDataEvolutionCompact(FileStoreTable table, boolean compactBlob)
             throws Exception {
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, compactBlob, false);
+                new DataEvolutionCompactCoordinator(
+                        table, compactBlob, false, table.latestSnapshot().get());
         List<CommitMessage> messages = new ArrayList<>();
         try {
             List<DataEvolutionCompactTask> tasks;

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -82,6 +82,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.CoreOptions.FILE_FORMAT_PARQUET;
+import static org.apache.paimon.append.dataevolution.DataEvolutionCompactTask.TaskType.BLOB;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -220,7 +221,7 @@ public class BlobTableTest extends TableTestBase {
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
         List<CommitMessage> compactMessages = new ArrayList<>();
         for (DataEvolutionCompactTask task : tasks) {
@@ -1154,7 +1155,7 @@ public class BlobTableTest extends TableTestBase {
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
         List<CommitMessage> compactMessages = new ArrayList<>();
         for (DataEvolutionCompactTask task : tasks) {
@@ -1180,7 +1181,7 @@ public class BlobTableTest extends TableTestBase {
         } catch (EndOfScanException e) {
             tasks2 = Collections.emptyList();
         }
-        assertThat(tasks2.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isFalse();
+        assertThat(tasks2.stream().anyMatch(task -> task.type() == BLOB)).isFalse();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -219,7 +219,8 @@ public class BlobTableTest extends TableTestBase {
         }
 
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
@@ -569,7 +570,8 @@ public class BlobTableTest extends TableTestBase {
         // Step 4: compact blob table using DataEvolutionCompactCoordinator
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.size()).isGreaterThan(0);
         List<CommitMessage> compactMessages = new ArrayList<>();
@@ -627,7 +629,8 @@ public class BlobTableTest extends TableTestBase {
 
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.size()).isGreaterThan(0);
         List<CommitMessage> compactMessages = new ArrayList<>();
@@ -697,7 +700,8 @@ public class BlobTableTest extends TableTestBase {
 
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.size()).isGreaterThan(0);
         List<CommitMessage> compactMessages = new ArrayList<>();
@@ -746,7 +750,8 @@ public class BlobTableTest extends TableTestBase {
         // Step 4: compact merges files into the same split
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.size()).isGreaterThan(0);
         List<CommitMessage> compactMessages = new ArrayList<>();
@@ -1153,7 +1158,8 @@ public class BlobTableTest extends TableTestBase {
 
         // Run blob compaction
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
@@ -1174,7 +1180,9 @@ public class BlobTableTest extends TableTestBase {
 
         // Verify no more blob compaction tasks needed
         table = getTableDefault();
-        coordinator = new DataEvolutionCompactCoordinator(table, true, false);
+        coordinator =
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks2;
         try {
             tasks2 = coordinator.plan();

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.append.dataevolution.DataEvolutionCompactTask.TaskType.BLOB;
 import static org.apache.paimon.format.blob.BlobFileFormat.isBlobFile;
 import static org.apache.paimon.operation.DataEvolutionSplitRead.splitFieldBunches;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -104,7 +105,7 @@ public class MultipleBlobTableTest extends TableTestBase {
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isTrue();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
         List<CommitMessage> compactMessages = new ArrayList<>();
         for (DataEvolutionCompactTask task : tasks) {
@@ -117,8 +118,7 @@ public class MultipleBlobTableTest extends TableTestBase {
                 after.stream().filter(file -> isBlobFile(file.fileName())).count();
         assertThat(afterBlobFileCount).isLessThan(beforeBlobFileCount);
         coordinator = new DataEvolutionCompactCoordinator(table, true, false);
-        assertThat(coordinator.plan().stream().anyMatch(DataEvolutionCompactTask::isBlobTask))
-                .isFalse();
+        assertThat(coordinator.plan().stream().anyMatch(task -> task.type() == BLOB)).isFalse();
 
         AtomicInteger integer = new AtomicInteger(0);
         readDefault(
@@ -147,7 +147,7 @@ public class MultipleBlobTableTest extends TableTestBase {
         DataEvolutionCompactCoordinator coordinator =
                 new DataEvolutionCompactCoordinator(table, true, false);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
-        assertThat(tasks.stream().anyMatch(DataEvolutionCompactTask::isBlobTask)).isFalse();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isFalse();
 
         List<DataFileMeta> after = currentDataFiles(getTableDefault());
         assertThat(after.stream().filter(file -> isBlobFile(file.fileName())).count())

--- a/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/MultipleBlobTableTest.java
@@ -103,7 +103,8 @@ public class MultipleBlobTableTest extends TableTestBase {
         assertThat(beforeBlobFileCount).isEqualTo(40);
 
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
 
@@ -117,7 +118,9 @@ public class MultipleBlobTableTest extends TableTestBase {
         long afterBlobFileCount =
                 after.stream().filter(file -> isBlobFile(file.fileName())).count();
         assertThat(afterBlobFileCount).isLessThan(beforeBlobFileCount);
-        coordinator = new DataEvolutionCompactCoordinator(table, true, false);
+        coordinator =
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         assertThat(coordinator.plan().stream().anyMatch(task -> task.type() == BLOB)).isFalse();
 
         AtomicInteger integer = new AtomicInteger(0);
@@ -145,7 +148,8 @@ public class MultipleBlobTableTest extends TableTestBase {
 
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isFalse();
 
@@ -372,7 +376,8 @@ public class MultipleBlobTableTest extends TableTestBase {
 
         FileStoreTable table = getTableDefault();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
 
         List<CommitMessage> compactMessages = new ArrayList<>();
@@ -502,7 +507,8 @@ public class MultipleBlobTableTest extends TableTestBase {
 
         // Run compaction
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, true, false);
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
         if (!tasks.isEmpty()) {
             List<CommitMessage> compactMessages = new ArrayList<>();

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -466,7 +466,7 @@ public class DataEvolutionCompactCoordinatorTest {
                 .thenReturn(Arrays.asList(entry1, entry2).iterator());
 
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(table, false, false, snapshot);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
 
         assertThat(tasks).hasSize(1);
@@ -546,7 +546,8 @@ public class DataEvolutionCompactCoordinatorTest {
         when(partitionPredicate.test(partitionB)).thenReturn(true);
 
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, partitionPredicate, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, partitionPredicate, false, false, snapshot);
         List<DataEvolutionCompactTask> tasks = coordinator.plan();
 
         assertThat(tasks).hasSize(1);

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionCompactCoordinatorTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.stats.StatsTestUtils;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.DeletionFile;
 import org.apache.paimon.table.source.ScanMode;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
@@ -205,7 +206,7 @@ public class DataEvolutionCompactCoordinatorTest {
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
         assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).isBlobTask()).isTrue();
+        assertThat(tasks.get(0).type()).isEqualTo(DataEvolutionCompactTask.TaskType.BLOB);
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(1).file(), entries.get(2).file());
     }
@@ -303,7 +304,7 @@ public class DataEvolutionCompactCoordinatorTest {
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
         assertThat(tasks).hasSize(2);
-        assertThat(tasks).allMatch(DataEvolutionCompactTask::isBlobTask);
+        assertThat(tasks).allMatch(task -> task.type() == DataEvolutionCompactTask.TaskType.BLOB);
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(1).file(), entries.get(2).file());
         assertThat(tasks.get(1).compactBefore())
@@ -329,7 +330,7 @@ public class DataEvolutionCompactCoordinatorTest {
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
         assertThat(tasks).hasSize(3);
-        assertThat(tasks).allMatch(DataEvolutionCompactTask::isBlobTask);
+        assertThat(tasks).allMatch(task -> task.type() == DataEvolutionCompactTask.TaskType.BLOB);
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(1).file(), entries.get(2).file());
         assertThat(tasks.get(1).compactBefore())
@@ -374,7 +375,7 @@ public class DataEvolutionCompactCoordinatorTest {
         List<DataEvolutionCompactTask> tasks = planner.compactPlan(entries);
 
         assertThat(tasks).hasSize(1);
-        assertThat(tasks.get(0).isBlobTask()).isTrue();
+        assertThat(tasks.get(0).type()).isEqualTo(DataEvolutionCompactTask.TaskType.BLOB);
         assertThat(tasks.get(0).compactBefore())
                 .containsExactly(entries.get(1).file(), entries.get(2).file());
     }
@@ -698,6 +699,9 @@ public class DataEvolutionCompactCoordinatorTest {
         return new DataEvolutionCompactCoordinator.CompactPlanner(
                 true,
                 false,
+                false,
+                null,
+                null,
                 targetFileSize,
                 targetFileSize,
                 openFileCost,
@@ -734,7 +738,7 @@ public class DataEvolutionCompactCoordinatorTest {
                         createDataFileMeta("file2.parquet", 100L, 100L, 0, 1024));
 
         DataEvolutionCompactTask task =
-                new DataEvolutionCompactTask(BinaryRow.EMPTY_ROW, files, false);
+                new DataEvolutionNormalCompactTask(BinaryRow.EMPTY_ROW, files);
 
         byte[] bytes = serializer.serialize(task);
         DataEvolutionCompactTask deserialized =
@@ -753,14 +757,14 @@ public class DataEvolutionCompactCoordinatorTest {
                         createDataFileMeta("file2.blob", 0L, 100L, 0, 1024));
 
         DataEvolutionCompactTask task =
-                new DataEvolutionCompactTask(BinaryRow.EMPTY_ROW, files, true);
+                new DataEvolutionBlobCompactTask(BinaryRow.EMPTY_ROW, files);
 
         byte[] bytes = serializer.serialize(task);
         DataEvolutionCompactTask deserialized =
                 serializer.deserialize(serializer.getVersion(), bytes);
 
         assertThat(deserialized).isEqualTo(task);
-        assertThat(deserialized.isBlobTask()).isTrue();
+        assertThat(deserialized.type()).isEqualTo(DataEvolutionCompactTask.TaskType.BLOB);
     }
 
     @Test
@@ -773,7 +777,7 @@ public class DataEvolutionCompactCoordinatorTest {
                         createDataFileMeta("file2.parquet", 100L, 100L, 0, 1024));
 
         BinaryRow partition = BinaryRow.singleColumn(42);
-        DataEvolutionCompactTask task = new DataEvolutionCompactTask(partition, files, false);
+        DataEvolutionCompactTask task = new DataEvolutionNormalCompactTask(partition, files);
 
         byte[] bytes = serializer.serialize(task);
         DataEvolutionCompactTask deserialized =
@@ -781,5 +785,31 @@ public class DataEvolutionCompactCoordinatorTest {
 
         assertThat(deserialized).isEqualTo(task);
         assertThat(deserialized.partition()).isEqualTo(partition);
+    }
+
+    @Test
+    public void testSerializerMaterializeDeletionTask() throws IOException {
+        DataEvolutionCompactTaskSerializer serializer = new DataEvolutionCompactTaskSerializer();
+
+        List<DataFileMeta> files =
+                Arrays.asList(
+                        createDataFileMeta("file1.parquet", 0L, 100L, 0, 1024),
+                        createDataFileMeta("file2.parquet", 100L, 100L, 0, 1024));
+        List<DeletionFile> deletionFiles =
+                Arrays.asList(new DeletionFile("/tmp/dv", 1, 2, 3L), null);
+
+        DataEvolutionCompactTask task =
+                new DataEvolutionMaterializeDeletionCompactTask(
+                        BinaryRow.EMPTY_ROW, files, deletionFiles);
+
+        byte[] bytes = serializer.serialize(task);
+        DataEvolutionCompactTask deserialized =
+                serializer.deserialize(serializer.getVersion(), bytes);
+
+        assertThat(deserialized).isEqualTo(task);
+        assertThat(deserialized.type())
+                .isEqualTo(DataEvolutionCompactTask.TaskType.MATERIALIZE_DELETION);
+        assertThat(((DataEvolutionMaterializeDeletionCompactTask) deserialized).deletionFiles())
+                .isEqualTo(deletionFiles);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
@@ -603,8 +604,9 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
     private void compactDataEvolutionTable(FileStoreTable table, boolean compactBlob)
             throws Exception {
+        Snapshot snapshot = table.latestSnapshot().get();
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, compactBlob, false);
+                new DataEvolutionCompactCoordinator(table, compactBlob, false, snapshot);
         List<CommitMessage> commitMessages = new ArrayList<>();
         try {
             while (true) {
@@ -617,7 +619,8 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         assertThat(commitMessages).isNotEmpty();
 
         commitMessages.addAll(
-                new DataEvolutionCompactionCommitPreparation(table).prepare(commitMessages));
+                new DataEvolutionCompactionCommitPreparation(table, snapshot)
+                        .prepare(commitMessages));
         commitDefault(commitMessages);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -25,6 +25,7 @@ import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.BinaryVector;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -77,12 +78,14 @@ import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests filename-anchored deletion vectors for data evolution tables. */
 public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
     private static final Range FULL_RANGE = new Range(0, 14);
     private static final Range FIRST_RANGE = new Range(0, 4);
+    private static final int VECTOR_DIM = 2;
     private static final List<DvSpec> DEFAULT_DV_SPECS =
             Arrays.asList(
                     new DvSpec(new Range(0, 4), 1, 4),
@@ -371,10 +374,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
-                        .key(),
-                "true");
+        dynamicOptions.put(CoreOptions.DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS.key(), "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -425,10 +425,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
         dynamicOptions.put(CoreOptions.TARGET_FILE_SIZE.key(), targetFileSize + " B");
         dynamicOptions.put(CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(), "1 B");
-        dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
-                        .key(),
-                "true");
+        dynamicOptions.put(CoreOptions.DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS.key(), "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -462,10 +459,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
-                        .key(),
-                "true");
+        dynamicOptions.put(CoreOptions.DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS.key(), "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -491,10 +485,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
-        dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
-                        .key(),
-                "true");
+        dynamicOptions.put(CoreOptions.DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS.key(), "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -508,6 +499,52 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         assertDeletionFileRanges(split);
         assertThat(split.mergedRowCount()).hasValue(10L);
         assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+    }
+
+    @Test
+    public void testMaterializeCompactionFailsFastForDedicatedVectorFiles() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.VECTOR(VECTOR_DIM, DataTypes.FLOAT()));
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "128 MB");
+        schemaBuilder.option(CoreOptions.VECTOR_TARGET_FILE_SIZE.key(), "128 MB");
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.VECTOR_FIELD.key(), "f1");
+        schemaBuilder.option(CoreOptions.VECTOR_FILE_FORMAT.key(), "json");
+        schemaBuilder.option(CoreOptions.FILE_COMPRESSION.key(), "none");
+        catalog.createTable(identifier("vector_dv_table"), schemaBuilder.build(), true);
+
+        FileStoreTable table = getTable(identifier("vector_dv_table"));
+        for (int batch = 0; batch < 2; batch++) {
+            BatchWriteBuilder builder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = builder.newWrite();
+                    BatchTableCommit commit = builder.newCommit()) {
+                for (int rowId = batch * 5; rowId < batch * 5 + 5; rowId++) {
+                    write.write(
+                            GenericRow.of(
+                                    rowId,
+                                    BinaryVector.fromPrimitiveArray(
+                                            new float[] {rowId, rowId + 0.5F})));
+                }
+                commit.commit(write.prepareCommit());
+            }
+        }
+        assertThat(
+                        table.store().newScan().plan().files().stream()
+                                .map(ManifestEntry::file)
+                                .anyMatch(file -> isVectorStoreFile(file.fileName())))
+                .isTrue();
+        commitDeletionVectors(table, Collections.singletonList(new DvSpec(FIRST_RANGE, 1)));
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(CoreOptions.DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS.key(), "true");
+        assertThatThrownBy(() -> compactDataEvolutionTable(table.copy(dynamicOptions), false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Materializing deletion vectors for vector-store files is not supported.");
     }
 
     @Test
@@ -629,7 +666,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         commitMessages.addAll(
                 new DataEvolutionCompactionCommitPreparation(table, snapshot)
                         .prepare(commitMessages));
-        commitDefault(commitMessages);
+        commit(table, commitMessages);
     }
 
     private void commitDeletionVectors(FileStoreTable table, List<DvSpec> deletionVectorSpecs)
@@ -659,7 +696,8 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
             }
         }
 
-        commitDefault(
+        commit(
+                table,
                 Collections.singletonList(
                         new CommitMessageImpl(
                                 BinaryRow.EMPTY_ROW,
@@ -672,6 +710,13 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                                         newIndexFiles,
                                         deletedIndexFiles),
                                 CompactIncrement.emptyIncrement())));
+    }
+
+    private static void commit(FileStoreTable table, List<CommitMessage> commitMessages)
+            throws Exception {
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(commitMessages);
+        }
     }
 
     private Map<Range, String> anchorFilesByRange(FileStoreTable table) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -372,7 +372,9 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
         dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
+                        .key(),
+                "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -424,7 +426,9 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         dynamicOptions.put(CoreOptions.TARGET_FILE_SIZE.key(), targetFileSize + " B");
         dynamicOptions.put(CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(), "1 B");
         dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
+                        .key(),
+                "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -459,7 +463,9 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
         dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
+                        .key(),
+                "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();
@@ -486,7 +492,9 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
         dynamicOptions.put(
-                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+                CoreOptions.DATA_EVOLUTION_COMPACTION_REASSIGN_ROW_ID_AND_MATERIALIZE_DELETIONS
+                        .key(),
+                "true");
         compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
 
         table = getTableDefault();

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -20,8 +20,8 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
-import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BlobData;
@@ -360,6 +360,148 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
     }
 
     @Test
+    public void testCompactMaterializesDeletionVectors() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(table, DEFAULT_DV_SPECS);
+        List<String> oldAnchorFiles = new ArrayList<>(anchorFilesByRange(table).values());
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(
+                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        List<String> expectedRows = expectedRows("updated", FULL_RANGE);
+        assertThat(readRows(table.newReadBuilder())).containsExactlyElementsOf(expectedRows);
+        assertThat(readProjectedStrings(table.newReadBuilder().withProjection(new int[] {2})))
+                .containsExactlyElementsOf(expectedProjectedStrings("updated", FULL_RANGE));
+        assertThat(readProjectedBlobValues(table.newReadBuilder().withProjection(new int[] {3})))
+                .containsExactlyElementsOf(expectedBlobValues(FULL_RANGE));
+
+        List<Range> materializedRanges = normalFileRowRanges(table);
+        assertThat(materializedRanges).containsExactly(new Range(15, 24));
+        // blobs should be compacted to a single range too.
+        assertBlobFileRowRanges(table, Collections.singletonList(new Range(15, 24)));
+        DataSplit materializedSplit = planDataSplit(table, materializedRanges.get(0));
+        assertDeletionFileRanges(materializedSplit);
+        assertThat(materializedSplit.mergedRowCount()).hasValue(10L);
+        assertThat(
+                        readRows(
+                                table.newReadBuilder()
+                                        .withRowRanges(
+                                                Collections.singletonList(
+                                                        materializedRanges.get(0)))))
+                .containsExactlyElementsOf(expectedRows);
+        assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+        assertThat(liveDeletionVectorDataFileNames(table))
+                .doesNotContainAnyElementsOf(oldAnchorFiles);
+    }
+
+    @Test
+    public void testMaterializeCompactionUsesRemainingSizeForLargeDeletedRange() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeRowsWithLargeFirstRange(table);
+        commitDeletionVectors(
+                table, Collections.singletonList(new DvSpec(FIRST_RANGE, 1, 2, 3, 4)));
+
+        Map<Range, List<DataFileMeta>> normalFilesByRange = normalFilesByRange(table);
+        List<DataFileMeta> firstRangeFiles = normalFilesByRange.get(FIRST_RANGE);
+        List<DataFileMeta> secondRangeFiles = normalFilesByRange.get(new Range(5, 9));
+        long firstRangeWeight = fileWeight(firstRangeFiles);
+        long estimatedFirstRangeWeight = estimatedFileWeight(firstRangeFiles, 1D / 5);
+        long targetFileSize =
+                estimatedFirstRangeWeight + Math.max(1L, fileWeight(secondRangeFiles) / 2);
+        assertThat(targetFileSize).isLessThan(firstRangeWeight);
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(CoreOptions.TARGET_FILE_SIZE.key(), targetFileSize + " B");
+        dynamicOptions.put(CoreOptions.SOURCE_SPLIT_OPEN_FILE_COST.key(), "1 B");
+        dynamicOptions.put(
+                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        // The compacted rows are assigned new row-tracking ids, while f0 keeps original values.
+        assertThat(normalFileRowRanges(table))
+                .containsExactly(new Range(10, 14), new Range(15, 20));
+        assertBlobFileRowRanges(
+                table,
+                Arrays.asList(
+                        new Range(10, 10),
+                        new Range(11, 11),
+                        new Range(12, 12),
+                        new Range(13, 13),
+                        new Range(14, 14),
+                        new Range(15, 20)));
+        assertThat(readF0Values(table.newReadBuilder()))
+                .containsExactly(0, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+        assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+    }
+
+    @Test
+    public void testMaterializeCompactionMergesSmallFilesWithInterleavedDeletionVectors()
+            throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(
+                table,
+                Arrays.asList(new DvSpec(FIRST_RANGE, 1), new DvSpec(new Range(10, 14), 12)));
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(
+                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        Range materializedRange = new Range(15, 27);
+        assertThat(normalFileRowRanges(table)).containsExactly(materializedRange);
+        assertBlobFileRowRanges(table, Collections.singletonList(materializedRange));
+        assertThat(readRows(table.newReadBuilder()))
+                .containsExactlyElementsOf(expectedRowsExcluding("updated", FULL_RANGE, 1, 12));
+        DataSplit split = planDataSplit(table, materializedRange);
+        assertDeletionFileRanges(split);
+        assertThat(split.mergedRowCount()).hasValue(13L);
+        assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+    }
+
+    @Test
+    public void testMaterializeCompactionHandlesFullyDeletedRange() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        updateStructuredColumn(table);
+        commitDeletionVectors(
+                table, Collections.singletonList(new DvSpec(FIRST_RANGE, 0, 1, 2, 3, 4)));
+
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put(CoreOptions.COMPACTION_MIN_FILE_NUM.key(), "2");
+        dynamicOptions.put(
+                CoreOptions.DATA_EVOLUTION_COMPACTION_MATERIALIZE_DELETIONS.key(), "true");
+        compactDataEvolutionTable(getTableDefault().copy(dynamicOptions), false);
+
+        table = getTableDefault();
+        Range materializedRange = new Range(15, 24);
+        assertThat(normalFileRowRanges(table)).containsExactly(materializedRange);
+        assertBlobFileRowRanges(table, Collections.singletonList(materializedRange));
+        assertThat(readRows(table.newReadBuilder()))
+                .containsExactlyElementsOf(
+                        expectedRowsExcluding("updated", FULL_RANGE, 0, 1, 2, 3, 4));
+        DataSplit split = planDataSplit(table, materializedRange);
+        assertDeletionFileRanges(split);
+        assertThat(split.mergedRowCount()).hasValue(10L);
+        assertThat(liveDeletionVectorDataFileNames(table)).isEmpty();
+    }
+
+    @Test
     public void testBlobCompactKeepsDeletionVectors() throws Exception {
         createTableDefault();
         FileStoreTable table = getTableDefault();
@@ -413,6 +555,35 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         }
     }
 
+    private void writeRowsWithLargeFirstRange(FileStoreTable table) throws Exception {
+        for (int batch = 0; batch < 3; batch++) {
+            BatchWriteBuilder builder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = builder.newWrite();
+                    BatchTableCommit commit = builder.newCommit()) {
+                for (int rowId = batch * 5; rowId < batch * 5 + 5; rowId++) {
+                    write.write(
+                            GenericRow.of(
+                                    rowId,
+                                    BinaryString.fromString(
+                                            batch == 0 ? largeString(rowId) : "name-" + rowId),
+                                    BinaryString.fromString("base-" + rowId),
+                                    new BlobData(new byte[] {(byte) rowId})));
+                }
+                commit.commit(write.prepareCommit());
+            }
+        }
+    }
+
+    private static String largeString(int rowId) {
+        StringBuilder builder = new StringBuilder(32 * 1024);
+        long value = rowId + 17L;
+        for (int i = 0; i < 32 * 1024; i++) {
+            value = value * 1103515245 + 12345;
+            builder.append((char) ('a' + ((value >>> 16) % 26)));
+        }
+        return builder.toString();
+    }
+
     private void updateStructuredColumn(FileStoreTable table) throws Exception {
         RowType writeType = table.rowType().project(Collections.singletonList("f2"));
         for (int batch = 0; batch < 3; batch++) {
@@ -446,8 +617,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         assertThat(commitMessages).isNotEmpty();
 
         commitMessages.addAll(
-                new DataEvolutionCompactDeletionVectorRewriter(table)
-                        .rewriteDeletionVectors(commitMessages));
+                new DataEvolutionCompactionCommitPreparation(table).prepare(commitMessages));
         commitDefault(commitMessages);
     }
 
@@ -705,6 +875,16 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
         return readRows(readBuilder, readBuilder.newScan().plan());
     }
 
+    private static List<Integer> readF0Values(ReadBuilder readBuilder) throws IOException {
+        List<Integer> values = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan())) {
+            reader.forEachRemaining(row -> values.add(row.getInt(0)));
+        }
+        Collections.sort(values);
+        return values;
+    }
+
     private static List<String> readProjectedStrings(ReadBuilder readBuilder) throws IOException {
         List<String> rows = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
@@ -753,17 +933,63 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
 
     private static void assertRegularFileRowRanges(
             List<DataFileMeta> dataFiles, List<Range> expected) {
-        List<Range> actual =
-                dataFiles.stream()
+        assertThat(normalFileRowRanges(dataFiles)).isEqualTo(expected);
+    }
+
+    private static List<Range> normalFileRowRanges(FileStoreTable table) {
+        return normalFileRowRanges(
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList()));
+    }
+
+    private static Map<Range, List<DataFileMeta>> normalFilesByRange(FileStoreTable table) {
+        List<DataFileMeta> normalFiles =
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
                         .filter(DataEvolutionDeletionVectorTest::isNormalFile)
-                        .map(DataFileMeta::nonNullRowIdRange)
-                        .sorted(Comparator.comparingLong(range -> range.from))
                         .collect(Collectors.toList());
-        assertThat(actual).isEqualTo(expected);
+        RangeHelper<DataFileMeta> rangeHelper = new RangeHelper<>(DataFileMeta::nonNullRowIdRange);
+        Map<Range, List<DataFileMeta>> result = new HashMap<>();
+        for (List<DataFileMeta> group : rangeHelper.mergeOverlappingRanges(normalFiles)) {
+            DataFileMeta anchor = retrieveAnchorFile(group, file -> file);
+            result.put(anchor.nonNullRowIdRange(), group);
+        }
+        return result;
+    }
+
+    private static List<Range> normalFileRowRanges(List<DataFileMeta> dataFiles) {
+        return dataFiles.stream()
+                .filter(DataEvolutionDeletionVectorTest::isNormalFile)
+                .map(DataFileMeta::nonNullRowIdRange)
+                .sorted(Comparator.comparingLong(range -> range.from))
+                .collect(Collectors.toList());
+    }
+
+    private static long fileWeight(List<DataFileMeta> files) {
+        return estimatedFileWeight(files, 1D);
+    }
+
+    private static long estimatedFileWeight(List<DataFileMeta> files, double remainingRatio) {
+        long weight = 0L;
+        for (DataFileMeta file : files) {
+            weight += Math.max((long) Math.ceil(file.fileSize() * remainingRatio), 1L);
+        }
+        return weight;
     }
 
     private static void assertFirstBlobFileRowRanges(
             FileStoreTable table, List<Range> expectedFirstRanges, int expectedCount) {
+        List<Range> actual = blobFileRowRanges(table);
+        assertThat(actual).hasSize(expectedCount);
+        assertThat(actual.subList(0, expectedFirstRanges.size())).isEqualTo(expectedFirstRanges);
+    }
+
+    private static void assertBlobFileRowRanges(FileStoreTable table, List<Range> expected) {
+        assertThat(blobFileRowRanges(table)).isEqualTo(expected);
+    }
+
+    private static List<Range> blobFileRowRanges(FileStoreTable table) {
         List<Range> actual =
                 table.store().newScan().plan().files().stream()
                         .map(ManifestEntry::file)
@@ -771,8 +997,7 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                         .map(DataFileMeta::nonNullRowIdRange)
                         .sorted(Comparator.comparingLong(range -> range.from))
                         .collect(Collectors.toList());
-        assertThat(actual).hasSize(expectedCount);
-        assertThat(actual.subList(0, expectedFirstRanges.size())).isEqualTo(expectedFirstRanges);
+        return actual;
     }
 
     private static Range splitRowRange(DataSplit split) {

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionTableTest.java
@@ -1023,7 +1023,8 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
         FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
         // Create coordinator and call plan multiple times
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
 
         // Each plan() call processes one manifest group
         List<DataEvolutionCompactTask> allTasks = new ArrayList<>();
@@ -1054,7 +1055,8 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
         FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
         // Create coordinator and call plan multiple times
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
 
         // Each plan() call processes one manifest group
         List<CommitMessage> commitMessages = new ArrayList<>();
@@ -1289,7 +1291,8 @@ public class DataEvolutionTableTest extends DataEvolutionTestBase {
 
         // Run compaction
         DataEvolutionCompactCoordinator coordinator =
-                new DataEvolutionCompactCoordinator(table, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, false, false, table.latestSnapshot().get());
         List<CommitMessage> commitMessages = new ArrayList<>();
         List<DataEvolutionCompactTask> tasks;
         try {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/DataEvolutionTableCompact.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/compact/DataEvolutionTableCompact.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.compact;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.sink.DataEvolutionTableCompactSink;
@@ -55,15 +56,20 @@ public class DataEvolutionTableCompact {
     }
 
     public void build() {
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        if (snapshot == null) {
+            return;
+        }
         DataEvolutionTableCompactSource source =
-                new DataEvolutionTableCompactSource(table, partitionPredicate);
+                new DataEvolutionTableCompactSource(table, partitionPredicate, snapshot);
         DataStreamSource<DataEvolutionCompactTask> sourceStream =
                 DataEvolutionTableCompactSource.buildSource(env, source, tableIdentifier);
 
-        sinkFromSource(sourceStream);
+        sinkFromSource(sourceStream, snapshot);
     }
 
-    private void sinkFromSource(DataStreamSource<DataEvolutionCompactTask> input) {
+    private void sinkFromSource(
+            DataStreamSource<DataEvolutionCompactTask> input, Snapshot snapshot) {
         Options conf = Options.fromMap(table.options());
         Integer compactionWorkerParallelism =
                 conf.get(FlinkConnectorOptions.UNAWARE_BUCKET_COMPACTION_PARALLELISM);
@@ -77,6 +83,6 @@ public class DataEvolutionTableCompact {
         }
 
         DataStream<DataEvolutionCompactTask> rebalanced = new DataStream<>(env, transformation);
-        DataEvolutionTableCompactSink.sink(table, rebalanced);
+        DataEvolutionTableCompactSink.sink(table, rebalanced, snapshot);
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
@@ -18,7 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
-import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -65,8 +65,7 @@ public class DataEvolutionCompactDeletionVectorOperator
             messages.add(committable.commitMessage());
         }
         for (CommitMessage message :
-                new DataEvolutionCompactDeletionVectorRewriter(table)
-                        .rewriteDeletionVectors(messages)) {
+                new DataEvolutionCompactionCommitPreparation(table).prepare(messages)) {
             toCommit.add(new Committable(toCommit.get(0).checkpointId(), message));
         }
         return toCommit;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionCompactDeletionVectorOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
@@ -37,12 +38,16 @@ public class DataEvolutionCompactDeletionVectorOperator
         extends PrepareCommitOperator<Committable, Committable> {
 
     private final FileStoreTable table;
+    private final Snapshot snapshot;
     private final List<Committable> committables;
 
     private DataEvolutionCompactDeletionVectorOperator(
-            StreamOperatorParameters<Committable> parameters, FileStoreTable table) {
+            StreamOperatorParameters<Committable> parameters,
+            FileStoreTable table,
+            Snapshot snapshot) {
         super(parameters, Options.fromMap(table.options()));
         this.table = table;
+        this.snapshot = snapshot;
         this.committables = new ArrayList<>();
     }
 
@@ -65,7 +70,7 @@ public class DataEvolutionCompactDeletionVectorOperator
             messages.add(committable.commitMessage());
         }
         for (CommitMessage message :
-                new DataEvolutionCompactionCommitPreparation(table).prepare(messages)) {
+                new DataEvolutionCompactionCommitPreparation(table, snapshot).prepare(messages)) {
             toCommit.add(new Committable(toCommit.get(0).checkpointId(), message));
         }
         return toCommit;
@@ -75,17 +80,19 @@ public class DataEvolutionCompactDeletionVectorOperator
     public static class Factory extends PrepareCommitOperator.Factory<Committable, Committable> {
 
         private final FileStoreTable table;
+        private final Snapshot snapshot;
 
-        public Factory(FileStoreTable table) {
+        public Factory(FileStoreTable table, Snapshot snapshot) {
             super(Options.fromMap(table.options()));
             this.table = table;
+            this.snapshot = snapshot;
         }
 
         @Override
         @SuppressWarnings("unchecked")
         public <T extends StreamOperator<Committable>> T createStreamOperator(
                 StreamOperatorParameters<Committable> parameters) {
-            return (T) new DataEvolutionCompactDeletionVectorOperator(parameters, table);
+            return (T) new DataEvolutionCompactDeletionVectorOperator(parameters, table, snapshot);
         }
 
         @Override

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionTableCompactSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/DataEvolutionTableCompactSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.sink;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.manifest.ManifestCommittable;
 import org.apache.paimon.table.FileStoreTable;
@@ -31,15 +32,18 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** Compaction Sink for data-evolution table. */
 public class DataEvolutionTableCompactSink extends FlinkSink<DataEvolutionCompactTask> {
 
-    public DataEvolutionTableCompactSink(FileStoreTable table) {
+    private final Snapshot snapshot;
+
+    public DataEvolutionTableCompactSink(FileStoreTable table, Snapshot snapshot) {
         super(table, true);
+        this.snapshot = snapshot;
     }
 
     public static DataStreamSink<?> sink(
-            FileStoreTable table, DataStream<DataEvolutionCompactTask> input) {
+            FileStoreTable table, DataStream<DataEvolutionCompactTask> input, Snapshot snapshot) {
         boolean isStreaming = isStreaming(input);
         checkArgument(!isStreaming, "Data evolution compaction sink only supports batch mode yet.");
-        return new DataEvolutionTableCompactSink(table).sinkFrom(input);
+        return new DataEvolutionTableCompactSink(table, snapshot).sinkFrom(input);
     }
 
     @Override
@@ -52,7 +56,8 @@ public class DataEvolutionTableCompactSink extends FlinkSink<DataEvolutionCompac
                                     "Data Evolution Compact Deletion Vector Rewriter : "
                                             + table.name(),
                                     new CommittableTypeInfo(),
-                                    new DataEvolutionCompactDeletionVectorOperator.Factory(table))
+                                    new DataEvolutionCompactDeletionVectorOperator.Factory(
+                                            table, snapshot))
                             .forceNonParallel();
         }
         return doCommit(written, initialCommitUser);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/DataEvolutionTableCompactSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.flink.sink.DataEvolutionCompactionTaskTypeInfo;
@@ -51,12 +52,14 @@ public class DataEvolutionTableCompactSource
             "DataEvolution Compaction Coordinator";
 
     private final FileStoreTable table;
-    private final PartitionPredicate partitionFilter;
+    @Nullable private final PartitionPredicate partitionFilter;
+    private final Snapshot snapshot;
 
     public DataEvolutionTableCompactSource(
-            FileStoreTable table, @Nullable PartitionPredicate partitionFilter) {
+            FileStoreTable table, @Nullable PartitionPredicate partitionFilter, Snapshot snapshot) {
         this.table = table;
         this.partitionFilter = partitionFilter;
+        this.snapshot = snapshot;
     }
 
     @Override
@@ -70,7 +73,7 @@ public class DataEvolutionTableCompactSource
         Preconditions.checkArgument(
                 readerContext.currentParallelism() == 1,
                 "Compaction Operator parallelism in paimon MUST be one.");
-        return new CompactSourceReader(table, partitionFilter);
+        return new CompactSourceReader(table, partitionFilter, snapshot);
     }
 
     /** BucketUnawareCompactSourceReader. */
@@ -78,10 +81,15 @@ public class DataEvolutionTableCompactSource
             extends AbstractNonCoordinatedSourceReader<DataEvolutionCompactTask> {
         private final DataEvolutionCompactCoordinator compactionCoordinator;
 
-        public CompactSourceReader(FileStoreTable table, PartitionPredicate partitions) {
+        public CompactSourceReader(
+                FileStoreTable table, @Nullable PartitionPredicate partitions, Snapshot snapshot) {
             compactionCoordinator =
                     new DataEvolutionCompactCoordinator(
-                            table, partitions, table.coreOptions().blobCompactionEnabled(), false);
+                            table,
+                            partitions,
+                            table.coreOptions().blobCompactionEnabled(),
+                            false,
+                            snapshot);
         }
 
         @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -20,6 +20,7 @@ package org.apache.paimon.spark.procedure;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.CoreOptions.OrderType;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.append.AppendCompactCoordinator;
 import org.apache.paimon.append.AppendCompactTask;
 import org.apache.paimon.append.cluster.IncrementalClusterManager;
@@ -498,8 +499,13 @@ public class CompactProcedure extends BaseProcedure {
             @Nullable Duration partitionIdleTime,
             JavaSparkContext javaSparkContext) {
         List<DataEvolutionCompactTask> compactionTasks;
+        Snapshot snapshot = table.snapshotManager().latestSnapshot();
+        if (snapshot == null) {
+            return;
+        }
         DataEvolutionCompactCoordinator compactCoordinator =
-                new DataEvolutionCompactCoordinator(table, partitionPredicate, false, false);
+                new DataEvolutionCompactCoordinator(
+                        table, partitionPredicate, false, false, snapshot);
         CommitMessageSerializer messageSerializerser = new CommitMessageSerializer();
         String commitUser = createCommitUser(table.coreOptions().toConfiguration());
         try {
@@ -581,7 +587,8 @@ public class CompactProcedure extends BaseProcedure {
                                         messageSerializerser.getVersion(), serializedMessage));
                     }
                     messages.addAll(
-                            new DataEvolutionCompactionCommitPreparation(table).prepare(messages));
+                            new DataEvolutionCompactionCommitPreparation(table, snapshot)
+                                    .prepare(messages));
                     commit.commit(messages);
                 } catch (Exception e) {
                     throw new RuntimeException("Deserialize commit message failed", e);

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/CompactProcedure.java
@@ -24,9 +24,9 @@ import org.apache.paimon.append.AppendCompactCoordinator;
 import org.apache.paimon.append.AppendCompactTask;
 import org.apache.paimon.append.cluster.IncrementalClusterManager;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactCoordinator;
-import org.apache.paimon.append.dataevolution.DataEvolutionCompactDeletionVectorRewriter;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTask;
 import org.apache.paimon.append.dataevolution.DataEvolutionCompactTaskSerializer;
+import org.apache.paimon.append.dataevolution.DataEvolutionCompactionCommitPreparation;
 import org.apache.paimon.compact.CompactUnit;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.disk.IOManager;
@@ -581,8 +581,7 @@ public class CompactProcedure extends BaseProcedure {
                                         messageSerializerser.getVersion(), serializedMessage));
                     }
                     messages.addAll(
-                            new DataEvolutionCompactDeletionVectorRewriter(table)
-                                    .rewriteDeletionVectors(messages));
+                            new DataEvolutionCompactionCommitPreparation(table).prepare(messages));
                     commit.commit(messages);
                 } catch (Exception e) {
                     throw new RuntimeException("Deserialize commit message failed", e);

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -605,7 +605,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |WHEN MATCHED THEN UPDATE SET t.b = s.b
             |""".stripMargin)
 
-      compactDataEvolutionTable(materializeDeletions = false)
+      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = false)
 
       checkAnswer(
         sql("SELECT id, b, c, _ROW_ID FROM t ORDER BY id"),
@@ -645,7 +645,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |WHEN MATCHED THEN UPDATE SET t.b = s.b
             |""".stripMargin)
 
-      compactDataEvolutionTable(materializeDeletions = true)
+      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = true)
 
       checkAnswer(
         sql("SELECT id, b, c FROM t ORDER BY id"),
@@ -692,7 +692,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
       assert(btreeIndexEntryCount("t") > 0)
 
       sql("DELETE FROM t WHERE id IN (2, 4)")
-      compactDataEvolutionTable(materializeDeletions = true)
+      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = true)
 
       checkAnswer(
         sql("SELECT id, name, b FROM t WHERE name IN ('name-1', 'name-2') ORDER BY id"),
@@ -701,10 +701,10 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
     }
   }
 
-  private def compactDataEvolutionTable(materializeDeletions: Boolean): Unit = {
+  private def compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions: Boolean): Unit = {
     val materializeOption =
-      if (materializeDeletions) {
-        ",data-evolution.compaction.materialize-deletions=true"
+      if (reassignRowIdAndMaterializeDeletions) {
+        ",data-evolution.compaction.reassign-row-id-and-materialize-deletions=true"
       } else {
         ""
       }

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -605,7 +605,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |WHEN MATCHED THEN UPDATE SET t.b = s.b
             |""".stripMargin)
 
-      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = false)
+      compactDataEvolutionTable(rewriteRowIds = false)
 
       checkAnswer(
         sql("SELECT id, b, c, _ROW_ID FROM t ORDER BY id"),
@@ -645,7 +645,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
             |WHEN MATCHED THEN UPDATE SET t.b = s.b
             |""".stripMargin)
 
-      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = true)
+      compactDataEvolutionTable(rewriteRowIds = true)
 
       checkAnswer(
         sql("SELECT id, b, c FROM t ORDER BY id"),
@@ -692,7 +692,7 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
       assert(btreeIndexEntryCount("t") > 0)
 
       sql("DELETE FROM t WHERE id IN (2, 4)")
-      compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions = true)
+      compactDataEvolutionTable(rewriteRowIds = true)
 
       checkAnswer(
         sql("SELECT id, name, b FROM t WHERE name IN ('name-1', 'name-2') ORDER BY id"),
@@ -701,14 +701,15 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
     }
   }
 
-  private def compactDataEvolutionTable(reassignRowIdAndMaterializeDeletions: Boolean): Unit = {
-    val materializeOption =
-      if (reassignRowIdAndMaterializeDeletions) {
-        ",data-evolution.compaction.reassign-row-id-and-materialize-deletions=true"
+  private def compactDataEvolutionTable(rewriteRowIds: Boolean): Unit = {
+    val rewriteRowIdsOption =
+      if (rewriteRowIds) {
+        ",data-evolution.compaction.rewrite-row-ids=true"
       } else {
         ""
       }
-    sql(s"CALL sys.compact(table => 't', options => 'compaction.min.file-num=2$materializeOption')")
+    sql(
+      s"CALL sys.compact(table => 't', options => 'compaction.min.file-num=2$rewriteRowIdsOption')")
   }
 
   private def btreeIndexEntryCount(tableName: String): Int = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -584,145 +584,120 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
   }
 
   test("Data Evolution deletion: non-materialized compact after delete and merge") {
-    withTable("t") {
-      withTempView("s") {
-        sql("""
-              |CREATE TABLE t (id INT, b INT, c INT)
-              |TBLPROPERTIES (
-              |  'row-tracking.enabled' = 'true',
-              |  'data-evolution.enabled' = 'true',
-              |  'deletion-vectors.enabled' = 'true')
-              |""".stripMargin)
-        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
-        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
-        sql("DELETE FROM t WHERE id IN (1, 6)")
+    withTable("t", "s") {
+      sql("""
+            |CREATE TABLE t (id INT, b INT, c INT)
+            |TBLPROPERTIES (
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true',
+            |  'deletion-vectors.enabled' = 'true')
+            |""".stripMargin)
+      sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
+      sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
+      sql("DELETE FROM t WHERE id IN (1, 6)")
 
-        sql("""
-              |CREATE OR REPLACE TEMP VIEW s AS
-              |SELECT * FROM VALUES
-              |  (1, 100),
-              |  (2, 200),
-              |  (6, 600),
-              |  (7, 700)
-              |AS s(id, b)
-              |""".stripMargin)
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.b = s.b
-              |""".stripMargin)
+      sql("CREATE TABLE s (id INT, b INT)")
+      sql("INSERT INTO s VALUES (1, 100), (2, 200), (6, 600), (7, 700)")
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.b = s.b
+            |""".stripMargin)
 
-        compactDataEvolutionTable(materializeDeletions = false)
+      compactDataEvolutionTable(materializeDeletions = false)
 
-        checkAnswer(
-          sql("SELECT id, b, c, _ROW_ID FROM t ORDER BY id"),
-          Seq(
-            Row(0, 0, 0, 0L),
-            Row(2, 200, 2, 2L),
-            Row(3, 3, 3, 3L),
-            Row(4, 4, 4, 4L),
-            Row(5, 5, 5, 5L),
-            Row(7, 700, 7, 7L),
-            Row(8, 8, 8, 8L),
-            Row(9, 9, 9, 9L)
-          )
+      checkAnswer(
+        sql("SELECT id, b, c, _ROW_ID FROM t ORDER BY id"),
+        Seq(
+          Row(0, 0, 0, 0L),
+          Row(2, 200, 2, 2L),
+          Row(3, 3, 3, 3L),
+          Row(4, 4, 4, 4L),
+          Row(5, 5, 5, 5L),
+          Row(7, 700, 7, 7L),
+          Row(8, 8, 8, 8L),
+          Row(9, 9, 9, 9L)
         )
-      }
+      )
     }
   }
 
   test("Data Evolution deletion: materialized compact after delete and merge") {
-    withTable("t") {
-      withTempView("s") {
-        sql("""
-              |CREATE TABLE t (id INT, b INT, c INT)
-              |TBLPROPERTIES (
-              |  'row-tracking.enabled' = 'true',
-              |  'data-evolution.enabled' = 'true',
-              |  'deletion-vectors.enabled' = 'true')
-              |""".stripMargin)
-        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
-        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
-        sql("DELETE FROM t WHERE id IN (1, 6)")
+    withTable("t", "s") {
+      sql("""
+            |CREATE TABLE t (id INT, b INT, c INT)
+            |TBLPROPERTIES (
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true',
+            |  'deletion-vectors.enabled' = 'true')
+            |""".stripMargin)
+      sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
+      sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
+      sql("DELETE FROM t WHERE id IN (1, 6)")
 
-        sql("""
-              |CREATE OR REPLACE TEMP VIEW s AS
-              |SELECT * FROM VALUES
-              |  (1, 100),
-              |  (2, 200),
-              |  (6, 600),
-              |  (7, 700)
-              |AS s(id, b)
-              |""".stripMargin)
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.b = s.b
-              |""".stripMargin)
+      sql("CREATE TABLE s (id INT, b INT)")
+      sql("INSERT INTO s VALUES (1, 100), (2, 200), (6, 600), (7, 700)")
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.b = s.b
+            |""".stripMargin)
 
-        compactDataEvolutionTable(materializeDeletions = true)
+      compactDataEvolutionTable(materializeDeletions = true)
 
-        checkAnswer(
-          sql("SELECT id, b, c FROM t ORDER BY id"),
-          Seq(
-            Row(0, 0, 0),
-            Row(2, 200, 2),
-            Row(3, 3, 3),
-            Row(4, 4, 4),
-            Row(5, 5, 5),
-            Row(7, 700, 7),
-            Row(8, 8, 8),
-            Row(9, 9, 9))
-        )
-      }
+      checkAnswer(
+        sql("SELECT id, b, c FROM t ORDER BY id"),
+        Seq(
+          Row(0, 0, 0),
+          Row(2, 200, 2),
+          Row(3, 3, 3),
+          Row(4, 4, 4),
+          Row(5, 5, 5),
+          Row(7, 700, 7),
+          Row(8, 8, 8),
+          Row(9, 9, 9))
+      )
     }
   }
 
   test("Data Evolution deletion: materialized compact drops global index after merge") {
-    withTable("t") {
-      withTempView("s") {
-        sql("""
-              |CREATE TABLE t (id INT, name STRING, b INT)
-              |TBLPROPERTIES (
-              |  'row-tracking.enabled' = 'true',
-              |  'data-evolution.enabled' = 'true',
-              |  'deletion-vectors.enabled' = 'true',
-              |  'global-index.search-mode' = 'full',
-              |  'btree-index.records-per-range' = '1000')
-              |""".stripMargin)
-        sql("""
-              |INSERT INTO t SELECT /*+ REPARTITION(1) */ id, concat('name-', id), id AS b
-              |FROM range(0, 5)
-              |""".stripMargin)
-        sql("""
-              |CREATE OR REPLACE TEMP VIEW s AS
-              |SELECT * FROM VALUES
-              |  (1, 100),
-              |  (3, 300)
-              |AS s(id, b)
-              |""".stripMargin)
-        sql("""
-              |MERGE INTO t
-              |USING s
-              |ON t.id = s.id
-              |WHEN MATCHED THEN UPDATE SET t.b = s.b
-              |""".stripMargin)
+    withTable("t", "s") {
+      sql("""
+            |CREATE TABLE t (id INT, name STRING, b INT)
+            |TBLPROPERTIES (
+            |  'row-tracking.enabled' = 'true',
+            |  'data-evolution.enabled' = 'true',
+            |  'deletion-vectors.enabled' = 'true',
+            |  'global-index.search-mode' = 'full',
+            |  'btree-index.records-per-range' = '1000')
+            |""".stripMargin)
+      sql("""
+            |INSERT INTO t SELECT /*+ REPARTITION(1) */ id, concat('name-', id), id AS b
+            |FROM range(0, 5)
+            |""".stripMargin)
+      sql("CREATE TABLE s (id INT, b INT)")
+      sql("INSERT INTO s VALUES (1, 100), (3, 300)")
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.b = s.b
+            |""".stripMargin)
 
-        sql(
-          "CALL sys.create_global_index(table => 'test.t', index_column => 'name', " +
-            "index_type => 'btree')")
-        assert(btreeIndexEntryCount("t") > 0)
+      sql(
+        "CALL sys.create_global_index(table => 'test.t', index_column => 'name', " +
+          "index_type => 'btree')")
+      assert(btreeIndexEntryCount("t") > 0)
 
-        sql("DELETE FROM t WHERE id IN (2, 4)")
-        compactDataEvolutionTable(materializeDeletions = true)
+      sql("DELETE FROM t WHERE id IN (2, 4)")
+      compactDataEvolutionTable(materializeDeletions = true)
 
-        checkAnswer(
-          sql("SELECT id, name, b FROM t WHERE name IN ('name-1', 'name-2') ORDER BY id"),
-          Seq(Row(1, "name-1", 100)))
-        assert(btreeIndexEntryCount("t") == 0)
-      }
+      checkAnswer(
+        sql("SELECT id, name, b FROM t WHERE name IN ('name-1', 'name-2') ORDER BY id"),
+        Seq(Row(1, "name-1", 100)))
+      assert(btreeIndexEntryCount("t") == 0)
     }
   }
 

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DataEvolutionDeletionTestBase.scala
@@ -22,6 +22,8 @@ import org.apache.paimon.spark.PaimonSparkTestBase
 
 import org.apache.spark.sql.Row
 
+import scala.collection.JavaConverters._
+
 abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
 
   test("Data Evolution deletion: delete from table with deletion vectors") {
@@ -579,5 +581,167 @@ abstract class DataEvolutionDeletionTestBase extends PaimonSparkTestBase {
         )
       )
     }
+  }
+
+  test("Data Evolution deletion: non-materialized compact after delete and merge") {
+    withTable("t") {
+      withTempView("s") {
+        sql("""
+              |CREATE TABLE t (id INT, b INT, c INT)
+              |TBLPROPERTIES (
+              |  'row-tracking.enabled' = 'true',
+              |  'data-evolution.enabled' = 'true',
+              |  'deletion-vectors.enabled' = 'true')
+              |""".stripMargin)
+        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
+        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
+        sql("DELETE FROM t WHERE id IN (1, 6)")
+
+        sql("""
+              |CREATE OR REPLACE TEMP VIEW s AS
+              |SELECT * FROM VALUES
+              |  (1, 100),
+              |  (2, 200),
+              |  (6, 600),
+              |  (7, 700)
+              |AS s(id, b)
+              |""".stripMargin)
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.b = s.b
+              |""".stripMargin)
+
+        compactDataEvolutionTable(materializeDeletions = false)
+
+        checkAnswer(
+          sql("SELECT id, b, c, _ROW_ID FROM t ORDER BY id"),
+          Seq(
+            Row(0, 0, 0, 0L),
+            Row(2, 200, 2, 2L),
+            Row(3, 3, 3, 3L),
+            Row(4, 4, 4, 4L),
+            Row(5, 5, 5, 5L),
+            Row(7, 700, 7, 7L),
+            Row(8, 8, 8, 8L),
+            Row(9, 9, 9, 9L)
+          )
+        )
+      }
+    }
+  }
+
+  test("Data Evolution deletion: materialized compact after delete and merge") {
+    withTable("t") {
+      withTempView("s") {
+        sql("""
+              |CREATE TABLE t (id INT, b INT, c INT)
+              |TBLPROPERTIES (
+              |  'row-tracking.enabled' = 'true',
+              |  'data-evolution.enabled' = 'true',
+              |  'deletion-vectors.enabled' = 'true')
+              |""".stripMargin)
+        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(0, 5)")
+        sql("INSERT INTO t SELECT /*+ REPARTITION(1) */ id, id AS b, id AS c FROM range(5, 10)")
+        sql("DELETE FROM t WHERE id IN (1, 6)")
+
+        sql("""
+              |CREATE OR REPLACE TEMP VIEW s AS
+              |SELECT * FROM VALUES
+              |  (1, 100),
+              |  (2, 200),
+              |  (6, 600),
+              |  (7, 700)
+              |AS s(id, b)
+              |""".stripMargin)
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.b = s.b
+              |""".stripMargin)
+
+        compactDataEvolutionTable(materializeDeletions = true)
+
+        checkAnswer(
+          sql("SELECT id, b, c FROM t ORDER BY id"),
+          Seq(
+            Row(0, 0, 0),
+            Row(2, 200, 2),
+            Row(3, 3, 3),
+            Row(4, 4, 4),
+            Row(5, 5, 5),
+            Row(7, 700, 7),
+            Row(8, 8, 8),
+            Row(9, 9, 9))
+        )
+      }
+    }
+  }
+
+  test("Data Evolution deletion: materialized compact drops global index after merge") {
+    withTable("t") {
+      withTempView("s") {
+        sql("""
+              |CREATE TABLE t (id INT, name STRING, b INT)
+              |TBLPROPERTIES (
+              |  'row-tracking.enabled' = 'true',
+              |  'data-evolution.enabled' = 'true',
+              |  'deletion-vectors.enabled' = 'true',
+              |  'global-index.search-mode' = 'full',
+              |  'btree-index.records-per-range' = '1000')
+              |""".stripMargin)
+        sql("""
+              |INSERT INTO t SELECT /*+ REPARTITION(1) */ id, concat('name-', id), id AS b
+              |FROM range(0, 5)
+              |""".stripMargin)
+        sql("""
+              |CREATE OR REPLACE TEMP VIEW s AS
+              |SELECT * FROM VALUES
+              |  (1, 100),
+              |  (3, 300)
+              |AS s(id, b)
+              |""".stripMargin)
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.b = s.b
+              |""".stripMargin)
+
+        sql(
+          "CALL sys.create_global_index(table => 'test.t', index_column => 'name', " +
+            "index_type => 'btree')")
+        assert(btreeIndexEntryCount("t") > 0)
+
+        sql("DELETE FROM t WHERE id IN (2, 4)")
+        compactDataEvolutionTable(materializeDeletions = true)
+
+        checkAnswer(
+          sql("SELECT id, name, b FROM t WHERE name IN ('name-1', 'name-2') ORDER BY id"),
+          Seq(Row(1, "name-1", 100)))
+        assert(btreeIndexEntryCount("t") == 0)
+      }
+    }
+  }
+
+  private def compactDataEvolutionTable(materializeDeletions: Boolean): Unit = {
+    val materializeOption =
+      if (materializeDeletions) {
+        ",data-evolution.compaction.materialize-deletions=true"
+      } else {
+        ""
+      }
+    sql(s"CALL sys.compact(table => 't', options => 'compaction.min.file-num=2$materializeOption')")
+  }
+
+  private def btreeIndexEntryCount(tableName: String): Int = {
+    loadTable(tableName)
+      .store()
+      .newIndexFileHandler()
+      .scanEntries()
+      .asScala
+      .count(_.indexFile().indexType() == "btree")
   }
 }


### PR DESCRIPTION
### Purpose
Parts of https://github.com/apache/paimon/issues/8322

This PR introduce a new option to control whether to materialize deletions of a data evolution table.
Why we don't always materialize deletions just like append tables? There are several reasons:
1. Materializing deletions will force compacting all columns including blobs at once(to keep row id alignment)
2. Materializing deletions will reassign row ids
3. Materializing deletions will force invalidating all global indices of influenced partitions

### Tests
See `DataEvolutionDeletionVectorTest` for core-module tests
See `DataEvolutionDeletionTestBase` for spark e2e tests

