### PR TITLE
[docs] Fix partition filter example wording in Flink procedures

### DIFF
--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -37,7 +37,7 @@ argument can be omitted. For the above example, the call statement is \
 ``CALL sys.compact(`table` => 'default.t', options => 'sink.parallelism=4')``.
 
 Specify partitions: we use string to represent partition filter. "," means "AND" and ";" means "OR". For example, if you want
-to specify two partitions date=01 and date=02, you need to write 'date=01;date=02'; If you want to specify one partition
+to specify two partitions date=01 or date=02, you need to write 'date=01;date=02'; If you want to specify one partition
 with date=01 and day=01, you need to write 'date=01,day=01'.
 
 Table options syntax: we use string to represent table options. The format is 'key1=value1,key2=value2...'.


### PR DESCRIPTION

### Purpose

fix #2917

- The partition-filter description in the `compact` procedure defines `";" means "OR"`, but the following example describes `'date=01;date=02'` as "date=01 and date=02" — contradicting the definition.
- Changes "and" to "or" so the example matches the `;`=OR definition.
- The parallel `,`=AND example ("date=01 and day=01" → `'date=01,day=01'`) and the sibling page `spark/procedures.md` are already consistent, isolating this single wrong word.

### Tests

- Documentation-only wording fix, no behavior change — no test added.
- Correction is self-evident from the same paragraph's `;`=OR definition and the consistent Spark sibling doc. Docs-only change, no module build.


