### PR TITLE
[arrow] Fix misleading exception message in ArrowBundleWriter

### DIFF
--- a/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowBundleWriter.java
+++ b/paimon-arrow/src/main/java/org/apache/paimon/arrow/writer/ArrowBundleWriter.java
@@ -68,7 +68,7 @@ public class ArrowBundleWriter implements BundleFormatWriter {
         if (!arrowFormatWriter.write(internalRow)) {
             flush();
             if (!arrowFormatWriter.write(internalRow)) {
-                throw new RuntimeException("Exception happens while write to orc file");
+                throw new RuntimeException("Exception happens while writing arrow record");
             }
         }
     }


### PR DESCRIPTION

### Purpose


- `ArrowBundleWriter.addElement()` threw `RuntimeException("Exception happens while write to orc file")`, but this class is the Arrow (not ORC) bundle writer — a dead reference left over from an ORC writer skeleton.
- The wrong format name misleads operators who debug Arrow/Lance write failures from the log or stack trace.
- Changed the message to `"Exception happens while writing arrow record"`, matching the sibling messages in the same class (`"Exception happens while add vsr"`, `"Exception happens while flush to file"`).

### Tests

- Typo/wording fix, no behavior change — no test added. `mvn -pl paimon-arrow spotless:check checkstyle:check` (JDK 11) passes; the module's native/JNI unit tests run in CI.


