### PR TITLE
[python] Fix mock REST snapshot serialization

### DIFF
--- a/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
+++ b/paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py
@@ -296,6 +296,35 @@ class TestRESTCatalogCommitSnapshot(unittest.TestCase):
 
 class TestRESTCommit(RESTBaseTest):
 
+    def test_multiple_row_tracking_commits_preserve_all_rows(self):
+        pa_schema = pa.schema([('id', pa.int32())])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            })
+        table_name = 'default.test_row_tracking_commits'
+        self.rest_catalog.create_table(table_name, schema, False)
+        table = self.rest_catalog.get_table(table_name)
+
+        for values in ([1, 2, 3], [4, 5, 6]):
+            write_builder = table.new_batch_write_builder()
+            table_write = write_builder.new_write()
+            table_commit = write_builder.new_commit()
+            table_write.write_arrow(
+                pa.Table.from_pydict({'id': values}, schema=pa_schema))
+            table_commit.commit(table_write.prepare_commit())
+            table_write.close()
+            table_commit.close()
+
+        read_builder = table.new_read_builder()
+        actual = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(actual.num_rows, 6)
+        self.assertEqual(
+            sorted(actual.column('id').to_pylist()), [1, 2, 3, 4, 5, 6])
+
     def test_commit_succeeded_on_server_but_client_fails(self):
         pa_schema = pa.schema([('id', pa.int32()), ('name', pa.string())])
         opts = {

--- a/paimon-python/pypaimon/tests/rest/rest_server.py
+++ b/paimon-python/pypaimon/tests/rest/rest_server.py
@@ -1263,9 +1263,7 @@ class RESTCatalogServer:
 
     def _write_snapshot_files(self, identifier: Identifier, snapshot, statistics):
         """Write snapshot and related files to the file system"""
-        import json
         import os
-        import uuid
 
         # Construct table path: {warehouse}/{database}/{table}
         table_path = os.path.join(self.data_path, self.warehouse, identifier.get_database_name(),
@@ -1278,22 +1276,8 @@ class RESTCatalogServer:
 
         # Write snapshot file (snapshot-{id})
         snapshot_file = os.path.join(snapshot_dir, f"snapshot-{snapshot.id}")
-        snapshot_data = {
-            "version": getattr(snapshot, 'version', 3),
-            "id": snapshot.id,
-            "schemaId": getattr(snapshot, 'schema_id', 0),
-            "baseManifestList": getattr(snapshot, 'base_manifest_list', f"manifest-list-{uuid.uuid4()}"),
-            "deltaManifestList": getattr(snapshot, 'delta_manifest_list', f"manifest-list-{uuid.uuid4()}"),
-            "totalRecordCount": getattr(snapshot, 'total_record_count'),
-            "deltaRecordCount": getattr(snapshot, 'delta_record_count'),
-            "commitUser": getattr(snapshot, 'commit_user', 'rest-server'),
-            "commitIdentifier": getattr(snapshot, 'commit_identifier', 1),
-            "commitKind": getattr(snapshot, 'commit_kind', 'APPEND'),
-            "timeMillis": getattr(snapshot, 'time_millis', 1703721600000)
-        }
-
         with open(snapshot_file, 'w') as f:
-            json.dump(snapshot_data, f, indent=2)
+            f.write(JSON.to_json(snapshot))
 
         # Write LATEST file
         latest_file = os.path.join(snapshot_dir, "LATEST")


### PR DESCRIPTION
### Purpose

The PyPaimon mock REST server did not persist the committed `Snapshot` object as-is. Instead, it rebuilt snapshot files from a small hand-written JSON payload, which silently dropped optional snapshot fields.

This breaks row-tracking/data-evolution tests because `nextRowId` is stored in the snapshot. After the first commit, the mock server drops `nextRowId`; the next commit reloads the snapshot with no row-id counter and starts assigning row ids from the beginning again. Those duplicated row ids make later rows shadow earlier rows, so appending `[1, 2, 3]` and then `[4, 5, 6]` can read back only `[4, 5, 6]`.

This PR writes the original `Snapshot` through the shared JSON serializer instead of maintaining a partial field mapping in the mock server. This preserves `nextRowId` and any other current/future snapshot fields covered by the dataclass serializer.

### Tests

- Added `TestRESTCommit.test_multiple_row_tracking_commits_preserve_all_rows`, which performs two REST commits on a row-tracking/data-evolution table and verifies all six rows are readable.
- `python -m pytest -q paimon-python/pypaimon/tests/rest/rest_catalog_commit_snapshot_test.py::TestRESTCommit::test_multiple_row_tracking_commits_preserve_all_rows`
