### PR TITLE
[docs] Fix compact_database mode default value in Flink procedures

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -120,8 +120,8 @@ All available procedures are listed below.
       <td>
          To compact databases. Arguments:
             <li>includingDatabases: to specify databases. You can use regular expression.</li>
-            <li>mode: compact mode. "divided": start a sink for each table, detecting the new table requires restarting the job;
-               "combined" (default): start a single combined sink for all tables, the new table will be automatically detected.
+            <li>mode: compact mode. "divided" (default): start a sink for each table, detecting the new table requires restarting the job;
+               "combined": start a single combined sink for all tables, the new table will be automatically detected.
             </li>
             <li>includingTables: to specify tables. You can use regular expression.</li>
             <li>excludingTables: to specify tables that are not compacted. You can use regular expression.</li>


### PR DESCRIPTION

### Purpose

fix #6934

- The `compact_database` procedure doc labels `"combined"` as the default `mode`, but the code default is `DIVIDED`.
- `CompactDatabaseAction.databaseCompactMode` is initialized to `MultiTablesSinkMode.DIVIDED`; when `mode` is omitted it resolves to `DIVIDED` (`MultiTablesSinkMode.fromString(null)` returns `DIVIDED`).
- Moves the `(default)` label from `"combined"` to `"divided"`, matching the sibling page `maintenance/dedicated-compaction.mdx` which already documents divided as the default.

### Tests

- Documentation-only wording fix, no behavior change — no test added.
- Default verified against `CompactDatabaseAction.java` and `MultiTablesSinkMode.java`. Docs-only change, no module build.


