### PR TITLE
[core] Fix DataEvolutionBatchScan shard chaining

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -78,7 +78,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
 
     @Override
     public DataTableScan withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
-        return batchScan.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
+        batchScan.withShard(indexOfThisSubtask, numberOfParallelSubtasks);
+        return this;
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableBatchScan;
+import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
@@ -97,6 +98,18 @@ public class DataEvolutionBatchScanTest {
         ArgumentCaptor<Predicate> captor = ArgumentCaptor.forClass(Predicate.class);
         verify(snapshotReader).withFilter(same(predicate), captor.capture());
         assertThat(captor.getValue()).isSameAs(nonRowIdPredicate);
+    }
+
+    @Test
+    public void testWithShardKeepsDataEvolutionWrapper() {
+        DataTableBatchScan batchScan = mock(DataTableBatchScan.class);
+        when(batchScan.withShard(0, 2)).thenReturn(batchScan);
+
+        DataEvolutionBatchScan scan = new DataEvolutionBatchScan(null, batchScan);
+        DataTableScan returned = scan.withShard(0, 2);
+
+        assertThat(returned).isSameAs(scan);
+        verify(batchScan).withShard(0, 2);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

`DataEvolutionBatchScan.withShard()` delegated to the inner `DataTableBatchScan` and returned that result. Chained calls such as `withShard(...).withFilter(...)` or `withShard(...).plan()` could leave the data-evolution wrapper and skip row-range/global-index handling.

This PR keeps shard delegation but returns the `DataEvolutionBatchScan` wrapper, matching the other wrapper methods. It also adds a regression test for the wrapper-preserving behavior.

### Tests

- `mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest=DataEvolutionBatchScanTest test`