### PR TITLE
[core] Fix copyWithLatestSchema option precedence

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -399,8 +399,8 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         Optional<TableSchema> optionalLatestSchema = schemaManager().latest();
         if (optionalLatestSchema.isPresent()) {
             TableSchema latestSchema = optionalLatestSchema.get();
-            Map<String, String> mergedOptions = new HashMap<>(latestSchema.options());
-            mergedOptions.putAll(tableSchema.options());
+            Map<String, String> mergedOptions = new HashMap<>(tableSchema.options());
+            mergedOptions.putAll(latestSchema.options());
             TableSchema newTableSchema = latestSchema.copy(mergedOptions);
             SchemaValidation.validateTableSchema(newTableSchema);
             return copy(newTableSchema);

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -399,8 +399,21 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         Optional<TableSchema> optionalLatestSchema = schemaManager().latest();
         if (optionalLatestSchema.isPresent()) {
             TableSchema latestSchema = optionalLatestSchema.get();
-            Map<String, String> mergedOptions = new HashMap<>(tableSchema.options());
-            mergedOptions.putAll(latestSchema.options());
+            // The current copy's options mix committed options with dynamic overrides applied via
+            // copy(dynamicOptions). Rebase onto the latest committed options so altered option
+            // values are picked up, then re-apply only the dynamic overrides (entries that differ
+            // from the committed schema this copy is based on) so runtime overrides survive.
+            Map<String, String> committedOptions =
+                    schemaManager().schema(tableSchema.id()).options();
+            Map<String, String> mergedOptions = new HashMap<>(latestSchema.options());
+            tableSchema
+                    .options()
+                    .forEach(
+                            (key, value) -> {
+                                if (!value.equals(committedOptions.get(key))) {
+                                    mergedOptions.put(key, value);
+                                }
+                            });
             TableSchema newTableSchema = latestSchema.copy(mergedOptions);
             SchemaValidation.validateTableSchema(newTableSchema);
             return copy(newTableSchema);

--- a/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FileStoreTable.java
@@ -113,7 +113,6 @@ public interface FileStoreTable extends DataTable {
     /** Doesn't change table schema even when there exists time travel scan options. */
     FileStoreTable copyWithoutTimeTravel(Map<String, String> dynamicOptions);
 
-    /** TODO: this method is weird, old options will overwrite new options. */
     FileStoreTable copyWithLatestSchema();
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -639,6 +639,23 @@ public abstract class SimpleTableTestBase {
     }
 
     @Test
+    public void testCopyWithLatestSchemaKeepsDynamicOptions() throws Exception {
+        FileStoreTable table =
+                createFileStoreTable(conf -> conf.set(SNAPSHOT_NUM_RETAINED_MAX, 100));
+        // apply a runtime dynamic override on top of the committed value
+        FileStoreTable withDynamic =
+                table.copy(Collections.singletonMap(SNAPSHOT_NUM_RETAINED_MAX.key(), "200"));
+
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+        schemaManager.commitChanges(SchemaChange.setOption(SNAPSHOT_NUM_RETAINED_MAX.key(), "10"));
+
+        // the dynamic override must survive the refresh rather than falling back to the
+        // committed value
+        FileStoreTable updated = withDynamic.copyWithLatestSchema();
+        assertThat(updated.coreOptions().snapshotNumRetainMax()).isEqualTo(200);
+    }
+
+    @Test
     public void testConsumerIdNotBlank() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(

--- a/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/SimpleTableTestBase.java
@@ -627,6 +627,18 @@ public abstract class SimpleTableTestBase {
     }
 
     @Test
+    public void testCopyWithLatestSchemaPicksUpAlteredOptionValues() throws Exception {
+        FileStoreTable table =
+                createFileStoreTable(conf -> conf.set(SNAPSHOT_NUM_RETAINED_MAX, 100));
+        SchemaManager schemaManager = new SchemaManager(table.fileIO(), table.location());
+
+        schemaManager.commitChanges(SchemaChange.setOption(SNAPSHOT_NUM_RETAINED_MAX.key(), "10"));
+
+        FileStoreTable updated = table.copyWithLatestSchema();
+        assertThat(updated.coreOptions().snapshotNumRetainMax()).isEqualTo(10);
+    }
+
+    @Test
     public void testConsumerIdNotBlank() throws Exception {
         FileStoreTable table =
                 createFileStoreTable(


### PR DESCRIPTION
### Purpose

fix #4957

- `copyWithLatestSchema()` now lets the latest committed schema options override stale options from the current table copy, so altered option values survive a refresh.
- Removes the obsolete TODO that described the previous broken precedence.

### Tests

- Added `AppendOnlySimpleTableTest#testCopyWithLatestSchemaPicksUpAlteredOptionValues`: alter `snapshot.num-retained.max` to 10, then assert `copyWithLatestSchema()` reflects it.
- Failed before the fix with `expected: 10 but was: 100`; passes after.
- `mvn -pl paimon-core -am clean install` ran the normal checks (checkstyle/spotless/rat); only `PostgresqlCatalogTest` was skipped for local Docker absence.
