### PR TITLE
[obs] FileSystem should be cached by authority

### DIFF
--- a/paimon-filesystems/paimon-obs-impl/src/main/java/org/apache/paimon/obs/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-obs-impl/src/main/java/org/apache/paimon/obs/HadoopCompliantFileIO.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.fs.FileSystem;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Hadoop {@link FileIO}.
@@ -41,7 +43,7 @@ public abstract class HadoopCompliantFileIO implements FileIO {
 
     private static final long serialVersionUID = 1L;
 
-    protected transient volatile FileSystem fs;
+    protected transient volatile Map<String, FileSystem> fsMap;
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
@@ -107,12 +109,24 @@ public abstract class HadoopCompliantFileIO implements FileIO {
     }
 
     private FileSystem getFileSystem(org.apache.hadoop.fs.Path path) throws IOException {
-        if (fs == null) {
+        if (fsMap == null) {
             synchronized (this) {
-                if (fs == null) {
-                    fs = createFileSystem(path);
+                if (fsMap == null) {
+                    fsMap = new ConcurrentHashMap<>();
                 }
             }
+        }
+
+        Map<String, FileSystem> map = fsMap;
+
+        String authority = path.toUri().getAuthority();
+        if (authority == null) {
+            authority = "DEFAULT";
+        }
+        FileSystem fs = map.get(authority);
+        if (fs == null) {
+            fs = createFileSystem(path);
+            map.put(authority, fs);
         }
         return fs;
     }


### PR DESCRIPTION

### Purpose

fix #8588

- `HadoopCompliantFileIO` cached a single `FileSystem` for the first authority and returned it for all paths, misrouting cross-bucket access when one `OBSFileIO` instance serves multiple OBS buckets.
- Cache per authority in a `Map<String, FileSystem>` keyed by `path.toUri().getAuthority()` (null → `"DEFAULT"`).
- Matches the sibling oss/s3/gs implementations, which already do this (oss #2417, fs/oss/s3 #2504).

### Tests

- No unit test added: this filesystem adapter has no `src/test` and requires a live OBS backend, consistent with the sibling oss/s3/gs fixes which merged without unit tests.
- Verified via `mvn -pl paimon-filesystems/paimon-obs-impl -DfailIfNoTests=false clean install` (checkstyle + spotless + rat + compile) — BUILD SUCCESS on JDK 11.

