### PR TITLE
[filesystem] Fix jersey-json typo in hadoop-shaded-3.4 pom comment

### DIFF
--- a/paimon-filesystems/paimon-hadoop-shaded-3.4/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-shaded-3.4/pom.xml
@@ -178,7 +178,7 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-reload4j</artifactId>
                 </exclusion>
-                <!-- Exclude jeysey-json because of incompatible license -->
+                <!-- Exclude jersey-json because of incompatible license -->
                 <exclusion>
                     <groupId>com.github.pjfanning</groupId>
                     <artifactId>jersey-json</artifactId>


### PR DESCRIPTION
### Purpose

- The dependency-exclusion comment in `paimon-hadoop-shaded-3.4/pom.xml` reads `Exclude jeysey-json`, while the excluded artifact is `com.github.pjfanning:jersey-json`. Corrects the comment to match.
- Introduced when the module was added in "[azure] Use hadoop 3.4.2 for azure FileIO"; it is the only `jeysey` occurrence in the repository.

### Tests

- Typo/wording fix, no behavior change — no test added. `mvn -pl paimon-filesystems/paimon-hadoop-shaded-3.4 -DfailIfNoTests=false clean install` passed (BUILD SUCCESS, JDK 11).
