### PR TITLE
[bundle] Fix stale lz4-java groupId in commented shade include

### DIFF
--- a/paimon-bundle/pom.xml
+++ b/paimon-bundle/pom.xml
@@ -123,7 +123,7 @@ under the License.
 
                                     <!-- Others, not shade to reduce conflicting -->
                                     <!-- <include>org.xerial.snappy:snappy-java</include> -->
-                                    <!-- <include>org.lz4:lz4-java</include> -->
+                                    <!-- <include>at.yawk.lz4:lz4-java</include> -->
                                     <!-- <include>com.google.code.findbugs:jsr305</include> -->
                                     <!-- <include>org.slf4j:slf4j-api</include> -->
                                 </includes>


### PR DESCRIPTION

### Purpose


- The commented example shade `<include>` for lz4-java still referenced the old groupId `org.lz4`, while the actual dependency is `at.yawk.lz4`.
- This completes the groupId rename from #7384 (lz4-java 1.10.4 CVE upgrade, `org.lz4` → `at.yawk.lz4`), which updated every active declaration but missed this commented example.
- Keeps the example aligned with the real artifact so uncommenting it would actually match. See `paimon-bundle/pom.xml` line 79 and `paimon-common/pom.xml`, both `at.yawk.lz4`.

### Tests

- Comment-only change in `paimon-bundle/pom.xml`, no behavior change — no test added.
- `mvn -pl paimon-bundle apache-rat:check spotless:check` passed (rat: 0 unapproved licenses; spotless: clean).
- `mvn -pl paimon-bundle -DfailIfNoTests=false clean install` passed.
- `paimon-bundle` has no Java sources, so there is no compile surface for this line; the pom is well-formed XML. Full reactor build covered by CI (fork Actions).


