### PR TITLE
[core] Keep raw-value pushdown off masked columns in query auth

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/PredicateVisitor.java
@@ -40,6 +40,17 @@ public interface PredicateVisitor<T> {
         return predicate.visit(new FieldNameCollector());
     }
 
+    /** Collects the field names referenced by a transform's inputs. */
+    static Set<String> collectFieldNames(Transform transform) {
+        Set<String> fieldNames = new HashSet<>();
+        for (Object input : transform.inputs()) {
+            if (input instanceof FieldRef) {
+                fieldNames.add(((FieldRef) input).name());
+            }
+        }
+        return fieldNames;
+    }
+
     static Set<Integer> collectFieldIds(RowType rowType, @Nullable Predicate predicate) {
         if (predicate == null) {
             return Collections.emptySet();
@@ -58,13 +69,7 @@ public interface PredicateVisitor<T> {
 
         @Override
         public Set<String> visit(LeafPredicate predicate) {
-            Set<String> fieldNames = new HashSet<>();
-            for (Object input : predicate.transform().inputs()) {
-                if (input instanceof FieldRef) {
-                    fieldNames.add(((FieldRef) input).name());
-                }
-            }
-            return fieldNames;
+            return collectFieldNames(predicate.transform());
         }
 
         @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -28,10 +28,12 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
@@ -41,10 +43,15 @@ import org.apache.paimon.utils.StringUtils;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -55,6 +62,10 @@ public class TableQueryAuthResult implements Serializable {
 
     private final @Nullable List<String> filter;
     private final @Nullable Map<String, String> columnMasking;
+
+    // lazily parsed views of the JSON rules; transient so serialization stays unchanged
+    private transient volatile Optional<Predicate> parsedFilter;
+    private transient volatile Map<String, Transform> parsedMasking;
 
     public TableQueryAuthResult(
             @Nullable List<String> filter, @Nullable Map<String, String> columnMasking) {
@@ -72,8 +83,39 @@ public class TableQueryAuthResult implements Serializable {
         return columnMasking;
     }
 
+    /** Whether this result carries any effective row-filter or masking rule. */
+    public boolean hasRules() {
+        return extractPredicate() != null || !extractColumnMasking().isEmpty();
+    }
+
+    /**
+     * Widens {@code readType} with the unprojected columns the rules read, or null when the
+     * projection already covers them. Scans apply this before planning file pruning.
+     */
+    @Nullable
+    public RowType widenReadType(RowType tableType, RowType readType) {
+        return appendMissingFields(
+                tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */
+    @Nullable
+    public static RowType appendMissingFields(
+            RowType tableType, RowType readType, Set<String> ruleFields) {
+        List<DataField> widenedFields = null;
+        for (DataField field : tableType.getFields()) {
+            if (ruleFields.contains(field.name()) && !readType.containsField(field.name())) {
+                if (widenedFields == null) {
+                    widenedFields = new ArrayList<>(readType.getFields());
+                }
+                widenedFields.add(field);
+            }
+        }
+        return widenedFields == null ? null : readType.copy(widenedFields);
+    }
+
     public TableScan.Plan convertPlan(TableScan.Plan plan) {
-        if (filter == null && (columnMasking == null || columnMasking.isEmpty())) {
+        if (!hasRules()) {
             return plan;
         }
         List<Split> authSplits =
@@ -85,6 +127,16 @@ public class TableQueryAuthResult implements Serializable {
 
     @Nullable
     public Predicate extractPredicate() {
+        Optional<Predicate> parsed = parsedFilter;
+        if (parsed == null) {
+            parsed = Optional.ofNullable(parsePredicate());
+            parsedFilter = parsed;
+        }
+        return parsed.orElse(null);
+    }
+
+    @Nullable
+    private Predicate parsePredicate() {
         Predicate rowFilter = null;
         if (filter != null && !filter.isEmpty()) {
             List<Predicate> predicates = new ArrayList<>();
@@ -117,6 +169,15 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     public Map<String, Transform> extractColumnMasking() {
+        Map<String, Transform> parsed = parsedMasking;
+        if (parsed == null) {
+            parsed = parseColumnMasking();
+            parsedMasking = parsed;
+        }
+        return parsed;
+    }
+
+    private Map<String, Transform> parseColumnMasking() {
         Map<String, Transform> result = new TreeMap<>();
         if (columnMasking != null && !columnMasking.isEmpty()) {
             for (Map.Entry<String, String> e : columnMasking.entrySet()) {
@@ -135,8 +196,122 @@ public class TableQueryAuthResult implements Serializable {
         return result;
     }
 
+    /**
+     * Validates that every column the auth rules reference exists in the table's <b>latest</b>
+     * schema (not a time-travel-pinned one). A rule keyed by a since-renamed column looks just like
+     * an unprojected one at read time and would silently stop masking: fail closed instead.
+     */
+    public void validateAgainstSchema(RowType tableType, @Nullable List<String> projectedFields) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            String target = entry.getKey();
+            // a mask on an unprojected system column is inert (never in the output); don't reject
+            if (SpecialFields.SYSTEM_FIELD_NAMES.contains(target)
+                    && (projectedFields == null || !projectedFields.contains(target))) {
+                continue;
+            }
+            checkFieldExists("Column masking", target, tableType, projectedFields);
+            for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                checkFieldExists("Column masking", input, tableType, projectedFields);
+            }
+        }
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            checkFieldExists("Row filter", operand, tableType, projectedFields);
+        }
+    }
+
+    /**
+     * Fails closed when a masked column is present in the read schema under a different name than
+     * the rule uses (renamed between the read snapshot and latest): name-based enforcement would
+     * skip the mask and leak the raw value. A column absent from the read schema is left inert.
+     */
+    public void validateReadableWithoutRename(RowType latestType, RowType readType) {
+        for (Map.Entry<String, Transform> entry : extractColumnMasking().entrySet()) {
+            checkNotRenamed(entry.getKey(), latestType, readType);
+            // a mask whose target is absent from the read schema is inert; skip its inputs
+            if (readType.containsField(entry.getKey())) {
+                for (String input : PredicateVisitor.collectFieldNames(entry.getValue())) {
+                    checkNotRenamed(input, latestType, readType);
+                }
+            }
+        }
+    }
+
+    private static void checkNotRenamed(String field, RowType latestType, RowType readType) {
+        // present by name: enforced fine. absent from latest: already thrown. else: renamed?
+        if (readType.containsField(field) || !latestType.containsField(field)) {
+            return;
+        }
+        int id = latestType.getField(field).id();
+        if (readType.containsField(id)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Column masking references column '%s' which the snapshot being read "
+                                    + "exposes as '%s' (renamed since); refusing to read to avoid "
+                                    + "applying the rule by a stale name.",
+                            field, readType.getField(id).name()));
+        }
+    }
+
+    /**
+     * The field names the auth rules read for a query projecting {@code projectedFields}: the
+     * row-filter operands, plus (transitively) the inputs of every mask whose target is readable —
+     * projected, or itself pulled in by the filter or another mask.
+     */
+    public Set<String> requiredAuthFields(List<String> projectedFields) {
+        Map<String, Transform> masking = extractColumnMasking();
+        Set<String> ruleFields = new HashSet<>();
+        Set<String> readable = new HashSet<>(projectedFields);
+        Deque<String> newlyReadable = new ArrayDeque<>(readable);
+        for (String operand : PredicateVisitor.collectFieldNames(extractPredicate())) {
+            ruleFields.add(operand);
+            if (readable.add(operand)) {
+                newlyReadable.add(operand);
+            }
+        }
+        while (!newlyReadable.isEmpty()) {
+            Transform mask = masking.get(newlyReadable.poll());
+            if (mask == null) {
+                continue;
+            }
+            for (String input : PredicateVisitor.collectFieldNames(mask)) {
+                ruleFields.add(input);
+                if (readable.add(input)) {
+                    newlyReadable.add(input);
+                }
+            }
+        }
+        return ruleFields;
+    }
+
+    private static void checkFieldExists(
+            String rule, String field, RowType tableType, @Nullable List<String> projectedFields) {
+        // system fields (e.g. _ROW_ID) are readable metadata absent from the table schema,
+        // but only when the query actually projects them -- they cannot be widened in
+        if (SpecialFields.SYSTEM_FIELD_NAMES.contains(field)) {
+            if (projectedFields != null && projectedFields.contains(field)) {
+                return;
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references system column '%s' which the query does not project.",
+                            rule, field));
+        }
+        if (!tableType.containsField(field)) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "%s references column '%s' which does not exist in table schema %s. "
+                                    + "The rule may be stale after a column rename or drop; "
+                                    + "refusing to read.",
+                            rule, field, tableType.getFieldNames()));
+        }
+    }
+
+    /**
+     * Applies the row filter and column masking to {@code reader}. Rules are remapped by name;
+     * masks apply only to targets in {@code activeFields}, the columns readable from the query.
+     */
     public RecordReader<InternalRow> doAuth(
-            RecordReader<InternalRow> reader, RowType outputRowType) {
+            RecordReader<InternalRow> reader, RowType outputRowType, Set<String> activeFields) {
         Predicate rowFilter = extractPredicate();
         if (rowFilter != null) {
             Predicate remappedFilter = remapPredicate(rowFilter, outputRowType);
@@ -146,9 +321,9 @@ public class TableQueryAuthResult implements Serializable {
         }
 
         Map<String, Transform> columnMasking = extractColumnMasking();
-        if (columnMasking != null && !columnMasking.isEmpty()) {
+        if (!columnMasking.isEmpty()) {
             Map<Integer, Transform> remappedMasking =
-                    transformRemapping(outputRowType, columnMasking);
+                    transformRemapping(outputRowType, columnMasking, activeFields);
             if (!remappedMasking.isEmpty()) {
                 reader = reader.transform(row -> transform(outputRowType, remappedMasking, row));
             }
@@ -175,12 +350,8 @@ public class TableQueryAuthResult implements Serializable {
     }
 
     private static Map<Integer, Transform> transformRemapping(
-            RowType outputRowType, Map<String, Transform> masking) {
+            RowType outputRowType, Map<String, Transform> masking, Set<String> activeFields) {
         Map<Integer, Transform> out = new HashMap<>();
-        if (masking == null || masking.isEmpty()) {
-            return out;
-        }
-
         for (Map.Entry<String, Transform> e : masking.entrySet()) {
             String targetColumn = e.getKey();
             Transform transform = e.getValue();
@@ -188,6 +359,10 @@ public class TableQueryAuthResult implements Serializable {
                 continue;
             }
 
+            if (!activeFields.contains(targetColumn)) {
+                // not readable from the query, at most retained in a widened read schema
+                continue;
+            }
             int targetIndex = outputRowType.getFieldIndex(targetColumn);
             if (targetIndex < 0) {
                 continue;

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/TableQueryAuthResult.java
@@ -25,6 +25,7 @@ import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.predicate.Transform;
 import org.apache.paimon.reader.RecordReader;
@@ -45,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -96,6 +98,40 @@ public class TableQueryAuthResult implements Serializable {
     public RowType widenReadType(RowType tableType, RowType readType) {
         return appendMissingFields(
                 tableType, readType, requiredAuthFields(readType.getFieldNames()));
+    }
+
+    /**
+     * Drops the conjuncts of {@code predicate} referencing any of {@code fields}; returns null when
+     * nothing remains. Used to keep raw-statistics pushdown off masked columns.
+     */
+    @Nullable
+    public static Predicate excludeFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, true);
+    }
+
+    /**
+     * Keeps only the conjuncts of {@code predicate} referencing any of {@code fields}; returns null
+     * when none does.
+     */
+    @Nullable
+    public static Predicate retainFields(Predicate predicate, Set<String> fields) {
+        return filterConjuncts(predicate, fields, false);
+    }
+
+    @Nullable
+    private static Predicate filterConjuncts(
+            Predicate predicate, Set<String> fields, boolean keepDisjoint) {
+        List<Predicate> kept = new ArrayList<>();
+        for (Predicate conjunct : PredicateBuilder.splitAnd(predicate)) {
+            if (Collections.disjoint(PredicateVisitor.collectFieldNames(conjunct), fields)
+                    == keepDisjoint) {
+                kept.add(conjunct);
+            }
+        }
+        if (kept.isEmpty()) {
+            return null;
+        }
+        return kept.size() == 1 ? kept.get(0) : PredicateBuilder.and(kept);
     }
 
     /** Appends the missing {@code ruleFields} of {@code tableType} to {@code readType}. */

--- a/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/DataEvolutionFileStoreScan.java
@@ -125,14 +125,14 @@ public class DataEvolutionFileStoreScan extends AppendOnlyFileStoreScan {
 
     @Override
     public FileStoreScan withReadType(RowType readType) {
-        if (readType != null) {
-            List<DataField> nonSystemFields =
-                    readType.getFields().stream()
-                            .filter(f -> !SpecialFields.isSystemField(f.id()))
-                            .collect(Collectors.toList());
-            if (!nonSystemFields.isEmpty()) {
-                this.readType = readType;
-            }
+        // a type without user columns does not prune column files; reset, as this
+        // method may be called again
+        if (readType != null
+                && readType.getFields().stream()
+                        .anyMatch(f -> !SpecialFields.isSystemField(f.id()))) {
+            this.readType = readType;
+        } else {
+            this.readType = null;
         }
         return this;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/MergeFileSplitRead.java
@@ -154,10 +154,9 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
         readerFactoryBuilder.withReadValueType(adjustedReadType);
         mergeSorter.setProjectedValueType(adjustedReadType);
 
-        // When finalReadType != readType, need to project the outer read type
-        if (adjustedReadType != readType) {
-            outerReadType = readType;
-        }
+        // project the outer type when adjusted; reset any previous projection, as this
+        // method may be called again
+        outerReadType = adjustedReadType != readType ? readType : null;
 
         return this;
     }
@@ -339,9 +338,11 @@ public class MergeFileSplitRead implements SplitRead<KeyValue> {
 
     /**
      * Returns the pushed read type if {@link #withReadType(RowType)} was called, else the default
-     * read type.
+     * read type. This is the value layout the merge, comparator and serializer run on internally;
+     * when a sequence field was appended for merging, {@link #createMergeReader} projects its
+     * output back to {@code outerReadType}, so the emitted rows can be narrower than this type.
      */
-    private RowType actualReadType() {
+    public RowType actualReadType() {
         return readerFactoryBuilder.readValueType();
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AbstractFileStoreTable.java
@@ -312,6 +312,7 @@ abstract class AbstractFileStoreTable implements FileStoreTable {
         DataTableStreamScan scan =
                 new DataTableStreamScan(
                         tableSchema,
+                        schemaManager(),
                         coreOptions(),
                         newSnapshotReader(),
                         snapshotManager(),

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.types.DataField;
@@ -33,6 +34,7 @@ import org.apache.paimon.utils.ProjectedRow;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -47,6 +49,11 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
+    // Query-auth reads evaluate predicates on masked values; reader-level filtering sees
+    // raw values, so it stays off for auth-enabled tables (as read-level TopN already
+    // does, see ReadBuilderImpl).
+    private final boolean queryAuthEnabled;
+
     // The read type the subclass reads with; differs from readType only when widened for
     // auth, and is fixed once a reader exists (split reads cache their format readers).
     @Nullable private RowType appliedReadType;
@@ -58,13 +65,16 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
         Set<String> blobViewFields = Collections.emptySet();
+        boolean queryAuthEnabled = false;
         if (schema != null) {
             CoreOptions options = CoreOptions.fromMap(schema.options());
             if (options.blobViewResolveEnabled()) {
                 blobViewFields = options.blobViewField();
             }
+            queryAuthEnabled = options.queryAuthEnabled();
         }
         this.resolvedBlobViewFields = blobViewFields;
+        this.queryAuthEnabled = queryAuthEnabled;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -79,6 +89,9 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withFilter(Predicate predicate) {
         this.predicate = predicate;
+        if (queryAuthEnabled) {
+            return this;
+        }
         return innerWithFilter(predicate);
     }
 
@@ -158,7 +171,17 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
         List<String> readFields = currentReadType().getFieldNames();
-        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        // conjuncts on masked columns evaluate here, post-mask (view semantics); their
+        // columns must be read and masked like rule fields
+        Set<String> maskedFilterFields =
+                maskedFilterFields(authResult.extractColumnMasking().keySet());
+        List<String> visibleFields = readFields;
+        if (!maskedFilterFields.isEmpty()) {
+            visibleFields = new ArrayList<>(readFields);
+            visibleFields.addAll(maskedFilterFields);
+        }
+        Set<String> ruleFields = authResult.requiredAuthFields(visibleFields);
+        ruleFields.addAll(maskedFilterFields);
         RowType widened = widenedReadType(authResult, ruleFields);
         if (widened != null && !readerCreated && !widened.equals(appliedReadType)) {
             applyReadType(widened);
@@ -191,7 +214,46 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         }
         RecordReader<InternalRow> reader =
                 authResult.doAuth(readSplit(split), outputType, activeFields);
+        reader = filterMaskedConjuncts(reader, outputType, maskedFilterFields);
         return backProject(reader);
+    }
+
+    /** The columns of the query filter that the current auth rules mask. */
+    private Set<String> maskedFilterFields(Set<String> maskTargets) {
+        if (predicate == null || maskTargets.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> fields = new HashSet<>(PredicateVisitor.collectFieldNames(predicate));
+        fields.retainAll(maskTargets);
+        return fields;
+    }
+
+    /**
+     * Evaluates the filter conjuncts sitting on masked columns, on the masked output. They are
+     * never pushed to the reader or into statistics pruning, and engines do not re-evaluate the
+     * conjuncts they consumed (partition filters), so this is where they take effect.
+     */
+    private RecordReader<InternalRow> filterMaskedConjuncts(
+            RecordReader<InternalRow> reader, RowType outputType, Set<String> maskedFilterFields) {
+        if (maskedFilterFields.isEmpty()) {
+            return reader;
+        }
+        Predicate maskedPart = TableQueryAuthResult.retainFields(predicate, maskedFilterFields);
+        if (maskedPart == null) {
+            return reader;
+        }
+        int[] projection = schema.logicalRowType().getFieldIndices(outputType.getFieldNames());
+        Optional<Predicate> remapped =
+                maskedPart.visit(PredicateProjectionConverter.fromProjection(projection));
+        if (!remapped.isPresent()) {
+            throw new IllegalStateException(
+                    "Filter on masked columns "
+                            + maskedFilterFields
+                            + " cannot be evaluated on read schema "
+                            + outputType.getFieldNames());
+        }
+        Predicate filter = remapped.get();
+        return reader.filter(filter::test);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableRead.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -25,20 +26,18 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateProjectionConverter;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.ListUtils;
 import org.apache.paimon.utils.ProjectedRow;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.apache.paimon.predicate.PredicateVisitor.collectFieldNames;
 
 /** A {@link InnerTableRead} for data table. */
 public abstract class AbstractDataTableRead implements InnerTableRead {
@@ -48,8 +47,24 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     private Predicate predicate;
     private final TableSchema schema;
 
-    public AbstractDataTableRead(TableSchema schema) {
+    // The read type the subclass reads with; differs from readType only when widened for
+    // auth, and is fixed once a reader exists (split reads cache their format readers).
+    @Nullable private RowType appliedReadType;
+    private boolean readerCreated = false;
+
+    // blob-view columns that only resolve through the dedicated blob-view read path
+    private final Set<String> resolvedBlobViewFields;
+
+    public AbstractDataTableRead(@Nullable TableSchema schema) {
         this.schema = schema;
+        Set<String> blobViewFields = Collections.emptySet();
+        if (schema != null) {
+            CoreOptions options = CoreOptions.fromMap(schema.options());
+            if (options.blobViewResolveEnabled()) {
+                blobViewFields = options.blobViewField();
+            }
+        }
+        this.resolvedBlobViewFields = blobViewFields;
     }
 
     public abstract void applyReadType(RowType readType);
@@ -86,6 +101,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
     @Override
     public final InnerTableRead withReadType(RowType readType) {
         this.readType = readType;
+        this.appliedReadType = readType;
         applyReadType(readType);
         return this;
     }
@@ -121,7 +137,7 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
             Split split, @Nullable TableQueryAuthResult authResult) throws IOException {
         RecordReader<InternalRow> reader;
         if (authResult == null) {
-            reader = reader(split);
+            reader = backProject(readSplit(split));
         } else {
             reader = authedReader(split, authResult);
         }
@@ -132,34 +148,107 @@ public abstract class AbstractDataTableRead implements InnerTableRead {
         return reader;
     }
 
+    private RecordReader<InternalRow> readSplit(Split split) throws IOException {
+        RecordReader<InternalRow> reader = reader(split);
+        // set only on success, so a transient failure does not fix the read schema
+        readerCreated = true;
+        return reader;
+    }
+
     private RecordReader<InternalRow> authedReader(Split split, TableQueryAuthResult authResult)
             throws IOException {
-        RecordReader<InternalRow> reader;
-        RowType tableType = schema.logicalRowType();
-        RowType readType = this.readType == null ? tableType : this.readType;
-        Predicate authPredicate = authResult.extractPredicate();
-        ProjectedRow backRow = null;
-        if (authPredicate != null) {
-            Set<String> authFields = collectFieldNames(authPredicate);
-            List<String> readFields = readType.getFieldNames();
-            List<String> authAddNames = new ArrayList<>();
-            Set<String> readFieldSet = new HashSet<>(readFields);
-            for (String field : tableType.getFieldNames()) {
-                if (authFields.contains(field) && !readFieldSet.contains(field)) {
-                    authAddNames.add(field);
+        List<String> readFields = currentReadType().getFieldNames();
+        Set<String> ruleFields = authResult.requiredAuthFields(readFields);
+        RowType widened = widenedReadType(authResult, ruleFields);
+        if (widened != null && !readerCreated && !widened.equals(appliedReadType)) {
+            applyReadType(widened);
+            appliedReadType = widened;
+        }
+        // the split read emits appliedReadType; rules are remapped against it by name
+        RowType outputType = appliedReadType != null ? appliedReadType : currentReadType();
+        if (widened != null && !widened.equals(outputType)) {
+            // rules changed after the read schema was fixed: fail clearly if they no longer fit
+            List<String> outputFields = outputType.getFieldNames();
+            for (String field : widened.getFieldNames()) {
+                if (!outputFields.contains(field)) {
+                    throw new IllegalStateException(
+                            String.format(
+                                    "Query auth rules changed and now require column '%s', but the "
+                                            + "read schema is already fixed to %s. Recreate the "
+                                            + "reader to apply the new rules.",
+                                    field, outputFields));
                 }
             }
-            if (!authAddNames.isEmpty()) {
-                readType = tableType.project(ListUtils.union(readFields, authAddNames));
-                withReadType(readType);
-                backRow = ProjectedRow.from(readType.projectIndexes(readFields));
+        }
+        // masks apply only to columns readable from the query; skip the set when no
+        // mask exists (filter-only auth)
+        Set<String> activeFields;
+        if (authResult.extractColumnMasking().isEmpty()) {
+            activeFields = Collections.emptySet();
+        } else {
+            activeFields = new HashSet<>(readFields);
+            activeFields.addAll(ruleFields);
+        }
+        RecordReader<InternalRow> reader =
+                authResult.doAuth(readSplit(split), outputType, activeFields);
+        return backProject(reader);
+    }
+
+    /**
+     * Project auth-widened rows back to the query's read type — on every split, since the widened
+     * read schema stays in effect even for splits without auth rules.
+     */
+    private RecordReader<InternalRow> backProject(RecordReader<InternalRow> reader) {
+        if (appliedReadType == null || appliedReadType == readType) {
+            return reader;
+        }
+        ProjectedRow backRow =
+                ProjectedRow.from(
+                        appliedReadType.projectIndexes(currentReadType().getFieldNames()));
+        return reader.transform(backRow::replaceRow);
+    }
+
+    /**
+     * The read type widened with the unprojected columns the auth rules read (mirrors the
+     * row-filter augmentation of #8447), or null when the projection already covers them. The
+     * projected fields are kept as-is to preserve nested pruning.
+     */
+    @Nullable
+    private RowType widenedReadType(TableQueryAuthResult authResult, Set<String> ruleFields) {
+        RowType tableType = schema.logicalRowType();
+        RowType readType = currentReadType();
+        Set<String> maskTargets = authResult.extractColumnMasking().keySet();
+        for (String name : readType.getFieldNames()) {
+            if (!ruleFields.contains(name) && !maskTargets.contains(name)) {
+                continue;
+            }
+            if (!tableType.containsField(name)) {
+                continue;
+            }
+            // rules must not touch a nested-pruned column (partial value)
+            DataField tableField = tableType.getField(name);
+            if (!readType.getField(name).type().equals(tableField.type())) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules involve column '%s', which the query "
+                                        + "projects with a pruned type %s instead of its "
+                                        + "table type %s; cannot apply the rules to a "
+                                        + "partial column.",
+                                name, readType.getField(name).type(), tableField.type()));
             }
         }
-        reader = authResult.doAuth(reader(split), readType);
-        if (backRow != null) {
-            reader = reader.transform(backRow::replaceRow);
+        for (String name : ruleFields) {
+            if (resolvedBlobViewFields.contains(name) && !readType.containsField(name)) {
+                // auth-added columns bypass blob-view resolution
+                throw new IllegalStateException(
+                        String.format(
+                                "Query auth rules read blob-view column '%s', which the query "
+                                        + "does not project; such columns cannot be resolved. "
+                                        + "Project the column or adjust the rule.",
+                                name));
+            }
         }
-        return reader;
+        return TableQueryAuthResult.appendMissingFields(tableType, readType, ruleFields);
     }
 
     private RecordReader<InternalRow> executeFilter(RecordReader<InternalRow> reader) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -30,6 +30,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.snapshot.CompactedStartingScanner;
@@ -67,6 +68,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -84,6 +86,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDataTableScan.class);
 
     protected final TableSchema schema;
+    protected final SchemaManager schemaManager;
     private final CoreOptions options;
     protected final SnapshotReader snapshotReader;
     private final TableQueryAuth queryAuth;
@@ -97,20 +100,26 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     protected AbstractDataTableScan(
             TableSchema schema,
+            SchemaManager schemaManager,
             CoreOptions options,
             SnapshotReader snapshotReader,
             TableQueryAuth queryAuth) {
         this.schema = schema;
+        this.schemaManager = schemaManager;
         this.options = options;
         this.snapshotReader = snapshotReader;
         this.queryAuth = queryAuth;
     }
+
+    // the read type last pushed to the snapshot reader; widened for auth when needed
+    @Nullable private RowType appliedScanReadType;
 
     @Override
     public final TableScan.Plan plan() {
         TableQueryAuthResult queryAuthResult = authQuery();
         // Always apply/clear the auth filter so removing auth leaves no stale partition pruning.
         applyAuthFilter(queryAuthResult == null ? null : queryAuthResult.extractPredicate());
+        applyAuthReadType(queryAuthResult);
         Plan plan = planWithoutAuth();
         if (queryAuthResult != null) {
             plan = queryAuthResult.convertPlan(plan);
@@ -208,6 +217,7 @@ abstract class AbstractDataTableScan implements DataTableScan {
     @Override
     public InnerTableScan withReadType(@Nullable RowType readType) {
         this.readType = readType;
+        this.appliedScanReadType = readType;
         snapshotReader.withReadType(readType);
         return this;
     }
@@ -258,7 +268,21 @@ abstract class AbstractDataTableScan implements DataTableScan {
         if (!options.queryAuthEnabled()) {
             return null;
         }
-        return queryAuth.auth(readType == null ? null : readType.getFieldNames());
+        List<String> select = readType == null ? null : readType.getFieldNames();
+        TableQueryAuthResult result = queryAuth.auth(select);
+        if (result != null && result.hasRules()) {
+            // validated on every plan (this path already pays an auth-service call per plan), so
+            // schema changes under a live scan fail closed: references stale in the latest schema,
+            // or renamed relative to the schema being read (e.g. time travel), are rejected
+            RowType latestSchema =
+                    schemaManager
+                            .latest()
+                            .map(TableSchema::logicalRowType)
+                            .orElseGet(schema::logicalRowType);
+            result.validateAgainstSchema(latestSchema, select);
+            result.validateReadableWithoutRename(latestSchema, schema.logicalRowType());
+        }
+        return result;
     }
 
     @Override
@@ -277,6 +301,38 @@ abstract class AbstractDataTableScan implements DataTableScan {
     public InnerTableScan withRowRangeIndex(RowRangeIndex rowRangeIndex) {
         snapshotReader.withRowRangeIndex(rowRangeIndex);
         return this;
+    }
+
+    /**
+     * Push the auth-widened read type to the snapshot reader before planning, so file-level column
+     * pruning keeps the files of the columns the rules read.
+     */
+    private void applyAuthReadType(@Nullable TableQueryAuthResult queryAuthResult) {
+        if (readType == null) {
+            return;
+        }
+        RowType desired = readType;
+        if (queryAuthResult != null && queryAuthResult.hasRules()) {
+            RowType widened = queryAuthResult.widenReadType(schema.logicalRowType(), readType);
+            if (widened != null) {
+                desired = widened;
+            }
+        }
+        // never narrow within this scan's lifetime: readers fix their schema on first use
+        if (appliedScanReadType != null) {
+            RowType widened =
+                    TableQueryAuthResult.appendMissingFields(
+                            appliedScanReadType,
+                            desired,
+                            new HashSet<>(appliedScanReadType.getFieldNames()));
+            if (widened != null) {
+                desired = widened;
+            }
+        }
+        if (!desired.equals(appliedScanReadType)) {
+            snapshotReader.withReadType(desired);
+            appliedScanReadType = desired;
+        }
     }
 
     public SnapshotReader snapshotReader() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractDataTableScan.java
@@ -30,6 +30,7 @@ import org.apache.paimon.operation.FileStoreScan;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateVisitor;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
@@ -68,11 +69,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static org.apache.paimon.CoreOptions.FULL_COMPACTION_DELTA_COMMITS;
@@ -97,6 +100,9 @@ abstract class AbstractDataTableScan implements DataTableScan {
     // Whether the auth predicate has a non-partition part (enforced only at read time). Used by
     // DataTableBatchScan to disable limit push down; not pushed through withFilter.
     protected boolean authHasNonPartitionFilter;
+    // mask targets of the current auth result, overwritten each plan(); TopN pruning
+    // reads raw statistics, which a mask may invalidate (DataTableBatchScan reads this)
+    protected Set<String> authMaskedFields = Collections.emptySet();
 
     protected AbstractDataTableScan(
             TableSchema schema,
@@ -113,12 +119,22 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     // the read type last pushed to the snapshot reader; widened for auth when needed
     @Nullable private RowType appliedScanReadType;
+    // the query filter; pushed on first use without the conjuncts on masked columns,
+    // whose raw statistics a mask invalidates
+    @Nullable private Predicate userFilter;
+    private boolean filterPushed = false;
+    private Set<String> pushedMaskedFields = Collections.emptySet();
 
     @Override
     public final TableScan.Plan plan() {
         TableQueryAuthResult queryAuthResult = authQuery();
         // Always apply/clear the auth filter so removing auth leaves no stale partition pruning.
         applyAuthFilter(queryAuthResult == null ? null : queryAuthResult.extractPredicate());
+        this.authMaskedFields =
+                queryAuthResult == null
+                        ? Collections.emptySet()
+                        : queryAuthResult.extractColumnMasking().keySet();
+        ensureFilterPushdown(authMaskedFields);
         applyAuthReadType(queryAuthResult);
         Plan plan = planWithoutAuth();
         if (queryAuthResult != null) {
@@ -161,7 +177,13 @@ abstract class AbstractDataTableScan implements DataTableScan {
 
     @Override
     public InnerTableScan withFilter(Predicate predicate) {
-        snapshotReader.withFilter(predicate);
+        if (!options.queryAuthEnabled()) {
+            // no masks to strip; push now, else chain-table sub-scans read before plan()
+            snapshotReader.withFilter(predicate);
+            return this;
+        }
+        // deferred to plan(), which strips conjuncts on masked columns before stats pruning
+        this.userFilter = predicate;
         return this;
     }
 
@@ -301,6 +323,38 @@ abstract class AbstractDataTableScan implements DataTableScan {
     public InnerTableScan withRowRangeIndex(RowRangeIndex rowRangeIndex) {
         snapshotReader.withRowRangeIndex(rowRangeIndex);
         return this;
+    }
+
+    /**
+     * Push the query filter once: the full filter marks the read-time filtering (so limit/TopN
+     * pruning stays off), while only the conjuncts free of masked columns are pushed down, since a
+     * mask invalidates their raw statistics. Also called by partition listing, which bypasses
+     * plan(); masks discovered afterwards on a pushed filter column fail closed.
+     */
+    protected final void ensureFilterPushdown(Set<String> maskedFields) {
+        if (userFilter == null) {
+            return;
+        }
+        Set<String> maskedInFilter = new HashSet<>(maskedFields);
+        maskedInFilter.retainAll(PredicateVisitor.collectFieldNames(userFilter));
+        if (!maskedInFilter.isEmpty()) {
+            // masked conjuncts drop rows only at read time, post-mask: keep limit/TopN
+            // split pruning off even when the filter is partition-only
+            authHasNonPartitionFilter = true;
+        }
+        if (!filterPushed) {
+            Predicate effective =
+                    maskedInFilter.isEmpty()
+                            ? userFilter
+                            : TableQueryAuthResult.excludeFields(userFilter, maskedInFilter);
+            snapshotReader.withFilter(userFilter, effective);
+            filterPushed = true;
+            pushedMaskedFields = maskedInFilter;
+        } else if (!pushedMaskedFields.containsAll(maskedInFilter)) {
+            throw new IllegalStateException(
+                    "Query auth rules changed and now mask a pushed-down filter column. "
+                            + "Recreate the scan to apply the new rules.");
+        }
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -135,6 +135,8 @@ public class DataTableBatchScan extends AbstractDataTableScan {
 
     @Override
     public List<PartitionEntry> listPartitionEntries() {
+        // partition listing bypasses plan(): push the deferred filter first
+        ensureFilterPushdown(java.util.Collections.emptySet());
         if (startingScanner == null) {
             startingScanner = createStartingScanner(false);
         }
@@ -206,6 +208,10 @@ public class DataTableBatchScan extends AbstractDataTableScan {
         }
 
         SortValue order = orders.get(0);
+        if (authMaskedFields.contains(order.field().name())) {
+            // the pruning below reads raw statistics; a mask may alter the ordering column
+            return Optional.empty();
+        }
         DataType type = order.field().type();
         if (!minmaxAvailable(type)) {
             return Optional.empty();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableBatchScan.java
@@ -64,7 +64,6 @@ public class DataTableBatchScan extends AbstractDataTableScan {
     private Integer pushDownLimit;
     private TopN topN;
 
-    private final SchemaManager schemaManager;
     @Nullable private String readProtectionTagName;
 
     public DataTableBatchScan(
@@ -73,10 +72,9 @@ public class DataTableBatchScan extends AbstractDataTableScan {
             CoreOptions options,
             SnapshotReader snapshotReader,
             TableQueryAuth queryAuth) {
-        super(schema, options, snapshotReader, queryAuth);
+        super(schema, schemaManager, options, snapshotReader, queryAuth);
 
         this.hasNext = true;
-        this.schemaManager = schemaManager;
         if (!schema.primaryKeys().isEmpty() && options.batchScanSkipLevel0()) {
             if (options.toConfiguration()
                     .get(CoreOptions.BATCH_SCAN_MODE)

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -106,7 +106,6 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
     @Override
     public DataTableStreamScan withFilter(Predicate predicate) {
         super.withFilter(predicate);
-        snapshotReader.withFilter(predicate);
         return this;
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataTableStreamScan.java
@@ -24,6 +24,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.consumer.Consumer;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.snapshot.AllDeltaFollowUpScanner;
@@ -77,6 +78,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
 
     public DataTableStreamScan(
             TableSchema schema,
+            SchemaManager schemaManager,
             CoreOptions options,
             SnapshotReader snapshotReader,
             SnapshotManager snapshotManager,
@@ -84,7 +86,7 @@ public class DataTableStreamScan extends AbstractDataTableScan implements Stream
             boolean supportStreamingReadOverwrite,
             TableQueryAuth queryAuth,
             boolean hasPk) {
-        super(schema, options, snapshotReader, queryAuth);
+        super(schema, schemaManager, options, snapshotReader, queryAuth);
 
         this.options = options;
         this.scanMode = options.toConfiguration().get(CoreOptions.STREAM_SCAN_MODE);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/splitread/IncrementalDiffSplitRead.java
@@ -106,8 +106,8 @@ public class IncrementalDiffSplitRead implements SplitRead<InternalRow> {
                         mergeRead.mergeSorter(),
                         forceKeepDelete);
         if (readType != null) {
-            ProjectedRow projectedRow =
-                    ProjectedRow.from(readType, mergeRead.tableSchema().logicalRowType());
+            // project from the merge read's actual output, which may itself be projected
+            ProjectedRow projectedRow = ProjectedRow.from(readType, mergeRead.actualReadType());
             reader = reader.transform(kv -> kv.replaceValue(projectedRow.replaceRow(kv.value())));
         }
         return KeyValueTableRead.unwrap(reader, mergeRead.tableSchema().options());

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/ReadOptimizedTable.java
@@ -147,7 +147,9 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
         CoreOptions options = wrapped.coreOptions();
         return new DataTableBatchScan(
                 wrapped.schema(),
-                schemaManager(),
+                // the per-branch manager: for a fallback read this scan may serve the
+                // fallback branch, whose rules must validate against that branch's schema
+                wrapped.schemaManager(),
                 options,
                 newSnapshotReader(wrapped),
                 wrapped.catalogEnvironment().tableQueryAuth(options));
@@ -161,6 +163,7 @@ public class ReadOptimizedTable implements DataTable, ReadonlyTable {
         }
         return new DataTableStreamScan(
                 wrapped.schema(),
+                schemaManager(),
                 coreOptions(),
                 newSnapshotReader(),
                 snapshotManager(),

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/TableQueryAuthResultTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.predicate.ConcatWsTransform;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link TableQueryAuthResult}. */
+public class TableQueryAuthResultTest {
+
+    private static final RowType TABLE_TYPE =
+            RowType.of(
+                    new org.apache.paimon.types.DataField(0, "display", DataTypes.STRING()),
+                    new org.apache.paimon.types.DataField(1, "extra", DataTypes.STRING()));
+
+    private static String maskJson() {
+        return JsonSerdeUtil.toFlatJson(
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "extra", DataTypes.STRING()))));
+    }
+
+    @Test
+    public void testHasRules() {
+        assertThat(new TableQueryAuthResult(null, null).hasRules()).isFalse();
+        assertThat(
+                        new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap())
+                                .hasRules())
+                .isFalse();
+        // blank filter entries parse to no predicate
+        assertThat(new TableQueryAuthResult(Collections.singletonList(""), null).hasRules())
+                .isFalse();
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        assertThat(new TableQueryAuthResult(null, masking).hasRules()).isTrue();
+    }
+
+    @Test
+    public void testWidenReadType() {
+        Map<String, String> masking = Collections.singletonMap("display", maskJson());
+        TableQueryAuthResult result = new TableQueryAuthResult(null, masking);
+        // the mask input is unprojected: widen
+        RowType widened = result.widenReadType(TABLE_TYPE, TABLE_TYPE.project("display"));
+        assertThat(widened).isNotNull();
+        assertThat(widened.getFieldNames()).containsExactly("display", "extra");
+        // already covered: no widening
+        assertThat(result.widenReadType(TABLE_TYPE, TABLE_TYPE)).isNull();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/MergeFileSplitReadTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.TestFileStore;
 import org.apache.paimon.TestKeyValueGenerator;
@@ -27,6 +28,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIOFinder;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.ManifestEntry;
 import org.apache.paimon.mergetree.compact.DeduplicateMergeFunction;
 import org.apache.paimon.mergetree.compact.MergeFunction;
@@ -39,6 +41,8 @@ import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.IncrementalSplit;
+import org.apache.paimon.table.source.splitread.IncrementalDiffSplitRead;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
@@ -219,6 +223,122 @@ public class MergeFileSplitReadTest {
         }
     }
 
+    @Test
+    public void testRepeatedReadTypeResetsOuterProjection() throws Exception {
+        // a second withReadType that needs no adjustment must clear the outer projection
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        List<KeyValue> data = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            data.add(gen.next());
+        }
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
+                        DeduplicateMergeFunction.factory(),
+                        Collections.singletonMap(CoreOptions.SEQUENCE_FIELD.key(), "orderId"));
+        store.commitData(data, gen::getPartition, kv -> 0);
+
+        FileStoreScan scan = store.newScan();
+        Long snapshotId = store.snapshotManager().latestSnapshotId();
+        Map<BinaryRow, List<ManifestEntry>> filesGroupedByPartition =
+                scan.withSnapshot(snapshotId).plan().files().stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::partition));
+
+        MergeFileSplitRead read = store.newRead();
+        // adjusted internally to include the sequence field: outer projection set
+        read.withReadType(TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr"));
+        // contains the sequence field, no adjustment: previous outer projection cleared
+        read.withReadType(
+                TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr", "orderId"));
+
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : filesGroupedByPartition.entrySet()) {
+            RecordReader<KeyValue> reader =
+                    read.createReader(
+                            DataSplit.builder()
+                                    .withSnapshot(snapshotId)
+                                    .withPartition(entry.getKey())
+                                    .withBucket(0)
+                                    .withDataFiles(
+                                            entry.getValue().stream()
+                                                    .map(ManifestEntry::file)
+                                                    .collect(Collectors.toList()))
+                                    .withBucketPath("not used")
+                                    .build());
+            RecordReaderIterator<KeyValue> iterator = new RecordReaderIterator<>(reader);
+            while (iterator.hasNext()) {
+                assertThat(iterator.next().value().getFieldCount()).isEqualTo(4);
+            }
+            iterator.close();
+        }
+    }
+
+    @Test
+    public void testIncrementalDiffReadOnProjectedMergeRead() throws Exception {
+        // the diff read projects the merge read's output; when the shared merge read
+        // is itself projected, the projection base must be its actual output type
+        TestKeyValueGenerator gen = new TestKeyValueGenerator();
+        List<KeyValue> before = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            before.add(gen.next());
+        }
+        List<KeyValue> after = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            after.add(gen.next());
+        }
+        TestFileStore store =
+                createStore(
+                        TestKeyValueGenerator.DEFAULT_PART_TYPE,
+                        TestKeyValueGenerator.KEY_TYPE,
+                        TestKeyValueGenerator.DEFAULT_ROW_TYPE,
+                        TestKeyValueGenerator.TestKeyValueFieldsExtractor.EXTRACTOR,
+                        DeduplicateMergeFunction.factory());
+        store.commitData(before, gen::getPartition, kv -> 0);
+        store.commitData(after, gen::getPartition, kv -> 0);
+
+        FileStoreScan scan = store.newScan();
+        Long snapshotId = store.snapshotManager().latestSnapshotId();
+        Map<BinaryRow, List<ManifestEntry>> filesByPartition =
+                scan.withSnapshot(snapshotId).plan().files().stream()
+                        .collect(Collectors.groupingBy(ManifestEntry::partition));
+
+        MergeFileSplitRead mergeRead = store.newRead();
+        // out-of-table-order projection, pushed into the shared merge read
+        RowType projection = TestKeyValueGenerator.DEFAULT_ROW_TYPE.project("shopId", "dt", "hr");
+        mergeRead.withReadType(projection);
+        SplitRead<InternalRow> diffRead = new IncrementalDiffSplitRead(mergeRead);
+        diffRead.withReadType(projection);
+
+        for (Map.Entry<BinaryRow, List<ManifestEntry>> entry : filesByPartition.entrySet()) {
+            List<DataFileMeta> files =
+                    entry.getValue().stream().map(ManifestEntry::file).collect(Collectors.toList());
+            IncrementalSplit split =
+                    new IncrementalSplit(
+                            snapshotId,
+                            entry.getKey(),
+                            0,
+                            1,
+                            Collections.emptyList(),
+                            null,
+                            files,
+                            null,
+                            false);
+            RecordReaderIterator<InternalRow> iterator =
+                    new RecordReaderIterator<>(diffRead.createReader(split));
+            while (iterator.hasNext()) {
+                InternalRow row = iterator.next();
+                assertThat(row.getFieldCount()).isEqualTo(3);
+                // shopId INT, dt STRING(len 8), hr INT: misprojection would misplace types
+                assertThat(row.getString(1).toString()).hasSize(8);
+                row.getInt(0);
+                row.getInt(2);
+            }
+            iterator.close();
+        }
+    }
+
     private List<KeyValue> writeThenRead(
             List<KeyValue> data,
             RowType readKeyType,
@@ -274,6 +394,18 @@ public class MergeFileSplitReadTest {
             KeyValueFieldsExtractor extractor,
             MergeFunctionFactory<KeyValue> mfFactory)
             throws Exception {
+        return createStore(
+                partitionType, keyType, valueType, extractor, mfFactory, Collections.emptyMap());
+    }
+
+    private TestFileStore createStore(
+            RowType partitionType,
+            RowType keyType,
+            RowType valueType,
+            KeyValueFieldsExtractor extractor,
+            MergeFunctionFactory<KeyValue> mfFactory,
+            Map<String, String> options)
+            throws Exception {
         Path path = new Path(tempDir.toUri());
         SchemaManager schemaManager = new SchemaManager(FileIOFinder.find(path), path);
         boolean valueCountMode = mfFactory.create() instanceof TestValueCountMergeFunction;
@@ -293,7 +425,7 @@ public class MergeFileSplitReadTest {
                                                                                 "")),
                                                 partitionType.getFieldNames().stream())
                                         .collect(Collectors.toList()),
-                        Collections.emptyMap(),
+                        options,
                         null);
         TableSchema tableSchema = schemaManager.createTable(schema);
         return new TestFileStore.Builder(

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -91,6 +91,7 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -3590,13 +3591,22 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     private Table createMaskingAuthTable(
             Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
             throws Exception {
+        return createMaskingAuthTable(
+                identifier, fields, Collections.emptyList(), Collections.emptyList(), extraOptions);
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier,
+            List<DataField> fields,
+            List<String> partitionKeys,
+            List<String> primaryKeys,
+            Map<String, String> extraOptions)
+            throws Exception {
         catalog.createDatabase(identifier.getDatabaseName(), true);
         Map<String, String> options = new HashMap<>(extraOptions);
         options.put(QUERY_AUTH_ENABLED.key(), "true");
         catalog.createTable(
-                identifier,
-                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
-                true);
+                identifier, new Schema(fields, partitionKeys, primaryKeys, options, ""), true);
         return catalog.getTable(identifier);
     }
 
@@ -4398,6 +4408,51 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
     }
 
     @Test
+    void testColumnMaskingDisablesTopNPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_topn");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.INT()));
+        fields.add(new DataField(1, "source", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits with opposite raw/masked ordering
+        for (int[] row : new int[][] {{100, 0}, {50, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+
+        // display := source inverts the ordering the raw statistics suggest
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("display", new FieldTransform(new FieldRef(1, "source", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        TopN topN =
+                new TopN(new FieldRef(0, "display", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withTopN(topN);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+        // split pruning must not drop the split holding the real top row (1000)
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
     void testColumnMaskingReadingSystemField() throws Exception {
         Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
         List<DataField> fields = new ArrayList<>();
@@ -4469,6 +4524,312 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         assertThatThrownBy(() -> readBuilder.newScan().plan())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("does not project");
+    }
+
+    @Test
+    void testColumnMaskingDisablesFilterStatsPruning() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_stats");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two splits whose raw and masked values order oppositely
+        for (int[] row : new int[][] {{1, 1000}, {900, 10}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the predicate applies to masked values, with no engine help (no executeFilter):
+        // raw statistics must not prune the split whose masked value matches, and the
+        // raw-matching row must not come back
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(amountFilter);
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactly(1000);
+    }
+
+    @Test
+    void testMaskGrowthOnPushedFilterColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pushed_filter");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("display", "other"), Collections.emptyMap());
+        writeStringRow(table, "d1", "o1");
+
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("d1")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(new int[] {0}).withFilter(displayFilter);
+        TableScan scan = readBuilder.newScan();
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(scan.plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+
+        // a mask now covers the filter column
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // this scan already pruned with the column's raw statistics: it must fail closed
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recreate the scan");
+
+        // a fresh scan carries no raw pruning, and the existing reader evaluates the
+        // filter on the masked value: 'd1' no longer matches
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> masked =
+                collectRows(read.createReader(splits), table.rowType().project("display"));
+        assertThat(masked).isEmpty();
+    }
+
+    @Test
+    void testDeferredFilterAppliesToPartitionListing() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "filter_partition_listing");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "p", DataTypes.STRING()));
+        fields.add(new DataField(1, "v", DataTypes.STRING()));
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        fields,
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""),
+                true);
+        Table table = catalog.getTable(identifier);
+        writeStringRow(table, "a", "v1");
+        writeStringRow(table, "b", "v2");
+
+        LeafPredicate partitionFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        // partition listing bypasses plan(): the filter must still prune
+        assertThat(
+                        table.newReadBuilder()
+                                .withFilter(partitionFilter)
+                                .newScan()
+                                .listPartitionEntries())
+                .hasSize(1);
+    }
+
+    @Test
+    void testColumnMaskingDisablesLimitPushdown() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_limit");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "amount", DataTypes.INT()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        for (int[] row : new int[][] {{900, 10}, {1, 1000}}) {
+            BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+            BatchTableWrite write = writeBuilder.newWrite();
+            write.write(GenericRow.of(row[0], row[1]));
+            BatchTableCommit commit = writeBuilder.newCommit();
+            commit.commit(write.prepareCommit());
+            write.close();
+            commit.close();
+        }
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("amount", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the whole filter sits on the masked column: nothing is pushed down, but limit
+        // pruning must still know a read-time filter drops rows
+        LeafPredicate amountFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "amount", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(500));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0})
+                        .withFilter(amountFilter)
+                        .withLimit(1);
+        TableRead read = readBuilder.newRead().executeFilter();
+        List<InternalRow> rows =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("amount"));
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getInt(0))
+                                .collect(java.util.stream.Collectors.toList()))
+                .contains(1000);
+    }
+
+    @Test
+    void testFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_partition");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+
+        // the partition column is masked to another column's value
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // engines consume partition filters without re-evaluating them, so the read
+        // itself must evaluate this predicate, on the masked value
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        List<InternalRow> rows = readWithFilter(table, maskedMatch, "p", "v");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("vb");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+
+        // the raw partition value must not match: matching it would reveal the raw value
+        LeafPredicate rawMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("a")));
+        assertThat(readWithFilter(table, rawMatch, "p", "v")).isEmpty();
+
+        // filter column not projected: it is read and masked for the filter only, then
+        // projected back out
+        List<InternalRow> unprojected = readWithFilter(table, maskedMatch, "v");
+        assertThat(unprojected).hasSize(1);
+        assertThat(unprojected.get(0).getString(0).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testLimitWithFilterOnMaskedPartitionColumn() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_partition_limit");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("p", "v"),
+                        Collections.singletonList("p"),
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        writeStringRow(table, "a", "va");
+        writeStringRow(table, "b", "vb");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the filter is partition-only but sits on a masked column, so it drops rows at
+        // read time: limit pruning must not pick splits by raw row counts
+        LeafPredicate maskedMatch =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "p", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("vb")));
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withProjection(new int[] {0, 1})
+                        .withFilter(maskedMatch)
+                        .withLimit(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("p", "v"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("vb");
+    }
+
+    @Test
+    void testMaskedPkFilterNotAppliedOnRawValues() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_pk_filter");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "id", DataTypes.INT().notNull()));
+        fields.add(new DataField(1, "src", DataTypes.INT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        Collections.singletonMap(CoreOptions.BUCKET.key(), "1"));
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(1, 500));
+        write.write(GenericRow.of(2, 600));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put("id", new FieldTransform(new FieldRef(1, "src", DataTypes.INT())));
+        setColumnMasking(identifier, masking);
+
+        // the key filter matches a masked value only: key-range skipping inside the
+        // merge read must not drop the row by its raw key
+        LeafPredicate idFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(500));
+        List<InternalRow> rows = readWithFilter(table, idFilter, "id", "src");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getInt(0)).isEqualTo(500);
+    }
+
+    private List<InternalRow> readWithFilter(Table table, Predicate filter, String... projected)
+            throws Exception {
+        int[] projection = table.rowType().getFieldIndices(Arrays.asList(projected));
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withProjection(projection).withFilter(filter);
+        return collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType().project(projected));
     }
 
     private static void readFully(Table table) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -31,6 +31,8 @@ import org.apache.paimon.catalog.PropertyChange;
 import org.apache.paimon.consumer.ConsumerInfo;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
@@ -87,10 +89,13 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.SnapshotNotExistException;
 import org.apache.paimon.utils.StringUtils;
@@ -3580,6 +3585,897 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .isEqualTo("prefix-example"); // col4 masked with ConcatWsTransform
         assertThat(row2.getString(4).toString())
                 .isEqualTo("value"); // col5 NOT masked - original value
+    }
+
+    private Table createMaskingAuthTable(
+            Identifier identifier, List<DataField> fields, Map<String, String> extraOptions)
+            throws Exception {
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        Map<String, String> options = new HashMap<>(extraOptions);
+        options.put(QUERY_AUTH_ENABLED.key(), "true");
+        catalog.createTable(
+                identifier,
+                new Schema(fields, Collections.emptyList(), Collections.emptyList(), options, ""),
+                true);
+        return catalog.getTable(identifier);
+    }
+
+    private static List<DataField> stringFields(String... names) {
+        List<DataField> fields = new ArrayList<>();
+        for (int i = 0; i < names.length; i++) {
+            fields.add(new DataField(i, names[i], DataTypes.STRING()));
+        }
+        return fields;
+    }
+
+    private static void writeStringRows(Table table, String[]... rows) throws Exception {
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        for (String[] values : rows) {
+            Object[] converted = new Object[values.length];
+            for (int i = 0; i < values.length; i++) {
+                converted[i] = BinaryString.fromString(values[i]);
+            }
+            write.write(GenericRow.of(converted));
+        }
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+    }
+
+    private static void writeStringRow(Table table, String... values) throws Exception {
+        writeStringRows(table, values);
+    }
+
+    /** Cross-column mask: display := concat_ws('-', first, last). */
+    private void maskDisplayWithFullName(Identifier identifier) {
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first", DataTypes.STRING()),
+                                new FieldRef(1, "last", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+    }
+
+    /** Rows must be copied: the auth back-projection reuses one ProjectedRow per split. */
+    private static List<InternalRow> collectRows(RecordReader<InternalRow> reader, RowType rowType)
+            throws Exception {
+        List<InternalRow> rows = new ArrayList<>();
+        reader.forEachRemaining(row -> rows.add(InternalRowUtils.copyInternalRow(row, rowType)));
+        return rows;
+    }
+
+    @Test
+    void testColumnMaskingCrossColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_cross_column");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        // two rows in one commit -> one split with multiple rows
+        writeStringRows(
+                table,
+                new String[] {"john", "doe", "ignored", "o1"},
+                new String[] {"jane", "roe", "ignored", "o2"});
+        maskDisplayWithFullName(identifier);
+
+        // project only the masked target; its input columns are not selected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        assertThat(rows).hasSize(2);
+        for (InternalRow row : rows) {
+            assertThat(row.getFieldCount()).isEqualTo(1);
+        }
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingProjectionAcrossMultipleSplits() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_multi_split");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        // one file per split, so the scan below yields multiple splits
+                        Collections.singletonMap(
+                                CoreOptions.SOURCE_SPLIT_TARGET_SIZE.key(), "1 b"));
+        // two commits -> two splits; the widening must not leak state across splits
+        writeStringRow(table, "john", "doe", "ignored");
+        writeStringRow(table, "jane", "roe", "ignored");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        assertThat(splits.size()).isGreaterThan(1);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("display"));
+
+        List<String> values = new ArrayList<>();
+        for (InternalRow row : rows) {
+            // every split must be projected back to the query's arity
+            assertThat(row.getFieldCount()).isEqualTo(1);
+            values.add(row.getString(0).toString());
+        }
+        assertThat(values).containsExactlyInAnyOrder("john-doe", "jane-roe");
+    }
+
+    @Test
+    void testColumnMaskingOnRowFilterColumnWithProjection() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_filter_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display", "other"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret", "o1");
+
+        // the filter pulls unprojected "display" into the read type, activating its mask
+        LeafPredicate displayFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(2, "display", DataTypes.STRING())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(BinaryString.fromString("secret")));
+        setRowFilter(identifier, Collections.singletonList(displayFilter));
+        maskDisplayWithFullName(identifier);
+
+        // project only "other": the mask target and inputs are all unprojected
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {3});
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(splits),
+                        table.rowType().project("other"));
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("o1");
+    }
+
+    @Test
+    void testColumnMaskingRevokedOnSameTableRead() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revoked");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+        maskDisplayWithFullName(identifier);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked).hasSize(1);
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("john-doe");
+
+        // revoke the rules: the same TableRead must drop the widened read type
+        setColumnMasking(identifier, new HashMap<>());
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+    }
+
+    @Test
+    void testColumnMaskingGrantedAfterReadSchemaFixed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_granted");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "plain");
+
+        // first read without rules fixes the read schema to the projection
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {2});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("plain");
+
+        // a mask granted afterwards needs columns outside the fixed schema: fail closed
+        maskDisplayWithFullName(identifier);
+        List<Split> splits = readBuilder.newScan().plan().splits();
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        read.createReader(splits),
+                                        table.rowType().project("display")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recreate the reader");
+    }
+
+    @Test
+    void testColumnMaskingPreservesNestedProjection() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_nested");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        fields.add(new DataField(4, "extra", DataTypes.STRING()));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("ignored"),
+                        GenericRow.of(BinaryString.fromString("AV"), BinaryString.fromString("BV")),
+                        BinaryString.fromString("EX")));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // a nested-pruned read type, as engines push down
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+
+        // sanity: the nested-pruned read works without masking
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+
+        // mask "display" from unprojected "extra": widening must keep "s" pruned
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(4, "extra", DataTypes.STRING()))));
+        setColumnMasking(identifier, columnMasking);
+
+        readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        prunedReadType);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getFieldCount()).isEqualTo(2);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("EX");
+        assertThat(rows.get(0).getRow(1, 1).getString(0).toString()).isEqualTo("BV");
+    }
+
+    @Test
+    void testColumnMaskingStaleRuleFailsClosed() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_stale");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("first", "last", "display"),
+                        Collections.emptyMap());
+        writeStringRow(table, "john", "doe", "secret");
+
+        // mask target absent from the schema (e.g. renamed since the rule was written)
+        Map<String, Transform> staleTarget = new HashMap<>();
+        staleTarget.put(
+                "renamed_away",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, staleTarget);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // mask input absent from the schema
+        Map<String, Transform> staleInput = new HashMap<>();
+        staleInput.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "ghost", DataTypes.STRING()))));
+        setColumnMasking(identifier, staleInput);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRuleChangeOnRetainedColumn() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_retained");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "hidden_a", "hidden_b"),
+                        Collections.emptyMap());
+        writeStringRow(table, "d1", "a1", "b1");
+
+        // first rules widen and fix the read schema to [display, hidden_a]
+        Map<String, Transform> rules = new HashMap<>();
+        rules.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "hidden_a", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        TableRead read = readBuilder.newRead();
+        List<InternalRow> masked =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(masked.get(0).getString(0).toString()).isEqualTo("a1");
+
+        // the new rules mask only hidden_a, retained but unread: must not activate
+        rules.clear();
+        rules.put(
+                "hidden_a",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "hidden_b", DataTypes.STRING()))));
+        setColumnMasking(identifier, rules);
+        List<InternalRow> plain =
+                collectRows(
+                        read.createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(plain).hasSize(1);
+        assertThat(plain.get(0).getFieldCount()).isEqualTo(1);
+        assertThat(plain.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedMaskTarget() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_target");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask TARGETS the struct column "s" (reading another column)
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "s",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would write the mask into a partial slot: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingOnColumnAddedAfterSnapshot() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_time_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "display"), Collections.emptyMap());
+        writeStringRow(table, "john", "d1"); // snapshot 1
+
+        // add a column, then mask it: the rule is valid only in the latest schema
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("extra", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "extra",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the new column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows).hasSize(1);
+        assertThat(latestRows.get(0).getString(2).toString()).isEqualTo("****");
+
+        // a time-travel read of the old snapshot must not fail on the newer rule
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> oldRows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(oldRows).hasSize(1);
+        assertThat(oldRows.get(0).getString(0).toString()).isEqualTo("john");
+    }
+
+    @Test
+    void testColumnMaskingRenamedColumnTimeTravelFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_rename_travel");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1"); // snapshot 1, column named "secret"
+
+        // rename the column, then mask it under the new name
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "masked_secret")),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "masked_secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        // the latest read masks the renamed column
+        Table latest = catalog.getTable(identifier);
+        ReadBuilder latestRead = latest.newReadBuilder();
+        List<InternalRow> latestRows =
+                collectRows(
+                        latestRead.newRead().createReader(latestRead.newScan().plan().splits()),
+                        latest.rowType());
+        assertThat(latestRows.get(0).getString(1).toString()).isEqualTo("****");
+
+        // a time-travel read of the pre-rename snapshot exposes the same physical column
+        // as "secret"; the rule keyed on "masked_secret" would be silently skipped by name
+        // and leak the raw value -- it must fail closed instead
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        assertThatThrownBy(() -> oldRead.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("renamed");
+    }
+
+    @Test
+    void testColumnMaskingSystemTargetInertWhenUnprojected() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_target");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask on a system column the query does not project must be inert, not reject
+        // the whole query at plan time
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_ROW_ID",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        table.rowType().project("display"));
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("d1");
+    }
+
+    @Test
+    void testColumnMaskingInertTargetWithRenamedInputTimeTravel() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_inert_input");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "old_input"), Collections.emptyMap());
+        writeStringRow(table, "john", "in1"); // snapshot 1
+
+        // rename the input, then add a target column masked from the renamed input
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("old_input", "renamed_input")),
+                false);
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.addColumn("display", DataTypes.STRING())),
+                false);
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(1, "renamed_input", DataTypes.STRING())));
+        setColumnMasking(identifier, masking);
+
+        // the pre-rename snapshot predates "display": the mask cannot output there, so the
+        // rename of its input must not fail the read
+        Table old =
+                catalog.getTable(identifier)
+                        .copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "1"));
+        ReadBuilder oldRead = old.newReadBuilder();
+        List<InternalRow> rows =
+                collectRows(
+                        oldRead.newRead().createReader(oldRead.newScan().plan().splits()),
+                        old.rowType());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getString(0).toString()).isEqualTo("john");
+        assertThat(rows.get(0).getString(1).toString()).isEqualTo("in1");
+    }
+
+    @Test
+    void testColumnMaskingRevalidatedAfterRulesDisappear() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_revalidate");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+
+        // plan 1: a valid mask on "secret" is validated and cached
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        scan.plan();
+
+        // plan 2: rules disappear -- the cached validation must be forgotten
+        setColumnMasking(identifier, Collections.emptyMap());
+        scan.plan();
+
+        // the masked column is renamed away, then the identical rule is restored; a stale-rule
+        // cache short-circuit would skip re-validation and silently stop masking
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRenamedUnderLiveScanFailsClosed() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_live_rename");
+        Table table =
+                createMaskingAuthTable(
+                        identifier, stringFields("first", "secret"), Collections.emptyMap());
+        writeStringRow(table, "john", "s1");
+
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "secret",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+
+        StreamTableScan scan = table.newReadBuilder().newStreamScan();
+        scan.plan();
+
+        // the masked column is renamed while the rules stay identical: the live scan must
+        // notice on its next plan and fail closed, not keep planning on the stale rule
+        catalog.alterTable(
+                identifier,
+                Collections.singletonList(SchemaChange.renameColumn("secret", "hidden")),
+                false);
+        assertThatThrownBy(scan::plan)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+    }
+
+    @Test
+    void testColumnMaskingRejectsNestedPrunedRuleInput() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_pruned_input");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(
+                new DataField(
+                        1,
+                        "s",
+                        DataTypes.ROW(
+                                new DataField(2, "a", DataTypes.STRING()),
+                                new DataField(3, "b", DataTypes.STRING()))));
+        Table table = createMaskingAuthTable(identifier, fields, Collections.emptyMap());
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        GenericRow.of(
+                                BinaryString.fromString("AV"), BinaryString.fromString("BV"))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask on "display" reads the whole struct column "s"
+        RowType tableRowType = table.rowType();
+        DataField sField = tableRowType.getField("s");
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new CastTransform(new FieldRef(1, "s", sField.type()), DataTypes.STRING()));
+        setColumnMasking(identifier, masking);
+
+        // projecting "s" nested-pruned would hand the mask a partial struct: fail closed
+        RowType prunedS = ((RowType) sField.type()).project("b");
+        RowType prunedReadType =
+                new RowType(
+                        Arrays.asList(
+                                tableRowType.getField("display"),
+                                new DataField(sField.id(), "s", prunedS)));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(prunedReadType);
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        prunedReadType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pruned");
+    }
+
+    @Test
+    void testColumnMaskingWithDataEvolutionColumnFiles() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_data_evolution");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "f0", DataTypes.INT()));
+        fields.add(new DataField(1, "f1", DataTypes.STRING()));
+        fields.add(new DataField(2, "f2", DataTypes.STRING()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        // one row group split across two columnar files: (f0, f1) and (f2)
+        RowType tableRowType = table.rowType();
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write0 =
+                builder.newWrite().withWriteType(tableRowType.project("f0", "f1"))) {
+            write0.write(GenericRow.of(0, BinaryString.fromString("a0")));
+            write0.write(GenericRow.of(1, BinaryString.fromString("a1")));
+            builder.newCommit().commit(write0.prepareCommit());
+        }
+        long rowId = ((FileStoreTable) table).snapshotManager().latestSnapshot().nextRowId() - 2;
+        builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write1 =
+                builder.newWrite().withWriteType(tableRowType.project("f2"))) {
+            write1.write(GenericRow.of(BinaryString.fromString("b0")));
+            write1.write(GenericRow.of(BinaryString.fromString("b1")));
+            List<CommitMessage> commitables = write1.prepareCommit();
+            for (CommitMessage c : commitables) {
+                CommitMessageImpl message = (CommitMessageImpl) c;
+                List<DataFileMeta> newFiles =
+                        new ArrayList<>(message.newFilesIncrement().newFiles());
+                message.newFilesIncrement().newFiles().clear();
+                for (DataFileMeta file : newFiles) {
+                    message.newFilesIncrement().newFiles().add(file.assignFirstRowId(rowId));
+                }
+            }
+            builder.newCommit().commit(commitables);
+        }
+
+        // mask f1 from f2 and project only f1: the scan must keep f2's file
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "f1",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(2, "f2", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {1});
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        tableRowType.project("f1"));
+        assertThat(rows).hasSize(2);
+        assertThat(
+                        rows.stream()
+                                .map(row -> row.isNullAt(0) ? null : row.getString(0).toString())
+                                .collect(java.util.stream.Collectors.toList()))
+                .containsExactlyInAnyOrder("b0", "b1");
+    }
+
+    @Test
+    void testColumnMaskingRejectsUnprojectedBlobViewInput() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_blob_view");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.STRING()));
+        fields.add(new DataField(1, "image", DataTypes.BLOB()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.BLOB_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_FIELD.key(), "image");
+        options.put(CoreOptions.BLOB_VIEW_RESOLVE_ENABLED.key(), "true");
+        Table table = createMaskingAuthTable(identifier, fields, options);
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(
+                GenericRow.of(
+                        BinaryString.fromString("d1"),
+                        Blob.fromView(new BlobViewStruct(identifier, 1, 0L))));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the unprojected blob-view column: resolution cannot apply
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(1, "image", DataTypes.STRING()))));
+        setColumnMasking(identifier, masking);
+
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(
+                        () ->
+                                collectRows(
+                                        readBuilder
+                                                .newRead()
+                                                .createReader(
+                                                        readBuilder.newScan().plan().splits()),
+                                        table.rowType().project("display")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blob-view");
+    }
+
+    @Test
+    void testColumnMaskingReadingSystemField() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_table_masking_row_id");
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(0, "display", DataTypes.BIGINT()));
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        fields,
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        BatchTableWrite write = writeBuilder.newWrite();
+        write.write(GenericRow.of(42L));
+        BatchTableCommit commit = writeBuilder.newCommit();
+        commit.commit(write.prepareCommit());
+        write.close();
+        commit.close();
+
+        // the mask reads the projected _ROW_ID metadata field: not a stale rule
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+
+        RowType readType =
+                new RowType(
+                        Arrays.asList(
+                                table.rowType().getField("display"),
+                                org.apache.paimon.table.SpecialFields.ROW_ID));
+        ReadBuilder readBuilder = table.newReadBuilder().withReadType(readType);
+        List<InternalRow> rows =
+                collectRows(
+                        readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                        readType);
+        assertThat(rows).hasSize(1);
+        // display masked to the row id
+        assertThat(rows.get(0).getLong(0)).isEqualTo(rows.get(0).getLong(1));
+    }
+
+    @Test
+    void testColumnMaskingSystemFieldValidation() throws Exception {
+        Identifier identifier =
+                Identifier.create("test_table_db", "auth_table_masking_system_validation");
+        Table table =
+                createMaskingAuthTable(
+                        identifier,
+                        stringFields("display", "other"),
+                        Collections.singletonMap(CoreOptions.ROW_TRACKING_ENABLED.key(), "true"));
+        writeStringRow(table, "d1", "o1");
+
+        // a mask keyed by a key-reader-internal name is stale, not a system field
+        Map<String, Transform> masking = new HashMap<>();
+        masking.put(
+                "_KEY_display",
+                new ConcatTransform(Collections.singletonList(BinaryString.fromString("****"))));
+        setColumnMasking(identifier, masking);
+        assertThatThrownBy(() -> readFully(table))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not exist in table schema");
+
+        // a rule reading an unprojected system field fails clearly at plan time
+        masking.clear();
+        masking.put(
+                "display",
+                new FieldTransform(new FieldRef(0, "_ROW_ID", DataTypes.BIGINT().notNull())));
+        setColumnMasking(identifier, masking);
+        ReadBuilder readBuilder = table.newReadBuilder().withProjection(new int[] {0});
+        assertThatThrownBy(() -> readBuilder.newScan().plan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not project");
+    }
+
+    private static void readFully(Table table) throws Exception {
+        ReadBuilder readBuilder = table.newReadBuilder();
+        collectRows(
+                readBuilder.newRead().createReader(readBuilder.newScan().plan().splits()),
+                table.rowType());
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/LookupDataTableScan.java
@@ -64,6 +64,7 @@ public class LookupDataTableScan extends DataTableStreamScan {
             LookupStreamScanMode lookupScanMode) {
         super(
                 table.schema(),
+                table.schemaManager(),
                 table.coreOptions(),
                 snapshotReader,
                 table.snapshotManager(),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -366,6 +366,51 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
     }
 
     @Test
+    public void testColumnMaskingCrossColumnWithProjection() {
+        String maskingTable = "cross_column_masking_table";
+        batchSql(
+                String.format(
+                        "CREATE TABLE %s.%s (first_name STRING, last_name STRING, display STRING, other_col STRING)"
+                                + " WITH ('query-auth.enabled' = 'true', 'source.split.target-size' = '1 b')",
+                        DATABASE_NAME, maskingTable));
+        // two commits so the scan yields multiple splits
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('john', 'doe', 'ignored', 'o1')",
+                        DATABASE_NAME, maskingTable));
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('jane', 'roe', 'ignored', 'o2')",
+                        DATABASE_NAME, maskingTable));
+
+        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first_name", DataTypes.STRING()),
+                                new FieldRef(1, "last_name", DataTypes.STRING()))));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
+
+        // project only the masked target: its input columns must be read regardless
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT display FROM %s.%s", DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("john-doe"), Row.of("jane-roe"));
+        // a projection without the masked column is unaffected
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT other_col FROM %s.%s",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("o1"), Row.of("o2"));
+    }
+
+    @Test
     public void testRowFilter() {
         String filterTable = "row_filter_table";
         batchSql(
@@ -758,7 +803,8 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
                                                 "SELECT id, name FROM %s.%s WHERE age > 30 ORDER BY id",
                                                 DATABASE_NAME, combinedTable)))
                 .rootCause()
-                .hasMessageContaining("Unable to read data without column non_existent_column");
+                .hasMessageContaining(
+                        "Row filter references column 'non_existent_column' which does not exist");
 
         // Clear both column masking and row filter
         restCatalogServer.setColumnMaskingAuth(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RESTCatalogITCase.java
@@ -411,6 +411,48 @@ class RESTCatalogITCase extends RESTCatalogITCaseBase {
     }
 
     @Test
+    public void testFilterOnMaskedPartitionColumn() {
+        String maskingTable = "partition_masking_table";
+        batchSql(
+                String.format(
+                        "CREATE TABLE %s.%s (p STRING, v STRING) PARTITIONED BY (p)"
+                                + " WITH ('query-auth.enabled' = 'true')",
+                        DATABASE_NAME, maskingTable));
+        batchSql(
+                String.format(
+                        "INSERT INTO %s.%s VALUES ('a', 'va'), ('b', 'vb')",
+                        DATABASE_NAME, maskingTable));
+
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put("p", new FieldTransform(new FieldRef(1, "v", DataTypes.STRING())));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create(DATABASE_NAME, maskingTable), columnMasking);
+
+        // Flink consumes bounded partition filters without re-evaluating them, so the
+        // source itself must evaluate the predicate, on the masked value
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT p, v FROM %s.%s WHERE p = 'vb'",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("vb", "vb"));
+        // the raw partition value must not match
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT p, v FROM %s.%s WHERE p = 'a'",
+                                        DATABASE_NAME, maskingTable)))
+                .isEmpty();
+        // filter column not projected
+        assertThat(
+                        batchSql(
+                                String.format(
+                                        "SELECT v FROM %s.%s WHERE p = 'vb'",
+                                        DATABASE_NAME, maskingTable)))
+                .containsExactlyInAnyOrder(Row.of("vb"));
+    }
+
+    @Test
     public void testRowFilter() {
         String filterTable = "row_filter_table";
         batchSql(

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -400,6 +400,28 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testRowFilterDisablesAggregatePushdown() {
+        spark.sql(
+                "CREATE TABLE t_agg_pushdown (id INT) TBLPROPERTIES"
+                        + " ('query-auth.enabled'='true')");
+        spark.sql("INSERT INTO t_agg_pushdown VALUES (1), (2), (3)");
+
+        LeafPredicate idFilter =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        GreaterThan.INSTANCE,
+                        Collections.singletonList(1));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_agg_pushdown"),
+                Collections.singletonList(idFilter));
+
+        // statistics-based aggregate pushdown must not bypass the read-time row filter
+        // (today it degrades because auth splits are not DataSplits; this anchors that)
+        assertThat(spark.sql("SELECT COUNT(*) FROM t_agg_pushdown").collectAsList().toString())
+                .isEqualTo("[[2]]");
+    }
+
+    @Test
     public void testRowFilter() {
         spark.sql(
                 "CREATE TABLE t_row_filter (id INT, name STRING, age INT, department STRING) TBLPROPERTIES"

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -365,6 +365,41 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testColumnMaskingCrossColumnWithProjection() {
+        spark.sql(
+                "CREATE TABLE t_cross_column_masking (first_name STRING, last_name STRING, display STRING, other_col STRING)"
+                        + " TBLPROPERTIES ('query-auth.enabled'='true', 'source.split.target-size'='1 b')");
+        // two commits so the scan yields multiple splits
+        spark.sql("INSERT INTO t_cross_column_masking VALUES ('john', 'doe', 'ignored', 'o1')");
+        spark.sql("INSERT INTO t_cross_column_masking VALUES ('jane', 'roe', 'ignored', 'o2')");
+
+        // the mask on "display" reads OTHER columns: concat_ws('-', first_name, last_name)
+        Map<String, Transform> columnMasking = new HashMap<>();
+        columnMasking.put(
+                "display",
+                new ConcatWsTransform(
+                        Arrays.asList(
+                                BinaryString.fromString("-"),
+                                new FieldRef(0, "first_name", DataTypes.STRING()),
+                                new FieldRef(1, "last_name", DataTypes.STRING()))));
+        restCatalogServer.setColumnMaskingAuth(
+                Identifier.create("db2", "t_cross_column_masking"), columnMasking);
+
+        // project only the masked target: its input columns must be read regardless
+        assertThat(
+                        spark.sql("SELECT display FROM t_cross_column_masking ORDER BY other_col")
+                                .collectAsList()
+                                .toString())
+                .isEqualTo("[[john-doe], [jane-roe]]");
+        // a projection without the masked column is unaffected
+        assertThat(
+                        spark.sql("SELECT other_col FROM t_cross_column_masking ORDER BY other_col")
+                                .collectAsList()
+                                .toString())
+                .isEqualTo("[[o1], [o2]]");
+    }
+
+    @Test
     public void testRowFilter() {
         spark.sql(
                 "CREATE TABLE t_row_filter (id INT, name STRING, age INT, department STRING) TBLPROPERTIES"
@@ -863,7 +898,8 @@ public class SparkCatalogWithRestTest {
                                 spark.sql(
                                                 "SELECT id, name FROM t_combined WHERE age > 30 ORDER BY id")
                                         .collectAsList())
-                .hasMessageContaining("Unable to read data without column non_existent_column");
+                .hasMessageContaining(
+                        "Row filter references column 'non_existent_column' which does not exist");
 
         // Clear both column masking and row filter
         restCatalogServer.setColumnMaskingAuth(


### PR DESCRIPTION
  Stacked on #8570 — review the top commit only; will be rebased once #8570 merges.

  Purpose

  A column mask changes the value domain of its target column. A predicate on a masked column therefore evaluates on the masked value (view semantics, as in Snowflake/Ranger): matching the raw value would reveal
  it. This makes every optimization that consumes the column's raw values or raw statistics unsafe on masked columns — file/split pruning by min-max or partition value, TopN selection, limit pushdown, and
  reader-level row filtering would drop or leak rows relative to what the query is entitled to see. This is a pre-existing issue of the merged masking feature (#8447/#8458), independent of #8570.

  The design follows the pattern ReadBuilderImpl already uses for read-level TopN on query-auth.enabled tables: never hand unsafe state to the reader, rather than pushing it and retracting it later.

  - Scan side: the query filter is deferred to plan()/listPartitionEntries and pushed once through the two-argument SnapshotReader.withFilter — the full filter marks read-time filtering, while only the conjuncts
  free of masked columns feed statistics and partition pruning. Masked conjuncts (even partition-only ones) keep limit/TopN split pruning off; TopN split pruning also skips masked ordering columns. A mask
  appearing on an already-pushed filter column fails closed, since raw statistics were already consumed.
  - Read side: on query-auth.enabled tables the filter is stored (for executeFilter) but not forwarded to reader internals; engines re-evaluate data filters on the masked output. The conjuncts on masked columns
  are evaluated inside the auth read, post-mask — engines do not re-evaluate the partition filters they consumed. A masked filter column the query does not project is widened into the read schema (same machinery
  as mask inputs in #8570) and projected back out.

  Scoped to query-auth.enabled tables: they conservatively lose reader-level filter pushdown even without mask rules, matching the existing read-level TopN behavior; scan-level pruning on safe conjuncts is
  retained. Tables without query auth are unaffected.

  Tests

  - MockRESTCatalogTest: filter on a masked partition column (projected and unprojected; engines consume partition filters, so the read must evaluate them), raw-value match returns nothing, limit with a masked
  partition-only filter, masked pk filter not applied on raw key ranges, mask growth on a pushed filter column fails the scan closed while a fresh scan + existing reader return masked-correct results,
  TopN/limit/stats-pruning disablement.
  - Flink RESTCatalogITCase: partition-column mask + WHERE on it through SQL (the consumed-filter path).
  - Spark SparkCatalogWithRestTest: statistics-based aggregate pushdown degrades on authed reads (regression anchor).