### PR TITLE
[filesystem] Fix misleading OBS comment in hadoop-uber shade config

### DIFF
--- a/paimon-filesystems/paimon-hadoop-uber/pom.xml
+++ b/paimon-filesystems/paimon-hadoop-uber/pom.xml
@@ -636,7 +636,7 @@
     <build>
         <plugins>
 
-            <!-- Relocate all OBS related classes -->
+            <!-- Relocate all Hadoop related classes -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
### Purpose

- The shade-plugin comment in `paimon-filesystems/paimon-hadoop-uber/pom.xml` read `Relocate all OBS related classes`, but this module is the Hadoop uber jar: it relocates the Hadoop stack (guava, asm, netty, curator, httpcomponents, htrace, jackson), not OBS. The wording was copy-pasted from `paimon-obs-impl`; corrected to "Hadoop".
- Sibling convention: `paimon-oss-impl/pom.xml:165` says "OSS", `paimon-obs-impl/pom.xml:84` says "OBS".
- Relocations and artifactSet are unchanged, so the produced jar is identical.

### Tests

- Wording-only fix, no behavior change — no test added.
- Jar output is unchanged; the full shade build is covered by fork CI. A standalone local `apache-rat:check` only flags pre-existing bundled `LICENSE*` files, unrelated to this change.
