### PR TITLE
[fs] Force CVE-patched commons-lang3 and snappy-java in hadoop-shaded

### DIFF
--- a/paimon-filesystems/paimon-hadoop-shaded/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-shaded/pom.xml
@@ -44,6 +44,18 @@
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons.beanutils.version}</version>
             </dependency>
+            <dependency>
+                <!-- Bumped for security purposes (CVE-2025-48924); aligns bundled version with NOTICE -->
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.18.0</version>
+            </dependency>
+            <dependency>
+                <!-- Bumped for security purposes; aligns bundled version with NOTICE -->
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>${snappy.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION

### Purpose

fix #8558

- `paimon-hadoop-shaded`'s NOTICE declares `commons-lang3:3.18.0` and `snappy-java:1.1.10.8`, but the shaded jar bundled the transitive `3.12.0` / `1.1.8.2` from `hadoop-common:3.3.4` — the CVE fixes #6781 (CVE-2025-48924) and #7383 only touched NOTICE / an inert root property, so they never reached this artifact.
- Add `dependencyManagement` overrides pinning both to the versions the NOTICE already declares, mirroring the existing `commons-beanutils` security bump in the same pom. No NOTICE change needed.
- Fix propagates to `paimon-hadoop-uber` and the oss/s3/obs/cosn/azure `-impl` modules, which bundle hadoop through this module.

### Tests

- Build-config change (no runtime behavior), same shape as the existing `commons-beanutils` bump — no unit test added.
- `mvn -pl paimon-filesystems/paimon-hadoop-shaded dependency:tree` now resolves `commons-lang3:3.18.0` and `snappy-java:1.1.10.8`.
- `mvn -pl paimon-filesystems/paimon-hadoop-shaded clean install` passes (shade + checkstyle + rat); the shaded jar bundles commons-lang3 3.18.0 and snappy-java 1.1.10.8.


