### PR TITLE
[core] Limit vector live-row planning to indexed ranges

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractVectorRead.java
@@ -127,13 +127,18 @@ public abstract class AbstractVectorRead implements Serializable {
     }
 
     protected List<RoaringNavigableMap64> preFilters(List<IndexVectorSearchSplit> splits) {
-        RoaringNavigableMap64 liveRows = GlobalIndexLiveRowFilter.liveRows(table, partitionFilter);
+        List<Range> indexedRowRanges = new ArrayList<>(splits.size());
+        for (IndexVectorSearchSplit split : splits) {
+            indexedRowRanges.add(new Range(split.rowRangeStart(), split.rowRangeEnd()));
+        }
+
+        RoaringNavigableMap64 liveRows =
+                GlobalIndexLiveRowFilter.liveRows(table, partitionFilter, indexedRowRanges);
         RoaringNavigableMap64 matchedRows = scalarMatchedRows(splits);
 
         List<RoaringNavigableMap64> includeRowIds = new ArrayList<>(splits.size());
         boolean hasFilter = false;
-        for (IndexVectorSearchSplit split : splits) {
-            Range splitRange = new Range(split.rowRangeStart(), split.rowRangeEnd());
+        for (Range splitRange : indexedRowRanges) {
             RoaringNavigableMap64 splitRows = bitmapOf(splitRange);
 
             RoaringNavigableMap64 include = new RoaringNavigableMap64();

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/GlobalIndexLiveRowFilter.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/GlobalIndexLiveRowFilter.java
@@ -23,6 +23,7 @@ import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
@@ -39,6 +40,14 @@ class GlobalIndexLiveRowFilter {
     @Nullable
     static RoaringNavigableMap64 liveRows(
             @Nullable FileStoreTable table, @Nullable PartitionPredicate partitionFilter) {
+        return liveRows(table, partitionFilter, null);
+    }
+
+    @Nullable
+    static RoaringNavigableMap64 liveRows(
+            @Nullable FileStoreTable table,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable List<Range> rowRanges) {
         if (table == null || !table.coreOptions().deletionVectorsEnabled()) {
             return null;
         }
@@ -48,14 +57,17 @@ class GlobalIndexLiveRowFilter {
             return null;
         }
 
-        RoaringNavigableMap64 liveRows = new RoaringNavigableMap64();
-        for (Split split :
+        SnapshotReader snapshotReader =
                 table.newSnapshotReader()
                         .withPartitionFilter(partitionFilter)
                         .withMode(ScanMode.ALL)
-                        .withSnapshot(snapshot)
-                        .read()
-                        .splits()) {
+                        .withSnapshot(snapshot);
+        if (rowRanges != null) {
+            snapshotReader.withRowRanges(rowRanges);
+        }
+
+        RoaringNavigableMap64 liveRows = new RoaringNavigableMap64();
+        for (Split split : snapshotReader.read().splits()) {
             if (split instanceof DataSplit) {
                 addLiveRows(table, liveRows, (DataSplit) split);
             }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.globalindex.GlobalIndexBuilderUtils;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
@@ -217,6 +218,55 @@ public class VectorSearchBuilderTest extends TableTestBase {
         assertThat(result.results()).contains(2L, 3L);
         assertThat(result.results()).doesNotContain(0L, 1L);
         assertThat(readIds(table, result)).containsExactly(2, 3);
+    }
+
+    @Test
+    public void testVectorLiveRowPlanningSkipsUnindexedDeletionVectors() throws Exception {
+        catalog.createTable(
+                identifier("vector_search_unindexed_deletion_vector"),
+                vectorSchemaBuilder(VECTOR_FIELD_NAME)
+                        .option(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true")
+                        .build(),
+                false);
+        FileStoreTable table = getTable(identifier("vector_search_unindexed_deletion_vector"));
+
+        float[][] indexedVectors = {{0.0f, 0.0f}, {1.0f, 0.0f}};
+        writeVectors(table, indexedVectors);
+        writeVectors(table, new float[][] {{2.0f, 0.0f}, {3.0f, 0.0f}});
+        buildAndCommitVectorIndex(table, indexedVectors, new Range(0, 1));
+        commitDeletionVectors(table, 3L);
+
+        DeletionFile unindexedDeletionFile = null;
+        for (Split split : table.newSnapshotReader().read().splits()) {
+            if (!(split instanceof DataSplit)) {
+                continue;
+            }
+            DataSplit dataSplit = (DataSplit) split;
+            List<DeletionFile> deletionFiles = dataSplit.deletionFiles().orElse(null);
+            if (deletionFiles == null) {
+                continue;
+            }
+            for (int i = 0; i < dataSplit.dataFiles().size(); i++) {
+                if (dataSplit
+                        .dataFiles()
+                        .get(i)
+                        .nonNullRowIdRange()
+                        .hasIntersection(new Range(3, 3))) {
+                    unindexedDeletionFile = deletionFiles.get(i);
+                }
+            }
+        }
+        assertThat(unindexedDeletionFile).isNotNull();
+        assertThat(table.fileIO().delete(new Path(unindexedDeletionFile.path()), false)).isTrue();
+
+        GlobalIndexResult result =
+                table.newVectorSearchBuilder()
+                        .withVector(new float[] {0.0f, 0.0f})
+                        .withLimit(2)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .executeLocal();
+
+        assertThat(result.results()).containsExactly(0L, 1L);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

Vector live-row pre-filter planning scans deletion vectors for the entire snapshot, even though indexed vector search only consumes row ranges covered by index splits. This reads unrelated deletion-vector files and adds unnecessary planning work.

This change pushes indexed row ranges into snapshot planning so files and deletion vectors outside those ranges are pruned. The existing full-text live-row path remains unchanged.

  ### Tests

  - `mvn -pl paimon-core -DskipTests spotless:check checkstyle:check`
  - `mvn -pl paimon-core -DwildcardSuites=none -Dtest=VectorSearchBuilderTest test`
  - `mvn -pl paimon-core -DwildcardSuites=none -Dtest=FullTextSearchBuilderTest#testFullTextSearchExcludesDeletedIndexedRows test`
  - `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=VectorSearchBuilderTest#testVectorLiveRowPlanningSkipsUnindexedDeletionVectors test`
