### PR TITLE
[filesystem] Correct OBSLoader Javadoc to Huawei OBS Storage

### DIFF
--- a/paimon-filesystems/paimon-obs/src/main/java/org/apache/paimon/obs/OBSLoader.java
+++ b/paimon-filesystems/paimon-obs/src/main/java/org/apache/paimon/obs/OBSLoader.java
@@ -28,7 +28,7 @@ import org.apache.paimon.plugin.PluginLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-/** obs Blob Storage {@link FileIOLoader}. */
+/** Huawei OBS Storage {@link FileIOLoader}. */
 public class OBSLoader implements FileIOLoader {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
### Purpose

- `OBSLoader`'s class Javadoc read `obs Blob Storage`, but OBS is Huawei Cloud Object Storage Service, not Azure "Blob Storage".
- Corrected to `Huawei OBS Storage`, matching the sibling `OBSFileIO` (`/** Huawei OBS Storage {@link FileIO}. */`) and the introducing PR #5417 ("Add filesystem support for Huawei OBS Storage").

### Tests

- Wording fix in a class Javadoc, no behavior change — no test added.
- `mvn -pl paimon-filesystems/paimon-obs -DfailIfNoTests=false clean install` passed (JDK 11): compile + checkstyle + spotless + rat + shade + install.
