### PR TITLE
[benchmark] Fix copy-paste labels in micro-benchmarks

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/arrow/ArrowWriteBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/arrow/ArrowWriteBenchmark.java
@@ -36,7 +36,7 @@ public class ArrowWriteBenchmark {
     public void testWrite() {
         int batch = 1024 * 20;
         Benchmark benchmark =
-                new Benchmark("read", batch * batch)
+                new Benchmark("write", batch * batch)
                         .setNumWarmupIters(1)
                         .setOutputPerIteration(true);
         RowType rowType =

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupReaderBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/lookup/LookupReaderBenchmark.java
@@ -42,7 +42,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Benchmark for measuring the throughput of writing for lookup. */
+/** Benchmark for measuring the throughput of reading for lookup. */
 @ExtendWith(ParameterizedTestExtension.class)
 public class LookupReaderBenchmark extends AbstractLookupBenchmark {
     private static final int QUERY_KEY_COUNT = 10000;


### PR DESCRIPTION

### Purpose


- Correct two non-behavioral copy-paste labels in `paimon-micro-benchmarks`.
- `LookupReaderBenchmark` Javadoc described writing; it is a reader benchmark, so the wording now says reading.
- `ArrowWriteBenchmark#testWrite` created `new Benchmark("read", ...)`, which the harness prints; the benchmark name is now `write`.

### Tests

- Typo/wording fix, no behavior change — no test added. `mvn spotless:check -pl paimon-benchmark/paimon-micro-benchmarks` passed.
- `mvn -pl paimon-benchmark/paimon-micro-benchmarks -DskipTests clean test-compile` passed; 17 test sources compiled. Benchmarks were not executed because each `@Test` runs a long benchmark.


