### PR TITLE
[core] Clean up index files on aborted commits

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -27,6 +27,8 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.manifest.FileEntry;
@@ -75,6 +77,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DataFilePathFactories;
 import org.apache.paimon.utils.FileStorePathFactory;
 import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.IndexFilePathFactories;
 import org.apache.paimon.utils.InternalRowPartitionComputer;
 import org.apache.paimon.utils.ListUtils;
 import org.apache.paimon.utils.Pair;
@@ -670,18 +673,29 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     @Override
     public void abort(List<CommitMessage> commitMessages) {
-        DataFilePathFactories factories = new DataFilePathFactories(pathFactory);
+        DataFilePathFactories dataFactories = new DataFilePathFactories(pathFactory);
+        IndexFilePathFactories indexFactories = new IndexFilePathFactories(pathFactory);
         for (CommitMessage message : commitMessages) {
-            DataFilePathFactory pathFactory = factories.get(message.partition(), message.bucket());
+            DataFilePathFactory dataPathFactory =
+                    dataFactories.get(message.partition(), message.bucket());
+            IndexPathFactory indexPathFactory =
+                    indexFactories.get(message.partition(), message.bucket());
             CommitMessageImpl commitMessage = (CommitMessageImpl) message;
-            List<DataFileMeta> toDelete = new ArrayList<>();
-            toDelete.addAll(commitMessage.newFilesIncrement().newFiles());
-            toDelete.addAll(commitMessage.newFilesIncrement().changelogFiles());
-            toDelete.addAll(commitMessage.compactIncrement().compactAfter());
-            toDelete.addAll(commitMessage.compactIncrement().changelogFiles());
+            List<DataFileMeta> dataFilesToDelete = new ArrayList<>();
+            dataFilesToDelete.addAll(commitMessage.newFilesIncrement().newFiles());
+            dataFilesToDelete.addAll(commitMessage.newFilesIncrement().changelogFiles());
+            dataFilesToDelete.addAll(commitMessage.compactIncrement().compactAfter());
+            dataFilesToDelete.addAll(commitMessage.compactIncrement().changelogFiles());
 
-            for (DataFileMeta file : toDelete) {
-                fileIO.deleteQuietly(pathFactory.toPath(file));
+            for (DataFileMeta file : dataFilesToDelete) {
+                fileIO.deleteQuietly(dataPathFactory.toPath(file));
+            }
+
+            List<IndexFileMeta> indexFilesToDelete = new ArrayList<>();
+            indexFilesToDelete.addAll(commitMessage.newFilesIncrement().newIndexFiles());
+            indexFilesToDelete.addAll(commitMessage.compactIncrement().newIndexFiles());
+            for (IndexFileMeta file : indexFilesToDelete) {
+                fileIO.deleteQuietly(indexPathFactory.toPath(file));
             }
         }
     }

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileStoreCommitTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexPathFactory;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
@@ -958,6 +959,58 @@ public class FileStoreCommitTest {
         assertThat(dvs.size()).isEqualTo(2);
         assertThat(dvs.get("f1").isDeleted(3)).isTrue();
         assertThat(dvs.get("f2").isDeleted(3)).isTrue();
+    }
+
+    @Test
+    public void testAbortIndexFiles() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.INDEX_FILE_IN_DATA_FILE_DIR.key(), "true");
+        TestAppendFileStore store = TestAppendFileStore.createAppendStore(tempDir, options);
+        BinaryRow partition = gen.getPartition(gen.next());
+        IndexPathFactory indexPathFactory = store.pathFactory().indexFileFactory(partition, 0);
+
+        Path dataNewPath = indexPathFactory.newPath();
+        IndexFileMeta dataNew = createIndexFile(store, dataNewPath, false);
+        Path compactNewPath = new Path(tempDir.resolve("external-new-index").toUri());
+        IndexFileMeta compactNew = createIndexFile(store, compactNewPath, true);
+        Path dataDeletedPath = indexPathFactory.newPath();
+        IndexFileMeta dataDeleted = createIndexFile(store, dataDeletedPath, false);
+        Path compactDeletedPath = indexPathFactory.newPath();
+        IndexFileMeta compactDeleted = createIndexFile(store, compactDeletedPath, false);
+
+        CommitMessage commitMessage =
+                new CommitMessageImpl(
+                        partition,
+                        0,
+                        store.options().bucket(),
+                        new DataIncrement(
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Collections.singletonList(dataNew),
+                                Collections.singletonList(dataDeleted)),
+                        new CompactIncrement(
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Collections.emptyList(),
+                                Collections.singletonList(compactNew),
+                                Collections.singletonList(compactDeleted)));
+
+        try (FileStoreCommitImpl commit = store.newCommit()) {
+            commit.abort(Collections.singletonList(commitMessage));
+        }
+
+        assertThat(store.fileIO().exists(dataNewPath)).isFalse();
+        assertThat(store.fileIO().exists(compactNewPath)).isFalse();
+        assertThat(store.fileIO().exists(dataDeletedPath)).isTrue();
+        assertThat(store.fileIO().exists(compactDeletedPath)).isTrue();
+    }
+
+    private static IndexFileMeta createIndexFile(
+            TestAppendFileStore store, Path path, boolean external) throws Exception {
+        store.fileIO().newOutputStream(path, false).close();
+        return new IndexFileMeta(
+                HASH_INDEX, path.getName(), 0, 0, null, external ? path.toString() : null, null);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

`FileStoreCommitImpl.abort` deleted uncommitted data and changelog files but ignored `newIndexFiles` from both data and compact increments. Aborted commits could therefore leave index files behind, including files stored at external paths.

Clean up both sets of new index files through `IndexFilePathFactories`. Keep `deletedIndexFiles` untouched because they still belong to the active snapshot when the commit is aborted.

### Tests

  - `mvn -pl paimon-core -Pfast-build -DwildcardSuites=none -Dtest=FileStoreCommitTest test`
  - `mvn -pl paimon-core -DskipTests verify`