### PR TITLE
[core] Fix column masking correctness in query-auth reads

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -40,6 +40,17 @@ public interface PredicateVisitor<T> {
         return predicate.visit(new FieldNameCollector());
     }
 
+    /** Collects the field names referenced by a transform's inputs. */
+    static Set<String> collectFieldNames(Transform transform) {
+        Set<String> fieldNames = new HashSet<>();
+        for (Object input : transform.inputs()) {
+            if (input instanceof FieldRef) {
+                fieldNames.add(((FieldRef) input).name());
+            }
+        }
+        return fieldNames;
+    }
+
     static Set<Integer> collectFieldIds(RowType rowType, @Nullable Predicate predicate) {
         if (predicate == null) {
             return Collections.emptySet();
@@ -58,13 +69,7 @@ public interface PredicateVisitor<T> {
 
         @Override
         public Set<String> visit(LeafPredicate predicate) {
-            Set<String> fieldNames = new HashSet<>();
-            for (Object input : predicate.transform().inputs()) {
-                if (input instanceof FieldRef) {
-                    fieldNames.add(((FieldRef) input).name());
-                }
-            }
-            return fieldNames;
+            return collectFieldNames(predicate.transform());
         }
 
         @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -40,7 +40,6 @@ public interface PredicateVisitor<T> {
         return predicate.visit(new FieldNameCollector());
     }
 
-    /** Collects the field names a transform's inputs reference. */
     static Set<String> collectTransformFieldNames(Transform transform) {
         Set<String> fieldNames = new HashSet<>();
         for (Object input : transform.inputs()) {

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -40,8 +40,8 @@ public interface PredicateVisitor<T> {
         return predicate.visit(new FieldNameCollector());
     }
 
-    /** Collects the field names referenced by a transform's inputs. */
-    static Set<String> collectFieldNames(Transform transform) {
+    /** Collects the field names a transform's inputs reference. */
+    static Set<String> collectTransformFieldNames(Transform transform) {
         Set<String> fieldNames = new HashSet<>();
         for (Object input : transform.inputs()) {
             if (input instanceof FieldRef) {
@@ -69,7 +69,7 @@ public interface PredicateVisitor<T> {
 
         @Override
         public Set<String> visit(LeafPredicate predicate) {
-            return collectFieldNames(predicate.transform());
+            return collectTransformFieldNames(predicate.transform());
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -32,6 +32,7 @@ import org.apache.paimon.partition.Partition;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.SchemaValidation;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.FileStoreTable;
@@ -168,17 +169,8 @@ public class CatalogUtils {
         if (tableType.equals(TableType.FORMAT_TABLE)) {
             validateFormatTableOptions(options, dataTokenEnabled);
         }
-        // only a file-store table reads through the auth reader; anywhere else the rules would
-        // be accepted and then silently not applied
-        if (options.get(CoreOptions.QUERY_AUTH_ENABLED)
-                && tableType != TableType.TABLE
-                && tableType != TableType.MATERIALIZED_TABLE) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "%s is not supported on a %s: its read does not apply row filters or "
-                                    + "column masks.",
-                            CoreOptions.QUERY_AUTH_ENABLED.key(), tableType));
-        }
+        SchemaValidation.validateQueryAuthTableType(
+                tableType, options.get(CoreOptions.QUERY_AUTH_ENABLED));
         for (DataField field : schema.fields()) {
             validateDefaultValue(field.type(), field.defaultValue());
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -168,6 +168,17 @@ public class CatalogUtils {
         if (tableType.equals(TableType.FORMAT_TABLE)) {
             validateFormatTableOptions(options, dataTokenEnabled);
         }
+        // only a file-store table reads through the auth reader; anywhere else the rules would
+        // be accepted and then silently not applied
+        if (options.get(CoreOptions.QUERY_AUTH_ENABLED)
+                && tableType != TableType.TABLE
+                && tableType != TableType.MATERIALIZED_TABLE) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s is not supported on a %s: its read does not apply row filters or "
+                                    + "column masks.",
+                            CoreOptions.QUERY_AUTH_ENABLED.key(), tableType));
+        }
         for (DataField field : schema.fields()) {
             validateDefaultValue(field.type(), field.defaultValue());
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -28,10 +28,12 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
@@ -41,10 +43,15 @@ import org.apache.paimon.utils.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -55,6 +62,10 @@ public class TableQueryAuthResult implements Serializable {
 
     private final @Nullable List<String> filter;
     private final @Nullable Map<String, String> columnMasking;
+
+    // lazily parsed views of the JSON rules; transient so serialization stays unchanged
+    private transient volatile Optional<Predicate> parsedFilter;
+    private transient volatile Map<String, Transform> parsedMasking;
 
     public TableQueryAuthResult(
             @Nullable List<String> filter, @Nullable Map<String, String> columnMasking) {
@@ -72,8 +83,39 @@ public class TableQueryAuthResult implements Serializable {
         return columnMasking;
     }
 
+    /** Whether this result carries any effective row-filter or masking rule. */
+    public boolean hasRules() {
+        return extractPredicate() != null || !extractColumnMasking().isEmpty();
+    }
+
+    /**
+     * Widens {@code readType} with the unprojected columns the rules read, or null when the
+     * projection already covers them. Scans apply this before planning file pruning.
+     */
+    @Nullable
+    public RowType widenReadType(RowType tableType, RowType readType) {
+        return appendMissingFields(
+                tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
+    @Nullable
+    public static RowType appendMissingFields(
+            RowType tableType, RowType readType, Set<String> ruleFields) {
+        List<DataField> widenedFields = null;
+        for (DataField field : tableType.getFields()) {
+            if (ruleFields.contains(field.name()) && !readType.containsField(field.name())) {
+                if (widenedFields == null) {
+                    widenedFields = new ArrayList<>(readType.getFields());
+                }
+                widenedFields.add(field);
+            }
+        }
+        return widenedFields == null ? null : readType.copy(widenedFields);
+    }
+
     public TableScan.Plan convertPlan(TableScan.Plan plan) {
-        if (filter == null && (columnMasking == null || columnMasking.isEmpty())) {
+        if (!hasRules()) {
             return plan;
         }
         List<Split> authSplits =
@@ -85,6 +127,16 @@ public class TableQueryAuthResult implements Serializable {
 
     @Nullable
     public Predicate extractPredicate() {
+        Optional<Predicate> parsed = parsedFilter;
+        if (parsed == null) {
+            parsed = Optional.ofNullable(parsePredicate());
+            parsedFilter = parsed;
+        }
+        return parsed.orElse(null);
+    }
+
+    @Nullable
+    private Predicate parsePredicate() {
         Predicate rowFilter = null;
         if (filter != null && !filter.isEmpty()) {
             List<Predicate> predicates = new ArrayList<>();
@@ -117,6 +169,15 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     public Map<String, Transform> extractColumnMasking() {
+        Map<String, Transform> parsed = parsedMasking;
+        if (parsed == null) {
+            parsed = parseColumnMasking();
+            parsedMasking = parsed;
+        }
+        return parsed;
+    }
+
+    private Map<String, Transform> parseColumnMasking() {
         Map<String, Transform> result = new TreeMap<>();
         if (columnMasking != null && !columnMasking.isEmpty()) {
             for (Map.Entry<String, String> e : columnMasking.entrySet()) {
@@ -135,8 +196,122 @@ public class TableQueryAuthResult implements Serializable {
         return result;
     }
 
+    /**
+     * Validates that every column the auth rules reference exists in the table's <b>latest</b>
+     * schema (not a time-travel-pinned one). A rule keyed by a since-renamed column looks just like
+     * an unprojected one at read time and would silently stop masking: fail closed instead.
+     */
+    public void validateAgainstSchema(RowType tableType, @Nullable List<String> projectedFields) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            String target = entry.getKey();
+            // a mask on an unprojected system column is inert (never in the output); don't reject
+            if (SpecialFields.SYSTEM_FIELD_NAMES.contains(target)
+                    && (projectedFields == null || !projectedFields.contains(target))) {
+                continue;
+            }
+            checkFieldExists("Column masking", target, tableType, projectedFields);
+            for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                checkFieldExists("Column masking", input, tableType, projectedFields);
+            }
+        }
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            checkFieldExists("Row filter", operand, tableType, projectedFields);
+        }
+    }
+
+    /**
+     * Fails closed when a masked column is present in the read schema under a different name than
+     * the rule uses (renamed between the read snapshot and latest): name-based enforcement would
+     * skip the mask and leak the raw value. A column absent from the read schema is left inert.
+     */
+    public void validateReadableWithoutRename(RowType latestType, RowType readType) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            checkNotRenamed(entry.getKey(), latestType, readType);
+            // a mask whose target is absent from the read schema is inert; skip its inputs
+            if (readType.containsField(entry.getKey())) {
+                for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                    checkNotRenamed(input, latestType, readType);
+                }
+            }
+        }
+    }
+
+    private static void checkNotRenamed(String field, RowType latestType, RowType readType) {
+        // present by name: enforced fine. absent from latest: already thrown. else: renamed?
+        if (readType.containsField(field) || !latestType.containsField(field)) {
+            return;
+        }
+        int id = latestType.getField(field).id();
+        if (readType.containsField(id)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Column masking references column '%s' which the snapshot being read "
+                                    + "exposes as '%s' (renamed since); refusing to read to avoid "
+                                    + "applying the rule by a stale name.",
+                            field, readType.getField(id).name()));
+        }
+    }
+
+    /**
+     * The field names the auth rules read for a query projecting {@code projectedFields}: the
+     * row-filter operands, plus (transitively) the inputs of every mask whose target is readable —
+     * projected, or itself pulled in by the filter or another mask.
+     */
+    public Set<String> requiredAuthFields(List<String> projectedFields) {
+        Map<String, Transform> masking = extractColumnMasking();
+        Set<String> ruleFields = new HashSet<>();
+        Set<String> readable = new HashSet<>(projectedFields);
+        Deque<String> newlyReadable = new ArrayDeque<>(readable);
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            ruleFields.add(operand);
+            if (readable.add(operand)) {
+                newlyReadable.add(operand);
+            }
+        }
+        while (!newlyReadable.isEmpty()) {
+            Transform mask = masking.get(newlyReadable.poll());
+            if (mask == null) {
+                continue;
+            }
+            for (String input : PredicateVisitor.collectFieldNames(mask)) {
+                ruleFields.add(input);
+                if (readable.add(input)) {
+                    newlyReadable.add(input);
+                }
+            }
+        }
+        return ruleFields;
+    }
+
+    private static void checkFieldExists(
+            String rule, String field, RowType tableType, @Nullable List<String> projectedFields) {
+        // system fields (e.g. _ROW_ID) are readable metadata absent from the table schema,
+        // but only when the query actually projects them -- they cannot be widened in
+        if (SpecialFields.SYSTEM_FIELD_NAMES.contains(field)) {
+            if (projectedFields != null && projectedFields.contains(field)) {
+                return;
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references system column '%s' which the query does not project.",
+                            rule, field));
+        }
+        if (!tableType.containsField(field)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references column '%s' which does not exist in table schema %s. "
+                                    + "The rule may be stale after a column rename or drop; "
+                                    + "refusing to read.",
+                            rule, field, tableType.getFieldNames()));
+        }
+    }
+
+    /**
+     * Applies the row filter and column masking to {@code reader}. Rules are remapped by name;
+     * masks apply only to targets in {@code activeFields}, the columns readable from the query.
+     */
     public RecordReader<InternalRow> doAuth(
-            RecordReader<InternalRow> reader, RowType outputRowType) {
+            RecordReader<InternalRow> reader, RowType outputRowType, Set<String> activeFields) {
         Predicate rowFilter = extractPredicate();
         if (rowFilter != null) {
             Predicate remappedFilter = remapPredicate(rowFilter, outputRowType);
@@ -146,9 +321,9 @@ public class TableQueryAuthResult implements Serializable {
         }
 
         Map<String, Transform> columnMasking = extractColumnMasking();
-        if (columnMasking != null && !columnMasking.isEmpty()) {
+        if (!columnMasking.isEmpty()) {
             Map<Integer, Transform> remappedMasking =
-                    transformRemapping(outputRowType, columnMasking);
+                    transformRemapping(outputRowType, columnMasking, activeFields);
             if (!remappedMasking.isEmpty()) {
                 reader = reader.transform(row -> transform(outputRowType, remappedMasking, row));
             }
@@ -175,12 +350,8 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     private static Map<Integer, Transform> transformRemapping(
-            RowType outputRowType, Map<String, Transform> masking) {
+            RowType outputRowType, Map<String, Transform> masking, Set<String> activeFields) {
         Map<Integer, Transform> out = new HashMap<>();
-        if (masking == null || masking.isEmpty()) {
-            return out;
-        }
-
         for (Map.Entry<String, Transform> e : masking.entrySet()) {
             String targetColumn = e.getKey();
             Transform transform = e.getValue();
@@ -188,6 +359,10 @@ public class TableQueryAuthResult implements Serializable {
                 continue;
             }
 
+            if (!activeFields.contains(targetColumn)) {
+                // not readable from the query, at most retained in a widened read schema
+                continue;
+            }
             int targetIndex = outputRowType.getFieldIndex(targetColumn);
             if (targetIndex < 0) {
                 continue;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -28,10 +28,12 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
@@ -41,10 +43,15 @@ import org.apache.paimon.utils.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -57,6 +64,10 @@ public class TableQueryAuthResult implements Serializable {
 
     private final @Nullable List<String> filter;
     private final @Nullable Map<String, String> columnMasking;
+
+    // lazily parsed views of the JSON rules; transient so serialization stays unchanged
+    private transient volatile Optional<Predicate> parsedFilter;
+    private transient volatile Map<String, Transform> parsedMasking;
 
     public TableQueryAuthResult(
             @Nullable List<String> filter, @Nullable Map<String, String> columnMasking) {
@@ -74,8 +85,39 @@ public class TableQueryAuthResult implements Serializable {
         return columnMasking;
     }
 
+    /** Whether this result carries any effective row-filter or masking rule. */
+    public boolean hasRules() {
+        return extractPredicate() != null || !extractColumnMasking().isEmpty();
+    }
+
+    /**
+     * Widens {@code readType} with the unprojected columns the rules read, or null when the
+     * projection already covers them. Scans apply this before planning file pruning.
+     */
+    @Nullable
+    public RowType widenReadType(RowType tableType, RowType readType) {
+        return appendMissingFields(
+                tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
+    @Nullable
+    public static RowType appendMissingFields(
+            RowType tableType, RowType readType, Set<String> ruleFields) {
+        List<DataField> widenedFields = null;
+        for (DataField field : tableType.getFields()) {
+            if (ruleFields.contains(field.name()) && !readType.containsField(field.name())) {
+                if (widenedFields == null) {
+                    widenedFields = new ArrayList<>(readType.getFields());
+                }
+                widenedFields.add(field);
+            }
+        }
+        return widenedFields == null ? null : readType.copy(widenedFields);
+    }
+
     public TableScan.Plan convertPlan(TableScan.Plan plan) {
-        if (filter == null && (columnMasking == null || columnMasking.isEmpty())) {
+        if (!hasRules()) {
             return plan;
         }
         List<Split> authSplits =
@@ -87,6 +129,16 @@ public class TableQueryAuthResult implements Serializable {
 
     @Nullable
     public Predicate extractPredicate() {
+        Optional<Predicate> parsed = parsedFilter;
+        if (parsed == null) {
+            parsed = Optional.ofNullable(parsePredicate());
+            parsedFilter = parsed;
+        }
+        return parsed.orElse(null);
+    }
+
+    @Nullable
+    private Predicate parsePredicate() {
         Predicate rowFilter = null;
         if (filter != null && !filter.isEmpty()) {
             List<Predicate> predicates = new ArrayList<>();
@@ -116,6 +168,15 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     public Map<String, Transform> extractColumnMasking() {
+        Map<String, Transform> parsed = parsedMasking;
+        if (parsed == null) {
+            parsed = parseColumnMasking();
+            parsedMasking = parsed;
+        }
+        return parsed;
+    }
+
+    private Map<String, Transform> parseColumnMasking() {
         Map<String, Transform> result = new TreeMap<>();
         if (columnMasking != null && !columnMasking.isEmpty()) {
             for (Map.Entry<String, String> e : columnMasking.entrySet()) {
@@ -131,6 +192,120 @@ public class TableQueryAuthResult implements Serializable {
         return result;
     }
 
+    /**
+     * Validates that every column the auth rules reference exists in the table's <b>latest</b>
+     * schema (not a time-travel-pinned one). A rule keyed by a since-renamed column looks just like
+     * an unprojected one at read time and would silently stop masking: fail closed instead.
+     */
+    public void validateAgainstSchema(RowType tableType, @Nullable List<String> projectedFields) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            String target = entry.getKey();
+            // a mask on an unprojected system column is inert (never in the output); don't reject
+            if (SpecialFields.SYSTEM_FIELD_NAMES.contains(target)
+                    && (projectedFields == null || !projectedFields.contains(target))) {
+                continue;
+            }
+            checkFieldExists("Column masking", target, tableType, projectedFields);
+            for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                checkFieldExists("Column masking", input, tableType, projectedFields);
+            }
+        }
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            checkFieldExists("Row filter", operand, tableType, projectedFields);
+        }
+    }
+
+    /**
+     * Fails closed when a masked column is present in the read schema under a different name than
+     * the rule uses (renamed between the read snapshot and latest): name-based enforcement would
+     * skip the mask and leak the raw value. A column absent from the read schema is left inert.
+     */
+    public void validateReadableWithoutRename(RowType latestType, RowType readType) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            checkNotRenamed(entry.getKey(), latestType, readType);
+            // a mask whose target is absent from the read schema is inert; skip its inputs
+            if (readType.containsField(entry.getKey())) {
+                for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                    checkNotRenamed(input, latestType, readType);
+                }
+            }
+        }
+    }
+
+    private static void checkNotRenamed(String field, RowType latestType, RowType readType) {
+        // present by name: enforced fine. absent from latest: already thrown. else: renamed?
+        if (readType.containsField(field) || !latestType.containsField(field)) {
+            return;
+        }
+        int id = latestType.getField(field).id();
+        if (readType.containsField(id)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Column masking references column '%s' which the snapshot being read "
+                                    + "exposes as '%s' (renamed since); refusing to read to avoid "
+                                    + "applying the rule by a stale name.",
+                            field, readType.getField(id).name()));
+        }
+    }
+
+    /**
+     * The field names the auth rules read for a query projecting {@code projectedFields}: the
+     * row-filter operands, plus (transitively) the inputs of every mask whose target is readable —
+     * projected, or itself pulled in by the filter or another mask.
+     */
+    public Set<String> requiredAuthFields(List<String> projectedFields) {
+        Map<String, Transform> masking = extractColumnMasking();
+        Set<String> ruleFields = new HashSet<>();
+        Set<String> readable = new HashSet<>(projectedFields);
+        Deque<String> newlyReadable = new ArrayDeque<>(readable);
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            ruleFields.add(operand);
+            if (readable.add(operand)) {
+                newlyReadable.add(operand);
+            }
+        }
+        while (!newlyReadable.isEmpty()) {
+            Transform mask = masking.get(newlyReadable.poll());
+            if (mask == null) {
+                continue;
+            }
+            for (String input : PredicateVisitor.collectFieldNames(mask)) {
+                ruleFields.add(input);
+                if (readable.add(input)) {
+                    newlyReadable.add(input);
+                }
+            }
+        }
+        return ruleFields;
+    }
+
+    private static void checkFieldExists(
+            String rule, String field, RowType tableType, @Nullable List<String> projectedFields) {
+        // system fields (e.g. _ROW_ID) are readable metadata absent from the table schema,
+        // but only when the query actually projects them -- they cannot be widened in
+        if (SpecialFields.SYSTEM_FIELD_NAMES.contains(field)) {
+            if (projectedFields != null && projectedFields.contains(field)) {
+                return;
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references system column '%s' which the query does not project.",
+                            rule, field));
+        }
+        if (!tableType.containsField(field)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references column '%s' which does not exist in table schema %s. "
+                                    + "The rule may be stale after a column rename or drop; "
+                                    + "refusing to read.",
+                            rule, field, tableType.getFieldNames()));
+        }
+    }
+
+    /**
+     * Applies the row filter and column masking to {@code reader}. Rules are remapped by name;
+     * masks apply only to targets in {@code activeFields}, the columns readable from the query.
+     */
     public RecordReader<InternalRow> doAuth(
             RecordReader<InternalRow> reader, RowType outputRowType) {
         return doAuth(reader, outputRowType, extractPredicate(), extractColumnMasking());
@@ -180,10 +355,6 @@ public class TableQueryAuthResult implements Serializable {
     private static Map<Integer, Transform> transformRemapping(
             RowType outputRowType, Map<String, Transform> masking) {
         Map<Integer, Transform> out = new HashMap<>();
-        if (masking == null || masking.isEmpty()) {
-            return out;
-        }
-
         for (Map.Entry<String, Transform> e : masking.entrySet()) {
             String targetColumn = e.getKey();
             Transform transform = e.getValue();

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -25,6 +25,7 @@ import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
@@ -45,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,7 +67,8 @@ public class TableQueryAuthResult implements Serializable {
     private final @Nullable List<String> filter;
     private final @Nullable Map<String, String> columnMasking;
 
-    // lazily parsed views of the JSON rules; transient so serialization stays unchanged
+    // Lazily parsed views of the JSON rules; transient so serialization stays unchanged. No
+    // invalidation needed: an instance is immutable and rebuilt for every plan().
     private transient volatile Optional<Predicate> parsedFilter;
     private transient volatile Map<String, Transform> parsedMasking;
 
@@ -98,6 +101,60 @@ public class TableQueryAuthResult implements Serializable {
     public RowType widenReadType(RowType tableType, RowType readType) {
         return appendMissingFields(
                 tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /**
+     * Drops the conjuncts of {@code predicate} referencing any of {@code fields}; returns null when
+     * nothing remains. Used to keep raw-statistics pushdown off masked columns.
+     */
+    @Nullable
+    public static Predicate excludeFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, true);
+    }
+
+    /**
+     * Keeps only the conjuncts of {@code predicate} referencing any of {@code fields}; returns null
+     * when none does.
+     */
+    @Nullable
+    public static Predicate retainFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, false);
+    }
+
+    @Nullable
+    private static Predicate filterConjuncts(
+            Predicate predicate, Set<String> fields, boolean keepDisjoint) {
+        List<Predicate> kept = new ArrayList<>();
+        for (Predicate conjunct : PredicateBuilder.splitAnd(predicate)) {
+            if (Collections.disjoint(PredicateVisitor.collectFieldNames(conjunct), fields)
+                    == keepDisjoint) {
+                kept.add(conjunct);
+            }
+        }
+        if (kept.isEmpty()) {
+            return null;
+        }
+        return kept.size() == 1 ? kept.get(0) : PredicateBuilder.and(kept);
+    }
+
+    /**
+     * Every column read by the conjuncts of {@code filter} that touch {@code maskTargets}. Their
+     * unmasked operands count too, since splitAnd does not split a disjunction.
+     */
+    public static Set<String> postMaskFilterFields(
+            @Nullable Predicate filter, Set<String> maskTargets) {
+        if (filter == null || maskTargets.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> maskedInFilter = new HashSet<>(PredicateVisitor.collectFieldNames(filter));
+        maskedInFilter.retainAll(maskTargets);
+        if (maskedInFilter.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Predicate retained = retainFields(filter, maskedInFilter);
+        return retained == null
+                ? Collections.emptySet()
+                : new HashSet<>(PredicateVisitor.collectFieldNames(retained));
     }
 
     /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
@@ -189,25 +246,38 @@ public class TableQueryAuthResult implements Serializable {
                 result.put(column, transform);
             }
         }
-        return result;
+        // the cache is shared by every caller, so hand out a view that cannot rewrite the rules
+        return Collections.unmodifiableMap(result);
     }
 
     /**
      * Validates that every column the auth rules reference exists in the table's <b>latest</b>
-     * schema (not a time-travel-pinned one). A rule keyed by a since-renamed column looks just like
-     * an unprojected one at read time and would silently stop masking: fail closed instead.
+     * schema. A rule keyed by a since-renamed column would silently stop masking; fail closed.
      */
     public void validateAgainstSchema(RowType tableType, @Nullable List<String> projectedFields) {
-        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+        Map<String, Transform> masking = extractColumnMasking();
+        for (Map.Entry<String, Transform> entry : masking.entrySet()) {
             String target = entry.getKey();
-            // a mask on an unprojected system column is inert (never in the output); don't reject
+            // a mask on an unprojected system column never reaches the output; inert, don't reject
             if (SpecialFields.SYSTEM_FIELD_NAMES.contains(target)
                     && (projectedFields == null || !projectedFields.contains(target))) {
                 continue;
             }
             checkFieldExists("Column masking", target, tableType, projectedFields);
-            for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+            for (String input : PredicateVisitor.collectTransformFieldNames(entry.getValue())) {
                 checkFieldExists("Column masking", input, tableType, projectedFields);
+                // A transform reads the raw row, so an input that is itself masked would be
+                // consumed unmasked and its raw value published through this target. Masking
+                // the target of another mask is only self-consistent if composed, which the
+                // read does not do; refuse the pair rather than leak.
+                if (!input.equals(target) && masking.containsKey(input)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Column masking on '%s' reads column '%s', which is masked "
+                                            + "too. The mask would be computed from the raw value "
+                                            + "of '%s' and expose it through '%s'.",
+                                    target, input, input, target));
+                }
             }
         }
         for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
@@ -216,42 +286,59 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     /**
-     * Fails closed when a masked column is present in the read schema under a different name than
-     * the rule uses (renamed between the read snapshot and latest): name-based enforcement would
-     * skip the mask and leak the raw value. A column absent from the read schema is left inert.
+     * Fails closed when the read schema exposes a rule's column under a different name, where
+     * enforcing by name would skip it. A column absent from that schema stays inert.
      */
     public void validateReadableWithoutRename(RowType latestType, RowType readType) {
         for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
-            checkNotRenamed(entry.getKey(), latestType, readType);
+            checkNotRenamed("Column masking", entry.getKey(), latestType, readType);
             // a mask whose target is absent from the read schema is inert; skip its inputs
             if (readType.containsField(entry.getKey())) {
-                for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
-                    checkNotRenamed(input, latestType, readType);
+                for (String input : PredicateVisitor.collectTransformFieldNames(entry.getValue())) {
+                    checkNotRenamed("Column masking", input, latestType, readType);
                 }
             }
         }
+        // the row filter is remapped by name as well, so it needs the same binding check
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            checkNotRenamed("Row filter", operand, latestType, readType);
+        }
     }
 
-    private static void checkNotRenamed(String field, RowType latestType, RowType readType) {
-        // present by name: enforced fine. absent from latest: already thrown. else: renamed?
-        if (readType.containsField(field) || !latestType.containsField(field)) {
+    private static void checkNotRenamed(
+            String rule, String field, RowType latestType, RowType readType) {
+        // absent from latest: already thrown by validateAgainstSchema
+        if (!latestType.containsField(field)) {
             return;
         }
         int id = latestType.getField(field).id();
+        if (readType.containsField(field)) {
+            // a dropped and re-added column keeps the name but gets a fresh id, so the same
+            // name may be an unrelated column in the snapshot being read
+            if (readType.getField(field).id() != id) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "%s references column '%s' which the snapshot being read exposes "
+                                        + "as a different column of the same name (dropped and "
+                                        + "re-added since); refusing to read to avoid applying the "
+                                        + "rule to unrelated data.",
+                                rule, field));
+            }
+            return;
+        }
         if (readType.containsField(id)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Column masking references column '%s' which the snapshot being read "
-                                    + "exposes as '%s' (renamed since); refusing to read to avoid "
-                                    + "applying the rule by a stale name.",
-                            field, readType.getField(id).name()));
+                            "%s references column '%s' which the snapshot being read exposes as "
+                                    + "'%s' (renamed since); refusing to read to avoid applying "
+                                    + "the rule by a stale name.",
+                            rule, field, readType.getField(id).name()));
         }
     }
 
     /**
      * The field names the auth rules read for a query projecting {@code projectedFields}: the
-     * row-filter operands, plus (transitively) the inputs of every mask whose target is readable —
-     * projected, or itself pulled in by the filter or another mask.
+     * row-filter operands, plus transitively the inputs of every mask whose target is readable.
      */
     public Set<String> requiredAuthFields(List<String> projectedFields) {
         Map<String, Transform> masking = extractColumnMasking();
@@ -269,7 +356,7 @@ public class TableQueryAuthResult implements Serializable {
             if (mask == null) {
                 continue;
             }
-            for (String input : PredicateVisitor.collectFieldNames(mask)) {
+            for (String input : PredicateVisitor.collectTransformFieldNames(mask)) {
                 ruleFields.add(input);
                 if (readable.add(input)) {
                     newlyReadable.add(input);
@@ -281,8 +368,7 @@ public class TableQueryAuthResult implements Serializable {
 
     private static void checkFieldExists(
             String rule, String field, RowType tableType, @Nullable List<String> projectedFields) {
-        // system fields (e.g. _ROW_ID) are readable metadata absent from the table schema,
-        // but only when the query actually projects them -- they cannot be widened in
+        // system fields (e.g. _ROW_ID) cannot be widened in; only usable when projected
         if (SpecialFields.SYSTEM_FIELD_NAMES.contains(field)) {
             if (projectedFields != null && projectedFields.contains(field)) {
                 return;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -29,7 +29,9 @@ import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.SpecialFields;
+import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
@@ -39,6 +41,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.utils.ListUtils;
 import org.apache.paimon.utils.StringUtils;
 
 import javax.annotation.Nullable;
@@ -88,9 +91,22 @@ public class TableQueryAuthResult implements Serializable {
         return columnMasking;
     }
 
-    /** Whether this result carries any effective row-filter or masking rule. */
     public boolean hasRules() {
         return extractPredicate() != null || !extractColumnMasking().isEmpty();
+    }
+
+    /**
+     * Rejects a search on a query-auth table. Called from the methods that produce a scan or a
+     * read, not from the builder constructors: the builders are serializable, and deserialization
+     * would skip a constructor check.
+     */
+    public static void rejectSearchUnderQueryAuth(@Nullable Table table) {
+        if (table instanceof FileStoreTable
+                && ((FileStoreTable) table).coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Search is not supported on a query-auth table: the index ranks raw values, "
+                            + "which a column mask invalidates.");
+        }
     }
 
     /**
@@ -124,6 +140,8 @@ public class TableQueryAuthResult implements Serializable {
         if (kept.isEmpty()) {
             return null;
         }
+        // and() folds an always-true/false leaf into a field-less constant, which would drop the
+        // field names the callers match against; a lone conjunct must come back untouched
         return kept.size() == 1 ? kept.get(0) : PredicateBuilder.and(kept);
     }
 
@@ -154,22 +172,17 @@ public class TableQueryAuthResult implements Serializable {
      */
     public Set<String> authFields(List<String> readFields, @Nullable Predicate filter) {
         Set<String> postMask = postMaskFilterFields(filter, extractColumnMasking().keySet());
-        List<String> visible = readFields;
-        if (!postMask.isEmpty()) {
-            visible = new ArrayList<>(readFields);
-            for (String field : postMask) {
-                if (!visible.contains(field)) {
-                    visible.add(field);
-                }
-            }
-        }
+        // requiredAuthFields de-duplicates, so a plain concatenation is enough here
+        List<String> visible =
+                postMask.isEmpty()
+                        ? readFields
+                        : ListUtils.union(readFields, new ArrayList<>(postMask));
         Set<String> ruleFields = requiredAuthFields(visible);
         // requiredAuthFields returns what the rules read, not the operands themselves
         ruleFields.addAll(postMask);
         return ruleFields;
     }
 
-    /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
     @Nullable
     public static RowType appendMissingFields(
             RowType tableType, RowType readType, Set<String> ruleFields) {
@@ -282,14 +295,15 @@ public class TableQueryAuthResult implements Serializable {
                 // consumed unmasked and its raw value published through this target. Masking
                 // the target of another mask is only self-consistent if composed, which the
                 // read does not do; refuse the pair rather than leak.
-                if (!input.equals(target) && masking.containsKey(input)) {
-                    throw new IllegalArgumentException(
-                            String.format(
-                                    "Column masking on '%s' reads column '%s', which is masked "
-                                            + "too. The mask would be computed from the raw value "
-                                            + "of '%s' and expose it through '%s'.",
-                                    target, input, input, target));
-                }
+                checkArgument(
+                        input.equals(target) || !masking.containsKey(input),
+                        "Column masking on '%s' reads column '%s', which is masked "
+                                + "too. The mask would be computed from the raw value "
+                                + "of '%s' and expose it through '%s'.",
+                        target,
+                        input,
+                        input,
+                        target);
             }
         }
         for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
@@ -327,17 +341,18 @@ public class TableQueryAuthResult implements Serializable {
         if (readType.containsField(field)) {
             // a dropped and re-added column keeps the name but gets a fresh id, so the same
             // name may be an unrelated column in the snapshot being read
-            if (readType.getField(field).id() != id) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "%s references column '%s' which the snapshot being read exposes "
-                                        + "as a different column of the same name (dropped and "
-                                        + "re-added since); refusing to read to avoid applying the "
-                                        + "rule to unrelated data.",
-                                rule, field));
-            }
+            checkArgument(
+                    readType.getField(field).id() == id,
+                    "%s references column '%s' which the snapshot being read exposes "
+                            + "as a different column of the same name (dropped and "
+                            + "re-added since); refusing to read to avoid applying the "
+                            + "rule to unrelated data.",
+                    rule,
+                    field);
             return;
         }
+        // not checkArgument: its arguments are evaluated eagerly, and getField(id) throws when
+        // the id is absent, which is the normal case here
         if (readType.containsField(id)) {
             throw new IllegalArgumentException(
                     String.format(
@@ -390,14 +405,14 @@ public class TableQueryAuthResult implements Serializable {
                             "%s references system column '%s' which the query does not project.",
                             rule, field));
         }
-        if (!tableType.containsField(field)) {
-            throw new IllegalArgumentException(
-                    String.format(
-                            "%s references column '%s' which does not exist in table schema %s. "
-                                    + "The rule may be stale after a column rename or drop; "
-                                    + "refusing to read.",
-                            rule, field, tableType.getFieldNames()));
-        }
+        checkArgument(
+                tableType.containsField(field),
+                "%s references column '%s' which does not exist in table schema %s. "
+                        + "The rule may be stale after a column rename or drop; "
+                        + "refusing to read.",
+                rule,
+                field,
+                tableType.getFieldNames());
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -25,6 +25,7 @@ import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
@@ -45,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,7 +65,8 @@ public class TableQueryAuthResult implements Serializable {
     private final @Nullable List<String> filter;
     private final @Nullable Map<String, String> columnMasking;
 
-    // lazily parsed views of the JSON rules; transient so serialization stays unchanged
+    // Lazily parsed views of the JSON rules; transient so serialization stays unchanged. No
+    // invalidation needed: an instance is immutable and rebuilt for every plan().
     private transient volatile Optional<Predicate> parsedFilter;
     private transient volatile Map<String, Transform> parsedMasking;
 
@@ -96,6 +99,60 @@ public class TableQueryAuthResult implements Serializable {
     public RowType widenReadType(RowType tableType, RowType readType) {
         return appendMissingFields(
                 tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /**
+     * Drops the conjuncts of {@code predicate} referencing any of {@code fields}; returns null when
+     * nothing remains. Used to keep raw-statistics pushdown off masked columns.
+     */
+    @Nullable
+    public static Predicate excludeFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, true);
+    }
+
+    /**
+     * Keeps only the conjuncts of {@code predicate} referencing any of {@code fields}; returns null
+     * when none does.
+     */
+    @Nullable
+    public static Predicate retainFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, false);
+    }
+
+    @Nullable
+    private static Predicate filterConjuncts(
+            Predicate predicate, Set<String> fields, boolean keepDisjoint) {
+        List<Predicate> kept = new ArrayList<>();
+        for (Predicate conjunct : PredicateBuilder.splitAnd(predicate)) {
+            if (Collections.disjoint(PredicateVisitor.collectFieldNames(conjunct), fields)
+                    == keepDisjoint) {
+                kept.add(conjunct);
+            }
+        }
+        if (kept.isEmpty()) {
+            return null;
+        }
+        return kept.size() == 1 ? kept.get(0) : PredicateBuilder.and(kept);
+    }
+
+    /**
+     * Every column read by the conjuncts of {@code filter} that touch {@code maskTargets}. Their
+     * unmasked operands count too, since splitAnd does not split a disjunction.
+     */
+    public static Set<String> postMaskFilterFields(
+            @Nullable Predicate filter, Set<String> maskTargets) {
+        if (filter == null || maskTargets.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> maskedInFilter = new HashSet<>(PredicateVisitor.collectFieldNames(filter));
+        maskedInFilter.retainAll(maskTargets);
+        if (maskedInFilter.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Predicate retained = retainFields(filter, maskedInFilter);
+        return retained == null
+                ? Collections.emptySet()
+                : new HashSet<>(PredicateVisitor.collectFieldNames(retained));
     }
 
     /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
@@ -193,25 +250,38 @@ public class TableQueryAuthResult implements Serializable {
                 result.put(column, transform);
             }
         }
-        return result;
+        // the cache is shared by every caller, so hand out a view that cannot rewrite the rules
+        return Collections.unmodifiableMap(result);
     }
 
     /**
      * Validates that every column the auth rules reference exists in the table's <b>latest</b>
-     * schema (not a time-travel-pinned one). A rule keyed by a since-renamed column looks just like
-     * an unprojected one at read time and would silently stop masking: fail closed instead.
+     * schema. A rule keyed by a since-renamed column would silently stop masking; fail closed.
      */
     public void validateAgainstSchema(RowType tableType, @Nullable List<String> projectedFields) {
-        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+        Map<String, Transform> masking = extractColumnMasking();
+        for (Map.Entry<String, Transform> entry : masking.entrySet()) {
             String target = entry.getKey();
-            // a mask on an unprojected system column is inert (never in the output); don't reject
+            // a mask on an unprojected system column never reaches the output; inert, don't reject
             if (SpecialFields.SYSTEM_FIELD_NAMES.contains(target)
                     && (projectedFields == null || !projectedFields.contains(target))) {
                 continue;
             }
             checkFieldExists("Column masking", target, tableType, projectedFields);
-            for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+            for (String input : PredicateVisitor.collectTransformFieldNames(entry.getValue())) {
                 checkFieldExists("Column masking", input, tableType, projectedFields);
+                // A transform reads the raw row, so an input that is itself masked would be
+                // consumed unmasked and its raw value published through this target. Masking
+                // the target of another mask is only self-consistent if composed, which the
+                // read does not do; refuse the pair rather than leak.
+                if (!input.equals(target) && masking.containsKey(input)) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Column masking on '%s' reads column '%s', which is masked "
+                                            + "too. The mask would be computed from the raw value "
+                                            + "of '%s' and expose it through '%s'.",
+                                    target, input, input, target));
+                }
             }
         }
         for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
@@ -220,42 +290,59 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     /**
-     * Fails closed when a masked column is present in the read schema under a different name than
-     * the rule uses (renamed between the read snapshot and latest): name-based enforcement would
-     * skip the mask and leak the raw value. A column absent from the read schema is left inert.
+     * Fails closed when the read schema exposes a rule's column under a different name, where
+     * enforcing by name would skip it. A column absent from that schema stays inert.
      */
     public void validateReadableWithoutRename(RowType latestType, RowType readType) {
         for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
-            checkNotRenamed(entry.getKey(), latestType, readType);
+            checkNotRenamed("Column masking", entry.getKey(), latestType, readType);
             // a mask whose target is absent from the read schema is inert; skip its inputs
             if (readType.containsField(entry.getKey())) {
-                for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
-                    checkNotRenamed(input, latestType, readType);
+                for (String input : PredicateVisitor.collectTransformFieldNames(entry.getValue())) {
+                    checkNotRenamed("Column masking", input, latestType, readType);
                 }
             }
         }
+        // the row filter is remapped by name as well, so it needs the same binding check
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            checkNotRenamed("Row filter", operand, latestType, readType);
+        }
     }
 
-    private static void checkNotRenamed(String field, RowType latestType, RowType readType) {
-        // present by name: enforced fine. absent from latest: already thrown. else: renamed?
-        if (readType.containsField(field) || !latestType.containsField(field)) {
+    private static void checkNotRenamed(
+            String rule, String field, RowType latestType, RowType readType) {
+        // absent from latest: already thrown by validateAgainstSchema
+        if (!latestType.containsField(field)) {
             return;
         }
         int id = latestType.getField(field).id();
+        if (readType.containsField(field)) {
+            // a dropped and re-added column keeps the name but gets a fresh id, so the same
+            // name may be an unrelated column in the snapshot being read
+            if (readType.getField(field).id() != id) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "%s references column '%s' which the snapshot being read exposes "
+                                        + "as a different column of the same name (dropped and "
+                                        + "re-added since); refusing to read to avoid applying the "
+                                        + "rule to unrelated data.",
+                                rule, field));
+            }
+            return;
+        }
         if (readType.containsField(id)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Column masking references column '%s' which the snapshot being read "
-                                    + "exposes as '%s' (renamed since); refusing to read to avoid "
-                                    + "applying the rule by a stale name.",
-                            field, readType.getField(id).name()));
+                            "%s references column '%s' which the snapshot being read exposes as "
+                                    + "'%s' (renamed since); refusing to read to avoid applying "
+                                    + "the rule by a stale name.",
+                            rule, field, readType.getField(id).name()));
         }
     }
 
     /**
      * The field names the auth rules read for a query projecting {@code projectedFields}: the
-     * row-filter operands, plus (transitively) the inputs of every mask whose target is readable —
-     * projected, or itself pulled in by the filter or another mask.
+     * row-filter operands, plus transitively the inputs of every mask whose target is readable.
      */
     public Set<String> requiredAuthFields(List<String> projectedFields) {
         Map<String, Transform> masking = extractColumnMasking();
@@ -273,7 +360,7 @@ public class TableQueryAuthResult implements Serializable {
             if (mask == null) {
                 continue;
             }
-            for (String input : PredicateVisitor.collectFieldNames(mask)) {
+            for (String input : PredicateVisitor.collectTransformFieldNames(mask)) {
                 ruleFields.add(input);
                 if (readable.add(input)) {
                     newlyReadable.add(input);
@@ -285,8 +372,7 @@ public class TableQueryAuthResult implements Serializable {
 
     private static void checkFieldExists(
             String rule, String field, RowType tableType, @Nullable List<String> projectedFields) {
-        // system fields (e.g. _ROW_ID) are readable metadata absent from the table schema,
-        // but only when the query actually projects them -- they cannot be widened in
+        // system fields (e.g. _ROW_ID) cannot be widened in; only usable when projected
         if (SpecialFields.SYSTEM_FIELD_NAMES.contains(field)) {
             if (projectedFields != null && projectedFields.contains(field)) {
                 return;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -92,16 +92,6 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     /**
-     * Widens {@code readType} with the unprojected columns the rules read, or null when the
-     * projection already covers them. Scans apply this before planning file pruning.
-     */
-    @Nullable
-    public RowType widenReadType(RowType tableType, RowType readType) {
-        return appendMissingFields(
-                tableType, readType, requiredAuthFields(readType.getFieldNames()));
-    }
-
-    /**
      * Drops the conjuncts of {@code predicate} referencing any of {@code fields}; returns null when
      * nothing remains. Used to keep raw-statistics pushdown off masked columns.
      */
@@ -139,7 +129,7 @@ public class TableQueryAuthResult implements Serializable {
      * Every column read by the conjuncts of {@code filter} that touch {@code maskTargets}. Their
      * unmasked operands count too, since splitAnd does not split a disjunction.
      */
-    public static Set<String> postMaskFilterFields(
+    private static Set<String> postMaskFilterFields(
             @Nullable Predicate filter, Set<String> maskTargets) {
         if (filter == null || maskTargets.isEmpty()) {
             return Collections.emptySet();
@@ -153,6 +143,28 @@ public class TableQueryAuthResult implements Serializable {
         return retained == null
                 ? Collections.emptySet()
                 : new HashSet<>(PredicateVisitor.collectFieldNames(retained));
+    }
+
+    /**
+     * The columns a read projecting {@code readFields} under {@code filter} must additionally
+     * expose: the rule fields, plus the operands of the conjuncts evaluated post-mask. The scan and
+     * the read both widen by this, and must agree — the read schema is fixed on first use.
+     */
+    public Set<String> authFields(List<String> readFields, @Nullable Predicate filter) {
+        Set<String> postMask = postMaskFilterFields(filter, extractColumnMasking().keySet());
+        List<String> visible = readFields;
+        if (!postMask.isEmpty()) {
+            visible = new ArrayList<>(readFields);
+            for (String field : postMask) {
+                if (!visible.contains(field)) {
+                    visible.add(field);
+                }
+            }
+        }
+        Set<String> ruleFields = requiredAuthFields(visible);
+        // requiredAuthFields returns what the rules read, not the operands themselves
+        ruleFields.addAll(postMask);
+        return ruleFields;
     }
 
     /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
@@ -344,7 +356,7 @@ public class TableQueryAuthResult implements Serializable {
      * The field names the auth rules read for a query projecting {@code projectedFields}: the
      * row-filter operands, plus transitively the inputs of every mask whose target is readable.
      */
-    public Set<String> requiredAuthFields(List<String> projectedFields) {
+    private Set<String> requiredAuthFields(List<String> projectedFields) {
         Map<String, Transform> masking = extractColumnMasking();
         Set<String> ruleFields = new HashSet<>();
         Set<String> readable = new HashSet<>(projectedFields);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -94,16 +94,6 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     /**
-     * Widens {@code readType} with the unprojected columns the rules read, or null when the
-     * projection already covers them. Scans apply this before planning file pruning.
-     */
-    @Nullable
-    public RowType widenReadType(RowType tableType, RowType readType) {
-        return appendMissingFields(
-                tableType, readType, requiredAuthFields(readType.getFieldNames()));
-    }
-
-    /**
      * Drops the conjuncts of {@code predicate} referencing any of {@code fields}; returns null when
      * nothing remains. Used to keep raw-statistics pushdown off masked columns.
      */
@@ -141,7 +131,7 @@ public class TableQueryAuthResult implements Serializable {
      * Every column read by the conjuncts of {@code filter} that touch {@code maskTargets}. Their
      * unmasked operands count too, since splitAnd does not split a disjunction.
      */
-    public static Set<String> postMaskFilterFields(
+    private static Set<String> postMaskFilterFields(
             @Nullable Predicate filter, Set<String> maskTargets) {
         if (filter == null || maskTargets.isEmpty()) {
             return Collections.emptySet();
@@ -155,6 +145,28 @@ public class TableQueryAuthResult implements Serializable {
         return retained == null
                 ? Collections.emptySet()
                 : new HashSet<>(PredicateVisitor.collectFieldNames(retained));
+    }
+
+    /**
+     * The columns a read projecting {@code readFields} under {@code filter} must additionally
+     * expose: the rule fields, plus the operands of the conjuncts evaluated post-mask. The scan and
+     * the read both widen by this, and must agree — the read schema is fixed on first use.
+     */
+    public Set<String> authFields(List<String> readFields, @Nullable Predicate filter) {
+        Set<String> postMask = postMaskFilterFields(filter, extractColumnMasking().keySet());
+        List<String> visible = readFields;
+        if (!postMask.isEmpty()) {
+            visible = new ArrayList<>(readFields);
+            for (String field : postMask) {
+                if (!visible.contains(field)) {
+                    visible.add(field);
+                }
+            }
+        }
+        Set<String> ruleFields = requiredAuthFields(visible);
+        // requiredAuthFields returns what the rules read, not the operands themselves
+        ruleFields.addAll(postMask);
+        return ruleFields;
     }
 
     /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
@@ -340,7 +352,7 @@ public class TableQueryAuthResult implements Serializable {
      * The field names the auth rules read for a query projecting {@code projectedFields}: the
      * row-filter operands, plus transitively the inputs of every mask whose target is readable.
      */
-    public Set<String> requiredAuthFields(List<String> projectedFields) {
+    private Set<String> requiredAuthFields(List<String> projectedFields) {
         Map<String, Transform> masking = extractColumnMasking();
         Set<String> ruleFields = new HashSet<>();
         Set<String> readable = new HashSet<>(projectedFields);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -90,9 +90,13 @@ public class DataEvolutionBatchScan implements DataTableScan {
             return this;
         }
 
-        Optional<List<Range>> rowRanges = predicate.visit(new RowIdPredicateVisitor());
-        if (rowRanges.isPresent()) {
-            withRowRanges(rowRanges.get());
+        // a mask on _ROW_ID makes the predicate's ids the masked ones, so they must not become
+        // a raw row range; the rules are not known yet, so skip the extraction altogether
+        if (!queryAuthEnabled()) {
+            Optional<List<Range>> rowRanges = predicate.visit(new RowIdPredicateVisitor());
+            if (rowRanges.isPresent()) {
+                withRowRanges(rowRanges.get());
+            }
         }
         this.filter = predicate;
 
@@ -301,6 +305,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
     }
 
     private boolean queryAuthEnabled() {
+        // the table is absent in tests that exercise withFilter in isolation
         CoreOptions options = table == null ? null : table.coreOptions();
         return options != null && options.queryAuthEnabled();
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -106,8 +106,6 @@ public class DataEvolutionBatchScan implements DataTableScan {
             // the wrapped scan defers the filter but strips only masked columns; row ids must
             // go here, since data-evolution statistics carry logical columns only
             Predicate residual = rowIdSafeResidualFilter(predicate);
-            // what is left out reaches the reader only, so the wrapped scan never learns a
-            // filter exists and would let limit/TopN prune ahead of it
             rowIdFilterDeferred = containsRowId(predicate);
             if (residual != null) {
                 batchScan.withFilter(residual);

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -97,9 +97,12 @@ public class DataEvolutionBatchScan implements DataTableScan {
         this.filter = predicate;
 
         if (queryAuthEnabled()) {
-            // let the wrapped scan defer the filter: a conjunct on a masked column must not
-            // reach raw statistics or the global index
-            batchScan.withFilter(predicate);
+            // the wrapped scan defers the filter but strips only masked columns; row ids must
+            // go here, since data-evolution statistics carry logical columns only
+            Predicate residual = rowIdSafeResidualFilter(predicate);
+            if (residual != null) {
+                batchScan.withFilter(residual);
+            }
             return this;
         }
         batchScan.snapshotReader().withFilter(predicate, rowIdSafeResidualFilter(predicate));

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -70,6 +70,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private Predicate filter;
     private TopN topN;
     private Integer pushDownLimit;
+    // set when part of the filter reaches the reader only, so limit/TopN must not prune ahead of it
+    private boolean rowIdFilterDeferred;
     private RowRangeIndex pushedRowRangeIndex;
     private GlobalIndexResult globalIndexResult;
 
@@ -90,9 +92,13 @@ public class DataEvolutionBatchScan implements DataTableScan {
             return this;
         }
 
-        Optional<List<Range>> rowRanges = predicate.visit(new RowIdPredicateVisitor());
-        if (rowRanges.isPresent()) {
-            withRowRanges(rowRanges.get());
+        // a mask on _ROW_ID makes the predicate's ids the masked ones, so they must not become
+        // a raw row range; the rules are not known yet, so skip the extraction altogether
+        if (!queryAuthEnabled()) {
+            Optional<List<Range>> rowRanges = predicate.visit(new RowIdPredicateVisitor());
+            if (rowRanges.isPresent()) {
+                withRowRanges(rowRanges.get());
+            }
         }
         this.filter = predicate;
 
@@ -100,6 +106,9 @@ public class DataEvolutionBatchScan implements DataTableScan {
             // the wrapped scan defers the filter but strips only masked columns; row ids must
             // go here, since data-evolution statistics carry logical columns only
             Predicate residual = rowIdSafeResidualFilter(predicate);
+            // what is left out reaches the reader only, so the wrapped scan never learns a
+            // filter exists and would let limit/TopN prune ahead of it
+            rowIdFilterDeferred = containsRowId(predicate);
             if (residual != null) {
                 batchScan.withFilter(residual);
             }
@@ -177,8 +186,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
 
     @Override
     public InnerTableScan withLimit(int limit) {
+        // forwarded in plan(), once withFilter has said whether a row-id part was deferred
         this.pushDownLimit = limit;
-        batchScan.withLimit(limit);
         return this;
     }
 
@@ -288,7 +297,11 @@ public class DataEvolutionBatchScan implements DataTableScan {
             }
         }
 
-        if (!globalIndexTopNCandidatesFound && topN != null) {
+        if (pushDownLimit != null && !rowIdFilterDeferred) {
+            batchScan.withLimit(pushDownLimit);
+        }
+
+        if (!globalIndexTopNCandidatesFound && topN != null && !rowIdFilterDeferred) {
             batchScan.withTopN(topN);
         }
 
@@ -301,19 +314,22 @@ public class DataEvolutionBatchScan implements DataTableScan {
     }
 
     private boolean queryAuthEnabled() {
+        // the table is absent in tests that exercise withFilter in isolation
         CoreOptions options = table == null ? null : table.coreOptions();
         return options != null && options.queryAuthEnabled();
     }
 
     private Optional<GlobalIndexResult> evalGlobalIndex() {
+        // the index ranks raw values, which a mask may invalidate; fall back to a full scan.
+        // Checked before the supplied result too: withGlobalIndexResult is public, so a caller
+        // can hand in one that was computed off the raw values.
+        if (queryAuthEnabled()) {
+            return Optional.empty();
+        }
         if (this.globalIndexResult != null) {
             return Optional.of(globalIndexResult);
         }
         if (filter == null) {
-            return Optional.empty();
-        }
-        if (queryAuthEnabled()) {
-            // the index ranks raw values, which a mask may invalidate; fall back to a full scan
             return Optional.empty();
         }
         CoreOptions options = table.coreOptions();

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -96,6 +96,12 @@ public class DataEvolutionBatchScan implements DataTableScan {
         }
         this.filter = predicate;
 
+        if (queryAuthEnabled()) {
+            // let the wrapped scan defer the filter: a conjunct on a masked column must not
+            // reach raw statistics or the global index
+            batchScan.withFilter(predicate);
+            return this;
+        }
         batchScan.snapshotReader().withFilter(predicate, rowIdSafeResidualFilter(predicate));
         return this;
     }
@@ -291,11 +297,20 @@ public class DataEvolutionBatchScan implements DataTableScan {
         return wrapToIndexSplits(splits, rowRangeIndex, scoreGetter);
     }
 
+    private boolean queryAuthEnabled() {
+        CoreOptions options = table == null ? null : table.coreOptions();
+        return options != null && options.queryAuthEnabled();
+    }
+
     private Optional<GlobalIndexResult> evalGlobalIndex() {
         if (this.globalIndexResult != null) {
             return Optional.of(globalIndexResult);
         }
         if (filter == null) {
+            return Optional.empty();
+        }
+        if (queryAuthEnabled()) {
+            // the index ranks raw values, which a mask may invalidate; fall back to a full scan
             return Optional.empty();
         }
         CoreOptions options = table.coreOptions();

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -127,8 +127,8 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
     @Override
     public FileStoreScan withReadType(RowType readType) {
-        // a type without user columns does not prune column files; reset, as this
-        // method may be called again
+        // a type without user columns prunes nothing; assign unconditionally, this method
+        // may be recalled
         if (readType != null
                 && readType.getFields().stream()
                         .anyMatch(f -> !SpecialFields.isSystemField(f.id()))) {

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -127,14 +127,14 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
     @Override
     public FileStoreScan withReadType(RowType readType) {
-        if (readType != null) {
-            List<DataField> nonSystemFields =
-                    readType.getFields().stream()
-                            .filter(f -> !SpecialFields.isSystemField(f.id()))
-                            .collect(Collectors.toList());
-            if (!nonSystemFields.isEmpty()) {
-                this.readType = readType;
-            }
+        // a type without user columns does not prune column files; reset, as this
+        // method may be called again
+        if (readType != null
+                && readType.getFields().stream()
+                        .anyMatch(f -> !SpecialFields.isSystemField(f.id()))) {
+            this.readType = readType;
+        } else {
+            this.readType = null;
         }
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -146,8 +146,7 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         readerFactoryBuilder.withReadValueType(adjustedReadType);
         mergeSorter.setProjectedValueType(adjustedReadType);
 
-        // Project away fields added for merging; reset any previous projection, as this
-        // method may be called again.
+        // reset rather than latch: this method may be called again
         outerReadType = adjustedReadType != readType ? readType : null;
 
         return this;

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -146,10 +146,9 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         readerFactoryBuilder.withReadValueType(adjustedReadType);
         mergeSorter.setProjectedValueType(adjustedReadType);
 
-        // Project away fields added for merging.
-        if (adjustedReadType != readType) {
-            outerReadType = readType;
-        }
+        // Project away fields added for merging; reset any previous projection, as this
+        // method may be called again.
+        outerReadType = adjustedReadType != readType ? readType : null;
 
         return this;
     }
@@ -516,9 +515,11 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
 
     /**
      * Returns the pushed read type if {@link #withReadType(RowType)} was called, else the default
-     * read type.
+     * read type. This is the value layout the merge, comparator and serializer run on internally;
+     * when a sequence field was appended for merging, {@link #createMergeReader} projects its
+     * output back to {@code outerReadType}, so the emitted rows can be narrower than this type.
      */
-    private RowType actualReadType() {
+    public RowType actualReadType() {
         return readerFactoryBuilder.readValueType();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -145,10 +145,9 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         readerFactoryBuilder.withReadValueType(adjustedReadType);
         mergeSorter.setProjectedValueType(adjustedReadType);
 
-        // Project away fields added for merging.
-        if (adjustedReadType != readType) {
-            outerReadType = readType;
-        }
+        // Project away fields added for merging; reset any previous projection, as this
+        // method may be called again.
+        outerReadType = adjustedReadType != readType ? readType : null;
 
         return this;
     }
@@ -509,9 +508,11 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
 
     /**
      * Returns the pushed read type if {@link #withReadType(RowType)} was called, else the default
-     * read type.
+     * read type. This is the value layout the merge, comparator and serializer run on internally;
+     * when a sequence field was appended for merging, {@link #createMergeReader} projects its
+     * output back to {@code outerReadType}, so the emitted rows can be narrower than this type.
      */
-    private RowType actualReadType() {
+    public RowType actualReadType() {
         return readerFactoryBuilder.readValueType();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -156,6 +156,19 @@ public class SchemaValidation {
 
         validateOnlyContainPrimitiveType(schema.fields(), schema.primaryKeys(), "primary key");
         validateOnlyContainPrimitiveType(schema.fields(), schema.partitionKeys(), "partition");
+        // only a file-store table reads through the auth reader; reject here rather than only at
+        // create time, so ALTER cannot turn the option on for a table type that ignores it
+        TableType tableType = options.type();
+        if (options.queryAuthEnabled()
+                && tableType != TableType.TABLE
+                && tableType != TableType.MATERIALIZED_TABLE) {
+            throw new RuntimeException(
+                    String.format(
+                            "%s is not supported on a %s: its read does not apply row filters or "
+                                    + "column masks.",
+                            CoreOptions.QUERY_AUTH_ENABLED.key(), tableType));
+        }
+
         if (options.primaryKeyNullable() && schema.primaryKeys().isEmpty()) {
             throw new IllegalArgumentException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -144,6 +144,19 @@ public class SchemaValidation {
 
         validateOnlyContainPrimitiveType(schema.fields(), schema.primaryKeys(), "primary key");
         validateOnlyContainPrimitiveType(schema.fields(), schema.partitionKeys(), "partition");
+        // only a file-store table reads through the auth reader; reject here rather than only at
+        // create time, so ALTER cannot turn the option on for a table type that ignores it
+        TableType tableType = options.type();
+        if (options.queryAuthEnabled()
+                && tableType != TableType.TABLE
+                && tableType != TableType.MATERIALIZED_TABLE) {
+            throw new RuntimeException(
+                    String.format(
+                            "%s is not supported on a %s: its read does not apply row filters or "
+                                    + "column masks.",
+                            CoreOptions.QUERY_AUTH_ENABLED.key(), tableType));
+        }
+
         if (options.primaryKeyNullable() && schema.primaryKeys().isEmpty()) {
             throw new IllegalArgumentException(
                     String.format(

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -156,18 +156,9 @@ public class SchemaValidation {
 
         validateOnlyContainPrimitiveType(schema.fields(), schema.primaryKeys(), "primary key");
         validateOnlyContainPrimitiveType(schema.fields(), schema.partitionKeys(), "partition");
-        // only a file-store table reads through the auth reader; reject here rather than only at
-        // create time, so ALTER cannot turn the option on for a table type that ignores it
-        TableType tableType = options.type();
-        if (options.queryAuthEnabled()
-                && tableType != TableType.TABLE
-                && tableType != TableType.MATERIALIZED_TABLE) {
-            throw new RuntimeException(
-                    String.format(
-                            "%s is not supported on a %s: its read does not apply row filters or "
-                                    + "column masks.",
-                            CoreOptions.QUERY_AUTH_ENABLED.key(), tableType));
-        }
+        // reject here rather than only at create time, so ALTER cannot turn the option on for a
+        // table type that ignores it
+        validateQueryAuthTableType(options.type(), options.queryAuthEnabled());
 
         if (options.primaryKeyNullable() && schema.primaryKeys().isEmpty()) {
             throw new IllegalArgumentException(
@@ -410,6 +401,20 @@ public class SchemaValidation {
         validatePkClusteringOverride(options);
 
         validateManifestSort(schema, options);
+    }
+
+    /**
+     * Only a file-store table reads through the auth reader; anywhere else the rules would be
+     * accepted and then silently not applied.
+     */
+    public static void validateQueryAuthTableType(TableType tableType, boolean queryAuthEnabled) {
+        checkArgument(
+                !queryAuthEnabled
+                        || tableType == TableType.TABLE
+                        || tableType == TableType.MATERIALIZED_TABLE,
+                "%s is not supported on a %s: its read does not apply row filters or column masks.",
+                CoreOptions.QUERY_AUTH_ENABLED.key(),
+                tableType);
     }
 
     public static void validateFallbackBranch(SchemaManager schemaManager, TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -290,6 +290,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         DataTableStreamScan scan =
                 new DataTableStreamScan(
                         tableSchema,
+                        schemaManager(),
                         coreOptions(),
                         newSnapshotReader(),
                         snapshotManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -289,6 +289,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         DataTableStreamScan scan =
                 new DataTableStreamScan(
                         tableSchema,
+                        schemaManager(),
                         coreOptions(),
                         newSnapshotReader(),
                         snapshotManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/query/LocalTableQuery.java
@@ -94,6 +94,12 @@ public class LocalTableQuery implements TableQuery {
 
     public LocalTableQuery(FileStoreTable table) {
         this.options = table.coreOptions();
+        if (options.queryAuthEnabled()) {
+            // the lookup cache serves rows straight from the store, past the auth reader
+            throw new UnsupportedOperationException(
+                    "Local table query is not supported on a query-auth table: it returns raw "
+                            + "values, outside row filters and column masks.");
+        }
         this.tableView = new ConcurrentHashMap<>();
         FileStore<?> tableStore = table.store();
         if (!(tableStore instanceof KeyValueFileStore)) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.SortValue;
@@ -151,6 +152,15 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
+        // partition listing bypasses plan(), so resolve the masks here too: pushing a filter on a
+        // masked column against raw partition values would drop partitions the query matches
+        TableQueryAuthResult authResult = authQuery();
+        this.authMaskedFields =
+                authResult == null
+                        ? java.util.Collections.emptySet()
+                        : authResult.extractColumnMasking().keySet();
+        rejectMaskedPartitionFilter();
+        ensureFilterPushdown(authMaskedFields);
         if (startingScanner == null) {
             startingScanner = createStartingScanner(false);
         }
@@ -222,6 +232,10 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
         }
 
         SortValue order = orders.get(0);
+        if (authMaskedFields.contains(order.field().name())) {
+            // the pruning below reads raw statistics; a mask may alter the ordering column
+            return Optional.empty();
+        }
         DataType type = order.field().type();
         if (!minmaxAvailable(type)) {
             return Optional.empty();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.SortValue;
@@ -42,7 +41,6 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -156,14 +154,7 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
         // partition listing bypasses plan(), so apply the rules here too: without the row filter
         // it would report partitions the caller cannot read, and pushing a filter on a masked
         // column against raw partition values would drop partitions the query matches
-        TableQueryAuthResult authResult = authQuery();
-        applyAuthFilter(authResult == null ? null : authResult.extractPredicate());
-        this.authMaskedFields =
-                authResult == null
-                        ? Collections.emptySet()
-                        : authResult.extractColumnMasking().keySet();
-        rejectMaskedPartitionFilter();
-        ensureFilterPushdown(authMaskedFields);
+        applyAuthRules();
         if (startingScanner == null) {
             startingScanner = createStartingScanner(false);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -151,12 +152,14 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
-        // partition listing bypasses plan(), so resolve the masks here too: pushing a filter on a
-        // masked column against raw partition values would drop partitions the query matches
+        // partition listing bypasses plan(), so apply the rules here too: without the row filter
+        // it would report partitions the caller cannot read, and pushing a filter on a masked
+        // column against raw partition values would drop partitions the query matches
         TableQueryAuthResult authResult = authQuery();
+        applyAuthFilter(authResult == null ? null : authResult.extractPredicate());
         this.authMaskedFields =
                 authResult == null
-                        ? java.util.Collections.emptySet()
+                        ? Collections.emptySet()
                         : authResult.extractColumnMasking().keySet();
         rejectMaskedPartitionFilter();
         ensureFilterPushdown(authMaskedFields);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -58,7 +58,6 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
     private Integer pushDownLimit;
     private TopN topN;
 
-    private final SchemaManager schemaManager;
     @Nullable private String readProtectionTagName;
 
     protected AbstractBatchTableScan(
@@ -67,10 +66,9 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
             CoreOptions options,
             SnapshotReader snapshotReader,
             TableQueryAuth queryAuth) {
-        super(schema, options, snapshotReader, queryAuth);
+        super(schema, schemaManager, options, snapshotReader, queryAuth);
 
         this.hasNext = true;
-        this.schemaManager = schemaManager;
         if (!schema.primaryKeys().isEmpty() && options.batchScanSkipLevel0()) {
             // Incremental scans read the delta or changelog files of historical snapshots, which
             // are always recorded at level 0. Skipping level 0 would drop all of their input.

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.SortValue;
@@ -150,6 +151,15 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
+        // partition listing bypasses plan(), so resolve the masks here too: pushing a filter on a
+        // masked column against raw partition values would drop partitions the query matches
+        TableQueryAuthResult authResult = authQuery();
+        this.authMaskedFields =
+                authResult == null
+                        ? java.util.Collections.emptySet()
+                        : authResult.extractColumnMasking().keySet();
+        rejectMaskedPartitionFilter();
+        ensureFilterPushdown(authMaskedFields);
         if (startingScanner == null) {
             startingScanner = createStartingScanner(false);
         }
@@ -221,6 +231,10 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
         }
 
         SortValue order = orders.get(0);
+        if (authMaskedFields.contains(order.field().name())) {
+            // the pruning below reads raw statistics; a mask may alter the ordering column
+            return Optional.empty();
+        }
         DataType type = order.field().type();
         if (!minmaxAvailable(type)) {
             return Optional.empty();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -152,12 +153,14 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
-        // partition listing bypasses plan(), so resolve the masks here too: pushing a filter on a
-        // masked column against raw partition values would drop partitions the query matches
+        // partition listing bypasses plan(), so apply the rules here too: without the row filter
+        // it would report partitions the caller cannot read, and pushing a filter on a masked
+        // column against raw partition values would drop partitions the query matches
         TableQueryAuthResult authResult = authQuery();
+        applyAuthFilter(authResult == null ? null : authResult.extractPredicate());
         this.authMaskedFields =
                 authResult == null
-                        ? java.util.Collections.emptySet()
+                        ? Collections.emptySet()
                         : authResult.extractColumnMasking().keySet();
         rejectMaskedPartitionFilter();
         ensureFilterPushdown(authMaskedFields);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -25,20 +26,18 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.ListUtils;
 import org.apache.paimon.utils.ProjectedRow;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 
 /** A {@link InnerTableRead} for data table. */
 public abstract class AbstractDataTableRead implements InnerTableRead {
@@ -48,8 +47,24 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
-    public AbstractDataTableRead(TableSchema schema) {
+    // The read type the subclass reads with; differs from readType only when widened for
+    // auth, and is fixed once a reader exists (split reads cache their format readers).
+    @Nullable private RowType appliedReadType;
+    private boolean readerCreated = false;
+
+    // blob-view columns that only resolve through the dedicated blob-view read path
+    private final Set<String> resolvedBlobViewFields;
+
+    public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
+        Set<String> blobViewFields = Collections.emptySet();
+        if (schema != null) {
+            CoreOptions options = CoreOptions.fromMap(schema.options());
+            if (options.blobViewResolveEnabled()) {
+                blobViewFields = options.blobViewField();
+            }
+        }
+        this.resolvedBlobViewFields = blobViewFields;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -86,6 +101,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withReadType(RowType readType) {
         this.readType = readType;
+        this.appliedReadType = readType;
         applyReadType(readType);
         return this;
     }
@@ -121,7 +137,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
             Split split, @Nullable TableQueryAuthResult authResult) throws IOException {
         RecordReader<InternalRow> reader;
         if (authResult == null) {
-            reader = reader(split);
+            reader = backProject(readSplit(split));
         } else {
             reader = authedReader(split, authResult);
         }
@@ -132,34 +148,107 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         return reader;
     }
 
+    private RecordReader<InternalRow> readSplit(Split split) throws IOException {
+        RecordReader<InternalRow> reader = reader(split);
+        // set only on success, so a transient failure does not fix the read schema
+        readerCreated = true;
+        return reader;
+    }
+
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
-        RecordReader<InternalRow> reader;
-        RowType tableType = schema.logicalRowType();
-        RowType readType = this.readType == null ? tableType : this.readType;
-        Predicate authPredicate = authResult.extractPredicate();
-        ProjectedRow backRow = null;
-        if (authPredicate != null) {
-            Set<String> authFields = collectFieldNames(authPredicate);
-            List<String> readFields = readType.getFieldNames();
-            List<String> authAddNames = new ArrayList<>();
-            Set<String> readFieldSet = new HashSet<>(readFields);
-            for (String field : tableType.getFieldNames()) {
-                if (authFields.contains(field) && !readFieldSet.contains(field)) {
-                    authAddNames.add(field);
+        List<String> readFields = currentReadType().getFieldNames();
+        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        RowType widened = widenedReadType(authResult, ruleFields);
+        if (widened != null && !readerCreated && !widened.equals(appliedReadType)) {
+            applyReadType(widened);
+            appliedReadType = widened;
+        }
+        // the split read emits appliedReadType; rules are remapped against it by name
+        RowType outputType = appliedReadType != null ? appliedReadType : currentReadType();
+        if (widened != null && !widened.equals(outputType)) {
+            // rules changed after the read schema was fixed: fail clearly if they no longer fit
+            List<String> outputFields = outputType.getFieldNames();
+            for (String field : widened.getFieldNames()) {
+                if (!outputFields.contains(field)) {
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Query auth rules changed and now require column '%s', but the "
+                                            + "read schema is already fixed to %s. Recreate the "
+                                            + "reader to apply the new rules.",
+                                    field, outputFields));
                 }
             }
-            if (!authAddNames.isEmpty()) {
-                readType = tableType.project(ListUtils.union(readFields, authAddNames));
-                withReadType(readType);
-                backRow = ProjectedRow.from(readType.projectIndexes(readFields));
+        }
+        // masks apply only to columns readable from the query; skip the set when no
+        // mask exists (filter-only auth)
+        Set<String> activeFields;
+        if (authResult.extractColumnMasking().isEmpty()) {
+            activeFields = Collections.emptySet();
+        } else {
+            activeFields = new HashSet<>(readFields);
+            activeFields.addAll(ruleFields);
+        }
+        RecordReader<InternalRow> reader =
+                authResult.doAuth(readSplit(split), outputType, activeFields);
+        return backProject(reader);
+    }
+
+    /**
+     * Project auth-widened rows back to the query's read type — on every split, since the widened
+     * read schema stays in effect even for splits without auth rules.
+     */
+    private RecordReader<InternalRow> backProject(RecordReader<InternalRow> reader) {
+        if (appliedReadType == null || appliedReadType == readType) {
+            return reader;
+        }
+        ProjectedRow backRow =
+                ProjectedRow.from(
+                        appliedReadType.projectIndexes(currentReadType().getFieldNames()));
+        return reader.transform(backRow::replaceRow);
+    }
+
+    /**
+     * The read type widened with the unprojected columns the auth rules read (mirrors the
+     * row-filter augmentation of #8447), or null when the projection already covers them. The
+     * projected fields are kept as-is to preserve nested pruning.
+     */
+    @Nullable
+    private RowType widenedReadType(TableQueryAuthResult authResult, Set<String> ruleFields) {
+        RowType tableType = schema.logicalRowType();
+        RowType readType = currentReadType();
+        Set<String> maskTargets = authResult.extractColumnMasking().keySet();
+        for (String name : readType.getFieldNames()) {
+            if (!ruleFields.contains(name) && !maskTargets.contains(name)) {
+                continue;
+            }
+            if (!tableType.containsField(name)) {
+                continue;
+            }
+            // rules must not touch a nested-pruned column (partial value)
+            DataField tableField = tableType.getField(name);
+            if (!readType.getField(name).type().equals(tableField.type())) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules involve column '%s', which the query "
+                                        + "projects with a pruned type %s instead of its "
+                                        + "table type %s; cannot apply the rules to a "
+                                        + "partial column.",
+                                name, readType.getField(name).type(), tableField.type()));
             }
         }
-        reader = authResult.doAuth(reader(split), readType);
-        if (backRow != null) {
-            reader = reader.transform(backRow::replaceRow);
+        for (String name : ruleFields) {
+            if (resolvedBlobViewFields.contains(name) && !readType.containsField(name)) {
+                // auth-added columns bypass blob-view resolution
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules read blob-view column '%s', which the query "
+                                        + "does not project; such columns cannot be resolved. "
+                                        + "Project the column or adjust the rule.",
+                                name));
+            }
         }
-        return reader;
+        return TableQueryAuthResult.appendMissingFields(tableType, readType, ruleFields);
     }
 
     private RecordReader<InternalRow> executeFilter(RecordReader<InternalRow> reader) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -261,17 +261,18 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         if (maskedPart == null) {
             return reader;
         }
-        int[] projection = schema.logicalRowType().getFieldIndices(outputType.getFieldNames());
-        Optional<Predicate> remapped =
-                maskedPart.visit(PredicateProjectionConverter.fromProjection(projection));
-        if (!remapped.isPresent()) {
+        // by name against the emitted schema: it may carry system fields the table schema lacks
+        Predicate filter;
+        try {
+            filter = TableQueryAuthResult.remapPredicate(maskedPart, outputType);
+        } catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Filter on masked columns "
                             + maskedFilterFields
                             + " cannot be evaluated on read schema "
-                            + outputType.getFieldNames());
+                            + outputType.getFieldNames(),
+                    e);
         }
-        Predicate filter = remapped.get();
         return reader.filter(filter::test);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -35,7 +35,6 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -178,21 +177,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         // masked filter columns are read and masked like rule fields, then evaluated post-mask
         Set<String> maskedFilterFields =
                 maskedFilterFields(authResult.extractColumnMasking().keySet());
-        // a retained conjunct may also reference unmasked columns; all must be readable
-        Set<String> postMaskFilterFields =
-                TableQueryAuthResult.postMaskFilterFields(
-                        predicate, authResult.extractColumnMasking().keySet());
-        List<String> visibleFields = readFields;
-        if (!postMaskFilterFields.isEmpty()) {
-            visibleFields = new ArrayList<>(readFields);
-            for (String field : postMaskFilterFields) {
-                if (!visibleFields.contains(field)) {
-                    visibleFields.add(field);
-                }
-            }
-        }
-        Set<String> ruleFields = authResult.requiredAuthFields(visibleFields);
-        ruleFields.addAll(postMaskFilterFields);
+        Set<String> ruleFields = authResult.authFields(readFields, predicate);
         RowType widened = widenedReadType(authResult, ruleFields);
         if (widened != null && !widened.equals(appliedReadType)) {
             applyReadType(widened);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -55,8 +55,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     // as read-level TopN already does (see ReadBuilderImpl)
     private final boolean queryAuthEnabled;
 
-    // the read type the subclass reads with; widened for auth when needed, and fixed
-    // once a reader exists (split reads cache their format readers)
+    // the auth-widened read type currently applied, or null when the plain read type is
     @Nullable private RowType appliedReadType;
 
     // blob-view columns that only resolve through the dedicated blob-view read path
@@ -114,7 +113,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withReadType(RowType readType) {
         this.readType = readType;
-        this.appliedReadType = readType;
+        this.appliedReadType = null;
         applyReadType(readType);
         return this;
     }
@@ -148,15 +147,17 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
 
     protected final RecordReader<InternalRow> createDataReader(
             Split split, @Nullable TableQueryAuthResult authResult) throws IOException {
-        // a TableRead is reused across splits; auth may have widened the projection for the
-        // previous one, so restore the requested type before deciding this split's widening
+        // A TableRead can be reused for multiple splits. Authentication may have expanded an
+        // explicitly configured physical projection for the previous split, so restore it before
+        // applying the current split's authorization dependencies. Without an explicit projection,
+        // the underlying reader must retain its own default read type.
         if (readType != null) {
             applyReadType(readType);
             appliedReadType = null;
         }
         RecordReader<InternalRow> reader;
         if (authResult == null) {
-            reader = backProject(readSplit(split));
+            reader = backProject(reader(split));
         } else {
             reader = authedReader(split, authResult);
         }
@@ -165,10 +166,6 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         }
 
         return reader;
-    }
-
-    private RecordReader<InternalRow> readSplit(Split split) throws IOException {
-        return reader(split);
     }
 
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
@@ -185,45 +182,30 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         }
         // the split read emits appliedReadType; rules are remapped against it by name
         RowType outputType = appliedReadType != null ? appliedReadType : currentReadType();
-        if (widened != null && !widened.equals(outputType)) {
-            // rules changed after the read schema was fixed: fail clearly if they no longer fit
-            List<String> outputFields = outputType.getFieldNames();
-            for (String field : widened.getFieldNames()) {
-                if (!outputFields.contains(field)) {
-                    throw new IllegalStateException(
-                            String.format(
-                                    "Query auth rules changed and now require column '%s', but the "
-                                            + "read schema is already fixed to %s. Recreate the "
-                                            + "reader to apply the new rules.",
-                                    field, outputFields));
-                }
-            }
-        }
         // masks apply only to columns readable from the query: the ones it projects plus the
         // ones the rules pulled in; a mask on anything else is inert
         Map<String, Transform> masking = authResult.extractColumnMasking();
-        Map<String, Transform> selectedMasking = Collections.emptyMap();
+        Map<String, Transform> selectedColumnMasking = Collections.emptyMap();
         if (!masking.isEmpty()) {
             Set<String> activeFields = new HashSet<>(readFields);
             activeFields.addAll(ruleFields);
-            selectedMasking = new HashMap<>();
+            selectedColumnMasking = new HashMap<>();
             for (Map.Entry<String, Transform> mask : masking.entrySet()) {
                 if (activeFields.contains(mask.getKey())) {
-                    selectedMasking.put(mask.getKey(), mask.getValue());
+                    selectedColumnMasking.put(mask.getKey(), mask.getValue());
                 }
             }
         }
         RecordReader<InternalRow> reader =
                 authResult.doAuth(
-                        readSplit(split),
+                        reader(split),
                         outputType,
                         authResult.extractPredicate(),
-                        selectedMasking);
+                        selectedColumnMasking);
         reader = filterMaskedConjuncts(reader, outputType, maskedFilterFields);
         return backProject(reader);
     }
 
-    /** The columns of the query filter that the current auth rules mask. */
     private Set<String> maskedFilterFields(Set<String> maskTargets) {
         if (predicate == null || maskTargets.isEmpty()) {
             return Collections.emptySet();
@@ -261,12 +243,9 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         return reader.filter(filter::test);
     }
 
-    /**
-     * Project auth-widened rows back to the query's read type — on every split, since the widened
-     * read schema stays in effect even for splits without auth rules.
-     */
+    /** Project auth-widened rows back to the read type the query asked for. */
     private RecordReader<InternalRow> backProject(RecordReader<InternalRow> reader) {
-        if (appliedReadType == null || appliedReadType == readType) {
+        if (appliedReadType == null) {
             return reader;
         }
         ProjectedRow backRow =

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -34,7 +34,6 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -173,21 +172,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         // masked filter columns are read and masked like rule fields, then evaluated post-mask
         Set<String> maskedFilterFields =
                 maskedFilterFields(authResult.extractColumnMasking().keySet());
-        // a retained conjunct may also reference unmasked columns; all must be readable
-        Set<String> postMaskFilterFields =
-                TableQueryAuthResult.postMaskFilterFields(
-                        predicate, authResult.extractColumnMasking().keySet());
-        List<String> visibleFields = readFields;
-        if (!postMaskFilterFields.isEmpty()) {
-            visibleFields = new ArrayList<>(readFields);
-            for (String field : postMaskFilterFields) {
-                if (!visibleFields.contains(field)) {
-                    visibleFields.add(field);
-                }
-            }
-        }
-        Set<String> ruleFields = authResult.requiredAuthFields(visibleFields);
-        ruleFields.addAll(postMaskFilterFields);
+        Set<String> ruleFields = authResult.authFields(readFields, predicate);
         RowType widened = widenedReadType(authResult, ruleFields);
         if (widened != null && !readerCreated && !widened.equals(appliedReadType)) {
             applyReadType(widened);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
@@ -34,6 +35,7 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,8 +52,12 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
-    // The read type the subclass reads with; differs from readType only when widened for
-    // auth, and is fixed once a reader exists (split reads cache their format readers).
+    // reader-level filtering sees raw values, so it stays off for auth-enabled tables,
+    // as read-level TopN already does (see ReadBuilderImpl)
+    private final boolean queryAuthEnabled;
+
+    // the read type the subclass reads with; widened for auth when needed, and fixed
+    // once a reader exists (split reads cache their format readers)
     @Nullable private RowType appliedReadType;
 
     // blob-view columns that only resolve through the dedicated blob-view read path
@@ -60,13 +66,16 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
         Set<String> blobViewFields = Collections.emptySet();
+        boolean queryAuthEnabled = false;
         if (schema != null) {
             CoreOptions options = CoreOptions.fromMap(schema.options());
             if (options.blobViewResolveEnabled()) {
                 blobViewFields = options.blobViewField();
             }
+            queryAuthEnabled = options.queryAuthEnabled();
         }
         this.resolvedBlobViewFields = blobViewFields;
+        this.queryAuthEnabled = queryAuthEnabled;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -81,6 +90,9 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withFilter(Predicate predicate) {
         this.predicate = predicate;
+        if (queryAuthEnabled) {
+            return this;
+        }
         return innerWithFilter(predicate);
     }
 
@@ -163,7 +175,24 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
         List<String> readFields = currentReadType().getFieldNames();
-        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        // masked filter columns are read and masked like rule fields, then evaluated post-mask
+        Set<String> maskedFilterFields =
+                maskedFilterFields(authResult.extractColumnMasking().keySet());
+        // a retained conjunct may also reference unmasked columns; all must be readable
+        Set<String> postMaskFilterFields =
+                TableQueryAuthResult.postMaskFilterFields(
+                        predicate, authResult.extractColumnMasking().keySet());
+        List<String> visibleFields = readFields;
+        if (!postMaskFilterFields.isEmpty()) {
+            visibleFields = new ArrayList<>(readFields);
+            for (String field : postMaskFilterFields) {
+                if (!visibleFields.contains(field)) {
+                    visibleFields.add(field);
+                }
+            }
+        }
+        Set<String> ruleFields = authResult.requiredAuthFields(visibleFields);
+        ruleFields.addAll(postMaskFilterFields);
         RowType widened = widenedReadType(authResult, ruleFields);
         if (widened != null && !widened.equals(appliedReadType)) {
             applyReadType(widened);
@@ -205,7 +234,45 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
                         outputType,
                         authResult.extractPredicate(),
                         selectedMasking);
+        reader = filterMaskedConjuncts(reader, outputType, maskedFilterFields);
         return backProject(reader);
+    }
+
+    /** The columns of the query filter that the current auth rules mask. */
+    private Set<String> maskedFilterFields(Set<String> maskTargets) {
+        if (predicate == null || maskTargets.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> fields = new HashSet<>(PredicateVisitor.collectFieldNames(predicate));
+        fields.retainAll(maskTargets);
+        return fields;
+    }
+
+    /**
+     * Evaluates the filter conjuncts on masked columns, on the masked output: they are never pushed
+     * down, and engines do not re-evaluate the conjuncts they consumed.
+     */
+    private RecordReader<InternalRow> filterMaskedConjuncts(
+            RecordReader<InternalRow> reader, RowType outputType, Set<String> maskedFilterFields) {
+        if (maskedFilterFields.isEmpty()) {
+            return reader;
+        }
+        Predicate maskedPart = TableQueryAuthResult.retainFields(predicate, maskedFilterFields);
+        if (maskedPart == null) {
+            return reader;
+        }
+        int[] projection = schema.logicalRowType().getFieldIndices(outputType.getFieldNames());
+        Optional<Predicate> remapped =
+                maskedPart.visit(PredicateProjectionConverter.fromProjection(projection));
+        if (!remapped.isPresent()) {
+            throw new IllegalStateException(
+                    "Filter on masked columns "
+                            + maskedFilterFields
+                            + " cannot be evaluated on read schema "
+                            + outputType.getFieldNames());
+        }
+        Predicate filter = remapped.get();
+        return reader.filter(filter::test);
     }
 
     /**
@@ -223,9 +290,8 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     }
 
     /**
-     * The read type widened with the unprojected columns the auth rules read (mirrors the
-     * row-filter augmentation of #8447), or null when the projection already covers them. The
-     * projected fields are kept as-is to preserve nested pruning.
+     * The read type widened with the unprojected columns the auth rules read, or null when the
+     * projection already covers them. Projected fields are kept as-is to preserve nested pruning.
      */
     @Nullable
     private RowType widenedReadType(TableQueryAuthResult authResult, Set<String> ruleFields) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -18,10 +18,10 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
 import org.apache.paimon.predicate.Transform;
@@ -34,15 +34,13 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 
 /** A {@link InnerTableRead} for data table. */
 public abstract class AbstractDataTableRead implements InnerTableRead {
@@ -52,8 +50,23 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
-    public AbstractDataTableRead(TableSchema schema) {
+    // The read type the subclass reads with; differs from readType only when widened for
+    // auth, and is fixed once a reader exists (split reads cache their format readers).
+    @Nullable private RowType appliedReadType;
+
+    // blob-view columns that only resolve through the dedicated blob-view read path
+    private final Set<String> resolvedBlobViewFields;
+
+    public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
+        Set<String> blobViewFields = Collections.emptySet();
+        if (schema != null) {
+            CoreOptions options = CoreOptions.fromMap(schema.options());
+            if (options.blobViewResolveEnabled()) {
+                blobViewFields = options.blobViewField();
+            }
+        }
+        this.resolvedBlobViewFields = blobViewFields;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -90,6 +103,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withReadType(RowType readType) {
         this.readType = readType;
+        this.appliedReadType = readType;
         applyReadType(readType);
         return this;
     }
@@ -123,16 +137,15 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
 
     protected final RecordReader<InternalRow> createDataReader(
             Split split, @Nullable TableQueryAuthResult authResult) throws IOException {
-        // A TableRead can be reused for multiple splits. Authentication may have expanded an
-        // explicitly configured physical projection for the previous split, so restore it before
-        // applying the current split's authorization dependencies. Without an explicit projection,
-        // the underlying reader must retain its own default read type.
+        // a TableRead is reused across splits; auth may have widened the projection for the
+        // previous one, so restore the requested type before deciding this split's widening
         if (readType != null) {
             applyReadType(readType);
+            appliedReadType = null;
         }
         RecordReader<InternalRow> reader;
         if (authResult == null) {
-            reader = reader(split);
+            reader = backProject(readSplit(split));
         } else {
             reader = authedReader(split, authResult);
         }
@@ -143,52 +156,113 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         return reader;
     }
 
+    private RecordReader<InternalRow> readSplit(Split split) throws IOException {
+        return reader(split);
+    }
+
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
-        RecordReader<InternalRow> reader;
+        List<String> readFields = currentReadType().getFieldNames();
+        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        RowType widened = widenedReadType(authResult, ruleFields);
+        if (widened != null && !widened.equals(appliedReadType)) {
+            applyReadType(widened);
+            appliedReadType = widened;
+        }
+        // the split read emits appliedReadType; rules are remapped against it by name
+        RowType outputType = appliedReadType != null ? appliedReadType : currentReadType();
+        if (widened != null && !widened.equals(outputType)) {
+            // rules changed after the read schema was fixed: fail clearly if they no longer fit
+            List<String> outputFields = outputType.getFieldNames();
+            for (String field : widened.getFieldNames()) {
+                if (!outputFields.contains(field)) {
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Query auth rules changed and now require column '%s', but the "
+                                            + "read schema is already fixed to %s. Recreate the "
+                                            + "reader to apply the new rules.",
+                                    field, outputFields));
+                }
+            }
+        }
+        // masks apply only to columns readable from the query: the ones it projects plus the
+        // ones the rules pulled in; a mask on anything else is inert
+        Map<String, Transform> masking = authResult.extractColumnMasking();
+        Map<String, Transform> selectedMasking = Collections.emptyMap();
+        if (!masking.isEmpty()) {
+            Set<String> activeFields = new HashSet<>(readFields);
+            activeFields.addAll(ruleFields);
+            selectedMasking = new HashMap<>();
+            for (Map.Entry<String, Transform> mask : masking.entrySet()) {
+                if (activeFields.contains(mask.getKey())) {
+                    selectedMasking.put(mask.getKey(), mask.getValue());
+                }
+            }
+        }
+        RecordReader<InternalRow> reader =
+                authResult.doAuth(
+                        readSplit(split),
+                        outputType,
+                        authResult.extractPredicate(),
+                        selectedMasking);
+        return backProject(reader);
+    }
+
+    /**
+     * Project auth-widened rows back to the query's read type — on every split, since the widened
+     * read schema stays in effect even for splits without auth rules.
+     */
+    private RecordReader<InternalRow> backProject(RecordReader<InternalRow> reader) {
+        if (appliedReadType == null || appliedReadType == readType) {
+            return reader;
+        }
+        ProjectedRow backRow =
+                ProjectedRow.from(
+                        appliedReadType.projectIndexes(currentReadType().getFieldNames()));
+        return reader.transform(backRow::replaceRow);
+    }
+
+    /**
+     * The read type widened with the unprojected columns the auth rules read (mirrors the
+     * row-filter augmentation of #8447), or null when the projection already covers them. The
+     * projected fields are kept as-is to preserve nested pruning.
+     */
+    @Nullable
+    private RowType widenedReadType(TableQueryAuthResult authResult, Set<String> ruleFields) {
         RowType tableType = schema.logicalRowType();
-        RowType readType = this.readType == null ? tableType : this.readType;
-        Predicate authPredicate = authResult.extractPredicate();
-        Map<String, Transform> columnMasking = authResult.extractColumnMasking();
-        ProjectedRow backRow = null;
-        List<String> readFields = readType.getFieldNames();
-        Set<String> readFieldSet = new HashSet<>(readFields);
-        Map<String, Transform> selectedColumnMasking = new HashMap<>();
-        for (Map.Entry<String, Transform> mask : columnMasking.entrySet()) {
-            if (readFieldSet.contains(mask.getKey())) {
-                selectedColumnMasking.put(mask.getKey(), mask.getValue());
+        RowType readType = currentReadType();
+        Set<String> maskTargets = authResult.extractColumnMasking().keySet();
+        for (String name : readType.getFieldNames()) {
+            if (!ruleFields.contains(name) && !maskTargets.contains(name)) {
+                continue;
+            }
+            if (!tableType.containsField(name)) {
+                continue;
+            }
+            // rules must not touch a nested-pruned column (partial value)
+            DataField tableField = tableType.getField(name);
+            if (!readType.getField(name).type().equals(tableField.type())) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules involve column '%s', which the query "
+                                        + "projects with a pruned type %s instead of its "
+                                        + "table type %s; cannot apply the rules to a "
+                                        + "partial column.",
+                                name, readType.getField(name).type(), tableField.type()));
             }
         }
-        Set<String> authFields = new HashSet<>();
-        if (authPredicate != null) {
-            authFields.addAll(collectFieldNames(authPredicate));
-        }
-        for (Map.Entry<String, Transform> mask : selectedColumnMasking.entrySet()) {
-            authFields.add(mask.getKey());
-            for (Object input : mask.getValue().inputs()) {
-                if (input instanceof FieldRef) {
-                    authFields.add(((FieldRef) input).name());
-                }
+        for (String name : ruleFields) {
+            if (resolvedBlobViewFields.contains(name) && !readType.containsField(name)) {
+                // auth-added columns bypass blob-view resolution
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules read blob-view column '%s', which the query "
+                                        + "does not project; such columns cannot be resolved. "
+                                        + "Project the column or adjust the rule.",
+                                name));
             }
         }
-        if (!authFields.isEmpty()) {
-            List<DataField> expandedFields = new ArrayList<>(readType.getFields());
-            for (DataField field : tableType.getFields()) {
-                if (authFields.contains(field.name()) && !readFieldSet.contains(field.name())) {
-                    expandedFields.add(field);
-                }
-            }
-            if (expandedFields.size() > readType.getFieldCount()) {
-                readType = readType.copy(expandedFields);
-                applyReadType(readType);
-                backRow = ProjectedRow.from(readType.projectIndexes(readFields));
-            }
-        }
-        reader = authResult.doAuth(reader(split), readType, authPredicate, selectedColumnMasking);
-        if (backRow != null) {
-            reader = reader.transform(backRow::replaceRow);
-        }
-        return reader;
+        return TableQueryAuthResult.appendMissingFields(tableType, readType, ruleFields);
     }
 
     private RecordReader<InternalRow> executeFilter(RecordReader<InternalRow> reader) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
@@ -33,6 +34,7 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -47,8 +49,12 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
-    // The read type the subclass reads with; differs from readType only when widened for
-    // auth, and is fixed once a reader exists (split reads cache their format readers).
+    // reader-level filtering sees raw values, so it stays off for auth-enabled tables,
+    // as read-level TopN already does (see ReadBuilderImpl)
+    private final boolean queryAuthEnabled;
+
+    // the read type the subclass reads with; widened for auth when needed, and fixed
+    // once a reader exists (split reads cache their format readers)
     @Nullable private RowType appliedReadType;
     private boolean readerCreated = false;
 
@@ -58,13 +64,16 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
         Set<String> blobViewFields = Collections.emptySet();
+        boolean queryAuthEnabled = false;
         if (schema != null) {
             CoreOptions options = CoreOptions.fromMap(schema.options());
             if (options.blobViewResolveEnabled()) {
                 blobViewFields = options.blobViewField();
             }
+            queryAuthEnabled = options.queryAuthEnabled();
         }
         this.resolvedBlobViewFields = blobViewFields;
+        this.queryAuthEnabled = queryAuthEnabled;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -79,6 +88,9 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withFilter(Predicate predicate) {
         this.predicate = predicate;
+        if (queryAuthEnabled) {
+            return this;
+        }
         return innerWithFilter(predicate);
     }
 
@@ -158,7 +170,24 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
         List<String> readFields = currentReadType().getFieldNames();
-        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        // masked filter columns are read and masked like rule fields, then evaluated post-mask
+        Set<String> maskedFilterFields =
+                maskedFilterFields(authResult.extractColumnMasking().keySet());
+        // a retained conjunct may also reference unmasked columns; all must be readable
+        Set<String> postMaskFilterFields =
+                TableQueryAuthResult.postMaskFilterFields(
+                        predicate, authResult.extractColumnMasking().keySet());
+        List<String> visibleFields = readFields;
+        if (!postMaskFilterFields.isEmpty()) {
+            visibleFields = new ArrayList<>(readFields);
+            for (String field : postMaskFilterFields) {
+                if (!visibleFields.contains(field)) {
+                    visibleFields.add(field);
+                }
+            }
+        }
+        Set<String> ruleFields = authResult.requiredAuthFields(visibleFields);
+        ruleFields.addAll(postMaskFilterFields);
         RowType widened = widenedReadType(authResult, ruleFields);
         if (widened != null && !readerCreated && !widened.equals(appliedReadType)) {
             applyReadType(widened);
@@ -166,22 +195,8 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         }
         // the split read emits appliedReadType; rules are remapped against it by name
         RowType outputType = appliedReadType != null ? appliedReadType : currentReadType();
-        if (widened != null && !widened.equals(outputType)) {
-            // rules changed after the read schema was fixed: fail clearly if they no longer fit
-            List<String> outputFields = outputType.getFieldNames();
-            for (String field : widened.getFieldNames()) {
-                if (!outputFields.contains(field)) {
-                    throw new IllegalStateException(
-                            String.format(
-                                    "Query auth rules changed and now require column '%s', but the "
-                                            + "read schema is already fixed to %s. Recreate the "
-                                            + "reader to apply the new rules.",
-                                    field, outputFields));
-                }
-            }
-        }
-        // masks apply only to columns readable from the query; skip the set when no
-        // mask exists (filter-only auth)
+        checkWidenedFitsFixedSchema(widened, outputType);
+        // masks apply only to columns readable from the query; empty means filter-only auth
         Set<String> activeFields;
         if (authResult.extractColumnMasking().isEmpty()) {
             activeFields = Collections.emptySet();
@@ -191,7 +206,63 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         }
         RecordReader<InternalRow> reader =
                 authResult.doAuth(readSplit(split), outputType, activeFields);
+        reader = filterMaskedConjuncts(reader, outputType, maskedFilterFields);
         return backProject(reader);
+    }
+
+    /** The columns of the query filter that the current auth rules mask. */
+    private Set<String> maskedFilterFields(Set<String> maskTargets) {
+        if (predicate == null || maskTargets.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> fields = new HashSet<>(PredicateVisitor.collectFieldNames(predicate));
+        fields.retainAll(maskTargets);
+        return fields;
+    }
+
+    /** Rules that grew after the read schema was fixed cannot be applied; say so clearly. */
+    private static void checkWidenedFitsFixedSchema(@Nullable RowType widened, RowType outputType) {
+        if (widened == null || widened.equals(outputType)) {
+            return;
+        }
+        List<String> outputFields = outputType.getFieldNames();
+        for (String field : widened.getFieldNames()) {
+            if (!outputFields.contains(field)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules changed and now require column '%s', but the "
+                                        + "read schema is already fixed to %s. Recreate the "
+                                        + "reader to apply the new rules.",
+                                field, outputFields));
+            }
+        }
+    }
+
+    /**
+     * Evaluates the filter conjuncts on masked columns, on the masked output: they are never pushed
+     * down, and engines do not re-evaluate the conjuncts they consumed.
+     */
+    private RecordReader<InternalRow> filterMaskedConjuncts(
+            RecordReader<InternalRow> reader, RowType outputType, Set<String> maskedFilterFields) {
+        if (maskedFilterFields.isEmpty()) {
+            return reader;
+        }
+        Predicate maskedPart = TableQueryAuthResult.retainFields(predicate, maskedFilterFields);
+        if (maskedPart == null) {
+            return reader;
+        }
+        int[] projection = schema.logicalRowType().getFieldIndices(outputType.getFieldNames());
+        Optional<Predicate> remapped =
+                maskedPart.visit(PredicateProjectionConverter.fromProjection(projection));
+        if (!remapped.isPresent()) {
+            throw new IllegalStateException(
+                    "Filter on masked columns "
+                            + maskedFilterFields
+                            + " cannot be evaluated on read schema "
+                            + outputType.getFieldNames());
+        }
+        Predicate filter = remapped.get();
+        return reader.filter(filter::test);
     }
 
     /**
@@ -209,9 +280,8 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     }
 
     /**
-     * The read type widened with the unprojected columns the auth rules read (mirrors the
-     * row-filter augmentation of #8447), or null when the projection already covers them. The
-     * projected fields are kept as-is to preserve nested pruning.
+     * The read type widened with the unprojected columns the auth rules read, or null when the
+     * projection already covers them. Projected fields are kept as-is to preserve nested pruning.
      */
     @Nullable
     private RowType widenedReadType(TableQueryAuthResult authResult, Set<String> ruleFields) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -251,17 +251,18 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         if (maskedPart == null) {
             return reader;
         }
-        int[] projection = schema.logicalRowType().getFieldIndices(outputType.getFieldNames());
-        Optional<Predicate> remapped =
-                maskedPart.visit(PredicateProjectionConverter.fromProjection(projection));
-        if (!remapped.isPresent()) {
+        // by name against the emitted schema: it may carry system fields the table schema lacks
+        Predicate filter;
+        try {
+            filter = TableQueryAuthResult.remapPredicate(maskedPart, outputType);
+        } catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Filter on masked columns "
                             + maskedFilterFields
                             + " cannot be evaluated on read schema "
-                            + outputType.getFieldNames());
+                            + outputType.getFieldNames(),
+                    e);
         }
-        Predicate filter = remapped.get();
         return reader.filter(filter::test);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -109,6 +109,8 @@ abstract class AbstractDataTableScan implements DataTableScan {
     private boolean filterPushed = false;
     private Set<String> pushedMaskedFields = Collections.emptySet();
     private Set<String> partitionFilterFields = Collections.emptySet();
+    // re-applied after the deferred filter push, which writes the same slot
+    @Nullable private Runnable repushPartitionFilter;
 
     protected AbstractDataTableScan(
             TableSchema schema,
@@ -209,21 +211,19 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     @Override
     public AbstractDataTableScan withPartitionFilter(Map<String, String> partitionSpec) {
-        partitionFilterFields =
+        return pushPartitionFilter(
                 partitionSpec == null
                         ? Collections.emptySet()
-                        : new HashSet<>(partitionSpec.keySet());
-        snapshotReader.withPartitionFilter(partitionSpec);
-        return this;
+                        : new HashSet<>(partitionSpec.keySet()),
+                () -> snapshotReader.withPartitionFilter(partitionSpec));
     }
 
     @Override
     public AbstractDataTableScan withPartitionFilter(List<BinaryRow> partitions) {
         // binary partitions carry no field names; assume every partition key
-        partitionFilterFields =
-                partitions == null ? Collections.emptySet() : new HashSet<>(schema.partitionKeys());
-        snapshotReader.withPartitionFilter(partitions);
-        return this;
+        return pushPartitionFilter(
+                partitions == null ? Collections.emptySet() : new HashSet<>(schema.partitionKeys()),
+                () -> snapshotReader.withPartitionFilter(partitions));
     }
 
     @Override
@@ -232,29 +232,25 @@ abstract class AbstractDataTableScan implements DataTableScan {
         if (partitions != null) {
             partitions.forEach(spec -> fields.addAll(spec.keySet()));
         }
-        partitionFilterFields = fields;
-        snapshotReader.withPartitionsFilter(partitions);
-        return this;
+        return pushPartitionFilter(fields, () -> snapshotReader.withPartitionsFilter(partitions));
     }
 
     @Override
     public AbstractDataTableScan withPartitionFilter(PartitionPredicate partitionPredicate) {
-        partitionFilterFields =
+        return pushPartitionFilter(
                 partitionPredicate == null
                         ? Collections.emptySet()
-                        : partitionPredicateFields(partitionPredicate);
-        snapshotReader.withPartitionFilter(partitionPredicate);
-        return this;
+                        : partitionPredicateFields(partitionPredicate),
+                () -> snapshotReader.withPartitionFilter(partitionPredicate));
     }
 
     @Override
     public InnerTableScan withPartitionFilter(Predicate predicate) {
-        partitionFilterFields =
+        return pushPartitionFilter(
                 predicate == null
                         ? Collections.emptySet()
-                        : PredicateVisitor.collectFieldNames(predicate);
-        snapshotReader.withPartitionFilter(predicate);
-        return this;
+                        : PredicateVisitor.collectFieldNames(predicate),
+                () -> snapshotReader.withPartitionFilter(predicate));
     }
 
     @Override
@@ -303,6 +299,13 @@ abstract class AbstractDataTableScan implements DataTableScan {
     @Override
     public InnerTableScan withRowRangeIndex(RowRangeIndex rowRangeIndex) {
         snapshotReader.withRowRangeIndex(rowRangeIndex);
+        return this;
+    }
+
+    private AbstractDataTableScan pushPartitionFilter(Set<String> fields, Runnable push) {
+        partitionFilterFields = fields;
+        repushPartitionFilter = push;
+        push.run();
         return this;
     }
 
@@ -360,6 +363,9 @@ abstract class AbstractDataTableScan implements DataTableScan {
             snapshotReader.withFilter(userFilter, effective);
             filterPushed = true;
             pushedMaskedFields = maskedInFilter;
+            if (repushPartitionFilter != null) {
+                repushPartitionFilter.run();
+            }
         } else if (!pushedMaskedFields.containsAll(maskedInFilter)) {
             throw new IllegalStateException(
                     "Query auth rules changed and now mask a pushed-down filter column. "

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -124,8 +124,12 @@ abstract class AbstractDataTableScan implements DataTableScan {
         this.queryAuth = queryAuth;
     }
 
-    @Override
-    public final TableScan.Plan plan() {
+    /**
+     * Refreshes the auth state and pushes what can be pushed. Every path that reaches the files
+     * must run this, so it stays the one place the order of these steps is defined.
+     */
+    @Nullable
+    protected final TableQueryAuthResult applyAuthRules() {
         TableQueryAuthResult queryAuthResult = authQuery();
         // Always apply/clear the auth filter so removing auth leaves no stale partition pruning.
         applyAuthFilter(queryAuthResult == null ? null : queryAuthResult.extractPredicate());
@@ -134,7 +138,13 @@ abstract class AbstractDataTableScan implements DataTableScan {
                         ? Collections.emptySet()
                         : queryAuthResult.extractColumnMasking().keySet();
         rejectMaskedPartitionFilter();
-        ensureFilterPushdown(authMaskedFields);
+        ensureFilterPushdown();
+        return queryAuthResult;
+    }
+
+    @Override
+    public final TableScan.Plan plan() {
+        TableQueryAuthResult queryAuthResult = applyAuthRules();
         applyAuthReadType(queryAuthResult);
         Plan plan = planWithoutAuth();
         if (queryAuthResult != null) {
@@ -145,7 +155,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     protected abstract TableScan.Plan planWithoutAuth();
 
-    protected void applyAuthFilter(@Nullable Predicate authPredicate) {
+    private void applyAuthFilter(@Nullable Predicate authPredicate) {
         if (Objects.equals(authPredicate, appliedAuthPredicate)) {
             return;
         }
@@ -323,7 +333,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
      * evaluation, so it can never be re-checked on the masked value. Fail closed. One routed
      * through withFilter is fine: that path defers it and evaluates it post-mask.
      */
-    protected void rejectMaskedPartitionFilter() {
+    private void rejectMaskedPartitionFilter() {
         if (partitionFilterFields.isEmpty() || authMaskedFields.isEmpty()) {
             return;
         }
@@ -344,11 +354,11 @@ abstract class AbstractDataTableScan implements DataTableScan {
      * Pushes the query filter once, minus the conjuncts on masked columns. Also called by partition
      * listing; a mask found later on an already-pushed column fails closed.
      */
-    protected final void ensureFilterPushdown(Set<String> maskedFields) {
+    private void ensureFilterPushdown() {
         if (userFilter == null) {
             return;
         }
-        Set<String> maskedInFilter = new HashSet<>(maskedFields);
+        Set<String> maskedInFilter = new HashSet<>(authMaskedFields);
         maskedInFilter.retainAll(PredicateVisitor.collectFieldNames(userFilter));
         if (!maskedInFilter.isEmpty()) {
             // masked conjuncts drop rows at read time only: keep limit/TopN pruning off
@@ -393,15 +403,13 @@ abstract class AbstractDataTableScan implements DataTableScan {
             }
         }
         // never narrow within this scan's lifetime: readers fix their schema on first use
-        if (appliedScanReadType != null) {
-            RowType widened =
-                    TableQueryAuthResult.appendMissingFields(
-                            appliedScanReadType,
-                            desired,
-                            new HashSet<>(appliedScanReadType.getFieldNames()));
-            if (widened != null) {
-                desired = widened;
-            }
+        RowType widenedToApplied =
+                TableQueryAuthResult.appendMissingFields(
+                        appliedScanReadType,
+                        desired,
+                        new HashSet<>(appliedScanReadType.getFieldNames()));
+        if (widenedToApplied != null) {
+            desired = widenedToApplied;
         }
         if (!desired.equals(appliedScanReadType)) {
             snapshotReader.withReadType(desired);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -145,7 +145,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     protected abstract TableScan.Plan planWithoutAuth();
 
-    private void applyAuthFilter(@Nullable Predicate authPredicate) {
+    protected void applyAuthFilter(@Nullable Predicate authPredicate) {
         if (Objects.equals(authPredicate, appliedAuthPredicate)) {
             return;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -30,6 +30,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.snapshot.CompactedStartingScanner;
 import org.apache.paimon.table.source.snapshot.ContinuousCompactorStartingScanner;
@@ -66,6 +67,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,6 +85,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDataTableScan.class);
 
     protected final TableSchema schema;
+    protected final SchemaManager schemaManager;
     private final CoreOptions options;
     protected final SnapshotReader snapshotReader;
     private final TableQueryAuth queryAuth;
@@ -96,20 +99,26 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     protected AbstractDataTableScan(
             TableSchema schema,
+            SchemaManager schemaManager,
             CoreOptions options,
             SnapshotReader snapshotReader,
             TableQueryAuth queryAuth) {
         this.schema = schema;
+        this.schemaManager = schemaManager;
         this.options = options;
         this.snapshotReader = snapshotReader;
         this.queryAuth = queryAuth;
     }
+
+    // the read type last pushed to the snapshot reader; widened for auth when needed
+    @Nullable private RowType appliedScanReadType;
 
     @Override
     public final TableScan.Plan plan() {
         TableQueryAuthResult queryAuthResult = authQuery();
         // Always apply/clear the auth filter so removing auth leaves no stale partition pruning.
         applyAuthFilter(queryAuthResult == null ? null : queryAuthResult.extractPredicate());
+        applyAuthReadType(queryAuthResult);
         Plan plan = planWithoutAuth();
         if (queryAuthResult != null) {
             plan = queryAuthResult.convertPlan(plan);
@@ -171,6 +180,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
     @Override
     public InnerTableScan withReadType(@Nullable RowType readType) {
         this.readType = readType;
+        this.appliedScanReadType = readType;
         snapshotReader.withReadType(readType);
         return this;
     }
@@ -221,7 +231,21 @@ abstract class AbstractDataTableScan implements DataTableScan {
         if (!options.queryAuthEnabled()) {
             return null;
         }
-        return queryAuth.auth(readType == null ? null : readType.getFieldNames());
+        List<String> select = readType == null ? null : readType.getFieldNames();
+        TableQueryAuthResult result = queryAuth.auth(select);
+        if (result != null && result.hasRules()) {
+            // validated on every plan (this path already pays an auth-service call per plan), so
+            // schema changes under a live scan fail closed: references stale in the latest schema,
+            // or renamed relative to the schema being read (e.g. time travel), are rejected
+            RowType latestSchema =
+                    schemaManager
+                            .latest()
+                            .map(TableSchema::logicalRowType)
+                            .orElseGet(schema::logicalRowType);
+            result.validateAgainstSchema(latestSchema, select);
+            result.validateReadableWithoutRename(latestSchema, schema.logicalRowType());
+        }
+        return result;
     }
 
     @Override
@@ -240,6 +264,38 @@ abstract class AbstractDataTableScan implements DataTableScan {
     public InnerTableScan withRowRangeIndex(RowRangeIndex rowRangeIndex) {
         snapshotReader.withRowRangeIndex(rowRangeIndex);
         return this;
+    }
+
+    /**
+     * Push the auth-widened read type to the snapshot reader before planning, so file-level column
+     * pruning keeps the files of the columns the rules read.
+     */
+    private void applyAuthReadType(@Nullable TableQueryAuthResult queryAuthResult) {
+        if (readType == null) {
+            return;
+        }
+        RowType desired = readType;
+        if (queryAuthResult != null && queryAuthResult.hasRules()) {
+            RowType widened = queryAuthResult.widenReadType(schema.logicalRowType(), readType);
+            if (widened != null) {
+                desired = widened;
+            }
+        }
+        // never narrow within this scan's lifetime: readers fix their schema on first use
+        if (appliedScanReadType != null) {
+            RowType widened =
+                    TableQueryAuthResult.appendMissingFields(
+                            appliedScanReadType,
+                            desired,
+                            new HashSet<>(appliedScanReadType.getFieldNames()));
+            if (widened != null) {
+                desired = widened;
+            }
+        }
+        if (!desired.equals(appliedScanReadType)) {
+            snapshotReader.withReadType(desired);
+            appliedScanReadType = desired;
+        }
     }
 
     public SnapshotReader snapshotReader() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -30,6 +30,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.snapshot.CompactedStartingScanner;
@@ -67,11 +68,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
@@ -96,6 +100,15 @@ abstract class AbstractDataTableScan implements DataTableScan {
     // Whether the auth predicate has a non-partition part (enforced only at read time). Used by
     // AbstractBatchTableScan to disable limit push down; not pushed through withFilter.
     protected boolean authHasNonPartitionFilter;
+    // auth state, refreshed each plan(). The filter is pushed once, without the conjuncts on
+    // masked columns, whose raw statistics a mask invalidates; the partition fields are
+    // replaced on each push, as ManifestsReader#withPartitionFilter overwrites rather than ands.
+    protected Set<String> authMaskedFields = Collections.emptySet();
+    @Nullable private RowType appliedScanReadType;
+    @Nullable private Predicate userFilter;
+    private boolean filterPushed = false;
+    private Set<String> pushedMaskedFields = Collections.emptySet();
+    private Set<String> partitionFilterFields = Collections.emptySet();
 
     protected AbstractDataTableScan(
             TableSchema schema,
@@ -110,14 +123,17 @@ abstract class AbstractDataTableScan implements DataTableScan {
         this.queryAuth = queryAuth;
     }
 
-    // the read type last pushed to the snapshot reader; widened for auth when needed
-    @Nullable private RowType appliedScanReadType;
-
     @Override
     public final TableScan.Plan plan() {
         TableQueryAuthResult queryAuthResult = authQuery();
         // Always apply/clear the auth filter so removing auth leaves no stale partition pruning.
         applyAuthFilter(queryAuthResult == null ? null : queryAuthResult.extractPredicate());
+        this.authMaskedFields =
+                queryAuthResult == null
+                        ? Collections.emptySet()
+                        : queryAuthResult.extractColumnMasking().keySet();
+        rejectMaskedPartitionFilter();
+        ensureFilterPushdown(authMaskedFields);
         applyAuthReadType(queryAuthResult);
         Plan plan = planWithoutAuth();
         if (queryAuthResult != null) {
@@ -161,7 +177,13 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        snapshotReader.withFilter(predicate);
+        if (!options.queryAuthEnabled()) {
+            // no masks to strip; push now, else chain-table sub-scans read before plan()
+            snapshotReader.withFilter(predicate);
+            return this;
+        }
+        // deferred to plan(), which strips conjuncts on masked columns before stats pruning
+        this.userFilter = predicate;
         return this;
     }
 
@@ -187,30 +209,50 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     @Override
     public AbstractDataTableScan withPartitionFilter(Map<String, String> partitionSpec) {
+        partitionFilterFields =
+                partitionSpec == null
+                        ? Collections.emptySet()
+                        : new HashSet<>(partitionSpec.keySet());
         snapshotReader.withPartitionFilter(partitionSpec);
         return this;
     }
 
     @Override
     public AbstractDataTableScan withPartitionFilter(List<BinaryRow> partitions) {
+        // binary partitions carry no field names; assume every partition key
+        partitionFilterFields =
+                partitions == null ? Collections.emptySet() : new HashSet<>(schema.partitionKeys());
         snapshotReader.withPartitionFilter(partitions);
         return this;
     }
 
     @Override
     public AbstractDataTableScan withPartitionsFilter(List<Map<String, String>> partitions) {
+        Set<String> fields = new HashSet<>();
+        if (partitions != null) {
+            partitions.forEach(spec -> fields.addAll(spec.keySet()));
+        }
+        partitionFilterFields = fields;
         snapshotReader.withPartitionsFilter(partitions);
         return this;
     }
 
     @Override
     public AbstractDataTableScan withPartitionFilter(PartitionPredicate partitionPredicate) {
+        partitionFilterFields =
+                partitionPredicate == null
+                        ? Collections.emptySet()
+                        : partitionPredicateFields(partitionPredicate);
         snapshotReader.withPartitionFilter(partitionPredicate);
         return this;
     }
 
     @Override
     public InnerTableScan withPartitionFilter(Predicate predicate) {
+        partitionFilterFields =
+                predicate == null
+                        ? Collections.emptySet()
+                        : PredicateVisitor.collectFieldNames(predicate);
         snapshotReader.withPartitionFilter(predicate);
         return this;
     }
@@ -234,9 +276,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
         List<String> select = readType == null ? null : readType.getFieldNames();
         TableQueryAuthResult result = queryAuth.auth(select);
         if (result != null && result.hasRules()) {
-            // validated on every plan (this path already pays an auth-service call per plan), so
-            // schema changes under a live scan fail closed: references stale in the latest schema,
-            // or renamed relative to the schema being read (e.g. time travel), are rejected
+            // re-validated every plan, so a schema change under a live scan fails closed
             RowType latestSchema =
                     schemaManager
                             .latest()
@@ -266,6 +306,67 @@ abstract class AbstractDataTableScan implements DataTableScan {
         return this;
     }
 
+    /** The partition columns a predicate references, or all of them when it cannot be read. */
+    private Set<String> partitionPredicateFields(PartitionPredicate partitionPredicate) {
+        if (partitionPredicate instanceof PartitionPredicate.DefaultPartitionPredicate) {
+            return PredicateVisitor.collectFieldNames(
+                    ((PartitionPredicate.DefaultPartitionPredicate) partitionPredicate)
+                            .predicate());
+        }
+        return new HashSet<>(schema.partitionKeys());
+    }
+
+    /**
+     * A partition predicate is consumed by pruning and, in Spark, dropped from post-scan
+     * evaluation, so it can never be re-checked on the masked value. Fail closed. One routed
+     * through withFilter is fine: that path defers it and evaluates it post-mask.
+     */
+    protected void rejectMaskedPartitionFilter() {
+        if (partitionFilterFields.isEmpty() || authMaskedFields.isEmpty()) {
+            return;
+        }
+        for (String partitionKey : partitionFilterFields) {
+            if (authMaskedFields.contains(partitionKey)) {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "A partition filter cannot be enforced on masked partition key "
+                                        + "'%s': engines push partition predicates past the "
+                                        + "reader, so it would be matched against the raw "
+                                        + "partition value.",
+                                partitionKey));
+            }
+        }
+    }
+
+    /**
+     * Pushes the query filter once, minus the conjuncts on masked columns. Also called by partition
+     * listing; a mask found later on an already-pushed column fails closed.
+     */
+    protected final void ensureFilterPushdown(Set<String> maskedFields) {
+        if (userFilter == null) {
+            return;
+        }
+        Set<String> maskedInFilter = new HashSet<>(maskedFields);
+        maskedInFilter.retainAll(PredicateVisitor.collectFieldNames(userFilter));
+        if (!maskedInFilter.isEmpty()) {
+            // masked conjuncts drop rows at read time only: keep limit/TopN pruning off
+            authHasNonPartitionFilter = true;
+        }
+        if (!filterPushed) {
+            Predicate effective =
+                    maskedInFilter.isEmpty()
+                            ? userFilter
+                            : TableQueryAuthResult.excludeFields(userFilter, maskedInFilter);
+            snapshotReader.withFilter(userFilter, effective);
+            filterPushed = true;
+            pushedMaskedFields = maskedInFilter;
+        } else if (!pushedMaskedFields.containsAll(maskedInFilter)) {
+            throw new IllegalStateException(
+                    "Query auth rules changed and now mask a pushed-down filter column. "
+                            + "Recreate the scan to apply the new rules.");
+        }
+    }
+
     /**
      * Push the auth-widened read type to the snapshot reader before planning, so file-level column
      * pruning keeps the files of the columns the rules read.
@@ -276,7 +377,25 @@ abstract class AbstractDataTableScan implements DataTableScan {
         }
         RowType desired = readType;
         if (queryAuthResult != null && queryAuthResult.hasRules()) {
-            RowType widened = queryAuthResult.widenReadType(schema.logicalRowType(), readType);
+            // post-mask conjuncts are evaluated at read time; their columns must survive planning
+            List<String> seed = readType.getFieldNames();
+            Set<String> postMask =
+                    TableQueryAuthResult.postMaskFilterFields(
+                            userFilter, queryAuthResult.extractColumnMasking().keySet());
+            if (!postMask.isEmpty()) {
+                seed = new ArrayList<>(seed);
+                for (String field : postMask) {
+                    if (!seed.contains(field)) {
+                        seed.add(field);
+                    }
+                }
+            }
+            Set<String> ruleFields = queryAuthResult.requiredAuthFields(seed);
+            // requiredAuthFields returns what the rules read, not the seed itself
+            ruleFields.addAll(postMask);
+            RowType widened =
+                    TableQueryAuthResult.appendMissingFields(
+                            schema.logicalRowType(), readType, ruleFields);
             if (widened != null) {
                 desired = widened;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -68,7 +68,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -110,7 +109,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
     private Set<String> pushedMaskedFields = Collections.emptySet();
     private Set<String> partitionFilterFields = Collections.emptySet();
     // re-applied after the deferred filter push, which writes the same slot
-    @Nullable private Runnable repushPartitionFilter;
+    @Nullable private Runnable reapplyPartitionFilter;
 
     protected AbstractDataTableScan(
             TableSchema schema,
@@ -304,7 +303,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     private AbstractDataTableScan pushPartitionFilter(Set<String> fields, Runnable push) {
         partitionFilterFields = fields;
-        repushPartitionFilter = push;
+        reapplyPartitionFilter = push;
         push.run();
         return this;
     }
@@ -363,8 +362,8 @@ abstract class AbstractDataTableScan implements DataTableScan {
             snapshotReader.withFilter(userFilter, effective);
             filterPushed = true;
             pushedMaskedFields = maskedInFilter;
-            if (repushPartitionFilter != null) {
-                repushPartitionFilter.run();
+            if (reapplyPartitionFilter != null) {
+                reapplyPartitionFilter.run();
             }
         } else if (!pushedMaskedFields.containsAll(maskedInFilter)) {
             throw new IllegalStateException(
@@ -384,24 +383,11 @@ abstract class AbstractDataTableScan implements DataTableScan {
         RowType desired = readType;
         if (queryAuthResult != null && queryAuthResult.hasRules()) {
             // post-mask conjuncts are evaluated at read time; their columns must survive planning
-            List<String> seed = readType.getFieldNames();
-            Set<String> postMask =
-                    TableQueryAuthResult.postMaskFilterFields(
-                            userFilter, queryAuthResult.extractColumnMasking().keySet());
-            if (!postMask.isEmpty()) {
-                seed = new ArrayList<>(seed);
-                for (String field : postMask) {
-                    if (!seed.contains(field)) {
-                        seed.add(field);
-                    }
-                }
-            }
-            Set<String> ruleFields = queryAuthResult.requiredAuthFields(seed);
-            // requiredAuthFields returns what the rules read, not the seed itself
-            ruleFields.addAll(postMask);
             RowType widened =
                     TableQueryAuthResult.appendMissingFields(
-                            schema.logicalRowType(), readType, ruleFields);
+                            schema.logicalRowType(),
+                            readType,
+                            queryAuthResult.authFields(readType.getFieldNames(), userFilter));
             if (widened != null) {
                 desired = widened;
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -125,7 +126,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public VectorScan newVectorScan() {
-        rejectUnderQueryAuth();
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
         if (isPrimaryKeyVectorSearch()) {
             return new PrimaryKeyVectorScan(
                     table,
@@ -139,7 +140,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public BatchVectorRead newBatchVectorRead() {
-        rejectUnderQueryAuth();
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
         checkNotNull(vectorColumn, "Vector column must be set via withVectorColumn()");
         checkArgument(
@@ -158,13 +159,5 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
     protected boolean isPrimaryKeyVectorSearch() {
         return vectorColumn != null
                 && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumn.name());
-    }
-
-    private void rejectUnderQueryAuth() {
-        if (table.coreOptions().queryAuthEnabled()) {
-            throw new UnsupportedOperationException(
-                    "Search is not supported on a query-auth table: the index ranks raw values, "
-                            + "which a column mask invalidates.");
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
@@ -125,6 +125,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public VectorScan newVectorScan() {
+        rejectUnderQueryAuth();
         if (isPrimaryKeyVectorSearch()) {
             return new PrimaryKeyVectorScan(
                     table,
@@ -156,5 +157,13 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
     protected boolean isPrimaryKeyVectorSearch() {
         return vectorColumn != null
                 && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumn.name());
+    }
+
+    private void rejectUnderQueryAuth() {
+        if (table.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Search is not supported on a query-auth table: the index ranks raw values, "
+                            + "which a column mask invalidates.");
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/BatchVectorSearchBuilderImpl.java
@@ -139,6 +139,7 @@ public class BatchVectorSearchBuilderImpl implements BatchVectorSearchBuilder {
 
     @Override
     public BatchVectorRead newBatchVectorRead() {
+        rejectUnderQueryAuth();
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
         checkNotNull(vectorColumn, "Vector column must be set via withVectorColumn()");
         checkArgument(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -106,7 +106,6 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
     @Override
     public DataTableStreamScan withFilter(Predicate predicate) {
         super.withFilter(predicate);
-        snapshotReader.withFilter(predicate);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -24,6 +24,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.Consumer;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.snapshot.AllDeltaFollowUpScanner;
@@ -77,6 +78,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
 
     public DataTableStreamScan(
             TableSchema schema,
+            SchemaManager schemaManager,
             CoreOptions options,
             SnapshotReader snapshotReader,
             SnapshotManager snapshotManager,
@@ -84,7 +86,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
             boolean supportStreamingReadOverwrite,
             TableQueryAuth queryAuth,
             boolean hasPk) {
-        super(schema, options, snapshotReader, queryAuth);
+        super(schema, schemaManager, options, snapshotReader, queryAuth);
 
         this.options = options;
         this.scanMode = options.toConfiguration().get(CoreOptions.STREAM_SCAN_MODE);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.index.pk.PrimaryKeyIndexDefinition;
 import org.apache.paimon.index.pk.PrimaryKeyIndexDefinitions;
 import org.apache.paimon.partition.PartitionPredicate;
@@ -72,7 +73,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
 
     @Override
     public FullTextScan newFullTextScan() {
-        rejectUnderQueryAuth();
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
         DataField textColumn = textColumn();
         Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);
         return definition.isPresent()
@@ -87,7 +88,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
 
     @Override
     public FullTextRead newFullTextRead() {
-        rejectUnderQueryAuth();
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
         DataField textColumn = textColumn();
         Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);
@@ -129,13 +130,5 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     FullTextSearchBuilderImpl withSnapshot(Snapshot snapshot) {
         this.pinnedSnapshot = snapshot;
         return this;
-    }
-
-    private void rejectUnderQueryAuth() {
-        if (table.coreOptions().queryAuthEnabled()) {
-            throw new UnsupportedOperationException(
-                    "Search is not supported on a query-auth table: the index ranks raw values, "
-                            + "which a column mask invalidates.");
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -87,6 +87,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
 
     @Override
     public FullTextRead newFullTextRead() {
+        rejectUnderQueryAuth();
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
         DataField textColumn = textColumn();
         Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -72,6 +72,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
 
     @Override
     public FullTextScan newFullTextScan() {
+        rejectUnderQueryAuth();
         DataField textColumn = textColumn();
         Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);
         return definition.isPresent()
@@ -127,5 +128,13 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     FullTextSearchBuilderImpl withSnapshot(Snapshot snapshot) {
         this.pinnedSnapshot = snapshot;
         return this;
+    }
+
+    private void rejectUnderQueryAuth() {
+        if (table.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Search is not supported on a query-auth table: the index ranks raw values, "
+                            + "which a column mask invalidates.");
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
@@ -128,6 +128,7 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
 
     @Override
     public List<Route> routeBuilders() {
+        rejectUnderQueryAuth();
         validateSearch();
 
         Snapshot snapshot = null;
@@ -376,5 +377,14 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
             fullTextSearchBuilder.withPartitionFilter(partitionFilter);
         }
         return fullTextSearchBuilder;
+    }
+
+    private void rejectUnderQueryAuth() {
+        if (table instanceof FileStoreTable
+                && ((FileStoreTable) table).coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Search is not supported on a query-auth table: the index ranks raw values, "
+                            + "which a column mask invalidates.");
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.HybridSearchRanker;
@@ -128,7 +129,7 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
 
     @Override
     public List<Route> routeBuilders() {
-        rejectUnderQueryAuth();
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
         validateSearch();
 
         Snapshot snapshot = null;
@@ -377,14 +378,5 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
             fullTextSearchBuilder.withPartitionFilter(partitionFilter);
         }
         return fullTextSearchBuilder;
-    }
-
-    private void rejectUnderQueryAuth() {
-        if (table instanceof FileStoreTable
-                && ((FileStoreTable) table).coreOptions().queryAuthEnabled()) {
-            throw new UnsupportedOperationException(
-                    "Search is not supported on a query-auth table: the index ranks raw values, "
-                            + "which a column mask invalidates.");
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
@@ -117,6 +117,11 @@ public class PrimaryKeyBatchScan extends AbstractBatchTableScan {
         if (globalIndexSplitResult == null) {
             return null;
         }
+        if (options().queryAuthEnabled()) {
+            // the splits were selected from raw index values, which a mask may invalidate;
+            // plan normally instead, as the index evaluation below already does
+            return null;
+        }
         if (globalIndexSplitResult.snapshotId() > 0) {
             maybeCreateReadProtectionTag(globalIndexSplitResult.snapshotId());
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileHandler;
@@ -135,8 +136,15 @@ public class PrimaryKeyBatchScan extends AbstractBatchTableScan {
                 || snapshotPlan.splits().isEmpty()) {
             return dataPlan;
         }
+        // the index is built over raw values, so a conjunct on a masked column must not reach it
+        Predicate indexCandidate =
+                filter == null || authMaskedFields.isEmpty()
+                        ? filter
+                        : TableQueryAuthResult.excludeFields(filter, authMaskedFields);
         Predicate indexFilter =
-                filter == null ? null : filter.visit(indexPredicateExtractor).orElse(null);
+                indexCandidate == null
+                        ? null
+                        : indexCandidate.visit(indexPredicateExtractor).orElse(null);
         if (indexFilter == null) {
             return dataPlan;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyBatchScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileHandler;
@@ -136,8 +137,15 @@ public class PrimaryKeyBatchScan extends AbstractBatchTableScan {
                 || snapshotPlan.splits().isEmpty()) {
             return dataPlan;
         }
+        // the index is built over raw values, so a conjunct on a masked column must not reach it
+        Predicate indexCandidate =
+                filter == null || authMaskedFields.isEmpty()
+                        ? filter
+                        : TableQueryAuthResult.excludeFields(filter, authMaskedFields);
         Predicate indexFilter =
-                filter == null ? null : filter.visit(indexPredicateExtractor).orElse(null);
+                indexCandidate == null
+                        ? null
+                        : indexCandidate.visit(indexPredicateExtractor).orElse(null);
         if (indexFilter == null) {
             return dataPlan;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -245,10 +245,11 @@ public class ReadBuilderImpl implements ReadBuilder {
             read.withReadType(readType);
         }
         if (queryAuthEnabled) {
-            // Skip TopN (engine re-applies it); apply the limit after auth only without a TopN,
-            // else an unordered limit could drop sorted rows.
+            // Skip TopN and, with a filter or a TopN present, the limit as well: the engine
+            // re-applies them. The reader does not evaluate the query filter on an auth-enabled
+            // table, so capping the rows here would cut away the rows that actually match.
             if (topN == null && limit != null) {
-                return new LimitTableRead(read, limit);
+                return new LimitTableRead(read, limit, filter != null);
             }
             return read;
         }
@@ -291,10 +292,15 @@ public class ReadBuilderImpl implements ReadBuilder {
 
         private final TableRead delegate;
         private final int limit;
+        // with a filter the reader only evaluates it once executeFilter() is requested;
+        // otherwise the engine does, after this limit, so capping here would drop matches
+        private final boolean filterPresent;
+        private boolean filterExecutedByReader = false;
 
-        private LimitTableRead(TableRead delegate, int limit) {
+        private LimitTableRead(TableRead delegate, int limit, boolean filterPresent) {
             this.delegate = delegate;
             this.limit = limit;
+            this.filterPresent = filterPresent;
         }
 
         @Override
@@ -306,6 +312,7 @@ public class ReadBuilderImpl implements ReadBuilder {
         @Override
         public TableRead executeFilter() {
             delegate.executeFilter();
+            this.filterExecutedByReader = true;
             return this;
         }
 
@@ -338,6 +345,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         }
 
         private RecordReader<InternalRow> limit(RecordReader<InternalRow> reader) {
+            if (filterPresent && !filterExecutedByReader) {
+                return reader;
+            }
             // Stop reading once the limit is reached (return EOF), rather than filtering and
             // draining the rest of the data.
             return new RecordReader<InternalRow>() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -245,9 +245,8 @@ public class ReadBuilderImpl implements ReadBuilder {
             read.withReadType(readType);
         }
         if (queryAuthEnabled) {
-            // Skip TopN and, with a filter or a TopN present, the limit as well: the engine
-            // re-applies them. The reader does not evaluate the query filter on an auth-enabled
-            // table, so capping the rows here would cut away the rows that actually match.
+            // the reader does not evaluate the query filter on an auth-enabled table, so
+            // capping the rows here would cut away rows that actually match
             if (topN == null && limit != null) {
                 return new LimitTableRead(read, limit, filter != null);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -244,10 +244,11 @@ public class ReadBuilderImpl implements ReadBuilder {
             read.withReadType(readType);
         }
         if (queryAuthEnabled) {
-            // Skip TopN (engine re-applies it); apply the limit after auth only without a TopN,
-            // else an unordered limit could drop sorted rows.
+            // Skip TopN and, with a filter or a TopN present, the limit as well: the engine
+            // re-applies them. The reader does not evaluate the query filter on an auth-enabled
+            // table, so capping the rows here would cut away the rows that actually match.
             if (topN == null && limit != null) {
-                return new LimitTableRead(read, limit);
+                return new LimitTableRead(read, limit, filter != null);
             }
             return read;
         }
@@ -290,10 +291,15 @@ public class ReadBuilderImpl implements ReadBuilder {
 
         private final TableRead delegate;
         private final int limit;
+        // with a filter the reader only evaluates it once executeFilter() is requested;
+        // otherwise the engine does, after this limit, so capping here would drop matches
+        private final boolean filterPresent;
+        private boolean filterExecutedByReader = false;
 
-        private LimitTableRead(TableRead delegate, int limit) {
+        private LimitTableRead(TableRead delegate, int limit, boolean filterPresent) {
             this.delegate = delegate;
             this.limit = limit;
+            this.filterPresent = filterPresent;
         }
 
         @Override
@@ -305,6 +311,7 @@ public class ReadBuilderImpl implements ReadBuilder {
         @Override
         public TableRead executeFilter() {
             delegate.executeFilter();
+            this.filterExecutedByReader = true;
             return this;
         }
 
@@ -331,6 +338,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         }
 
         private RecordReader<InternalRow> limit(RecordReader<InternalRow> reader) {
+            if (filterPresent && !filterExecutedByReader) {
+                return reader;
+            }
             // Stop reading once the limit is reached (return EOF), rather than filtering and
             // draining the rest of the data.
             return new RecordReader<InternalRow>() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -144,6 +144,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
 
     @Override
     public VectorRead newVectorRead() {
+        rejectUnderQueryAuth();
         checkNotNull(vector, "vector must be set via withVector()");
         if (isPrimaryKeyVectorSearch()) {
             return new PrimaryKeyVectorRead(table, vectorColumn, vector, limit, options, filter);
@@ -162,7 +163,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
         return this;
     }
 
-    private void rejectUnderQueryAuth() {
+    protected void rejectUnderQueryAuth() {
         if (table.coreOptions().queryAuthEnabled()) {
             throw new UnsupportedOperationException(
                     "Search is not supported on a query-auth table: the index ranks raw values, "

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -164,10 +165,6 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
     }
 
     protected void rejectUnderQueryAuth() {
-        if (table.coreOptions().queryAuthEnabled()) {
-            throw new UnsupportedOperationException(
-                    "Search is not supported on a query-auth table: the index ranks raw values, "
-                            + "which a column mask invalidates.");
-        }
+        TableQueryAuthResult.rejectSearchUnderQueryAuth(table);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -128,6 +128,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
 
     @Override
     public VectorScan newVectorScan() {
+        rejectUnderQueryAuth();
         if (isPrimaryKeyVectorSearch()) {
             return new PrimaryKeyVectorScan(
                     table,
@@ -159,5 +160,13 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
     public VectorSearchBuilderImpl withSnapshot(Snapshot snapshot) {
         this.pinnedSnapshot = snapshot;
         return this;
+    }
+
+    private void rejectUnderQueryAuth() {
+        if (table.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Search is not supported on a query-auth table: the index ranks raw values, "
+                            + "which a column mask invalidates.");
+        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -106,8 +106,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
                         mergeRead.mergeSorter(),
                         forceKeepDelete);
         if (readType != null) {
-            ProjectedRow projectedRow =
-                    ProjectedRow.from(readType, mergeRead.tableSchema().logicalRowType());
+            // project from the merge read's actual output, which may itself be projected
+            ProjectedRow projectedRow = ProjectedRow.from(readType, mergeRead.actualReadType());
             reader = reader.transform(kv -> kv.replaceValue(projectedRow.replaceRow(kv.value())));
         }
         return KeyValueTableRead.unwrap(reader, mergeRead.tableSchema().options());

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -113,8 +113,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
                         mergeRead.mergeSorter(),
                         forceKeepDelete);
         if (readType != null) {
-            ProjectedRow projectedRow =
-                    ProjectedRow.from(readType, mergeRead.tableSchema().logicalRowType());
+            // project from the merge read's actual output, which may itself be projected
+            ProjectedRow projectedRow = ProjectedRow.from(readType, mergeRead.actualReadType());
             reader = reader.transform(kv -> kv.replaceValue(projectedRow.replaceRow(kv.value())));
         }
         return KeyValueTableRead.unwrap(reader, mergeRead.tableSchema().options());

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -146,6 +146,7 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
         }
         return new DataTableStreamScan(
                 wrapped.schema(),
+                schemaManager(),
                 coreOptions(),
                 newSnapshotReader(),
                 snapshotManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -93,11 +93,11 @@ public class SystemTableLoader {
             Arrays.asList(ALL_TABLES, ALL_PARTITIONS, ALL_TABLE_OPTIONS, CATALOG_OPTIONS);
 
     /**
-     * System tables built from raw DataSplit metadata -- file names, row counts, per-column min/max
-     * -- none of which a column mask covers.
+     * System tables built from raw metadata -- file names, row counts, per-column min/max and
+     * distinct/null counts -- none of which a column mask covers.
      */
     private static final List<String> PHYSICAL_METADATA_TABLES =
-            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG);
+            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG, STATISTICS);
 
     @Nullable
     public static Table load(String type, FileStoreTable dataTable) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -95,11 +95,11 @@ public class SystemTableLoader {
             Arrays.asList(ALL_TABLES, ALL_PARTITIONS, ALL_TABLE_OPTIONS, CATALOG_OPTIONS);
 
     /**
-     * System tables built from raw DataSplit metadata -- file names, row counts, per-column min/max
-     * -- none of which a column mask covers.
+     * System tables built from raw metadata -- file names, row counts, per-column min/max and
+     * distinct/null counts -- none of which a column mask covers.
      */
     private static final List<String> PHYSICAL_METADATA_TABLES =
-            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG);
+            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG, STATISTICS);
 
     @Nullable
     public static Table load(String type, FileStoreTable dataTable) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -92,9 +92,25 @@ public class SystemTableLoader {
     public static final List<String> GLOBAL_SYSTEM_TABLES =
             Arrays.asList(ALL_TABLES, ALL_PARTITIONS, ALL_TABLE_OPTIONS, CATALOG_OPTIONS);
 
+    /**
+     * System tables built from raw DataSplit metadata -- file names, row counts, per-column min/max
+     * -- none of which a column mask covers.
+     */
+    private static final List<String> PHYSICAL_METADATA_TABLES =
+            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG);
+
     @Nullable
     public static Table load(String type, FileStoreTable dataTable) {
-        return Optional.ofNullable(SYSTEM_TABLE_LOADERS.get(type.toLowerCase()))
+        String name = type.toLowerCase();
+        if (PHYSICAL_METADATA_TABLES.contains(name) && dataTable.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "System table '%s' is not supported on a query-auth table: it reports "
+                                    + "raw file statistics, which column masking cannot be applied "
+                                    + "to.",
+                            name));
+        }
+        return Optional.ofNullable(SYSTEM_TABLE_LOADERS.get(name))
                 .map(f -> f.apply(dataTable))
                 .orElse(null);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/SystemTableLoader.java
@@ -94,9 +94,25 @@ public class SystemTableLoader {
     public static final List<String> GLOBAL_SYSTEM_TABLES =
             Arrays.asList(ALL_TABLES, ALL_PARTITIONS, ALL_TABLE_OPTIONS, CATALOG_OPTIONS);
 
+    /**
+     * System tables built from raw DataSplit metadata -- file names, row counts, per-column min/max
+     * -- none of which a column mask covers.
+     */
+    private static final List<String> PHYSICAL_METADATA_TABLES =
+            Arrays.asList(FILES, FILE_KEY_RANGES, BINLOG);
+
     @Nullable
     public static Table load(String type, FileStoreTable dataTable) {
-        return Optional.ofNullable(SYSTEM_TABLE_LOADERS.get(type.toLowerCase()))
+        String name = type.toLowerCase();
+        if (PHYSICAL_METADATA_TABLES.contains(name) && dataTable.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "System table '%s' is not supported on a query-auth table: it reports "
+                                    + "raw file statistics, which column masking cannot be applied "
+                                    + "to.",
+                            name));
+        }
+        return Optional.ofNullable(SYSTEM_TABLE_LOADERS.get(name))
                 .map(f -> f.apply(dataTable))
                 .orElse(null);
     }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.predicate.ConcatWsTransform;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link TableQueryAuthResult}. */
+public class TableQueryAuthResultTest {
+
+    private static final RowType TABLE_TYPE =
+            RowType.of(
+                    new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                    new org.apache.paimon.types.DataField(1, "extra", DataTypes.STRING()));
+
+    private static String maskJson() {
+        return JsonSerdeUtil.toFlatJson(
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "extra", DataTypes.STRING()))));
+    }
+
+    @Test
+    public void testHasRules() {
+        assertThat(new TableQueryAuthResult(null, null).hasRules()).isFalse();
+        assertThat(
+                        new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap())
+                                .hasRules())
+                .isFalse();
+        // blank filter entries parse to no predicate
+        assertThat(new TableQueryAuthResult(Collections.singletonList(""), null).hasRules())
+                .isFalse();
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        assertThat(new TableQueryAuthResult(null, masking).hasRules()).isTrue();
+    }
+
+    @Test
+    public void testWidenReadType() {
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
+        // the mask input is unprojected: widen
+        RowType widened = result.widenReadType(TABLE_TYPE, TABLE_TYPE.project("display"));
+        assertThat(widened).isNotNull();
+        assertThat(widened.getFieldNames()).containsExactly("display", "extra");
+        // already covered: no widening
+        assertThat(result.widenReadType(TABLE_TYPE, TABLE_TYPE)).isNull();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -67,13 +67,9 @@ public class TableQueryAuthResultTest {
         Map<String, String> masking = Collections.singletonMap("display", maskJson());
         TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
 
-        // same names and ids: the rule binds to the same physical columns
         assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
                 .doesNotThrowAnyException();
 
-        // the mask input 'extra' was dropped and re-added, so the latest schema gives it a fresh
-        // id. A time-travel read of the pre-drop snapshot still has an 'extra', but it is an
-        // unrelated column; resolving the rule by name would mask with its values.
         RowType latest =
                 RowType.of(
                         new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
@@ -85,7 +81,6 @@ public class TableQueryAuthResultTest {
 
     @Test
     public void testValidateRejectsReAddedColumnForRowFilter() {
-        // a row filter is remapped by name too, so it needs the same binding check as a mask
         TableQueryAuthResult result =
                 new TableQueryAuthResult(Collections.singletonList(filterJson()), null);
         assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
@@ -108,22 +103,9 @@ public class TableQueryAuthResultTest {
                         new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap())
                                 .hasRules())
                 .isFalse();
-        // blank filter entries parse to no predicate
         assertThat(new TableQueryAuthResult(Collections.singletonList(""), null).hasRules())
                 .isFalse();
         Map<String, String> masking = Collections.singletonMap("display", maskJson());
         assertThat(new TableQueryAuthResult(null, masking).hasRules()).isTrue();
-    }
-
-    @Test
-    public void testWidenReadType() {
-        Map<String, String> masking = Collections.singletonMap("display", maskJson());
-        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
-        // the mask input is unprojected: widen
-        RowType widened = result.widenReadType(TABLE_TYPE, TABLE_TYPE.project("display"));
-        assertThat(widened).isNotNull();
-        assertThat(widened.getFieldNames()).containsExactly("display", "extra");
-        // already covered: no widening
-        assertThat(result.widenReadType(TABLE_TYPE, TABLE_TYPE)).isNull();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -20,7 +20,10 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.ConcatWsTransform;
+import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FieldTransform;
+import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -33,6 +36,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests that malformed query-authorization definitions cannot be silently ignored. */
@@ -97,12 +101,59 @@ public class TableQueryAuthResultTest {
                     new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
                     new org.apache.paimon.types.DataField(1, "extra", DataTypes.STRING()));
 
+    private static String filterJson() {
+        return JsonSerdeUtil.toFlatJson(
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "extra", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x"))));
+    }
+
     private static String maskJson() {
         return JsonSerdeUtil.toFlatJson(
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(1, "extra", DataTypes.STRING()))));
+    }
+
+    @Test
+    public void testValidateRejectsReAddedColumnOfSameName() {
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
+
+        // same names and ids: the rule binds to the same physical columns
+        assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
+                .doesNotThrowAnyException();
+
+        // the mask input 'extra' was dropped and re-added, so the latest schema gives it a fresh
+        // id. A time-travel read of the pre-drop snapshot still has an 'extra', but it is an
+        // unrelated column; resolving the rule by name would mask with its values.
+        RowType latest =
+                RowType.of(
+                        new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                        new org.apache.paimon.types.DataField(7, "extra", DataTypes.STRING()));
+        assertThatThrownBy(() -> result.validateReadableWithoutRename(latest, TABLE_TYPE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dropped and re-added");
+    }
+
+    @Test
+    public void testValidateRejectsReAddedColumnForRowFilter() {
+        // a row filter is remapped by name too, so it needs the same binding check as a mask
+        TableQueryAuthResult result =
+                new TableQueryAuthResult(Collections.singletonList(filterJson()), null);
+        assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
+                .doesNotThrowAnyException();
+
+        RowType latest =
+                RowType.of(
+                        new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                        new org.apache.paimon.types.DataField(7, "extra", DataTypes.STRING()));
+        assertThatThrownBy(() -> result.validateReadableWithoutRename(latest, TABLE_TYPE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Row filter")
+                .hasMessageContaining("dropped and re-added");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -18,14 +18,21 @@
 
 package org.apache.paimon.catalog;
 
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.predicate.ConcatWsTransform;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests that malformed query-authorization definitions cannot be silently ignored. */
@@ -83,5 +90,42 @@ public class TableQueryAuthResultTest {
                                         .extractColumnMasking())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("JSON null");
+    }
+
+    private static final RowType TABLE_TYPE =
+            RowType.of(
+                    new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                    new org.apache.paimon.types.DataField(1, "extra", DataTypes.STRING()));
+
+    private static String maskJson() {
+        return JsonSerdeUtil.toFlatJson(
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "extra", DataTypes.STRING()))));
+    }
+
+    @Test
+    public void testHasRules() {
+        assertThat(new TableQueryAuthResult(null, null).hasRules()).isFalse();
+        assertThat(
+                        new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap())
+                                .hasRules())
+                .isFalse();
+        // a blank entry is now rejected rather than ignored, see testInvalidRowFilterFailsClosed
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        assertThat(new TableQueryAuthResult(null, masking).hasRules()).isTrue();
+    }
+
+    @Test
+    public void testWidenReadType() {
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
+        // the mask input is unprojected: widen
+        RowType widened = result.widenReadType(TABLE_TYPE, TABLE_TYPE.project("display"));
+        assertThat(widened).isNotNull();
+        assertThat(widened.getFieldNames()).containsExactly("display", "extra");
+        // already covered: no widening
+        assertThat(result.widenReadType(TABLE_TYPE, TABLE_TYPE)).isNull();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -122,13 +122,9 @@ public class TableQueryAuthResultTest {
         Map<String, String> masking = Collections.singletonMap("display", maskJson());
         TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
 
-        // same names and ids: the rule binds to the same physical columns
         assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
                 .doesNotThrowAnyException();
 
-        // the mask input 'extra' was dropped and re-added, so the latest schema gives it a fresh
-        // id. A time-travel read of the pre-drop snapshot still has an 'extra', but it is an
-        // unrelated column; resolving the rule by name would mask with its values.
         RowType latest =
                 RowType.of(
                         new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
@@ -140,7 +136,6 @@ public class TableQueryAuthResultTest {
 
     @Test
     public void testValidateRejectsReAddedColumnForRowFilter() {
-        // a row filter is remapped by name too, so it needs the same binding check as a mask
         TableQueryAuthResult result =
                 new TableQueryAuthResult(Collections.singletonList(filterJson()), null);
         assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
@@ -166,17 +161,5 @@ public class TableQueryAuthResultTest {
         // a blank entry is now rejected rather than ignored, see testInvalidRowFilterFailsClosed
         Map<String, String> masking = Collections.singletonMap("display", maskJson());
         assertThat(new TableQueryAuthResult(null, masking).hasRules()).isTrue();
-    }
-
-    @Test
-    public void testWidenReadType() {
-        Map<String, String> masking = Collections.singletonMap("display", maskJson());
-        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
-        // the mask input is unprojected: widen
-        RowType widened = result.widenReadType(TABLE_TYPE, TABLE_TYPE.project("display"));
-        assertThat(widened).isNotNull();
-        assertThat(widened.getFieldNames()).containsExactly("display", "extra");
-        // already covered: no widening
-        assertThat(result.widenReadType(TABLE_TYPE, TABLE_TYPE)).isNull();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -20,7 +20,10 @@ package org.apache.paimon.catalog;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.ConcatWsTransform;
+import org.apache.paimon.predicate.Equal;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FieldTransform;
+import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.JsonSerdeUtil;
@@ -32,6 +35,8 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link TableQueryAuthResult}. */
 public class TableQueryAuthResultTest {
@@ -41,12 +46,59 @@ public class TableQueryAuthResultTest {
                     new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
                     new org.apache.paimon.types.DataField(1, "extra", DataTypes.STRING()));
 
+    private static String filterJson() {
+        return JsonSerdeUtil.toFlatJson(
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "extra", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x"))));
+    }
+
     private static String maskJson() {
         return JsonSerdeUtil.toFlatJson(
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(1, "extra", DataTypes.STRING()))));
+    }
+
+    @Test
+    public void testValidateRejectsReAddedColumnOfSameName() {
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
+
+        // same names and ids: the rule binds to the same physical columns
+        assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
+                .doesNotThrowAnyException();
+
+        // the mask input 'extra' was dropped and re-added, so the latest schema gives it a fresh
+        // id. A time-travel read of the pre-drop snapshot still has an 'extra', but it is an
+        // unrelated column; resolving the rule by name would mask with its values.
+        RowType latest =
+                RowType.of(
+                        new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                        new org.apache.paimon.types.DataField(7, "extra", DataTypes.STRING()));
+        assertThatThrownBy(() -> result.validateReadableWithoutRename(latest, TABLE_TYPE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dropped and re-added");
+    }
+
+    @Test
+    public void testValidateRejectsReAddedColumnForRowFilter() {
+        // a row filter is remapped by name too, so it needs the same binding check as a mask
+        TableQueryAuthResult result =
+                new TableQueryAuthResult(Collections.singletonList(filterJson()), null);
+        assertThatCode(() -> result.validateReadableWithoutRename(TABLE_TYPE, TABLE_TYPE))
+                .doesNotThrowAnyException();
+
+        RowType latest =
+                RowType.of(
+                        new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                        new org.apache.paimon.types.DataField(7, "extra", DataTypes.STRING()));
+        assertThatThrownBy(() -> result.validateReadableWithoutRename(latest, TABLE_TYPE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Row filter")
+                .hasMessageContaining("dropped and re-added");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -349,6 +349,8 @@ public class MergeFileSplitReadTest {
                 scan.withSnapshot(snapshotId).plan().files().stream()
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
 
+        int rowsRead = 0;
+
         MergeFileSplitRead read = store.newRead();
         read.withReadType(TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr"));
         read.withReadType(
@@ -370,9 +372,11 @@ public class MergeFileSplitReadTest {
             RecordReaderIterator<KeyValue> iterator = new RecordReaderIterator<>(reader);
             while (iterator.hasNext()) {
                 assertThat(iterator.next().value().getFieldCount()).isEqualTo(4);
+                rowsRead++;
             }
             iterator.close();
         }
+        assertThat(rowsRead).isPositive();
     }
 
     @Test
@@ -476,6 +480,8 @@ public class MergeFileSplitReadTest {
         SplitRead<InternalRow> diffRead = new IncrementalDiffSplitRead(mergeRead);
         diffRead.withReadType(projection);
 
+        int rowsRead = 0;
+
         for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : filesByPartition.entrySet()) {
             List<DataFileMeta> files =
                     entry.getValue().stream().map(ManifestEntry::file).collect(Collectors.toList());
@@ -498,9 +504,11 @@ public class MergeFileSplitReadTest {
                 assertThat(row.getString(1).toString()).hasSize(8);
                 row.getInt(0);
                 row.getInt(2);
+                rowsRead++;
             }
             iterator.close();
         }
+        assertThat(rowsRead).isPositive();
     }
 
     private List<KeyValue> writeThenRead(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.TestFileStore;
 import org.apache.paimon.TestKeyValueGenerator;
@@ -44,6 +45,8 @@ import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.PrimaryKeyTableUtils;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.IncrementalSplit;
+import org.apache.paimon.table.source.splitread.IncrementalDiffSplitRead;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -324,6 +327,58 @@ public class MergeFileSplitReadTest {
     }
 
     @Test
+    public void testRepeatedReadTypeResetsOuterProjection() throws Exception {
+        // a second withReadType that needs no adjustment must clear the outer projection
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        List<KeyValue> data = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            data.add(gen.next());
+        }
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
+                        DeduplicateMergeFunction.factory(),
+                        Collections.singletonMap(CoreOptions.SEQUENCE_FIELD.key(), "orderId"));
+        store.commitData(data, gen::getPartition, kv -> 0);
+
+        FileStoreScan scan = store.newScan();
+        Long snapshotId = store.snapshotManager().latestSnapshotId();
+        Map<BinaryRow, List<ManifestEntry>> filesGroupedByPartition =
+                scan.withSnapshot(snapshotId).plan().files().stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::partition));
+
+        MergeFileSplitRead read = store.newRead();
+        // adjusted internally to include the sequence field: outer projection set
+        read.withReadType(TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr"));
+        // contains the sequence field, no adjustment: previous outer projection cleared
+        read.withReadType(
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr", "orderId"));
+
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : filesGroupedByPartition.entrySet()) {
+            RecordReader<KeyValue> reader =
+                    read.createReader(
+                            DataSplit.builder()
+                                    .withSnapshot(snapshotId)
+                                    .withPartition(entry.getKey())
+                                    .withBucket(0)
+                                    .withDataFiles(
+                                            entry.getValue().stream()
+                                                    .map(ManifestEntry::file)
+                                                    .collect(Collectors.toList()))
+                                    .withBucketPath("not used")
+                                    .build());
+            RecordReaderIterator<KeyValue> iterator = new RecordReaderIterator<>(reader);
+            while (iterator.hasNext()) {
+                assertThat(iterator.next().value().getFieldCount()).isEqualTo(4);
+            }
+            iterator.close();
+        }
+    }
+
+    @Test
     public void testPostponeReader() throws Exception {
         RowType keyType =
                 RowType.of(
@@ -391,6 +446,70 @@ public class MergeFileSplitReadTest {
         return new KeyValue().replace(GenericRow.of(key), sequenceNumber, kind, row);
     }
 
+    @Test
+    public void testIncrementalDiffReadOnProjectedMergeRead() throws Exception {
+        // the diff read projects the merge read's output; when the shared merge read
+        // is itself projected, the projection base must be its actual output type
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        List<KeyValue> before = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            before.add(gen.next());
+        }
+        List<KeyValue> after = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            after.add(gen.next());
+        }
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
+                        DeduplicateMergeFunction.factory());
+        store.commitData(before, gen::getPartition, kv -> 0);
+        store.commitData(after, gen::getPartition, kv -> 0);
+
+        FileStoreScan scan = store.newScan();
+        Long snapshotId = store.snapshotManager().latestSnapshotId();
+        Map<BinaryRow, List<ManifestEntry>> filesByPartition =
+                scan.withSnapshot(snapshotId).plan().files().stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::partition));
+
+        MergeFileSplitRead mergeRead = store.newRead();
+        // out-of-table-order projection, pushed into the shared merge read
+        RowType projection = TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr");
+        mergeRead.withReadType(projection);
+        SplitRead<InternalRow> diffRead = new IncrementalDiffSplitRead(mergeRead);
+        diffRead.withReadType(projection);
+
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : filesByPartition.entrySet()) {
+            List<DataFileMeta> files =
+                    entry.getValue().stream().map(ManifestEntry::file).collect(Collectors.toList());
+            IncrementalSplit split =
+                    new IncrementalSplit(
+                            snapshotId,
+                            entry.getKey(),
+                            0,
+                            1,
+                            Collections.emptyList(),
+                            null,
+                            files,
+                            null,
+                            false);
+            RecordReaderIterator<InternalRow> iterator =
+                    new RecordReaderIterator<>(diffRead.createReader(split));
+            while (iterator.hasNext()) {
+                InternalRow row = iterator.next();
+                assertThat(row.getFieldCount()).isEqualTo(3);
+                // shopId INT, dt STRING(len 8), hr INT: misprojection would misplace types
+                assertThat(row.getString(1).toString()).hasSize(8);
+                row.getInt(0);
+                row.getInt(2);
+            }
+            iterator.close();
+        }
+    }
+
     private List<KeyValue> writeThenRead(
             List<KeyValue> data,
             RowType readKeyType,
@@ -446,7 +565,8 @@ public class MergeFileSplitReadTest {
             KeyValueFieldsExtractor extractor,
             MergeFunctionFactory<KeyValue> mfFactory)
             throws Exception {
-        return createStore(1, partitionType, keyType, valueType, extractor, mfFactory);
+        return createStore(
+                1, partitionType, keyType, valueType, extractor, mfFactory, Collections.emptyMap());
     }
 
     private TestFileStore createStore(
@@ -456,6 +576,36 @@ public class MergeFileSplitReadTest {
             RowType valueType,
             KeyValueFieldsExtractor extractor,
             MergeFunctionFactory<KeyValue> mfFactory)
+            throws Exception {
+        return createStore(
+                numBuckets,
+                partitionType,
+                keyType,
+                valueType,
+                extractor,
+                mfFactory,
+                Collections.emptyMap());
+    }
+
+    private TestFileStore createStore(
+            RowType partitionType,
+            RowType keyType,
+            RowType valueType,
+            KeyValueFieldsExtractor extractor,
+            MergeFunctionFactory<KeyValue> mfFactory,
+            Map<String, String> options)
+            throws Exception {
+        return createStore(1, partitionType, keyType, valueType, extractor, mfFactory, options);
+    }
+
+    private TestFileStore createStore(
+            int numBuckets,
+            RowType partitionType,
+            RowType keyType,
+            RowType valueType,
+            KeyValueFieldsExtractor extractor,
+            MergeFunctionFactory<KeyValue> mfFactory,
+            Map<String, String> options)
             throws Exception {
         Path path = new Path(tempDir.toUri());
         SchemaManager schemaManager = new SchemaManager(FileIOFinder.find(path), path);
@@ -476,7 +626,7 @@ public class MergeFileSplitReadTest {
                                                                                 "")),
                                                 partitionType.getFieldNames().stream())
                                         .collect(Collectors.toList()),
-                        Collections.emptyMap(),
+                        options,
                         null);
         TableSchema tableSchema = schemaManager.createTable(schema);
         return new TestFileStore.Builder(

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -328,7 +328,6 @@ public class MergeFileSplitReadTest {
 
     @Test
     public void testRepeatedReadTypeResetsOuterProjection() throws Exception {
-        // a second withReadType that needs no adjustment must clear the outer projection
         TestKeyValueGenerator gen = new TestKeyValueGenerator();
         List<KeyValue> data = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
@@ -351,9 +350,7 @@ public class MergeFileSplitReadTest {
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
 
         MergeFileSplitRead read = store.newRead();
-        // adjusted internally to include the sequence field: outer projection set
         read.withReadType(TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr"));
-        // contains the sequence field, no adjustment: previous outer projection cleared
         read.withReadType(
                 TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr", "orderId"));
 
@@ -448,8 +445,6 @@ public class MergeFileSplitReadTest {
 
     @Test
     public void testIncrementalDiffReadOnProjectedMergeRead() throws Exception {
-        // the diff read projects the merge read's output; when the shared merge read
-        // is itself projected, the projection base must be its actual output type
         TestKeyValueGenerator gen = new TestKeyValueGenerator();
         List<KeyValue> before = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
@@ -476,7 +471,6 @@ public class MergeFileSplitReadTest {
                         .collect(Collectors.groupingBy(ManifestEntry::partition));
 
         MergeFileSplitRead mergeRead = store.newRead();
-        // out-of-table-order projection, pushed into the shared merge read
         RowType projection = TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr");
         mergeRead.withReadType(projection);
         SplitRead<InternalRow> diffRead = new IncrementalDiffSplitRead(mergeRead);
@@ -501,7 +495,6 @@ public class MergeFileSplitReadTest {
             while (iterator.hasNext()) {
                 InternalRow row = iterator.next();
                 assertThat(row.getFieldCount()).isEqualTo(3);
-                // shopId INT, dt STRING(len 8), hr INT: misprojection would misplace types
                 assertThat(row.getString(1).toString()).hasSize(8);
                 row.getInt(0);
                 row.getInt(2);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -42,9 +42,11 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.function.Function;
 import org.apache.paimon.function.FunctionChange;
 import org.apache.paimon.function.FunctionDefinition;
+import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.BaseAppendFileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.options.Options;
@@ -104,6 +106,7 @@ import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
 import org.apache.paimon.utils.StringUtils;
@@ -4838,6 +4841,51 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testStreamScanFilterOnMaskedColumnNotPushedToStats() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_stream_masking_filter_stats");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
+        StreamTableScan scan = readBuilder.newStreamScan();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(scan.plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactly(1000);
+    }
+
+    @Test
     void testMaskGrowthOnPushedFilterColumn() throws Exception {
         Identifier identifier =
                 Identifier.create("test_table_db", "auth_table_masking_pushed_filter");
@@ -4908,6 +4956,32 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                                 .newScan()
                                 .listPartitionEntries())
                 .hasSize(1);
+    }
+
+    @Test
+    void testRowFilterAppliesToPartitionListing() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_row_filter_partition_listing");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"a", "v1"}, new String[] {"b", "v2"});
+
+        LeafPredicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        setRowFilter(identifier, Collections.singletonList(onA));
+
+        List<PartitionEntry> entries =
+                catalog.getTable(identifier).newReadBuilder().newScan().listPartitionEntries();
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).partition().getString(0).toString()).isEqualTo("a");
     }
 
     @Test
@@ -5858,7 +5932,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
+        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog", "statistics")) {
             Identifier sysId =
                     Identifier.create(
                             identifier.getDatabaseName(),
@@ -5947,6 +6021,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
+
+        assertThatThrownBy(() -> ((FileStoreTable) table).newVectorSearchBuilder().newVectorRead())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
     }
 
     @Test
@@ -5978,6 +6056,105 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(0L));
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(onRowId);
         assertThat(readBuilder.newScan().plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testSuppliedGlobalIndexResultIgnoredUnderQueryAuth() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_de_supplied_index");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        for (int v : new int[] {10, 20, 30}) {
+            BatchWriteBuilder builder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = builder.newWrite()) {
+                write.write(GenericRow.of(v));
+                builder.newCommit().commit(write.prepareCommit());
+            }
+        }
+
+        InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
+        scan.withGlobalIndexResult(GlobalIndexResult.fromRange(new Range(0, 1)));
+        assertThat(scan.plan().splits()).hasSize(3);
+    }
+
+    @Test
+    void testRowIdFilterWithLimitOnDataEvolutionQueryAuthTable() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_de_rowid_limit");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        for (int v : new int[] {10, 20, 30}) {
+            BatchWriteBuilder builder = table.newBatchWriteBuilder();
+            try (BatchTableWrite write = builder.newWrite()) {
+                write.write(GenericRow.of(v));
+                builder.newCommit().commit(write.prepareCommit());
+            }
+        }
+
+        Predicate onLastRowId =
+                LeafPredicate.of(
+                        new FieldTransform(
+                                new FieldRef(
+                                        SpecialFields.ROW_ID.id(),
+                                        SpecialFields.ROW_ID.name(),
+                                        DataTypes.BIGINT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(2L));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onLastRowId).withLimit(1);
+        assertThat(readBuilder.newScan().plan().splits()).hasSize(3);
+    }
+
+    @Test
+    void testMaskedRowIdFilterOnDataEvolutionQueryAuthTable() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_de_masked_rowid");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.BIGINT()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite()) {
+            write.write(GenericRow.of(42L));
+            builder.newCommit().commit(write.prepareCommit());
+        }
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                SpecialFields.ROW_ID.name(),
+                new FieldTransform(new FieldRef(0, "f0", DataTypes.BIGINT())));
+        setColumnMasking(identifier, masking);
+
+        Predicate onMaskedRowId =
+                LeafPredicate.of(
+                        new FieldTransform(
+                                new FieldRef(
+                                        SpecialFields.ROW_ID.id(),
+                                        SpecialFields.ROW_ID.name(),
+                                        DataTypes.BIGINT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(42L));
+        RowType readType =
+                new RowType(Arrays.asList(table.rowType().getField("f0"), SpecialFields.ROW_ID));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withReadType(readType).withFilter(onMaskedRowId);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        readType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getLong(1)).isEqualTo(42L);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -31,6 +31,8 @@ import org.apache.paimon.catalog.PropertyChange;
 import org.apache.paimon.consumer.ConsumerInfo;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
@@ -92,11 +94,13 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
 import org.apache.paimon.utils.StringUtils;
@@ -3897,6 +3901,896 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isEqualTo("prefix-example"); // col4 masked with ConcatWsTransform
         assertThat(row2.getString(4).toString())
                 .isEqualTo("value"); // col5 NOT masked - original value
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
+            throws Exception {
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Map<String, String> options = new HashMap<>(extraOptions);
+        options.put(QUERY_AUTH_ENABLED.key(), "true");
+        catalog.createTable(
+                identifier,
+                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
+                true);
+        return catalog.getTable(identifier);
+    }
+
+    private static List<DataField> stringFields(String... names) {
+        List<DataField> fields = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            fields.add(new DataField(i, names[i], DataTypes.STRING()));
+        }
+        return fields;
+    }
+
+    private static void writeStringRows(Table table, String[]... rows) throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        for (String[] values : rows) {
+            Object[] converted = new Object[values.length];
+            for (int i = 0; i < values.length; i++) {
+                converted[i] = BinaryString.fromString(values[i]);
+            }
+            write.write(GenericRow.of(converted));
+        }
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+    }
+
+    private static void writeStringRow(Table table, String... values) throws Exception {
+        writeStringRows(table, values);
+    }
+
+    /** Cross-column mask: display := concat_ws('-', first, last). */
+    private void maskDisplayWithFullName(Identifier identifier) {
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first", DataTypes.STRING()),
+                                new FieldRef(1, "last", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+    }
+
+    /** Rows must be copied: the auth back-projection reuses one ProjectedRow per split. */
+    private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
+            throws Exception {
+        List<InternalRow> rows = new ArrayList<>();
+        reader.forEachRemaining(row -> rows.add(InternalRowUtils.copyInternalRow(row, rowType)));
+        return rows;
+    }
+
+    @Test
+    void testColumnMaskingCrossColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_cross_column");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        // two rows in one commit -> one split with multiple rows
+        writeStringRows(
+                table,
+                new String[] {"john", "doe", "ignored", "o1"},
+                new String[] {"jane", "roe", "ignored", "o2"});
+        maskDisplayWithFullName(identifier);
+
+        // project only the masked target; its input columns are not selected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        assertThat(rows).hasSize(2);
+        for (InternalRow row : rows) {
+            assertThat(row.getFieldCount()).isEqualTo(1);
+        }
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingProjectionAcrossMultipleSplits() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_multi_split");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        // one file per split, so the scan below yields multiple splits
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two commits -> two splits; the widening must not leak state across splits
+        writeStringRow(table, "john", "doe", "ignored");
+        writeStringRow(table, "jane", "roe", "ignored");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        assertThat(splits.size()).isGreaterThan(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        List<String> values = new ArrayList<>();
+        for (InternalRow row : rows) {
+            // every split must be projected back to the query's arity
+            assertThat(row.getFieldCount()).isEqualTo(1);
+            values.add(row.getString(0).toString());
+        }
+        assertThat(values).containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingOnRowFilterColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret", "o1");
+
+        // the filter pulls unprojected "display" into the read type, activating its mask
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("secret")));
+        setRowFilter(identifier, Collections.singletonList(displayFilter));
+        maskDisplayWithFullName(identifier);
+
+        // project only "other": the mask target and inputs are all unprojected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {3});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("other"));
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("o1");
+    }
+
+    @Test
+    void testColumnMaskingRevokedOnSameTableRead() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revoked");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked).hasSize(1);
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
+
+        // revoke the rules: the same TableRead must drop the widened read type
+        setColumnMasking(identifier, new HashMap<>());
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+    }
+
+    @Test
+    void testColumnMaskingGrantedAfterReadSchemaFixed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_granted");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+
+        // first read without rules fixes the read schema to the projection
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+
+        // a mask granted afterwards needs columns outside that projection: the same reader
+        // widens for this split and still emits only the projected column
+        maskDisplayWithFullName(identifier);
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
+    }
+
+    @Test
+    void testColumnMaskingPreservesNestedProjection() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_nested");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        fields.add(new DataField(4, "extra", DataTypes.STRING()));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("ignored"),
+                        GenericRow.of(BinaryString.fromString("AV"), BinaryString.fromString("BV")),
+                        BinaryString.fromString("EX")));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // a nested-pruned read type, as engines push down
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+
+        // sanity: the nested-pruned read works without masking
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+
+        // mask "display" from unprojected "extra": widening must keep "s" pruned
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(4, "extra", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+
+        readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(2);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("EX");
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+    }
+
+    @Test
+    void testColumnMaskingStaleRuleFailsClosed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_stale");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret");
+
+        // mask target absent from the schema (e.g. renamed since the rule was written)
+        Map<String, Transform> staleTarget = new HashMap<>();
+        staleTarget.put(
+                "renamed_away",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, staleTarget);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // mask input absent from the schema
+        Map<String, Transform> staleInput = new HashMap<>();
+        staleInput.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "ghost", DataTypes.STRING()))));
+        setColumnMasking(identifier, staleInput);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRuleChangeOnRetainedColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_retained");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "hidden_a", "hidden_b"),
+                        Collections.emptyMap());
+        writeStringRow(table, "d1", "a1", "b1");
+
+        // first rules widen and fix the read schema to [display, hidden_a]
+        Map<String, Transform> rules = new HashMap<>();
+        rules.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "hidden_a", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("a1");
+
+        // the new rules mask only hidden_a, retained but unread: must not activate
+        rules.clear();
+        rules.put(
+                "hidden_a",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "hidden_b", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedMaskTarget() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_target");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask TARGETS the struct column "s" (reading another column)
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "s",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would write the mask into a partial slot: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingOnColumnAddedAfterSnapshot() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_time_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "display"), Collections.emptyMap());
+        writeStringRow(table, "john", "d1"); // snapshot 1
+
+        // add a column, then mask it: the rule is valid only in the latest schema
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "extra",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the new column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows).hasSize(1);
+        assertThat(latestRows.get(0).getString(2).toString()).isEqualTo("****");
+
+        // a time-travel read of the old snapshot must not fail on the newer rule
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> oldRows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(oldRows).hasSize(1);
+        assertThat(oldRows.get(0).getString(0).toString()).isEqualTo("john");
+    }
+
+    @Test
+    void testColumnMaskingRenamedColumnTimeTravelFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_rename_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1"); // snapshot 1, column named "secret"
+
+        // rename the column, then mask it under the new name
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "masked_secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the renamed column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows.get(0).getString(1).toString()).isEqualTo("****");
+
+        // a time-travel read of the pre-rename snapshot exposes the same physical column
+        // as "secret"; the rule keyed on "masked_secret" would be silently skipped by name
+        // and leak the raw value -- it must fail closed instead
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        assertThatThrownBy(() -> oldRead.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("renamed");
+    }
+
+    @Test
+    void testColumnMaskingSystemTargetInertWhenUnprojected() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask on a system column the query does not project must be inert, not reject
+        // the whole query at plan time
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_ROW_ID",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingInertTargetWithRenamedInputTimeTravel() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_inert_input");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "old_input"), Collections.emptyMap());
+        writeStringRow(table, "john", "in1"); // snapshot 1
+
+        // rename the input, then add a target column masked from the renamed input
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("old_input", "renamed_input")),
+                false);
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("display", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the pre-rename snapshot predates "display": the mask cannot output there, so the
+        // rename of its input must not fail the read
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> rows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("john");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("in1");
+    }
+
+    @Test
+    void testColumnMaskingRevalidatedAfterRulesDisappear() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revalidate");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+
+        // plan 1: a valid mask on "secret" is validated and cached
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        scan.plan();
+
+        // plan 2: rules disappear -- the cached validation must be forgotten
+        setColumnMasking(identifier, Collections.emptyMap());
+        scan.plan();
+
+        // the masked column is renamed away, then the identical rule is restored; a stale-rule
+        // cache short-circuit would skip re-validation and silently stop masking
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRenamedUnderLiveScanFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_live_rename");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+        scan.plan();
+
+        // the masked column is renamed while the rules stay identical: the live scan must
+        // notice on its next plan and fail closed, not keep planning on the stale rule
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedRuleInput() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_input");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask on "display" reads the whole struct column "s"
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would hand the mask a partial struct: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingWithDataEvolutionColumnFiles() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_data_evolution");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        fields.add(new DataField(1, "f1", DataTypes.STRING()));
+        fields.add(new DataField(2, "f2", DataTypes.STRING()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        // one row group split across two columnar files: (f0, f1) and (f2)
+        RowType tableRowType = table.rowType();
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write0 =
+                builder.newWrite().withWriteType(tableRowType.project("f0", "f1"))) {
+            write0.write(GenericRow.of(0, BinaryString.fromString("a0")));
+            write0.write(GenericRow.of(1, BinaryString.fromString("a1")));
+            builder.newCommit().commit(write0.prepareCommit());
+        }
+        long rowId = ((FileStoreTable) table).snapshotManager().latestSnapshot().nextRowId() - 2;
+        builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write1 =
+                builder.newWrite().withWriteType(tableRowType.project("f2"))) {
+            write1.write(GenericRow.of(BinaryString.fromString("b0")));
+            write1.write(GenericRow.of(BinaryString.fromString("b1")));
+            List<CommitMessage> commitables = write1.prepareCommit();
+            for (CommitMessage c : commitables) {
+                CommitMessageImpl message = (CommitMessageImpl) c;
+                List<DataFileMeta> newFiles =
+                        new ArrayList<>(message.newFilesIncrement().newFiles());
+                message.newFilesIncrement().newFiles().clear();
+                for (DataFileMeta file : newFiles) {
+                    message.newFilesIncrement().newFiles().add(file.assignFirstRowId(rowId));
+                }
+            }
+            builder.newCommit().commit(commitables);
+        }
+
+        // mask f1 from f2 and project only f1: the scan must keep f2's file
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "f1",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "f2", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {1});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        tableRowType.project("f1"));
+        assertThat(rows).hasSize(2);
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.isNullAt(0) ? null : row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("b0", "b1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsUnprojectedBlobViewInput() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_blob_view");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(new DataField(1, "image", DataTypes.BLOB()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.BLOB_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_RESOLVE_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        Blob.fromView(new BlobViewStruct(identifier, 1, 0L))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the unprojected blob-view column: resolution cannot apply
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "image", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        table.rowType().project("display")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blob-view");
+    }
+
+    @Test
+    void testColumnMaskingReadingSystemField() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.BIGINT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(42L));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the projected _ROW_ID metadata field: not a stale rule
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+
+        RowType readType =
+                new RowType(
+                        Arrays.asList(
+                                table.rowType().getField("display"),
+                                org.apache.paimon.table.SpecialFields.ROW_ID));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        readType);
+        assertThat(rows).hasSize(1);
+        // display masked to the row id
+        assertThat(rows.get(0).getLong(0)).isEqualTo(rows.get(0).getLong(1));
+    }
+
+    @Test
+    void testColumnMaskingSystemFieldValidation() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_validation");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask keyed by a key-reader-internal name is stale, not a system field
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_KEY_display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // a rule reading an unprojected system field fails clearly at plan time
+        masking.clear();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(() -> readBuilder.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not project");
+    }
+
+    private static void readFully(Table table) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder();
+        collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -45,6 +45,7 @@ import org.apache.paimon.function.FunctionDefinition;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.operation.BaseAppendFileStoreWrite;
 import org.apache.paimon.operation.FileStoreWrite;
 import org.apache.paimon.options.Options;
@@ -4837,6 +4838,51 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testStreamScanFilterOnMaskedColumnNotPushedToStats() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_stream_masking_filter_stats");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
+        StreamTableScan scan = readBuilder.newStreamScan();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(scan.plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactly(1000);
+    }
+
+    @Test
     void testMaskGrowthOnPushedFilterColumn() throws Exception {
         Identifier identifier =
                 Identifier.create("test_table_db", "auth_table_masking_pushed_filter");
@@ -4907,6 +4953,32 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                                 .newScan()
                                 .listPartitionEntries())
                 .hasSize(1);
+    }
+
+    @Test
+    void testRowFilterAppliesToPartitionListing() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_row_filter_partition_listing");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"a", "v1"}, new String[] {"b", "v2"});
+
+        LeafPredicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        setRowFilter(identifier, Collections.singletonList(onA));
+
+        List<PartitionEntry> entries =
+                catalog.getTable(identifier).newReadBuilder().newScan().listPartitionEntries();
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).partition().getString(0).toString()).isEqualTo("a");
     }
 
     @Test
@@ -5857,7 +5929,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
+        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog", "statistics")) {
             Identifier sysId =
                     Identifier.create(
                             identifier.getDatabaseName(),
@@ -5946,6 +6018,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
+
+        assertThatThrownBy(() -> ((FileStoreTable) table).newVectorSearchBuilder().newVectorRead())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
     }
 
     @Test
@@ -5977,6 +6053,49 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(0L));
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(onRowId);
         assertThat(readBuilder.newScan().plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testMaskedRowIdFilterOnDataEvolutionQueryAuthTable() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_de_masked_rowid");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.BIGINT()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite()) {
+            write.write(GenericRow.of(42L));
+            builder.newCommit().commit(write.prepareCommit());
+        }
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                SpecialFields.ROW_ID.name(),
+                new FieldTransform(new FieldRef(0, "f0", DataTypes.BIGINT())));
+        setColumnMasking(identifier, masking);
+
+        Predicate onMaskedRowId =
+                LeafPredicate.of(
+                        new FieldTransform(
+                                new FieldRef(
+                                        SpecialFields.ROW_ID.id(),
+                                        SpecialFields.ROW_ID.name(),
+                                        DataTypes.BIGINT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(42L));
+        RowType readType =
+                new RowType(Arrays.asList(table.rowType().getField("f0"), SpecialFields.ROW_ID));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withReadType(readType).withFilter(onMaskedRowId);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        readType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getLong(1)).isEqualTo(42L);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -3955,7 +3955,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRows(table, values);
     }
 
-    /** Cross-column mask: display := concat_ws('-', first, last). */
     private void maskDisplayWithFullName(Identifier identifier) {
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
@@ -3968,7 +3967,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setColumnMasking(identifier, columnMasking);
     }
 
-    /** Rows must be copied: the auth back-projection reuses one ProjectedRow per split. */
     private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
             throws Exception {
         List<InternalRow> rows = new ArrayList<>();
@@ -3985,14 +3983,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier,
                         stringFields("first", "last", "display", "other"),
                         Collections.emptyMap());
-        // two rows in one commit -> one split with multiple rows
         writeStringRows(
                 table,
                 new String[] {"john", "doe", "ignored", "o1"},
                 new String[] {"jane", "roe", "ignored", "o2"});
         maskDisplayWithFullName(identifier);
 
-        // project only the masked target; its input columns are not selected
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> rows =
@@ -4019,10 +4015,8 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 createMaskingAuthTable(
                         identifier,
                         stringFields("first", "last", "display"),
-                        // one file per split, so the scan below yields multiple splits
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two commits -> two splits; the widening must not leak state across splits
         writeStringRow(table, "john", "doe", "ignored");
         writeStringRow(table, "jane", "roe", "ignored");
         maskDisplayWithFullName(identifier);
@@ -4037,7 +4031,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         List<String> values = new ArrayList<>();
         for (InternalRow row : rows) {
-            // every split must be projected back to the query's arity
             assertThat(row.getFieldCount()).isEqualTo(1);
             values.add(row.getString(0).toString());
         }
@@ -4055,7 +4048,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "secret", "o1");
 
-        // the filter pulls unprojected "display" into the read type, activating its mask
         LeafPredicate displayFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
@@ -4064,7 +4056,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setRowFilter(identifier, Collections.singletonList(displayFilter));
         maskDisplayWithFullName(identifier);
 
-        // project only "other": the mask target and inputs are all unprojected
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {3});
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> rows =
@@ -4097,7 +4088,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(masked).hasSize(1);
         assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
 
-        // revoke the rules: the same TableRead must drop the widened read type
         setColumnMasking(identifier, new HashMap<>());
         List<InternalRow> plain =
                 collectRows(
@@ -4118,7 +4108,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "plain");
 
-        // first read without rules fixes the read schema to the projection
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
         TableRead read = readBuilder.newRead();
         List<InternalRow> plain =
@@ -4127,7 +4116,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
 
-        // a mask granted afterwards needs columns outside the fixed schema: fail closed
         maskDisplayWithFullName(identifier);
         List<Split> splits = readBuilder.newScan().plan().splits();
         assertThatThrownBy(
@@ -4166,7 +4154,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // a nested-pruned read type, as engines push down
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         RowType prunedS = ((RowType) sField.type()).project("b");
@@ -4176,7 +4163,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                                 tableRowType.getField("display"),
                                 new DataField(sField.id(), "s", prunedS)));
 
-        // sanity: the nested-pruned read works without masking
         ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
         List<InternalRow> rows =
                 collectRows(
@@ -4185,7 +4171,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
 
-        // mask "display" from unprojected "extra": widening must keep "s" pruned
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
                 "display",
@@ -4216,7 +4201,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "secret");
 
-        // mask target absent from the schema (e.g. renamed since the rule was written)
         Map<String, Transform> staleTarget = new HashMap<>();
         staleTarget.put(
                 "renamed_away",
@@ -4226,7 +4210,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
 
-        // mask input absent from the schema
         Map<String, Transform> staleInput = new HashMap<>();
         staleInput.put(
                 "display",
@@ -4250,7 +4233,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "d1", "a1", "b1");
 
-        // first rules widen and fix the read schema to [display, hidden_a]
         Map<String, Transform> rules = new HashMap<>();
         rules.put(
                 "display",
@@ -4268,7 +4250,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(masked.get(0).getString(0).toString()).isEqualTo("a1");
 
-        // the new rules mask only hidden_a, retained but unread: must not activate
         rules.clear();
         rules.put(
                 "hidden_a",
@@ -4313,7 +4294,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask TARGETS the struct column "s" (reading another column)
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         Map<String, Transform> masking = new HashMap<>();
@@ -4322,7 +4302,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // projecting "s" nested-pruned would write the mask into a partial slot: fail closed
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
                 new RowType(
@@ -4351,7 +4330,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "display"), Collections.emptyMap());
         writeStringRow(table, "john", "d1"); // snapshot 1
 
-        // add a column, then mask it: the rule is valid only in the latest schema
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
@@ -4362,7 +4340,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // the latest read masks the new column
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
         List<InternalRow> latestRows =
@@ -4372,7 +4349,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(latestRows).hasSize(1);
         assertThat(latestRows.get(0).getString(2).toString()).isEqualTo("****");
 
-        // a time-travel read of the old snapshot must not fail on the newer rule
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4394,7 +4370,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "secret"), Collections.emptyMap());
         writeStringRow(table, "john", "s1"); // snapshot 1, column named "secret"
 
-        // rename the column, then mask it under the new name
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
@@ -4405,7 +4380,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // the latest read masks the renamed column
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
         List<InternalRow> latestRows =
@@ -4414,9 +4388,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         latest.rowType());
         assertThat(latestRows.get(0).getString(1).toString()).isEqualTo("****");
 
-        // a time-travel read of the pre-rename snapshot exposes the same physical column
-        // as "secret"; the rule keyed on "masked_secret" would be silently skipped by name
-        // and leak the raw value -- it must fail closed instead
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4437,8 +4408,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
         writeStringRow(table, "d1", "o1");
 
-        // a mask on a system column the query does not project must be inert, not reject
-        // the whole query at plan time
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "_ROW_ID",
@@ -4463,7 +4432,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "old_input"), Collections.emptyMap());
         writeStringRow(table, "john", "in1"); // snapshot 1
 
-        // rename the input, then add a target column masked from the renamed input
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("old_input", "renamed_input")),
@@ -4478,8 +4446,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // the pre-rename snapshot predates "display": the mask cannot output there, so the
-        // rename of its input must not fail the read
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4503,7 +4469,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
 
-        // plan 1: a valid mask on "secret" is validated and cached
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "secret",
@@ -4511,12 +4476,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setColumnMasking(identifier, masking);
         scan.plan();
 
-        // plan 2: rules disappear -- the cached validation must be forgotten
         setColumnMasking(identifier, Collections.emptyMap());
         scan.plan();
 
-        // the masked column is renamed away, then the identical rule is restored; a stale-rule
-        // cache short-circuit would skip re-validation and silently stop masking
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
@@ -4545,8 +4507,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
         scan.plan();
 
-        // the masked column is renamed while the rules stay identical: the live scan must
-        // notice on its next plan and fail closed, not keep planning on the stale rule
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
@@ -4583,7 +4543,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask on "display" reads the whole struct column "s"
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         Map<String, Transform> masking = new HashMap<>();
@@ -4592,7 +4551,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
         setColumnMasking(identifier, masking);
 
-        // projecting "s" nested-pruned would hand the mask a partial struct: fail closed
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
                 new RowType(
@@ -4625,7 +4583,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
         Table table = createMaskingAuthTable(identifier, fields, options);
 
-        // one row group split across two columnar files: (f0, f1) and (f2)
         RowType tableRowType = table.rowType();
         BatchWriteBuilder builder = table.newBatchWriteBuilder();
         try (BatchTableWrite write0 =
@@ -4653,7 +4610,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             builder.newCommit().commit(commitables);
         }
 
-        // mask f1 from f2 and project only f1: the scan must keep f2's file
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "f1",
@@ -4701,7 +4657,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask reads the unprojected blob-view column: resolution cannot apply
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
@@ -4736,7 +4691,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         fields,
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two splits with opposite raw/masked ordering
         for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
             BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
             BatchTableWrite write = writeBuilder.newWrite();
@@ -4747,7 +4701,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             commit.close();
         }
 
-        // display := source inverts the ordering the raw statistics suggest
         Map<String, Transform> masking = new HashMap<>();
         masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
         setColumnMasking(identifier, masking);
@@ -4761,7 +4714,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 collectRows(
                         readBuilder.newRead().createReader(splits),
                         table.rowType().project("display"));
-        // split pruning must not drop the split holding the real top row (1000)
         assertThat(
                         rows.stream()
                                 .map(row -> row.getInt(0))
@@ -4788,7 +4740,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask reads the projected _ROW_ID metadata field: not a stale rule
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
@@ -4806,7 +4757,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
                         readType);
         assertThat(rows).hasSize(1);
-        // display masked to the row id
         assertThat(rows.get(0).getLong(0)).isEqualTo(rows.get(0).getLong(1));
     }
 
@@ -4821,7 +4771,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
         writeStringRow(table, "d1", "o1");
 
-        // a mask keyed by a key-reader-internal name is stale, not a system field
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "_KEY_display",
@@ -4831,7 +4780,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
 
-        // a rule reading an unprojected system field fails clearly at plan time
         masking.clear();
         masking.put(
                 "display",
@@ -4856,7 +4804,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         fields,
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two splits whose raw and masked values order oppositely
         for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
             BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
             BatchTableWrite write = writeBuilder.newWrite();
@@ -4870,9 +4817,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the predicate applies to masked values, with no engine help (no executeFilter):
-        // raw statistics must not prune the split whose masked value matches, and the
-        // raw-matching row must not come back
         LeafPredicate amountFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
@@ -4916,20 +4860,16 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(plain).hasSize(1);
 
-        // a mask now covers the filter column
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // this scan already pruned with the column's raw statistics: it must fail closed
         assertThatThrownBy(scan::plan)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Recreate the scan");
 
-        // a fresh scan carries no raw pruning, and the existing reader evaluates the
-        // filter on the masked value: 'd1' no longer matches
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> masked =
                 collectRows(read.createReader(splits), table.rowType().project("display"));
@@ -4961,7 +4901,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("a")));
-        // partition listing bypasses plan(): the filter must still prune
         assertThat(
                         table.newReadBuilder()
                                 .withFilter(partitionFilter)
@@ -4995,8 +4934,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the whole filter sits on the masked column: nothing is pushed down, but limit
-        // pruning must still know a read-time filter drops rows
         LeafPredicate amountFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
@@ -5032,13 +4969,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "a", "va");
         writeStringRow(table, "b", "vb");
 
-        // the partition column is masked to another column's value
         Map<String, Transform> masking = new HashMap<>();
         masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // engines consume partition filters without re-evaluating them, so the read
-        // itself must evaluate this predicate, on the masked value
         LeafPredicate maskedMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5049,7 +4983,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
         assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
 
-        // the raw partition value must not match: matching it would reveal the raw value
         LeafPredicate rawMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5057,8 +4990,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(BinaryString.fromString("a")));
         assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
 
-        // filter column not projected: it is read and masked for the filter only, then
-        // projected back out
         List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
         assertThat(unprojected).hasSize(1);
         assertThat(unprojected.get(0).getString(0).toString()).isEqualTo("vb");
@@ -5081,8 +5012,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // the filter is partition-only but sits on a masked column, so it drops rows at
-        // read time: limit pruning must not pick splits by raw row counts
         LeafPredicate maskedMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5127,8 +5056,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the key filter matches a masked value only: key-range skipping inside the
-        // merge read must not drop the row by its raw key
         LeafPredicate idFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
@@ -5624,16 +5551,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         BinaryString.fromString("bee"),
                         BinaryString.fromString("cee")));
 
-        // mask a -> "MASKED"; b and c are not masked
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "a",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
         setColumnMasking(identifier, masking);
 
-        // WHERE a = 'MASKED' OR b = 'bee' -- one masked operand, one plain, neither projected.
-        // splitAnd does not split the OR, so retainFields keeps the whole disjunction, but only
-        // the masked column 'a' is widened in; 'b' is missing from the read schema.
         Predicate onMasked =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5689,8 +5612,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("MASKED")));
 
-        // listPartitionEntries() bypasses plan(); a later plan() on the same scan must not treat
-        // the masks discovered then as a rule change against an already-pushed filter.
         InnerTableScan scan =
                 (InnerTableScan) table.newReadBuilder().withFilter(onMasked).newScan();
         assertThat(scan.listPartitionEntries()).hasSize(1);
@@ -5714,15 +5635,11 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         ""),
                 true);
         Table table = catalog.getTable(identifier);
-        // one file, the matching row second
         commitRows(
                 table,
                 GenericRow.of(BinaryString.fromString("no"), BinaryString.fromString("r1")),
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")));
 
-        // The reader does not evaluate the query filter on an auth-enabled table; engines
-        // re-apply it. A read-level limit would cap the raw rows at "no" and the engine would
-        // then filter it away, losing the matching row entirely.
         Predicate onA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5760,15 +5677,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("vb")));
 
-        // routed through withPartitionFilter (as Spark does) the predicate never reaches the
-        // masked value, so it must fail closed rather than prune on the raw partition value
         InnerTableScan partitionScan = (InnerTableScan) table.newReadBuilder().newScan();
         partitionScan.withPartitionFilter(maskedMatch);
         assertThatThrownBy(partitionScan::plan)
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("masked partition key");
 
-        // the same predicate through withFilter is evaluated post-mask and still works
         assertThat(readWithFilter(table, maskedMatch, "p", "v")).hasSize(1);
     }
 
@@ -5784,12 +5698,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"x", "a", "v1"}, new String[] {"y", "b", "v2"});
 
-        // only p2 is masked
         Map<String, Transform> masking = new HashMap<>();
         masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // a partition predicate touching only the UNMASKED key stays prunable
         LeafPredicate onP1 =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
@@ -5799,7 +5711,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         okScan.withPartitionFilter(onP1);
         assertThat(okScan.plan().splits()).isNotEmpty();
 
-        // touching the masked key is still rejected
         LeafPredicate onP2 =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
@@ -5824,8 +5735,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"a", "va"}, new String[] {"b", "vb"});
 
-        // no masking: query auth alone defers the filter push, which must not overwrite
-        // the caller's partition filter
         LeafPredicate pAtLeastA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5833,7 +5742,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(BinaryString.fromString("a")));
         assertThat(readPartitionB(table, pAtLeastA)).containsExactly("b");
 
-        // control: without query auth the filter is pushed eagerly, so this always held
         Identifier plain = Identifier.create("test_table_db", "plain_part_filter_with_filter");
         catalog.createTable(
                 plain,
@@ -5886,8 +5794,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")),
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r3")));
 
-        // executeFilter() means the reader evaluates the predicate itself, so capping after it
-        // is safe and the caller's limit must still be honoured
         Predicate onA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5906,8 +5812,8 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
-    void testPartitionFilterFieldsReplacedOnRepush() throws Exception {
-        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_repush");
+    void testPartitionFilterFieldsReplacedOnReapply() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_reapply");
         Table table =
                 createMaskingAuthTable(
                         identifier,
@@ -5932,8 +5838,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("x")));
 
-        // the second push overwrites the first in ManifestsReader, so the tracked fields must be
-        // replaced too: the effective predicate only touches the unmasked key
         InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
         scan.withPartitionFilter(onMaskedP2);
         scan.withPartitionFilter(onPlainP1);
@@ -5953,7 +5857,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // these report per-column min/max of the raw files, which no mask can cover
         for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
             Identifier sysId =
                     Identifier.create(
@@ -5964,7 +5867,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                     .hasMessageContaining("query-auth table");
         }
 
-        // the row-producing ones read through the masking reader and stay available
         for (String suffix : Arrays.asList("audit_log", "ro")) {
             Identifier sysId =
                     Identifier.create(
@@ -5984,8 +5886,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("secret", "display"), Collections.emptyMap());
         writeStringRow(table, "TOPSECRET", "ignored");
 
-        // display := secret, while secret is masked. A transform reads the raw row, so this
-        // would publish secret's raw value through display.
         Map<String, Transform> compose = new HashMap<>();
         compose.put(
                 "secret",
@@ -5996,7 +5896,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("which is masked too");
 
-        // a mask reading an unmasked column, and one reading its own column, both stay valid
         Map<String, Transform> plain = new HashMap<>();
         plain.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
         setColumnMasking(identifier, plain);
@@ -6013,8 +5912,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     @Test
     void testQueryAuthRejectedWhereItCannotBeEnforced() throws Exception {
-        // a non-file-store table never reads through the auth reader, so accepting the option
-        // would leave the rules silently inert
         for (String type : Arrays.asList("format-table", "object-table")) {
             Map<String, String> opts = new HashMap<>();
             opts.put(QUERY_AUTH_ENABLED.key(), "true");
@@ -6037,7 +5934,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                     .hasMessageContaining(QUERY_AUTH_ENABLED.key());
         }
 
-        // search ranks raw index values, so it is refused rather than answered from them
         Identifier identifier = Identifier.create("test_table_db", "auth_search_rejected");
         Table table =
                 createMaskingAuthTable(
@@ -6047,7 +5943,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
 
-        // the lookup cache serves rows straight from the store
         assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
@@ -6071,8 +5966,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             builder.newCommit().commit(write.prepareCommit());
         }
 
-        // no masking rules at all -- a _ROW_ID predicate must still plan. Data-evolution
-        // statistics carry only logical columns, so the row-id part must not be pushed.
         Predicate onRowId =
                 LeafPredicate.of(
                         new FieldTransform(

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -3956,7 +3956,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRows(table, values);
     }
 
-    /** Cross-column mask: display := concat_ws('-', first, last). */
     private void maskDisplayWithFullName(Identifier identifier) {
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
@@ -3969,7 +3968,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setColumnMasking(identifier, columnMasking);
     }
 
-    /** Rows must be copied: the auth back-projection reuses one ProjectedRow per split. */
     private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
             throws Exception {
         List<InternalRow> rows = new ArrayList<>();
@@ -3986,14 +3984,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier,
                         stringFields("first", "last", "display", "other"),
                         Collections.emptyMap());
-        // two rows in one commit -> one split with multiple rows
         writeStringRows(
                 table,
                 new String[] {"john", "doe", "ignored", "o1"},
                 new String[] {"jane", "roe", "ignored", "o2"});
         maskDisplayWithFullName(identifier);
 
-        // project only the masked target; its input columns are not selected
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> rows =
@@ -4020,10 +4016,8 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 createMaskingAuthTable(
                         identifier,
                         stringFields("first", "last", "display"),
-                        // one file per split, so the scan below yields multiple splits
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two commits -> two splits; the widening must not leak state across splits
         writeStringRow(table, "john", "doe", "ignored");
         writeStringRow(table, "jane", "roe", "ignored");
         maskDisplayWithFullName(identifier);
@@ -4038,7 +4032,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         List<String> values = new ArrayList<>();
         for (InternalRow row : rows) {
-            // every split must be projected back to the query's arity
             assertThat(row.getFieldCount()).isEqualTo(1);
             values.add(row.getString(0).toString());
         }
@@ -4056,7 +4049,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "secret", "o1");
 
-        // the filter pulls unprojected "display" into the read type, activating its mask
         LeafPredicate displayFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
@@ -4065,7 +4057,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setRowFilter(identifier, Collections.singletonList(displayFilter));
         maskDisplayWithFullName(identifier);
 
-        // project only "other": the mask target and inputs are all unprojected
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {3});
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> rows =
@@ -4098,7 +4089,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(masked).hasSize(1);
         assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
 
-        // revoke the rules: the same TableRead must drop the widened read type
         setColumnMasking(identifier, new HashMap<>());
         List<InternalRow> plain =
                 collectRows(
@@ -4119,7 +4109,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "plain");
 
-        // first read without rules fixes the read schema to the projection
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
         TableRead read = readBuilder.newRead();
         List<InternalRow> plain =
@@ -4166,7 +4155,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // a nested-pruned read type, as engines push down
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         RowType prunedS = ((RowType) sField.type()).project("b");
@@ -4176,7 +4164,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                                 tableRowType.getField("display"),
                                 new DataField(sField.id(), "s", prunedS)));
 
-        // sanity: the nested-pruned read works without masking
         ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
         List<InternalRow> rows =
                 collectRows(
@@ -4185,7 +4172,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
 
-        // mask "display" from unprojected "extra": widening must keep "s" pruned
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
                 "display",
@@ -4216,7 +4202,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "secret");
 
-        // mask target absent from the schema (e.g. renamed since the rule was written)
         Map<String, Transform> staleTarget = new HashMap<>();
         staleTarget.put(
                 "renamed_away",
@@ -4226,7 +4211,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
 
-        // mask input absent from the schema
         Map<String, Transform> staleInput = new HashMap<>();
         staleInput.put(
                 "display",
@@ -4250,7 +4234,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "d1", "a1", "b1");
 
-        // first rules widen and fix the read schema to [display, hidden_a]
         Map<String, Transform> rules = new HashMap<>();
         rules.put(
                 "display",
@@ -4268,7 +4251,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(masked.get(0).getString(0).toString()).isEqualTo("a1");
 
-        // the new rules mask only hidden_a, retained but unread: must not activate
         rules.clear();
         rules.put(
                 "hidden_a",
@@ -4313,7 +4295,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask TARGETS the struct column "s" (reading another column)
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         Map<String, Transform> masking = new HashMap<>();
@@ -4322,7 +4303,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // projecting "s" nested-pruned would write the mask into a partial slot: fail closed
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
                 new RowType(
@@ -4351,7 +4331,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "display"), Collections.emptyMap());
         writeStringRow(table, "john", "d1"); // snapshot 1
 
-        // add a column, then mask it: the rule is valid only in the latest schema
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
@@ -4362,7 +4341,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // the latest read masks the new column
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
         List<InternalRow> latestRows =
@@ -4372,7 +4350,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(latestRows).hasSize(1);
         assertThat(latestRows.get(0).getString(2).toString()).isEqualTo("****");
 
-        // a time-travel read of the old snapshot must not fail on the newer rule
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4394,7 +4371,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "secret"), Collections.emptyMap());
         writeStringRow(table, "john", "s1"); // snapshot 1, column named "secret"
 
-        // rename the column, then mask it under the new name
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
@@ -4405,7 +4381,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // the latest read masks the renamed column
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
         List<InternalRow> latestRows =
@@ -4414,9 +4389,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         latest.rowType());
         assertThat(latestRows.get(0).getString(1).toString()).isEqualTo("****");
 
-        // a time-travel read of the pre-rename snapshot exposes the same physical column
-        // as "secret"; the rule keyed on "masked_secret" would be silently skipped by name
-        // and leak the raw value -- it must fail closed instead
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4437,8 +4409,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
         writeStringRow(table, "d1", "o1");
 
-        // a mask on a system column the query does not project must be inert, not reject
-        // the whole query at plan time
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "_ROW_ID",
@@ -4463,7 +4433,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "old_input"), Collections.emptyMap());
         writeStringRow(table, "john", "in1"); // snapshot 1
 
-        // rename the input, then add a target column masked from the renamed input
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("old_input", "renamed_input")),
@@ -4478,8 +4447,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // the pre-rename snapshot predates "display": the mask cannot output there, so the
-        // rename of its input must not fail the read
         Table old =
                 catalog.getTable(identifier)
                         .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
@@ -4503,7 +4470,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
 
-        // plan 1: a valid mask on "secret" is validated and cached
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "secret",
@@ -4511,12 +4477,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         setColumnMasking(identifier, masking);
         scan.plan();
 
-        // plan 2: rules disappear -- the cached validation must be forgotten
         setColumnMasking(identifier, Collections.emptyMap());
         scan.plan();
 
-        // the masked column is renamed away, then the identical rule is restored; a stale-rule
-        // cache short-circuit would skip re-validation and silently stop masking
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
@@ -4545,8 +4508,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
         scan.plan();
 
-        // the masked column is renamed while the rules stay identical: the live scan must
-        // notice on its next plan and fail closed, not keep planning on the stale rule
         catalog.alterTable(
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
@@ -4583,7 +4544,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask on "display" reads the whole struct column "s"
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
         Map<String, Transform> masking = new HashMap<>();
@@ -4592,7 +4552,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
         setColumnMasking(identifier, masking);
 
-        // projecting "s" nested-pruned would hand the mask a partial struct: fail closed
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
                 new RowType(
@@ -4625,7 +4584,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
         Table table = createMaskingAuthTable(identifier, fields, options);
 
-        // one row group split across two columnar files: (f0, f1) and (f2)
         RowType tableRowType = table.rowType();
         BatchWriteBuilder builder = table.newBatchWriteBuilder();
         try (BatchTableWrite write0 =
@@ -4653,7 +4611,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             builder.newCommit().commit(commitables);
         }
 
-        // mask f1 from f2 and project only f1: the scan must keep f2's file
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "f1",
@@ -4701,7 +4658,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask reads the unprojected blob-view column: resolution cannot apply
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
@@ -4736,7 +4692,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         fields,
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two splits with opposite raw/masked ordering
         for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
             BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
             BatchTableWrite write = writeBuilder.newWrite();
@@ -4747,7 +4702,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             commit.close();
         }
 
-        // display := source inverts the ordering the raw statistics suggest
         Map<String, Transform> masking = new HashMap<>();
         masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
         setColumnMasking(identifier, masking);
@@ -4761,7 +4715,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 collectRows(
                         readBuilder.newRead().createReader(splits),
                         table.rowType().project("display"));
-        // split pruning must not drop the split holding the real top row (1000)
         assertThat(
                         rows.stream()
                                 .map(row -> row.getInt(0))
@@ -4788,7 +4741,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        // the mask reads the projected _ROW_ID metadata field: not a stale rule
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
@@ -4806,7 +4758,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
                         readType);
         assertThat(rows).hasSize(1);
-        // display masked to the row id
         assertThat(rows.get(0).getLong(0)).isEqualTo(rows.get(0).getLong(1));
     }
 
@@ -4821,7 +4772,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
         writeStringRow(table, "d1", "o1");
 
-        // a mask keyed by a key-reader-internal name is stale, not a system field
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "_KEY_display",
@@ -4831,7 +4781,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
 
-        // a rule reading an unprojected system field fails clearly at plan time
         masking.clear();
         masking.put(
                 "display",
@@ -4856,7 +4805,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         fields,
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
-        // two splits whose raw and masked values order oppositely
         for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
             BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
             BatchTableWrite write = writeBuilder.newWrite();
@@ -4870,9 +4818,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the predicate applies to masked values, with no engine help (no executeFilter):
-        // raw statistics must not prune the split whose masked value matches, and the
-        // raw-matching row must not come back
         LeafPredicate amountFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
@@ -4916,20 +4861,16 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(plain).hasSize(1);
 
-        // a mask now covers the filter column
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "display",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // this scan already pruned with the column's raw statistics: it must fail closed
         assertThatThrownBy(scan::plan)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Recreate the scan");
 
-        // a fresh scan carries no raw pruning, and the existing reader evaluates the
-        // filter on the masked value: 'd1' no longer matches
         List<Split> splits = readBuilder.newScan().plan().splits();
         List<InternalRow> masked =
                 collectRows(read.createReader(splits), table.rowType().project("display"));
@@ -4961,7 +4902,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("a")));
-        // partition listing bypasses plan(): the filter must still prune
         assertThat(
                         table.newReadBuilder()
                                 .withFilter(partitionFilter)
@@ -4995,8 +4935,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the whole filter sits on the masked column: nothing is pushed down, but limit
-        // pruning must still know a read-time filter drops rows
         LeafPredicate amountFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
@@ -5032,13 +4970,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "a", "va");
         writeStringRow(table, "b", "vb");
 
-        // the partition column is masked to another column's value
         Map<String, Transform> masking = new HashMap<>();
         masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // engines consume partition filters without re-evaluating them, so the read
-        // itself must evaluate this predicate, on the masked value
         LeafPredicate maskedMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5049,7 +4984,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
         assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
 
-        // the raw partition value must not match: matching it would reveal the raw value
         LeafPredicate rawMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5057,8 +4991,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(BinaryString.fromString("a")));
         assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
 
-        // filter column not projected: it is read and masked for the filter only, then
-        // projected back out
         List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
         assertThat(unprojected).hasSize(1);
         assertThat(unprojected.get(0).getString(0).toString()).isEqualTo("vb");
@@ -5081,8 +5013,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // the filter is partition-only but sits on a masked column, so it drops rows at
-        // read time: limit pruning must not pick splits by raw row counts
         LeafPredicate maskedMatch =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5127,8 +5057,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
         setColumnMasking(identifier, masking);
 
-        // the key filter matches a masked value only: key-range skipping inside the
-        // merge read must not drop the row by its raw key
         LeafPredicate idFilter =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
@@ -5624,16 +5552,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         BinaryString.fromString("bee"),
                         BinaryString.fromString("cee")));
 
-        // mask a -> "MASKED"; b and c are not masked
         Map<String, Transform> masking = new HashMap<>();
         masking.put(
                 "a",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
         setColumnMasking(identifier, masking);
 
-        // WHERE a = 'MASKED' OR b = 'bee' -- one masked operand, one plain, neither projected.
-        // splitAnd does not split the OR, so retainFields keeps the whole disjunction, but only
-        // the masked column 'a' is widened in; 'b' is missing from the read schema.
         Predicate onMasked =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5689,8 +5613,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("MASKED")));
 
-        // listPartitionEntries() bypasses plan(); a later plan() on the same scan must not treat
-        // the masks discovered then as a rule change against an already-pushed filter.
         InnerTableScan scan =
                 (InnerTableScan) table.newReadBuilder().withFilter(onMasked).newScan();
         assertThat(scan.listPartitionEntries()).hasSize(1);
@@ -5714,15 +5636,11 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         ""),
                 true);
         Table table = catalog.getTable(identifier);
-        // one file, the matching row second
         commitRows(
                 table,
                 GenericRow.of(BinaryString.fromString("no"), BinaryString.fromString("r1")),
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")));
 
-        // The reader does not evaluate the query filter on an auth-enabled table; engines
-        // re-apply it. A read-level limit would cap the raw rows at "no" and the engine would
-        // then filter it away, losing the matching row entirely.
         Predicate onA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5760,15 +5678,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("vb")));
 
-        // routed through withPartitionFilter (as Spark does) the predicate never reaches the
-        // masked value, so it must fail closed rather than prune on the raw partition value
         InnerTableScan partitionScan = (InnerTableScan) table.newReadBuilder().newScan();
         partitionScan.withPartitionFilter(maskedMatch);
         assertThatThrownBy(partitionScan::plan)
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("masked partition key");
 
-        // the same predicate through withFilter is evaluated post-mask and still works
         assertThat(readWithFilter(table, maskedMatch, "p", "v")).hasSize(1);
     }
 
@@ -5784,12 +5699,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"x", "a", "v1"}, new String[] {"y", "b", "v2"});
 
-        // only p2 is masked
         Map<String, Transform> masking = new HashMap<>();
         masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
         setColumnMasking(identifier, masking);
 
-        // a partition predicate touching only the UNMASKED key stays prunable
         LeafPredicate onP1 =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
@@ -5799,7 +5712,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         okScan.withPartitionFilter(onP1);
         assertThat(okScan.plan().splits()).isNotEmpty();
 
-        // touching the masked key is still rejected
         LeafPredicate onP2 =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
@@ -5824,8 +5736,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"a", "va"}, new String[] {"b", "vb"});
 
-        // no masking: query auth alone defers the filter push, which must not overwrite
-        // the caller's partition filter
         LeafPredicate pAtLeastA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
@@ -5833,7 +5743,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonList(BinaryString.fromString("a")));
         assertThat(readPartitionB(table, pAtLeastA)).containsExactly("b");
 
-        // control: without query auth the filter is pushed eagerly, so this always held
         Identifier plain = Identifier.create("test_table_db", "plain_part_filter_with_filter");
         catalog.createTable(
                 plain,
@@ -5886,8 +5795,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")),
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r3")));
 
-        // executeFilter() means the reader evaluates the predicate itself, so capping after it
-        // is safe and the caller's limit must still be honoured
         Predicate onA =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
@@ -5906,8 +5813,8 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
-    void testPartitionFilterFieldsReplacedOnRepush() throws Exception {
-        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_repush");
+    void testPartitionFilterFieldsReplacedOnReapply() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_reapply");
         Table table =
                 createMaskingAuthTable(
                         identifier,
@@ -5932,8 +5839,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Equal.INSTANCE,
                         Collections.singletonList(BinaryString.fromString("x")));
 
-        // the second push overwrites the first in ManifestsReader, so the tracked fields must be
-        // replaced too: the effective predicate only touches the unmasked key
         InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
         scan.withPartitionFilter(onMaskedP2);
         scan.withPartitionFilter(onPlainP1);
@@ -5953,7 +5858,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
         setColumnMasking(identifier, masking);
 
-        // these report per-column min/max of the raw files, which no mask can cover
         for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
             Identifier sysId =
                     Identifier.create(
@@ -5964,7 +5868,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                     .hasMessageContaining("query-auth table");
         }
 
-        // the row-producing ones read through the masking reader and stay available
         for (String suffix : Arrays.asList("audit_log", "ro")) {
             Identifier sysId =
                     Identifier.create(
@@ -5984,8 +5887,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("secret", "display"), Collections.emptyMap());
         writeStringRow(table, "TOPSECRET", "ignored");
 
-        // display := secret, while secret is masked. A transform reads the raw row, so this
-        // would publish secret's raw value through display.
         Map<String, Transform> compose = new HashMap<>();
         compose.put(
                 "secret",
@@ -5996,7 +5897,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("which is masked too");
 
-        // a mask reading an unmasked column, and one reading its own column, both stay valid
         Map<String, Transform> plain = new HashMap<>();
         plain.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
         setColumnMasking(identifier, plain);
@@ -6013,8 +5913,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
     @Test
     void testQueryAuthRejectedWhereItCannotBeEnforced() throws Exception {
-        // a non-file-store table never reads through the auth reader, so accepting the option
-        // would leave the rules silently inert
         for (String type : Arrays.asList("format-table", "object-table")) {
             Map<String, String> opts = new HashMap<>();
             opts.put(QUERY_AUTH_ENABLED.key(), "true");
@@ -6037,7 +5935,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                     .hasMessageContaining(QUERY_AUTH_ENABLED.key());
         }
 
-        // search ranks raw index values, so it is refused rather than answered from them
         Identifier identifier = Identifier.create("test_table_db", "auth_search_rejected");
         Table table =
                 createMaskingAuthTable(
@@ -6047,7 +5944,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
 
-        // the lookup cache serves rows straight from the store
         assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
@@ -6071,8 +5967,6 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             builder.newCommit().commit(write.prepareCommit());
         }
 
-        // no masking rules at all -- a _ROW_ID predicate must still plan. Data-evolution
-        // statistics carry only logical columns, so the row-id part must not be pushed.
         Predicate onRowId =
                 LeafPredicate.of(
                         new FieldTransform(

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -83,6 +83,7 @@ import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.table.object.ObjectTable;
+import org.apache.paimon.table.query.LocalTableQuery;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -96,6 +97,7 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -3905,13 +3907,22 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     private Table createMaskingAuthTable(
             Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
             throws Exception {
+        return createMaskingAuthTable(
+                identifier, fields, Collections.emptyList(), Collections.emptyList(), extraOptions);
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier,
+            List<DataField> fields,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            Map<String, String> extraOptions)
+            throws Exception {
         catalog.createDatabase(identifier.getDatabaseName(), true);
         Map<String, String> options = new HashMap<>(extraOptions);
         options.put(QUERY_AUTH_ENABLED.key(), "true");
         catalog.createTable(
-                identifier,
-                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
-                true);
+                identifier, new Schema(fields, partitionKeys, primaryKeys, options, ""), true);
         return catalog.getTable(identifier);
     }
 
@@ -4713,6 +4724,51 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testColumnMaskingDisablesTopNPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_topn");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.INT()));
+        fields.add(new DataField(1, "source", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits with opposite raw/masked ordering
+        for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+
+        // display := source inverts the ordering the raw statistics suggest
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        TopN topN =
+                new TopN(new FieldRef(0, "display", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withTopN(topN);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+        // split pruning must not drop the split holding the real top row (1000)
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
     void testColumnMaskingReadingSystemField() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
         List<DataField> fields = new ArrayList<>();
@@ -4784,6 +4840,312 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> readBuilder.newScan().plan())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not project");
+    }
+
+    @Test
+    void testColumnMaskingDisablesFilterStatsPruning() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_stats");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits whose raw and masked values order oppositely
+        for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the predicate applies to masked values, with no engine help (no executeFilter):
+        // raw statistics must not prune the split whose masked value matches, and the
+        // raw-matching row must not come back
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactly(1000);
+    }
+
+    @Test
+    void testMaskGrowthOnPushedFilterColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pushed_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("display", "other"), Collections.emptyMap());
+        writeStringRow(table, "d1", "o1");
+
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("d1")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(displayFilter);
+        TableScan scan = readBuilder.newScan();
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(scan.plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+
+        // a mask now covers the filter column
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // this scan already pruned with the column's raw statistics: it must fail closed
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recreate the scan");
+
+        // a fresh scan carries no raw pruning, and the existing reader evaluates the
+        // filter on the masked value: 'd1' no longer matches
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> masked =
+                collectRows(read.createReader(splits), table.rowType().project("display"));
+        assertThat(masked).isEmpty();
+    }
+
+    @Test
+    void testDeferredFilterAppliesToPartitionListing() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "filter_partition_listing");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "p", DataTypes.STRING()));
+        fields.add(new DataField(1, "v", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        writeStringRow(table, "a", "v1");
+        writeStringRow(table, "b", "v2");
+
+        LeafPredicate partitionFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        // partition listing bypasses plan(): the filter must still prune
+        assertThat(
+                        table.newReadBuilder()
+                                .withFilter(partitionFilter)
+                                .newScan()
+                                .listPartitionEntries())
+                .hasSize(1);
+    }
+
+    @Test
+    void testColumnMaskingDisablesLimitPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_limit");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        for (int[] row : new int[][] {{900, 10}, {1, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the whole filter sits on the masked column: nothing is pushed down, but limit
+        // pruning must still know a read-time filter drops rows
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0})
+                        .withFilter(amountFilter)
+                        .withLimit(1);
+        TableRead read = readBuilder.newRead().executeFilter();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
+    void testFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_partition");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+
+        // the partition column is masked to another column's value
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // engines consume partition filters without re-evaluating them, so the read
+        // itself must evaluate this predicate, on the masked value
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        List<InternalRow> rows = readWithFilter(table, maskedMatch, "p", "v");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+
+        // the raw partition value must not match: matching it would reveal the raw value
+        LeafPredicate rawMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
+
+        // filter column not projected: it is read and masked for the filter only, then
+        // projected back out
+        List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
+        assertThat(unprojected).hasSize(1);
+        assertThat(unprojected.get(0).getString(0).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testLimitWithFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_partition_limit");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the filter is partition-only but sits on a masked column, so it drops rows at
+        // read time: limit pruning must not pick splits by raw row counts
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0, 1})
+                        .withFilter(maskedMatch)
+                        .withLimit(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("p", "v"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testMaskedPkFilterNotAppliedOnRawValues() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_pk_filter");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "id", DataTypes.INT().notNull()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        Collections.singletonMap(CoreOptions.BUCKET.key(), "1"));
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(1, 500));
+        write.write(GenericRow.of(2, 600));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the key filter matches a masked value only: key-range skipping inside the
+        // merge read must not drop the row by its raw key
+        LeafPredicate idFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(500));
+        List<InternalRow> rows = readWithFilter(table, idFilter, "id", "src");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getInt(0)).isEqualTo(500);
+    }
+
+    private List<InternalRow> readWithFilter(Table table, Predicate filter, String... projected)
+            throws Exception {
+        int[] projection = table.rowType().getFieldIndices(Arrays.asList(projected));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(projection).withFilter(filter);
+        return collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType().project(projected));
     }
 
     private static void readFully(Table table) throws Exception {
@@ -5234,6 +5596,409 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         ReadBuilder readBuilder = table.newReadBuilder().withTopN(topN).withLimit(1);
         List<String> result = batchRead(table, readBuilder.newScan().plan().splits(), readBuilder);
         assertThat(result).containsExactlyInAnyOrder("+I[3, 30]", "+I[4, 40]");
+    }
+
+    @Test
+    void testColumnMaskingOrFilterWithUnprojectedOperand() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_or_filter_unprojected");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        fields.add(new DataField(2, "c", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(
+                        BinaryString.fromString("raw"),
+                        BinaryString.fromString("bee"),
+                        BinaryString.fromString("cee")));
+
+        // mask a -> "MASKED"; b and c are not masked
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "a",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
+        setColumnMasking(identifier, masking);
+
+        // WHERE a = 'MASKED' OR b = 'bee' -- one masked operand, one plain, neither projected.
+        // splitAnd does not split the OR, so retainFields keeps the whole disjunction, but only
+        // the masked column 'a' is widened in; 'b' is missing from the read schema.
+        Predicate onMasked =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("MASKED")));
+        Predicate onPlain =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "b", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("bee")));
+        Predicate disjunction = PredicateBuilder.or(onMasked, onPlain);
+
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {2}).withFilter(disjunction);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits)) {
+            reader.forEachRemaining(r -> out.add(r.getString(0).toString()));
+        }
+        assertThat(out).containsExactly("cee");
+    }
+
+    @Test
+    void testColumnMaskingPartitionListingBeforePlan() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_partition_listing");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "pt", DataTypes.STRING()));
+        fields.add(new DataField(1, "a", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.singletonList("pt"),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("p1"), BinaryString.fromString("raw")));
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "a",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
+        setColumnMasking(identifier, masking);
+
+        Predicate onMasked =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("MASKED")));
+
+        // listPartitionEntries() bypasses plan(); a later plan() on the same scan must not treat
+        // the masks discovered then as a rule change against an already-pushed filter.
+        InnerTableScan scan =
+                (InnerTableScan) table.newReadBuilder().withFilter(onMasked).newScan();
+        assertThat(scan.listPartitionEntries()).hasSize(1);
+        assertThat(scan.plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testQueryAuthLimitDoesNotCutRowsBeforeFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_limit_with_filter");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        // one file, the matching row second
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("no"), BinaryString.fromString("r1")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")));
+
+        // The reader does not evaluate the query filter on an auth-enabled table; engines
+        // re-apply it. A read-level limit would cap the raw rows at "no" and the engine would
+        // then filter it away, losing the matching row entirely.
+        Predicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("yes")));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(1);
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits())) {
+            reader.forEachRemaining(r -> out.add(r.getString(1).toString()));
+        }
+        assertThat(out).contains("r2");
+    }
+
+    @Test
+    void testMaskedPartitionKeyRejectsPartitionFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_masked_part_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+
+        // routed through withPartitionFilter (as Spark does) the predicate never reaches the
+        // masked value, so it must fail closed rather than prune on the raw partition value
+        InnerTableScan partitionScan = (InnerTableScan) table.newReadBuilder().newScan();
+        partitionScan.withPartitionFilter(maskedMatch);
+        assertThatThrownBy(partitionScan::plan)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("masked partition key");
+
+        // the same predicate through withFilter is evaluated post-mask and still works
+        assertThat(readWithFilter(table, maskedMatch, "p", "v")).hasSize(1);
+    }
+
+    @Test
+    void testPartitionFilterAllowedOnUnmaskedPartitionKey() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_two_part_keys");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p1", "p2", "v"),
+                        Arrays.asList("p1", "p2"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"x", "a", "v1"}, new String[] {"y", "b", "v2"});
+
+        // only p2 is masked
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // a partition predicate touching only the UNMASKED key stays prunable
+        LeafPredicate onP1 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x")));
+        InnerTableScan okScan = (InnerTableScan) table.newReadBuilder().newScan();
+        okScan.withPartitionFilter(onP1);
+        assertThat(okScan.plan().splits()).isNotEmpty();
+
+        // touching the masked key is still rejected
+        LeafPredicate onP2 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("v1")));
+        InnerTableScan badScan = (InnerTableScan) table.newReadBuilder().newScan();
+        badScan.withPartitionFilter(onP2);
+        assertThatThrownBy(badScan::plan)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("masked partition key");
+    }
+
+    @Test
+    void testQueryAuthLimitAppliesWhenReaderExecutesFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_limit_execute_filter");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r1")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r3")));
+
+        // executeFilter() means the reader evaluates the predicate itself, so capping after it
+        // is safe and the caller's limit must still be honoured
+        Predicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("yes")));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(2);
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder
+                        .newRead()
+                        .executeFilter()
+                        .createReader(readBuilder.newScan().plan().splits())) {
+            reader.forEachRemaining(r -> out.add(r.getString(1).toString()));
+        }
+        assertThat(out).hasSize(2);
+    }
+
+    @Test
+    void testPartitionFilterFieldsReplacedOnRepush() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_repush");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p1", "p2", "v"),
+                        Arrays.asList("p1", "p2"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"x", "a", "v1"});
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate onMaskedP2 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("v1")));
+        LeafPredicate onPlainP1 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x")));
+
+        // the second push overwrites the first in ManifestsReader, so the tracked fields must be
+        // replaced too: the effective predicate only touches the unmasked key
+        InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
+        scan.withPartitionFilter(onMaskedP2);
+        scan.withPartitionFilter(onPlainP1);
+        assertThat(scan.plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testPhysicalMetadataSystemTablesRejectedUnderQueryAuth() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_systab_physical");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "other"), Collections.emptyMap());
+        writeStringRow(table, "TOPSECRET", "o1");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // these report per-column min/max of the raw files, which no mask can cover
+        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
+            Identifier sysId =
+                    Identifier.create(
+                            identifier.getDatabaseName(),
+                            identifier.getObjectName() + "$" + suffix);
+            assertThatThrownBy(() -> catalog.getTable(sysId))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("query-auth table");
+        }
+
+        // the row-producing ones read through the masking reader and stay available
+        for (String suffix : Arrays.asList("audit_log", "ro")) {
+            Identifier sysId =
+                    Identifier.create(
+                            identifier.getDatabaseName(),
+                            identifier.getObjectName() + "$" + suffix);
+            assertThat(batchRead(catalog.getTable(sysId)).toString())
+                    .contains("****")
+                    .doesNotContain("TOPSECRET");
+        }
+    }
+
+    @Test
+    void testMaskReadingAnotherMaskedColumnRejected() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_mask_compose");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "display"), Collections.emptyMap());
+        writeStringRow(table, "TOPSECRET", "ignored");
+
+        // display := secret, while secret is masked. A transform reads the raw row, so this
+        // would publish secret's raw value through display.
+        Map<String, Transform> compose = new HashMap<>();
+        compose.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        compose.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
+        setColumnMasking(identifier, compose);
+        assertThatThrownBy(() -> batchRead(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("which is masked too");
+
+        // a mask reading an unmasked column, and one reading its own column, both stay valid
+        Map<String, Transform> plain = new HashMap<>();
+        plain.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
+        setColumnMasking(identifier, plain);
+        assertThat(batchRead(table).toString()).contains("TOPSECRET");
+
+        Map<String, Transform> selfRef = new HashMap<>();
+        selfRef.put(
+                "secret",
+                new UpperTransform(
+                        Collections.singletonList(new FieldRef(0, "secret", DataTypes.STRING()))));
+        setColumnMasking(identifier, selfRef);
+        assertThat(batchRead(table).toString()).contains("TOPSECRET");
+    }
+
+    @Test
+    void testQueryAuthRejectedWhereItCannotBeEnforced() throws Exception {
+        // a non-file-store table never reads through the auth reader, so accepting the option
+        // would leave the rules silently inert
+        for (String type : Arrays.asList("format-table", "object-table")) {
+            Map<String, String> opts = new HashMap<>();
+            opts.put(QUERY_AUTH_ENABLED.key(), "true");
+            opts.put("type", type);
+            opts.put("file.format", "csv");
+            Identifier id =
+                    Identifier.create(
+                            "test_table_db", "auth_unsupported_" + type.replace('-', '_'));
+            assertThatThrownBy(
+                            () ->
+                                    catalog.createTable(
+                                            id,
+                                            new Schema(
+                                                    stringFields("secret"),
+                                                    Collections.emptyList(),
+                                                    Collections.emptyList(),
+                                                    opts,
+                                                    ""),
+                                            false))
+                    .hasMessageContaining(QUERY_AUTH_ENABLED.key());
+        }
+
+        // search ranks raw index values, so it is refused rather than answered from them
+        Identifier identifier = Identifier.create("test_table_db", "auth_search_rejected");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "other"), Collections.emptyMap());
+        assertThatThrownBy(
+                        () -> ((FileStoreTable) table).newFullTextSearchBuilder().newFullTextScan())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
+
+        // the lookup cache serves rows straight from the store
+        assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -80,6 +80,7 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.Instant;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.table.object.ObjectTable;
@@ -5999,6 +6000,39 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("query-auth table");
+    }
+
+    @Test
+    void testRowIdFilterOnDataEvolutionQueryAuthTable() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_de_rowid_filter");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        fields.add(new DataField(1, "f1", DataTypes.STRING()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite()) {
+            write.write(GenericRow.of(0, BinaryString.fromString("a0")));
+            write.write(GenericRow.of(1, BinaryString.fromString("a1")));
+            builder.newCommit().commit(write.prepareCommit());
+        }
+
+        // no masking rules at all -- a _ROW_ID predicate must still plan. Data-evolution
+        // statistics carry only logical columns, so the row-id part must not be pushed.
+        Predicate onRowId =
+                LeafPredicate.of(
+                        new FieldTransform(
+                                new FieldRef(
+                                        SpecialFields.ROW_ID.id(),
+                                        SpecialFields.ROW_ID.name(),
+                                        DataTypes.BIGINT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(0L));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onRowId);
+        assertThat(readBuilder.newScan().plan().splits()).isNotEmpty();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -60,6 +60,7 @@ import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.FieldTransform;
 import org.apache.paimon.predicate.GreaterOrEqual;
 import org.apache.paimon.predicate.GreaterThan;
+import org.apache.paimon.predicate.LeafFunction;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -103,6 +104,7 @@ import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
@@ -3931,6 +3933,28 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         return catalog.getTable(identifier);
     }
 
+    private static LeafPredicate leaf(
+            int index, String name, DataType type, LeafFunction function, Object literal) {
+        return LeafPredicate.of(
+                new FieldTransform(new FieldRef(index, name, type)),
+                function,
+                Collections.singletonList(literal));
+    }
+
+    private void setColumnMask(Identifier identifier, String target, Transform transform) {
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(target, transform);
+        setColumnMasking(identifier, masking);
+    }
+
+    /** Masks {@code target} with the constant {@code ****}. */
+    private void maskConstant(Identifier identifier, String target) {
+        setColumnMask(
+                identifier,
+                target,
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+    }
+
     private static List<DataField> stringFields(String... names) {
         List<DataField> fields = new ArrayList<>();
         for (int i = 0; i < names.length; i++) {
@@ -3960,15 +3984,14 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     private void maskDisplayWithFullName(Identifier identifier) {
-        Map<String, Transform> columnMasking = new HashMap<>();
-        columnMasking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(0, "first", DataTypes.STRING()),
                                 new FieldRef(1, "last", DataTypes.STRING()))));
-        setColumnMasking(identifier, columnMasking);
     }
 
     private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
@@ -4053,10 +4076,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "john", "doe", "secret", "o1");
 
         LeafPredicate displayFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
+                leaf(
+                        2,
+                        "display",
+                        DataTypes.STRING(),
                         Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("secret")));
+                        BinaryString.fromString("secret"));
         setRowFilter(identifier, Collections.singletonList(displayFilter));
         maskDisplayWithFullName(identifier);
 
@@ -4175,14 +4200,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
 
-        Map<String, Transform> columnMasking = new HashMap<>();
-        columnMasking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(4, "extra", DataTypes.STRING()))));
-        setColumnMasking(identifier, columnMasking);
 
         readBuilder = table.newReadBuilder().withReadType(prunedReadType);
         rows =
@@ -4205,23 +4229,18 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "john", "doe", "secret");
 
-        Map<String, Transform> staleTarget = new HashMap<>();
-        staleTarget.put(
-                "renamed_away",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, staleTarget);
+        maskConstant(identifier, "renamed_away");
         assertThatThrownBy(() -> readFully(table))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
 
-        Map<String, Transform> staleInput = new HashMap<>();
-        staleInput.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(0, "ghost", DataTypes.STRING()))));
-        setColumnMasking(identifier, staleInput);
         assertThatThrownBy(() -> readFully(table))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not exist in table schema");
@@ -4300,11 +4319,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "s",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "s");
 
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
@@ -4338,11 +4353,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 identifier,
                 Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
                 false);
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "extra",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "extra");
 
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
@@ -4378,11 +4389,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 identifier,
                 Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
                 false);
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "masked_secret",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "masked_secret");
 
         Table latest = catalog.getTable(identifier);
         ReadBuilder latestRead = latest.newReadBuilder();
@@ -4412,11 +4419,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
         writeStringRow(table, "d1", "o1");
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "_ROW_ID",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "_ROW_ID");
 
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
         List<InternalRow> rows =
@@ -4444,11 +4447,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 identifier,
                 Collections.singletonList(SchemaChange.addColumn("display", DataTypes.STRING())),
                 false);
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
 
         Table old =
                 catalog.getTable(identifier)
@@ -4502,11 +4504,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         identifier, stringFields("first", "secret"), Collections.emptyMap());
         writeStringRow(table, "john", "s1");
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "secret",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "secret");
 
         StreamTableScan scan = table.newReadBuilder().newStreamScan();
         scan.plan();
@@ -4549,11 +4547,10 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         RowType tableRowType = table.rowType();
         DataField sField = tableRowType.getField("s");
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
-        setColumnMasking(identifier, masking);
 
         RowType prunedS = ((RowType) sField.type()).project("b");
         RowType prunedReadType =
@@ -4614,14 +4611,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
             builder.newCommit().commit(commitables);
         }
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "f1",
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(2, "f2", DataTypes.STRING()))));
-        setColumnMasking(identifier, masking);
 
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {1});
         List<InternalRow> rows =
@@ -4661,14 +4657,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         write.close();
         commit.close();
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new ConcatWsTransform(
                         Arrays.asList(
                                 BinaryString.fromString("-"),
                                 new FieldRef(1, "image", DataTypes.STRING()))));
-        setColumnMasking(identifier, masking);
 
         ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
         assertThatThrownBy(
@@ -4696,18 +4691,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
         for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
-            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-            BatchTableWrite write = writeBuilder.newWrite();
-            write.write(GenericRow.of(row[0], row[1]));
-            BatchTableCommit commit = writeBuilder.newCommit();
-            commit.commit(write.prepareCommit());
-            write.close();
-            commit.close();
+            commitRows(table, GenericRow.of(row[0], row[1]));
         }
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier,
+                "display",
+                new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
 
         TopN topN =
                 new TopN(new FieldRef(0, "display", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
@@ -4736,19 +4726,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         fields,
                         Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
 
-        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-        BatchTableWrite write = writeBuilder.newWrite();
-        write.write(GenericRow.of(42L));
-        BatchTableCommit commit = writeBuilder.newCommit();
-        commit.commit(write.prepareCommit());
-        write.close();
-        commit.close();
+        commitRows(table, GenericRow.of(42L));
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "display",
                 new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
-        setColumnMasking(identifier, masking);
 
         RowType readType =
                 new RowType(
@@ -4809,23 +4792,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
         for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
-            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-            BatchTableWrite write = writeBuilder.newWrite();
-            write.write(GenericRow.of(row[0], row[1]));
-            BatchTableCommit commit = writeBuilder.newCommit();
-            commit.commit(write.prepareCommit());
-            write.close();
-            commit.close();
+            commitRows(table, GenericRow.of(row[0], row[1]));
         }
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
 
-        LeafPredicate amountFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
-                        GreaterThan.INSTANCE,
-                        Collections.singletonList(500));
+        LeafPredicate amountFilter = leaf(0, "amount", DataTypes.INT(), GreaterThan.INSTANCE, 500);
         ReadBuilder readBuilder =
                 table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
         TableRead read = readBuilder.newRead();
@@ -4854,23 +4826,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
         for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
-            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-            BatchTableWrite write = writeBuilder.newWrite();
-            write.write(GenericRow.of(row[0], row[1]));
-            BatchTableCommit commit = writeBuilder.newCommit();
-            commit.commit(write.prepareCommit());
-            write.close();
-            commit.close();
+            commitRows(table, GenericRow.of(row[0], row[1]));
         }
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
 
-        LeafPredicate amountFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
-                        GreaterThan.INSTANCE,
-                        Collections.singletonList(500));
+        LeafPredicate amountFilter = leaf(0, "amount", DataTypes.INT(), GreaterThan.INSTANCE, 500);
         ReadBuilder readBuilder =
                 table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
         StreamTableScan scan = readBuilder.newStreamScan();
@@ -4895,10 +4856,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "d1", "o1");
 
         LeafPredicate displayFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "display", DataTypes.STRING())),
+                leaf(
+                        0,
+                        "display",
+                        DataTypes.STRING(),
                         Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("d1")));
+                        BinaryString.fromString("d1"));
         ReadBuilder readBuilder =
                 table.newReadBuilder().withProjection(new int[] {0}).withFilter(displayFilter);
         TableScan scan = readBuilder.newScan();
@@ -4909,11 +4872,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         table.rowType().project("display"));
         assertThat(plain).hasSize(1);
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "display",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "display");
 
         assertThatThrownBy(scan::plan)
                 .isInstanceOf(IllegalStateException.class)
@@ -4946,10 +4905,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "b", "v2");
 
         LeafPredicate partitionFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("a")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("a"));
         assertThat(
                         table.newReadBuilder()
                                 .withFilter(partitionFilter)
@@ -4972,10 +4928,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRows(table, new String[] {"a", "v1"}, new String[] {"b", "v2"});
 
         LeafPredicate onA =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("a")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("a"));
         setRowFilter(identifier, Collections.singletonList(onA));
 
         List<PartitionEntry> entries =
@@ -4997,23 +4950,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.singletonMap(
                                 CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
         for (int[] row : new int[][] {{900, 10}, {1, 1000}}) {
-            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-            BatchTableWrite write = writeBuilder.newWrite();
-            write.write(GenericRow.of(row[0], row[1]));
-            BatchTableCommit commit = writeBuilder.newCommit();
-            commit.commit(write.prepareCommit());
-            write.close();
-            commit.close();
+            commitRows(table, GenericRow.of(row[0], row[1]));
         }
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
 
-        LeafPredicate amountFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
-                        GreaterThan.INSTANCE,
-                        Collections.singletonList(500));
+        LeafPredicate amountFilter = leaf(0, "amount", DataTypes.INT(), GreaterThan.INSTANCE, 500);
         ReadBuilder readBuilder =
                 table.newReadBuilder()
                         .withProjection(new int[] {0})
@@ -5044,25 +4986,18 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "a", "va");
         writeStringRow(table, "b", "vb");
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
 
         LeafPredicate maskedMatch =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("vb")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("vb"));
         List<InternalRow> rows = readWithFilter(table, maskedMatch, "p", "v");
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
         assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
 
         LeafPredicate rawMatch =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("a")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("a"));
         assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
 
         List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
@@ -5083,15 +5018,11 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRow(table, "a", "va");
         writeStringRow(table, "b", "vb");
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
 
         LeafPredicate maskedMatch =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("vb")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("vb"));
         ReadBuilder readBuilder =
                 table.newReadBuilder()
                         .withProjection(new int[] {0, 1})
@@ -5118,24 +5049,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyList(),
                         Collections.singletonList("id"),
                         Collections.singletonMap(CoreOptions.BUCKET.key(), "1"));
-        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
-        BatchTableWrite write = writeBuilder.newWrite();
-        write.write(GenericRow.of(1, 500));
-        write.write(GenericRow.of(2, 600));
-        BatchTableCommit commit = writeBuilder.newCommit();
-        commit.commit(write.prepareCommit());
-        write.close();
-        commit.close();
+        commitRows(table, GenericRow.of(1, 500), GenericRow.of(2, 600));
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
 
-        LeafPredicate idFilter =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(500));
+        LeafPredicate idFilter = leaf(0, "id", DataTypes.INT(), Equal.INSTANCE, 500);
         List<InternalRow> rows = readWithFilter(table, idFilter, "id", "src");
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getInt(0)).isEqualTo(500);
@@ -5604,21 +5523,9 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     @Test
     void testColumnMaskingOrFilterWithUnprojectedOperand() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_or_filter_unprojected");
-        catalog.createDatabase(identifier.getDatabaseName(), true);
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "a", DataTypes.STRING()));
-        fields.add(new DataField(1, "b", DataTypes.STRING()));
-        fields.add(new DataField(2, "c", DataTypes.STRING()));
-        catalog.createTable(
-                identifier,
-                new Schema(
-                        fields,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
-                        ""),
-                true);
-        Table table = catalog.getTable(identifier);
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("a", "b", "c"), Collections.emptyMap());
         commitRows(
                 table,
                 GenericRow.of(
@@ -5626,22 +5533,15 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         BinaryString.fromString("bee"),
                         BinaryString.fromString("cee")));
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "a",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
-        setColumnMasking(identifier, masking);
 
         Predicate onMasked =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("MASKED")));
+                leaf(0, "a", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("MASKED"));
         Predicate onPlain =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(1, "b", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("bee")));
+                leaf(1, "b", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("bee"));
         Predicate disjunction = PredicateBuilder.or(onMasked, onPlain);
 
         ReadBuilder readBuilder =
@@ -5657,35 +5557,24 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     @Test
     void testColumnMaskingPartitionListingBeforePlan() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_partition_listing");
-        catalog.createDatabase(identifier.getDatabaseName(), true);
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "pt", DataTypes.STRING()));
-        fields.add(new DataField(1, "a", DataTypes.STRING()));
-        catalog.createTable(
-                identifier,
-                new Schema(
-                        fields,
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("pt", "a"),
                         Collections.singletonList("pt"),
                         Collections.emptyList(),
-                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
-                        ""),
-                true);
-        Table table = catalog.getTable(identifier);
+                        Collections.emptyMap());
         commitRows(
                 table,
                 GenericRow.of(BinaryString.fromString("p1"), BinaryString.fromString("raw")));
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
+        setColumnMask(
+                identifier,
                 "a",
                 new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
-        setColumnMasking(identifier, masking);
 
         Predicate onMasked =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(1, "a", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("MASKED")));
+                leaf(1, "a", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("MASKED"));
 
         InnerTableScan scan =
                 (InnerTableScan) table.newReadBuilder().withFilter(onMasked).newScan();
@@ -5696,30 +5585,15 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     @Test
     void testQueryAuthLimitDoesNotCutRowsBeforeFilter() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_limit_with_filter");
-        catalog.createDatabase(identifier.getDatabaseName(), true);
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "a", DataTypes.STRING()));
-        fields.add(new DataField(1, "b", DataTypes.STRING()));
-        catalog.createTable(
-                identifier,
-                new Schema(
-                        fields,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
-                        ""),
-                true);
-        Table table = catalog.getTable(identifier);
+        Table table =
+                createMaskingAuthTable(identifier, stringFields("a", "b"), Collections.emptyMap());
         commitRows(
                 table,
                 GenericRow.of(BinaryString.fromString("no"), BinaryString.fromString("r1")),
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")));
 
         Predicate onA =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("yes")));
+                leaf(0, "a", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("yes"));
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(1);
         List<String> out = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
@@ -5742,15 +5616,11 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRow(table, "a", "va");
         writeStringRow(table, "b", "vb");
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
 
         LeafPredicate maskedMatch =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("vb")));
+                leaf(0, "p", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("vb"));
 
         InnerTableScan partitionScan = (InnerTableScan) table.newReadBuilder().newScan();
         partitionScan.withPartitionFilter(maskedMatch);
@@ -5773,24 +5643,17 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"x", "a", "v1"}, new String[] {"y", "b", "v2"});
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
 
         LeafPredicate onP1 =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("x")));
+                leaf(0, "p1", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("x"));
         InnerTableScan okScan = (InnerTableScan) table.newReadBuilder().newScan();
         okScan.withPartitionFilter(onP1);
         assertThat(okScan.plan().splits()).isNotEmpty();
 
         LeafPredicate onP2 =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("v1")));
+                leaf(1, "p2", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("v1"));
         InnerTableScan badScan = (InnerTableScan) table.newReadBuilder().newScan();
         badScan.withPartitionFilter(onP2);
         assertThatThrownBy(badScan::plan)
@@ -5811,10 +5674,12 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         writeStringRows(table, new String[] {"a", "va"}, new String[] {"b", "vb"});
 
         LeafPredicate pAtLeastA =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                leaf(
+                        0,
+                        "p",
+                        DataTypes.STRING(),
                         GreaterOrEqual.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("a")));
+                        BinaryString.fromString("a"));
         assertThat(readPartitionB(table, pAtLeastA)).containsExactly("b");
 
         Identifier plain = Identifier.create("test_table_db", "plain_part_filter_with_filter");
@@ -5849,20 +5714,8 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     @Test
     void testQueryAuthLimitAppliesWhenReaderExecutesFilter() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_limit_execute_filter");
-        catalog.createDatabase(identifier.getDatabaseName(), true);
-        List<DataField> fields = new ArrayList<>();
-        fields.add(new DataField(0, "a", DataTypes.STRING()));
-        fields.add(new DataField(1, "b", DataTypes.STRING()));
-        catalog.createTable(
-                identifier,
-                new Schema(
-                        fields,
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
-                        ""),
-                true);
-        Table table = catalog.getTable(identifier);
+        Table table =
+                createMaskingAuthTable(identifier, stringFields("a", "b"), Collections.emptyMap());
         commitRows(
                 table,
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r1")),
@@ -5870,10 +5723,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r3")));
 
         Predicate onA =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("yes")));
+                leaf(0, "a", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("yes"));
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(2);
         List<String> out = new ArrayList<>();
         try (RecordReader<InternalRow> reader =
@@ -5898,20 +5748,13 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                         Collections.emptyMap());
         writeStringRows(table, new String[] {"x", "a", "v1"});
 
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
-        setColumnMasking(identifier, masking);
+        setColumnMask(
+                identifier, "p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
 
         LeafPredicate onMaskedP2 =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("v1")));
+                leaf(1, "p2", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("v1"));
         LeafPredicate onPlainP1 =
-                LeafPredicate.of(
-                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
-                        Equal.INSTANCE,
-                        Collections.singletonList(BinaryString.fromString("x")));
+                leaf(0, "p1", DataTypes.STRING(), Equal.INSTANCE, BinaryString.fromString("x"));
 
         InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
         scan.withPartitionFilter(onMaskedP2);
@@ -5926,11 +5769,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 createMaskingAuthTable(
                         identifier, stringFields("secret", "other"), Collections.emptyMap());
         writeStringRow(table, "TOPSECRET", "o1");
-        Map<String, Transform> masking = new HashMap<>();
-        masking.put(
-                "secret",
-                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
-        setColumnMasking(identifier, masking);
+        maskConstant(identifier, "secret");
 
         for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog", "statistics")) {
             Identifier sysId =

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -31,6 +31,8 @@ import org.apache.paimon.catalog.PropertyChange;
 import org.apache.paimon.consumer.ConsumerInfo;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
@@ -92,11 +94,13 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
 import org.apache.paimon.utils.StringUtils;
@@ -3896,6 +3900,897 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isEqualTo("prefix-example"); // col4 masked with ConcatWsTransform
         assertThat(row2.getString(4).toString())
                 .isEqualTo("value"); // col5 NOT masked - original value
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
+            throws Exception {
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Map<String, String> options = new HashMap<>(extraOptions);
+        options.put(QUERY_AUTH_ENABLED.key(), "true");
+        catalog.createTable(
+                identifier,
+                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
+                true);
+        return catalog.getTable(identifier);
+    }
+
+    private static List<DataField> stringFields(String... names) {
+        List<DataField> fields = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            fields.add(new DataField(i, names[i], DataTypes.STRING()));
+        }
+        return fields;
+    }
+
+    private static void writeStringRows(Table table, String[]... rows) throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        for (String[] values : rows) {
+            Object[] converted = new Object[values.length];
+            for (int i = 0; i < values.length; i++) {
+                converted[i] = BinaryString.fromString(values[i]);
+            }
+            write.write(GenericRow.of(converted));
+        }
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+    }
+
+    private static void writeStringRow(Table table, String... values) throws Exception {
+        writeStringRows(table, values);
+    }
+
+    /** Cross-column mask: display := concat_ws('-', first, last). */
+    private void maskDisplayWithFullName(Identifier identifier) {
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first", DataTypes.STRING()),
+                                new FieldRef(1, "last", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+    }
+
+    /** Rows must be copied: the auth back-projection reuses one ProjectedRow per split. */
+    private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
+            throws Exception {
+        List<InternalRow> rows = new ArrayList<>();
+        reader.forEachRemaining(row -> rows.add(InternalRowUtils.copyInternalRow(row, rowType)));
+        return rows;
+    }
+
+    @Test
+    void testColumnMaskingCrossColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_cross_column");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        // two rows in one commit -> one split with multiple rows
+        writeStringRows(
+                table,
+                new String[] {"john", "doe", "ignored", "o1"},
+                new String[] {"jane", "roe", "ignored", "o2"});
+        maskDisplayWithFullName(identifier);
+
+        // project only the masked target; its input columns are not selected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        assertThat(rows).hasSize(2);
+        for (InternalRow row : rows) {
+            assertThat(row.getFieldCount()).isEqualTo(1);
+        }
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingProjectionAcrossMultipleSplits() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_multi_split");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        // one file per split, so the scan below yields multiple splits
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two commits -> two splits; the widening must not leak state across splits
+        writeStringRow(table, "john", "doe", "ignored");
+        writeStringRow(table, "jane", "roe", "ignored");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        assertThat(splits.size()).isGreaterThan(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        List<String> values = new ArrayList<>();
+        for (InternalRow row : rows) {
+            // every split must be projected back to the query's arity
+            assertThat(row.getFieldCount()).isEqualTo(1);
+            values.add(row.getString(0).toString());
+        }
+        assertThat(values).containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingOnRowFilterColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret", "o1");
+
+        // the filter pulls unprojected "display" into the read type, activating its mask
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("secret")));
+        setRowFilter(identifier, Collections.singletonList(displayFilter));
+        maskDisplayWithFullName(identifier);
+
+        // project only "other": the mask target and inputs are all unprojected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {3});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("other"));
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("o1");
+    }
+
+    @Test
+    void testColumnMaskingRevokedOnSameTableRead() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revoked");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked).hasSize(1);
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
+
+        // revoke the rules: the same TableRead must drop the widened read type
+        setColumnMasking(identifier, new HashMap<>());
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+    }
+
+    @Test
+    void testColumnMaskingGrantedAfterReadSchemaFixed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_granted");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+
+        // first read without rules fixes the read schema to the projection
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+
+        // a mask granted afterwards needs columns outside the fixed schema: fail closed
+        maskDisplayWithFullName(identifier);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        read.createReader(splits),
+                                        table.rowType().project("display")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recreate the reader");
+    }
+
+    @Test
+    void testColumnMaskingPreservesNestedProjection() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_nested");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        fields.add(new DataField(4, "extra", DataTypes.STRING()));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("ignored"),
+                        GenericRow.of(BinaryString.fromString("AV"), BinaryString.fromString("BV")),
+                        BinaryString.fromString("EX")));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // a nested-pruned read type, as engines push down
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+
+        // sanity: the nested-pruned read works without masking
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+
+        // mask "display" from unprojected "extra": widening must keep "s" pruned
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(4, "extra", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+
+        readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(2);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("EX");
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+    }
+
+    @Test
+    void testColumnMaskingStaleRuleFailsClosed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_stale");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret");
+
+        // mask target absent from the schema (e.g. renamed since the rule was written)
+        Map<String, Transform> staleTarget = new HashMap<>();
+        staleTarget.put(
+                "renamed_away",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, staleTarget);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // mask input absent from the schema
+        Map<String, Transform> staleInput = new HashMap<>();
+        staleInput.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "ghost", DataTypes.STRING()))));
+        setColumnMasking(identifier, staleInput);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRuleChangeOnRetainedColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_retained");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "hidden_a", "hidden_b"),
+                        Collections.emptyMap());
+        writeStringRow(table, "d1", "a1", "b1");
+
+        // first rules widen and fix the read schema to [display, hidden_a]
+        Map<String, Transform> rules = new HashMap<>();
+        rules.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "hidden_a", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("a1");
+
+        // the new rules mask only hidden_a, retained but unread: must not activate
+        rules.clear();
+        rules.put(
+                "hidden_a",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "hidden_b", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedMaskTarget() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_target");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask TARGETS the struct column "s" (reading another column)
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "s",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would write the mask into a partial slot: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingOnColumnAddedAfterSnapshot() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_time_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "display"), Collections.emptyMap());
+        writeStringRow(table, "john", "d1"); // snapshot 1
+
+        // add a column, then mask it: the rule is valid only in the latest schema
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "extra",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the new column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows).hasSize(1);
+        assertThat(latestRows.get(0).getString(2).toString()).isEqualTo("****");
+
+        // a time-travel read of the old snapshot must not fail on the newer rule
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> oldRows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(oldRows).hasSize(1);
+        assertThat(oldRows.get(0).getString(0).toString()).isEqualTo("john");
+    }
+
+    @Test
+    void testColumnMaskingRenamedColumnTimeTravelFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_rename_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1"); // snapshot 1, column named "secret"
+
+        // rename the column, then mask it under the new name
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "masked_secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the renamed column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows.get(0).getString(1).toString()).isEqualTo("****");
+
+        // a time-travel read of the pre-rename snapshot exposes the same physical column
+        // as "secret"; the rule keyed on "masked_secret" would be silently skipped by name
+        // and leak the raw value -- it must fail closed instead
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        assertThatThrownBy(() -> oldRead.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("renamed");
+    }
+
+    @Test
+    void testColumnMaskingSystemTargetInertWhenUnprojected() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask on a system column the query does not project must be inert, not reject
+        // the whole query at plan time
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_ROW_ID",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingInertTargetWithRenamedInputTimeTravel() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_inert_input");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "old_input"), Collections.emptyMap());
+        writeStringRow(table, "john", "in1"); // snapshot 1
+
+        // rename the input, then add a target column masked from the renamed input
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("old_input", "renamed_input")),
+                false);
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("display", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the pre-rename snapshot predates "display": the mask cannot output there, so the
+        // rename of its input must not fail the read
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> rows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("john");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("in1");
+    }
+
+    @Test
+    void testColumnMaskingRevalidatedAfterRulesDisappear() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revalidate");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+
+        // plan 1: a valid mask on "secret" is validated and cached
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        scan.plan();
+
+        // plan 2: rules disappear -- the cached validation must be forgotten
+        setColumnMasking(identifier, Collections.emptyMap());
+        scan.plan();
+
+        // the masked column is renamed away, then the identical rule is restored; a stale-rule
+        // cache short-circuit would skip re-validation and silently stop masking
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRenamedUnderLiveScanFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_live_rename");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+        scan.plan();
+
+        // the masked column is renamed while the rules stay identical: the live scan must
+        // notice on its next plan and fail closed, not keep planning on the stale rule
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedRuleInput() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_input");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask on "display" reads the whole struct column "s"
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would hand the mask a partial struct: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingWithDataEvolutionColumnFiles() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_data_evolution");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        fields.add(new DataField(1, "f1", DataTypes.STRING()));
+        fields.add(new DataField(2, "f2", DataTypes.STRING()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        // one row group split across two columnar files: (f0, f1) and (f2)
+        RowType tableRowType = table.rowType();
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write0 =
+                builder.newWrite().withWriteType(tableRowType.project("f0", "f1"))) {
+            write0.write(GenericRow.of(0, BinaryString.fromString("a0")));
+            write0.write(GenericRow.of(1, BinaryString.fromString("a1")));
+            builder.newCommit().commit(write0.prepareCommit());
+        }
+        long rowId = ((FileStoreTable) table).snapshotManager().latestSnapshot().nextRowId() - 2;
+        builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write1 =
+                builder.newWrite().withWriteType(tableRowType.project("f2"))) {
+            write1.write(GenericRow.of(BinaryString.fromString("b0")));
+            write1.write(GenericRow.of(BinaryString.fromString("b1")));
+            List<CommitMessage> commitables = write1.prepareCommit();
+            for (CommitMessage c : commitables) {
+                CommitMessageImpl message = (CommitMessageImpl) c;
+                List<DataFileMeta> newFiles =
+                        new ArrayList<>(message.newFilesIncrement().newFiles());
+                message.newFilesIncrement().newFiles().clear();
+                for (DataFileMeta file : newFiles) {
+                    message.newFilesIncrement().newFiles().add(file.assignFirstRowId(rowId));
+                }
+            }
+            builder.newCommit().commit(commitables);
+        }
+
+        // mask f1 from f2 and project only f1: the scan must keep f2's file
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "f1",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "f2", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {1});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        tableRowType.project("f1"));
+        assertThat(rows).hasSize(2);
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.isNullAt(0) ? null : row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("b0", "b1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsUnprojectedBlobViewInput() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_blob_view");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(new DataField(1, "image", DataTypes.BLOB()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.BLOB_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_RESOLVE_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        Blob.fromView(new BlobViewStruct(identifier, 1, 0L))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the unprojected blob-view column: resolution cannot apply
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "image", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        table.rowType().project("display")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blob-view");
+    }
+
+    @Test
+    void testColumnMaskingReadingSystemField() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.BIGINT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(42L));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the projected _ROW_ID metadata field: not a stale rule
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+
+        RowType readType =
+                new RowType(
+                        Arrays.asList(
+                                table.rowType().getField("display"),
+                                org.apache.paimon.table.SpecialFields.ROW_ID));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        readType);
+        assertThat(rows).hasSize(1);
+        // display masked to the row id
+        assertThat(rows.get(0).getLong(0)).isEqualTo(rows.get(0).getLong(1));
+    }
+
+    @Test
+    void testColumnMaskingSystemFieldValidation() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_validation");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask keyed by a key-reader-internal name is stale, not a system field
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_KEY_display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // a rule reading an unprojected system field fails clearly at plan time
+        masking.clear();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(() -> readBuilder.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not project");
+    }
+
+    private static void readFully(Table table) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder();
+        collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -5813,6 +5813,57 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testExplicitPartitionFilterSurvivesDeferredQueryFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_with_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"a", "va"}, new String[] {"b", "vb"});
+
+        // no masking: query auth alone defers the filter push, which must not overwrite
+        // the caller's partition filter
+        LeafPredicate pAtLeastA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        GreaterOrEqual.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        assertThat(readPartitionB(table, pAtLeastA)).containsExactly("b");
+
+        // control: without query auth the filter is pushed eagerly, so this always held
+        Identifier plain = Identifier.create("test_table_db", "plain_part_filter_with_filter");
+        catalog.createTable(
+                plain,
+                new Schema(
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""),
+                true);
+        Table plainTable = catalog.getTable(plain);
+        writeStringRows(plainTable, new String[] {"a", "va"}, new String[] {"b", "vb"});
+        assertThat(readPartitionB(plainTable, pAtLeastA)).containsExactly("b");
+    }
+
+    private static List<String> readPartitionB(Table table, Predicate filter) throws Exception {
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withFilter(filter)
+                        .withPartitionFilter(Collections.singletonMap("p", "b"));
+        return collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType())
+                .stream()
+                .map(row -> row.getString(0).toString())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Test
     void testQueryAuthLimitAppliesWhenReaderExecutesFilter() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_limit_execute_filter");
         catalog.createDatabase(identifier.getDatabaseName(), true);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -83,6 +83,7 @@ import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.table.object.ObjectTable;
+import org.apache.paimon.table.query.LocalTableQuery;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -96,6 +97,7 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -3906,13 +3908,22 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     private Table createMaskingAuthTable(
             Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
             throws Exception {
+        return createMaskingAuthTable(
+                identifier, fields, Collections.emptyList(), Collections.emptyList(), extraOptions);
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier,
+            List<DataField> fields,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            Map<String, String> extraOptions)
+            throws Exception {
         catalog.createDatabase(identifier.getDatabaseName(), true);
         Map<String, String> options = new HashMap<>(extraOptions);
         options.put(QUERY_AUTH_ENABLED.key(), "true");
         catalog.createTable(
-                identifier,
-                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
-                true);
+                identifier, new Schema(fields, partitionKeys, primaryKeys, options, ""), true);
         return catalog.getTable(identifier);
     }
 
@@ -4713,6 +4724,51 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testColumnMaskingDisablesTopNPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_topn");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.INT()));
+        fields.add(new DataField(1, "source", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits with opposite raw/masked ordering
+        for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+
+        // display := source inverts the ordering the raw statistics suggest
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        TopN topN =
+                new TopN(new FieldRef(0, "display", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withTopN(topN);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+        // split pruning must not drop the split holding the real top row (1000)
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
     void testColumnMaskingReadingSystemField() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
         List<DataField> fields = new ArrayList<>();
@@ -4784,6 +4840,312 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> readBuilder.newScan().plan())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not project");
+    }
+
+    @Test
+    void testColumnMaskingDisablesFilterStatsPruning() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_stats");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits whose raw and masked values order oppositely
+        for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the predicate applies to masked values, with no engine help (no executeFilter):
+        // raw statistics must not prune the split whose masked value matches, and the
+        // raw-matching row must not come back
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactly(1000);
+    }
+
+    @Test
+    void testMaskGrowthOnPushedFilterColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pushed_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("display", "other"), Collections.emptyMap());
+        writeStringRow(table, "d1", "o1");
+
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("d1")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(displayFilter);
+        TableScan scan = readBuilder.newScan();
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(scan.plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+
+        // a mask now covers the filter column
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // this scan already pruned with the column's raw statistics: it must fail closed
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recreate the scan");
+
+        // a fresh scan carries no raw pruning, and the existing reader evaluates the
+        // filter on the masked value: 'd1' no longer matches
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> masked =
+                collectRows(read.createReader(splits), table.rowType().project("display"));
+        assertThat(masked).isEmpty();
+    }
+
+    @Test
+    void testDeferredFilterAppliesToPartitionListing() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "filter_partition_listing");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "p", DataTypes.STRING()));
+        fields.add(new DataField(1, "v", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        writeStringRow(table, "a", "v1");
+        writeStringRow(table, "b", "v2");
+
+        LeafPredicate partitionFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        // partition listing bypasses plan(): the filter must still prune
+        assertThat(
+                        table.newReadBuilder()
+                                .withFilter(partitionFilter)
+                                .newScan()
+                                .listPartitionEntries())
+                .hasSize(1);
+    }
+
+    @Test
+    void testColumnMaskingDisablesLimitPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_limit");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        for (int[] row : new int[][] {{900, 10}, {1, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the whole filter sits on the masked column: nothing is pushed down, but limit
+        // pruning must still know a read-time filter drops rows
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0})
+                        .withFilter(amountFilter)
+                        .withLimit(1);
+        TableRead read = readBuilder.newRead().executeFilter();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
+    void testFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_partition");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+
+        // the partition column is masked to another column's value
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // engines consume partition filters without re-evaluating them, so the read
+        // itself must evaluate this predicate, on the masked value
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        List<InternalRow> rows = readWithFilter(table, maskedMatch, "p", "v");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+
+        // the raw partition value must not match: matching it would reveal the raw value
+        LeafPredicate rawMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
+
+        // filter column not projected: it is read and masked for the filter only, then
+        // projected back out
+        List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
+        assertThat(unprojected).hasSize(1);
+        assertThat(unprojected.get(0).getString(0).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testLimitWithFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_partition_limit");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the filter is partition-only but sits on a masked column, so it drops rows at
+        // read time: limit pruning must not pick splits by raw row counts
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0, 1})
+                        .withFilter(maskedMatch)
+                        .withLimit(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("p", "v"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testMaskedPkFilterNotAppliedOnRawValues() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_pk_filter");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "id", DataTypes.INT().notNull()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        Collections.singletonMap(CoreOptions.BUCKET.key(), "1"));
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(1, 500));
+        write.write(GenericRow.of(2, 600));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the key filter matches a masked value only: key-range skipping inside the
+        // merge read must not drop the row by its raw key
+        LeafPredicate idFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(500));
+        List<InternalRow> rows = readWithFilter(table, idFilter, "id", "src");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getInt(0)).isEqualTo(500);
+    }
+
+    private List<InternalRow> readWithFilter(Table table, Predicate filter, String... projected)
+            throws Exception {
+        int[] projection = table.rowType().getFieldIndices(Arrays.asList(projected));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(projection).withFilter(filter);
+        return collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType().project(projected));
     }
 
     private static void readFully(Table table) throws Exception {
@@ -5234,6 +5596,409 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         ReadBuilder readBuilder = table.newReadBuilder().withTopN(topN).withLimit(1);
         List<String> result = batchRead(table, readBuilder.newScan().plan().splits(), readBuilder);
         assertThat(result).containsExactlyInAnyOrder("+I[3, 30]", "+I[4, 40]");
+    }
+
+    @Test
+    void testColumnMaskingOrFilterWithUnprojectedOperand() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_or_filter_unprojected");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        fields.add(new DataField(2, "c", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(
+                        BinaryString.fromString("raw"),
+                        BinaryString.fromString("bee"),
+                        BinaryString.fromString("cee")));
+
+        // mask a -> "MASKED"; b and c are not masked
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "a",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
+        setColumnMasking(identifier, masking);
+
+        // WHERE a = 'MASKED' OR b = 'bee' -- one masked operand, one plain, neither projected.
+        // splitAnd does not split the OR, so retainFields keeps the whole disjunction, but only
+        // the masked column 'a' is widened in; 'b' is missing from the read schema.
+        Predicate onMasked =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("MASKED")));
+        Predicate onPlain =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "b", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("bee")));
+        Predicate disjunction = PredicateBuilder.or(onMasked, onPlain);
+
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {2}).withFilter(disjunction);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(splits)) {
+            reader.forEachRemaining(r -> out.add(r.getString(0).toString()));
+        }
+        assertThat(out).containsExactly("cee");
+    }
+
+    @Test
+    void testColumnMaskingPartitionListingBeforePlan() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_partition_listing");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "pt", DataTypes.STRING()));
+        fields.add(new DataField(1, "a", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.singletonList("pt"),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("p1"), BinaryString.fromString("raw")));
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "a",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("MASKED"))));
+        setColumnMasking(identifier, masking);
+
+        Predicate onMasked =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("MASKED")));
+
+        // listPartitionEntries() bypasses plan(); a later plan() on the same scan must not treat
+        // the masks discovered then as a rule change against an already-pushed filter.
+        InnerTableScan scan =
+                (InnerTableScan) table.newReadBuilder().withFilter(onMasked).newScan();
+        assertThat(scan.listPartitionEntries()).hasSize(1);
+        assertThat(scan.plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testQueryAuthLimitDoesNotCutRowsBeforeFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_limit_with_filter");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        // one file, the matching row second
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("no"), BinaryString.fromString("r1")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")));
+
+        // The reader does not evaluate the query filter on an auth-enabled table; engines
+        // re-apply it. A read-level limit would cap the raw rows at "no" and the engine would
+        // then filter it away, losing the matching row entirely.
+        Predicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("yes")));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(1);
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits())) {
+            reader.forEachRemaining(r -> out.add(r.getString(1).toString()));
+        }
+        assertThat(out).contains("r2");
+    }
+
+    @Test
+    void testMaskedPartitionKeyRejectsPartitionFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_masked_part_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+
+        // routed through withPartitionFilter (as Spark does) the predicate never reaches the
+        // masked value, so it must fail closed rather than prune on the raw partition value
+        InnerTableScan partitionScan = (InnerTableScan) table.newReadBuilder().newScan();
+        partitionScan.withPartitionFilter(maskedMatch);
+        assertThatThrownBy(partitionScan::plan)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("masked partition key");
+
+        // the same predicate through withFilter is evaluated post-mask and still works
+        assertThat(readWithFilter(table, maskedMatch, "p", "v")).hasSize(1);
+    }
+
+    @Test
+    void testPartitionFilterAllowedOnUnmaskedPartitionKey() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_two_part_keys");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p1", "p2", "v"),
+                        Arrays.asList("p1", "p2"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"x", "a", "v1"}, new String[] {"y", "b", "v2"});
+
+        // only p2 is masked
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // a partition predicate touching only the UNMASKED key stays prunable
+        LeafPredicate onP1 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x")));
+        InnerTableScan okScan = (InnerTableScan) table.newReadBuilder().newScan();
+        okScan.withPartitionFilter(onP1);
+        assertThat(okScan.plan().splits()).isNotEmpty();
+
+        // touching the masked key is still rejected
+        LeafPredicate onP2 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("v1")));
+        InnerTableScan badScan = (InnerTableScan) table.newReadBuilder().newScan();
+        badScan.withPartitionFilter(onP2);
+        assertThatThrownBy(badScan::plan)
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("masked partition key");
+    }
+
+    @Test
+    void testQueryAuthLimitAppliesWhenReaderExecutesFilter() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_limit_execute_filter");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "a", DataTypes.STRING()));
+        fields.add(new DataField(1, "b", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        commitRows(
+                table,
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r1")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r2")),
+                GenericRow.of(BinaryString.fromString("yes"), BinaryString.fromString("r3")));
+
+        // executeFilter() means the reader evaluates the predicate itself, so capping after it
+        // is safe and the caller's limit must still be honoured
+        Predicate onA =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "a", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("yes")));
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(onA).withLimit(2);
+        List<String> out = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                readBuilder
+                        .newRead()
+                        .executeFilter()
+                        .createReader(readBuilder.newScan().plan().splits())) {
+            reader.forEachRemaining(r -> out.add(r.getString(1).toString()));
+        }
+        assertThat(out).hasSize(2);
+    }
+
+    @Test
+    void testPartitionFilterFieldsReplacedOnRepush() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_part_filter_repush");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p1", "p2", "v"),
+                        Arrays.asList("p1", "p2"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRows(table, new String[] {"x", "a", "v1"});
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p2", new FieldTransform(new FieldRef(2, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        LeafPredicate onMaskedP2 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(1, "p2", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("v1")));
+        LeafPredicate onPlainP1 =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p1", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("x")));
+
+        // the second push overwrites the first in ManifestsReader, so the tracked fields must be
+        // replaced too: the effective predicate only touches the unmasked key
+        InnerTableScan scan = (InnerTableScan) table.newReadBuilder().newScan();
+        scan.withPartitionFilter(onMaskedP2);
+        scan.withPartitionFilter(onPlainP1);
+        assertThat(scan.plan().splits()).isNotEmpty();
+    }
+
+    @Test
+    void testPhysicalMetadataSystemTablesRejectedUnderQueryAuth() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_systab_physical");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "other"), Collections.emptyMap());
+        writeStringRow(table, "TOPSECRET", "o1");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // these report per-column min/max of the raw files, which no mask can cover
+        for (String suffix : Arrays.asList("files", "file_key_ranges", "binlog")) {
+            Identifier sysId =
+                    Identifier.create(
+                            identifier.getDatabaseName(),
+                            identifier.getObjectName() + "$" + suffix);
+            assertThatThrownBy(() -> catalog.getTable(sysId))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("query-auth table");
+        }
+
+        // the row-producing ones read through the masking reader and stay available
+        for (String suffix : Arrays.asList("audit_log", "ro")) {
+            Identifier sysId =
+                    Identifier.create(
+                            identifier.getDatabaseName(),
+                            identifier.getObjectName() + "$" + suffix);
+            assertThat(batchRead(catalog.getTable(sysId)).toString())
+                    .contains("****")
+                    .doesNotContain("TOPSECRET");
+        }
+    }
+
+    @Test
+    void testMaskReadingAnotherMaskedColumnRejected() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_mask_compose");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "display"), Collections.emptyMap());
+        writeStringRow(table, "TOPSECRET", "ignored");
+
+        // display := secret, while secret is masked. A transform reads the raw row, so this
+        // would publish secret's raw value through display.
+        Map<String, Transform> compose = new HashMap<>();
+        compose.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        compose.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
+        setColumnMasking(identifier, compose);
+        assertThatThrownBy(() -> batchRead(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("which is masked too");
+
+        // a mask reading an unmasked column, and one reading its own column, both stay valid
+        Map<String, Transform> plain = new HashMap<>();
+        plain.put("display", new FieldTransform(new FieldRef(0, "secret", DataTypes.STRING())));
+        setColumnMasking(identifier, plain);
+        assertThat(batchRead(table).toString()).contains("TOPSECRET");
+
+        Map<String, Transform> selfRef = new HashMap<>();
+        selfRef.put(
+                "secret",
+                new UpperTransform(
+                        Collections.singletonList(new FieldRef(0, "secret", DataTypes.STRING()))));
+        setColumnMasking(identifier, selfRef);
+        assertThat(batchRead(table).toString()).contains("TOPSECRET");
+    }
+
+    @Test
+    void testQueryAuthRejectedWhereItCannotBeEnforced() throws Exception {
+        // a non-file-store table never reads through the auth reader, so accepting the option
+        // would leave the rules silently inert
+        for (String type : Arrays.asList("format-table", "object-table")) {
+            Map<String, String> opts = new HashMap<>();
+            opts.put(QUERY_AUTH_ENABLED.key(), "true");
+            opts.put("type", type);
+            opts.put("file.format", "csv");
+            Identifier id =
+                    Identifier.create(
+                            "test_table_db", "auth_unsupported_" + type.replace('-', '_'));
+            assertThatThrownBy(
+                            () ->
+                                    catalog.createTable(
+                                            id,
+                                            new Schema(
+                                                    stringFields("secret"),
+                                                    Collections.emptyList(),
+                                                    Collections.emptyList(),
+                                                    opts,
+                                                    ""),
+                                            false))
+                    .hasMessageContaining(QUERY_AUTH_ENABLED.key());
+        }
+
+        // search ranks raw index values, so it is refused rather than answered from them
+        Identifier identifier = Identifier.create("test_table_db", "auth_search_rejected");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("secret", "other"), Collections.emptyMap());
+        assertThatThrownBy(
+                        () -> ((FileStoreTable) table).newFullTextSearchBuilder().newFullTextScan())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
+
+        // the lookup cache serves rows straight from the store
+        assertThatThrownBy(() -> new LocalTableQuery((FileStoreTable) table))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("query-auth table");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -721,6 +721,35 @@ class SchemaValidationTest {
                         "Primary-key managed BLOB tables do not support 'pk-clustering-override'.");
     }
 
+    @Test
+    public void testQueryAuthOnlyOnFileStoreTables() {
+        for (String type : Arrays.asList("format-table", "object-table")) {
+            Map<String, String> options = new HashMap<>();
+            options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+            options.put(CoreOptions.TYPE.key(), type);
+            assertThatThrownBy(() -> validateTableSchema(queryAuthSchema(options)))
+                    .hasMessageContaining(CoreOptions.QUERY_AUTH_ENABLED.key());
+        }
+
+        for (String type : Arrays.asList("table", "materialized-table")) {
+            Map<String, String> options = new HashMap<>();
+            options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+            options.put(CoreOptions.TYPE.key(), type);
+            validateTableSchema(queryAuthSchema(options));
+        }
+    }
+
+    private TableSchema queryAuthSchema(Map<String, String> options) {
+        return new TableSchema(
+                1,
+                singletonList(new DataField(0, "id", DataTypes.INT())),
+                10,
+                emptyList(),
+                emptyList(),
+                options,
+                "");
+    }
+
     private TableSchema primaryKeyBlobSchema(
             Map<String, String> options, List<String> primaryKeys, List<String> partitionKeys) {
         return new TableSchema(

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -769,6 +769,35 @@ class SchemaValidationTest {
                         "Primary-key managed BLOB tables do not support 'pk-clustering-override'.");
     }
 
+    @Test
+    public void testQueryAuthOnlyOnFileStoreTables() {
+        for (String type : Arrays.asList("format-table", "object-table")) {
+            Map<String, String> options = new HashMap<>();
+            options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+            options.put(CoreOptions.TYPE.key(), type);
+            assertThatThrownBy(() -> validateTableSchema(queryAuthSchema(options)))
+                    .hasMessageContaining(CoreOptions.QUERY_AUTH_ENABLED.key());
+        }
+
+        for (String type : Arrays.asList("table", "materialized-table")) {
+            Map<String, String> options = new HashMap<>();
+            options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+            options.put(CoreOptions.TYPE.key(), type);
+            validateTableSchema(queryAuthSchema(options));
+        }
+    }
+
+    private TableSchema queryAuthSchema(Map<String, String> options) {
+        return new TableSchema(
+                1,
+                singletonList(new DataField(0, "id", DataTypes.INT())),
+                10,
+                emptyList(),
+                emptyList(),
+                options,
+                "");
+    }
+
     private TableSchema primaryKeyBlobSchema(
             Map<String, String> options, List<String> primaryKeys, List<String> partitionKeys) {
         return new TableSchema(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
@@ -64,6 +64,7 @@ public class LookupDataTableScan extends DataTableStreamScan {
             LookupStreamScanMode lookupScanMode) {
         super(
                 table.schema(),
+                table.schemaManager(),
                 table.coreOptions(),
                 snapshotReader,
                 table.snapshotManager(),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/vectorsearch/FlinkVectorSearchBuilderImpl.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/vectorsearch/FlinkVectorSearchBuilderImpl.java
@@ -40,6 +40,7 @@ public class FlinkVectorSearchBuilderImpl extends VectorSearchBuilderImpl {
 
     @Override
     public VectorRead newVectorRead() {
+        rejectUnderQueryAuth();
         checkNotNull(vector, "vector must be set via withVector()");
         if (isPrimaryKeyVectorSearch()) {
             return new FlinkPrimaryKeyVectorRead(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -366,6 +366,51 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
     }
 
     @Test
+    public void testColumnMaskingCrossColumnWithProjection() {
+        String maskingTable = "cross_column_masking_table";
+        batchSql(
+                String.format(
+                        "CREATE TABLE %s.%s (first_name STRING, last_name STRING, display STRING, other_col STRING)"
+                                + " WITH ('query-auth.enabled' = 'true', 'source.split.target-size' = '1 b')",
+                        DATABASE_NAME, maskingTable));
+        // two commits so the scan yields multiple splits
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('john', 'doe', 'ignored', 'o1')",
+                        DATABASE_NAME, maskingTable));
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('jane', 'roe', 'ignored', 'o2')",
+                        DATABASE_NAME, maskingTable));
+
+        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first_name", DataTypes.STRING()),
+                                new FieldRef(1, "last_name", DataTypes.STRING()))));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
+
+        // project only the masked target: its input columns must be read regardless
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT display FROM %s.%s", DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("john-doe"), Row.of("jane-roe"));
+        // a projection without the masked column is unaffected
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT other_col FROM %s.%s",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("o1"), Row.of("o2"));
+    }
+
+    @Test
     public void testRowFilter() {
         String filterTable = "row_filter_table";
         batchSql(
@@ -758,7 +803,8 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
                                                 "SELECT id, name FROM %s.%s WHERE age > 30 ORDER BY id",
                                                 DATABASE_NAME, combinedTable)))
                 .rootCause()
-                .hasMessageContaining("Unable to read data without column non_existent_column");
+                .hasMessageContaining(
+                        "Row filter references column 'non_existent_column' which does not exist");
 
         // Clear both column masking and row filter
         restCatalogServer.setColumnMaskingAuth(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -411,6 +411,48 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
     }
 
     @Test
+    public void testFilterOnMaskedPartitionColumn() {
+        String maskingTable = "partition_masking_table";
+        batchSql(
+                String.format(
+                        "CREATE TABLE %s.%s (p STRING, v STRING) PARTITIONED BY (p)"
+                                + " WITH ('query-auth.enabled' = 'true')",
+                        DATABASE_NAME, maskingTable));
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('a', 'va'), ('b', 'vb')",
+                        DATABASE_NAME, maskingTable));
+
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
+
+        // Flink consumes bounded partition filters without re-evaluating them, so the
+        // source itself must evaluate the predicate, on the masked value
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT p, v FROM %s.%s WHERE p = 'vb'",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("vb", "vb"));
+        // the raw partition value must not match
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT p, v FROM %s.%s WHERE p = 'a'",
+                                        DATABASE_NAME, maskingTable)))
+                .isEmpty();
+        // filter column not projected
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT v FROM %s.%s WHERE p = 'vb'",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("vb"));
+    }
+
+    @Test
     public void testRowFilter() {
         String filterTable = "row_filter_table";
         batchSql(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -373,7 +373,6 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
                         "CREATE TABLE %s.%s (first_name STRING, last_name STRING, display STRING, other_col STRING)"
                                 + " WITH ('query-auth.enabled' = 'true', 'source.split.target-size' = '1 b')",
                         DATABASE_NAME, maskingTable));
-        // two commits so the scan yields multiple splits
         batchSql(
                 String.format(
                         "INSERT INTO %s.%s VALUES ('john', 'doe', 'ignored', 'o1')",
@@ -383,7 +382,6 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
                         "INSERT INTO %s.%s VALUES ('jane', 'roe', 'ignored', 'o2')",
                         DATABASE_NAME, maskingTable));
 
-        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
                 "display",
@@ -395,13 +393,11 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
         restCatalogServer.setColumnMaskingAuth(
                 Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
 
-        // project only the masked target: its input columns must be read regardless
         assertThat(
                         batchSql(
                                 String.format(
                                         "SELECT display FROM %s.%s", DATABASE_NAME, maskingTable)))
                 .containsExactlyInAnyOrder(Row.of("john-doe"), Row.of("jane-roe"));
-        // a projection without the masked column is unaffected
         assertThat(
                         batchSql(
                                 String.format(
@@ -428,22 +424,18 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
         restCatalogServer.setColumnMaskingAuth(
                 Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
 
-        // Flink consumes bounded partition filters without re-evaluating them, so the
-        // source itself must evaluate the predicate, on the masked value
         assertThat(
                         batchSql(
                                 String.format(
                                         "SELECT p, v FROM %s.%s WHERE p = 'vb'",
                                         DATABASE_NAME, maskingTable)))
                 .containsExactlyInAnyOrder(Row.of("vb", "vb"));
-        // the raw partition value must not match
         assertThat(
                         batchSql(
                                 String.format(
                                         "SELECT p, v FROM %s.%s WHERE p = 'a'",
                                         DATABASE_NAME, maskingTable)))
                 .isEmpty();
-        // filter column not projected
         assertThat(
                         batchSql(
                                 String.format(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorSearchBuilderImpl.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/read/SparkVectorSearchBuilderImpl.java
@@ -38,6 +38,7 @@ public class SparkVectorSearchBuilderImpl extends VectorSearchBuilderImpl {
 
     @Override
     public VectorRead newVectorRead() {
+        rejectUnderQueryAuth();
         if (isPrimaryKeyVectorSearch()) {
             return new SparkPrimaryKeyVectorRead(
                     table, vectorColumn, vector, limit, options, filter);

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -365,6 +365,41 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testColumnMaskingCrossColumnWithProjection() {
+        spark.sql(
+                "CREATE TABLE t_cross_column_masking (first_name STRING, last_name STRING, display STRING, other_col STRING)"
+                        + " TBLPROPERTIES ('query-auth.enabled'='true', 'source.split.target-size'='1 b')");
+        // two commits so the scan yields multiple splits
+        spark.sql("INSERT INTO t_cross_column_masking VALUES ('john', 'doe', 'ignored', 'o1')");
+        spark.sql("INSERT INTO t_cross_column_masking VALUES ('jane', 'roe', 'ignored', 'o2')");
+
+        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first_name", DataTypes.STRING()),
+                                new FieldRef(1, "last_name", DataTypes.STRING()))));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create("db2", "t_cross_column_masking"), columnMasking);
+
+        // project only the masked target: its input columns must be read regardless
+        assertThat(
+                        spark.sql("SELECT display FROM t_cross_column_masking ORDER BY other_col")
+                                .collectAsList()
+                                .toString())
+                .isEqualTo("[[john-doe], [jane-roe]]");
+        // a projection without the masked column is unaffected
+        assertThat(
+                        spark.sql("SELECT other_col FROM t_cross_column_masking ORDER BY other_col")
+                                .collectAsList()
+                                .toString())
+                .isEqualTo("[[o1], [o2]]");
+    }
+
+    @Test
     public void testRowFilter() {
         spark.sql(
                 "CREATE TABLE t_row_filter (id INT, name STRING, age INT, department STRING) TBLPROPERTIES"
@@ -863,7 +898,8 @@ public class SparkCatalogWithRestTest {
                                 spark.sql(
                                                 "SELECT id, name FROM t_combined WHERE age > 30 ORDER BY id")
                                         .collectAsList())
-                .hasMessageContaining("Unable to read data without column non_existent_column");
+                .hasMessageContaining(
+                        "Row filter references column 'non_existent_column' which does not exist");
 
         // Clear both column masking and row filter
         restCatalogServer.setColumnMaskingAuth(

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -400,6 +400,27 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testRowFilterDisablesAggregatePushdown() {
+        spark.sql(
+                "CREATE TABLE t_agg_pushdown (id INT) TBLPROPERTIES"
+                        + " ('query-auth.enabled'='true')");
+        spark.sql("INSERT INTO t_agg_pushdown VALUES (1), (2), (3)");
+
+        LeafPredicate idFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(1));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_agg_pushdown"), Collections.singletonList(idFilter));
+
+        // statistics-based aggregate pushdown must not bypass the read-time row filter
+        // (today it degrades because auth splits are not DataSplits; this anchors that)
+        assertThat(spark.sql("SELECT COUNT(*) FROM t_agg_pushdown").collectAsList().toString())
+                .isEqualTo("[[2]]");
+    }
+
+    @Test
     public void testRowFilter() {
         spark.sql(
                 "CREATE TABLE t_row_filter (id INT, name STRING, age INT, department STRING) TBLPROPERTIES"

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -369,11 +369,9 @@ public class SparkCatalogWithRestTest {
         spark.sql(
                 "CREATE TABLE t_cross_column_masking (first_name STRING, last_name STRING, display STRING, other_col STRING)"
                         + " TBLPROPERTIES ('query-auth.enabled'='true', 'source.split.target-size'='1 b')");
-        // two commits so the scan yields multiple splits
         spark.sql("INSERT INTO t_cross_column_masking VALUES ('john', 'doe', 'ignored', 'o1')");
         spark.sql("INSERT INTO t_cross_column_masking VALUES ('jane', 'roe', 'ignored', 'o2')");
 
-        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
         Map<String, Transform> columnMasking = new HashMap<>();
         columnMasking.put(
                 "display",
@@ -385,13 +383,11 @@ public class SparkCatalogWithRestTest {
         restCatalogServer.setColumnMaskingAuth(
                 Identifier.create("db2", "t_cross_column_masking"), columnMasking);
 
-        // project only the masked target: its input columns must be read regardless
         assertThat(
                         spark.sql("SELECT display FROM t_cross_column_masking ORDER BY other_col")
                                 .collectAsList()
                                 .toString())
                 .isEqualTo("[[john-doe], [jane-roe]]");
-        // a projection without the masked column is unaffected
         assertThat(
                         spark.sql("SELECT other_col FROM t_cross_column_masking ORDER BY other_col")
                                 .collectAsList()
@@ -414,8 +410,6 @@ public class SparkCatalogWithRestTest {
         restCatalogServer.setRowFilterAuth(
                 Identifier.create("db2", "t_agg_pushdown"), Collections.singletonList(idFilter));
 
-        // statistics-based aggregate pushdown must not bypass the read-time row filter
-        // (today it degrades because auth splits are not DataSplits; this anchors that)
         assertThat(spark.sql("SELECT COUNT(*) FROM t_agg_pushdown").collectAsList().toString())
                 .isEqualTo("[[2]]");
     }


### PR DESCRIPTION
### Purpose

Makes column masking correct on the read path of `query-auth.enabled` tables. Folds in #8582
as asked in the first review; #8582 is closed.

Two bugs: a cross-column mask threw `Column masking refers to field 'first' which is not
present in output row type` when the query projected the masked target but not the mask's
inputs; and a predicate on a masked column was pushed into raw statistics, where it matched
the raw value rather than the masked one, returning an empty result.

Mask inputs are now widened into the read projection and projected back out, as row-filter
operands already are (#8447), transitively and preserving nested pruning. The widened type is
pushed before planning so column-file pruning keeps the files those columns live in. The read
schema is then fixed once the first split reader exists — split reads cache their format
readers, so without this the auth-added columns leaked into later splits of the same
`TableRead`, which also affected the pre-existing row-filter path. `MergeFileSplitRead`,
`DataEvolutionFileStoreScan` and `IncrementalDiffSplitRead` reset stale projections on
re-configuration accordingly.

The query filter is deferred to `plan()`: only the conjuncts free of masked columns feed
statistics and partition pruning, and the masked ones are evaluated inside the auth read,
post-mask. Rules referencing a column absent from the latest schema fail closed at plan time
(projected system fields such as `_ROW_ID` stay valid), and rules bind by field id, so a
dropped and re-added column of the same name cannot make a time-travel read apply a rule to
unrelated data.

**Behaviour changes.** Each is a case where the mask cannot be enforced, so it fails closed —
accepting the query would leave the rules silently inert, which is worse than an error.

| Change | Why |
|---|---|
| `t$files`, `t$file_key_ranges`, `t$binlog` rejected | They publish per-column min/max raw values. `t$audit_log` and `t$ro` read through the masking reader and keep working. |
| Vector / full-text / hybrid search rejected | The indexes rank raw values. |
| `LocalTableQuery` (lookup join) rejected | Serves rows straight from the lookup cache. |
| Partition predicate on a masked partition key rejected | Pruning consumes it and Spark drops it from post-scan evaluation. The same predicate through `withFilter` still works. |
| `query-auth.enabled` rejected on a non-file-store table | Their reads never reach the auth reader. Checked before and after catalog table defaults. |
| A mask reading another masked column rejected | Transforms evaluate on the raw row. Masking a column with itself stays valid. |
| Global index not consulted | Ranks raw values; falls back to a full scan. Performance, not correctness. |
| Read-level limit applied only after the filter | Engines re-apply the filter afterwards, so capping first dropped matching rows. |

**Known limitations.** The list of bypass paths is not proven complete: the guard lives on
`AbstractDataTableScan`, but `DataEvolutionBatchScan` is a sibling and `PrimaryKeyBatchScan`
keeps a private copy of the filter — both found by review, not by design. Reviewers who know
the global-index and data-evolution code should take a second look. Not handled here:

  - **Branch reads.** `t$branch_x` asks the catalog for its own identifier, and paimon does not
    enforce that it inherits the main table's rules; whether they apply is up to the catalog.
  - **The physical row count** carried on a split is still visible under a row filter.
  - **Partition metadata.** `$partitions`, `$buckets` and `$manifests`, and the global
    `all_partitions` / `all_tables`, report partition values straight from the manifest, so a
    masked partition key shows its raw value there. None of them reads through the auth reader.
    Rejecting them would also block tables that enable query auth without masking a partition
    key, which is the common case.