### PR TITLE
[fs] Declare serialVersionUID in COSNLoader for Serializable consistency

### DIFF
--- a/paimon-filesystems/paimon-cosn/src/main/java/org/apache/paimon/cosn/COSNLoader.java
+++ b/paimon-filesystems/paimon-cosn/src/main/java/org/apache/paimon/cosn/COSNLoader.java
@@ -30,6 +30,9 @@ import java.util.List;
 
 /** A {@link PluginLoader} to load cosn. */
 public class COSNLoader implements FileIOLoader {
+
+    private static final long serialVersionUID = 1L;
+
     private static final String COSN_JAR = "paimon-plugin-cosn";
     private static final String COSN_CLASS = "org.apache.paimon.cosn.COSNFileIO";
     // Singleton lazy initialization


### PR DESCRIPTION

### Purpose


- `FileIOLoader` is `@Public` and `extends Serializable`, so its implementations are serialized.
- Among the loaders using the `PluginFileIO` pattern (`OBSLoader`, `OSSLoader`, `S3Loader`, `GSLoader`, `AzureLoader`, `COSNLoader`), `COSNLoader` is the only one that declares `serialVersionUID` on its inner `PluginFileIO` but omits it on the outer loader class.
- Declaring it pins the UID to `1L` instead of relying on the compiler-computed value, aligning `COSNLoader` with the other five loaders.

### Tests

- Consistency change with no behavior change — no test added (matches the sibling loaders, which declare `serialVersionUID` without dedicated tests; the thin loader modules have no `src/test`).
- `mvn -pl paimon-filesystems/paimon-cosn -DfailIfNoTests=false clean install` passed (spotless / checkstyle / rat / enforcer) on JDK 11.

