### PR TITLE
[flink-cdc] Stabilize schema change IT under load

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -801,6 +801,11 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
             tableName = getNewTableName(pick);
             records = recordsMap.get(tableName);
 
+            // Wait for the newly added table to finish its incremental snapshot before altering it.
+            // Under load a snapshot split can capture the post-ALTER schema and the binlog split
+            // then replays pre-ALTER rows against it (row smaller than column index error).
+            Thread.sleep(10000);
+
             statement.executeUpdate(
                     String.format(
                             "ALTER TABLE `%s`.`%s` ADD COLUMN v2 INT", databaseName, tableName));


### PR DESCRIPTION
### Purpose
 - `testNewlyAddedTable` intermittently fails with Debezium under load.
 - At high concurrency, table's incremental snapshot can capture the post ALTER schema, the binlog split then replays pre ALTER rows and the CDC job terminates.
 - Wait for the snapshot to settle before applying the schema change.
 - Fixes CI flakiness
### Tests
 - Previously failure was 1 in 6 runs approx
 - Post change 0 failure in 120 runs