### PR TITLE
[spark] Reject SET LOCATION for Paimon tables

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonAnalysis.scala
@@ -78,6 +78,10 @@ class PaimonAnalysis(session: SparkSession) extends Rule[LogicalPlan] {
         PaimonDropPartitions.validate(table, parts.asResolvedPartitionSpecs)
         d
 
+      case SetTableLocation(ResolvedTable(_, _, _: SparkTable, _), _, _) =>
+        throw new UnsupportedOperationException(
+          "ALTER TABLE ... SET LOCATION is not supported for Paimon tables.")
+
       case r: ReplaceColumns if r.resolved && isPaimonTable(r.table) =>
         // Spark rewrites REPLACE COLUMNS into a batch that drops every existing column and re-adds
         // the new set. Re-adding columns assigns brand-new field ids while existing data files keep

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala
@@ -135,6 +135,21 @@ abstract class DDLTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Paimon DDL: alter table set location is not supported") {
+    withTempDir {
+      newLocation =>
+        withTable("paimon_tbl") {
+          sql("CREATE TABLE paimon_tbl (id int)")
+
+          val error = intercept[Exception] {
+            sql(s"ALTER TABLE paimon_tbl SET LOCATION '${newLocation.getCanonicalPath}'")
+          }.getMessage
+
+          assert(error.contains("ALTER TABLE ... SET LOCATION is not supported for Paimon tables."))
+        }
+    }
+  }
+
   test("Paimon DDL: create table like with paimon SparkCatalog") {
     assume(gteqSpark3_4)
     withTable("source_tbl", "target_tbl") {


### PR DESCRIPTION
### Purpose
Reject `ALTER TABLE ... SET LOCATION` for Paimon tables at Spark analysis time instead of letting the command silently pass through.
This change adds a rule-level check in `PaimonAnalysis` for `SetTableLocation` when the resolved target is a Paimon `SparkTable`, and throws a clear unsupported-operation error:
`ALTER TABLE ... SET LOCATION is not supported for Paimon tables.`
### Tests
Added unit coverage in:
`paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/DDLTestBase.scala`