### PR TITLE
[cdc] Fix PostgresTypeUtils to map out-of-range numeric precision to STRING

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
@@ -124,13 +124,21 @@ public class PostgresTypeUtils {
                 return DataTypes.ARRAY(DataTypes.DOUBLE());
             case PG_NUMERIC:
                 // see SPARK-26538: handle numeric without explicit precision and scale.
-                if (precision > 0) {
+                // Postgres numeric allows precision up to 1000, but Paimon DECIMAL max is 38.
+                // Fall back to STRING when out of range, mirroring MySqlTypeUtils.
+                if (precision > DecimalType.MAX_PRECISION) {
+                    return DataTypes.STRING();
+                } else if (precision > 0) {
                     return DataTypes.DECIMAL(precision, scale);
                 }
                 return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
             case PG_NUMERIC_ARRAY:
                 // see SPARK-26538: handle numeric without explicit precision and scale.
-                if (precision > 0) {
+                // Postgres numeric allows precision up to 1000, but Paimon DECIMAL max is 38.
+                // Fall back to STRING when out of range, mirroring MySqlTypeUtils.
+                if (precision > DecimalType.MAX_PRECISION) {
+                    return DataTypes.ARRAY(DataTypes.STRING());
+                } else if (precision > 0) {
                     return DataTypes.ARRAY(DataTypes.DECIMAL(precision, scale));
                 }
                 return DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtils.java
@@ -124,24 +124,28 @@ public class PostgresTypeUtils {
                 return DataTypes.ARRAY(DataTypes.DOUBLE());
             case PG_NUMERIC:
                 // see SPARK-26538: handle numeric without explicit precision and scale.
-                // Postgres numeric allows precision up to 1000, but Paimon DECIMAL max is 38.
-                // Fall back to STRING when out of range, mirroring MySqlTypeUtils.
-                if (precision > DecimalType.MAX_PRECISION) {
-                    return DataTypes.STRING();
-                } else if (precision > 0) {
-                    return DataTypes.DECIMAL(precision, scale);
+                // Postgres numeric allows precision up to 1000 and (since PG 15) a scale
+                // outside [0, precision], but Paimon DECIMAL requires precision <= 38 and
+                // 0 <= scale <= precision. Fall back to STRING when out of range, mirroring
+                // MySqlTypeUtils.
+                if (precision <= 0) {
+                    return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
                 }
-                return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
+                return isDecimalOutOfRange(precision, scale)
+                        ? DataTypes.STRING()
+                        : DataTypes.DECIMAL(precision, scale);
             case PG_NUMERIC_ARRAY:
                 // see SPARK-26538: handle numeric without explicit precision and scale.
-                // Postgres numeric allows precision up to 1000, but Paimon DECIMAL max is 38.
-                // Fall back to STRING when out of range, mirroring MySqlTypeUtils.
-                if (precision > DecimalType.MAX_PRECISION) {
-                    return DataTypes.ARRAY(DataTypes.STRING());
-                } else if (precision > 0) {
-                    return DataTypes.ARRAY(DataTypes.DECIMAL(precision, scale));
+                // Postgres numeric allows precision up to 1000 and (since PG 15) a scale
+                // outside [0, precision], but Paimon DECIMAL requires precision <= 38 and
+                // 0 <= scale <= precision. Fall back to STRING when out of range, mirroring
+                // MySqlTypeUtils.
+                if (precision <= 0) {
+                    return DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));
                 }
-                return DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));
+                return isDecimalOutOfRange(precision, scale)
+                        ? DataTypes.ARRAY(DataTypes.STRING())
+                        : DataTypes.ARRAY(DataTypes.DECIMAL(precision, scale));
             case PG_CHAR:
             case PG_CHARACTER:
                 return DataTypes.CHAR(precision);
@@ -178,6 +182,15 @@ public class PostgresTypeUtils {
                 throw new UnsupportedOperationException(
                         String.format("Doesn't support Postgres type '%s' yet", typeName));
         }
+    }
+
+    private static boolean isDecimalOutOfRange(int precision, int scale) {
+        // Paimon DECIMAL requires precision <= 38 and 0 <= scale <= precision; Postgres
+        // numeric can exceed both (precision up to 1000, and negative or over-precision
+        // scale since PG 15), which would otherwise throw from the DecimalType constructor.
+        return precision > DecimalType.MAX_PRECISION
+                || scale < DecimalType.MIN_SCALE
+                || scale > precision;
     }
 
     public static JdbcToPaimonTypeVisitor toPaimonTypeVisitor() {

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
@@ -58,6 +58,21 @@ public class PostgresTypeUtilsTest {
                 .isEqualTo(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));
     }
 
+    /**
+     * Even with in-range precision, a scale outside {@code [0, precision]} (both legal in Postgres
+     * 15+, e.g. {@code numeric(10, 20)} or {@code numeric(10, -2)}) would throw from the {@link
+     * DecimalType} constructor, so it must fall back to {@code STRING} rather than crash.
+     */
+    @Test
+    public void testNumericOutOfRangeScaleMapsToString() {
+        assertThat(PostgresTypeUtils.toDataType("numeric", 10, 20, EMPTY))
+                .isEqualTo(DataTypes.STRING());
+        assertThat(PostgresTypeUtils.toDataType("numeric", 10, -2, EMPTY))
+                .isEqualTo(DataTypes.STRING());
+        assertThat(PostgresTypeUtils.toDataType("_numeric", 10, 20, EMPTY))
+                .isEqualTo(DataTypes.ARRAY(DataTypes.STRING()));
+    }
+
     /** The {@code _numeric} array type mirrors the scalar behaviour element-wise. */
     @Test
     public void testNumericArrayMirrorsScalarMapping() {

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/postgres/PostgresTypeUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action.cdc.postgres;
+
+import org.apache.paimon.flink.action.cdc.TypeMapping;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.DecimalType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link PostgresTypeUtils#toDataType}. */
+public class PostgresTypeUtilsTest {
+
+    private static final TypeMapping EMPTY = TypeMapping.defaultMapping();
+
+    /**
+     * Postgres {@code numeric} allows precision up to 1000, which exceeds Paimon {@link
+     * DecimalType#MAX_PRECISION} (38). Out-of-range precision must fall back to {@code STRING}
+     * instead of throwing, mirroring {@code MySqlTypeUtils}.
+     */
+    @Test
+    public void testNumericPrecisionOutOfRangeMapsToString() {
+        assertThat(PostgresTypeUtils.toDataType("numeric", 50, 2, EMPTY))
+                .isEqualTo(DataTypes.STRING());
+    }
+
+    /** In-range precision keeps its {@code DECIMAL(precision, scale)} mapping. */
+    @Test
+    public void testNumericInRangeMapsToDecimal() {
+        assertThat(PostgresTypeUtils.toDataType("numeric", 10, 2, EMPTY))
+                .isEqualTo(DataTypes.DECIMAL(10, 2));
+        assertThat(PostgresTypeUtils.toDataType("numeric", DecimalType.MAX_PRECISION, 0, EMPTY))
+                .isEqualTo(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 0));
+    }
+
+    /** Unspecified precision (0) preserves the default {@code DECIMAL(38, 18)} mapping. */
+    @Test
+    public void testNumericWithoutPrecisionMapsToDefaultDecimal() {
+        assertThat(PostgresTypeUtils.toDataType("numeric", 0, 0, EMPTY))
+                .isEqualTo(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));
+    }
+
+    /** The {@code _numeric} array type mirrors the scalar behaviour element-wise. */
+    @Test
+    public void testNumericArrayMirrorsScalarMapping() {
+        assertThat(PostgresTypeUtils.toDataType("_numeric", 50, 2, EMPTY))
+                .isEqualTo(DataTypes.ARRAY(DataTypes.STRING()));
+        assertThat(PostgresTypeUtils.toDataType("_numeric", 10, 2, EMPTY))
+                .isEqualTo(DataTypes.ARRAY(DataTypes.DECIMAL(10, 2)));
+        assertThat(PostgresTypeUtils.toDataType("_numeric", 0, 0, EMPTY))
+                .isEqualTo(DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18)));
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8605

- Postgres `numeric` allows precision up to 1000, but Paimon `DecimalType.MAX_PRECISION` is 38, so `PostgresTypeUtils.toDataType()` threw `IllegalArgumentException` on a `numeric(50,2)` column and schema derivation failed before the CDC sink could start.
- Now precision > 38 falls back to `STRING` (`ARRAY(STRING)` for `_numeric`); precision 0 default (`DECIMAL(38,18)`) and the 1..38 behavior are preserved.
- Mirrors the sibling `MySqlTypeUtils.toDataType()` guard (`length <= 38 ? DECIMAL : STRING`) under the same `JdbcToPaimonTypeVisitor` SPI.

### Tests

- Added `PostgresTypeUtilsTest` covering precision 50 → STRING, 10/38 → DECIMAL, 0 → DECIMAL(38,18), and `_numeric` array symmetry.
- `mvn -pl paimon-flink/paimon-flink-cdc -am -Pflink1 clean install` — 4 tests passed (checkstyle/spotless/rat green).
