### PR TITLE
[filesystem] Fix S3Loader Javadoc referring to oss instead of s3

### DIFF
--- a/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
+++ b/paimon-filesystems/paimon-s3/src/main/java/org/apache/paimon/s3/S3Loader.java
@@ -28,7 +28,7 @@ import org.apache.paimon.plugin.PluginLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-/** A {@link PluginLoader} to load oss. */
+/** A {@link PluginLoader} to load s3. */
 public class S3Loader implements FileIOLoader {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
### Purpose

- `S3Loader`'s class Javadoc said "to load oss", a copy-paste artifact from `OSSLoader`.
- The loader's `getScheme()` returns `"s3"`, so the comment should read "to load s3".
- Matches the sibling convention `to load <scheme>` used by `OSSLoader` (oss), `COSNLoader` (cosn), and `GSLoader` (gcs).

### Tests

- Typo/wording fix, no behavior change — no test added. `mvn -pl paimon-filesystems/paimon-s3 clean install` passed (checkstyle/spotless/rat green).
