### PR TITLE
[cosn] Log Hadoop config entries at debug level instead of warn

### DIFF
--- a/paimon-filesystems/paimon-cosn-impl/src/main/java/org/apache/paimon/cosn/COSNFileIO.java
+++ b/paimon-filesystems/paimon-cosn-impl/src/main/java/org/apache/paimon/cosn/COSNFileIO.java
@@ -80,7 +80,7 @@ public class COSNFileIO extends HadoopCompliantFileIO {
                         key = CASE_SENSITIVE_KEYS.get(key.toLowerCase());
                     }
                     hadoopOptions.set(key, value);
-                    LOG.warn(
+                    LOG.debug(
                             "Adding config entry for {} as {} to Hadoop config",
                             key,
                             hadoopOptions.get(key));


### PR DESCRIPTION

### Purpose

fix #8553

- `COSNFileIO.configure()` logged each `fs.cosn.*` entry with `LOG.warn`; change it to `LOG.debug`.
- Restores parity: the five sibling filesystem impls (oss/obs/s3/azure/jindo) all log this identical "Adding config entry" statement at `LOG.debug`; COSN was the outlier.
- Side benefit: the `fs.cosn.userinfo.secretKey` value is no longer emitted at the default WARN level (siblings also log the value, but only at debug — this change aligns the level only, it does not mask the value).

### Tests

- No unit test added: log-level assertions are not idiomatic in Paimon (no sibling filesystem impl tests `configure()` log levels, and `paimon-cosn-impl` has no test source dir).
- Verified by `mvn -pl paimon-filesystems/paimon-cosn-impl -am -DfailIfNoTests=false clean install` (JDK 11) — BUILD SUCCESS, including spotless-check, checkstyle, and rat.

