### PR TITLE
[docs] Escape ampersand (&) in config doc generator's escapeCharacters

### DIFF
--- a/paimon-docs/src/main/java/org/apache/paimon/docs/util/Utils.java
+++ b/paimon-docs/src/main/java/org/apache/paimon/docs/util/Utils.java
@@ -29,6 +29,7 @@ public class Utils {
 
     public static String escapeCharacters(String value) {
         return value.replaceAll("<wbr>", TEMPORARY_PLACEHOLDER)
+                .replaceAll("&", "&amp;")
                 .replaceAll("<", "&lt;")
                 .replaceAll(">", "&gt;")
                 .replaceAll(TEMPORARY_PLACEHOLDER, "<wbr>");

--- a/paimon-docs/src/test/java/org/apache/paimon/docs/util/UtilsTest.java
+++ b/paimon-docs/src/test/java/org/apache/paimon/docs/util/UtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.docs.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link Utils}. */
+class UtilsTest {
+
+    @Test
+    void testEscapeAmpersand() {
+        assertThat(Utils.escapeCharacters("a&b")).isEqualTo("a&amp;b");
+    }
+
+    @Test
+    void testAmpersandEscapedBeforeAngleBrackets() {
+        // '&' must be replaced first so the '&' produced by the '<'/'>' escaping is not
+        // double-escaped into "&amp;lt;"/"&amp;gt;".
+        assertThat(Utils.escapeCharacters("<a&b>")).isEqualTo("&lt;a&amp;b&gt;");
+    }
+
+    @Test
+    void testWbrPreservedWhileAmpersandEscaped() {
+        assertThat(Utils.escapeCharacters("x&<wbr>y")).isEqualTo("x&amp;<wbr>y");
+    }
+
+    @Test
+    void testAngleBracketsStillEscaped() {
+        assertThat(Utils.escapeCharacters("<a>")).isEqualTo("&lt;a&gt;");
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8551

- `Utils.escapeCharacters` escaped `<` and `>` but not `&`, so an `&` in a config option key/default/type/enum column was left unescaped in the generated HTML.
- Add a `&` -> `&amp;` replacement first (before `<`/`>`) so the `&` in the produced `&lt;`/`&gt;` is not double-escaped.
- Matches the sibling `HtmlFormatter.escapeCharacters` (paimon-api), which renders the Description column of the same table and already escapes `&`, `<`, `>`.

### Tests

- Added `UtilsTest` covering `&` escaping, order correctness (`<a&b>` -> `&lt;a&amp;b&gt;`), `<wbr>` preservation, and unchanged `<`/`>` escaping.
- `mvn -pl paimon-docs -DfailIfNoTests=false clean install` — 13 unit tests passed. Generated-docs diff is 0 (no existing option contains `&`), so `ConfigOptionsDocsCompletenessITCase` is unaffected and passed.
