### PR TITLE
[flink] Fix incorrect argument names in action help messages

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagActionFactory.java
@@ -54,7 +54,8 @@ public class CreateTagActionFactory extends CreateOrReplaceTagActionFactory {
                         + "--database <database_name> \\\n"
                         + "--table <table_name> \\\n"
                         + "--tag_name <tag_name> \\\n"
-                        + "[--snapshot <snapshot_id>]");
+                        + "[--snapshot <snapshot_id>] \\\n"
+                        + "[--time_retained <time_retained>]");
         System.out.println();
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromTimestampActionFactory.java
@@ -65,7 +65,7 @@ public class CreateTagFromTimestampActionFactory implements ActionFactory {
                         + "--table <table_name> \\\n"
                         + "--tag <tag> \\\n"
                         + "--timestamp <timestamp> \\\n"
-                        + "[--timeRetained <duration>] \\\n"
+                        + "[--time_retained <duration>] \\\n"
                         + "[--options <key>=<value>,<key>=<value>,...]");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/CreateTagFromWatermarkActionFactory.java
@@ -68,7 +68,7 @@ public class CreateTagFromWatermarkActionFactory implements ActionFactory {
                         + "--table <table_name> \\\n"
                         + "--tag <tag> \\\n"
                         + "--watermark <watermark> \\\n"
-                        + "[--timeRetained <duration>] \\\n"
+                        + "[--time_retained <duration>] \\\n"
                         + "[--options <key>=<value>,<key>=<value>,...]");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireChangelogsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireChangelogsActionFactory.java
@@ -75,7 +75,7 @@ public class ExpireChangelogsActionFactory implements ActionFactory {
                         + "--retain_max <max> \\\n"
                         + "--retain_min <min> \\\n"
                         + "--older_than <older_than> \\\n"
-                        + "--max_delete <max_delete> \\\n"
+                        + "--max_deletes <max_deletes> \\\n"
                         + "--delete_all <delete_all>");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpirePartitionsActionFactory.java
@@ -58,7 +58,6 @@ public class ExpirePartitionsActionFactory implements ActionFactory {
                         + "--warehouse <warehouse_path> \\\n"
                         + "--database <database_name> \\\n"
                         + "--table <table_name> \\\n"
-                        + "--tag_name <tag_name> \\\n"
                         + "--expiration_time <expiration_time> \\\n"
                         + "--timestamp_formatter <timestamp_formatter> \\\n"
                         + "[--timestamp_pattern <timestamp_pattern>] \\\n"

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/ExpireSnapshotsActionFactory.java
@@ -77,6 +77,6 @@ public class ExpireSnapshotsActionFactory implements ActionFactory {
                         + "--retain_max <max> \\\n"
                         + "--retain_min <min> \\\n"
                         + "--older_than <older_than> \\\n"
-                        + "--max_delete <max_delete>");
+                        + "--max_deletes <max_deletes>");
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RenameTagActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RenameTagActionFactory.java
@@ -54,6 +54,8 @@ public class RenameTagActionFactory implements ActionFactory {
         System.out.println(
                 "  rename_tag \\\n"
                         + "--warehouse <warehouse_path> \\\n"
+                        + "--database <database_name> \\\n"
+                        + "--table <table_name> \\\n"
                         + "--tag_name <tag_name> \\\n"
                         + "--target_tag_name <target_tag_name>");
         System.out.println();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToTimestampActionFactory.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/RollbackToTimestampActionFactory.java
@@ -52,7 +52,7 @@ public class RollbackToTimestampActionFactory implements ActionFactory {
 
         System.out.println("Syntax:");
         System.out.println(
-                "  rollback_to \\\n"
+                "  rollback_to_timestamp \\\n"
                         + "--warehouse <warehouse_path> \\\n"
                         + "--database <database_name> \\\n"
                         + "--table <table_name> \\\n"


### PR DESCRIPTION

### Purpose


- Several `ActionFactory.printHelp()` messages advertise argument names the parser does not read; `MultipleParameterToolAdapter` only accepts the exact snake_case key (or its `_`→`-` variant), so the advertised form is silently dropped (e.g. `--max_delete` ignored loses the delete cap, `--timeRetained` ignored keeps a tag forever).
- Corrects 8 factories to match their parser keys and sibling factories:
  - `CreateTagFromTimestamp`/`CreateTagFromWatermark`: `--timeRetained` → `--time_retained`.
  - `ExpireSnapshots`/`ExpireChangelogs`: `--max_delete` → `--max_deletes`.
  - `ExpirePartitions`: remove phantom `--tag_name` (never parsed by `create()`).
  - `RollbackToTimestamp`: syntax header `rollback_to` → `rollback_to_timestamp`.
  - `RenameTag`: add required `--database`/`--table` (mirrors `DeleteTagActionFactory`).
  - `CreateTag`: add `[--time_retained]` parsed by the parent factory (mirrors `ReplaceTagActionFactory`).
- Precedent single-sweep help fix: apache/paimon#2440.

### Tests

- Help-text only change, no behavior change — no test added. `mvn spotless:check` and `checkstyle:check` passed (`-Pflink1`).


