### PR TITLE
WIP: [spark] Avoid row-id pushdown for non-DE row tracking tables

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonBaseScanBuilder.scala
@@ -21,7 +21,7 @@ package org.apache.paimon.spark
 import org.apache.paimon.CoreOptions
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates
-import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, TopN, VectorSearch}
+import org.apache.paimon.predicate.{PartitionPredicateVisitor, Predicate, PredicateVisitor, TopN, VectorSearch}
 import org.apache.paimon.predicate.FullTextSearch
 import org.apache.paimon.table.{SpecialFields, Table}
 import org.apache.paimon.types.RowType
@@ -81,12 +81,16 @@ abstract class PaimonBaseScanBuilder
       predicate =>
         converter.convert(predicate) match {
           case Some(paimonPredicate) =>
-            pushable.append(predicate)
-            if (paimonPredicate.visit(partitionPredicateVisitor)) {
-              pushablePartitionDataFilters.append(paimonPredicate)
-            } else {
-              pushableDataFilters.append(paimonPredicate)
+            if (shouldPostScanRowTrackingPredicate(paimonPredicate)) {
               postScan.append(predicate)
+            } else {
+              pushable.append(predicate)
+              if (paimonPredicate.visit(partitionPredicateVisitor)) {
+                pushablePartitionDataFilters.append(paimonPredicate)
+              } else {
+                pushableDataFilters.append(paimonPredicate)
+                postScan.append(predicate)
+              }
             }
           case None =>
             postScan.append(predicate)
@@ -112,6 +116,16 @@ abstract class PaimonBaseScanBuilder
       this.hasPostScanPredicates = true
     }
     postScan.toArray
+  }
+
+  private def shouldPostScanRowTrackingPredicate(predicate: Predicate): Boolean = {
+    coreOptions.rowTrackingEnabled() && !coreOptions.dataEvolutionEnabled() &&
+    PredicateVisitor
+      .collectFieldNames(predicate)
+      .asScala
+      .exists(
+        field =>
+          field == SpecialFields.ROW_ID.name() || field == SpecialFields.SEQUENCE_NUMBER.name())
   }
 
   override def pushedPredicates: Array[SparkPredicate] = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/RowTrackingTestBase.scala
@@ -1223,6 +1223,18 @@ abstract class RowTrackingTestBase extends PaimonSparkTestBase with AdaptiveSpar
     }
   }
 
+  test("Row Tracking: query row_tracking system table with row id filter") {
+    withTable("t") {
+      sql("CREATE TABLE t (a INT, b INT) TBLPROPERTIES ('row-tracking.enabled' = 'true')")
+      sql("INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)")
+
+      checkAnswer(
+        sql("SELECT a, b, _ROW_ID FROM `t$row_tracking` WHERE _ROW_ID = 0"),
+        Seq(Row(1, 10, 0))
+      )
+    }
+  }
+
   test("Data Evolution: compact fields action") {
     withTable("s", "t") {
       sql("CREATE TABLE s (id INT, b INT)")


### PR DESCRIPTION
### Purpose

For a row-tracking table without data evolution, Spark can push predicates on `_ROW_ID` from the `$row_tracking` system table into the Paimon scan. The underlying append-only scan still uses data-file stats for physical columns only, so planning can fail when stats predicates access the row-tracking field index.

This patch keeps row-tracking field predicates as Spark residual filters when row tracking is enabled but data evolution is disabled. Data-evolution row-tracking scans keep the existing pushdown behavior.

### Changes

- Skip Paimon predicate pushdown for `_ROW_ID` and `_SEQUENCE_NUMBER` predicates on non-DE row-tracking tables.
- Add a Spark regression test for querying `$row_tracking` with `_ROW_ID = 0`.

### Tests

- `mvn -pl paimon-spark/paimon-spark-common -am -Pfast-build -Pspark3 -DskipTests compile`
- `mvn -pl paimon-spark/paimon-spark-common,paimon-spark/paimon-spark-ut -Pspark3 -DskipTests -Dcheckstyle.skip=true -Drat.skip=true spotless:apply`
- `mvn -pl paimon-spark/paimon-spark-3.5 -am -Pfast-build -Pspark3 -DwildcardSuites=org.apache.paimon.spark.sql.RowTrackingTest -Dtest=none -DfailIfNoTests=false test` (the added test passes; the full suite has existing local CodeGenerator plugin discovery failures)
