### PR TITLE
[flink][spark] Fix conflict error for no-op file index rewrites

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RewriteFileIndexSink.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RewriteFileIndexSink.java
@@ -101,6 +101,9 @@ public class RewriteFileIndexSink extends FlinkWriteSink<ManifestEntry> {
             BinaryRow partition = entry.partition();
             int bucket = entry.bucket();
             DataFileMeta indexedFile = fileIndexProcessor.process(partition, bucket, entry);
+            if (entry.file().equals(indexedFile)) {
+                return;
+            }
 
             CommitMessageImpl commitMessage =
                     new CommitMessageImpl(

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/RewriteFileIndexProcedureITCase.java
@@ -227,5 +227,14 @@ public class RewriteFileIndexProcedureITCase extends CatalogITCaseBase {
 
             Assertions.assertThat(extraFiles.size()).isEqualTo(0);
         }
+
+        long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        if (isNamedArgument) {
+            sql("CALL sys.rewrite_file_index(`table` => 'default.T')");
+        } else {
+            sql("CALL sys.rewrite_file_index('default.T')");
+        }
+        Assertions.assertThat(table.snapshotManager().latestSnapshotId())
+                .isEqualTo(latestSnapshotId);
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RewriteFileIndexProcedure.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/procedure/RewriteFileIndexProcedure.java
@@ -190,6 +190,9 @@ public class RewriteFileIndexProcedure extends BaseProcedure {
                 BinaryRow partition = entry.partition();
                 int bucket = entry.bucket();
                 DataFileMeta indexedFile = fileIndexProcessor.process(partition, bucket, entry);
+                if (entry.file().equals(indexedFile)) {
+                    continue;
+                }
 
                 CommitMessageImpl commitMessage =
                         new CommitMessageImpl(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RewriteFileIndexProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RewriteFileIndexProcedureTest.scala
@@ -32,6 +32,13 @@ class RewriteFileIndexProcedureTest extends PaimonSparkTestBase {
             |""".stripMargin)
 
       sql("INSERT INTO t VALUES (1, 'a', '2025-08-17', 5), (2, 'b', '2025-10-06', 0)")
+      val latestSnapshotId = loadTable("t").snapshotManager().latestSnapshotId()
+      checkAnswer(
+        sql("CALL sys.rewrite_file_index(table => 't')"),
+        Row(0, 0)
+      )
+      assert(loadTable("t").snapshotManager().latestSnapshotId() == latestSnapshotId)
+
       sql("ALTER TABLE t SET TBLPROPERTIES ('file-index.bloom-filter.columns'='k,v')")
       checkAnswer(
         sql("CALL sys.rewrite_file_index(table => 't')"),


### PR DESCRIPTION
### Purpose

`rewrite_file_index` currently generates a compaction commit message even when file index processing does not change the data file metadata, for example when the table has no file index configured.

This produces identical `compactBefore` and `compactAfter` entries and incorrectly triggers file deletion conflict detection.

This PR skips unchanged files in both Flink and Spark.

### Tests

* `RewriteFileIndexProcedureITCase`
* `RewriteFileIndexProcedureTest`
