### PR TITLE
[e2e] Fix mislabeled result sink column in FileStoreBatchE2eTest

### DIFF
--- a/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
+++ b/paimon-e2e-tests/src/test/java/org/apache/paimon/tests/FileStoreBatchE2eTest.java
@@ -172,7 +172,7 @@ public class FileStoreBatchE2eTest extends E2eTestBase {
                 catalogDdl,
                 useCatalogCmd,
                 paimonDdl,
-                createResultSink("result4", "dt VARCHAR, hr VARCHAR, total INT"));
+                createResultSink("result4", "dt VARCHAR, category VARCHAR, total INT"));
         checkResult(
                 "20211110, Drink, 200",
                 "20211110, Food, 160",


### PR DESCRIPTION
### Purpose

- Test #4 in `FileStoreBatchE2eTest` inserts `SELECT dt, category, sum(price) AS total ... GROUP BY dt, category`, so the second sink column holds `category` values.
- The result sink DDL mislabeled that column `hr` (copy-pasted from result1-3's full schema); renamed it to `category` to match the projected data.
- The print sink is positional, so runtime output and `checkResult` are unchanged.

### Tests

- Typo/wording fix, no behavior change — no test added. `mvn spotless:check -pl paimon-e2e-tests` passed.
- E2E suite is Docker/testcontainers-based (integration), covered by CI (fork Actions).
