### PR TITLE
[spark] Honor generic global index build options

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilder.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_BUILD_MAX_PARALLELISM;
 import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_ROW_COUNT_PER_SHARD;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
@@ -95,14 +96,7 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             List<DataField> extraFields,
             Options options)
             throws IOException {
-        Options tableOptions = table.coreOptions().toConfiguration();
-        long rowsPerShard =
-                tableOptions
-                        .getOptional(GLOBAL_INDEX_ROW_COUNT_PER_SHARD)
-                        .orElse(GLOBAL_INDEX_ROW_COUNT_PER_SHARD.defaultValue());
-        checkArgument(
-                rowsPerShard > 0,
-                "Option 'global-index.row-count-per-shard' must be greater than 0.");
+        long rowsPerShard = rowsPerShard(options);
 
         Snapshot snapshot = table.snapshotManager().latestSnapshot();
         if (snapshot == null) {
@@ -161,12 +155,29 @@ public class DefaultGlobalIndexTopoBuilder implements GlobalIndexTopologyBuilder
             return Collections.emptyList();
         }
 
+        int parallelism = parallelism(taskList.size(), options);
         List<byte[]> commitMessageBytes =
                 javaSparkContext
-                        .parallelize(taskList, taskList.size())
+                        .parallelize(taskList, parallelism)
                         .map(DefaultGlobalIndexTopoBuilder::buildIndex)
                         .collect();
         return CommitMessageSerializer.deserializeAll(commitMessageBytes);
+    }
+
+    static long rowsPerShard(Options options) {
+        long rowsPerShard = options.get(GLOBAL_INDEX_ROW_COUNT_PER_SHARD);
+        checkArgument(
+                rowsPerShard > 0,
+                "Option 'global-index.row-count-per-shard' must be greater than 0.");
+        return rowsPerShard;
+    }
+
+    static int parallelism(int taskCount, Options options) {
+        int maxParallelism = options.get(GLOBAL_INDEX_BUILD_MAX_PARALLELISM);
+        checkArgument(
+                maxParallelism > 0,
+                "Option 'global-index.build.max-parallelism' must be greater than 0.");
+        return Math.min(taskCount, maxParallelism);
     }
 
     private static byte[] buildIndex(Pair<byte[], byte[]> builderAndSplits) throws Exception {

--- a/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilderTest.java
+++ b/paimon-spark/paimon-spark-common/src/test/java/org/apache/paimon/spark/globalindex/DefaultGlobalIndexTopoBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.globalindex;
+
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_BUILD_MAX_PARALLELISM;
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_ROW_COUNT_PER_SHARD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link DefaultGlobalIndexTopoBuilder}. */
+public class DefaultGlobalIndexTopoBuilderTest {
+
+    @Test
+    void testRowsPerShardUsesMergedBuildOptions() {
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put(GLOBAL_INDEX_ROW_COUNT_PER_SHARD.key(), "1000");
+        Map<String, String> buildOptions = new HashMap<>();
+        buildOptions.put(GLOBAL_INDEX_ROW_COUNT_PER_SHARD.key(), "25");
+
+        assertThat(
+                        DefaultGlobalIndexTopoBuilder.rowsPerShard(
+                                new Options(tableOptions, buildOptions)))
+                .isEqualTo(25L);
+    }
+
+    @Test
+    void testParallelismUsesBuildMaxParallelism() {
+        Options options =
+                new Options(
+                        Collections.singletonMap(GLOBAL_INDEX_BUILD_MAX_PARALLELISM.key(), "2"));
+
+        assertThat(DefaultGlobalIndexTopoBuilder.parallelism(5, options)).isEqualTo(2);
+        assertThat(DefaultGlobalIndexTopoBuilder.parallelism(1, options)).isEqualTo(1);
+    }
+
+    @Test
+    void testRowsPerShardMustBePositive() {
+        Options options =
+                new Options(Collections.singletonMap(GLOBAL_INDEX_ROW_COUNT_PER_SHARD.key(), "0"));
+
+        assertThatThrownBy(() -> DefaultGlobalIndexTopoBuilder.rowsPerShard(options))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Option 'global-index.row-count-per-shard' must be greater than 0.");
+    }
+
+    @Test
+    void testMaxParallelismMustBePositive() {
+        Options options =
+                new Options(
+                        Collections.singletonMap(GLOBAL_INDEX_BUILD_MAX_PARALLELISM.key(), "0"));
+
+        assertThatThrownBy(() -> DefaultGlobalIndexTopoBuilder.parallelism(5, options))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Option 'global-index.build.max-parallelism' must be greater than 0.");
+    }
+}


### PR DESCRIPTION
### Purpose

Spark create global index procedure already passes merged table/procedure options into the topology builder, but the generic Spark builder still read `global-index.row-count-per-shard` from table options only and used shard task count as Spark parallelism. Procedure build options therefore could not control non-sorted global index shard size or max Spark parallelism.

This PR reads shard size and `global-index.build.max-parallelism` from the merged options and caps Spark parallelism with `min(taskCount, maxParallelism)`, aligning Spark with the documented behavior and Flink generic build semantics.

### Tests

  - `mvn -pl paimon-spark/paimon-spark-common -Pspark3 -DskipTests spotless:check`
  - `mvn -pl paimon-spark/paimon-spark-common -Pspark3 -DskipTests apache-rat:check`