### PR TITLE
[api] Recurse into element type in MultisetType field-id comparison

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/types/MultisetType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/MultisetType.java
@@ -101,6 +101,36 @@ public class MultisetType extends DataType {
     }
 
     @Override
+    public boolean equalsIgnoreFieldId(DataType o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MultisetType that = (MultisetType) o;
+        return elementType.equalsIgnoreFieldId(that.elementType);
+    }
+
+    @Override
+    public boolean isPrunedFrom(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MultisetType that = (MultisetType) o;
+        return elementType.isPrunedFrom(that.elementType);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), elementType);
     }

--- a/paimon-api/src/test/java/org/apache/paimon/types/MultisetTypeTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/types/MultisetTypeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MultisetType}. */
+class MultisetTypeTest {
+
+    @Test
+    void testEqualsIgnoreFieldIdRecursesIntoElementType() {
+        MultisetType left =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.INT())));
+        MultisetType rightDifferentFieldId =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(2, "f", DataTypes.INT())));
+
+        // field ids differ, but names and element types match
+        assertThat(left.equals(rightDifferentFieldId)).isFalse();
+        assertThat(left.equalsIgnoreFieldId(rightDifferentFieldId)).isTrue();
+    }
+
+    @Test
+    void testEqualsIgnoreFieldIdRejectsDifferentElement() {
+        MultisetType left =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.INT())));
+        MultisetType differentName =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "g", DataTypes.INT())));
+        MultisetType differentType =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.BIGINT())));
+
+        assertThat(left.equalsIgnoreFieldId(differentName)).isFalse();
+        assertThat(left.equalsIgnoreFieldId(differentType)).isFalse();
+    }
+
+    @Test
+    void testIsPrunedFromRecursesIntoElementType() {
+        MultisetType pruned =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.INT())));
+        MultisetType full =
+                DataTypes.MULTISET(
+                        DataTypes.ROW(
+                                DataTypes.FIELD(1, "f", DataTypes.INT()),
+                                DataTypes.FIELD(2, "g", DataTypes.INT())));
+
+        assertThat(pruned.equals(full)).isFalse();
+        assertThat(pruned.isPrunedFrom(full)).isTrue();
+    }
+
+    @Test
+    void testIsPrunedFromRejectsDifferentElement() {
+        MultisetType left =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.INT())));
+        MultisetType differentType =
+                DataTypes.MULTISET(DataTypes.ROW(DataTypes.FIELD(1, "f", DataTypes.BIGINT())));
+
+        assertThat(left.isPrunedFrom(differentType)).isFalse();
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8516

- `MultisetType` did not override `equalsIgnoreFieldId(DataType)` or `isPrunedFrom(Object)`, so it inherited the `DataType` base methods that just `return equals(o)` and compare element field ids.
- For `MULTISET<ROW<...>>` this made ignore-field-id comparison and pruning wrongly return false, corrupting schema-evolution comparison up the chain (`DataField.equalsIgnoreFieldId` / `RowType.equalsIgnoreFieldId`).
- Add both overrides recursing into `elementType`, matching sibling `ArrayType`/`MapType`/`RowType`/`VectorType`.

### Tests

- Added `MultisetTypeTest` covering positive (differing field ids equal, pruned element) and negative (different name/type) cases for both methods.
- `mvn -pl paimon-api test` — MultisetTypeTest 4 tests passed; module `clean install` green (no profiles).
