### PR TITLE
[fs] Fix GSFileIO to return actual file access time and owner

### DIFF
--- a/paimon-filesystems/paimon-gs-impl/src/main/java/org/apache/paimon/gs/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-gs-impl/src/main/java/org/apache/paimon/gs/HadoopCompliantFileIO.java
@@ -286,5 +286,15 @@ public abstract class HadoopCompliantFileIO implements FileIO {
         public long getModificationTime() {
             return status.getModificationTime();
         }
+
+        @Override
+        public long getAccessTime() {
+            return status.getAccessTime();
+        }
+
+        @Override
+        public String getOwner() {
+            return status.getOwner();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

fix #8556

- `HadoopCompliantFileIO.HadoopFileStatus` in `paimon-gs-impl` did not override `getAccessTime()`/`getOwner()`, so on GCS file status always returned the `FileStatus` interface defaults (`0` and `null`) instead of the values carried by the wrapped Hadoop `FileStatus`.
- Add the two delegating overrides, restoring parity with the s3/oss/obs/cosn/azure impls, which already do this.
- The delegation originated in core `HadoopFileIO`+s3+oss (#4459) and was added per module for the others; the later GS impl (#5238) omitted it.

### Tests

- No unit test added: `HadoopFileStatus` is a private static delegation wrapper reachable only through a live GCS `FileSystem`; the five sibling impls merged the identical overrides without one.
- `mvn -pl paimon-filesystems/paimon-gs-impl clean install` passed (compile + checkstyle + spotless + rat).
