### PR TITLE
[core] Improve row id reassign retry reuse

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -129,21 +129,13 @@ public class DataEvolutionRowIdReassigner {
         Optional<AssignmentPlan> optionalPlan =
                 planAssignment(manifestList.readDataManifests(latest), manifestFile, context);
         if (!optionalPlan.isPresent()) {
-            return Result.skipped(
-                    latest.id(),
-                    nextRowId,
-                    partitionFilterEnabled()
-                            ? "partition filter matches no current files"
-                            : "table has no current files");
-        }
-        AssignmentPlan assignmentPlan = optionalPlan.get();
-        if (assignmentPlan.rowIdMappings.isEmpty()) {
             LOG.info(
-                    "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
+                    "Skip reassigning row IDs for table {} because no partition requires reassignment.",
                     table.name());
             return Result.skipped(
-                    latest.id(), nextRowId, "partition row IDs are already contiguous");
+                    latest.id(), nextRowId, "no partition requires row-id reassignment");
         }
+        AssignmentPlan assignmentPlan = optionalPlan.get();
 
         for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
             Assignment assignment = assignmentPlan.createAssignment(latest);
@@ -206,7 +198,6 @@ public class DataEvolutionRowIdReassigner {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         Map<BinaryRow, List<ManifestEntry>> entriesToReassignByPartition = new LinkedHashMap<>();
         Set<String> manifestsToRewrite = new HashSet<>();
-        boolean hasCurrentFilesInScope = false;
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
             if (skipManifestGroupByPartitionFilter(manifestGroup)) {
@@ -217,7 +208,6 @@ public class DataEvolutionRowIdReassigner {
             if (currentManifest.currentEntries.isEmpty()) {
                 continue;
             }
-            hasCurrentFilesInScope = true;
 
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition =
                     entriesByPartition(currentManifest.currentEntries);
@@ -236,6 +226,10 @@ public class DataEvolutionRowIdReassigner {
             }
         }
 
+        if (entriesToReassignByPartition.isEmpty()) {
+            return Optional.empty();
+        }
+
         List<ManifestFileMeta> manifestMetasToRewrite = new ArrayList<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestsToRewrite.contains(manifestMeta.fileName())) {
@@ -243,9 +237,6 @@ public class DataEvolutionRowIdReassigner {
             }
         }
 
-        if (!hasCurrentFilesInScope) {
-            return Optional.empty();
-        }
         return Optional.of(
                 new AssignmentPlan(
                         manifestMetasToRewrite,
@@ -872,7 +863,7 @@ public class DataEvolutionRowIdReassigner {
             Map<BinaryRow, List<Range>> logicalRangesByPartition) {
         List<BinaryRow> partitions = new ArrayList<>(logicalRangesByPartition.keySet());
         RecordComparator partitionComparator = partitionComparator();
-        Collections.sort(partitions, partitionComparator::compare);
+        Collections.sort(partitions, partitionComparator);
 
         Map<BinaryRow, RowRangeMappingIndex> result = new LinkedHashMap<>();
         long nextOffset = 0L;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -126,10 +126,9 @@ public class DataEvolutionRowIdReassigner {
             return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
         }
 
-        AssignmentPlan assignment =
-                planAssignment(
-                        latest, manifestList.readDataManifests(latest), manifestFile, context);
-        if (!assignment.hasCurrentFiles) {
+        PlanAssignmentResult planResult =
+                planAssignment(manifestList.readDataManifests(latest), manifestFile, context);
+        if (!planResult.hasCurrentFiles) {
             return Result.skipped(
                     latest.id(),
                     nextRowId,
@@ -137,7 +136,8 @@ public class DataEvolutionRowIdReassigner {
                             ? "partition filter matches no current files"
                             : "table has no current files");
         }
-        if (assignment.plannedFiles.isEmpty()) {
+        AssignmentPlan assignmentPlan = planResult.assignmentPlan;
+        if (assignmentPlan.rowIdMappings.isEmpty()) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
                     table.name());
@@ -146,6 +146,7 @@ public class DataEvolutionRowIdReassigner {
         }
 
         for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
+            Assignment assignment = assignmentPlan.createAssignment(latest);
             CommitAssignmentResult commitResult =
                     commitAssignment(assignment, manifestFile, manifestList, context, commitUser);
             if (commitResult.success) {
@@ -155,13 +156,13 @@ public class DataEvolutionRowIdReassigner {
                         assignment.firstAssignedRowId,
                         assignment.nextRowId,
                         assignment.rowIdMappings.size(),
-                        assignment.plannedFiles.size(),
-                        assignment.logicalRowCount);
+                        commitResult.fileCount,
+                        assignment.logicalRowCount());
                 return new Result(
                         assignment.snapshot.id(),
                         assignment.snapshot.id() + 1,
-                        assignment.plannedFiles.size(),
-                        assignment.logicalRowCount,
+                        commitResult.fileCount,
+                        assignment.logicalRowCount(),
                         commitResult.indexFileCount,
                         assignment.firstAssignedRowId,
                         assignment.nextRowId);
@@ -174,7 +175,8 @@ public class DataEvolutionRowIdReassigner {
 
             Snapshot newLatest = table.snapshotManager().latestSnapshot();
             checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
-            advanceAssignment(assignment, newLatest, manifestFile, manifestList, context);
+            advanceAssignmentPlan(
+                    assignmentPlan, latest, newLatest, manifestFile, manifestList, context);
             LOG.info(
                     "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
                     table.name(),
@@ -197,14 +199,13 @@ public class DataEvolutionRowIdReassigner {
         return nextRowId;
     }
 
-    private AssignmentPlan planAssignment(
-            Snapshot snapshot,
+    private PlanAssignmentResult planAssignment(
             List<ManifestFileMeta> manifestMetas,
             ManifestFile manifestFile,
             ReassignContext context) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
-        Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition =
-                new LinkedHashMap<>();
+        Map<BinaryRow, List<ManifestEntry>> entriesToReassignByPartition = new LinkedHashMap<>();
+        Set<String> manifestsToRewrite = new HashSet<>();
         boolean hasCurrentFiles = false;
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
@@ -229,16 +230,24 @@ public class DataEvolutionRowIdReassigner {
                 if (partitionsToReassign.contains(entry.entry.partition())) {
                     entriesToReassignByPartition
                             .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
-                            .add(entry);
+                            .add(entry.entry);
+                    manifestsToRewrite.add(entry.manifest.fileName());
                 }
             }
         }
 
-        AssignmentPlan assignment =
+        List<ManifestFileMeta> manifestMetasToRewrite = new ArrayList<>();
+        for (ManifestFileMeta manifestMeta : manifestMetas) {
+            if (manifestsToRewrite.contains(manifestMeta.fileName())) {
+                manifestMetasToRewrite.add(manifestMeta);
+            }
+        }
+
+        AssignmentPlan assignmentPlan =
                 new AssignmentPlan(
-                        snapshot, manifestMetas, entriesToReassignByPartition, hasCurrentFiles);
-        recalculateAssignment(assignment, requireNextRowId(snapshot));
-        return assignment;
+                        manifestMetasToRewrite,
+                        createRelativeRowIdMappings(entriesToReassignByPartition));
+        return new PlanAssignmentResult(assignmentPlan, hasCurrentFiles);
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -482,19 +491,20 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private CommitAssignmentResult commitAssignment(
-            AssignmentPlan assignment,
+            Assignment assignment,
             ManifestFile manifestFile,
             ManifestList manifestList,
             ReassignContext context,
             String commitUser) {
-        Map<String, List<ManifestFileMeta>> rewrittenManifestMetas =
+        RewrittenDataManifests rewrittenDataManifests =
                 writeManifestReplacements(assignment, manifestFile);
         Pair<String, Long> baseManifestList =
                 writeBaseManifestList(
-                        assignment.manifestMetas, rewrittenManifestMetas, manifestList);
+                        manifestList.readDataManifests(assignment.snapshot),
+                        rewrittenDataManifests.manifestMetas,
+                        manifestList);
         Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
-        RewrittenIndexManifest rewrittenIndexManifest =
-                rewriteIndexManifest(assignment.snapshot, assignment, context);
+        RewrittenIndexManifest rewrittenIndexManifest = rewriteIndexManifest(assignment, context);
 
         boolean success;
         try (FileStoreCommitImpl commit =
@@ -509,23 +519,27 @@ public class DataEvolutionRowIdReassigner {
                             rewrittenIndexManifest.indexManifest,
                             assignment.nextRowId);
         }
-        return new CommitAssignmentResult(success, rewrittenIndexManifest.indexFileCount);
+        return new CommitAssignmentResult(
+                success, rewrittenDataManifests.fileCount, rewrittenIndexManifest.indexFileCount);
     }
 
-    private void advanceAssignment(
-            AssignmentPlan assignment,
+    private void advanceAssignmentPlan(
+            AssignmentPlan assignmentPlan,
+            Snapshot previous,
             Snapshot latest,
             ManifestFile manifestFile,
             ManifestList manifestList,
             ReassignContext context) {
         checkState(
-                latest.id() > assignment.snapshot.id(),
+                latest.id() > previous.id(),
                 "Cannot advance row-id assignment from snapshot %s to %s.",
-                assignment.snapshot.id(),
+                previous.id(),
                 latest.id());
 
+        Map<BinaryRow, List<ManifestEntry>> appendedEntriesByPlannedPartition =
+                new LinkedHashMap<>();
         Set<BinaryRow> touchedUnplannedPartitions = new HashSet<>();
-        for (long id = assignment.snapshot.id() + 1; id <= latest.id(); id++) {
+        for (long id = previous.id() + 1; id <= latest.id(); id++) {
             Snapshot snapshot;
             try {
                 snapshot = table.snapshotManager().tryGetSnapshot(id);
@@ -542,7 +556,7 @@ public class DataEvolutionRowIdReassigner {
                 throw new RuntimeException(
                         String.format(
                                 "Abort row-id reassignment because %s snapshot %s was committed after snapshot %s.",
-                                snapshot.commitKind(), snapshot.id(), assignment.snapshot.id()));
+                                snapshot.commitKind(), snapshot.id(), previous.id()));
             }
             if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE) {
                 continue;
@@ -560,14 +574,30 @@ public class DataEvolutionRowIdReassigner {
                             "APPEND snapshot %s contains non-ADD manifest entry %s.",
                             snapshot.id(),
                             entry);
-                    SourcedManifestEntry sourced = new SourcedManifestEntry(manifestMeta, entry);
-                    if (assignment.containsPartition(entry.partition())) {
-                        assignment.add(sourced);
+                    if (assignmentPlan.containsPartition(entry.partition())) {
+                        appendedEntriesByPlannedPartition
+                                .computeIfAbsent(entry.partition(), ignored -> new ArrayList<>())
+                                .add(entry);
                     } else {
                         touchedUnplannedPartitions.add(entry.partition());
                     }
                 }
             }
+        }
+
+        Map<BinaryRow, List<Range>> logicalRangesByPartition = new LinkedHashMap<>();
+        for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping :
+                assignmentPlan.rowIdMappings.entrySet()) {
+            logicalRangesByPartition.put(mapping.getKey(), mapping.getValue().oldRanges());
+        }
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> appended :
+                appendedEntriesByPlannedPartition.entrySet()) {
+            for (ManifestEntry entry : appended.getValue()) {
+                validatePlanningEntry(entry);
+            }
+            logicalRangesByPartition
+                    .get(appended.getKey())
+                    .addAll(logicalRanges(appended.getValue()));
         }
 
         List<ManifestFileMeta> latestManifestMetas = manifestList.readDataManifests(latest);
@@ -582,16 +612,19 @@ public class DataEvolutionRowIdReassigner {
                     entries.add(sourced.entry);
                 }
                 if (!partitionRowIdsAreContiguous(entries)) {
-                    assignment.addAll(partition.getValue());
+                    logicalRangesByPartition.put(partition.getKey(), logicalRanges(entries));
                 }
             }
         }
 
-        relocatePlannedFiles(assignment, latestManifestMetas, manifestFile, context);
+        assignmentPlan.rowIdMappings.clear();
+        assignmentPlan.rowIdMappings.putAll(
+                createRelativeRowIdMappingsFromRanges(logicalRangesByPartition));
+        assignmentPlan.manifestMetasToRewrite.clear();
+        assignmentPlan.manifestMetasToRewrite.addAll(
+                findManifestMetasToRewrite(
+                        latestManifestMetas, assignmentPlan.rowIdMappings, manifestFile, context));
         context.retainLatest(latestManifestMetas, latest.indexManifest());
-        assignment.snapshot = latest;
-        assignment.manifestMetas = latestManifestMetas;
-        recalculateAssignment(assignment, requireNextRowId(latest));
     }
 
     private Map<BinaryRow, List<SourcedManifestEntry>> currentEntriesByPartition(
@@ -645,32 +678,19 @@ public class DataEvolutionRowIdReassigner {
         return false;
     }
 
-    private void relocatePlannedFiles(
-            AssignmentPlan assignment,
-            List<ManifestFileMeta> latestManifestMetas,
+    private List<ManifestFileMeta> findManifestMetasToRewrite(
+            List<ManifestFileMeta> manifestMetas,
+            Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
             ManifestFile manifestFile,
             ReassignContext context) {
-        Set<String> previousManifestFiles = manifestFileNames(assignment.manifestMetas);
-        Set<String> latestManifestFiles = manifestFileNames(latestManifestMetas);
-        Set<FileEntry.Identifier> unresolved = new HashSet<>();
-        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
-                assignment.plannedFiles.entrySet()) {
-            ManifestFileMeta source = planned.getValue().manifest;
-            if (source == null || !latestManifestFiles.contains(source.fileName())) {
-                planned.getValue().manifest = null;
-                unresolved.add(planned.getKey());
-            }
-        }
-
-        if (unresolved.isEmpty()) {
-            return;
-        }
-
-        for (ManifestFileMeta manifestMeta : latestManifestMetas) {
-            if (unresolved.isEmpty()) {
-                break;
-            }
-            if (previousManifestFiles.contains(manifestMeta.fileName())) {
+        PartitionPredicate plannedPartitionPredicate =
+                PartitionPredicate.fromMultiple(
+                        table.schema().logicalPartitionType(), rowIdMappings.keySet());
+        checkState(plannedPartitionPredicate != null, "Planned partition predicate is null.");
+        List<ManifestFileMeta> result = new ArrayList<>();
+        for (ManifestFileMeta manifestMeta : manifestMetas) {
+            if (!manifestGroupMayContainPartitions(
+                    Collections.singletonList(manifestMeta), plannedPartitionPredicate)) {
                 continue;
             }
             for (ManifestEntry entry :
@@ -678,22 +698,12 @@ public class DataEvolutionRowIdReassigner {
                 if (entry.kind() != FileKind.ADD) {
                     continue;
                 }
-                FileEntry.Identifier identifier = entry.identifier();
-                if (unresolved.remove(identifier)) {
-                    assignment.plannedFiles.get(identifier).manifest = manifestMeta;
+                RowRangeMappingIndex mapping = rowIdMappings.get(entry.partition());
+                if (mapping != null && mapping.map(entry.file().nonNullRowIdRange()).isPresent()) {
+                    result.add(manifestMeta);
+                    break;
                 }
             }
-        }
-        checkState(
-                unresolved.isEmpty(),
-                "Cannot locate planned files %s in the latest APPEND manifests.",
-                unresolved);
-    }
-
-    private Set<String> manifestFileNames(List<ManifestFileMeta> manifestMetas) {
-        Set<String> result = new HashSet<>();
-        for (ManifestFileMeta manifestMeta : manifestMetas) {
-            result.add(manifestMeta.fileName());
         }
         return result;
     }
@@ -715,63 +725,38 @@ public class DataEvolutionRowIdReassigner {
         return manifestList.write(baseManifestMetas);
     }
 
-    private Map<String, List<ManifestFileMeta>> writeManifestReplacements(
-            AssignmentPlan assignment, ManifestFile manifestFile) {
-        Map<String, Integer> assignmentsByManifest = new HashMap<>();
-        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
-                assignment.plannedFiles.entrySet()) {
-            ManifestFileMeta manifest = planned.getValue().manifest;
-            Long reassignedFirstRowId = planned.getValue().reassignedFirstRowId;
-            checkState(
-                    manifest != null,
-                    "Cannot locate manifest for planned file %s.",
-                    planned.getKey());
-            checkState(
-                    reassignedFirstRowId != null,
-                    "Cannot find reassigned first row ID for planned file %s.",
-                    planned.getKey());
-            assignmentsByManifest.merge(manifest.fileName(), 1, Integer::sum);
-        }
-
+    private RewrittenDataManifests writeManifestReplacements(
+            Assignment assignment, ManifestFile manifestFile) {
         Map<String, List<ManifestFileMeta>> rewrittenManifestMetas = new HashMap<>();
-        for (ManifestFileMeta manifestMeta : assignment.manifestMetas) {
-            Integer expectedAssignments = assignmentsByManifest.remove(manifestMeta.fileName());
-            if (expectedAssignments == null) {
-                continue;
-            }
-
+        long fileCount = 0L;
+        for (ManifestFileMeta manifestMeta : assignment.manifestMetasToRewrite) {
             List<ManifestEntry> entries =
                     manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
-            Set<FileEntry.Identifier> rewrittenIdentifiers = new HashSet<>();
+            long manifestFileCount = 0L;
             for (int i = 0; i < entries.size(); i++) {
                 ManifestEntry entry = entries.get(i);
-                if (entry.kind() == FileKind.ADD) {
-                    SourcedManifestEntry planned = assignment.plannedFiles.get(entry.identifier());
-                    if (planned != null
-                            && planned.manifest != null
-                            && planned.manifest.fileName().equals(manifestMeta.fileName())) {
-                        checkState(
-                                rewrittenIdentifiers.add(entry.identifier()),
-                                "Duplicate planned file %s in manifest %s.",
-                                entry.identifier(),
-                                manifestMeta.fileName());
-                        entries.set(i, entry.assignFirstRowId(planned.reassignedFirstRowId));
-                    }
+                if (entry.kind() != FileKind.ADD) {
+                    continue;
+                }
+                RowRangeMappingIndex mapping = assignment.rowIdMappings.get(entry.partition());
+                if (mapping == null) {
+                    continue;
+                }
+                Optional<Range> reassignedRange = mapping.map(entry.file().nonNullRowIdRange());
+                if (reassignedRange.isPresent()) {
+                    validatePlanningEntry(entry);
+                    entries.set(i, entry.assignFirstRowId(reassignedRange.get().from));
+                    manifestFileCount++;
                 }
             }
             checkState(
-                    rewrittenIdentifiers.size() == expectedAssignments,
-                    "Expected %s planned files in manifest %s, but found %s.",
-                    expectedAssignments,
-                    manifestMeta.fileName(),
-                    rewrittenIdentifiers.size());
+                    manifestFileCount > 0,
+                    "Cannot find entries to reassign in planned manifest %s.",
+                    manifestMeta.fileName());
             rewrittenManifestMetas.put(manifestMeta.fileName(), manifestFile.write(entries));
+            fileCount += manifestFileCount;
         }
-        checkState(
-                assignmentsByManifest.isEmpty(),
-                "Cannot find planned manifests %s in the latest snapshot.",
-                assignmentsByManifest.keySet());
-        return rewrittenManifestMetas;
+        return new RewrittenDataManifests(rewrittenManifestMetas, fileCount);
     }
 
     private Map<BinaryRow, List<ManifestEntry>> entriesByPartition(
@@ -815,6 +800,9 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private boolean partitionRowIdsAreContiguous(List<ManifestEntry> entries) {
+        for (ManifestEntry entry : entries) {
+            validatePlanningEntry(entry);
+        }
         List<Range> logicalRanges = logicalRanges(entries);
         if (logicalRanges.size() <= 1) {
             return true;
@@ -848,84 +836,42 @@ public class DataEvolutionRowIdReassigner {
         return logicalRanges;
     }
 
-    private void recalculateAssignment(AssignmentPlan assignment, long firstRowId) {
-        assignment.rowIdMappings.clear();
-        for (SourcedManifestEntry plannedFile : assignment.plannedFiles.values()) {
-            plannedFile.reassignedFirstRowId = null;
+    private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappings(
+            Map<BinaryRow, List<ManifestEntry>> entriesByPartition) {
+        Map<BinaryRow, List<Range>> logicalRangesByPartition = new LinkedHashMap<>();
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> partition : entriesByPartition.entrySet()) {
+            for (ManifestEntry entry : partition.getValue()) {
+                validatePlanningEntry(entry);
+            }
+            logicalRangesByPartition.put(partition.getKey(), logicalRanges(partition.getValue()));
         }
-        List<BinaryRow> partitions =
-                new ArrayList<>(assignment.entriesToReassignByPartition.keySet());
+        return createRelativeRowIdMappingsFromRanges(logicalRangesByPartition);
+    }
+
+    private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappingsFromRanges(
+            Map<BinaryRow, List<Range>> logicalRangesByPartition) {
+        List<BinaryRow> partitions = new ArrayList<>(logicalRangesByPartition.keySet());
         RecordComparator partitionComparator = partitionComparator();
         Collections.sort(partitions, partitionComparator::compare);
 
-        long nextRowId = firstRowId;
-        long logicalRowCount = 0;
+        Map<BinaryRow, RowRangeMappingIndex> result = new LinkedHashMap<>();
+        long nextOffset = 0L;
         for (BinaryRow partition : partitions) {
-            List<SourcedManifestEntry> sourcedEntries =
-                    assignment.entriesToReassignByPartition.get(partition);
-            List<ManifestEntry> entries = new ArrayList<>(sourcedEntries.size());
-            for (SourcedManifestEntry sourcedEntry : sourcedEntries) {
-                validatePlanningEntry(sourcedEntry.entry);
-                entries.add(sourcedEntry.entry);
+            List<Range> ranges = new ArrayList<>(logicalRangesByPartition.get(partition));
+            Collections.sort(
+                    ranges,
+                    (left, right) -> {
+                        int compare = Long.compare(left.from, right.from);
+                        return compare == 0 ? Long.compare(left.to, right.to) : compare;
+                    });
+            List<RowRangeMappingIndex.Mapping> mappings = new ArrayList<>(ranges.size());
+            for (Range range : ranges) {
+                mappings.add(RowRangeMappingIndex.mapping(range.from, range.to, nextOffset));
+                nextOffset = Math.addExact(nextOffset, range.count());
             }
-
-            long partitionFirstRowId = nextRowId;
-            PartitionAssignment partitionAssignment =
-                    assignPartition(entries, assignment.plannedFiles, nextRowId);
-            assignment.rowIdMappings.put(partition, partitionAssignment.rowIdMappings);
-            nextRowId = partitionAssignment.nextRowId;
-            logicalRowCount += nextRowId - partitionFirstRowId;
+            result.put(partition, RowRangeMappingIndex.create(mappings));
         }
-
-        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
-                assignment.plannedFiles.entrySet()) {
-            checkState(
-                    planned.getValue().reassignedFirstRowId != null,
-                    "Cannot find assignment for planned file %s.",
-                    planned.getKey());
-        }
-        assignment.firstAssignedRowId = firstRowId;
-        assignment.nextRowId = nextRowId;
-        assignment.logicalRowCount = logicalRowCount;
-    }
-
-    private PartitionAssignment assignPartition(
-            List<ManifestEntry> entries,
-            Map<FileEntry.Identifier, SourcedManifestEntry> plannedFiles,
-            long firstRowId) {
-        RangeHelper<ManifestEntry> rangeHelper =
-                new RangeHelper<>(entry -> entry.file().nonNullRowIdRange());
-        List<List<ManifestEntry>> groups = rangeHelper.mergeOverlappingRanges(entries);
-
-        List<RowRangeMappingIndex.Mapping> mappings = new ArrayList<>();
-        long nextRowId = firstRowId;
-
-        for (List<ManifestEntry> group : groups) {
-            Collections.sort(group, entryComparatorWithoutPartition());
-            Range oldLogicalRange = oldLogicalRange(group);
-            mappings.add(
-                    RowRangeMappingIndex.mapping(
-                            oldLogicalRange.from, oldLogicalRange.to, nextRowId));
-
-            for (ManifestEntry entry : group) {
-                long oldFirstRowId = entry.file().nonNullFirstRowId();
-                long newFirstRowId = nextRowId + oldFirstRowId - oldLogicalRange.from;
-                SourcedManifestEntry plannedFile = plannedFiles.get(entry.identifier());
-                checkState(
-                        plannedFile != null,
-                        "Cannot find planned manifest entry for file %s.",
-                        entry.identifier());
-                checkState(
-                        plannedFile.reassignedFirstRowId == null,
-                        "Duplicate current manifest entry for file %s.",
-                        entry.identifier());
-                plannedFile.reassignedFirstRowId = newFirstRowId;
-            }
-
-            nextRowId += oldLogicalRange.count();
-        }
-
-        return new PartitionAssignment(RowRangeMappingIndex.create(mappings), nextRowId);
+        return result;
     }
 
     private Range oldLogicalRange(List<ManifestEntry> group) {
@@ -975,14 +921,15 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private RewrittenIndexManifest rewriteIndexManifest(
-            Snapshot latest, AssignmentPlan assignment, ReassignContext context) {
-        if (latest.indexManifest() == null) {
+            Assignment assignment, ReassignContext context) {
+        if (assignment.snapshot.indexManifest() == null) {
             return new RewrittenIndexManifest(null, 0);
         }
 
         IndexManifestFile indexManifestFile = table.store().indexManifestFileFactory().create();
         List<IndexManifestEntry> indexEntries =
-                readIndexManifestEntries(indexManifestFile, latest.indexManifest(), context);
+                readIndexManifestEntries(
+                        indexManifestFile, assignment.snapshot.indexManifest(), context);
         if (indexEntries.isEmpty()) {
             return new RewrittenIndexManifest(null, 0);
         }
@@ -993,7 +940,7 @@ public class DataEvolutionRowIdReassigner {
             checkState(
                     entry.kind() == FileKind.ADD,
                     "Index manifest '%s' contains non-current entry %s.",
-                    latest.indexManifest(),
+                    assignment.snapshot.indexManifest(),
                     entry);
 
             IndexFileMeta indexFile = entry.indexFile();
@@ -1231,61 +1178,97 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private static class AssignmentPlan {
-        private Snapshot snapshot;
-        private List<ManifestFileMeta> manifestMetas;
-        private final Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition;
-        private final Map<FileEntry.Identifier, SourcedManifestEntry> plannedFiles;
+        private final List<ManifestFileMeta> manifestMetasToRewrite;
         private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
-        private long firstAssignedRowId;
-        private long nextRowId;
-        private long logicalRowCount;
-        private final boolean hasCurrentFiles;
 
         private AssignmentPlan(
-                Snapshot snapshot,
-                List<ManifestFileMeta> manifestMetas,
-                Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition,
-                boolean hasCurrentFiles) {
-            this.snapshot = snapshot;
-            this.manifestMetas = manifestMetas;
-            this.entriesToReassignByPartition = new LinkedHashMap<>();
-            this.plannedFiles = new LinkedHashMap<>();
-            this.rowIdMappings = new LinkedHashMap<>();
-            this.hasCurrentFiles = hasCurrentFiles;
-            for (List<SourcedManifestEntry> entries : entriesToReassignByPartition.values()) {
-                addAll(entries);
-            }
+                List<ManifestFileMeta> manifestMetasToRewrite,
+                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings) {
+            this.manifestMetasToRewrite = new ArrayList<>(manifestMetasToRewrite);
+            this.rowIdMappings = new LinkedHashMap<>(rowIdMappings);
         }
 
         private boolean containsPartition(BinaryRow partition) {
-            return entriesToReassignByPartition.containsKey(partition);
+            return rowIdMappings.containsKey(partition);
         }
 
-        private void addAll(List<SourcedManifestEntry> entries) {
-            for (SourcedManifestEntry entry : entries) {
-                add(entry);
-            }
-        }
-
-        private void add(SourcedManifestEntry entry) {
-            FileEntry.Identifier identifier = entry.entry.identifier();
+        private Assignment createAssignment(Snapshot snapshot) {
+            Long firstAssignedRowId = snapshot.nextRowId();
             checkState(
-                    !plannedFiles.containsKey(identifier),
-                    "Duplicate planned manifest entry for file %s.",
-                    entry.entry);
-            plannedFiles.put(identifier, entry);
-            entriesToReassignByPartition
-                    .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
-                    .add(entry);
+                    firstAssignedRowId != null,
+                    "Next row id cannot be null for snapshot %s.",
+                    snapshot.id());
+            Map<BinaryRow, RowRangeMappingIndex> absoluteRowIdMappings = new LinkedHashMap<>();
+            long nextOffset = 0L;
+            for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping : rowIdMappings.entrySet()) {
+                absoluteRowIdMappings.put(
+                        mapping.getKey(), mapping.getValue().shiftNewStarts(firstAssignedRowId));
+                nextOffset = Math.max(nextOffset, mapping.getValue().maxNewEndExclusive());
+            }
+            return new Assignment(
+                    snapshot,
+                    manifestMetasToRewrite,
+                    absoluteRowIdMappings,
+                    firstAssignedRowId,
+                    Math.addExact(firstAssignedRowId, nextOffset));
+        }
+    }
+
+    private static class PlanAssignmentResult {
+        private final AssignmentPlan assignmentPlan;
+        private final boolean hasCurrentFiles;
+
+        private PlanAssignmentResult(AssignmentPlan assignmentPlan, boolean hasCurrentFiles) {
+            this.assignmentPlan = assignmentPlan;
+            this.hasCurrentFiles = hasCurrentFiles;
+        }
+    }
+
+    private static class Assignment {
+        private final Snapshot snapshot;
+        private final List<ManifestFileMeta> manifestMetasToRewrite;
+        private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
+        private final long firstAssignedRowId;
+        private final long nextRowId;
+
+        private Assignment(
+                Snapshot snapshot,
+                List<ManifestFileMeta> manifestMetasToRewrite,
+                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
+                long firstAssignedRowId,
+                long nextRowId) {
+            this.snapshot = snapshot;
+            this.manifestMetasToRewrite =
+                    Collections.unmodifiableList(new ArrayList<>(manifestMetasToRewrite));
+            this.rowIdMappings = Collections.unmodifiableMap(new LinkedHashMap<>(rowIdMappings));
+            this.firstAssignedRowId = firstAssignedRowId;
+            this.nextRowId = nextRowId;
+        }
+
+        private long logicalRowCount() {
+            return nextRowId - firstAssignedRowId;
+        }
+    }
+
+    private static class RewrittenDataManifests {
+        private final Map<String, List<ManifestFileMeta>> manifestMetas;
+        private final long fileCount;
+
+        private RewrittenDataManifests(
+                Map<String, List<ManifestFileMeta>> manifestMetas, long fileCount) {
+            this.manifestMetas = manifestMetas;
+            this.fileCount = fileCount;
         }
     }
 
     private static class CommitAssignmentResult {
         private final boolean success;
+        private final long fileCount;
         private final long indexFileCount;
 
-        private CommitAssignmentResult(boolean success, long indexFileCount) {
+        private CommitAssignmentResult(boolean success, long fileCount, long indexFileCount) {
             this.success = success;
+            this.fileCount = fileCount;
             this.indexFileCount = indexFileCount;
         }
     }
@@ -1299,9 +1282,8 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private static class SourcedManifestEntry {
-        @Nullable private ManifestFileMeta manifest;
+        private final ManifestFileMeta manifest;
         private final ManifestEntry entry;
-        @Nullable private Long reassignedFirstRowId;
 
         private SourcedManifestEntry(ManifestFileMeta manifest, ManifestEntry entry) {
             this.manifest = manifest;
@@ -1327,16 +1309,6 @@ public class DataEvolutionRowIdReassigner {
             this.maxPartition = maxPartition;
             this.containsNullPartition = containsNullPartition;
             this.originalIndex = originalIndex;
-        }
-    }
-
-    private static class PartitionAssignment {
-        private final RowRangeMappingIndex rowIdMappings;
-        private final long nextRowId;
-
-        private PartitionAssignment(RowRangeMappingIndex rowIdMappings, long nextRowId) {
-            this.rowIdMappings = rowIdMappings;
-            this.nextRowId = nextRowId;
         }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -128,7 +128,7 @@ public class DataEvolutionRowIdReassigner {
 
         PlanAssignmentResult planResult =
                 planAssignment(manifestList.readDataManifests(latest), manifestFile, context);
-        if (!planResult.hasCurrentFiles) {
+        if (!planResult.hasCurrentFilesInScope) {
             return Result.skipped(
                     latest.id(),
                     nextRowId,
@@ -206,7 +206,7 @@ public class DataEvolutionRowIdReassigner {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         Map<BinaryRow, List<ManifestEntry>> entriesToReassignByPartition = new LinkedHashMap<>();
         Set<String> manifestsToRewrite = new HashSet<>();
-        boolean hasCurrentFiles = false;
+        boolean hasCurrentFilesInScope = false;
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
             if (skipManifestGroupByPartitionFilter(manifestGroup)) {
@@ -217,7 +217,7 @@ public class DataEvolutionRowIdReassigner {
             if (currentManifest.currentEntries.isEmpty()) {
                 continue;
             }
-            hasCurrentFiles = true;
+            hasCurrentFilesInScope = true;
 
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition =
                     entriesByPartition(currentManifest.currentEntries);
@@ -247,7 +247,7 @@ public class DataEvolutionRowIdReassigner {
                 new AssignmentPlan(
                         manifestMetasToRewrite,
                         createRelativeRowIdMappings(entriesToReassignByPartition));
-        return new PlanAssignmentResult(assignmentPlan, hasCurrentFiles);
+        return new PlanAssignmentResult(assignmentPlan, hasCurrentFilesInScope);
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -1234,11 +1234,12 @@ public class DataEvolutionRowIdReassigner {
 
     private static class PlanAssignmentResult {
         private final AssignmentPlan assignmentPlan;
-        private final boolean hasCurrentFiles;
+        private final boolean hasCurrentFilesInScope;
 
-        private PlanAssignmentResult(AssignmentPlan assignmentPlan, boolean hasCurrentFiles) {
+        private PlanAssignmentResult(
+                AssignmentPlan assignmentPlan, boolean hasCurrentFilesInScope) {
             this.assignmentPlan = assignmentPlan;
-            this.hasCurrentFiles = hasCurrentFiles;
+            this.hasCurrentFilesInScope = hasCurrentFilesInScope;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -203,7 +203,8 @@ public class DataEvolutionRowIdReassigner {
             ManifestFile manifestFile,
             ReassignContext context) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
-        Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassign = new LinkedHashMap<>();
+        Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition =
+                new LinkedHashMap<>();
         boolean hasCurrentFiles = false;
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
@@ -226,7 +227,7 @@ public class DataEvolutionRowIdReassigner {
 
             for (SourcedManifestEntry entry : currentManifest.currentEntries) {
                 if (partitionsToReassign.contains(entry.entry.partition())) {
-                    entriesToReassign
+                    entriesToReassignByPartition
                             .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
                             .add(entry);
                 }
@@ -234,7 +235,8 @@ public class DataEvolutionRowIdReassigner {
         }
 
         AssignmentPlan assignment =
-                new AssignmentPlan(snapshot, manifestMetas, entriesToReassign, hasCurrentFiles);
+                new AssignmentPlan(
+                        snapshot, manifestMetas, entriesToReassignByPartition, hasCurrentFiles);
         recalculateAssignment(assignment, requireNextRowId(snapshot));
         return assignment;
     }
@@ -851,7 +853,8 @@ public class DataEvolutionRowIdReassigner {
         for (SourcedManifestEntry plannedFile : assignment.plannedFiles.values()) {
             plannedFile.reassignedFirstRowId = null;
         }
-        List<BinaryRow> partitions = new ArrayList<>(assignment.entriesByPartition.keySet());
+        List<BinaryRow> partitions =
+                new ArrayList<>(assignment.entriesToReassignByPartition.keySet());
         RecordComparator partitionComparator = partitionComparator();
         Collections.sort(partitions, partitionComparator::compare);
 
@@ -859,7 +862,7 @@ public class DataEvolutionRowIdReassigner {
         long logicalRowCount = 0;
         for (BinaryRow partition : partitions) {
             List<SourcedManifestEntry> sourcedEntries =
-                    assignment.entriesByPartition.get(partition);
+                    assignment.entriesToReassignByPartition.get(partition);
             List<ManifestEntry> entries = new ArrayList<>(sourcedEntries.size());
             for (SourcedManifestEntry sourcedEntry : sourcedEntries) {
                 validatePlanningEntry(sourcedEntry.entry);
@@ -1230,7 +1233,7 @@ public class DataEvolutionRowIdReassigner {
     private static class AssignmentPlan {
         private Snapshot snapshot;
         private List<ManifestFileMeta> manifestMetas;
-        private final Map<BinaryRow, List<SourcedManifestEntry>> entriesByPartition;
+        private final Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition;
         private final Map<FileEntry.Identifier, SourcedManifestEntry> plannedFiles;
         private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
         private long firstAssignedRowId;
@@ -1241,21 +1244,21 @@ public class DataEvolutionRowIdReassigner {
         private AssignmentPlan(
                 Snapshot snapshot,
                 List<ManifestFileMeta> manifestMetas,
-                Map<BinaryRow, List<SourcedManifestEntry>> entriesByPartition,
+                Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassignByPartition,
                 boolean hasCurrentFiles) {
             this.snapshot = snapshot;
             this.manifestMetas = manifestMetas;
-            this.entriesByPartition = new LinkedHashMap<>();
+            this.entriesToReassignByPartition = new LinkedHashMap<>();
             this.plannedFiles = new LinkedHashMap<>();
             this.rowIdMappings = new LinkedHashMap<>();
             this.hasCurrentFiles = hasCurrentFiles;
-            for (List<SourcedManifestEntry> entries : entriesByPartition.values()) {
+            for (List<SourcedManifestEntry> entries : entriesToReassignByPartition.values()) {
                 addAll(entries);
             }
         }
 
         private boolean containsPartition(BinaryRow partition) {
-            return entriesByPartition.containsKey(partition);
+            return entriesToReassignByPartition.containsKey(partition);
         }
 
         private void addAll(List<SourcedManifestEntry> entries) {
@@ -1271,7 +1274,7 @@ public class DataEvolutionRowIdReassigner {
                     "Duplicate planned manifest entry for file %s.",
                     entry.entry);
             plannedFiles.put(identifier, entry);
-            entriesByPartition
+            entriesToReassignByPartition
                     .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
                     .add(entry);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -221,12 +221,14 @@ public class DataEvolutionRowIdReassigner {
             return Optional.empty();
         }
 
-        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings =
+        Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> relativeRowIdMappings =
                 createRelativeRowIdMappings(entriesToReassignByPartition);
         return Optional.of(
                 new AssignmentPlan(
-                        findManifestMetasToRewrite(manifestMetas, rowIdMappings, manifestFile),
-                        rowIdMappings));
+                        findManifestMetasToRewrite(
+                                manifestMetas, relativeRowIdMappings.getLeft(), manifestFile),
+                        relativeRowIdMappings.getLeft(),
+                        relativeRowIdMappings.getRight()));
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -523,7 +525,9 @@ public class DataEvolutionRowIdReassigner {
                     plannedManifestFile);
         }
         return new AssignmentPlan(
-                new ArrayList<>(manifestMetasToRewrite.values()), assignmentPlan.rowIdMappings);
+                new ArrayList<>(manifestMetasToRewrite.values()),
+                assignmentPlan.rowIdMappings,
+                assignmentPlan.totalOffset);
     }
 
     private boolean appendedEntryNeedsReassign(
@@ -718,7 +722,7 @@ public class DataEvolutionRowIdReassigner {
         return logicalRanges;
     }
 
-    private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappings(
+    private Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> createRelativeRowIdMappings(
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition) {
         Map<BinaryRow, List<Range>> logicalRangesByPartition = new LinkedHashMap<>();
         for (Map.Entry<BinaryRow, List<ManifestEntry>> partition : entriesByPartition.entrySet()) {
@@ -730,7 +734,7 @@ public class DataEvolutionRowIdReassigner {
         return createRelativeRowIdMappingsFromRanges(logicalRangesByPartition);
     }
 
-    private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappingsFromRanges(
+    private Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> createRelativeRowIdMappingsFromRanges(
             Map<BinaryRow, List<Range>> logicalRangesByPartition) {
         List<BinaryRow> partitions = new ArrayList<>(logicalRangesByPartition.keySet());
         RecordComparator partitionComparator = partitionComparator();
@@ -753,7 +757,7 @@ public class DataEvolutionRowIdReassigner {
             }
             result.put(partition, RowRangeMappingIndex.create(mappings));
         }
-        return result;
+        return Pair.of(result, nextOffset);
     }
 
     private Range oldLogicalRange(List<ManifestEntry> group) {
@@ -1026,12 +1030,15 @@ public class DataEvolutionRowIdReassigner {
     private static class AssignmentPlan {
         private final List<ManifestFileMeta> manifestMetasToRewrite;
         private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
+        private final long totalOffset;
 
         private AssignmentPlan(
                 List<ManifestFileMeta> manifestMetasToRewrite,
-                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings) {
+                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
+                long totalOffset) {
             this.manifestMetasToRewrite = new ArrayList<>(manifestMetasToRewrite);
             this.rowIdMappings = new LinkedHashMap<>(rowIdMappings);
+            this.totalOffset = totalOffset;
         }
 
         private Assignment createAssignment(Snapshot snapshot) {
@@ -1041,18 +1048,16 @@ public class DataEvolutionRowIdReassigner {
                     "Next row id cannot be null for snapshot %s.",
                     snapshot.id());
             Map<BinaryRow, RowRangeMappingIndex> absoluteRowIdMappings = new LinkedHashMap<>();
-            long nextOffset = 0L;
             for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping : rowIdMappings.entrySet()) {
                 absoluteRowIdMappings.put(
                         mapping.getKey(), mapping.getValue().shiftNewStarts(firstAssignedRowId));
-                nextOffset = Math.max(nextOffset, mapping.getValue().maxNewEndExclusive());
             }
             return new Assignment(
                     snapshot,
                     manifestMetasToRewrite,
                     absoluteRowIdMappings,
                     firstAssignedRowId,
-                    Math.addExact(firstAssignedRowId, nextOffset));
+                    Math.addExact(firstAssignedRowId, totalOffset));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -136,6 +136,7 @@ public class DataEvolutionRowIdReassigner {
                     latest.id(), nextRowId, "no partition requires row-id reassignment");
         }
         AssignmentPlan assignmentPlan = optionalPlan.get();
+        context.clearPlanningManifestEntries();
 
         for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
             Assignment assignment = assignmentPlan.createAssignment(latest);
@@ -540,7 +541,8 @@ public class DataEvolutionRowIdReassigner {
                     "Cannot advance row-id assignment because planned manifest %s no longer exists after APPEND manifest merge.",
                     plannedManifestFile);
         }
-        context.retainLatest(latestManifestMetas, latest.indexManifest());
+        context.clearPlanningManifestEntries();
+        context.retainIndexManifest(latest.indexManifest());
         return new AssignmentPlan(
                 new ArrayList<>(manifestMetasToRewrite.values()), assignmentPlan.rowIdMappings);
     }
@@ -557,14 +559,11 @@ public class DataEvolutionRowIdReassigner {
             return true;
         }
 
-        for (Range plannedRange : mapping.oldRanges()) {
-            checkState(
-                    !rangesOverlap(plannedRange, appendedRange),
-                    "Cannot advance row-id assignment because appended row-id range %s partially overlaps planned range %s in partition %s.",
-                    appendedRange,
-                    plannedRange,
-                    appendedEntry.partition());
-        }
+        checkState(
+                !mapping.overlaps(appendedRange),
+                "Cannot advance row-id assignment because appended row-id range %s partially overlaps planned ranges in partition %s.",
+                appendedRange,
+                appendedEntry.partition());
         return false;
     }
 
@@ -740,10 +739,6 @@ public class DataEvolutionRowIdReassigner {
             logicalRanges.add(oldLogicalRange(group));
         }
         return logicalRanges;
-    }
-
-    private boolean rangesOverlap(Range left, Range right) {
-        return left.from <= right.to && right.from <= left.to;
     }
 
     private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappings(
@@ -1080,9 +1075,11 @@ public class DataEvolutionRowIdReassigner {
                 new HashMap<>();
         private final Map<String, List<IndexManifestEntry>> indexManifestEntries = new HashMap<>();
 
-        private void retainLatest(
-                List<ManifestFileMeta> manifestMetas, @Nullable String indexManifest) {
-            planningManifestEntries.keySet().retainAll(new HashSet<>(manifestMetas));
+        private void clearPlanningManifestEntries() {
+            planningManifestEntries.clear();
+        }
+
+        private void retainIndexManifest(@Nullable String indexManifest) {
             if (indexManifest == null) {
                 indexManifestEntries.clear();
             } else {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -114,7 +114,6 @@ public class DataEvolutionRowIdReassigner {
 
         ManifestFile manifestFile = table.store().manifestFileFactory().create();
         ManifestList manifestList = table.store().manifestListFactory().create();
-        ReassignContext context = new ReassignContext();
         Snapshot latest = table.snapshotManager().latestSnapshot();
         checkArgument(
                 latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
@@ -127,7 +126,7 @@ public class DataEvolutionRowIdReassigner {
         }
 
         Optional<AssignmentPlan> optionalPlan =
-                planAssignment(manifestList.readDataManifests(latest), manifestFile, context);
+                planAssignment(manifestList.readDataManifests(latest), manifestFile);
         if (!optionalPlan.isPresent()) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because no partition requires reassignment.",
@@ -136,12 +135,11 @@ public class DataEvolutionRowIdReassigner {
                     latest.id(), nextRowId, "no partition requires row-id reassignment");
         }
         AssignmentPlan assignmentPlan = optionalPlan.get();
-        context.clearPlanningManifestEntries();
 
         for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
             Assignment assignment = assignmentPlan.createAssignment(latest);
             CommitAssignmentResult commitResult =
-                    commitAssignment(assignment, manifestFile, manifestList, context, commitUser);
+                    commitAssignment(assignment, manifestFile, manifestList, commitUser);
             if (commitResult.success) {
                 LOG.info(
                         "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
@@ -170,7 +168,7 @@ public class DataEvolutionRowIdReassigner {
             checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
             assignmentPlan =
                     advanceAssignmentPlan(
-                            assignmentPlan, latest, newLatest, manifestFile, manifestList, context);
+                            assignmentPlan, latest, newLatest, manifestFile, manifestList);
             LOG.info(
                     "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
                     table.name(),
@@ -194,9 +192,7 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private Optional<AssignmentPlan> planAssignment(
-            List<ManifestFileMeta> manifestMetas,
-            ManifestFile manifestFile,
-            ReassignContext context) {
+            List<ManifestFileMeta> manifestMetas, ManifestFile manifestFile) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         Map<BinaryRow, List<ManifestEntry>> entriesToReassignByPartition = new LinkedHashMap<>();
 
@@ -205,8 +201,7 @@ public class DataEvolutionRowIdReassigner {
                 continue;
             }
 
-            List<ManifestEntry> currentEntries =
-                    currentEntries(manifestGroup, manifestFile, context);
+            List<ManifestEntry> currentEntries = currentEntries(manifestGroup, manifestFile);
             if (currentEntries.isEmpty()) {
                 continue;
             }
@@ -235,8 +230,7 @@ public class DataEvolutionRowIdReassigner {
                 createRelativeRowIdMappings(entriesToReassignByPartition);
         return Optional.of(
                 new AssignmentPlan(
-                        findManifestMetasToRewrite(
-                                manifestMetas, rowIdMappings, manifestFile, context),
+                        findManifestMetasToRewrite(manifestMetas, rowIdMappings, manifestFile),
                         rowIdMappings));
     }
 
@@ -382,19 +376,16 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private List<ManifestEntry> currentEntries(
-            List<ManifestFileMeta> manifestMetas,
-            ManifestFile manifestFile,
-            ReassignContext context) {
+            List<ManifestFileMeta> manifestMetas, ManifestFile manifestFile) {
         Set<FileEntry.Identifier> deletedIdentifiers =
-                deletedIdentifiers(manifestFile, manifestMetas, context);
+                deletedIdentifiers(manifestFile, manifestMetas);
 
         List<ManifestEntry> currentEntries = new ArrayList<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestMeta.numAddedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries =
-                    readPlanningManifestEntries(manifestFile, manifestMeta, context);
+            List<ManifestEntry> entries = readPlanningManifestEntries(manifestFile, manifestMeta);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.ADD
                         && partitionIncluded(entry.partition())
@@ -407,16 +398,13 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private Set<FileEntry.Identifier> deletedIdentifiers(
-            ManifestFile manifestFile,
-            List<ManifestFileMeta> manifestMetas,
-            ReassignContext context) {
+            ManifestFile manifestFile, List<ManifestFileMeta> manifestMetas) {
         Set<FileEntry.Identifier> deletedIdentifiers = new HashSet<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestMeta.numDeletedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries =
-                    readPlanningManifestEntries(manifestFile, manifestMeta, context);
+            List<ManifestEntry> entries = readPlanningManifestEntries(manifestFile, manifestMeta);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.DELETE && partitionIncluded(entry.partition())) {
                     deletedIdentifiers.add(entry.identifier());
@@ -438,7 +426,6 @@ public class DataEvolutionRowIdReassigner {
             Assignment assignment,
             ManifestFile manifestFile,
             ManifestList manifestList,
-            ReassignContext context,
             String commitUser) {
         RewrittenDataManifests rewrittenDataManifests =
                 writeManifestReplacements(assignment, manifestFile);
@@ -448,7 +435,7 @@ public class DataEvolutionRowIdReassigner {
                         rewrittenDataManifests.manifestMetas,
                         manifestList);
         Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
-        RewrittenIndexManifest rewrittenIndexManifest = rewriteIndexManifest(assignment, context);
+        RewrittenIndexManifest rewrittenIndexManifest = rewriteIndexManifest(assignment);
 
         boolean success;
         try (FileStoreCommitImpl commit =
@@ -472,8 +459,7 @@ public class DataEvolutionRowIdReassigner {
             Snapshot previous,
             Snapshot latest,
             ManifestFile manifestFile,
-            ManifestList manifestList,
-            ReassignContext context) {
+            ManifestList manifestList) {
         checkState(
                 latest.id() > previous.id(),
                 "Cannot advance row-id assignment from snapshot %s to %s.",
@@ -514,7 +500,7 @@ public class DataEvolutionRowIdReassigner {
             for (ManifestFileMeta manifestMeta : manifestList.readDeltaManifests(snapshot)) {
                 boolean needsReassign = false;
                 for (ManifestEntry entry :
-                        readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
+                        readPlanningManifestEntries(manifestFile, manifestMeta)) {
                     checkState(
                             entry.kind() == FileKind.ADD,
                             "APPEND snapshot %s contains non-ADD manifest entry %s.",
@@ -541,8 +527,6 @@ public class DataEvolutionRowIdReassigner {
                     "Cannot advance row-id assignment because planned manifest %s no longer exists after APPEND manifest merge.",
                     plannedManifestFile);
         }
-        context.clearPlanningManifestEntries();
-        context.retainIndexManifest(latest.indexManifest());
         return new AssignmentPlan(
                 new ArrayList<>(manifestMetasToRewrite.values()), assignmentPlan.rowIdMappings);
     }
@@ -590,8 +574,7 @@ public class DataEvolutionRowIdReassigner {
     private List<ManifestFileMeta> findManifestMetasToRewrite(
             List<ManifestFileMeta> manifestMetas,
             Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
-            ManifestFile manifestFile,
-            ReassignContext context) {
+            ManifestFile manifestFile) {
         PartitionPredicate plannedPartitionPredicate =
                 PartitionPredicate.fromMultiple(
                         table.schema().logicalPartitionType(), rowIdMappings.keySet());
@@ -602,8 +585,7 @@ public class DataEvolutionRowIdReassigner {
                     Collections.singletonList(manifestMeta), plannedPartitionPredicate)) {
                 continue;
             }
-            for (ManifestEntry entry :
-                    readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
+            for (ManifestEntry entry : readPlanningManifestEntries(manifestFile, manifestMeta)) {
                 RowRangeMappingIndex mapping = rowIdMappings.get(entry.partition());
                 if (mapping != null && mapping.map(entry.file().nonNullRowIdRange()).isPresent()) {
                     result.add(manifestMeta);
@@ -825,16 +807,14 @@ public class DataEvolutionRowIdReassigner {
         return new Range(min, max);
     }
 
-    private RewrittenIndexManifest rewriteIndexManifest(
-            Assignment assignment, ReassignContext context) {
+    private RewrittenIndexManifest rewriteIndexManifest(Assignment assignment) {
         if (assignment.snapshot.indexManifest() == null) {
             return new RewrittenIndexManifest(null, 0);
         }
 
         IndexManifestFile indexManifestFile = table.store().indexManifestFileFactory().create();
         List<IndexManifestEntry> indexEntries =
-                readIndexManifestEntries(
-                        indexManifestFile, assignment.snapshot.indexManifest(), context);
+                indexManifestFile.read(assignment.snapshot.indexManifest());
         if (indexEntries.isEmpty()) {
             return new RewrittenIndexManifest(null, 0);
         }
@@ -897,37 +877,15 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private List<ManifestEntry> readPlanningManifestEntries(
-            ManifestFile manifestFile, ManifestFileMeta manifestMeta, ReassignContext context) {
-        // Rewrites reread full entries so this retry cache can safely omit value stats.
-        return context.planningManifestEntries.computeIfAbsent(
-                manifestMeta,
-                ignored ->
-                        Collections.unmodifiableList(
-                                readPlanningManifestEntries(
-                                        manifestFile, manifestMeta, partitionPredicate)));
-    }
-
-    private List<ManifestEntry> readPlanningManifestEntries(
-            ManifestFile manifestFile,
-            ManifestFileMeta manifestMeta,
-            @Nullable PartitionPredicate effectivePartitionPredicate) {
+            ManifestFile manifestFile, ManifestFileMeta manifestMeta) {
         return manifestFile.read(
                 manifestMeta.fileName(),
                 manifestMeta.fileSize(),
-                effectivePartitionPredicate,
+                partitionPredicate,
                 null,
                 Filter.alwaysTrue(),
-                entry ->
-                        effectivePartitionPredicate == null
-                                || effectivePartitionPredicate.test(entry.partition()),
+                entry -> partitionPredicate == null || partitionPredicate.test(entry.partition()),
                 ManifestEntry::copyWithoutStats);
-    }
-
-    private List<IndexManifestEntry> readIndexManifestEntries(
-            IndexManifestFile indexManifestFile, String indexManifest, ReassignContext context) {
-        return context.indexManifestEntries.computeIfAbsent(
-                indexManifest,
-                ignored -> Collections.unmodifiableList(indexManifestFile.read(indexManifest)));
     }
 
     private Comparator<ManifestEntry> entryComparator() {
@@ -1067,24 +1025,6 @@ public class DataEvolutionRowIdReassigner {
         private RewrittenIndexManifest(@Nullable String indexManifest, long indexFileCount) {
             this.indexManifest = indexManifest;
             this.indexFileCount = indexFileCount;
-        }
-    }
-
-    private static class ReassignContext {
-        private final Map<ManifestFileMeta, List<ManifestEntry>> planningManifestEntries =
-                new HashMap<>();
-        private final Map<String, List<IndexManifestEntry>> indexManifestEntries = new HashMap<>();
-
-        private void clearPlanningManifestEntries() {
-            planningManifestEntries.clear();
-        }
-
-        private void retainIndexManifest(@Nullable String indexManifest) {
-            if (indexManifest == null) {
-                indexManifestEntries.clear();
-            } else {
-                indexManifestEntries.keySet().retainAll(Collections.singleton(indexManifest));
-            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -221,14 +221,13 @@ public class DataEvolutionRowIdReassigner {
             return Optional.empty();
         }
 
-        Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> relativeRowIdMappings =
+        RelativeRowIdMappings relativeRowIdMappings =
                 createRelativeRowIdMappings(entriesToReassignByPartition);
         return Optional.of(
                 new AssignmentPlan(
                         findManifestMetasToRewrite(
-                                manifestMetas, relativeRowIdMappings.getLeft(), manifestFile),
-                        relativeRowIdMappings.getLeft(),
-                        relativeRowIdMappings.getRight()));
+                                manifestMetas, relativeRowIdMappings.mappings, manifestFile),
+                        relativeRowIdMappings));
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -526,13 +525,13 @@ public class DataEvolutionRowIdReassigner {
         }
         return new AssignmentPlan(
                 new ArrayList<>(manifestMetasToRewrite.values()),
-                assignmentPlan.rowIdMappings,
-                assignmentPlan.totalOffset);
+                assignmentPlan.relativeRowIdMappings);
     }
 
     private boolean appendedEntryNeedsReassign(
             AssignmentPlan assignmentPlan, ManifestEntry appendedEntry) {
-        RowRangeMappingIndex mapping = assignmentPlan.rowIdMappings.get(appendedEntry.partition());
+        RowRangeMappingIndex mapping =
+                assignmentPlan.relativeRowIdMappings.mappings.get(appendedEntry.partition());
         if (mapping == null) {
             return false;
         }
@@ -722,7 +721,7 @@ public class DataEvolutionRowIdReassigner {
         return logicalRanges;
     }
 
-    private Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> createRelativeRowIdMappings(
+    private RelativeRowIdMappings createRelativeRowIdMappings(
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition) {
         Map<BinaryRow, List<Range>> logicalRangesByPartition = new LinkedHashMap<>();
         for (Map.Entry<BinaryRow, List<ManifestEntry>> partition : entriesByPartition.entrySet()) {
@@ -734,7 +733,7 @@ public class DataEvolutionRowIdReassigner {
         return createRelativeRowIdMappingsFromRanges(logicalRangesByPartition);
     }
 
-    private Pair<Map<BinaryRow, RowRangeMappingIndex>, Long> createRelativeRowIdMappingsFromRanges(
+    private RelativeRowIdMappings createRelativeRowIdMappingsFromRanges(
             Map<BinaryRow, List<Range>> logicalRangesByPartition) {
         List<BinaryRow> partitions = new ArrayList<>(logicalRangesByPartition.keySet());
         RecordComparator partitionComparator = partitionComparator();
@@ -757,7 +756,7 @@ public class DataEvolutionRowIdReassigner {
             }
             result.put(partition, RowRangeMappingIndex.create(mappings));
         }
-        return Pair.of(result, nextOffset);
+        return new RelativeRowIdMappings(result, nextOffset);
     }
 
     private Range oldLogicalRange(List<ManifestEntry> group) {
@@ -1027,18 +1026,26 @@ public class DataEvolutionRowIdReassigner {
         }
     }
 
+    private static class RelativeRowIdMappings {
+        private final Map<BinaryRow, RowRangeMappingIndex> mappings;
+        private final long totalOffset;
+
+        private RelativeRowIdMappings(
+                Map<BinaryRow, RowRangeMappingIndex> mappings, long totalOffset) {
+            this.mappings = Collections.unmodifiableMap(new LinkedHashMap<>(mappings));
+            this.totalOffset = totalOffset;
+        }
+    }
+
     private static class AssignmentPlan {
         private final List<ManifestFileMeta> manifestMetasToRewrite;
-        private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
-        private final long totalOffset;
+        private final RelativeRowIdMappings relativeRowIdMappings;
 
         private AssignmentPlan(
                 List<ManifestFileMeta> manifestMetasToRewrite,
-                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
-                long totalOffset) {
+                RelativeRowIdMappings relativeRowIdMappings) {
             this.manifestMetasToRewrite = new ArrayList<>(manifestMetasToRewrite);
-            this.rowIdMappings = new LinkedHashMap<>(rowIdMappings);
-            this.totalOffset = totalOffset;
+            this.relativeRowIdMappings = relativeRowIdMappings;
         }
 
         private Assignment createAssignment(Snapshot snapshot) {
@@ -1048,7 +1055,8 @@ public class DataEvolutionRowIdReassigner {
                     "Next row id cannot be null for snapshot %s.",
                     snapshot.id());
             Map<BinaryRow, RowRangeMappingIndex> absoluteRowIdMappings = new LinkedHashMap<>();
-            for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping : rowIdMappings.entrySet()) {
+            for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping :
+                    relativeRowIdMappings.mappings.entrySet()) {
                 absoluteRowIdMappings.put(
                         mapping.getKey(), mapping.getValue().shiftNewStarts(firstAssignedRowId));
             }
@@ -1057,7 +1065,7 @@ public class DataEvolutionRowIdReassigner {
                     manifestMetasToRewrite,
                     absoluteRowIdMappings,
                     firstAssignedRowId,
-                    Math.addExact(firstAssignedRowId, totalOffset));
+                    Math.addExact(firstAssignedRowId, relativeRowIdMappings.totalOffset));
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -115,7 +115,11 @@ public class DataEvolutionRowIdReassigner {
         Snapshot latest = table.snapshotManager().latestSnapshot();
         checkArgument(
                 latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
-        long nextRowId = requireNextRowId(latest);
+        Long nextRowId = latest.nextRowId();
+        checkState(
+                nextRowId != null,
+                "Next row id cannot be null for row-tracking table '%s'.",
+                table.name());
         if (table.schema().logicalPartitionType().getFieldCount() == 0) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because it is not partitioned.",
@@ -180,15 +184,6 @@ public class DataEvolutionRowIdReassigner {
         }
 
         throw new IllegalStateException("Unreachable retry state while reassigning row IDs.");
-    }
-
-    private long requireNextRowId(Snapshot snapshot) {
-        Long nextRowId = snapshot.nextRowId();
-        checkState(
-                nextRowId != null,
-                "Next row id cannot be null for row-tracking table '%s'.",
-                table.name());
-        return nextRowId;
     }
 
     private Optional<AssignmentPlan> planAssignment(

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -126,9 +126,9 @@ public class DataEvolutionRowIdReassigner {
             return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
         }
 
-        PlanAssignmentResult planResult =
+        Optional<AssignmentPlan> optionalPlan =
                 planAssignment(manifestList.readDataManifests(latest), manifestFile, context);
-        if (!planResult.hasCurrentFilesInScope) {
+        if (!optionalPlan.isPresent()) {
             return Result.skipped(
                     latest.id(),
                     nextRowId,
@@ -136,7 +136,7 @@ public class DataEvolutionRowIdReassigner {
                             ? "partition filter matches no current files"
                             : "table has no current files");
         }
-        AssignmentPlan assignmentPlan = planResult.assignmentPlan;
+        AssignmentPlan assignmentPlan = optionalPlan.get();
         if (assignmentPlan.rowIdMappings.isEmpty()) {
             LOG.info(
                     "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
@@ -199,7 +199,7 @@ public class DataEvolutionRowIdReassigner {
         return nextRowId;
     }
 
-    private PlanAssignmentResult planAssignment(
+    private Optional<AssignmentPlan> planAssignment(
             List<ManifestFileMeta> manifestMetas,
             ManifestFile manifestFile,
             ReassignContext context) {
@@ -243,11 +243,13 @@ public class DataEvolutionRowIdReassigner {
             }
         }
 
-        AssignmentPlan assignmentPlan =
+        if (!hasCurrentFilesInScope) {
+            return Optional.empty();
+        }
+        return Optional.of(
                 new AssignmentPlan(
                         manifestMetasToRewrite,
-                        createRelativeRowIdMappings(entriesToReassignByPartition));
-        return new PlanAssignmentResult(assignmentPlan, hasCurrentFilesInScope);
+                        createRelativeRowIdMappings(entriesToReassignByPartition)));
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -1229,17 +1231,6 @@ public class DataEvolutionRowIdReassigner {
                     absoluteRowIdMappings,
                     firstAssignedRowId,
                     Math.addExact(firstAssignedRowId, nextOffset));
-        }
-    }
-
-    private static class PlanAssignmentResult {
-        private final AssignmentPlan assignmentPlan;
-        private final boolean hasCurrentFilesInScope;
-
-        private PlanAssignmentResult(
-                AssignmentPlan assignmentPlan, boolean hasCurrentFilesInScope) {
-            this.assignmentPlan = assignmentPlan;
-            this.hasCurrentFilesInScope = hasCurrentFilesInScope;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -20,6 +20,7 @@ package org.apache.paimon.append.dataevolution;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
@@ -69,9 +70,11 @@ public class DataEvolutionRowIdReassigner {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionRowIdReassigner.class);
     private static final String COMMIT_USER_PREFIX = "reassign-row-id";
+    private static final int MAX_COMMIT_ATTEMPTS = 3;
 
     private final FileStoreTable table;
     private final @Nullable PartitionPredicate partitionPredicate;
+    private final Runnable beforeCommit;
 
     public DataEvolutionRowIdReassigner(FileStoreTable table) {
         this(table, null);
@@ -79,8 +82,17 @@ public class DataEvolutionRowIdReassigner {
 
     public DataEvolutionRowIdReassigner(
             FileStoreTable table, @Nullable PartitionPredicate partitionPredicate) {
+        this(table, partitionPredicate, () -> {});
+    }
+
+    @VisibleForTesting
+    DataEvolutionRowIdReassigner(
+            FileStoreTable table,
+            @Nullable PartitionPredicate partitionPredicate,
+            Runnable beforeCommit) {
         this.table = table;
         this.partitionPredicate = partitionPredicate;
+        this.beforeCommit = beforeCommit;
     }
 
     public Result reassign() {
@@ -99,84 +111,106 @@ public class DataEvolutionRowIdReassigner {
                 "Table '%s' must enable 'data-evolution.enabled=true' before reassigning row IDs.",
                 table.name());
 
-        Snapshot latest = table.snapshotManager().latestSnapshot();
-        checkArgument(
-                latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
-        Long nextRowId = latest.nextRowId();
-        checkState(
-                nextRowId != null,
-                "Next row id cannot be null for row-tracking table '%s'.",
-                table.name());
-        if (table.schema().logicalPartitionType().getFieldCount() == 0) {
-            LOG.info(
-                    "Skip reassigning row IDs for table {} because it is not partitioned.",
-                    table.name());
-            return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
-        }
-
         ManifestFile manifestFile = table.store().manifestFileFactory().create();
         ManifestList manifestList = table.store().manifestListFactory().create();
-        List<ManifestFileMeta> manifestMetas = manifestList.readDataManifests(latest);
-        AssignmentPlan assignment = planAssignment(manifestMetas, manifestFile, nextRowId);
-        if (!assignment.hasCurrentFiles) {
-            return Result.skipped(
-                    latest.id(),
-                    nextRowId,
-                    partitionFilterEnabled()
-                            ? "partition filter matches no current files"
-                            : "table has no current files");
-        }
-        if (assignment.reassignedFileCount == 0) {
-            LOG.info(
-                    "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
+        ReassignContext context = new ReassignContext();
+        for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
+            Snapshot latest = table.snapshotManager().latestSnapshot();
+            checkArgument(
+                    latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
+            Long nextRowId = latest.nextRowId();
+            checkState(
+                    nextRowId != null,
+                    "Next row id cannot be null for row-tracking table '%s'.",
                     table.name());
-            return Result.skipped(
-                    latest.id(), nextRowId, "partition row IDs are already contiguous");
-        }
-
-        Pair<String, Long> baseManifestList =
-                writeBaseManifestList(
-                        manifestMetas, assignment.rewrittenManifestMetas, manifestList);
-        Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
-
-        RewrittenIndexManifest rewrittenIndexManifest = rewriteIndexManifest(latest, assignment);
-
-        try (FileStoreCommitImpl commit =
-                (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
-            boolean success =
-                    commit.replaceManifestList(
-                            latest,
-                            latest.totalRecordCount(),
-                            baseManifestList,
-                            deltaManifestList,
-                            rewrittenIndexManifest.indexManifest,
-                            assignment.nextRowId);
-            if (!success) {
-                throw new RuntimeException(
-                        "Failed to reassign row IDs because a newer snapshot has been committed.");
+            if (table.schema().logicalPartitionType().getFieldCount() == 0) {
+                LOG.info(
+                        "Skip reassigning row IDs for table {} because it is not partitioned.",
+                        table.name());
+                return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
             }
+
+            List<ManifestFileMeta> manifestMetas = manifestList.readDataManifests(latest);
+            AssignmentPlan assignment =
+                    planAssignment(manifestMetas, manifestFile, nextRowId, context);
+            if (!assignment.hasCurrentFiles) {
+                return Result.skipped(
+                        latest.id(),
+                        nextRowId,
+                        partitionFilterEnabled()
+                                ? "partition filter matches no current files"
+                                : "table has no current files");
+            }
+            if (assignment.reassignedFileCount == 0) {
+                LOG.info(
+                        "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
+                        table.name());
+                return Result.skipped(
+                        latest.id(), nextRowId, "partition row IDs are already contiguous");
+            }
+
+            Pair<String, Long> baseManifestList =
+                    writeBaseManifestList(
+                            manifestMetas, assignment.rewrittenManifestMetas, manifestList);
+            Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
+
+            RewrittenIndexManifest rewrittenIndexManifest =
+                    rewriteIndexManifest(latest, assignment, context);
+
+            boolean success;
+            try (FileStoreCommitImpl commit =
+                    (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
+                beforeCommit.run();
+                success =
+                        commit.replaceManifestList(
+                                latest,
+                                latest.totalRecordCount(),
+                                baseManifestList,
+                                deltaManifestList,
+                                rewrittenIndexManifest.indexManifest,
+                                assignment.nextRowId);
+            }
+            if (!success) {
+                if (attempt == MAX_COMMIT_ATTEMPTS) {
+                    throw new RuntimeException(
+                            "Failed to reassign row IDs because a newer snapshot has been committed.");
+                }
+                LOG.info(
+                        "Failed to commit row-id reassignment for table {} based on snapshot {} because a newer snapshot {} has been committed. Retrying {}/{} with cached manifest reads.",
+                        table.name(),
+                        latest.id(),
+                        table.snapshotManager().latestSnapshotId(),
+                        attempt + 1,
+                        MAX_COMMIT_ATTEMPTS);
+                continue;
+            }
+
+            LOG.info(
+                    "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
+                    table.name(),
+                    nextRowId,
+                    assignment.nextRowId,
+                    assignment.rowIdMappings.size(),
+                    assignment.reassignedFileCount,
+                    assignment.logicalRowCount);
+            return new Result(
+                    latest.id(),
+                    latest.id() + 1,
+                    assignment.reassignedFileCount,
+                    assignment.logicalRowCount,
+                    rewrittenIndexManifest.indexFileCount,
+                    nextRowId,
+                    assignment.nextRowId);
         }
 
-        LOG.info(
-                "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
-                table.name(),
-                nextRowId,
-                assignment.nextRowId,
-                assignment.rowIdMappings.size(),
-                assignment.reassignedFileCount,
-                assignment.logicalRowCount);
-        return new Result(
-                latest.id(),
-                latest.id() + 1,
-                assignment.reassignedFileCount,
-                assignment.logicalRowCount,
-                rewrittenIndexManifest.indexFileCount,
-                nextRowId,
-                assignment.nextRowId);
+        throw new IllegalStateException("Unreachable retry state while reassigning row IDs.");
     }
 
     private AssignmentPlan planAssignment(
-            List<ManifestFileMeta> manifestMetas, ManifestFile manifestFile, long firstRowId) {
+            List<ManifestFileMeta> manifestMetas,
+            ManifestFile manifestFile,
+            long firstRowId,
+            ReassignContext context) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         Map<String, List<ManifestFileMeta>> rewrittenManifestMetas = new HashMap<>();
         Map<BinaryRow, RowRangeMappingIndex> rowIdMappings = new LinkedHashMap<>();
@@ -190,7 +224,7 @@ public class DataEvolutionRowIdReassigner {
                 continue;
             }
 
-            CurrentManifest currentManifest = currentManifest(manifestGroup, manifestFile);
+            CurrentManifest currentManifest = currentManifest(manifestGroup, manifestFile, context);
             List<ManifestEntry> currentEntries = currentManifest.entries();
             if (currentEntries.isEmpty()) {
                 continue;
@@ -221,7 +255,11 @@ public class DataEvolutionRowIdReassigner {
 
             Map<String, List<ManifestFileMeta>> groupRewrittenManifestMetas =
                     writeManifestReplacements(
-                            currentManifest, groupAssignment, partitionsToReassign, manifestFile);
+                            currentManifest,
+                            groupAssignment,
+                            partitionsToReassign,
+                            manifestFile,
+                            context);
             for (Map.Entry<String, List<ManifestFileMeta>> rewritten :
                     groupRewrittenManifestMetas.entrySet()) {
                 List<ManifestFileMeta> previous =
@@ -348,17 +386,18 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private CurrentManifest currentManifest(
-            List<ManifestFileMeta> manifestMetas, ManifestFile manifestFile) {
+            List<ManifestFileMeta> manifestMetas,
+            ManifestFile manifestFile,
+            ReassignContext context) {
         Set<FileEntry.Identifier> deletedIdentifiers =
-                deletedIdentifiers(manifestFile, manifestMetas);
+                deletedIdentifiers(manifestFile, manifestMetas, context);
 
         List<SourcedManifestEntry> currentEntries = new ArrayList<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestMeta.numAddedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries =
-                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
+            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.ADD
                         && partitionIncluded(entry.partition())
@@ -371,14 +410,15 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private Set<FileEntry.Identifier> deletedIdentifiers(
-            ManifestFile manifestFile, List<ManifestFileMeta> manifestMetas) {
+            ManifestFile manifestFile,
+            List<ManifestFileMeta> manifestMetas,
+            ReassignContext context) {
         Set<FileEntry.Identifier> deletedIdentifiers = new HashSet<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestMeta.numDeletedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries =
-                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
+            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.DELETE && partitionIncluded(entry.partition())) {
                     deletedIdentifiers.add(entry.identifier());
@@ -417,7 +457,8 @@ public class DataEvolutionRowIdReassigner {
             CurrentManifest currentManifest,
             Assignment assignment,
             Set<BinaryRow> partitionsToReassign,
-            ManifestFile manifestFile) {
+            ManifestFile manifestFile,
+            ReassignContext context) {
         Set<String> manifestsToRewrite =
                 manifestsToRewrite(currentManifest.currentEntries, partitionsToReassign);
         Map<FileEntry.Identifier, ManifestEntry> reassignedEntries =
@@ -430,8 +471,7 @@ public class DataEvolutionRowIdReassigner {
             }
 
             List<ManifestEntry> rewrittenEntries = new ArrayList<>();
-            List<ManifestEntry> entries =
-                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
+            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.ADD) {
                     ManifestEntry reassignedEntry = reassignedEntries.get(entry.identifier());
@@ -638,13 +678,14 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private RewrittenIndexManifest rewriteIndexManifest(
-            Snapshot latest, AssignmentPlan assignment) {
+            Snapshot latest, AssignmentPlan assignment, ReassignContext context) {
         if (latest.indexManifest() == null) {
             return new RewrittenIndexManifest(null, 0);
         }
 
         IndexManifestFile indexManifestFile = table.store().indexManifestFileFactory().create();
-        List<IndexManifestEntry> indexEntries = indexManifestFile.read(latest.indexManifest());
+        List<IndexManifestEntry> indexEntries =
+                readIndexManifestEntries(indexManifestFile, latest.indexManifest(), context);
         if (indexEntries.isEmpty()) {
             return new RewrittenIndexManifest(null, 0);
         }
@@ -700,6 +741,23 @@ public class DataEvolutionRowIdReassigner {
 
         return new RewrittenIndexManifest(
                 indexManifestFile.writeWithoutRolling(rewritten), globalIndexFileCount);
+    }
+
+    private List<ManifestEntry> readManifestEntries(
+            ManifestFile manifestFile, ManifestFileMeta manifestMeta, ReassignContext context) {
+        return context.manifestEntries.computeIfAbsent(
+                manifestMeta,
+                ignored ->
+                        Collections.unmodifiableList(
+                                manifestFile.read(
+                                        manifestMeta.fileName(), manifestMeta.fileSize())));
+    }
+
+    private List<IndexManifestEntry> readIndexManifestEntries(
+            IndexManifestFile indexManifestFile, String indexManifest, ReassignContext context) {
+        return context.indexManifestEntries.computeIfAbsent(
+                indexManifest,
+                ignored -> Collections.unmodifiableList(indexManifestFile.read(indexManifest)));
     }
 
     private Comparator<ManifestEntry> entryComparator() {
@@ -840,6 +898,11 @@ public class DataEvolutionRowIdReassigner {
             this.indexManifest = indexManifest;
             this.indexFileCount = indexFileCount;
         }
+    }
+
+    private static class ReassignContext {
+        private final Map<ManifestFileMeta, List<ManifestEntry>> manifestEntries = new HashMap<>();
+        private final Map<String, List<IndexManifestEntry>> indexManifestEntries = new HashMap<>();
     }
 
     private static class Assignment {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -863,6 +863,10 @@ public class DataEvolutionRowIdReassigner {
 
             Optional<Range> newRange = mappingIndex.map(globalIndex.rowRange());
             if (!newRange.isPresent()) {
+                if (!mappingIndex.overlaps(globalIndex.rowRange())) {
+                    rewritten.add(entry);
+                    continue;
+                }
                 LOG.warn(
                         "Drop global index file '{}' from table {} during row-id reassignment because its row range {} cannot be rewritten safely.",
                         indexFile.fileName(),

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -167,8 +167,9 @@ public class DataEvolutionRowIdReassigner {
 
             Snapshot newLatest = table.snapshotManager().latestSnapshot();
             checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
-            advanceAssignmentPlan(
-                    assignmentPlan, latest, newLatest, manifestFile, manifestList, context);
+            assignmentPlan =
+                    advanceAssignmentPlan(
+                            assignmentPlan, latest, newLatest, manifestFile, manifestList, context);
             LOG.info(
                     "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
                     table.name(),
@@ -516,7 +517,7 @@ public class DataEvolutionRowIdReassigner {
                 success, rewrittenDataManifests.fileCount, rewrittenIndexManifest.indexFileCount);
     }
 
-    private void advanceAssignmentPlan(
+    private AssignmentPlan advanceAssignmentPlan(
             AssignmentPlan assignmentPlan,
             Snapshot previous,
             Snapshot latest,
@@ -624,14 +625,13 @@ public class DataEvolutionRowIdReassigner {
             }
         }
 
-        assignmentPlan.rowIdMappings.clear();
-        assignmentPlan.rowIdMappings.putAll(
-                createRelativeRowIdMappingsFromRanges(logicalRangesByPartition));
-        assignmentPlan.manifestMetasToRewrite.clear();
-        assignmentPlan.manifestMetasToRewrite.addAll(
+        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings =
+                createRelativeRowIdMappingsFromRanges(logicalRangesByPartition);
+        List<ManifestFileMeta> manifestMetasToRewrite =
                 findManifestMetasToRewrite(
-                        latestManifestMetas, assignmentPlan.rowIdMappings, manifestFile, context));
+                        latestManifestMetas, rowIdMappings, manifestFile, context);
         context.retainLatest(latestManifestMetas, latest.indexManifest());
+        return new AssignmentPlan(manifestMetasToRewrite, rowIdMappings);
     }
 
     private Map<BinaryRow, List<SourcedManifestEntry>> currentEntriesByPartition(

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -226,7 +226,7 @@ public class DataEvolutionRowIdReassigner {
         return Optional.of(
                 new AssignmentPlan(
                         findManifestMetasToRewrite(
-                                manifestMetas, relativeRowIdMappings.mappings, manifestFile),
+                                manifestMetas, relativeRowIdMappings, manifestFile),
                         relativeRowIdMappings));
     }
 
@@ -571,11 +571,12 @@ public class DataEvolutionRowIdReassigner {
 
     private List<ManifestFileMeta> findManifestMetasToRewrite(
             List<ManifestFileMeta> manifestMetas,
-            Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
+            RelativeRowIdMappings relativeRowIdMappings,
             ManifestFile manifestFile) {
         PartitionPredicate plannedPartitionPredicate =
                 PartitionPredicate.fromMultiple(
-                        table.schema().logicalPartitionType(), rowIdMappings.keySet());
+                        table.schema().logicalPartitionType(),
+                        relativeRowIdMappings.mappings.keySet());
         checkState(plannedPartitionPredicate != null, "Planned partition predicate is null.");
         List<ManifestFileMeta> result = new ArrayList<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
@@ -584,7 +585,8 @@ public class DataEvolutionRowIdReassigner {
                 continue;
             }
             for (ManifestEntry entry : readPlanningManifestEntries(manifestFile, manifestMeta)) {
-                RowRangeMappingIndex mapping = rowIdMappings.get(entry.partition());
+                RowRangeMappingIndex mapping =
+                        relativeRowIdMappings.mappings.get(entry.partition());
                 if (mapping != null && mapping.map(entry.file().nonNullRowIdRange()).isPresent()) {
                     result.add(manifestMeta);
                     break;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -595,9 +595,23 @@ public class DataEvolutionRowIdReassigner {
             for (ManifestEntry entry : appended.getValue()) {
                 validatePlanningEntry(entry);
             }
-            logicalRangesByPartition
-                    .get(appended.getKey())
-                    .addAll(logicalRanges(appended.getValue()));
+            List<Range> plannedRanges = logicalRangesByPartition.get(appended.getKey());
+            RowRangeMappingIndex plannedMapping =
+                    assignmentPlan.rowIdMappings.get(appended.getKey());
+            for (Range appendedRange : logicalRanges(appended.getValue())) {
+                if (plannedMapping.map(appendedRange).isPresent()) {
+                    continue;
+                }
+                for (Range plannedRange : plannedRanges) {
+                    checkState(
+                            !rangesOverlap(plannedRange, appendedRange),
+                            "Cannot advance row-id assignment because appended row-id range %s partially overlaps planned range %s in partition %s.",
+                            appendedRange,
+                            plannedRange,
+                            appended.getKey());
+                }
+                plannedRanges.add(appendedRange);
+            }
         }
 
         List<ManifestFileMeta> latestManifestMetas = manifestList.readDataManifests(latest);
@@ -834,6 +848,10 @@ public class DataEvolutionRowIdReassigner {
             logicalRanges.add(oldLogicalRange(group));
         }
         return logicalRanges;
+    }
+
+    private boolean rangesOverlap(Range left, Range right) {
+        return left.from <= right.to && right.from <= left.to;
     }
 
     private Map<BinaryRow, RowRangeMappingIndex> createRelativeRowIdMappings(

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -198,31 +198,30 @@ public class DataEvolutionRowIdReassigner {
             ReassignContext context) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
         Map<BinaryRow, List<ManifestEntry>> entriesToReassignByPartition = new LinkedHashMap<>();
-        Set<String> manifestsToRewrite = new HashSet<>();
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
             if (skipManifestGroupByPartitionFilter(manifestGroup)) {
                 continue;
             }
 
-            CurrentManifest currentManifest = currentManifest(manifestGroup, manifestFile, context);
-            if (currentManifest.currentEntries.isEmpty()) {
+            List<ManifestEntry> currentEntries =
+                    currentEntries(manifestGroup, manifestFile, context);
+            if (currentEntries.isEmpty()) {
                 continue;
             }
 
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition =
-                    entriesByPartition(currentManifest.currentEntries);
+                    entriesByPartition(currentEntries);
             Set<BinaryRow> partitionsToReassign = partitionsToReassign(entriesByPartition);
             if (partitionsToReassign.isEmpty()) {
                 continue;
             }
 
-            for (SourcedManifestEntry entry : currentManifest.currentEntries) {
-                if (partitionsToReassign.contains(entry.entry.partition())) {
+            for (ManifestEntry entry : currentEntries) {
+                if (partitionsToReassign.contains(entry.partition())) {
                     entriesToReassignByPartition
-                            .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
-                            .add(entry.entry);
-                    manifestsToRewrite.add(entry.manifest.fileName());
+                            .computeIfAbsent(entry.partition(), ignored -> new ArrayList<>())
+                            .add(entry);
                 }
             }
         }
@@ -231,17 +230,13 @@ public class DataEvolutionRowIdReassigner {
             return Optional.empty();
         }
 
-        List<ManifestFileMeta> manifestMetasToRewrite = new ArrayList<>();
-        for (ManifestFileMeta manifestMeta : manifestMetas) {
-            if (manifestsToRewrite.contains(manifestMeta.fileName())) {
-                manifestMetasToRewrite.add(manifestMeta);
-            }
-        }
-
+        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings =
+                createRelativeRowIdMappings(entriesToReassignByPartition);
         return Optional.of(
                 new AssignmentPlan(
-                        manifestMetasToRewrite,
-                        createRelativeRowIdMappings(entriesToReassignByPartition)));
+                        findManifestMetasToRewrite(
+                                manifestMetas, rowIdMappings, manifestFile, context),
+                        rowIdMappings));
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -385,14 +380,14 @@ public class DataEvolutionRowIdReassigner {
         return false;
     }
 
-    private CurrentManifest currentManifest(
+    private List<ManifestEntry> currentEntries(
             List<ManifestFileMeta> manifestMetas,
             ManifestFile manifestFile,
             ReassignContext context) {
         Set<FileEntry.Identifier> deletedIdentifiers =
                 deletedIdentifiers(manifestFile, manifestMetas, context);
 
-        List<SourcedManifestEntry> currentEntries = new ArrayList<>();
+        List<ManifestEntry> currentEntries = new ArrayList<>();
         for (ManifestFileMeta manifestMeta : manifestMetas) {
             if (manifestMeta.numAddedFiles() <= 0) {
                 continue;
@@ -403,57 +398,11 @@ public class DataEvolutionRowIdReassigner {
                 if (entry.kind() == FileKind.ADD
                         && partitionIncluded(entry.partition())
                         && !deletedIdentifiers.contains(entry.identifier())) {
-                    currentEntries.add(new SourcedManifestEntry(manifestMeta, entry));
+                    currentEntries.add(entry);
                 }
             }
         }
-        return new CurrentManifest(currentEntries);
-    }
-
-    private CurrentManifest currentManifest(
-            List<ManifestFileMeta> manifestMetas,
-            ManifestFile manifestFile,
-            PartitionPredicate effectivePartitionPredicate) {
-        Map<ManifestFileMeta, List<ManifestEntry>> entriesByManifest = new HashMap<>();
-        Set<FileEntry.Identifier> deletedIdentifiers = new HashSet<>();
-        for (ManifestFileMeta manifestMeta : manifestMetas) {
-            if (manifestMeta.numDeletedFiles() <= 0) {
-                continue;
-            }
-            for (ManifestEntry entry :
-                    entriesByManifest.computeIfAbsent(
-                            manifestMeta,
-                            ignored ->
-                                    readPlanningManifestEntries(
-                                            manifestFile,
-                                            manifestMeta,
-                                            effectivePartitionPredicate))) {
-                if (entry.kind() == FileKind.DELETE) {
-                    deletedIdentifiers.add(entry.identifier());
-                }
-            }
-        }
-
-        List<SourcedManifestEntry> currentEntries = new ArrayList<>();
-        for (ManifestFileMeta manifestMeta : manifestMetas) {
-            if (manifestMeta.numAddedFiles() <= 0) {
-                continue;
-            }
-            for (ManifestEntry entry :
-                    entriesByManifest.computeIfAbsent(
-                            manifestMeta,
-                            ignored ->
-                                    readPlanningManifestEntries(
-                                            manifestFile,
-                                            manifestMeta,
-                                            effectivePartitionPredicate))) {
-                if (entry.kind() == FileKind.ADD
-                        && !deletedIdentifiers.contains(entry.identifier())) {
-                    currentEntries.add(new SourcedManifestEntry(manifestMeta, entry));
-                }
-            }
-        }
-        return new CurrentManifest(currentEntries);
+        return currentEntries;
     }
 
     private Set<FileEntry.Identifier> deletedIdentifiers(
@@ -530,9 +479,10 @@ public class DataEvolutionRowIdReassigner {
                 previous.id(),
                 latest.id());
 
-        Map<BinaryRow, List<ManifestEntry>> appendedEntriesByPlannedPartition =
-                new LinkedHashMap<>();
-        Set<BinaryRow> touchedUnplannedPartitions = new HashSet<>();
+        Map<String, ManifestFileMeta> manifestMetasToRewrite = new LinkedHashMap<>();
+        for (ManifestFileMeta manifestMeta : assignmentPlan.manifestMetasToRewrite) {
+            manifestMetasToRewrite.put(manifestMeta.fileName(), manifestMeta);
+        }
         for (long id = previous.id() + 1; id <= latest.id(); id++) {
             Snapshot snapshot;
             try {
@@ -561,6 +511,7 @@ public class DataEvolutionRowIdReassigner {
                     snapshot.commitKind());
 
             for (ManifestFileMeta manifestMeta : manifestList.readDeltaManifests(snapshot)) {
+                boolean needsReassign = false;
                 for (ManifestEntry entry :
                         readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
                     checkState(
@@ -568,101 +519,53 @@ public class DataEvolutionRowIdReassigner {
                             "APPEND snapshot %s contains non-ADD manifest entry %s.",
                             snapshot.id(),
                             entry);
-                    if (assignmentPlan.containsPartition(entry.partition())) {
-                        appendedEntriesByPlannedPartition
-                                .computeIfAbsent(entry.partition(), ignored -> new ArrayList<>())
-                                .add(entry);
-                    } else {
-                        touchedUnplannedPartitions.add(entry.partition());
+                    if (appendedEntryNeedsReassign(assignmentPlan, entry)) {
+                        needsReassign = true;
                     }
                 }
-            }
-        }
-
-        Map<BinaryRow, List<Range>> logicalRangesByPartition = new LinkedHashMap<>();
-        for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping :
-                assignmentPlan.rowIdMappings.entrySet()) {
-            logicalRangesByPartition.put(mapping.getKey(), mapping.getValue().oldRanges());
-        }
-        for (Map.Entry<BinaryRow, List<ManifestEntry>> appended :
-                appendedEntriesByPlannedPartition.entrySet()) {
-            for (ManifestEntry entry : appended.getValue()) {
-                validatePlanningEntry(entry);
-            }
-            List<Range> plannedRanges = logicalRangesByPartition.get(appended.getKey());
-            RowRangeMappingIndex plannedMapping =
-                    assignmentPlan.rowIdMappings.get(appended.getKey());
-            for (Range appendedRange : logicalRanges(appended.getValue())) {
-                if (plannedMapping.map(appendedRange).isPresent()) {
-                    continue;
+                if (needsReassign) {
+                    manifestMetasToRewrite.put(manifestMeta.fileName(), manifestMeta);
                 }
-                for (Range plannedRange : plannedRanges) {
-                    checkState(
-                            !rangesOverlap(plannedRange, appendedRange),
-                            "Cannot advance row-id assignment because appended row-id range %s partially overlaps planned range %s in partition %s.",
-                            appendedRange,
-                            plannedRange,
-                            appended.getKey());
-                }
-                plannedRanges.add(appendedRange);
             }
         }
 
         List<ManifestFileMeta> latestManifestMetas = manifestList.readDataManifests(latest);
-        if (!touchedUnplannedPartitions.isEmpty()) {
-            Map<BinaryRow, List<SourcedManifestEntry>> touchedEntries =
-                    currentEntriesByPartition(
-                            latestManifestMetas, touchedUnplannedPartitions, manifestFile);
-            for (Map.Entry<BinaryRow, List<SourcedManifestEntry>> partition :
-                    touchedEntries.entrySet()) {
-                List<ManifestEntry> entries = new ArrayList<>(partition.getValue().size());
-                for (SourcedManifestEntry sourced : partition.getValue()) {
-                    entries.add(sourced.entry);
-                }
-                if (!partitionRowIdsAreContiguous(entries)) {
-                    logicalRangesByPartition.put(partition.getKey(), logicalRanges(entries));
-                }
-            }
+        Set<String> latestManifestFiles = new HashSet<>();
+        for (ManifestFileMeta manifestMeta : latestManifestMetas) {
+            latestManifestFiles.add(manifestMeta.fileName());
         }
-
-        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings =
-                createRelativeRowIdMappingsFromRanges(logicalRangesByPartition);
-        List<ManifestFileMeta> manifestMetasToRewrite =
-                findManifestMetasToRewrite(
-                        latestManifestMetas, rowIdMappings, manifestFile, context);
+        for (String plannedManifestFile : manifestMetasToRewrite.keySet()) {
+            checkState(
+                    latestManifestFiles.contains(plannedManifestFile),
+                    "Cannot advance row-id assignment because planned manifest %s no longer exists after APPEND manifest merge.",
+                    plannedManifestFile);
+        }
         context.retainLatest(latestManifestMetas, latest.indexManifest());
-        return new AssignmentPlan(manifestMetasToRewrite, rowIdMappings);
+        return new AssignmentPlan(
+                new ArrayList<>(manifestMetasToRewrite.values()), assignmentPlan.rowIdMappings);
     }
 
-    private Map<BinaryRow, List<SourcedManifestEntry>> currentEntriesByPartition(
-            List<ManifestFileMeta> manifestMetas,
-            Set<BinaryRow> partitions,
-            ManifestFile manifestFile) {
-        Map<BinaryRow, List<SourcedManifestEntry>> result = new LinkedHashMap<>();
-        PartitionPredicate touchedPartitionPredicate =
-                PartitionPredicate.fromMultiple(table.schema().logicalPartitionType(), partitions);
-        checkState(touchedPartitionPredicate != null, "Touched partition predicate is null.");
-        List<PartitionPredicate> predicates = new ArrayList<>();
-        if (partitionPredicate != null) {
-            predicates.add(partitionPredicate);
+    private boolean appendedEntryNeedsReassign(
+            AssignmentPlan assignmentPlan, ManifestEntry appendedEntry) {
+        RowRangeMappingIndex mapping = assignmentPlan.rowIdMappings.get(appendedEntry.partition());
+        if (mapping == null) {
+            return false;
         }
-        predicates.add(touchedPartitionPredicate);
-        PartitionPredicate effectivePartitionPredicate = PartitionPredicate.and(predicates);
-        checkState(effectivePartitionPredicate != null, "Effective partition predicate is null.");
-        for (List<ManifestFileMeta> manifestGroup : manifestGroupsByPartition(manifestMetas)) {
-            if (!manifestGroupMayContainPartitions(manifestGroup, effectivePartitionPredicate)) {
-                continue;
-            }
-            CurrentManifest currentManifest =
-                    currentManifest(manifestGroup, manifestFile, effectivePartitionPredicate);
-            for (SourcedManifestEntry entry : currentManifest.currentEntries) {
-                if (partitions.contains(entry.entry.partition())) {
-                    result.computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
-                            .add(entry);
-                }
-            }
+
+        Range appendedRange = appendedEntry.file().nonNullRowIdRange();
+        if (mapping.map(appendedRange).isPresent()) {
+            return true;
         }
-        return result;
+
+        for (Range plannedRange : mapping.oldRanges()) {
+            checkState(
+                    !rangesOverlap(plannedRange, appendedRange),
+                    "Cannot advance row-id assignment because appended row-id range %s partially overlaps planned range %s in partition %s.",
+                    appendedRange,
+                    plannedRange,
+                    appendedEntry.partition());
+        }
+        return false;
     }
 
     private boolean manifestGroupMayContainPartitions(
@@ -702,9 +605,6 @@ public class DataEvolutionRowIdReassigner {
             }
             for (ManifestEntry entry :
                     readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
-                if (entry.kind() != FileKind.ADD) {
-                    continue;
-                }
                 RowRangeMappingIndex mapping = rowIdMappings.get(entry.partition());
                 if (mapping != null && mapping.map(entry.file().nonNullRowIdRange()).isPresent()) {
                     result.add(manifestMeta);
@@ -739,12 +639,10 @@ public class DataEvolutionRowIdReassigner {
         for (ManifestFileMeta manifestMeta : assignment.manifestMetasToRewrite) {
             List<ManifestEntry> entries =
                     manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
-            long manifestFileCount = 0L;
+            long reassignedAddFileCount = 0L;
+            boolean hasRewrittenEntry = false;
             for (int i = 0; i < entries.size(); i++) {
                 ManifestEntry entry = entries.get(i);
-                if (entry.kind() != FileKind.ADD) {
-                    continue;
-                }
                 RowRangeMappingIndex mapping = assignment.rowIdMappings.get(entry.partition());
                 if (mapping == null) {
                     continue;
@@ -753,27 +651,28 @@ public class DataEvolutionRowIdReassigner {
                 if (reassignedRange.isPresent()) {
                     validatePlanningEntry(entry);
                     entries.set(i, entry.assignFirstRowId(reassignedRange.get().from));
-                    manifestFileCount++;
+                    hasRewrittenEntry = true;
+                    if (entry.kind() == FileKind.ADD) {
+                        reassignedAddFileCount++;
+                    }
                 }
             }
             checkState(
-                    manifestFileCount > 0,
+                    hasRewrittenEntry,
                     "Cannot find entries to reassign in planned manifest %s.",
                     manifestMeta.fileName());
             rewrittenManifestMetas.put(manifestMeta.fileName(), manifestFile.write(entries));
-            fileCount += manifestFileCount;
+            fileCount += reassignedAddFileCount;
         }
         return new RewrittenDataManifests(rewrittenManifestMetas, fileCount);
     }
 
-    private Map<BinaryRow, List<ManifestEntry>> entriesByPartition(
-            List<SourcedManifestEntry> entries) {
+    private Map<BinaryRow, List<ManifestEntry>> entriesByPartition(List<ManifestEntry> entries) {
         Comparator<ManifestEntry> comparator = entryComparator();
-        Collections.sort(entries, (left, right) -> comparator.compare(left.entry, right.entry));
+        Collections.sort(entries, comparator);
 
         Map<BinaryRow, List<ManifestEntry>> entriesByPartition = new LinkedHashMap<>();
-        for (SourcedManifestEntry sourcedEntry : entries) {
-            ManifestEntry entry = sourcedEntry.entry;
+        for (ManifestEntry entry : entries) {
             validatePlanningEntry(entry);
             entriesByPartition
                     .computeIfAbsent(entry.partition(), k -> new ArrayList<>())
@@ -1199,10 +1098,6 @@ public class DataEvolutionRowIdReassigner {
             this.rowIdMappings = new LinkedHashMap<>(rowIdMappings);
         }
 
-        private boolean containsPartition(BinaryRow partition) {
-            return rowIdMappings.containsKey(partition);
-        }
-
         private Assignment createAssignment(Snapshot snapshot) {
             Long firstAssignedRowId = snapshot.nextRowId();
             checkState(
@@ -1271,24 +1166,6 @@ public class DataEvolutionRowIdReassigner {
             this.success = success;
             this.fileCount = fileCount;
             this.indexFileCount = indexFileCount;
-        }
-    }
-
-    private static class CurrentManifest {
-        private final List<SourcedManifestEntry> currentEntries;
-
-        private CurrentManifest(List<SourcedManifestEntry> currentEntries) {
-            this.currentEntries = currentEntries;
-        }
-    }
-
-    private static class SourcedManifestEntry {
-        private final ManifestFileMeta manifest;
-        private final ManifestEntry entry;
-
-        private SourcedManifestEntry(ManifestFileMeta manifest, ManifestEntry entry) {
-            this.manifest = manifest;
-            this.entry = entry;
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -112,8 +112,6 @@ public class DataEvolutionRowIdReassigner {
                 "Table '%s' must enable 'data-evolution.enabled=true' before reassigning row IDs.",
                 table.name());
 
-        ManifestFile manifestFile = table.store().manifestFileFactory().create();
-        ManifestList manifestList = table.store().manifestListFactory().create();
         Snapshot latest = table.snapshotManager().latestSnapshot();
         checkArgument(
                 latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
@@ -125,6 +123,8 @@ public class DataEvolutionRowIdReassigner {
             return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
         }
 
+        ManifestFile manifestFile = table.store().manifestFileFactory().create();
+        ManifestList manifestList = table.store().manifestListFactory().create();
         Optional<AssignmentPlan> optionalPlan =
                 planAssignment(manifestList.readDataManifests(latest), manifestFile);
         if (!optionalPlan.isPresent()) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassigner.java
@@ -40,6 +40,7 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RangeHelper;
@@ -114,109 +115,95 @@ public class DataEvolutionRowIdReassigner {
         ManifestFile manifestFile = table.store().manifestFileFactory().create();
         ManifestList manifestList = table.store().manifestListFactory().create();
         ReassignContext context = new ReassignContext();
-        for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
-            Snapshot latest = table.snapshotManager().latestSnapshot();
-            checkArgument(
-                    latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
-            Long nextRowId = latest.nextRowId();
-            checkState(
-                    nextRowId != null,
-                    "Next row id cannot be null for row-tracking table '%s'.",
-                    table.name());
-            if (table.schema().logicalPartitionType().getFieldCount() == 0) {
-                LOG.info(
-                        "Skip reassigning row IDs for table {} because it is not partitioned.",
-                        table.name());
-                return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
-            }
-
-            List<ManifestFileMeta> manifestMetas = manifestList.readDataManifests(latest);
-            AssignmentPlan assignment =
-                    planAssignment(manifestMetas, manifestFile, nextRowId, context);
-            if (!assignment.hasCurrentFiles) {
-                return Result.skipped(
-                        latest.id(),
-                        nextRowId,
-                        partitionFilterEnabled()
-                                ? "partition filter matches no current files"
-                                : "table has no current files");
-            }
-            if (assignment.reassignedFileCount == 0) {
-                LOG.info(
-                        "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
-                        table.name());
-                return Result.skipped(
-                        latest.id(), nextRowId, "partition row IDs are already contiguous");
-            }
-
-            Pair<String, Long> baseManifestList =
-                    writeBaseManifestList(
-                            manifestMetas, assignment.rewrittenManifestMetas, manifestList);
-            Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
-
-            RewrittenIndexManifest rewrittenIndexManifest =
-                    rewriteIndexManifest(latest, assignment, context);
-
-            boolean success;
-            try (FileStoreCommitImpl commit =
-                    (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
-                beforeCommit.run();
-                success =
-                        commit.replaceManifestList(
-                                latest,
-                                latest.totalRecordCount(),
-                                baseManifestList,
-                                deltaManifestList,
-                                rewrittenIndexManifest.indexManifest,
-                                assignment.nextRowId);
-            }
-            if (!success) {
-                if (attempt == MAX_COMMIT_ATTEMPTS) {
-                    throw new RuntimeException(
-                            "Failed to reassign row IDs because a newer snapshot has been committed.");
-                }
-                LOG.info(
-                        "Failed to commit row-id reassignment for table {} based on snapshot {} because a newer snapshot {} has been committed. Retrying {}/{} with cached manifest reads.",
-                        table.name(),
-                        latest.id(),
-                        table.snapshotManager().latestSnapshotId(),
-                        attempt + 1,
-                        MAX_COMMIT_ATTEMPTS);
-                continue;
-            }
-
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        checkArgument(
+                latest != null, "Cannot reassign row IDs for empty table '%s'.", table.name());
+        long nextRowId = requireNextRowId(latest);
+        if (table.schema().logicalPartitionType().getFieldCount() == 0) {
             LOG.info(
-                    "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
-                    table.name(),
-                    nextRowId,
-                    assignment.nextRowId,
-                    assignment.rowIdMappings.size(),
-                    assignment.reassignedFileCount,
-                    assignment.logicalRowCount);
-            return new Result(
+                    "Skip reassigning row IDs for table {} because it is not partitioned.",
+                    table.name());
+            return Result.skipped(latest.id(), nextRowId, "table is not partitioned");
+        }
+
+        AssignmentPlan assignment =
+                planAssignment(
+                        latest, manifestList.readDataManifests(latest), manifestFile, context);
+        if (!assignment.hasCurrentFiles) {
+            return Result.skipped(
                     latest.id(),
-                    latest.id() + 1,
-                    assignment.reassignedFileCount,
-                    assignment.logicalRowCount,
-                    rewrittenIndexManifest.indexFileCount,
                     nextRowId,
-                    assignment.nextRowId);
+                    partitionFilterEnabled()
+                            ? "partition filter matches no current files"
+                            : "table has no current files");
+        }
+        if (assignment.plannedFiles.isEmpty()) {
+            LOG.info(
+                    "Skip reassigning row IDs for table {} because partition row IDs are already contiguous.",
+                    table.name());
+            return Result.skipped(
+                    latest.id(), nextRowId, "partition row IDs are already contiguous");
+        }
+
+        for (int attempt = 1; attempt <= MAX_COMMIT_ATTEMPTS; attempt++) {
+            CommitAssignmentResult commitResult =
+                    commitAssignment(assignment, manifestFile, manifestList, context, commitUser);
+            if (commitResult.success) {
+                LOG.info(
+                        "Reassigned row IDs for table {} from {} to {}, partitions={}, files={}, rows={}.",
+                        table.name(),
+                        assignment.firstAssignedRowId,
+                        assignment.nextRowId,
+                        assignment.rowIdMappings.size(),
+                        assignment.plannedFiles.size(),
+                        assignment.logicalRowCount);
+                return new Result(
+                        assignment.snapshot.id(),
+                        assignment.snapshot.id() + 1,
+                        assignment.plannedFiles.size(),
+                        assignment.logicalRowCount,
+                        commitResult.indexFileCount,
+                        assignment.firstAssignedRowId,
+                        assignment.nextRowId);
+            }
+
+            if (attempt == MAX_COMMIT_ATTEMPTS) {
+                throw new RuntimeException(
+                        "Failed to reassign row IDs because a newer snapshot has been committed.");
+            }
+
+            Snapshot newLatest = table.snapshotManager().latestSnapshot();
+            checkState(newLatest != null, "Latest snapshot disappeared while reassigning row IDs.");
+            advanceAssignment(assignment, newLatest, manifestFile, manifestList, context);
+            LOG.info(
+                    "Failed to commit row-id reassignment for table {} based on snapshot {} because snapshot {} has been committed. Retrying {}/{} with the updated assignment plan.",
+                    table.name(),
+                    latest.id(),
+                    newLatest.id(),
+                    attempt + 1,
+                    MAX_COMMIT_ATTEMPTS);
+            latest = newLatest;
         }
 
         throw new IllegalStateException("Unreachable retry state while reassigning row IDs.");
     }
 
+    private long requireNextRowId(Snapshot snapshot) {
+        Long nextRowId = snapshot.nextRowId();
+        checkState(
+                nextRowId != null,
+                "Next row id cannot be null for row-tracking table '%s'.",
+                table.name());
+        return nextRowId;
+    }
+
     private AssignmentPlan planAssignment(
+            Snapshot snapshot,
             List<ManifestFileMeta> manifestMetas,
             ManifestFile manifestFile,
-            long firstRowId,
             ReassignContext context) {
         List<List<ManifestFileMeta>> manifestGroups = manifestGroupsByPartition(manifestMetas);
-        Map<String, List<ManifestFileMeta>> rewrittenManifestMetas = new HashMap<>();
-        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings = new LinkedHashMap<>();
-        long nextRowId = firstRowId;
-        long logicalRowCount = 0;
-        long reassignedFileCount = 0;
+        Map<BinaryRow, List<SourcedManifestEntry>> entriesToReassign = new LinkedHashMap<>();
         boolean hasCurrentFiles = false;
 
         for (List<ManifestFileMeta> manifestGroup : manifestGroups) {
@@ -225,59 +212,31 @@ public class DataEvolutionRowIdReassigner {
             }
 
             CurrentManifest currentManifest = currentManifest(manifestGroup, manifestFile, context);
-            List<ManifestEntry> currentEntries = currentManifest.entries();
-            if (currentEntries.isEmpty()) {
+            if (currentManifest.currentEntries.isEmpty()) {
                 continue;
             }
             hasCurrentFiles = true;
 
             Map<BinaryRow, List<ManifestEntry>> entriesByPartition =
-                    entriesByPartition(currentEntries);
+                    entriesByPartition(currentManifest.currentEntries);
             Set<BinaryRow> partitionsToReassign = partitionsToReassign(entriesByPartition);
             if (partitionsToReassign.isEmpty()) {
                 continue;
             }
 
-            Assignment groupAssignment =
-                    assign(entriesByPartition, partitionsToReassign, nextRowId);
-            nextRowId = groupAssignment.nextRowId;
-            logicalRowCount += groupAssignment.logicalRowCount;
-            reassignedFileCount += groupAssignment.reassignedFileCount;
-            for (Map.Entry<BinaryRow, RowRangeMappingIndex> mapping :
-                    groupAssignment.rowIdMappings.entrySet()) {
-                RowRangeMappingIndex previous =
-                        rowIdMappings.put(mapping.getKey(), mapping.getValue());
-                checkState(
-                        previous == null,
-                        "Partition %s appears in multiple manifest groups.",
-                        table.store().pathFactory().getPartitionString(mapping.getKey()));
-            }
-
-            Map<String, List<ManifestFileMeta>> groupRewrittenManifestMetas =
-                    writeManifestReplacements(
-                            currentManifest,
-                            groupAssignment,
-                            partitionsToReassign,
-                            manifestFile,
-                            context);
-            for (Map.Entry<String, List<ManifestFileMeta>> rewritten :
-                    groupRewrittenManifestMetas.entrySet()) {
-                List<ManifestFileMeta> previous =
-                        rewrittenManifestMetas.put(rewritten.getKey(), rewritten.getValue());
-                checkState(
-                        previous == null,
-                        "Manifest file %s appears in multiple manifest groups.",
-                        rewritten.getKey());
+            for (SourcedManifestEntry entry : currentManifest.currentEntries) {
+                if (partitionsToReassign.contains(entry.entry.partition())) {
+                    entriesToReassign
+                            .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
+                            .add(entry);
+                }
             }
         }
 
-        return new AssignmentPlan(
-                rewrittenManifestMetas,
-                rowIdMappings,
-                nextRowId,
-                logicalRowCount,
-                reassignedFileCount,
-                hasCurrentFiles);
+        AssignmentPlan assignment =
+                new AssignmentPlan(snapshot, manifestMetas, entriesToReassign, hasCurrentFiles);
+        recalculateAssignment(assignment, requireNextRowId(snapshot));
+        return assignment;
     }
 
     private List<List<ManifestFileMeta>> manifestGroupsByPartition(
@@ -310,6 +269,7 @@ public class DataEvolutionRowIdReassigner {
                             manifestMeta,
                             manifestMeta.partitionStats().minValues(),
                             manifestMeta.partitionStats().maxValues(),
+                            containsNullPartition(manifestMeta, partitionFieldCount),
                             i));
         }
         Collections.sort(
@@ -341,6 +301,32 @@ public class DataEvolutionRowIdReassigner {
             }
         }
         groupedManifestRanges.add(currentGroup);
+
+        // Partition min/max excludes nulls, so null-bearing ranges need an extra shared group.
+        List<PartitionManifestRange> nullPartitionGroup = new ArrayList<>();
+        int nullPartitionGroupIndex = -1;
+        for (int i = 0; i < groupedManifestRanges.size(); ) {
+            List<PartitionManifestRange> group = groupedManifestRanges.get(i);
+            boolean containsNullPartition = false;
+            for (PartitionManifestRange range : group) {
+                if (range.containsNullPartition) {
+                    containsNullPartition = true;
+                    break;
+                }
+            }
+            if (containsNullPartition) {
+                if (nullPartitionGroupIndex < 0) {
+                    nullPartitionGroupIndex = i;
+                }
+                nullPartitionGroup.addAll(group);
+                groupedManifestRanges.remove(i);
+            } else {
+                i++;
+            }
+        }
+        if (!nullPartitionGroup.isEmpty()) {
+            groupedManifestRanges.add(nullPartitionGroupIndex, nullPartitionGroup);
+        }
 
         List<List<ManifestFileMeta>> groups = new ArrayList<>();
         for (List<PartitionManifestRange> group : groupedManifestRanges) {
@@ -385,6 +371,15 @@ public class DataEvolutionRowIdReassigner {
                 && partitionStats.nullCounts().size() == partitionFieldCount;
     }
 
+    private boolean containsNullPartition(ManifestFileMeta manifestMeta, int partitionFieldCount) {
+        for (int i = 0; i < partitionFieldCount; i++) {
+            if (manifestMeta.partitionStats().nullCounts().getLong(i) != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private CurrentManifest currentManifest(
             List<ManifestFileMeta> manifestMetas,
             ManifestFile manifestFile,
@@ -397,7 +392,8 @@ public class DataEvolutionRowIdReassigner {
             if (manifestMeta.numAddedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
+            List<ManifestEntry> entries =
+                    readPlanningManifestEntries(manifestFile, manifestMeta, context);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.ADD
                         && partitionIncluded(entry.partition())
@@ -406,7 +402,53 @@ public class DataEvolutionRowIdReassigner {
                 }
             }
         }
-        return new CurrentManifest(manifestMetas, currentEntries);
+        return new CurrentManifest(currentEntries);
+    }
+
+    private CurrentManifest currentManifest(
+            List<ManifestFileMeta> manifestMetas,
+            ManifestFile manifestFile,
+            PartitionPredicate effectivePartitionPredicate) {
+        Map<ManifestFileMeta, List<ManifestEntry>> entriesByManifest = new HashMap<>();
+        Set<FileEntry.Identifier> deletedIdentifiers = new HashSet<>();
+        for (ManifestFileMeta manifestMeta : manifestMetas) {
+            if (manifestMeta.numDeletedFiles() <= 0) {
+                continue;
+            }
+            for (ManifestEntry entry :
+                    entriesByManifest.computeIfAbsent(
+                            manifestMeta,
+                            ignored ->
+                                    readPlanningManifestEntries(
+                                            manifestFile,
+                                            manifestMeta,
+                                            effectivePartitionPredicate))) {
+                if (entry.kind() == FileKind.DELETE) {
+                    deletedIdentifiers.add(entry.identifier());
+                }
+            }
+        }
+
+        List<SourcedManifestEntry> currentEntries = new ArrayList<>();
+        for (ManifestFileMeta manifestMeta : manifestMetas) {
+            if (manifestMeta.numAddedFiles() <= 0) {
+                continue;
+            }
+            for (ManifestEntry entry :
+                    entriesByManifest.computeIfAbsent(
+                            manifestMeta,
+                            ignored ->
+                                    readPlanningManifestEntries(
+                                            manifestFile,
+                                            manifestMeta,
+                                            effectivePartitionPredicate))) {
+                if (entry.kind() == FileKind.ADD
+                        && !deletedIdentifiers.contains(entry.identifier())) {
+                    currentEntries.add(new SourcedManifestEntry(manifestMeta, entry));
+                }
+            }
+        }
+        return new CurrentManifest(currentEntries);
     }
 
     private Set<FileEntry.Identifier> deletedIdentifiers(
@@ -418,7 +460,8 @@ public class DataEvolutionRowIdReassigner {
             if (manifestMeta.numDeletedFiles() <= 0) {
                 continue;
             }
-            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
+            List<ManifestEntry> entries =
+                    readPlanningManifestEntries(manifestFile, manifestMeta, context);
             for (ManifestEntry entry : entries) {
                 if (entry.kind() == FileKind.DELETE && partitionIncluded(entry.partition())) {
                     deletedIdentifiers.add(entry.identifier());
@@ -434,6 +477,223 @@ public class DataEvolutionRowIdReassigner {
 
     private boolean partitionFilterEnabled() {
         return partitionPredicate != null;
+    }
+
+    private CommitAssignmentResult commitAssignment(
+            AssignmentPlan assignment,
+            ManifestFile manifestFile,
+            ManifestList manifestList,
+            ReassignContext context,
+            String commitUser) {
+        Map<String, List<ManifestFileMeta>> rewrittenManifestMetas =
+                writeManifestReplacements(assignment, manifestFile);
+        Pair<String, Long> baseManifestList =
+                writeBaseManifestList(
+                        assignment.manifestMetas, rewrittenManifestMetas, manifestList);
+        Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
+        RewrittenIndexManifest rewrittenIndexManifest =
+                rewriteIndexManifest(assignment.snapshot, assignment, context);
+
+        boolean success;
+        try (FileStoreCommitImpl commit =
+                (FileStoreCommitImpl) table.store().newCommit(commitUser, table)) {
+            beforeCommit.run();
+            success =
+                    commit.replaceManifestList(
+                            assignment.snapshot,
+                            assignment.snapshot.totalRecordCount(),
+                            baseManifestList,
+                            deltaManifestList,
+                            rewrittenIndexManifest.indexManifest,
+                            assignment.nextRowId);
+        }
+        return new CommitAssignmentResult(success, rewrittenIndexManifest.indexFileCount);
+    }
+
+    private void advanceAssignment(
+            AssignmentPlan assignment,
+            Snapshot latest,
+            ManifestFile manifestFile,
+            ManifestList manifestList,
+            ReassignContext context) {
+        checkState(
+                latest.id() > assignment.snapshot.id(),
+                "Cannot advance row-id assignment from snapshot %s to %s.",
+                assignment.snapshot.id(),
+                latest.id());
+
+        Set<BinaryRow> touchedUnplannedPartitions = new HashSet<>();
+        for (long id = assignment.snapshot.id() + 1; id <= latest.id(); id++) {
+            Snapshot snapshot;
+            try {
+                snapshot = table.snapshotManager().tryGetSnapshot(id);
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        String.format(
+                                "Abort row-id reassignment because snapshot %s cannot be read.",
+                                id),
+                        e);
+            }
+
+            if (snapshot.commitKind() == Snapshot.CommitKind.COMPACT
+                    || snapshot.commitKind() == Snapshot.CommitKind.OVERWRITE) {
+                throw new RuntimeException(
+                        String.format(
+                                "Abort row-id reassignment because %s snapshot %s was committed after snapshot %s.",
+                                snapshot.commitKind(), snapshot.id(), assignment.snapshot.id()));
+            }
+            if (snapshot.commitKind() == Snapshot.CommitKind.ANALYZE) {
+                continue;
+            }
+            checkState(
+                    snapshot.commitKind() == Snapshot.CommitKind.APPEND,
+                    "Unsupported snapshot kind %s while advancing row-id assignment.",
+                    snapshot.commitKind());
+
+            for (ManifestFileMeta manifestMeta : manifestList.readDeltaManifests(snapshot)) {
+                for (ManifestEntry entry :
+                        readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
+                    checkState(
+                            entry.kind() == FileKind.ADD,
+                            "APPEND snapshot %s contains non-ADD manifest entry %s.",
+                            snapshot.id(),
+                            entry);
+                    SourcedManifestEntry sourced = new SourcedManifestEntry(manifestMeta, entry);
+                    if (assignment.containsPartition(entry.partition())) {
+                        assignment.add(sourced);
+                    } else {
+                        touchedUnplannedPartitions.add(entry.partition());
+                    }
+                }
+            }
+        }
+
+        List<ManifestFileMeta> latestManifestMetas = manifestList.readDataManifests(latest);
+        if (!touchedUnplannedPartitions.isEmpty()) {
+            Map<BinaryRow, List<SourcedManifestEntry>> touchedEntries =
+                    currentEntriesByPartition(
+                            latestManifestMetas, touchedUnplannedPartitions, manifestFile);
+            for (Map.Entry<BinaryRow, List<SourcedManifestEntry>> partition :
+                    touchedEntries.entrySet()) {
+                List<ManifestEntry> entries = new ArrayList<>(partition.getValue().size());
+                for (SourcedManifestEntry sourced : partition.getValue()) {
+                    entries.add(sourced.entry);
+                }
+                if (!partitionRowIdsAreContiguous(entries)) {
+                    assignment.addAll(partition.getValue());
+                }
+            }
+        }
+
+        relocatePlannedFiles(assignment, latestManifestMetas, manifestFile, context);
+        context.retainLatest(latestManifestMetas, latest.indexManifest());
+        assignment.snapshot = latest;
+        assignment.manifestMetas = latestManifestMetas;
+        recalculateAssignment(assignment, requireNextRowId(latest));
+    }
+
+    private Map<BinaryRow, List<SourcedManifestEntry>> currentEntriesByPartition(
+            List<ManifestFileMeta> manifestMetas,
+            Set<BinaryRow> partitions,
+            ManifestFile manifestFile) {
+        Map<BinaryRow, List<SourcedManifestEntry>> result = new LinkedHashMap<>();
+        PartitionPredicate touchedPartitionPredicate =
+                PartitionPredicate.fromMultiple(table.schema().logicalPartitionType(), partitions);
+        checkState(touchedPartitionPredicate != null, "Touched partition predicate is null.");
+        List<PartitionPredicate> predicates = new ArrayList<>();
+        if (partitionPredicate != null) {
+            predicates.add(partitionPredicate);
+        }
+        predicates.add(touchedPartitionPredicate);
+        PartitionPredicate effectivePartitionPredicate = PartitionPredicate.and(predicates);
+        checkState(effectivePartitionPredicate != null, "Effective partition predicate is null.");
+        for (List<ManifestFileMeta> manifestGroup : manifestGroupsByPartition(manifestMetas)) {
+            if (!manifestGroupMayContainPartitions(manifestGroup, effectivePartitionPredicate)) {
+                continue;
+            }
+            CurrentManifest currentManifest =
+                    currentManifest(manifestGroup, manifestFile, effectivePartitionPredicate);
+            for (SourcedManifestEntry entry : currentManifest.currentEntries) {
+                if (partitions.contains(entry.entry.partition())) {
+                    result.computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
+                            .add(entry);
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean manifestGroupMayContainPartitions(
+            List<ManifestFileMeta> manifestGroup, PartitionPredicate effectivePartitionPredicate) {
+        int partitionFieldCount = table.schema().logicalPartitionType().getFieldCount();
+        for (ManifestFileMeta manifestMeta : manifestGroup) {
+            if (!containsPartitionStats(manifestMeta, partitionFieldCount)) {
+                return true;
+            }
+
+            SimpleStats partitionStats = manifestMeta.partitionStats();
+            if (effectivePartitionPredicate.test(
+                    manifestMeta.numAddedFiles() + manifestMeta.numDeletedFiles(),
+                    partitionStats.minValues(),
+                    partitionStats.maxValues(),
+                    partitionStats.nullCounts())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void relocatePlannedFiles(
+            AssignmentPlan assignment,
+            List<ManifestFileMeta> latestManifestMetas,
+            ManifestFile manifestFile,
+            ReassignContext context) {
+        Set<String> previousManifestFiles = manifestFileNames(assignment.manifestMetas);
+        Set<String> latestManifestFiles = manifestFileNames(latestManifestMetas);
+        Set<FileEntry.Identifier> unresolved = new HashSet<>();
+        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
+                assignment.plannedFiles.entrySet()) {
+            ManifestFileMeta source = planned.getValue().manifest;
+            if (source == null || !latestManifestFiles.contains(source.fileName())) {
+                planned.getValue().manifest = null;
+                unresolved.add(planned.getKey());
+            }
+        }
+
+        if (unresolved.isEmpty()) {
+            return;
+        }
+
+        for (ManifestFileMeta manifestMeta : latestManifestMetas) {
+            if (unresolved.isEmpty()) {
+                break;
+            }
+            if (previousManifestFiles.contains(manifestMeta.fileName())) {
+                continue;
+            }
+            for (ManifestEntry entry :
+                    readPlanningManifestEntries(manifestFile, manifestMeta, context)) {
+                if (entry.kind() != FileKind.ADD) {
+                    continue;
+                }
+                FileEntry.Identifier identifier = entry.identifier();
+                if (unresolved.remove(identifier)) {
+                    assignment.plannedFiles.get(identifier).manifest = manifestMeta;
+                }
+            }
+        }
+        checkState(
+                unresolved.isEmpty(),
+                "Cannot locate planned files %s in the latest APPEND manifests.",
+                unresolved);
+    }
+
+    private Set<String> manifestFileNames(List<ManifestFileMeta> manifestMetas) {
+        Set<String> result = new HashSet<>();
+        for (ManifestFileMeta manifestMeta : manifestMetas) {
+            result.add(manifestMeta.fileName());
+        }
+        return result;
     }
 
     private Pair<String, Long> writeBaseManifestList(
@@ -454,81 +714,91 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private Map<String, List<ManifestFileMeta>> writeManifestReplacements(
-            CurrentManifest currentManifest,
-            Assignment assignment,
-            Set<BinaryRow> partitionsToReassign,
-            ManifestFile manifestFile,
-            ReassignContext context) {
-        Set<String> manifestsToRewrite =
-                manifestsToRewrite(currentManifest.currentEntries, partitionsToReassign);
-        Map<FileEntry.Identifier, ManifestEntry> reassignedEntries =
-                entriesByIdentifier(assignment.entries);
+            AssignmentPlan assignment, ManifestFile manifestFile) {
+        Map<String, Integer> assignmentsByManifest = new HashMap<>();
+        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
+                assignment.plannedFiles.entrySet()) {
+            ManifestFileMeta manifest = planned.getValue().manifest;
+            Long reassignedFirstRowId = planned.getValue().reassignedFirstRowId;
+            checkState(
+                    manifest != null,
+                    "Cannot locate manifest for planned file %s.",
+                    planned.getKey());
+            checkState(
+                    reassignedFirstRowId != null,
+                    "Cannot find reassigned first row ID for planned file %s.",
+                    planned.getKey());
+            assignmentsByManifest.merge(manifest.fileName(), 1, Integer::sum);
+        }
 
         Map<String, List<ManifestFileMeta>> rewrittenManifestMetas = new HashMap<>();
-        for (ManifestFileMeta manifestMeta : currentManifest.manifestMetas) {
-            if (!manifestsToRewrite.contains(manifestMeta.fileName())) {
+        for (ManifestFileMeta manifestMeta : assignment.manifestMetas) {
+            Integer expectedAssignments = assignmentsByManifest.remove(manifestMeta.fileName());
+            if (expectedAssignments == null) {
                 continue;
             }
 
-            List<ManifestEntry> rewrittenEntries = new ArrayList<>();
-            List<ManifestEntry> entries = readManifestEntries(manifestFile, manifestMeta, context);
-            for (ManifestEntry entry : entries) {
+            List<ManifestEntry> entries =
+                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
+            Set<FileEntry.Identifier> rewrittenIdentifiers = new HashSet<>();
+            for (int i = 0; i < entries.size(); i++) {
+                ManifestEntry entry = entries.get(i);
                 if (entry.kind() == FileKind.ADD) {
-                    ManifestEntry reassignedEntry = reassignedEntries.get(entry.identifier());
-                    if (reassignedEntry != null) {
-                        entry = reassignedEntry;
+                    SourcedManifestEntry planned = assignment.plannedFiles.get(entry.identifier());
+                    if (planned != null
+                            && planned.manifest != null
+                            && planned.manifest.fileName().equals(manifestMeta.fileName())) {
+                        checkState(
+                                rewrittenIdentifiers.add(entry.identifier()),
+                                "Duplicate planned file %s in manifest %s.",
+                                entry.identifier(),
+                                manifestMeta.fileName());
+                        entries.set(i, entry.assignFirstRowId(planned.reassignedFirstRowId));
                     }
                 }
-                rewrittenEntries.add(entry);
             }
-            rewrittenManifestMetas.put(
-                    manifestMeta.fileName(), manifestFile.write(rewrittenEntries));
+            checkState(
+                    rewrittenIdentifiers.size() == expectedAssignments,
+                    "Expected %s planned files in manifest %s, but found %s.",
+                    expectedAssignments,
+                    manifestMeta.fileName(),
+                    rewrittenIdentifiers.size());
+            rewrittenManifestMetas.put(manifestMeta.fileName(), manifestFile.write(entries));
         }
+        checkState(
+                assignmentsByManifest.isEmpty(),
+                "Cannot find planned manifests %s in the latest snapshot.",
+                assignmentsByManifest.keySet());
         return rewrittenManifestMetas;
     }
 
-    private Set<String> manifestsToRewrite(
-            List<SourcedManifestEntry> currentEntries, Set<BinaryRow> partitionsToReassign) {
-        Set<String> manifestsToRewrite = new HashSet<>();
-        for (SourcedManifestEntry currentEntry : currentEntries) {
-            if (partitionsToReassign.contains(currentEntry.entry.partition())) {
-                manifestsToRewrite.add(currentEntry.manifest.fileName());
-            }
-        }
-        return manifestsToRewrite;
-    }
-
-    private Map<FileEntry.Identifier, ManifestEntry> entriesByIdentifier(
-            List<ManifestEntry> entries) {
-        Map<FileEntry.Identifier, ManifestEntry> result = new HashMap<>();
-        for (ManifestEntry entry : entries) {
-            ManifestEntry previous = result.put(entry.identifier(), entry);
-            checkState(previous == null, "Duplicate current manifest entry for file %s.", entry);
-        }
-        return result;
-    }
-
-    private Map<BinaryRow, List<ManifestEntry>> entriesByPartition(List<ManifestEntry> entries) {
-        List<ManifestEntry> sorted = new ArrayList<>(entries);
-        Collections.sort(sorted, entryComparator());
+    private Map<BinaryRow, List<ManifestEntry>> entriesByPartition(
+            List<SourcedManifestEntry> entries) {
+        Comparator<ManifestEntry> comparator = entryComparator();
+        Collections.sort(entries, (left, right) -> comparator.compare(left.entry, right.entry));
 
         Map<BinaryRow, List<ManifestEntry>> entriesByPartition = new LinkedHashMap<>();
-        for (ManifestEntry entry : sorted) {
-            List<String> writeCols = entry.file().writeCols();
-            checkState(
-                    writeCols == null || !writeCols.contains(SpecialFields.ROW_ID.name()),
-                    "Cannot reassign row IDs for file '%s' because it physically stores the row-id field.",
-                    entry.file().fileName());
-            checkState(
-                    entry.file().firstRowId() != null,
-                    "File '%s' in table '%s' does not have first row id.",
-                    entry.file().fileName(),
-                    table.name());
+        for (SourcedManifestEntry sourcedEntry : entries) {
+            ManifestEntry entry = sourcedEntry.entry;
+            validatePlanningEntry(entry);
             entriesByPartition
                     .computeIfAbsent(entry.partition(), k -> new ArrayList<>())
                     .add(entry);
         }
         return entriesByPartition;
+    }
+
+    private void validatePlanningEntry(ManifestEntry entry) {
+        List<String> writeCols = entry.file().writeCols();
+        checkState(
+                writeCols == null || !writeCols.contains(SpecialFields.ROW_ID.name()),
+                "Cannot reassign row IDs for file '%s' because it physically stores the row-id field.",
+                entry.file().fileName());
+        checkState(
+                entry.file().firstRowId() != null,
+                "File '%s' in table '%s' does not have first row id.",
+                entry.file().fileName(),
+                table.name());
     }
 
     private Set<BinaryRow> partitionsToReassign(
@@ -576,38 +846,54 @@ public class DataEvolutionRowIdReassigner {
         return logicalRanges;
     }
 
-    private Assignment assign(
-            Map<BinaryRow, List<ManifestEntry>> entriesByPartition,
-            Set<BinaryRow> partitionsToReassign,
-            long firstRowId) {
-        List<ManifestEntry> entries = new ArrayList<>();
-        Map<BinaryRow, RowRangeMappingIndex> rowIdMappings = new LinkedHashMap<>();
+    private void recalculateAssignment(AssignmentPlan assignment, long firstRowId) {
+        assignment.rowIdMappings.clear();
+        for (SourcedManifestEntry plannedFile : assignment.plannedFiles.values()) {
+            plannedFile.reassignedFirstRowId = null;
+        }
+        List<BinaryRow> partitions = new ArrayList<>(assignment.entriesByPartition.keySet());
+        RecordComparator partitionComparator = partitionComparator();
+        Collections.sort(partitions, partitionComparator::compare);
+
         long nextRowId = firstRowId;
         long logicalRowCount = 0;
-        long reassignedFileCount = 0;
-        for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : entriesByPartition.entrySet()) {
-            if (partitionsToReassign.contains(entry.getKey())) {
-                long partitionFirstRowId = nextRowId;
-                PartitionAssignment partitionAssignment =
-                        assignPartition(entry.getValue(), nextRowId);
-                entries.addAll(partitionAssignment.entries);
-                rowIdMappings.put(entry.getKey(), partitionAssignment.rowIdMappings);
-                nextRowId = partitionAssignment.nextRowId;
-                logicalRowCount += nextRowId - partitionFirstRowId;
-                reassignedFileCount += partitionAssignment.entries.size();
+        for (BinaryRow partition : partitions) {
+            List<SourcedManifestEntry> sourcedEntries =
+                    assignment.entriesByPartition.get(partition);
+            List<ManifestEntry> entries = new ArrayList<>(sourcedEntries.size());
+            for (SourcedManifestEntry sourcedEntry : sourcedEntries) {
+                validatePlanningEntry(sourcedEntry.entry);
+                entries.add(sourcedEntry.entry);
             }
+
+            long partitionFirstRowId = nextRowId;
+            PartitionAssignment partitionAssignment =
+                    assignPartition(entries, assignment.plannedFiles, nextRowId);
+            assignment.rowIdMappings.put(partition, partitionAssignment.rowIdMappings);
+            nextRowId = partitionAssignment.nextRowId;
+            logicalRowCount += nextRowId - partitionFirstRowId;
         }
 
-        return new Assignment(
-                entries, rowIdMappings, nextRowId, logicalRowCount, reassignedFileCount);
+        for (Map.Entry<FileEntry.Identifier, SourcedManifestEntry> planned :
+                assignment.plannedFiles.entrySet()) {
+            checkState(
+                    planned.getValue().reassignedFirstRowId != null,
+                    "Cannot find assignment for planned file %s.",
+                    planned.getKey());
+        }
+        assignment.firstAssignedRowId = firstRowId;
+        assignment.nextRowId = nextRowId;
+        assignment.logicalRowCount = logicalRowCount;
     }
 
-    private PartitionAssignment assignPartition(List<ManifestEntry> entries, long firstRowId) {
+    private PartitionAssignment assignPartition(
+            List<ManifestEntry> entries,
+            Map<FileEntry.Identifier, SourcedManifestEntry> plannedFiles,
+            long firstRowId) {
         RangeHelper<ManifestEntry> rangeHelper =
                 new RangeHelper<>(entry -> entry.file().nonNullRowIdRange());
         List<List<ManifestEntry>> groups = rangeHelper.mergeOverlappingRanges(entries);
 
-        List<ManifestEntry> reassigned = new ArrayList<>(entries.size());
         List<RowRangeMappingIndex.Mapping> mappings = new ArrayList<>();
         long nextRowId = firstRowId;
 
@@ -621,14 +907,22 @@ public class DataEvolutionRowIdReassigner {
             for (ManifestEntry entry : group) {
                 long oldFirstRowId = entry.file().nonNullFirstRowId();
                 long newFirstRowId = nextRowId + oldFirstRowId - oldLogicalRange.from;
-                reassigned.add(entry.assignFirstRowId(newFirstRowId));
+                SourcedManifestEntry plannedFile = plannedFiles.get(entry.identifier());
+                checkState(
+                        plannedFile != null,
+                        "Cannot find planned manifest entry for file %s.",
+                        entry.identifier());
+                checkState(
+                        plannedFile.reassignedFirstRowId == null,
+                        "Duplicate current manifest entry for file %s.",
+                        entry.identifier());
+                plannedFile.reassignedFirstRowId = newFirstRowId;
             }
 
             nextRowId += oldLogicalRange.count();
         }
 
-        return new PartitionAssignment(
-                reassigned, RowRangeMappingIndex.create(mappings), nextRowId);
+        return new PartitionAssignment(RowRangeMappingIndex.create(mappings), nextRowId);
     }
 
     private Range oldLogicalRange(List<ManifestEntry> group) {
@@ -743,14 +1037,31 @@ public class DataEvolutionRowIdReassigner {
                 indexManifestFile.writeWithoutRolling(rewritten), globalIndexFileCount);
     }
 
-    private List<ManifestEntry> readManifestEntries(
+    private List<ManifestEntry> readPlanningManifestEntries(
             ManifestFile manifestFile, ManifestFileMeta manifestMeta, ReassignContext context) {
-        return context.manifestEntries.computeIfAbsent(
+        // Rewrites reread full entries so this retry cache can safely omit value stats.
+        return context.planningManifestEntries.computeIfAbsent(
                 manifestMeta,
                 ignored ->
                         Collections.unmodifiableList(
-                                manifestFile.read(
-                                        manifestMeta.fileName(), manifestMeta.fileSize())));
+                                readPlanningManifestEntries(
+                                        manifestFile, manifestMeta, partitionPredicate)));
+    }
+
+    private List<ManifestEntry> readPlanningManifestEntries(
+            ManifestFile manifestFile,
+            ManifestFileMeta manifestMeta,
+            @Nullable PartitionPredicate effectivePartitionPredicate) {
+        return manifestFile.read(
+                manifestMeta.fileName(),
+                manifestMeta.fileSize(),
+                effectivePartitionPredicate,
+                null,
+                Filter.alwaysTrue(),
+                entry ->
+                        effectivePartitionPredicate == null
+                                || effectivePartitionPredicate.test(entry.partition()),
+                ManifestEntry::copyWithoutStats);
     }
 
     private List<IndexManifestEntry> readIndexManifestEntries(
@@ -901,77 +1212,93 @@ public class DataEvolutionRowIdReassigner {
     }
 
     private static class ReassignContext {
-        private final Map<ManifestFileMeta, List<ManifestEntry>> manifestEntries = new HashMap<>();
+        private final Map<ManifestFileMeta, List<ManifestEntry>> planningManifestEntries =
+                new HashMap<>();
         private final Map<String, List<IndexManifestEntry>> indexManifestEntries = new HashMap<>();
-    }
 
-    private static class Assignment {
-        private final List<ManifestEntry> entries;
-        private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
-        private final long nextRowId;
-        private final long logicalRowCount;
-        private final long reassignedFileCount;
-
-        private Assignment(
-                List<ManifestEntry> entries,
-                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
-                long nextRowId,
-                long logicalRowCount,
-                long reassignedFileCount) {
-            this.entries = entries;
-            this.rowIdMappings = rowIdMappings;
-            this.nextRowId = nextRowId;
-            this.logicalRowCount = logicalRowCount;
-            this.reassignedFileCount = reassignedFileCount;
+        private void retainLatest(
+                List<ManifestFileMeta> manifestMetas, @Nullable String indexManifest) {
+            planningManifestEntries.keySet().retainAll(new HashSet<>(manifestMetas));
+            if (indexManifest == null) {
+                indexManifestEntries.clear();
+            } else {
+                indexManifestEntries.keySet().retainAll(Collections.singleton(indexManifest));
+            }
         }
     }
 
     private static class AssignmentPlan {
-        private final Map<String, List<ManifestFileMeta>> rewrittenManifestMetas;
+        private Snapshot snapshot;
+        private List<ManifestFileMeta> manifestMetas;
+        private final Map<BinaryRow, List<SourcedManifestEntry>> entriesByPartition;
+        private final Map<FileEntry.Identifier, SourcedManifestEntry> plannedFiles;
         private final Map<BinaryRow, RowRangeMappingIndex> rowIdMappings;
-        private final long nextRowId;
-        private final long logicalRowCount;
-        private final long reassignedFileCount;
+        private long firstAssignedRowId;
+        private long nextRowId;
+        private long logicalRowCount;
         private final boolean hasCurrentFiles;
 
         private AssignmentPlan(
-                Map<String, List<ManifestFileMeta>> rewrittenManifestMetas,
-                Map<BinaryRow, RowRangeMappingIndex> rowIdMappings,
-                long nextRowId,
-                long logicalRowCount,
-                long reassignedFileCount,
+                Snapshot snapshot,
+                List<ManifestFileMeta> manifestMetas,
+                Map<BinaryRow, List<SourcedManifestEntry>> entriesByPartition,
                 boolean hasCurrentFiles) {
-            this.rewrittenManifestMetas = rewrittenManifestMetas;
-            this.rowIdMappings = rowIdMappings;
-            this.nextRowId = nextRowId;
-            this.logicalRowCount = logicalRowCount;
-            this.reassignedFileCount = reassignedFileCount;
+            this.snapshot = snapshot;
+            this.manifestMetas = manifestMetas;
+            this.entriesByPartition = new LinkedHashMap<>();
+            this.plannedFiles = new LinkedHashMap<>();
+            this.rowIdMappings = new LinkedHashMap<>();
             this.hasCurrentFiles = hasCurrentFiles;
+            for (List<SourcedManifestEntry> entries : entriesByPartition.values()) {
+                addAll(entries);
+            }
+        }
+
+        private boolean containsPartition(BinaryRow partition) {
+            return entriesByPartition.containsKey(partition);
+        }
+
+        private void addAll(List<SourcedManifestEntry> entries) {
+            for (SourcedManifestEntry entry : entries) {
+                add(entry);
+            }
+        }
+
+        private void add(SourcedManifestEntry entry) {
+            FileEntry.Identifier identifier = entry.entry.identifier();
+            checkState(
+                    !plannedFiles.containsKey(identifier),
+                    "Duplicate planned manifest entry for file %s.",
+                    entry.entry);
+            plannedFiles.put(identifier, entry);
+            entriesByPartition
+                    .computeIfAbsent(entry.entry.partition(), ignored -> new ArrayList<>())
+                    .add(entry);
+        }
+    }
+
+    private static class CommitAssignmentResult {
+        private final boolean success;
+        private final long indexFileCount;
+
+        private CommitAssignmentResult(boolean success, long indexFileCount) {
+            this.success = success;
+            this.indexFileCount = indexFileCount;
         }
     }
 
     private static class CurrentManifest {
-        private final List<ManifestFileMeta> manifestMetas;
         private final List<SourcedManifestEntry> currentEntries;
 
-        private CurrentManifest(
-                List<ManifestFileMeta> manifestMetas, List<SourcedManifestEntry> currentEntries) {
-            this.manifestMetas = manifestMetas;
+        private CurrentManifest(List<SourcedManifestEntry> currentEntries) {
             this.currentEntries = currentEntries;
-        }
-
-        private List<ManifestEntry> entries() {
-            List<ManifestEntry> entries = new ArrayList<>(currentEntries.size());
-            for (SourcedManifestEntry currentEntry : currentEntries) {
-                entries.add(currentEntry.entry);
-            }
-            return entries;
         }
     }
 
     private static class SourcedManifestEntry {
-        private final ManifestFileMeta manifest;
+        @Nullable private ManifestFileMeta manifest;
         private final ManifestEntry entry;
+        @Nullable private Long reassignedFirstRowId;
 
         private SourcedManifestEntry(ManifestFileMeta manifest, ManifestEntry entry) {
             this.manifest = manifest;
@@ -983,28 +1310,28 @@ public class DataEvolutionRowIdReassigner {
         private final ManifestFileMeta manifest;
         private final BinaryRow minPartition;
         private final BinaryRow maxPartition;
+        private final boolean containsNullPartition;
         private final int originalIndex;
 
         private PartitionManifestRange(
                 ManifestFileMeta manifest,
                 BinaryRow minPartition,
                 BinaryRow maxPartition,
+                boolean containsNullPartition,
                 int originalIndex) {
             this.manifest = manifest;
             this.minPartition = minPartition;
             this.maxPartition = maxPartition;
+            this.containsNullPartition = containsNullPartition;
             this.originalIndex = originalIndex;
         }
     }
 
     private static class PartitionAssignment {
-        private final List<ManifestEntry> entries;
         private final RowRangeMappingIndex rowIdMappings;
         private final long nextRowId;
 
-        private PartitionAssignment(
-                List<ManifestEntry> entries, RowRangeMappingIndex rowIdMappings, long nextRowId) {
-            this.entries = entries;
+        private PartitionAssignment(RowRangeMappingIndex rowIdMappings, long nextRowId) {
             this.rowIdMappings = rowIdMappings;
             this.nextRowId = nextRowId;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
@@ -137,6 +137,14 @@ final class RowRangeMappingIndex {
         return Optional.of(new Range(newFrom, newTo));
     }
 
+    boolean overlaps(Range oldRange) {
+        checkArgument(oldRange != null, "Old row range cannot be null.");
+        checkArgument(oldRange.from <= oldRange.to, "Invalid old row range %s.", oldRange);
+
+        int index = lowerBound(oldEnds, oldRange.from);
+        return index < mappings.size() && mappings.get(index).oldStart <= oldRange.to;
+    }
+
     private static int lowerBound(long[] sorted, long target) {
         int left = 0;
         int right = sorted.length;

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
@@ -70,14 +70,6 @@ final class RowRangeMappingIndex {
         return new Mapping(oldStart, oldEnd, newStart);
     }
 
-    List<Range> oldRanges() {
-        List<Range> ranges = new ArrayList<>(mappings.size());
-        for (Mapping mapping : mappings) {
-            ranges.add(new Range(mapping.oldStart, mapping.oldEnd));
-        }
-        return ranges;
-    }
-
     RowRangeMappingIndex shiftNewStarts(long offset) {
         List<Mapping> shifted = new ArrayList<>(mappings.size());
         for (Mapping mapping : mappings) {

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
@@ -90,15 +90,6 @@ final class RowRangeMappingIndex {
         return create(shifted);
     }
 
-    long maxNewEndExclusive() {
-        long result = Long.MIN_VALUE;
-        for (Mapping mapping : mappings) {
-            long count = Math.addExact(Math.subtractExact(mapping.oldEnd, mapping.oldStart), 1L);
-            result = Math.max(result, Math.addExact(mapping.newStart, count));
-        }
-        return result;
-    }
-
     Optional<Range> map(Range oldRange) {
         checkArgument(oldRange != null, "Old row range cannot be null.");
         checkArgument(oldRange.from <= oldRange.to, "Invalid old row range %s.", oldRange);

--- a/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
+++ b/paimon-core/src/main/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndex.java
@@ -70,6 +70,35 @@ final class RowRangeMappingIndex {
         return new Mapping(oldStart, oldEnd, newStart);
     }
 
+    List<Range> oldRanges() {
+        List<Range> ranges = new ArrayList<>(mappings.size());
+        for (Mapping mapping : mappings) {
+            ranges.add(new Range(mapping.oldStart, mapping.oldEnd));
+        }
+        return ranges;
+    }
+
+    RowRangeMappingIndex shiftNewStarts(long offset) {
+        List<Mapping> shifted = new ArrayList<>(mappings.size());
+        for (Mapping mapping : mappings) {
+            shifted.add(
+                    mapping(
+                            mapping.oldStart,
+                            mapping.oldEnd,
+                            Math.addExact(mapping.newStart, offset)));
+        }
+        return create(shifted);
+    }
+
+    long maxNewEndExclusive() {
+        long result = Long.MIN_VALUE;
+        for (Mapping mapping : mappings) {
+            long count = Math.addExact(Math.subtractExact(mapping.oldEnd, mapping.oldStart), 1L);
+            result = Math.max(result, Math.addExact(mapping.newStart, count));
+        }
+        return result;
+    }
+
     Optional<Range> map(Range oldRange) {
         checkArgument(oldRange != null, "Old row range cannot be null.");
         checkArgument(oldRange.from <= oldRange.to, "Invalid old row range %s.", oldRange);

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -66,7 +66,6 @@ import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.SnapshotManager;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -91,8 +90,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
 
     private static final int LARGE_ENTRY_COUNT = 10_000;
     private static final int LARGE_MANIFEST_FILE_COUNT = 20;
-    private static final int ONE_MILLION_ENTRY_COUNT = 1_000_000;
-    private static final int ONE_MILLION_MANIFEST_FILE_COUNT = 200;
     private static final long LARGE_ENTRY_ROW_COUNT = 2L;
     private static final long RANDOM_PARTITION_SEED = 20260519L;
     private static final String LARGE_FILE_PREFIX = "large-partition-";
@@ -1108,13 +1105,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     @Test
     public void testReassignManyOutOfOrderPartitionEntries() throws Exception {
         verifyReassignOutOfOrderPartitionEntries(LARGE_ENTRY_COUNT, LARGE_MANIFEST_FILE_COUNT);
-    }
-
-    @Disabled("Writes one million manifest entries; run manually for large metadata stress tests.")
-    @Test
-    public void testReassignOneMillionOutOfOrderPartitionEntries() throws Exception {
-        verifyReassignOutOfOrderPartitionEntries(
-                ONE_MILLION_ENTRY_COUNT, ONE_MILLION_MANIFEST_FILE_COUNT);
     }
 
     private FileStoreTable createTableWithInterleavedPartitions() throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -726,7 +726,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 new DataEvolutionRowIdReassigner(table).reassign("test-skip-row-id");
 
         assertThat(result.reassigned).isFalse();
-        assertThat(result.skipReason).isEqualTo("partition row IDs are already contiguous");
+        assertThat(result.skipReason).isEqualTo("no partition requires row-id reassignment");
         assertThat(result.previousSnapshotId).isEqualTo(3L);
         assertThat(result.newSnapshotId).isEqualTo(3L);
         assertThat(result.firstAssignedRowId).isEqualTo(5L);

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -226,7 +226,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     }
 
     @Test
-    public void testReassignIncludesConcurrentAppendToPlannedPartition() throws Exception {
+    public void testReassignLeavesDisjointConcurrentAppendOutOfPlan() throws Exception {
         FileStoreTable table = createTableWithInterleavedPartitions();
         Snapshot before = table.snapshotManager().latestSnapshot();
 
@@ -249,16 +249,49 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
         assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
-        assertThat(result.nextRowId).isEqualTo(12L);
-        assertThat(result.fileCount).isEqualTo(6L);
-        assertThat(result.rowCount).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(11L);
+        assertThat(result.fileCount).isEqualTo(5L);
+        assertThat(result.rowCount).isEqualTo(5L);
         assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L, 9L))
-                .containsEntry("pt=b/", Arrays.asList(10L, 11L));
+                .containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L, 8L))
+                .containsEntry("pt=b/", Arrays.asList(9L, 10L));
     }
 
     @Test
-    public void testReassignRetriesAfterConcurrentAppendMergesPlannedManifests() throws Exception {
+    public void testReassignAbortsForPartiallyOverlappingConcurrentAppend() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean appended = new AtomicBoolean();
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionRowIdReassigner(
+                                                table,
+                                                null,
+                                                () -> {
+                                                    if (appended.compareAndSet(false, true)) {
+                                                        try {
+                                                            writePartialPayload(
+                                                                    table,
+                                                                    "a",
+                                                                    4L,
+                                                                    "overlap-4",
+                                                                    "overlap-5");
+                                                        } catch (Exception e) {
+                                                            throw new RuntimeException(e);
+                                                        }
+                                                    }
+                                                })
+                                        .reassign("test-reassign-partially-overlapping-append"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("partially overlaps planned range");
+
+        assertThat(appended).isTrue();
+        assertThat(table.snapshotManager().latestSnapshot().id()).isEqualTo(before.id() + 1);
+    }
+
+    @Test
+    public void testReassignAbortsWhenConcurrentAppendMergesPlannedManifests() throws Exception {
         FileStoreTable originalTable = createTableWithInterleavedPartitions();
         List<String> plannedManifestFiles = dataManifestFileNames(originalTable);
         assertThat(plannedManifestFiles).hasSizeGreaterThan(1);
@@ -267,39 +300,84 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         Snapshot before = table.snapshotManager().latestSnapshot();
 
         AtomicBoolean merged = new AtomicBoolean();
-        DataEvolutionRowIdReassigner.Result result =
-                new DataEvolutionRowIdReassigner(
-                                table,
-                                null,
-                                () -> {
-                                    if (merged.compareAndSet(false, true)) {
-                                        try {
-                                            writeOneRow(table, "c", 100);
-                                            Snapshot appendSnapshot =
-                                                    table.snapshotManager().latestSnapshot();
-                                            assertThat(appendSnapshot.commitKind())
-                                                    .isEqualTo(Snapshot.CommitKind.APPEND);
-                                            assertThat(dataManifestFileNames(table))
-                                                    .doesNotContainAnyElementsOf(
-                                                            plannedManifestFiles);
-                                        } catch (Exception e) {
-                                            throw new RuntimeException(e);
-                                        }
-                                    }
-                                })
-                        .reassign("test-reassign-append-manifest-merge");
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionRowIdReassigner(
+                                                table,
+                                                null,
+                                                () -> {
+                                                    if (merged.compareAndSet(false, true)) {
+                                                        try {
+                                                            writeOneRow(table, "c", 100);
+                                                            Snapshot appendSnapshot =
+                                                                    table.snapshotManager()
+                                                                            .latestSnapshot();
+                                                            assertThat(appendSnapshot.commitKind())
+                                                                    .isEqualTo(
+                                                                            Snapshot.CommitKind
+                                                                                    .APPEND);
+                                                            assertThat(dataManifestFileNames(table))
+                                                                    .doesNotContainAnyElementsOf(
+                                                                            plannedManifestFiles);
+                                                        } catch (Exception e) {
+                                                            throw new RuntimeException(e);
+                                                        }
+                                                    }
+                                                })
+                                        .reassign("test-reassign-append-manifest-merge"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("planned manifest")
+                .hasMessageContaining("no longer exists");
 
         assertThat(merged).isTrue();
-        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
-        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
-        assertThat(result.firstAssignedRowId).isEqualTo(6L);
-        assertThat(result.nextRowId).isEqualTo(11L);
-        assertThat(result.fileCount).isEqualTo(5L);
-        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(table.snapshotManager().latestSnapshot().id()).isEqualTo(before.id() + 1);
         assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L))
-                .containsEntry("pt=b/", Arrays.asList(9L, 10L))
+                .containsEntry("pt=a/", Arrays.asList(0L, 2L, 4L))
+                .containsEntry("pt=b/", Arrays.asList(1L, 3L))
                 .containsEntry("pt=c/", Collections.singletonList(5L));
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|v0", "100|c|v100", "1|b|v1", "2|a|v2", "3|b|v3", "4|a|v4");
+    }
+
+    @Test
+    public void testReassignKeepsHistoricalAddDeleteEntriesConsistent() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        FileEntry.Identifier compactedFile = compactOneFile(table, "pt=a/");
+        long oldFirstRowId = assertAddDeleteEntriesConsistent(table, compactedFile);
+
+        new DataEvolutionRowIdReassigner(table)
+                .reassign("test-reassign-historical-add-delete-without-retry");
+
+        assertThat(assertAddDeleteEntriesConsistent(table, compactedFile))
+                .isNotEqualTo(oldFirstRowId);
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|v0", "1|b|v1", "2|a|v2", "3|b|v3", "4|a|v4");
+    }
+
+    @Test
+    public void testReassignKeepsHistoricalAddDeleteEntriesConsistentAfterRetry() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        FileEntry.Identifier compactedFile = compactOneFile(table, "pt=a/");
+        long oldFirstRowId = assertAddDeleteEntriesConsistent(table, compactedFile);
+
+        AtomicBoolean appended = new AtomicBoolean();
+        new DataEvolutionRowIdReassigner(
+                        table,
+                        null,
+                        () -> {
+                            if (appended.compareAndSet(false, true)) {
+                                try {
+                                    writeOneRow(table, "c", 100);
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        })
+                .reassign("test-reassign-historical-add-delete");
+
+        assertThat(appended).isTrue();
+        assertThat(assertAddDeleteEntriesConsistent(table, compactedFile))
+                .isNotEqualTo(oldFirstRowId);
         assertThat(readTableRows(table))
                 .containsExactly("0|a|v0", "100|c|v100", "1|b|v1", "2|a|v2", "3|b|v3", "4|a|v4");
     }
@@ -311,8 +389,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         writeRows(originalTable, "a", 0, 1);
         writeOneRow(originalTable, "b", 2);
         writeRows(originalTable, "a", 3, 4);
-        List<String> plannedManifestFiles = dataManifestFileNames(originalTable);
-        FileStoreTable table = withManifestMergeOnNextAppend(originalTable);
+        FileStoreTable table = originalTable;
         Snapshot before = table.snapshotManager().latestSnapshot();
 
         AtomicBoolean appended = new AtomicBoolean();
@@ -343,9 +420,6 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                                                                     .latestSnapshot()
                                                                     .nextRowId())
                                                     .isEqualTo(5L);
-                                            assertThat(dataManifestFileNames(table))
-                                                    .doesNotContainAnyElementsOf(
-                                                            plannedManifestFiles);
                                         } catch (Exception e) {
                                             throw new RuntimeException(e);
                                         }
@@ -396,12 +470,12 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 3);
         assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
         assertThat(result.firstAssignedRowId).isEqualTo(8L);
-        assertThat(result.nextRowId).isEqualTo(14L);
-        assertThat(result.fileCount).isEqualTo(6L);
-        assertThat(result.rowCount).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(13L);
+        assertThat(result.fileCount).isEqualTo(5L);
+        assertThat(result.rowCount).isEqualTo(5L);
         assertThat(rowIdsByPartition(table))
-                .containsEntry("pt=a/", Arrays.asList(8L, 9L, 10L, 11L))
-                .containsEntry("pt=b/", Arrays.asList(12L, 13L))
+                .containsEntry("pt=a/", Arrays.asList(7L, 8L, 9L, 10L))
+                .containsEntry("pt=b/", Arrays.asList(11L, 12L))
                 .containsEntry("pt=c/", Collections.singletonList(5L))
                 .containsEntry("pt=d/", Collections.singletonList(6L));
     }
@@ -440,8 +514,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     }
 
     @Test
-    public void testReassignIncludesNewlyNonContiguousPartitionAfterConcurrentAppend()
-            throws Exception {
+    public void testReassignDoesNotExpandPlanForNewlyNonContiguousPartition() throws Exception {
         FileStoreTable table = createTableWithPartiallyOverlappedPartitions();
         Snapshot before = table.snapshotManager().latestSnapshot();
 
@@ -464,13 +537,13 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
         assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
         assertThat(result.firstAssignedRowId).isEqualTo(6L);
-        assertThat(result.nextRowId).isEqualTo(11L);
-        assertThat(result.fileCount).isEqualTo(4L);
-        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(result.nextRowId).isEqualTo(8L);
+        assertThat(result.fileCount).isEqualTo(2L);
+        assertThat(result.rowCount).isEqualTo(2L);
         assertThat(expandedRowIdsByPartition(table))
                 .containsEntry("pt=a/", Arrays.asList(6L, 7L))
                 .containsEntry("pt=b/", Collections.singletonList(3L))
-                .containsEntry("pt=c/", Arrays.asList(8L, 9L, 10L));
+                .containsEntry("pt=c/", Arrays.asList(0L, 1L, 5L));
     }
 
     @Test
@@ -1517,6 +1590,71 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.compactManifests();
         }
+    }
+
+    private FileEntry.Identifier compactOneFile(FileStoreTable table, String partitionPath)
+            throws Exception {
+        ManifestEntry compactBefore =
+                currentEntries(table).stream()
+                        .filter(
+                                entry ->
+                                        table.store()
+                                                .pathFactory()
+                                                .getPartitionString(entry.partition())
+                                                .equals(partitionPath))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Cannot find file in partition " + partitionPath));
+        DataEvolutionCompactTask task =
+                new DataEvolutionCompactTask(
+                        compactBefore.partition(),
+                        Collections.singletonList(compactBefore.file()),
+                        false);
+        CommitMessage message = task.doCompact(table, "test-compact-before-reassign");
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(Collections.singletonList(message));
+        }
+        return compactBefore.identifier();
+    }
+
+    private long assertAddDeleteEntriesConsistent(
+            FileStoreTable table, FileEntry.Identifier identifier) {
+        ManifestFile manifestFile = table.store().manifestFileFactory().create();
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        List<ManifestEntry> matchingEntries = new ArrayList<>();
+        Set<String> matchingManifestFiles = new HashSet<>();
+        for (ManifestFileMeta manifestMeta : manifestList.readDataManifests(latest)) {
+            for (ManifestEntry entry :
+                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize())) {
+                if (entry.identifier().equals(identifier)) {
+                    matchingEntries.add(entry);
+                    matchingManifestFiles.add(manifestMeta.fileName());
+                }
+            }
+        }
+
+        assertThat(matchingEntries).hasSize(2);
+        assertThat(matchingManifestFiles).hasSize(2);
+        ManifestEntry add =
+                matchingEntries.stream()
+                        .filter(entry -> entry.kind() == FileKind.ADD)
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new AssertionError("Missing ADD entry for " + identifier));
+        ManifestEntry delete =
+                matchingEntries.stream()
+                        .filter(entry -> entry.kind() == FileKind.DELETE)
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new AssertionError("Missing DELETE entry for " + identifier));
+        assertThat(delete.partition()).isEqualTo(add.partition());
+        assertThat(delete.bucket()).isEqualTo(add.bucket());
+        assertThat(delete.totalBuckets()).isEqualTo(add.totalBuckets());
+        assertThat(delete.file()).isEqualTo(add.file());
+        return add.file().nonNullFirstRowId();
     }
 
     private void updateStatistics(FileStoreTable table) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -26,11 +26,15 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.globalindex.btree.BTreeIndexOptions;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexBuilder;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataFilePathFactory;
+import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.FileEntry;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.FileSource;
@@ -1648,12 +1652,24 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                                 () ->
                                         new IllegalStateException(
                                                 "Cannot find file in partition " + partitionPath));
-        DataEvolutionCompactTask task =
-                new DataEvolutionCompactTask(
+        DataFilePathFactory pathFactory =
+                table.store()
+                        .pathFactory()
+                        .createDataFilePathFactory(
+                                compactBefore.partition(), compactBefore.bucket());
+        Path compactAfterPath = pathFactory.newPath();
+        table.fileIO().copyFile(pathFactory.toPath(compactBefore.file()), compactAfterPath, false);
+        DataFileMeta compactAfter = compactBefore.file().rename(compactAfterPath.getName());
+        CommitMessage message =
+                new CommitMessageImpl(
                         compactBefore.partition(),
-                        Collections.singletonList(compactBefore.file()),
-                        false);
-        CommitMessage message = task.doCompact(table, "test-compact-before-reassign");
+                        compactBefore.bucket(),
+                        compactBefore.totalBuckets(),
+                        DataIncrement.emptyIncrement(),
+                        new CompactIncrement(
+                                Collections.singletonList(compactBefore.file()),
+                                Collections.singletonList(compactAfter),
+                                Collections.emptyList()));
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(Collections.singletonList(message));
         }

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -134,6 +135,43 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(rowIdsByPartition).containsEntry("pt=a/", Arrays.asList(5L, 6L, 7L));
         assertThat(rowIdsByPartition).containsEntry("pt=b/", Arrays.asList(8L, 9L));
         assertThat(table.snapshotManager().latestSnapshot().nextRowId()).isEqualTo(10L);
+    }
+
+    @Test
+    public void testReassignRetriesWithLatestNextRowIdAfterConcurrentAppend() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+        assertThat(before.nextRowId()).isEqualTo(5L);
+
+        AtomicBoolean appended = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (appended.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "c", 100);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-conflict-retry");
+
+        assertThat(appended).isTrue();
+        assertThat(result.reassigned).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(11L);
+        assertThat(result.fileCount).isEqualTo(5L);
+        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L))
+                .containsEntry("pt=b/", Arrays.asList(9L, 10L))
+                .containsEntry("pt=c/", Collections.singletonList(5L));
+        assertThat(table.snapshotManager().latestSnapshot().nextRowId()).isEqualTo(11L);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -53,9 +53,11 @@ import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
+import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.SnapshotManager;
@@ -253,6 +255,116 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         assertThat(rowIdsByPartition(table))
                 .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L, 9L))
                 .containsEntry("pt=b/", Arrays.asList(10L, 11L));
+    }
+
+    @Test
+    public void testReassignRetriesAfterConcurrentAppendMergesPlannedManifests() throws Exception {
+        FileStoreTable originalTable = createTableWithInterleavedPartitions();
+        List<String> plannedManifestFiles = dataManifestFileNames(originalTable);
+        assertThat(plannedManifestFiles).hasSizeGreaterThan(1);
+
+        FileStoreTable table = withManifestMergeOnNextAppend(originalTable);
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean merged = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (merged.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "c", 100);
+                                            Snapshot appendSnapshot =
+                                                    table.snapshotManager().latestSnapshot();
+                                            assertThat(appendSnapshot.commitKind())
+                                                    .isEqualTo(Snapshot.CommitKind.APPEND);
+                                            assertThat(dataManifestFileNames(table))
+                                                    .doesNotContainAnyElementsOf(
+                                                            plannedManifestFiles);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-append-manifest-merge");
+
+        assertThat(merged).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(11L);
+        assertThat(result.fileCount).isEqualTo(5L);
+        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L))
+                .containsEntry("pt=b/", Arrays.asList(9L, 10L))
+                .containsEntry("pt=c/", Collections.singletonList(5L));
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|v0", "100|c|v100", "1|b|v1", "2|a|v2", "3|b|v3", "4|a|v4");
+    }
+
+    @Test
+    public void testReassignRetriesAfterConcurrentPartialColumnAppend() throws Exception {
+        createTableDefault();
+        FileStoreTable originalTable = getTableDefault();
+        writeRows(originalTable, "a", 0, 1);
+        writeOneRow(originalTable, "b", 2);
+        writeRows(originalTable, "a", 3, 4);
+        List<String> plannedManifestFiles = dataManifestFileNames(originalTable);
+        FileStoreTable table = withManifestMergeOnNextAppend(originalTable);
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean appended = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (appended.compareAndSet(false, true)) {
+                                        try {
+                                            writePartialPayload(
+                                                    table, "a", 0L, "updated-0", "updated-1");
+                                            List<ManifestEntry> sharedRangeEntries =
+                                                    currentEntriesAtRange(table, "pt=a/", 0L, 1L);
+                                            assertThat(sharedRangeEntries).hasSize(2);
+                                            assertThat(
+                                                            sharedRangeEntries
+                                                                    .get(0)
+                                                                    .file()
+                                                                    .maxSequenceNumber())
+                                                    .isNotEqualTo(
+                                                            sharedRangeEntries
+                                                                    .get(1)
+                                                                    .file()
+                                                                    .maxSequenceNumber());
+                                            assertThat(
+                                                            table.snapshotManager()
+                                                                    .latestSnapshot()
+                                                                    .nextRowId())
+                                                    .isEqualTo(5L);
+                                            assertThat(dataManifestFileNames(table))
+                                                    .doesNotContainAnyElementsOf(
+                                                            plannedManifestFiles);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-partial-column-append");
+
+        assertThat(appended).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(5L);
+        assertThat(result.nextRowId).isEqualTo(9L);
+        assertThat(result.fileCount).isEqualTo(3L);
+        assertThat(result.rowCount).isEqualTo(4L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(5L, 5L, 7L))
+                .containsEntry("pt=b/", Collections.singletonList(2L));
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|updated-0", "1|a|updated-1", "2|b|v2", "3|a|v3", "4|a|v4");
     }
 
     @Test
@@ -1325,6 +1437,46 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         }
     }
 
+    private void writePartialPayload(
+            FileStoreTable table, String partition, long firstRowId, String... payloads)
+            throws Exception {
+        RowType writeType = table.rowType().project(Arrays.asList("pt", "payload"));
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite().withWriteType(writeType);
+                BatchTableCommit commit = builder.newCommit()) {
+            for (String payload : payloads) {
+                write.write(
+                        GenericRow.of(
+                                BinaryString.fromString(partition),
+                                BinaryString.fromString(payload)));
+            }
+            List<CommitMessage> messages = write.prepareCommit();
+            assignFirstRowId(messages, firstRowId);
+            commit.commit(messages);
+        }
+    }
+
+    private FileStoreTable withManifestMergeOnNextAppend(FileStoreTable table) {
+        Map<String, String> mergeOptions = new HashMap<>();
+        mergeOptions.put(CoreOptions.MANIFEST_TARGET_FILE_SIZE.key(), "1GB");
+        mergeOptions.put(CoreOptions.MANIFEST_MERGE_MIN_COUNT.key(), "2");
+        mergeOptions.put(CoreOptions.MANIFEST_FULL_COMPACTION_FILE_SIZE.key(), "1GB");
+        mergeOptions.put(CoreOptions.MANIFEST_SORT_ENABLED.key(), "false");
+        return table.copy(mergeOptions);
+    }
+
+    private void assignFirstRowId(List<CommitMessage> messages, long firstRowId) {
+        for (CommitMessage message : messages) {
+            CommitMessageImpl commitMessage = (CommitMessageImpl) message;
+            List<DataFileMeta> files =
+                    new ArrayList<>(commitMessage.newFilesIncrement().newFiles());
+            commitMessage.newFilesIncrement().newFiles().clear();
+            for (DataFileMeta file : files) {
+                commitMessage.newFilesIncrement().newFiles().add(file.assignFirstRowId(firstRowId));
+            }
+        }
+    }
+
     private void writeRowsInPartitions(
             FileStoreTable table,
             String firstPartition,
@@ -1404,6 +1556,21 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 .withSnapshot(table.snapshotManager().latestSnapshot())
                 .plan()
                 .files();
+    }
+
+    private List<ManifestEntry> currentEntriesAtRange(
+            FileStoreTable table, String partitionPath, long firstRowId, long lastRowId) {
+        List<ManifestEntry> result = new ArrayList<>();
+        for (ManifestEntry entry : currentEntries(table)) {
+            String partition = table.store().pathFactory().getPartitionString(entry.partition());
+            Range range = entry.file().nonNullRowIdRange();
+            if (partitionPath.equals(partition)
+                    && range.from == firstRowId
+                    && range.to == lastRowId) {
+                result.add(entry);
+            }
+        }
+        return result;
     }
 
     private Map<String, Long> rowCountsByPartition(FileStoreTable table) {

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -887,6 +887,47 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     }
 
     @Test
+    public void testReassignKeepsConcurrentDisjointGlobalIndexRange() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        createBTreeIndex(table);
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean indexed = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (indexed.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "a", 100);
+                                            appendGlobalIndexRange(table, "pt=a/", new Range(5, 5));
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-disjoint-global-index");
+
+        assertThat(indexed).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(11L);
+        assertThat(result.indexFileCount).isEqualTo(5L);
+        assertThat(globalIndexRanges(table))
+                .containsExactly(
+                        new Range(5, 5),
+                        new Range(6, 6),
+                        new Range(7, 7),
+                        new Range(8, 8),
+                        new Range(9, 9),
+                        new Range(10, 10));
+        assertThat(readTableRows(table))
+                .containsExactly("0|a|v0", "100|a|v100", "1|b|v1", "2|a|v2", "3|b|v3", "4|a|v4");
+    }
+
+    @Test
     public void testDropUnsafeGlobalIndexEntryWhenRangeCannotBeRewrittenByMetadataOnly()
             throws Exception {
         FileStoreTable table = createTableWithInterleavedPartitions();
@@ -1928,6 +1969,52 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         }
 
         String staleIndexManifest = indexManifestFile.writeWithoutRolling(rewritten);
+        replaceLatestSnapshotIndexManifest(table, latest, staleIndexManifest);
+    }
+
+    private void appendGlobalIndexRange(FileStoreTable table, String partition, Range rowRange)
+            throws Exception {
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        IndexManifestFile indexManifestFile = table.store().indexManifestFileFactory().create();
+        List<IndexManifestEntry> entries = indexManifestFile.read(latest.indexManifest());
+        IndexManifestEntry template = null;
+        for (IndexManifestEntry entry : entries) {
+            if (table.store()
+                    .pathFactory()
+                    .getPartitionString(entry.partition())
+                    .equals(partition)) {
+                template = entry;
+                break;
+            }
+        }
+        assertThat(template).isNotNull();
+        IndexFileMeta indexFile = template.indexFile();
+        GlobalIndexMeta globalIndex = indexFile.globalIndexMeta();
+        assertThat(globalIndex).isNotNull();
+        entries.add(
+                new IndexManifestEntry(
+                        template.kind(),
+                        template.partition(),
+                        template.bucket(),
+                        new IndexFileMeta(
+                                indexFile.indexType(),
+                                indexFile.fileName(),
+                                indexFile.fileSize(),
+                                indexFile.rowCount(),
+                                indexFile.dvRanges(),
+                                indexFile.externalPath(),
+                                new GlobalIndexMeta(
+                                        rowRange.from,
+                                        rowRange.to,
+                                        globalIndex.indexFieldId(),
+                                        globalIndex.extraFieldIds(),
+                                        globalIndex.indexMeta()))));
+        replaceLatestSnapshotIndexManifest(
+                table, latest, indexManifestFile.writeWithoutRolling(entries));
+    }
+
+    private void replaceLatestSnapshotIndexManifest(
+            FileStoreTable table, Snapshot latest, String indexManifest) throws Exception {
         Snapshot staleSnapshot =
                 new Snapshot(
                         latest.version(),
@@ -1939,7 +2026,7 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                         latest.deltaManifestListSize(),
                         latest.changelogManifestList(),
                         latest.changelogManifestListSize(),
-                        staleIndexManifest,
+                        indexManifest,
                         latest.commitUser(),
                         latest.commitIdentifier(),
                         latest.commitKind(),

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/DataEvolutionRowIdReassignerTest.java
@@ -46,6 +46,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.sink.BatchTableCommit;
@@ -65,6 +66,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -73,8 +75,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DataEvolutionRowIdReassigner}. */
 public class DataEvolutionRowIdReassignerTest extends TableTestBase {
@@ -88,6 +92,10 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     private static final String LARGE_FILE_PREFIX = "large-partition-";
     private static final String LARGE_FILE_SUFFIX = ".parquet";
     private static final int LARGE_PARTITION_ID_WIDTH = 7;
+    private static final String[] DATA_INTEGRITY_PARTITIONS = {"a", "b", "c", "d"};
+    private static final int DATA_INTEGRITY_FILES_PER_PARTITION = 6;
+    private static final long SCRAMBLED_ROW_ID_GAP = 100_000_000L;
+    private static final long SCRAMBLED_ROW_ID_SEED = 20260710L;
 
     @Override
     protected Schema schemaDefault() {
@@ -138,10 +146,50 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     }
 
     @Test
+    public void testReassignNullPartitionAcrossManifestGroups() throws Exception {
+        createTableDefault();
+        FileStoreTable table =
+                getTableDefault()
+                        .copy(
+                                Collections.singletonMap(
+                                        CoreOptions.ROW_TRACKING_PARTITION_GROUP_ON_COMMIT.key(),
+                                        "false"));
+        writeRowsInPartitions(table, null, 0, "a", 1);
+        writeOneRow(table, "z", 2);
+        writeOneRow(table, null, 3);
+
+        BinaryRow nullPartition =
+                new InternalRowSerializer(table.schema().logicalPartitionType())
+                        .toBinaryRow(GenericRow.of((Object) null));
+        String nullPartitionPath = table.store().pathFactory().getPartitionString(nullPartition);
+        Map<String, List<Long>> beforeRowIds = rowIdsByPartition(table);
+        assertThat(beforeRowIds)
+                .containsEntry(nullPartitionPath, Arrays.asList(1L, 3L))
+                .containsEntry("pt=a/", Collections.singletonList(0L))
+                .containsEntry("pt=z/", Collections.singletonList(2L));
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(table)
+                        .reassign("test-reassign-null-partition-row-id");
+
+        assertThat(result.firstAssignedRowId).isEqualTo(4L);
+        assertThat(result.nextRowId).isEqualTo(6L);
+        assertThat(result.fileCount).isEqualTo(2L);
+        assertThat(result.rowCount).isEqualTo(2L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry(nullPartitionPath, Arrays.asList(4L, 5L))
+                .containsEntry("pt=a/", Collections.singletonList(0L))
+                .containsEntry("pt=z/", Collections.singletonList(2L));
+    }
+
+    @Test
     public void testReassignRetriesWithLatestNextRowIdAfterConcurrentAppend() throws Exception {
         FileStoreTable table = createTableWithInterleavedPartitions();
         Snapshot before = table.snapshotManager().latestSnapshot();
+        Map<String, SimpleStats> valueStatsBefore = valueStatsByFile(table);
         assertThat(before.nextRowId()).isEqualTo(5L);
+        assertThat(valueStatsBefore.values())
+                .allSatisfy(stats -> assertThat(stats).isNotEqualTo(SimpleStats.EMPTY_STATS));
 
         AtomicBoolean appended = new AtomicBoolean();
         DataEvolutionRowIdReassigner.Result result =
@@ -171,7 +219,234 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L))
                 .containsEntry("pt=b/", Arrays.asList(9L, 10L))
                 .containsEntry("pt=c/", Collections.singletonList(5L));
+        assertThat(valueStatsByFile(table)).containsAllEntriesOf(valueStatsBefore);
         assertThat(table.snapshotManager().latestSnapshot().nextRowId()).isEqualTo(11L);
+    }
+
+    @Test
+    public void testReassignIncludesConcurrentAppendToPlannedPartition() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean appended = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (appended.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "a", 100);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-append-planned-partition");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(12L);
+        assertThat(result.fileCount).isEqualTo(6L);
+        assertThat(result.rowCount).isEqualTo(6L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L, 9L))
+                .containsEntry("pt=b/", Arrays.asList(10L, 11L));
+    }
+
+    @Test
+    public void testReassignAdvancesAcrossRepeatedAppendConflicts() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicInteger beforeCommits = new AtomicInteger();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    try {
+                                        int attempt = beforeCommits.getAndIncrement();
+                                        if (attempt == 0) {
+                                            writeOneRow(table, "c", 100);
+                                            writeOneRow(table, "d", 101);
+                                        } else if (attempt == 1) {
+                                            writeOneRow(table, "a", 102);
+                                        }
+                                    } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .reassign("test-reassign-multiple-append-conflicts");
+
+        assertThat(beforeCommits).hasValue(3);
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 3);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 4);
+        assertThat(result.firstAssignedRowId).isEqualTo(8L);
+        assertThat(result.nextRowId).isEqualTo(14L);
+        assertThat(result.fileCount).isEqualTo(6L);
+        assertThat(result.rowCount).isEqualTo(6L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(8L, 9L, 10L, 11L))
+                .containsEntry("pt=b/", Arrays.asList(12L, 13L))
+                .containsEntry("pt=c/", Collections.singletonList(5L))
+                .containsEntry("pt=d/", Collections.singletonList(6L));
+    }
+
+    @Test
+    public void testReassignPartitionFilterAfterConcurrentAppendOutsideFilter() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean appended = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                partitionPredicate(table, "a"),
+                                () -> {
+                                    if (appended.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "c", 100);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-filter-after-append-conflict");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(9L);
+        assertThat(result.fileCount).isEqualTo(3L);
+        assertThat(result.rowCount).isEqualTo(3L);
+        assertThat(rowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L, 8L))
+                .containsEntry("pt=b/", Arrays.asList(1L, 3L))
+                .containsEntry("pt=c/", Collections.singletonList(5L));
+    }
+
+    @Test
+    public void testReassignIncludesNewlyNonContiguousPartitionAfterConcurrentAppend()
+            throws Exception {
+        FileStoreTable table = createTableWithPartiallyOverlappedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean appended = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (appended.compareAndSet(false, true)) {
+                                        try {
+                                            writeOneRow(table, "c", 100);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-append-new-partition");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(6L);
+        assertThat(result.nextRowId).isEqualTo(11L);
+        assertThat(result.fileCount).isEqualTo(4L);
+        assertThat(result.rowCount).isEqualTo(5L);
+        assertThat(expandedRowIdsByPartition(table))
+                .containsEntry("pt=a/", Arrays.asList(6L, 7L))
+                .containsEntry("pt=b/", Collections.singletonList(3L))
+                .containsEntry("pt=c/", Arrays.asList(8L, 9L, 10L));
+    }
+
+    @Test
+    public void testReassignAbortsAfterConcurrentOverwrite() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean overwritten = new AtomicBoolean();
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionRowIdReassigner(
+                                                table,
+                                                null,
+                                                () -> {
+                                                    if (overwritten.compareAndSet(false, true)) {
+                                                        try {
+                                                            overwriteOneRow(table, "c", 100);
+                                                        } catch (Exception e) {
+                                                            throw new RuntimeException(e);
+                                                        }
+                                                    }
+                                                })
+                                        .reassign("test-reassign-overwrite-conflict"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("OVERWRITE snapshot");
+
+        assertThat(table.snapshotManager().latestSnapshot().id()).isEqualTo(before.id() + 1);
+        assertThat(table.snapshotManager().latestSnapshot().commitKind())
+                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
+    }
+
+    @Test
+    public void testReassignAbortsAfterConcurrentManifestCompaction() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean compacted = new AtomicBoolean();
+        assertThatThrownBy(
+                        () ->
+                                new DataEvolutionRowIdReassigner(
+                                                table,
+                                                null,
+                                                () -> {
+                                                    if (compacted.compareAndSet(false, true)) {
+                                                        try {
+                                                            compactManifests(table);
+                                                        } catch (Exception e) {
+                                                            throw new RuntimeException(e);
+                                                        }
+                                                    }
+                                                })
+                                        .reassign("test-reassign-compact-conflict"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("COMPACT snapshot");
+
+        assertThat(table.snapshotManager().latestSnapshot().id()).isEqualTo(before.id() + 1);
+        assertThat(table.snapshotManager().latestSnapshot().commitKind())
+                .isEqualTo(Snapshot.CommitKind.COMPACT);
+    }
+
+    @Test
+    public void testReassignContinuesAfterConcurrentAnalyze() throws Exception {
+        FileStoreTable table = createTableWithInterleavedPartitions();
+        Snapshot before = table.snapshotManager().latestSnapshot();
+
+        AtomicBoolean analyzed = new AtomicBoolean();
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table,
+                                null,
+                                () -> {
+                                    if (analyzed.compareAndSet(false, true)) {
+                                        try {
+                                            updateStatistics(table);
+                                        } catch (Exception e) {
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                })
+                        .reassign("test-reassign-analyze-conflict");
+
+        assertThat(result.previousSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 2);
+        assertThat(result.firstAssignedRowId).isEqualTo(5L);
+        assertThat(result.nextRowId).isEqualTo(10L);
+        assertThat(table.snapshotManager().latestSnapshot().statistics()).isNotNull();
+        assertThat(table.snapshotManager().latestSnapshot().commitKind())
+                .isEqualTo(Snapshot.CommitKind.OVERWRITE);
     }
 
     @Test
@@ -468,6 +743,139 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
     }
 
     @Test
+    public void testFullReassignPreservesDataInTableWithLargeRowIdGaps() throws Exception {
+        FileStoreTable table = createDataIntegrityTable();
+        long scrambledNextRowId = scrambleCurrentRowIds(table);
+        createBTreeIndex(table);
+
+        Snapshot before = table.snapshotManager().latestSnapshot();
+        List<String> expectedRows = readTableRows(table);
+        Map<String, List<Object>> expectedFileMetadata = fileMetadataWithoutRowId(table);
+        Map<String, SimpleStats> expectedValueStats = valueStatsByFile(table);
+        Map<String, Long> rowCountsByPartition = rowCountsByPartition(table);
+        Map<String, List<Long>> scrambledRowIds = rowIdsByPartition(table);
+        int expectedFileCount = expectedFileMetadata.size();
+        int expectedIndexFileCount = globalIndexRanges(table).size();
+
+        assertThat(before.nextRowId()).isEqualTo(scrambledNextRowId);
+        assertThat(before.totalRecordCount()).isEqualTo(expectedRows.size());
+        assertThat(expectedFileCount)
+                .isEqualTo(DATA_INTEGRITY_PARTITIONS.length * DATA_INTEGRITY_FILES_PER_PARTITION);
+        assertThat(expectedIndexFileCount).isGreaterThan(0);
+        assertPartitionsHaveLargeRowIdGaps(scrambledRowIds);
+        assertTableDataQueryable(table, expectedRows);
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(table)
+                        .reassign("test-full-reassign-data-integrity");
+
+        assertThat(result.reassigned).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id());
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.firstAssignedRowId).isEqualTo(scrambledNextRowId);
+        assertThat(result.fileCount).isEqualTo(expectedFileCount);
+        assertThat(result.rowCount).isEqualTo(expectedRows.size());
+        assertThat(result.indexFileCount).isEqualTo(expectedIndexFileCount);
+
+        long expectedNextRowId =
+                assertContiguousRowIds(
+                        expandedRowIdsByPartition(table),
+                        rowCountsByPartition,
+                        Arrays.asList(DATA_INTEGRITY_PARTITIONS),
+                        scrambledNextRowId);
+        assertThat(result.nextRowId).isEqualTo(expectedNextRowId);
+        assertThat(table.snapshotManager().latestSnapshot().nextRowId())
+                .isEqualTo(expectedNextRowId);
+        assertThat(table.snapshotManager().latestSnapshot().totalRecordCount())
+                .isEqualTo(before.totalRecordCount());
+        assertThat(fileMetadataWithoutRowId(table)).isEqualTo(expectedFileMetadata);
+        assertThat(valueStatsByFile(table)).isEqualTo(expectedValueStats);
+        List<Range> reassignedIndexRanges = globalIndexRanges(table);
+        assertThat(reassignedIndexRanges).hasSize(expectedIndexFileCount);
+        for (Range range : reassignedIndexRanges) {
+            assertThat(range.from).isGreaterThanOrEqualTo(scrambledNextRowId);
+            assertThat(range.to).isLessThan(expectedNextRowId);
+        }
+        assertTableDataQueryable(table, expectedRows);
+    }
+
+    @Test
+    public void testPartitionReassignPreservesDataAndOtherPartitionRowIds() throws Exception {
+        FileStoreTable table = createDataIntegrityTable();
+        long scrambledNextRowId = scrambleCurrentRowIds(table);
+        createBTreeIndex(table);
+
+        Snapshot before = table.snapshotManager().latestSnapshot();
+        List<String> expectedRows = readTableRows(table);
+        Map<String, List<Object>> expectedFileMetadata = fileMetadataWithoutRowId(table);
+        Map<String, SimpleStats> expectedValueStats = valueStatsByFile(table);
+        Map<String, Long> rowCountsByPartition = rowCountsByPartition(table);
+        Map<String, List<Long>> beforeFirstRowIds = rowIdsByPartition(table);
+        Map<String, List<Long>> beforeExpandedRowIds = expandedRowIdsByPartition(table);
+        Map<String, List<Range>> beforeIndexRanges = globalIndexRangesByPartition(table);
+        String reassignedPartition = "c";
+        String reassignedPartitionPath = "pt=" + reassignedPartition + "/";
+
+        assertThat(before.nextRowId()).isEqualTo(scrambledNextRowId);
+        assertThat(before.totalRecordCount()).isEqualTo(expectedRows.size());
+        assertPartitionsHaveLargeRowIdGaps(beforeFirstRowIds);
+        assertTableDataQueryable(table, expectedRows);
+
+        DataEvolutionRowIdReassigner.Result result =
+                new DataEvolutionRowIdReassigner(
+                                table, partitionPredicate(table, reassignedPartition))
+                        .reassign("test-partition-reassign-data-integrity");
+
+        long reassignedRowCount = rowCountsByPartition.get(reassignedPartitionPath);
+        long expectedNextRowId = scrambledNextRowId + reassignedRowCount;
+        assertThat(result.reassigned).isTrue();
+        assertThat(result.previousSnapshotId).isEqualTo(before.id());
+        assertThat(result.newSnapshotId).isEqualTo(before.id() + 1);
+        assertThat(result.firstAssignedRowId).isEqualTo(scrambledNextRowId);
+        assertThat(result.nextRowId).isEqualTo(expectedNextRowId);
+        assertThat(result.fileCount).isEqualTo(DATA_INTEGRITY_FILES_PER_PARTITION);
+        assertThat(result.rowCount).isEqualTo(reassignedRowCount);
+        assertThat(result.indexFileCount)
+                .isEqualTo(beforeIndexRanges.get(reassignedPartitionPath).size());
+
+        Map<String, List<Long>> afterFirstRowIds = rowIdsByPartition(table);
+        Map<String, List<Long>> afterExpandedRowIds = expandedRowIdsByPartition(table);
+        Map<String, List<Range>> afterIndexRanges = globalIndexRangesByPartition(table);
+        assertContiguousRowIds(
+                afterExpandedRowIds,
+                rowCountsByPartition,
+                Collections.singletonList(reassignedPartition),
+                scrambledNextRowId);
+        assertThat(afterFirstRowIds.get(reassignedPartitionPath))
+                .isNotEqualTo(beforeFirstRowIds.get(reassignedPartitionPath));
+        for (String partition : DATA_INTEGRITY_PARTITIONS) {
+            String partitionPath = "pt=" + partition + "/";
+            if (!partition.equals(reassignedPartition)) {
+                assertThat(afterFirstRowIds.get(partitionPath))
+                        .isEqualTo(beforeFirstRowIds.get(partitionPath));
+                assertThat(afterExpandedRowIds.get(partitionPath))
+                        .isEqualTo(beforeExpandedRowIds.get(partitionPath));
+                assertThat(afterIndexRanges.get(partitionPath))
+                        .isEqualTo(beforeIndexRanges.get(partitionPath));
+            }
+        }
+        assertThat(afterIndexRanges.get(reassignedPartitionPath))
+                .hasSameSizeAs(beforeIndexRanges.get(reassignedPartitionPath));
+        for (Range range : afterIndexRanges.get(reassignedPartitionPath)) {
+            assertThat(range.from).isGreaterThanOrEqualTo(scrambledNextRowId);
+            assertThat(range.to).isLessThan(expectedNextRowId);
+        }
+
+        assertThat(table.snapshotManager().latestSnapshot().nextRowId())
+                .isEqualTo(expectedNextRowId);
+        assertThat(table.snapshotManager().latestSnapshot().totalRecordCount())
+                .isEqualTo(before.totalRecordCount());
+        assertThat(fileMetadataWithoutRowId(table)).isEqualTo(expectedFileMetadata);
+        assertThat(valueStatsByFile(table)).isEqualTo(expectedValueStats);
+        assertTableDataQueryable(table, expectedRows);
+    }
+
+    @Test
     public void testReassignManyOutOfOrderPartitionEntries() throws Exception {
         verifyReassignOutOfOrderPartitionEntries(LARGE_ENTRY_COUNT, LARGE_MANIFEST_FILE_COUNT);
     }
@@ -498,6 +906,88 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         writeOneRow(table, "b", 3);
         writeOneRow(table, "a", 4);
         return table;
+    }
+
+    private FileStoreTable createDataIntegrityTable() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        int nextId = 0;
+        for (int file = 0; file < DATA_INTEGRITY_FILES_PER_PARTITION; file++) {
+            for (int partition = 0; partition < DATA_INTEGRITY_PARTITIONS.length; partition++) {
+                int rowCount = 3 + (file + partition) % 5;
+                int[] ids = new int[rowCount];
+                for (int row = 0; row < rowCount; row++) {
+                    ids[row] = nextId++;
+                }
+                writeRows(table, DATA_INTEGRITY_PARTITIONS[partition], ids);
+            }
+        }
+        return table;
+    }
+
+    private long scrambleCurrentRowIds(FileStoreTable table) throws Exception {
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        assertThat(latest.indexManifest()).isNull();
+        List<ManifestEntry> currentEntries = currentEntries(table);
+        List<Long> rowIdSlots = new ArrayList<>(currentEntries.size());
+        for (int i = 0; i < currentEntries.size(); i++) {
+            rowIdSlots.add((i + 1L) * SCRAMBLED_ROW_ID_GAP);
+        }
+        Collections.shuffle(rowIdSlots, new Random(SCRAMBLED_ROW_ID_SEED));
+
+        Map<FileEntry.Identifier, Long> assignments = new HashMap<>();
+        for (int i = 0; i < currentEntries.size(); i++) {
+            assignments.put(currentEntries.get(i).identifier(), rowIdSlots.get(i));
+        }
+
+        ManifestFile manifestFile = table.store().manifestFileFactory().create();
+        ManifestList manifestList = table.store().manifestListFactory().create();
+        List<ManifestFileMeta> rewrittenManifestMetas = new ArrayList<>();
+        int rewrittenEntryCount = 0;
+        for (ManifestFileMeta manifestMeta : manifestList.readDataManifests(latest)) {
+            List<ManifestEntry> entries =
+                    manifestFile.read(manifestMeta.fileName(), manifestMeta.fileSize());
+            boolean rewritten = false;
+            for (int i = 0; i < entries.size(); i++) {
+                ManifestEntry entry = entries.get(i);
+                Long firstRowId =
+                        entry.kind() == FileKind.ADD ? assignments.get(entry.identifier()) : null;
+                if (firstRowId != null) {
+                    entries.set(i, entry.assignFirstRowId(firstRowId));
+                    rewritten = true;
+                    rewrittenEntryCount++;
+                }
+            }
+            if (rewritten) {
+                rewrittenManifestMetas.addAll(manifestFile.write(entries));
+            } else {
+                rewrittenManifestMetas.add(manifestMeta);
+            }
+        }
+        assertThat(rewrittenEntryCount).isEqualTo(currentEntries.size());
+
+        Pair<String, Long> baseManifestList = manifestList.write(rewrittenManifestMetas);
+        Pair<String, Long> deltaManifestList = manifestList.write(Collections.emptyList());
+        long scrambledNextRowId = (currentEntries.size() + 10L) * SCRAMBLED_ROW_ID_GAP;
+        try (FileStoreCommitImpl commit =
+                (FileStoreCommitImpl) table.store().newCommit("test-scramble-row-ids", table)) {
+            assertThat(
+                            commit.replaceManifestList(
+                                    latest,
+                                    latest.totalRecordCount(),
+                                    baseManifestList,
+                                    deltaManifestList,
+                                    null,
+                                    scrambledNextRowId))
+                    .isTrue();
+        }
+
+        Map<FileEntry.Identifier, Long> committedAssignments = new HashMap<>();
+        for (ManifestEntry entry : currentEntries(table)) {
+            committedAssignments.put(entry.identifier(), entry.file().nonNullFirstRowId());
+        }
+        assertThat(committedAssignments).isEqualTo(assignments);
+        return scrambledNextRowId;
     }
 
     private void verifyReassignOutOfOrderPartitionEntries(int entryCount, int manifestFileCount)
@@ -829,13 +1319,64 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         try (BatchTableWrite write = builder.newWrite();
                 BatchTableCommit commit = builder.newCommit()) {
             for (int id : ids) {
-                write.write(
-                        GenericRow.of(
-                                BinaryString.fromString(partition),
-                                id,
-                                BinaryString.fromString("v" + id)));
+                write.write(row(partition, id));
             }
             commit.commit(write.prepareCommit());
+        }
+    }
+
+    private void writeRowsInPartitions(
+            FileStoreTable table,
+            String firstPartition,
+            int firstId,
+            String secondPartition,
+            int secondId)
+            throws Exception {
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite();
+                BatchTableCommit commit = builder.newCommit()) {
+            write.write(row(firstPartition, firstId));
+            write.write(row(secondPartition, secondId));
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private GenericRow row(String partition, int id) {
+        return GenericRow.of(
+                partition == null ? null : BinaryString.fromString(partition),
+                id,
+                BinaryString.fromString("v" + id));
+    }
+
+    private void overwriteOneRow(FileStoreTable table, String partition, int id) throws Exception {
+        BatchWriteBuilder builder = table.newBatchWriteBuilder().withOverwrite();
+        try (BatchTableWrite write = builder.newWrite();
+                BatchTableCommit commit = builder.newCommit()) {
+            write.write(
+                    GenericRow.of(
+                            BinaryString.fromString(partition),
+                            id,
+                            BinaryString.fromString("v" + id)));
+            commit.commit(write.prepareCommit());
+        }
+    }
+
+    private void compactManifests(FileStoreTable table) throws Exception {
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.compactManifests();
+        }
+    }
+
+    private void updateStatistics(FileStoreTable table) throws Exception {
+        Snapshot latest = table.snapshotManager().latestSnapshot();
+        Statistics statistics =
+                new Statistics(
+                        latest.id(),
+                        latest.schemaId(),
+                        latest.totalRecordCount(),
+                        latest.totalRecordCount() * 100L);
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.updateStatistics(statistics);
         }
     }
 
@@ -857,15 +1398,85 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                 table.coreOptions().partitionDefaultName());
     }
 
+    private List<ManifestEntry> currentEntries(FileStoreTable table) {
+        return table.store()
+                .newScan()
+                .withSnapshot(table.snapshotManager().latestSnapshot())
+                .plan()
+                .files();
+    }
+
+    private Map<String, Long> rowCountsByPartition(FileStoreTable table) {
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (ManifestEntry entry : currentEntries(table)) {
+            String partition = table.store().pathFactory().getPartitionString(entry.partition());
+            result.merge(partition, entry.file().rowCount(), Long::sum);
+        }
+        return result;
+    }
+
+    private Map<String, List<Object>> fileMetadataWithoutRowId(FileStoreTable table) {
+        Map<String, List<Object>> result = new LinkedHashMap<>();
+        for (ManifestEntry entry : currentEntries(table)) {
+            DataFileMeta file = entry.file();
+            String partition = table.store().pathFactory().getPartitionString(entry.partition());
+            String key = partition + entry.bucket() + "/" + file.fileName();
+            List<Object> metadata =
+                    Arrays.asList(
+                            entry.kind(),
+                            entry.totalBuckets(),
+                            file.fileSize(),
+                            file.rowCount(),
+                            file.minSequenceNumber(),
+                            file.maxSequenceNumber(),
+                            file.schemaId(),
+                            file.level(),
+                            file.extraFiles(),
+                            file.deleteRowCount(),
+                            file.fileSource(),
+                            file.valueStatsCols(),
+                            file.externalPath(),
+                            file.writeCols());
+            assertThat(result.put(key, metadata)).isNull();
+        }
+        return result;
+    }
+
+    private void assertPartitionsHaveLargeRowIdGaps(
+            Map<String, List<Long>> firstRowIdsByPartition) {
+        assertThat(firstRowIdsByPartition).hasSize(DATA_INTEGRITY_PARTITIONS.length);
+        for (String partition : DATA_INTEGRITY_PARTITIONS) {
+            List<Long> firstRowIds = firstRowIdsByPartition.get("pt=" + partition + "/");
+            assertThat(firstRowIds).hasSize(DATA_INTEGRITY_FILES_PER_PARTITION);
+            for (int i = 1; i < firstRowIds.size(); i++) {
+                assertThat(firstRowIds.get(i) - firstRowIds.get(i - 1))
+                        .isGreaterThanOrEqualTo(SCRAMBLED_ROW_ID_GAP);
+            }
+        }
+    }
+
+    private long assertContiguousRowIds(
+            Map<String, List<Long>> rowIdsByPartition,
+            Map<String, Long> rowCountsByPartition,
+            List<String> partitions,
+            long firstRowId) {
+        long nextRowId = firstRowId;
+        for (String partition : partitions) {
+            String partitionPath = "pt=" + partition + "/";
+            long rowCount = rowCountsByPartition.get(partitionPath);
+            List<Long> rowIds = rowIdsByPartition.get(partitionPath);
+            assertThat(rowIds).hasSize(Math.toIntExact(rowCount));
+            for (int i = 0; i < rowIds.size(); i++) {
+                assertThat(rowIds.get(i)).isEqualTo(nextRowId + i);
+            }
+            nextRowId += rowCount;
+        }
+        return nextRowId;
+    }
+
     private Map<String, List<Long>> rowIdsByPartition(FileStoreTable table) {
-        List<ManifestEntry> entries =
-                table.store()
-                        .newScan()
-                        .withSnapshot(table.snapshotManager().latestSnapshot())
-                        .plan()
-                        .files();
         Map<String, List<Long>> result = new LinkedHashMap<>();
-        for (ManifestEntry entry : entries) {
+        for (ManifestEntry entry : currentEntries(table)) {
             String partition = table.store().pathFactory().getPartitionString(entry.partition());
             result.computeIfAbsent(partition, k -> new ArrayList<>())
                     .add(entry.file().nonNullFirstRowId());
@@ -876,15 +1487,18 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
         return result;
     }
 
+    private Map<String, SimpleStats> valueStatsByFile(FileStoreTable table) {
+        Map<String, SimpleStats> result = new LinkedHashMap<>();
+        for (ManifestEntry entry : currentEntries(table)) {
+            SimpleStats previous = result.put(entry.file().fileName(), entry.file().valueStats());
+            assertThat(previous).isNull();
+        }
+        return result;
+    }
+
     private Map<String, List<Long>> expandedRowIdsByPartition(FileStoreTable table) {
-        List<ManifestEntry> entries =
-                table.store()
-                        .newScan()
-                        .withSnapshot(table.snapshotManager().latestSnapshot())
-                        .plan()
-                        .files();
         Map<String, List<Long>> result = new LinkedHashMap<>();
-        for (ManifestEntry entry : entries) {
+        for (ManifestEntry entry : currentEntries(table)) {
             String partition = table.store().pathFactory().getPartitionString(entry.partition());
             List<Long> rowIds = result.computeIfAbsent(partition, k -> new ArrayList<>());
             Range range = entry.file().nonNullRowIdRange();
@@ -1061,6 +1675,100 @@ public class DataEvolutionRowIdReassignerTest extends TableTestBase {
                     return result == 0 ? Long.compare(left.to, right.to) : result;
                 });
         return ranges;
+    }
+
+    private Map<String, List<Range>> globalIndexRangesByPartition(FileStoreTable table) {
+        Map<String, List<Range>> result = new LinkedHashMap<>();
+        List<IndexManifestEntry> entries =
+                table.store()
+                        .indexManifestFileFactory()
+                        .create()
+                        .read(table.snapshotManager().latestSnapshot().indexManifest());
+        for (IndexManifestEntry entry : entries) {
+            GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
+            if (globalIndex == null) {
+                continue;
+            }
+            String partition = table.store().pathFactory().getPartitionString(entry.partition());
+            result.computeIfAbsent(partition, ignored -> new ArrayList<>())
+                    .add(globalIndex.rowRange());
+        }
+        for (List<Range> ranges : result.values()) {
+            Collections.sort(
+                    ranges,
+                    (left, right) -> {
+                        int compare = Long.compare(left.from, right.from);
+                        return compare == 0 ? Long.compare(left.to, right.to) : compare;
+                    });
+        }
+        return result;
+    }
+
+    private void assertTableDataQueryable(FileStoreTable table, List<String> expectedRows)
+            throws Exception {
+        assertThat(readTableRows(table)).containsExactlyElementsOf(expectedRows);
+
+        PredicateBuilder predicateBuilder = new PredicateBuilder(table.rowType());
+        int partitionField = table.rowType().getFieldIndex("pt");
+        for (String partition : DATA_INTEGRITY_PARTITIONS) {
+            Predicate predicate =
+                    predicateBuilder.equal(partitionField, BinaryString.fromString(partition));
+            assertThat(readTableRows(table, predicate))
+                    .containsExactlyElementsOf(rowsForPartition(expectedRows, partition));
+        }
+
+        int idField = table.rowType().getFieldIndex("id");
+        int[] pointIds = {0, expectedRows.size() / 2, expectedRows.size() - 1};
+        for (int id : pointIds) {
+            Predicate predicate = predicateBuilder.equal(idField, id);
+            assertThat(readTableRows(table, predicate)).containsAll(rowsForId(expectedRows, id));
+        }
+    }
+
+    private List<String> rowsForPartition(List<String> rows, String partition) {
+        List<String> result = new ArrayList<>();
+        for (String row : rows) {
+            if (row.split("\\|", 3)[1].equals(partition)) {
+                result.add(row);
+            }
+        }
+        return result;
+    }
+
+    private List<String> rowsForId(List<String> rows, int id) {
+        List<String> result = new ArrayList<>();
+        String prefix = id + "|";
+        for (String row : rows) {
+            if (row.startsWith(prefix)) {
+                result.add(row);
+            }
+        }
+        return result;
+    }
+
+    private List<String> readTableRows(FileStoreTable table) throws Exception {
+        return readTableRows(table.newReadBuilder());
+    }
+
+    private List<String> readTableRows(FileStoreTable table, Predicate predicate) throws Exception {
+        return readTableRows(table.newReadBuilder().withFilter(predicate));
+    }
+
+    private List<String> readTableRows(ReadBuilder readBuilder) throws Exception {
+        List<String> result = new ArrayList<>();
+        readBuilder
+                .newRead()
+                .createReader(readBuilder.newScan().plan())
+                .forEachRemaining(
+                        row -> {
+                            InternalRow projected = row;
+                            String partition = projected.getString(0).toString();
+                            int id = projected.getInt(1);
+                            String payload = projected.getString(2).toString();
+                            result.add(id + "|" + partition + "|" + payload);
+                        });
+        Collections.sort(result);
+        return result;
     }
 
     private List<String> readPayloads(FileStoreTable table, Predicate predicate) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
@@ -81,7 +81,6 @@ public class RowRangeMappingIndexTest {
                                 RowRangeMappingIndex.mapping(20, 24, 5)));
 
         assertThat(relative.oldRanges()).containsExactly(new Range(10, 14), new Range(20, 24));
-        assertThat(relative.maxNewEndExclusive()).isEqualTo(10L);
 
         RowRangeMappingIndex absolute = relative.shiftNewStarts(100L);
         assertThat(absolute.map(new Range(10, 14))).hasValue(new Range(100, 104));

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
@@ -80,8 +80,6 @@ public class RowRangeMappingIndexTest {
                                 RowRangeMappingIndex.mapping(10, 14, 0),
                                 RowRangeMappingIndex.mapping(20, 24, 5)));
 
-        assertThat(relative.oldRanges()).containsExactly(new Range(10, 14), new Range(20, 24));
-
         RowRangeMappingIndex absolute = relative.shiftNewStarts(100L);
         assertThat(absolute.map(new Range(10, 14))).hasValue(new Range(100, 104));
         assertThat(absolute.map(new Range(20, 24))).hasValue(new Range(105, 109));

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
@@ -87,4 +87,20 @@ public class RowRangeMappingIndexTest {
         assertThat(absolute.map(new Range(10, 14))).hasValue(new Range(100, 104));
         assertThat(absolute.map(new Range(20, 24))).hasValue(new Range(105, 109));
     }
+
+    @Test
+    public void testOverlaps() {
+        RowRangeMappingIndex index =
+                RowRangeMappingIndex.create(
+                        Arrays.asList(
+                                RowRangeMappingIndex.mapping(10, 14, 100),
+                                RowRangeMappingIndex.mapping(20, 24, 105)));
+
+        assertThat(index.overlaps(new Range(5, 9))).isFalse();
+        assertThat(index.overlaps(new Range(5, 10))).isTrue();
+        assertThat(index.overlaps(new Range(15, 19))).isFalse();
+        assertThat(index.overlaps(new Range(14, 20))).isTrue();
+        assertThat(index.overlaps(new Range(24, 30))).isTrue();
+        assertThat(index.overlaps(new Range(25, 30))).isFalse();
+    }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/dataevolution/RowRangeMappingIndexTest.java
@@ -71,4 +71,20 @@ public class RowRangeMappingIndexTest {
 
         assertThat(index.map(new Range(12, 17))).isEmpty();
     }
+
+    @Test
+    public void testRelativeMappingCanBeShiftedToAbsoluteRowIds() {
+        RowRangeMappingIndex relative =
+                RowRangeMappingIndex.create(
+                        Arrays.asList(
+                                RowRangeMappingIndex.mapping(10, 14, 0),
+                                RowRangeMappingIndex.mapping(20, 24, 5)));
+
+        assertThat(relative.oldRanges()).containsExactly(new Range(10, 14), new Range(20, 24));
+        assertThat(relative.maxNewEndExclusive()).isEqualTo(10L);
+
+        RowRangeMappingIndex absolute = relative.shiftNewStarts(100L);
+        assertThat(absolute.map(new Range(10, 14))).hasValue(new Range(100, 104));
+        assertThat(absolute.map(new Range(20, 24))).hasValue(new Range(105, 109));
+    }
 }


### PR DESCRIPTION
### Purpose

`DataEvolutionRowIdReassigner` can lose a commit race when a normal append commits a newer snapshot between planning and `replaceManifestList`. Previously the next reassignment invocation had to start the manifest read work from scratch.

### Changes

- Retry `replaceManifestList` conflicts up to three times in the same reassignment call.
- Reuse already deserialized data manifest and index manifest entries across retry attempts.
- Recompute assignment from the latest snapshot and latest `nextRowId` on every retry to avoid row-id range overlap with concurrent appends.
- Add a deterministic conflict test that appends before the first reassign commit and verifies the retry uses the latest `nextRowId`.

### Tests

- `mvn -pl paimon-core spotless:apply`
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=DataEvolutionRowIdReassignerTest#testReassignRetriesWithLatestNextRowIdAfterConcurrentAppend test`
- `mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest=DataEvolutionRowIdReassignerTest test`
- `git diff --check`