### PR TITLE
[flink] Fix migrate actions crashing when parallelism is not specified

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactory.java
@@ -41,7 +41,8 @@ public class MigrateDatabaseActionFactory implements ActionFactory {
         String sourceHiveDatabase = params.get(DATABASE);
         Map<String, String> catalogConfig = catalogConfigMap(params);
         String tableConf = params.get(OPTIONS);
-        Integer parallelism = Integer.parseInt(params.get(PARALLELISM));
+        Integer parallelism =
+                params.has(PARALLELISM) ? Integer.parseInt(params.get(PARALLELISM)) : null;
 
         MigrateDatabaseAction migrateDatabaseAction =
                 new MigrateDatabaseAction(
@@ -62,6 +63,7 @@ public class MigrateDatabaseActionFactory implements ActionFactory {
                         + "--source_type hive \\\n"
                         + "--database <database_name> \\\n"
                         + "[--catalog_conf <key>=<value] \\\n"
-                        + "[--options <key>=<value>,<key>=<value>,...]");
+                        + "[--options <key>=<value>,<key>=<value>,...] \\\n"
+                        + "[--parallelism <parallelism>]");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/MigrateTableActionFactory.java
@@ -41,7 +41,8 @@ public class MigrateTableActionFactory implements ActionFactory {
         String sourceHiveTable = params.get(TABLE);
         Map<String, String> catalogConfig = catalogConfigMap(params);
         String tableConf = params.get(OPTIONS);
-        Integer parallelism = Integer.parseInt(params.get(PARALLELISM));
+        Integer parallelism =
+                params.has(PARALLELISM) ? Integer.parseInt(params.get(PARALLELISM)) : null;
 
         MigrateTableAction migrateTableAction =
                 new MigrateTableAction(
@@ -61,6 +62,7 @@ public class MigrateTableActionFactory implements ActionFactory {
                         + "--source_type hive \\\n"
                         + "--table <database.table_name> \\\n"
                         + "[--catalog_conf <key>=<value] \\\n"
-                        + "[--options <key>=<value>,<key>=<value>,...]");
+                        + "[--options <key>=<value>,<key>=<value>,...] \\\n"
+                        + "[--parallelism <parallelism>]");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MigrateDatabaseActionFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/** Tests for {@link MigrateDatabaseActionFactory#create}. */
+public class MigrateDatabaseActionFactoryTest extends ActionITCaseBase {
+
+    @Test
+    public void testCreateWithoutParallelismDoesNotThrow() {
+        // --parallelism is optional; omitting it must not throw NumberFormatException.
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        MigrateDatabaseAction.class,
+                                                        "migrate_database",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--source_type",
+                                                        "hive",
+                                                        "--database",
+                                                        "default"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testCreateWithParallelism() {
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        MigrateDatabaseAction.class,
+                                                        "migrate_database",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--source_type",
+                                                        "hive",
+                                                        "--database",
+                                                        "default",
+                                                        "--parallelism",
+                                                        "4"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MigrateTableActionFactoryTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/MigrateTableActionFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.action;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/** Tests for {@link MigrateTableActionFactory#create}. */
+public class MigrateTableActionFactoryTest extends ActionITCaseBase {
+
+    @Test
+    public void testCreateWithoutParallelismDoesNotThrow() {
+        // --parallelism is optional; omitting it must not throw NumberFormatException.
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        MigrateTableAction.class,
+                                                        "migrate_table",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--source_type",
+                                                        "hive",
+                                                        "--table",
+                                                        "default.T"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testCreateWithParallelism() {
+        assertThatCode(
+                        () ->
+                                assertThat(
+                                                createAction(
+                                                        MigrateTableAction.class,
+                                                        "migrate_table",
+                                                        "--warehouse",
+                                                        warehouse,
+                                                        "--source_type",
+                                                        "hive",
+                                                        "--table",
+                                                        "default.T",
+                                                        "--parallelism",
+                                                        "4"))
+                                        .isNotNull())
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION

### Purpose

fix #8607

- `MigrateTableActionFactory.create()` and `MigrateDatabaseActionFactory.create()` parsed the optional `--parallelism` with an unguarded `Integer.parseInt(params.get(PARALLELISM))`, throwing `NumberFormatException` on `parseInt(null)` when the argument was omitted.
- Guard the parse with `params.has(PARALLELISM) ? Integer.parseInt(...) : null`, matching sibling `CloneActionFactory`/`ExpireSnapshotsActionFactory`; the downstream procedures already treat null as `availableProcessors()`.
- List the missing `[--parallelism <parallelism>]` option in both `printHelp()` blocks.
- Follow-up to migrate PR #4177, which introduced the parameter without the null guard.

### Tests

- Added `MigrateTableActionFactoryTest` and `MigrateDatabaseActionFactoryTest`, each with `testCreateWithoutParallelismDoesNotThrow` (reproduces the bug) and `testCreateWithParallelism`.
- `mvn -pl paimon-flink/paimon-flink-common -Pflink1 test` — 4 tests pass; `spotless:check` and `checkstyle:check` clean.


