### PR TITLE
[hive] Correct column.name.delimiter

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonRecordReader.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/mapred/PaimonRecordReader.java
@@ -197,7 +197,7 @@ public class PaimonRecordReader implements RecordReader<Void, RowDataContainer> 
                 jobConf.get(
                         // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
                         // versions, so we use a constant string instead
-                        "column.name.delimite", String.valueOf(SerDeUtils.COMMA));
+                        "column.name.delimiter", String.valueOf(SerDeUtils.COMMA));
         if (columns == null || delimiter == null) {
             return Optional.empty();
         } else {


### PR DESCRIPTION
### Purpose
org.apache.hadoop.hive.serde.serdeConstants#COLUMN_NAME_DELIMITER
```java
  public static final java.lang.String COLUMN_NAME_DELIMITER = "column.name.delimiter";
```

### Tests
