### PR TITLE
[flink] size aware partitioner for full compaction job

### DIFF
--- a/docs/generated/flink_connector_configuration.html
+++ b/docs/generated/flink_connector_configuration.html
@@ -27,6 +27,12 @@ under the License.
     </thead>
     <tbody>
         <tr>
+            <td><h5>compaction.bucket-distribution-strategy</h5></td>
+            <td style="word-wrap: break-word;">linear</td>
+            <td><p>Enum</p></td>
+            <td>Defines how dedicated bucket compaction jobs distribute compact buckets to writers. 'linear' uses the existing stable partition-plus-bucket mapping. 'size-aware-batch' assigns bounded full-compaction bucket splits by total data file size and forwards them to writers to reduce compaction long tail.<br /><br />Possible values:<ul><li>"linear": Distribute compact buckets by the existing stable partition-plus-bucket channel mapping.</li><li>"size-aware-batch": For bounded full compaction, assign compact bucket splits by total data file size and forward them to writers to reduce long-tail compaction tasks.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>changelog.precommit-compact.thread-num</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -84,6 +84,16 @@ public class FlinkConnectorOptions {
                                     + "This eliminates data transfer overhead when the source already "
                                     + "provides suitable data distribution (e.g., Kafka partitions).");
 
+    public static final ConfigOption<CompactionBucketDistributionStrategy>
+            COMPACTION_BUCKET_DISTRIBUTION_STRATEGY =
+                    ConfigOptions.key("compaction.bucket-distribution-strategy")
+                            .enumType(CompactionBucketDistributionStrategy.class)
+                            .defaultValue(CompactionBucketDistributionStrategy.LINEAR)
+                            .withDescription(
+                                    "Defines how dedicated bucket compaction jobs distribute compact buckets to writers. "
+                                            + "'linear' uses the existing stable partition-plus-bucket mapping. "
+                                            + "'size-aware-batch' assigns bounded full-compaction bucket splits by total data file size and forwards them to writers to reduce compaction long tail.");
+
     public static final ConfigOption<Boolean> INFER_SCAN_PARALLELISM =
             ConfigOptions.key("scan.infer-parallelism")
                     .booleanType()

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkConnectorOptions.java
@@ -640,6 +640,34 @@ public class FlinkConnectorOptions {
         }
     }
 
+    /** Bucket distribution strategy for dedicated compaction jobs. */
+    public enum CompactionBucketDistributionStrategy implements DescribedEnum {
+        LINEAR(
+                "linear",
+                "Distribute compact buckets by the existing stable partition-plus-bucket channel mapping."),
+        SIZE_AWARE_BATCH(
+                "size-aware-batch",
+                "For bounded full compaction, assign compact bucket splits by total data file size and forward them to writers to reduce long-tail compaction tasks.");
+
+        private final String value;
+        private final String description;
+
+        CompactionBucketDistributionStrategy(String value, String description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return text(description);
+        }
+    }
+
     /**
      * Split assign mode for {@link org.apache.paimon.flink.source.StaticFileStoreSplitEnumerator}.
      */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactAction.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
 import org.apache.paimon.flink.compact.AppendTableCompact;
 import org.apache.paimon.flink.compact.DataEvolutionTableCompact;
 import org.apache.paimon.flink.compact.IncrementalClusterCompact;
@@ -159,6 +160,20 @@ public class CompactAction extends TableActionBase {
         return true;
     }
 
+    static CompactionBucketDistributionStrategy compactionBucketDistributionStrategy(
+            FileStoreTable table, boolean fullCompaction, boolean isStreaming) {
+        return compactionBucketDistributionStrategy(
+                table.coreOptions().toConfiguration(), fullCompaction, isStreaming);
+    }
+
+    static CompactionBucketDistributionStrategy compactionBucketDistributionStrategy(
+            Options options, boolean fullCompaction, boolean isStreaming) {
+        if (!fullCompaction || isStreaming) {
+            return CompactionBucketDistributionStrategy.LINEAR;
+        }
+        return options.get(FlinkConnectorOptions.COMPACTION_BUCKET_DISTRIBUTION_STRATEGY);
+    }
+
     protected void buildForBucketedTableCompact(
             StreamExecutionEnvironment env, FileStoreTable table, boolean isStreaming)
             throws Exception {
@@ -185,9 +200,14 @@ public class CompactAction extends TableActionBase {
                     };
             table = table.copy(dynamicOptions);
         }
+        CompactionBucketDistributionStrategy bucketDistributionStrategy =
+                compactionBucketDistributionStrategy(table, fullCompaction, isStreaming);
         CompactorSourceBuilder sourceBuilder =
-                new CompactorSourceBuilder(identifier.getFullName(), table);
-        CompactorSinkBuilder sinkBuilder = new CompactorSinkBuilder(table, fullCompaction);
+                new CompactorSourceBuilder(identifier.getFullName(), table)
+                        .withBucketDistributionStrategy(bucketDistributionStrategy);
+        CompactorSinkBuilder sinkBuilder =
+                new CompactorSinkBuilder(table, fullCompaction)
+                        .withBucketDistributionStrategy(bucketDistributionStrategy);
 
         sourceBuilder.withPartitionPredicate(getPartitionPredicate());
         DataStreamSource<RowData> source =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CompactDatabaseAction.java
@@ -23,6 +23,7 @@ import org.apache.paimon.append.MultiTableAppendCompactTask;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
 import org.apache.paimon.flink.compact.AppendTableCompact;
 import org.apache.paimon.flink.sink.BucketsRowChannelComputer;
 import org.apache.paimon.flink.sink.CombinedTableCompactorSink;
@@ -266,10 +267,16 @@ public class CompactDatabaseAction extends ActionBase {
             table = table.copy(dynamicOptions);
         }
 
+        CompactionBucketDistributionStrategy bucketDistributionStrategy =
+                CompactAction.compactionBucketDistributionStrategy(
+                        table, fullCompaction, isStreaming);
         CompactorSourceBuilder sourceBuilder =
                 new CompactorSourceBuilder(fullName, table)
-                        .withPartitionIdleTime(partitionIdleTime);
-        CompactorSinkBuilder sinkBuilder = new CompactorSinkBuilder(table, fullCompaction);
+                        .withPartitionIdleTime(partitionIdleTime)
+                        .withBucketDistributionStrategy(bucketDistributionStrategy);
+        CompactorSinkBuilder sinkBuilder =
+                new CompactorSinkBuilder(table, fullCompaction)
+                        .withBucketDistributionStrategy(bucketDistributionStrategy);
 
         DataStreamSource<RowData> source =
                 sourceBuilder.withEnv(env).withContinuousMode(isStreaming).build();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -19,15 +19,18 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.table.data.RowData;
 
 import java.util.Optional;
 
+import static org.apache.paimon.flink.sink.FlinkSink.createCommitUser;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
 
 /** Builder for {@link CompactorSink}. */
@@ -39,6 +42,9 @@ public class CompactorSinkBuilder {
 
     private final boolean fullCompaction;
 
+    private CompactionBucketDistributionStrategy bucketDistributionStrategy =
+            CompactionBucketDistributionStrategy.LINEAR;
+
     public CompactorSinkBuilder(FileStoreTable table, boolean fullCompaction) {
         this.table = table;
         this.fullCompaction = fullCompaction;
@@ -46,6 +52,12 @@ public class CompactorSinkBuilder {
 
     public CompactorSinkBuilder withInput(DataStream<RowData> input) {
         this.input = input;
+        return this;
+    }
+
+    public CompactorSinkBuilder withBucketDistributionStrategy(
+            CompactionBucketDistributionStrategy bucketDistributionStrategy) {
+        this.bucketDistributionStrategy = bucketDistributionStrategy;
         return this;
     }
 
@@ -66,8 +78,19 @@ public class CompactorSinkBuilder {
                                 table.options().get(FlinkConnectorOptions.SINK_PARALLELISM.key()))
                         .map(Integer::valueOf)
                         .orElse(null);
-        DataStream<RowData> partitioned =
-                partition(input, new BucketsRowChannelComputer(), parallelism);
-        return new CompactorSink(table, fullCompaction).sinkFrom(partitioned);
+        switch (bucketDistributionStrategy) {
+            case SIZE_AWARE_BATCH:
+                CompactorSink sink = new CompactorSink(table, fullCompaction);
+                String commitUser = createCommitUser(table.coreOptions().toConfiguration());
+                DataStream<Committable> written = sink.doWrite(input, commitUser, null);
+                return sink.doCommit(
+                        ((SingleOutputStreamOperator<Committable>) written).startNewChain(),
+                        commitUser);
+            case LINEAR:
+            default:
+                DataStream<RowData> partitioned =
+                        partition(input, new BucketsRowChannelComputer(), parallelism);
+                return new CompactorSink(table, fullCompaction).sinkFrom(partitioned);
+        }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/CompactorSinkBuilder.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.data.RowData;
 
 import java.util.Optional;
 
-import static org.apache.paimon.flink.sink.FlinkSink.createCommitUser;
+import static org.apache.paimon.CoreOptions.createCommitUser;
 import static org.apache.paimon.flink.sink.FlinkStreamPartitioner.partition;
 
 /** Builder for {@link CompactorSink}. */

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -22,6 +22,7 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
+import org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
 import org.apache.paimon.flink.LogicalTypeConversion;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
@@ -106,11 +107,14 @@ public class CompactorSourceBuilder {
             return new ContinuousFileStoreSource(readBuilder, compactBucketsTable.options(), null);
         } else {
             Options options = compactBucketsTable.coreOptions().toConfiguration();
+            SplitAssignMode splitAssignMode =
+                    options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE);
+            validateBucketDistributionStrategy(bucketDistributionStrategy, splitAssignMode);
             return new StaticFileStoreSource(
                     readBuilder,
                     null,
                     options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
-                    options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE),
+                    splitAssignMode,
                     bucketDistributionStrategy
                                     == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
                             ? split -> bucketFileSize((DataSplit) split.split())
@@ -221,6 +225,20 @@ public class CompactorSourceBuilder {
             CompactionBucketDistributionStrategy bucketDistributionStrategy) {
         this.bucketDistributionStrategy = bucketDistributionStrategy;
         return this;
+    }
+
+    static void validateBucketDistributionStrategy(
+            CompactionBucketDistributionStrategy bucketDistributionStrategy,
+            SplitAssignMode splitAssignMode) {
+        if (bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
+                && splitAssignMode == SplitAssignMode.PREEMPTIVE) {
+            throw new IllegalArgumentException(
+                    "compaction.bucket-distribution-strategy=size-aware-batch requires "
+                            + "scan.split-enumerator.mode=fair because it relies on grouped "
+                            + "bucket assignment. Preemptive split assignment can split the "
+                            + "same bucket across different writers while the sink skips "
+                            + "bucket shuffle.");
+        }
     }
 
     static Integer sourceParallelism(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -21,12 +21,14 @@ package org.apache.paimon.flink.source;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
 import org.apache.paimon.flink.LogicalTypeConversion;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.partition.PartitionValuesTimeExpireStrategy;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.system.CompactBucketsTable;
 import org.apache.paimon.types.RowType;
@@ -65,6 +67,9 @@ public class CompactorSourceBuilder {
     private StreamExecutionEnvironment env;
     @Nullable private PartitionPredicate partitionPredicate = null;
     @Nullable private Duration partitionIdleTime = null;
+
+    private CompactionBucketDistributionStrategy bucketDistributionStrategy =
+            CompactionBucketDistributionStrategy.LINEAR;
 
     public CompactorSourceBuilder(String tableIdentifier, FileStoreTable table) {
         this.tableIdentifier = tableIdentifier;
@@ -106,6 +111,12 @@ public class CompactorSourceBuilder {
                     null,
                     options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
                     options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE),
+                    bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
+                            ? split -> bucketFileSize((DataSplit) split.split())
+                            : null,
+                    bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
+                            ? split -> bucketKey((DataSplit) split.split())
+                            : null,
                     options.get(CoreOptions.BLOB_AS_DESCRIPTOR));
         }
     }
@@ -162,8 +173,7 @@ public class CompactorSourceBuilder {
                             });
             dataStream = new DataStreamSource<>(filterStream);
         }
-        Integer parallelism =
-                Options.fromMap(table.options()).get(FlinkConnectorOptions.SCAN_PARALLELISM);
+        Integer parallelism = sourceParallelism(Options.fromMap(table.options()), bucketDistributionStrategy);
         if (parallelism != null) {
             dataStream.setParallelism(parallelism);
         }
@@ -202,6 +212,56 @@ public class CompactorSourceBuilder {
             @Nullable PartitionPredicate partitionPredicate) {
         this.partitionPredicate = partitionPredicate;
         return this;
+    }
+
+    public CompactorSourceBuilder withBucketDistributionStrategy(
+            CompactionBucketDistributionStrategy bucketDistributionStrategy) {
+        this.bucketDistributionStrategy = bucketDistributionStrategy;
+        return this;
+    }
+
+    static Integer sourceParallelism(
+            Options tableOptions, CompactionBucketDistributionStrategy bucketDistributionStrategy) {
+        Integer parallelism = tableOptions.get(FlinkConnectorOptions.SCAN_PARALLELISM);
+        if (bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH) {
+            Integer sinkParallelism = tableOptions.get(FlinkConnectorOptions.SINK_PARALLELISM);
+            if (sinkParallelism != null) {
+                parallelism = sinkParallelism;
+            }
+        }
+        return parallelism;
+    }
+
+    static long bucketFileSize(DataSplit split) {
+        return split.dataFiles().stream().mapToLong(dataFile -> dataFile.fileSize()).sum();
+    }
+
+    static BucketKey bucketKey(DataSplit split) {
+        return new BucketKey(split.partition(), split.bucket());
+    }
+
+    static class BucketKey {
+        private final BinaryRow partition;
+        private final int bucket;
+
+        private BucketKey(BinaryRow partition, int bucket) {
+            this.partition = partition.copy();
+            this.bucket = bucket;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof BucketKey)) {
+                return false;
+            }
+            BucketKey that = (BucketKey) o;
+            return bucket == that.bucket && partition.equals(that.partition);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * partition.hashCode() + bucket;
+        }
     }
 
     private Map<BinaryRow, Long> getPartitionInfo(CompactBucketsTable table) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -111,10 +111,12 @@ public class CompactorSourceBuilder {
                     null,
                     options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_BATCH_SIZE),
                     options.get(FlinkConnectorOptions.SCAN_SPLIT_ENUMERATOR_ASSIGN_MODE),
-                    bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
+                    bucketDistributionStrategy
+                                    == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
                             ? split -> bucketFileSize((DataSplit) split.split())
                             : null,
-                    bucketDistributionStrategy == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
+                    bucketDistributionStrategy
+                                    == CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH
                             ? split -> bucketKey((DataSplit) split.split())
                             : null,
                     options.get(CoreOptions.BLOB_AS_DESCRIPTOR));
@@ -173,7 +175,8 @@ public class CompactorSourceBuilder {
                             });
             dataStream = new DataStreamSource<>(filterStream);
         }
-        Integer parallelism = sourceParallelism(Options.fromMap(table.options()), bucketDistributionStrategy);
+        Integer parallelism =
+                sourceParallelism(Options.fromMap(table.options()), bucketDistributionStrategy);
         if (parallelism != null) {
             dataStream.setParallelism(parallelism);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/CompactorSourceBuilder.java
@@ -134,12 +134,21 @@ public class CompactorSourceBuilder {
 
         CompactBucketsTable compactBucketsTable = new CompactBucketsTable(table, isContinuous);
         RowType produceType = compactBucketsTable.rowType();
+        Integer parallelism =
+                sourceParallelism(Options.fromMap(table.options()), bucketDistributionStrategy);
         DataStreamSource<RowData> dataStream =
                 env.fromSource(
                         buildSource(compactBucketsTable),
                         WatermarkStrategy.noWatermarks(),
                         tableIdentifier + "-compact-source",
                         InternalTypeInfo.of(LogicalTypeConversion.toLogicalType(produceType)));
+        if (parallelism != null) {
+            // Size-aware assignment depends on source-reader to writer alignment. Set the
+            // parallelism on the original source before adding downstream filters; otherwise the
+            // configured parallelism may only apply to a filter and source-to-filter redistribution
+            // could break grouped bucket assignment.
+            dataStream.setParallelism(parallelism);
+        }
         if (isContinuous) {
             Preconditions.checkArgument(
                     partitionIdleTime == null, "Streaming mode does not support partitionIdleTime");
@@ -157,6 +166,9 @@ public class CompactorSourceBuilder {
                                 BinaryRow partition = deserializeBinaryRow(rowData.getBinary(1));
                                 return partitionInfo.get(partition) <= historyMilli;
                             });
+            if (parallelism != null) {
+                filterStream.setParallelism(parallelism);
+            }
             dataStream = new DataStreamSource<>(filterStream);
         }
         CoreOptions coreOptions = table.coreOptions();
@@ -177,12 +189,10 @@ public class CompactorSourceBuilder {
                                 BinaryRow partition = deserializeBinaryRow(rowData.getBinary(1));
                                 return !expireStrategy.isExpired(expireDateTime, partition);
                             });
+            if (parallelism != null) {
+                filterStream.setParallelism(parallelism);
+            }
             dataStream = new DataStreamSource<>(filterStream);
-        }
-        Integer parallelism =
-                sourceParallelism(Options.fromMap(table.options()), bucketDistributionStrategy);
-        if (parallelism != null) {
-            dataStream.setParallelism(parallelism);
         }
         return dataStream;
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -27,6 +27,7 @@ import org.apache.paimon.table.ChainGroupReadTable;
 import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
@@ -50,6 +51,10 @@ public class StaticFileStoreSource extends FlinkSource {
 
     @Nullable private final DynamicPartitionFilteringInfo dynamicPartitionFilteringInfo;
 
+    @Nullable private final SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc;
+
+    @Nullable private final SerializableFunction<FileStoreSourceSplit, ?> splitGroupFunc;
+
     private final boolean skipPreloadTargetSnapshot;
 
     public StaticFileStoreSource(
@@ -65,6 +70,8 @@ public class StaticFileStoreSource extends FlinkSource {
                 splitAssignMode,
                 null,
                 null,
+                null,
+                null,
                 blobAsDescriptor,
                 false);
     }
@@ -78,10 +85,57 @@ public class StaticFileStoreSource extends FlinkSource {
             @Nullable NestedProjectedRowData rowData,
             boolean blobAsDescriptor,
             boolean skipPreloadTargetSnapshot) {
+        this(
+                readBuilder,
+                limit,
+                splitBatchSize,
+                splitAssignMode,
+                dynamicPartitionFilteringInfo,
+                rowData,
+                null,
+                null,
+                blobAsDescriptor,
+                skipPreloadTargetSnapshot);
+    }
+
+    public StaticFileStoreSource(
+            ReadBuilder readBuilder,
+            @Nullable Long limit,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            @Nullable SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> splitGroupFunc,
+            boolean blobAsDescriptor) {
+        this(
+                readBuilder,
+                limit,
+                splitBatchSize,
+                splitAssignMode,
+                null,
+                null,
+                splitWeightFunc,
+                splitGroupFunc,
+                blobAsDescriptor,
+                false);
+    }
+
+    public StaticFileStoreSource(
+            ReadBuilder readBuilder,
+            @Nullable Long limit,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            @Nullable DynamicPartitionFilteringInfo dynamicPartitionFilteringInfo,
+            @Nullable NestedProjectedRowData rowData,
+            @Nullable SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> splitGroupFunc,
+            boolean blobAsDescriptor,
+            boolean skipPreloadTargetSnapshot) {
         super(readBuilder, limit, rowData, blobAsDescriptor);
         this.splitBatchSize = splitBatchSize;
         this.splitAssignMode = splitAssignMode;
         this.dynamicPartitionFilteringInfo = dynamicPartitionFilteringInfo;
+        this.splitWeightFunc = splitWeightFunc;
+        this.splitGroupFunc = splitGroupFunc;
         this.skipPreloadTargetSnapshot = skipPreloadTargetSnapshot;
     }
 
@@ -97,7 +151,13 @@ public class StaticFileStoreSource extends FlinkSource {
         Collection<FileStoreSourceSplit> splits =
                 checkpoint == null ? getSplits(context) : checkpoint.splits();
         SplitAssigner splitAssigner =
-                createSplitAssigner(context, splitBatchSize, splitAssignMode, splits);
+                createSplitAssigner(
+                        context,
+                        splitBatchSize,
+                        splitAssignMode,
+                        splits,
+                        splitWeightFunc,
+                        splitGroupFunc);
         return new StaticFileStoreSplitEnumerator(
                 context, null, splitAssigner, dynamicPartitionFilteringInfo);
     }
@@ -121,9 +181,20 @@ public class StaticFileStoreSource extends FlinkSource {
             int splitBatchSize,
             SplitAssignMode splitAssignMode,
             Collection<FileStoreSourceSplit> splits) {
+        return createSplitAssigner(context, splitBatchSize, splitAssignMode, splits, null, null);
+    }
+
+    public static SplitAssigner createSplitAssigner(
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            Collection<FileStoreSourceSplit> splits,
+            @Nullable SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> splitGroupFunc) {
         switch (splitAssignMode) {
             case FAIR:
-                return new PreAssignSplitAssigner(splitBatchSize, context, splits);
+                return new PreAssignSplitAssigner(
+                        splitBatchSize, context, splits, splitWeightFunc, splitGroupFunc);
             case PREEMPTIVE:
                 return new FIFOSplitAssigner(splits);
             default:

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/StaticFileStoreSource.java
@@ -189,6 +189,16 @@ public class StaticFileStoreSource extends FlinkSource {
             int splitBatchSize,
             SplitAssignMode splitAssignMode,
             Collection<FileStoreSourceSplit> splits,
+            @Nullable SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc) {
+        return createSplitAssigner(
+                context, splitBatchSize, splitAssignMode, splits, splitWeightFunc, null);
+    }
+
+    public static SplitAssigner createSplitAssigner(
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            int splitBatchSize,
+            SplitAssignMode splitAssignMode,
+            Collection<FileStoreSourceSplit> splits,
             @Nullable SerializableFunction<FileStoreSourceSplit, Long> splitWeightFunc,
             @Nullable SerializableFunction<FileStoreSourceSplit, ?> splitGroupFunc) {
         switch (splitAssignMode) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
@@ -141,10 +141,10 @@ public class PreAssignSplitAssigner implements SplitAssigner {
         this.splitBatchSize = splitBatchSize;
         this.parallelism = parallelism;
         this.splits = splits;
-        this.weightFunc = weightFunc;
+        this.weightFunc = weightFunc == null ? split -> split.split().rowCount() : weightFunc;
         this.groupFunc = groupFunc;
         this.pendingSplitAssignment =
-                createBatchFairSplitAssignment(splits, parallelism, weightFunc, groupFunc);
+                createBatchFairSplitAssignment(splits, parallelism, this.weightFunc, groupFunc);
         this.numberOfPendingSplits = new AtomicInteger(splits.size());
     }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
@@ -24,6 +24,7 @@ import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.utils.BinPacking;
+import org.apache.paimon.utils.SerializableFunction;
 
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.table.connector.source.DynamicFilteringData;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -59,12 +61,31 @@ public class PreAssignSplitAssigner implements SplitAssigner {
 
     private final AtomicInteger numberOfPendingSplits;
     private final Collection<FileStoreSourceSplit> splits;
+    private final SerializableFunction<FileStoreSourceSplit, Long> weightFunc;
+    @Nullable private final SerializableFunction<FileStoreSourceSplit, ?> groupFunc;
 
     public PreAssignSplitAssigner(
             int splitBatchSize,
             SplitEnumeratorContext<FileStoreSourceSplit> context,
             Collection<FileStoreSourceSplit> splits) {
         this(splitBatchSize, context.currentParallelism(), splits);
+    }
+
+    public PreAssignSplitAssigner(
+            int splitBatchSize,
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            Collection<FileStoreSourceSplit> splits,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc) {
+        this(splitBatchSize, context.currentParallelism(), splits, weightFunc);
+    }
+
+    public PreAssignSplitAssigner(
+            int splitBatchSize,
+            SplitEnumeratorContext<FileStoreSourceSplit> context,
+            Collection<FileStoreSourceSplit> splits,
+            @Nullable SerializableFunction<FileStoreSourceSplit, Long> weightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> groupFunc) {
+        this(splitBatchSize, context.currentParallelism(), splits, weightFunc, groupFunc);
     }
 
     public PreAssignSplitAssigner(
@@ -76,17 +97,54 @@ public class PreAssignSplitAssigner implements SplitAssigner {
         this(
                 splitBatchSize,
                 parallelism,
+                splits,
+                partitionRowProjection,
+                dynamicFilteringData,
+                split -> split.split().rowCount());
+    }
+
+    public PreAssignSplitAssigner(
+            int splitBatchSize,
+            int parallelism,
+            Collection<FileStoreSourceSplit> splits,
+            Projection partitionRowProjection,
+            DynamicFilteringData dynamicFilteringData,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc) {
+        this(
+                splitBatchSize,
+                parallelism,
                 splits.stream()
                         .filter(s -> filter(partitionRowProjection, dynamicFilteringData, s))
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),
+                weightFunc);
     }
 
     public PreAssignSplitAssigner(
             int splitBatchSize, int parallelism, Collection<FileStoreSourceSplit> splits) {
+        this(splitBatchSize, parallelism, splits, split -> split.split().rowCount());
+    }
+
+    public PreAssignSplitAssigner(
+            int splitBatchSize,
+            int parallelism,
+            Collection<FileStoreSourceSplit> splits,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc) {
+        this(splitBatchSize, parallelism, splits, weightFunc, null);
+    }
+
+    public PreAssignSplitAssigner(
+            int splitBatchSize,
+            int parallelism,
+            Collection<FileStoreSourceSplit> splits,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> groupFunc) {
         this.splitBatchSize = splitBatchSize;
         this.parallelism = parallelism;
         this.splits = splits;
-        this.pendingSplitAssignment = createBatchFairSplitAssignment(splits, parallelism);
+        this.weightFunc = weightFunc;
+        this.groupFunc = groupFunc;
+        this.pendingSplitAssignment =
+                createBatchFairSplitAssignment(splits, parallelism, weightFunc, groupFunc);
         this.numberOfPendingSplits = new AtomicInteger(splits.size());
     }
 
@@ -132,16 +190,75 @@ public class PreAssignSplitAssigner implements SplitAssigner {
      * this method only reload restore for batch execute, because in streaming mode, we need to
      * assign certain bucket to certain task.
      */
-    private static Map<Integer, LinkedList<FileStoreSourceSplit>> createBatchFairSplitAssignment(
-            Collection<FileStoreSourceSplit> splits, int numReaders) {
-        List<List<FileStoreSourceSplit>> assignmentList =
-                BinPacking.packForFixedBinNumber(
-                        splits, split -> split.split().rowCount(), numReaders);
+    public static Map<Integer, LinkedList<FileStoreSourceSplit>> createBatchFairSplitAssignment(
+            Collection<FileStoreSourceSplit> splits,
+            int numReaders,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc) {
+        return createBatchFairSplitAssignment(splits, numReaders, weightFunc, null);
+    }
+
+    public static Map<Integer, LinkedList<FileStoreSourceSplit>> createBatchFairSplitAssignment(
+            Collection<FileStoreSourceSplit> splits,
+            int numReaders,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc,
+            @Nullable SerializableFunction<FileStoreSourceSplit, ?> groupFunc) {
+        List<List<FileStoreSourceSplit>> assignmentList;
+        if (groupFunc == null) {
+            assignmentList = BinPacking.packForFixedBinNumber(splits, weightFunc, numReaders);
+        } else {
+            List<GroupedSplit> groupedSplits = groupSplits(splits, weightFunc, groupFunc);
+            List<List<GroupedSplit>> groupedAssignment =
+                    BinPacking.packForFixedBinNumber(groupedSplits, GroupedSplit::weight, numReaders);
+            assignmentList =
+                    groupedAssignment.stream()
+                            .map(
+                                    group ->
+                                            group.stream()
+                                                    .flatMap(groupedSplit -> groupedSplit.splits().stream())
+                                                    .collect(Collectors.toList()))
+                            .collect(Collectors.toList());
+        }
         Map<Integer, LinkedList<FileStoreSourceSplit>> assignment = new HashMap<>();
         for (int i = 0; i < assignmentList.size(); i++) {
             assignment.put(i, new LinkedList<>(assignmentList.get(i)));
         }
         return assignment;
+    }
+
+    private static List<GroupedSplit> groupSplits(
+            Collection<FileStoreSourceSplit> splits,
+            SerializableFunction<FileStoreSourceSplit, Long> weightFunc,
+            SerializableFunction<FileStoreSourceSplit, ?> groupFunc) {
+        Map<Object, List<FileStoreSourceSplit>> grouped = new HashMap<>();
+        for (FileStoreSourceSplit split : splits) {
+            grouped.computeIfAbsent(Objects.requireNonNull(groupFunc.apply(split)), ignored -> new ArrayList<>())
+                    .add(split);
+        }
+        return grouped.values().stream()
+                .map(
+                        group ->
+                                new GroupedSplit(
+                                        group,
+                                        group.stream().mapToLong(weightFunc::apply).sum()))
+                .collect(Collectors.toList());
+    }
+
+    private static class GroupedSplit {
+        private final List<FileStoreSourceSplit> splits;
+        private final long weight;
+
+        private GroupedSplit(List<FileStoreSourceSplit> splits, long weight) {
+            this.splits = splits;
+            this.weight = weight;
+        }
+
+        private List<FileStoreSourceSplit> splits() {
+            return splits;
+        }
+
+        private long weight() {
+            return weight;
+        }
     }
 
     @Override
@@ -160,7 +277,12 @@ public class PreAssignSplitAssigner implements SplitAssigner {
     public SplitAssigner ofDynamicPartitionPruning(
             Projection partitionRowProjection, DynamicFilteringData dynamicFilteringData) {
         return new PreAssignSplitAssigner(
-                splitBatchSize, parallelism, splits, partitionRowProjection, dynamicFilteringData);
+                splitBatchSize,
+                parallelism,
+                splits,
+                partitionRowProjection,
+                dynamicFilteringData,
+                weightFunc);
     }
 
     private static boolean filter(

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
@@ -35,10 +35,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.Objects;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -208,13 +208,16 @@ public class PreAssignSplitAssigner implements SplitAssigner {
         } else {
             List<GroupedSplit> groupedSplits = groupSplits(splits, weightFunc, groupFunc);
             List<List<GroupedSplit>> groupedAssignment =
-                    BinPacking.packForFixedBinNumber(groupedSplits, GroupedSplit::weight, numReaders);
+                    BinPacking.packForFixedBinNumber(
+                            groupedSplits, GroupedSplit::weight, numReaders);
             assignmentList =
                     groupedAssignment.stream()
                             .map(
                                     group ->
                                             group.stream()
-                                                    .flatMap(groupedSplit -> groupedSplit.splits().stream())
+                                                    .flatMap(
+                                                            groupedSplit ->
+                                                                    groupedSplit.splits().stream())
                                                     .collect(Collectors.toList()))
                             .collect(Collectors.toList());
         }
@@ -231,15 +234,16 @@ public class PreAssignSplitAssigner implements SplitAssigner {
             SerializableFunction<FileStoreSourceSplit, ?> groupFunc) {
         Map<Object, List<FileStoreSourceSplit>> grouped = new HashMap<>();
         for (FileStoreSourceSplit split : splits) {
-            grouped.computeIfAbsent(Objects.requireNonNull(groupFunc.apply(split)), ignored -> new ArrayList<>())
+            grouped.computeIfAbsent(
+                            Objects.requireNonNull(groupFunc.apply(split)),
+                            ignored -> new ArrayList<>())
                     .add(split);
         }
         return grouped.values().stream()
                 .map(
                         group ->
                                 new GroupedSplit(
-                                        group,
-                                        group.stream().mapToLong(weightFunc::apply).sum()))
+                                        group, group.stream().mapToLong(weightFunc::apply).sum()))
                 .collect(Collectors.toList());
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactionBucketDistributionStrategyTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/CompactionBucketDistributionStrategyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for compaction bucket distribution strategy resolution. */
+public class CompactionBucketDistributionStrategyTest {
+
+    @Test
+    public void testDefaultStrategyIsLinear() {
+        assertThat(
+                        Options.fromMap(java.util.Collections.emptyMap())
+                                .get(FlinkConnectorOptions.COMPACTION_BUCKET_DISTRIBUTION_STRATEGY))
+                .isEqualTo(CompactionBucketDistributionStrategy.LINEAR);
+    }
+
+    @Test
+    public void testStrategyOptionParsing() {
+        assertThat(strategy("linear")).isEqualTo(CompactionBucketDistributionStrategy.LINEAR);
+        assertThat(strategy("size-aware-batch"))
+                .isEqualTo(CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH);
+    }
+
+    @Test
+    public void testStrategyOnlyAppliesToBatchFullCompaction() {
+        Options options =
+                Options.fromMap(
+                        java.util.Collections.singletonMap(
+                                FlinkConnectorOptions.COMPACTION_BUCKET_DISTRIBUTION_STRATEGY.key(),
+                                "size-aware-batch"));
+
+        assertThat(CompactAction.compactionBucketDistributionStrategy(options, true, false))
+                .isEqualTo(CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH);
+        assertThat(CompactAction.compactionBucketDistributionStrategy(options, false, false))
+                .isEqualTo(CompactionBucketDistributionStrategy.LINEAR);
+        assertThat(CompactAction.compactionBucketDistributionStrategy(options, true, true))
+                .isEqualTo(CompactionBucketDistributionStrategy.LINEAR);
+    }
+
+    private static CompactionBucketDistributionStrategy strategy(String value) {
+        return Options.fromMap(
+                        java.util.Collections.singletonMap(
+                                FlinkConnectorOptions.COMPACTION_BUCKET_DISTRIBUTION_STRATEGY.key(),
+                                value))
+                .get(FlinkConnectorOptions.COMPACTION_BUCKET_DISTRIBUTION_STRATEGY);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.FlinkConnectorOptions;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.source.DataSplit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CompactorSourceBuilder}. */
+public class CompactorSourceBuilderTest {
+
+    @Test
+    public void testSizeAwareBatchUsesSinkParallelismForSource() {
+        Options options = optionsWithParallelism(4, 16);
+
+        assertThat(
+                        CompactorSourceBuilder.sourceParallelism(
+                                options, CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH))
+                .isEqualTo(16);
+    }
+
+    @Test
+    public void testNonSizeAwareBatchUsesScanParallelismForSource() {
+        Options options = optionsWithParallelism(4, 16);
+
+        assertThat(
+                        CompactorSourceBuilder.sourceParallelism(
+                                options, CompactionBucketDistributionStrategy.LINEAR))
+                .isEqualTo(4);
+    }
+
+    @Test
+    public void testSizeAwareBatchFallsBackToScanParallelismWithoutSinkParallelism() {
+        Map<String, String> map = new HashMap<>();
+        map.put(FlinkConnectorOptions.SCAN_PARALLELISM.key(), "4");
+        Options options = Options.fromMap(map);
+
+        assertThat(
+                        CompactorSourceBuilder.sourceParallelism(
+                                options, CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH))
+                .isEqualTo(4);
+    }
+
+    @Test
+    public void testBucketFileSizeUsesTotalDataFileSize() {
+        DataSplit split =
+                DataSplit.builder()
+                        .withSnapshot(1)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(
+                                Arrays.asList(dataFile("file-1", 10L), dataFile("file-2", 25L)))
+                        .build();
+
+        assertThat(CompactorSourceBuilder.bucketFileSize(split)).isEqualTo(35L);
+    }
+
+    private static Options optionsWithParallelism(int scanParallelism, int sinkParallelism) {
+        Map<String, String> map = new HashMap<>();
+        map.put(FlinkConnectorOptions.SCAN_PARALLELISM.key(), String.valueOf(scanParallelism));
+        map.put(FlinkConnectorOptions.SINK_PARALLELISM.key(), String.valueOf(sinkParallelism));
+        return Options.fromMap(map);
+    }
+
+    private static DataFileMeta dataFile(String fileName, long fileSize) {
+        return DataFileMeta.forAppend(
+                fileName,
+                fileSize,
+                1L,
+                null,
+                0L,
+                0L,
+                0L,
+                Collections.emptyList(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
@@ -70,16 +70,26 @@ public class CompactorSourceBuilderTest {
     }
 
     @Test
+    public void testBucketKeyUsesPartitionAndBucket() {
+        DataSplit split1 = dataSplit(1L, BinaryRow.EMPTY_ROW, 0, dataFile("file-1", 10L));
+        DataSplit split2 = dataSplit(2L, BinaryRow.EMPTY_ROW, 0, dataFile("file-2", 25L));
+        DataSplit split3 = dataSplit(3L, BinaryRow.EMPTY_ROW, 1, dataFile("file-3", 30L));
+
+        assertThat(CompactorSourceBuilder.bucketKey(split1))
+                .isEqualTo(CompactorSourceBuilder.bucketKey(split2));
+        assertThat(CompactorSourceBuilder.bucketKey(split1))
+                .isNotEqualTo(CompactorSourceBuilder.bucketKey(split3));
+    }
+
+    @Test
     public void testBucketFileSizeUsesTotalDataFileSize() {
         DataSplit split =
-                DataSplit.builder()
-                        .withSnapshot(1)
-                        .withPartition(BinaryRow.EMPTY_ROW)
-                        .withBucket(0)
-                        .withBucketPath("bucket-0")
-                        .withDataFiles(
-                                Arrays.asList(dataFile("file-1", 10L), dataFile("file-2", 25L)))
-                        .build();
+                dataSplit(
+                        1L,
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        dataFile("file-1", 10L),
+                        dataFile("file-2", 25L));
 
         assertThat(CompactorSourceBuilder.bucketFileSize(split)).isEqualTo(35L);
     }
@@ -89,6 +99,17 @@ public class CompactorSourceBuilderTest {
         map.put(FlinkConnectorOptions.SCAN_PARALLELISM.key(), String.valueOf(scanParallelism));
         map.put(FlinkConnectorOptions.SINK_PARALLELISM.key(), String.valueOf(sinkParallelism));
         return Options.fromMap(map);
+    }
+
+    private static DataSplit dataSplit(
+            long snapshot, BinaryRow partition, int bucket, DataFileMeta... dataFiles) {
+        return DataSplit.builder()
+                .withSnapshot(snapshot)
+                .withPartition(partition)
+                .withBucket(bucket)
+                .withBucketPath("bucket-" + bucket)
+                .withDataFiles(Arrays.asList(dataFiles))
+                .build();
     }
 
     private static DataFileMeta dataFile(String fileName, long fileSize) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceBuilderTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.source;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.FlinkConnectorOptions;
 import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
+import org.apache.paimon.flink.FlinkConnectorOptions.SplitAssignMode;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.source.DataSplit;
@@ -33,6 +34,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CompactorSourceBuilder}. */
 public class CompactorSourceBuilderTest {
@@ -67,6 +70,28 @@ public class CompactorSourceBuilderTest {
                         CompactorSourceBuilder.sourceParallelism(
                                 options, CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH))
                 .isEqualTo(4);
+    }
+
+    @Test
+    public void testSizeAwareBatchRejectsPreemptiveSplitAssignment() {
+        assertThatThrownBy(
+                        () ->
+                                CompactorSourceBuilder.validateBucketDistributionStrategy(
+                                        CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH,
+                                        SplitAssignMode.PREEMPTIVE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size-aware-batch requires")
+                .hasMessageContaining("scan.split-enumerator.mode=fair");
+    }
+
+    @Test
+    public void testSizeAwareBatchAllowsFairSplitAssignment() {
+        assertThatCode(
+                        () ->
+                                CompactorSourceBuilder.validateBucketDistributionStrategy(
+                                        CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH,
+                                        SplitAssignMode.FAIR))
+                .doesNotThrowAnyException();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
@@ -42,6 +42,10 @@ import org.apache.paimon.types.RowType;
 
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.BeforeEach;
@@ -286,6 +290,52 @@ public class CompactorSourceITCase extends AbstractTestBase {
         it.close();
     }
 
+    @Test
+    public void testSizeAwareSourceAndFilterKeepSameParallelismWithoutShuffle() throws Exception {
+        FileStoreTable table =
+                createFileStoreTable()
+                        .copy(
+                                new HashMap<String, String>() {
+                                    {
+                                        put("sink.parallelism", "4");
+                                        put("scan.parallelism", "2");
+                                        put(
+                                                "compaction.bucket-distribution-strategy",
+                                                "size-aware-batch");
+                                    }
+                                });
+        StreamWriteBuilder streamWriteBuilder =
+                table.newStreamWriteBuilder().withCommitUser(commitUser);
+        StreamTableWrite write = streamWriteBuilder.newWrite();
+        StreamTableCommit commit = streamWriteBuilder.newCommit();
+        write.write(rowData(1, 1510, BinaryString.fromString("20221208"), 15));
+        commit.commit(0, write.prepareCommit(true, 0));
+
+        StreamExecutionEnvironment env =
+                streamExecutionEnvironmentBuilder().streamingMode().build();
+        new CompactorSourceBuilder("test", table)
+                .withContinuousMode(false)
+                .withPartitionIdleTime(Duration.ofMillis(1))
+                .withEnv(env)
+                .build();
+
+        StreamGraph streamGraph = env.getStreamGraph(false);
+        StreamNode sourceNode = findStreamNode(streamGraph, "test-compact-source");
+        StreamNode filterNode = findStreamNode(streamGraph, "Filter");
+        assertThat(sourceNode.getParallelism()).isEqualTo(4);
+        assertThat(filterNode.getParallelism()).isEqualTo(4);
+
+        StreamEdge sourceToFilterEdge =
+                sourceNode.getOutEdges().stream()
+                        .filter(edge -> edge.getTargetId() == filterNode.getId())
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("Source to filter edge not found"));
+        assertThat(sourceToFilterEdge.getPartitioner()).isInstanceOf(ForwardPartitioner.class);
+
+        write.close();
+        commit.close();
+    }
+
     @ParameterizedTest(name = "defaultOptions = {0}")
     @ValueSource(booleans = {true, false})
     public void testHistoryPartitionRead(boolean defaultOptions) throws Exception {
@@ -332,6 +382,14 @@ public class CompactorSourceITCase extends AbstractTestBase {
         write.close();
         commit.close();
         it.close();
+    }
+
+    private StreamNode findStreamNode(StreamGraph streamGraph, String operatorNameContains) {
+        return streamGraph.getStreamNodes().stream()
+                .filter(node -> node.getOperatorName().contains(operatorNameContains))
+                .findFirst()
+                .orElseThrow(
+                        () -> new AssertionError("Stream node not found: " + operatorNameContains));
     }
 
     private String toString(RowData rowData) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/CompactorSourceITCase.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.flink.FlinkConnectorOptions.CompactionBucketDistributionStrategy;
 import org.apache.paimon.flink.util.AbstractTestBase;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -315,6 +316,8 @@ public class CompactorSourceITCase extends AbstractTestBase {
                 streamExecutionEnvironmentBuilder().streamingMode().build();
         new CompactorSourceBuilder("test", table)
                 .withContinuousMode(false)
+                .withBucketDistributionStrategy(
+                        CompactionBucketDistributionStrategy.SIZE_AWARE_BATCH)
                 .withPartitionIdleTime(Duration.ofMillis(1))
                 .withEnv(env)
                 .build();

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FairAssignModeTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FairAssignModeTest.java
@@ -102,6 +102,55 @@ public class FairAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
     }
 
     @Test
+    public void testGroupedSplitAllocationBalancesByBucketTotalWeight() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(2);
+
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        // Bucket 0 has two splits, each with weight 50. Bucket 1 has one split with weight 100.
+        // The assigner should first group by bucket, calculate bucket-level total weight, and then
+        // bin-pack the two bucket groups evenly across readers. This also guarantees all splits of
+        // the same bucket go to the same downstream writer.
+        splits.add(createSnapshotSplit(1, 0, Collections.emptyList()));
+        splits.add(createSnapshotSplit(2, 0, Collections.emptyList()));
+        splits.add(createSnapshotSplit(3, 1, Collections.emptyList()));
+
+        StaticFileStoreSplitEnumerator enumerator =
+                new StaticFileStoreSplitEnumerator(
+                        context,
+                        null,
+                        StaticFileStoreSource.createSplitAssigner(
+                                context,
+                                10,
+                                SplitAssignMode.FAIR,
+                                splits,
+                                split -> ((DataSplit) split.split()).bucket() == 0 ? 50L : 100L,
+                                split -> ((DataSplit) split.split()).bucket()));
+
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+
+        assertThat(assignments).containsOnlyKeys(0, 1);
+        assertThat(assignments.values())
+                .anySatisfy(
+                        assignment ->
+                                assertThat(assignment.getAssignedSplits())
+                                        .containsExactlyInAnyOrder(splits.get(0), splits.get(1)));
+        assertThat(assignments.values())
+                .anySatisfy(
+                        assignment ->
+                                assertThat(assignment.getAssignedSplits())
+                                        .containsExactly(splits.get(2)));
+        assertThat(assignments.values())
+                .allSatisfy(
+                        assignment ->
+                                assertThat(groupedTotalWeight(assignment.getAssignedSplits()))
+                                        .isEqualTo(100L));
+    }
+
+    @Test
     public void testSplitBatch() {
         final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
                 getSplitEnumeratorContext(2);
@@ -190,6 +239,12 @@ public class FairAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
                             int snapshotId = (int) ((DataSplit) split.split()).snapshotId();
                             return snapshotId == 1 || snapshotId == 2 ? 100L : 1L;
                         })
+                .sum();
+    }
+
+    private long groupedTotalWeight(List<FileStoreSourceSplit> splits) {
+        return splits.stream()
+                .mapToLong(split -> ((DataSplit) split.split()).bucket() == 0 ? 50L : 100L)
                 .sum();
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FairAssignModeTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FairAssignModeTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.table.source.DataSplit;
+
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +64,41 @@ public class FairAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
         enumerator.handleSplitRequest(0, "test-host");
         assertThat(assignments.get(0).getAssignedSplits())
                 .containsExactly(splits.get(0), splits.get(2));
+    }
+
+    @Test
+    public void testSplitAllocationWithCustomWeight() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(2);
+
+        List<FileStoreSourceSplit> splits = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            splits.add(createSnapshotSplit(i, 0, Collections.emptyList()));
+        }
+        StaticFileStoreSplitEnumerator enumerator =
+                new StaticFileStoreSplitEnumerator(
+                        context,
+                        null,
+                        StaticFileStoreSource.createSplitAssigner(
+                                context,
+                                10,
+                                SplitAssignMode.FAIR,
+                                splits,
+                                split -> {
+                                    int snapshotId = (int) ((DataSplit) split.split()).snapshotId();
+                                    return snapshotId == 1 || snapshotId == 2 ? 100L : 1L;
+                                }));
+
+        enumerator.handleSplitRequest(0, "test-host");
+        enumerator.handleSplitRequest(1, "test-host");
+        Map<Integer, SplitAssignmentState<FileStoreSourceSplit>> assignments =
+                context.getSplitAssignments();
+
+        assertThat(assignments).containsOnlyKeys(0, 1);
+        assertThat(totalWeight(assignments.get(0).getAssignedSplits())).isEqualTo(101L);
+        assertThat(totalWeight(assignments.get(1).getAssignedSplits())).isEqualTo(101L);
+        assertThat(assignments.get(0).getAssignedSplits()).hasSize(2);
+        assertThat(assignments.get(1).getAssignedSplits()).hasSize(2);
     }
 
     @Test
@@ -144,6 +181,16 @@ public class FairAssignModeTest extends StaticFileStoreSplitEnumeratorTestBase {
         assertThat(assignments.get(0).getAssignedSplits()).containsExactly(splits.get(0));
         assertThat(assignments.get(1).getAssignedSplits()).containsExactly(splits.get(1));
         assertThat(assignments.get(2).getAssignedSplits()).isEmpty();
+    }
+
+    private long totalWeight(List<FileStoreSourceSplit> splits) {
+        return splits.stream()
+                .mapToLong(
+                        split -> {
+                            int snapshotId = (int) ((DataSplit) split.split()).snapshotId();
+                            return snapshotId == 1 || snapshotId == 2 ? 100L : 1L;
+                        })
+                .sum();
     }
 
     @Override


### PR DESCRIPTION
## Summary

This PR adds a new dedicated compaction bucket distribution strategy:

```text
compaction.bucket-distribution-strategy=size-aware-batch
```
The new strategy is intended for bounded full compaction jobs. It improves compaction workload balance by assigning compact buckets based on their total input file size, instead of relying on the existing linear partition/bucket channel mapping.

## Problem
The previous compaction distribution strategy could assign multiple heavy buckets to the same writer while other writers received much lighter work. This caused long-tail compaction tasks where a small number of writers determined the overall job runtime.
This was especially visible in high-parallelism full compaction jobs where the total workload was large, but writer-level input distribution was uneven.

## What changed
When compaction.bucket-distribution-strategy=size-aware-batch is enabled for a batch full compaction job:

 1.  The compaction source enumerator groups input splits by (partition, bucket).
 2.  It calculates the total input data file size for each bucket group.
 3.  It uses size-aware bin packing to assign bucket groups to downstream writers.
 4.  All splits for the same (partition, bucket) are kept together and sent to the same writer.
 5.  The sink skips the old sink-side repartitioning step, preserving the source-side size-aware assignment.
 6.  The compaction writer starts a new operator chain to avoid chaining source and writer operators together.
This keeps compaction correctness while improving writer-level workload balance.

## Scope
The new strategy is only applied to:

batch full compaction
For streaming compaction or non-full compaction, the strategy falls back to the existing linear behavior.

## Why bucket-level grouping is needed
A single (partition, bucket) can be split into multiple DataSplits. If size-aware assignment were done at the individual split level, splits from the same bucket could be sent to different writers, causing multiple writers to compact the same bucket and potentially conflict during commit.
To avoid this, the assignment is performed at the bucket-group level:

group key = partition + bucket
weight = sum(data file sizes across all splits in that bucket group)
This ensures that each bucket is compacted by only one writer while still balancing heavy buckets across the job.

## Expected impact
This should reduce compaction long tail by distributing heavy buckets more evenly across writers. In benchmark runs, size-aware compaction significantly improved writer input balance and reduced overall full-compaction wall-clock time for large Paimon tables.

## Tests
Added/updated tests for:

•  parsing compaction.bucket-distribution-strategy
•  ensuring size-aware-batch is only used for batch full compaction
•  source parallelism selection for size-aware compaction
•  bucket file-size weight calculation
•  grouping splits by (partition, bucket)
•  ensuring splits from the same bucket group are assigned to the same downstream writer
•  preserving existing fair split assignment behavior when no grouping function is provided

We also verified this change in compaction job. The new stragety can reduce compaction time from 5 hours to 1.5 hours without any significant long tail workers processing heavy buckets.