### PR TITLE
[codegen-loader] Fix stale dependency comments

### DIFF
--- a/paimon-codegen-loader/pom.xml
+++ b/paimon-codegen-loader/pom.xml
@@ -46,10 +46,10 @@ under the License.
             <version>${project.version}</version>
             <!-- We don't want any production code from paimon-core to reference paimon-codegen directly -->
             <scope>runtime</scope>
-            <!-- Prevent dependency from being accessible to modules depending on paimon-core -->
+            <!-- Prevent dependency from being accessible to modules depending on paimon-codegen-loader -->
             <optional>true</optional>
             <exclusions>
-                <!-- Prevent akka and scala from being visible to other modules depending on paimon-core -->
+                <!-- Prevent transitive dependencies from being visible to modules depending on paimon-codegen-loader -->
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>


### PR DESCRIPTION

### Purpose

- Correct stale `paimon-codegen-loader` dependency comments that referred to modules depending on `paimon-core`.
- The comments now describe the actual boundary guarded by `optional` and wildcard exclusions: modules depending on `paimon-codegen-loader` should not see `paimon-codegen` or its transitive dependencies.
- No issue: typo/comment-only fix.

### Tests

- Typo/wording fix, no behavior change — no test added.
- `mvn spotless:check -pl paimon-codegen-loader` passed under JDK 11. Log: `output/20260710084732-/logs/spotless-check.log`.
- `mvn -pl paimon-codegen-loader -DfailIfNoTests=false clean install` passed under JDK 11. Log: `output/20260710084732-/logs/clean-install.log`.


