### PR TITLE
[flink] Fix scan.partitions error message placeholder in PartitionLoader

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PartitionLoader.java
@@ -91,7 +91,7 @@ public abstract class PartitionLoader implements Serializable {
 
         Preconditions.checkArgument(
                 !table.partitionKeys().isEmpty(),
-                "{} is not supported for non-partitioned table.",
+                "%s is not supported for non-partitioned table.",
                 FlinkConnectorOptions.SCAN_PARTITIONS.key());
 
         int maxPartitionNum = -1;

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/DynamicPartitionLevelLoaderTest.java
@@ -199,6 +199,22 @@ public class DynamicPartitionLevelLoaderTest {
         commit.close();
     }
 
+    @Test
+    public void testScanPartitionsOnNonPartitionedTable() throws Exception {
+        table =
+                createFileStoreTable(
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(FlinkConnectorOptions.SCAN_PARTITIONS.key(), "max_pt()");
+        table = table.copy(customOptions);
+
+        assertThatCode(() -> PartitionLoader.of(table))
+                .hasMessage(
+                        FlinkConnectorOptions.SCAN_PARTITIONS.key()
+                                + " is not supported for non-partitioned table.");
+    }
+
     private FileStoreTable createFileStoreTable(
             List<String> partitionKeys, List<String> primaryKeys, Map<String, String> customOptions)
             throws Exception {


### PR DESCRIPTION

### Purpose

fix #8606

- `PartitionLoader.of()` used an SLF4J-style `{}` placeholder, but `org.apache.paimon.utils.Preconditions` substitutes only `%s`.
- The rendered error was `{} is not supported for non-partitioned table. [scan.partitions]` instead of `scan.partitions is not supported for non-partitioned table.`.
- Change is `{}` -> `%s`, aligning with every other `checkArgument` message in the module.

### Tests

- Added `DynamicPartitionLevelLoaderTest#testScanPartitionsOnNonPartitionedTable` asserting the rendered message on a non-partitioned table.
- `mvn -pl paimon-flink/paimon-flink-common -Pflink1 clean install` — checkstyle/spotless/rat passed; `DynamicPartitionLevelLoaderTest` 4 tests passed. `*ITCase` covered by CI (fork Actions).


