### PR TITLE
[common] Fix bounded bulk reads past end of stream

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/OffsetSeekableInputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/OffsetSeekableInputStream.java
@@ -62,11 +62,20 @@ public class OffsetSeekableInputStream extends SeekableInputStream {
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
         if (length != -1) {
-            len = (int) Math.min(len, length - getPos());
-            if (len == 0) {
+            long remaining = length - getPos();
+            if (remaining <= 0) {
                 return -1;
             }
+            len = (int) Math.min(len, remaining);
         }
         return wrapped.read(b, off, len);
     }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/OffsetSeekableInputStreamTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -147,6 +148,56 @@ public class OffsetSeekableInputStreamTest {
             byte[] buffer = new byte[5];
             int bytesRead = stream.read(buffer, 0, 5);
             assertThat(bytesRead).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    public void testReadByteArrayPastEnd() throws IOException {
+        long offset = 5;
+        long length = 10;
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            stream.seek(length + 1);
+            assertThat(stream.read(new byte[5], 0, 5)).isEqualTo(-1);
+        }
+    }
+
+    @Test
+    public void testReadZeroLength() throws IOException {
+        long offset = 5;
+        long length = 10;
+        byte[] buffer = new byte[5];
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            assertThat(stream.read(buffer, 0, 0)).isZero();
+
+            stream.seek(length);
+            assertThat(stream.read(buffer, 0, 0)).isZero();
+
+            stream.seek(length + 1);
+            assertThat(stream.read(buffer, 0, 0)).isZero();
+        }
+    }
+
+    @Test
+    public void testInvalidReadArguments() throws IOException {
+        long offset = 5;
+        long length = 10;
+        byte[] buffer = new byte[5];
+        try (OffsetSeekableInputStream stream =
+                new OffsetSeekableInputStream(wrapped, offset, length)) {
+            stream.seek(length);
+
+            assertThatThrownBy(() -> stream.read(null, 0, 1))
+                    .isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> stream.read(buffer, -1, 1))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            assertThatThrownBy(() -> stream.read(buffer, 0, -1))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            assertThatThrownBy(() -> stream.read(buffer, buffer.length + 1, 0))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
+            assertThatThrownBy(() -> stream.read(buffer, 1, buffer.length))
+                    .isInstanceOf(IndexOutOfBoundsException.class);
         }
     }
 


### PR DESCRIPTION
### Purpose

`OffsetSeekableInputStream.read(byte[], int, int)` capped the requested length with the remaining bounded range. After seeking past the range, this produced a negative length and passed it to the wrapped stream, causing an `IndexOutOfBoundsException`.
  It also returned EOF for zero-length reads and skipped argument validation at EOF.

Validate arguments first, return zero for zero-length reads, and return EOF when the bounded range has no remaining bytes.

  ### Tests

  - `mvn -pl paimon-common -am clean test`
