### PR TITLE
[iceberg] Fix UnsupportedOperationException reading multiset columns

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/metadata/IcebergDataField.java
@@ -32,6 +32,7 @@ import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.TimestampType;
@@ -206,6 +207,14 @@ public class IcebergDataField {
                         SpecialFields.getMapValueFieldId(fieldId, depth + 1),
                         !mapType.getValueType().isNullable(),
                         toTypeObject(mapType.getValueType(), fieldId, depth + 1));
+            case MULTISET:
+                MultisetType multisetType = (MultisetType) dataType;
+                return new IcebergMapType(
+                        SpecialFields.getMapKeyFieldId(fieldId, depth + 1),
+                        toTypeObject(multisetType.getElementType(), fieldId, depth + 1),
+                        SpecialFields.getMapValueFieldId(fieldId, depth + 1),
+                        true,
+                        "int");
             case ROW:
                 RowType rowType = (RowType) dataType;
                 return new IcebergStructType(

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergDataFieldTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/metadata/IcebergDataFieldTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.iceberg.metadata;
 
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
@@ -31,6 +32,7 @@ import org.apache.paimon.types.FloatType;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.LocalZonedTimestampType;
 import org.apache.paimon.types.MapType;
+import org.apache.paimon.types.MultisetType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarBinaryType;
@@ -286,6 +288,26 @@ class IcebergDataFieldTest {
         assertThat(mapType.key()).isEqualTo("string");
         assertThat(mapType.value()).isEqualTo("int");
         assertThat(mapType.valueRequired()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test multiset type conversion")
+    void testMultisetTypeConversion() {
+        DataField multisetField =
+                new DataField(
+                        1,
+                        "multiset",
+                        new MultisetType(false, new VarCharType(false, VarCharType.MAX_LENGTH)));
+        IcebergDataField icebergMultiset = new IcebergDataField(multisetField);
+
+        assertThat(icebergMultiset.type()).isInstanceOf(IcebergMapType.class);
+        IcebergMapType mapType = (IcebergMapType) icebergMultiset.type();
+        assertThat(mapType.type()).isEqualTo("map");
+        assertThat(mapType.key()).isEqualTo("string");
+        assertThat(mapType.value()).isEqualTo("int");
+        assertThat(mapType.valueRequired()).isTrue();
+        assertThat(mapType.keyId()).isEqualTo(SpecialFields.getMapKeyFieldId(1, 1));
+        assertThat(mapType.valueId()).isEqualTo(SpecialFields.getMapValueFieldId(1, 1));
     }
 
     @Test


### PR DESCRIPTION
### Purpose
 - Tables with multiset column fail on commit, when iceberg compatibility is enabled due to `UnsupportedOperationException`.
 - Multiset is already stored as `InternalMap<element, Int>`, however iceberg converter was missing this info.
 - Add support for the same 
### Tests
 - UT added