### PR TITLE
[docs] Fix stale sink.writer-coordinator.cache-memory default value

### DIFF
--- a/docs/docs/maintenance/write-performance.md
+++ b/docs/docs/maintenance/write-performance.md
@@ -126,7 +126,7 @@ execution.checkpointing.timeout = 60 min
 In the initialization of write, the writer of the bucket needs to read all historical files. If there is a bottleneck
 here (For example, writing a large number of partitions simultaneously), you can use `sink.writer-coordinator.enabled`
 to use a Flink coordinator to cache the read manifest data to accelerate initialization. The cache memory for coordinator
-is `sink.writer-coordinator.cache-memory`, default is 1GB in Job Manager.
+is `sink.writer-coordinator.cache-memory`, default is 2GB in Job Manager.
 
 The coordinator manifest cache normally holds entries with soft references, so the JVM can reclaim them when the Job
 Manager runs low on heap. On a heavily loaded Job Manager this can backfire: the JVM reclaims cached manifests, writers


### PR DESCRIPTION

### Purpose


- The "Write Initialize" section states the default of `sink.writer-coordinator.cache-memory` as 1GB, but the source default is 2GB.
- `FlinkConnectorOptions.SINK_WRITER_COORDINATOR_CACHE_MEMORY` is defined as `defaultValue(MemorySize.ofMebiBytes(2048))` (= 2GB).
- Commit `abb779813` raised the default from `ofMebiBytes(1024)` to `ofMebiBytes(2048)`, but this hand-written prose was never updated. Fixes the doc-vs-code drift so users tune Job Manager memory with the correct value.

### Tests

- Documentation-only wording fix, no behavior change — no test added.
- Corrected value verified against `FlinkConnectorOptions.java` (`ofMebiBytes(2048)` = 2GB). Docs-only change, no module build.


