### PR TITLE
[parquet] Fix that parquet filter pushdown wrong for decimal

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -73,7 +73,7 @@ public class ParquetFileFormat extends FileFormat implements SupportsFieldMetada
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> filters) {
-        return ParquetReaderFactory.create(options, projectedRowType, readBatchSize, filters);
+        return new ParquetReaderFactory(options, projectedRowType, readBatchSize, filters);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetFileFormat.java
@@ -36,7 +36,6 @@ import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.RowType;
 
 import org.apache.parquet.ParquetReadOptions;
-import org.apache.parquet.filter2.predicate.ParquetFilters;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 
@@ -74,8 +73,7 @@ public class ParquetFileFormat extends FileFormat implements SupportsFieldMetada
             RowType dataSchemaRowType,
             RowType projectedRowType,
             @Nullable List<Predicate> filters) {
-        return new ParquetReaderFactory(
-                options, projectedRowType, readBatchSize, ParquetFilters.convert(filters));
+        return ParquetReaderFactory.create(options, projectedRowType, readBatchSize, filters);
     }
 
     @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -32,6 +32,7 @@ import org.apache.paimon.format.shredding.ShreddingReadPlanFactories;
 import org.apache.paimon.format.shredding.ShreddingReadPlanFactory;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
@@ -44,7 +45,9 @@ import org.apache.paimon.utils.Preconditions;
 
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.ParquetFilters;
 import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.schema.ConversionPatterns;
@@ -84,6 +87,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     private final int batchSize;
     private final boolean caseSensitive;
     @Nullable private final FilterCompat.Filter filter;
+    @Nullable private final List<Predicate> predicates;
 
     /**
      * Cache: fileSchema -> requestedSchema.
@@ -100,11 +104,26 @@ public class ParquetReaderFactory implements FormatReaderFactory {
 
     public ParquetReaderFactory(
             Options conf, RowType readType, int batchSize, @Nullable FilterCompat.Filter filter) {
+        this(conf, readType, batchSize, filter, null);
+    }
+
+    public static ParquetReaderFactory create(
+            Options conf, RowType readType, int batchSize, @Nullable List<Predicate> predicates) {
+        return new ParquetReaderFactory(conf, readType, batchSize, null, predicates);
+    }
+
+    private ParquetReaderFactory(
+            Options conf,
+            RowType readType,
+            int batchSize,
+            @Nullable FilterCompat.Filter filter,
+            @Nullable List<Predicate> predicates) {
         this.conf = conf;
         this.readType = readType;
         this.batchSize = batchSize;
         this.caseSensitive = conf.getOptional(CatalogOptions.CASE_SENSITIVE).orElse(true);
         this.filter = filter;
+        this.predicates = predicates;
     }
 
     @VisibleForTesting
@@ -115,17 +134,7 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     @Override
     public FileRecordReader<InternalRow> createReader(FormatReaderFactory.Context context)
             throws IOException {
-        ParquetReadOptions.Builder builder =
-                ParquetUtil.getParquetReadOptionsBuilder(conf)
-                        .withRecordFilter(filter)
-                        .withRange(0, context.fileSize());
-
-        ParquetFileReader reader =
-                new ParquetFileReader(
-                        ParquetInputFile.fromPath(
-                                context.fileIO(), context.filePath(), context.fileSize()),
-                        builder.build(),
-                        context.selection());
+        ParquetFileReader reader = createParquetFileReader(context);
         MessageType fileSchema = reader.getFileMetaData().getSchema();
         ShreddingReadPlan readPlan =
                 ShreddingReadPlanFactories.createReadPlan(
@@ -168,6 +177,40 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         return readPlan.isIdentity()
                 ? parquetReader
                 : new ShreddingFormatReader(parquetReader, readPlan);
+    }
+
+    private ParquetFileReader createParquetFileReader(FormatReaderFactory.Context context)
+            throws IOException {
+        ParquetInputFile inputFile =
+                ParquetInputFile.fromPath(context.fileIO(), context.filePath(), context.fileSize());
+        ParquetReadOptions footerReadOptions =
+                ParquetUtil.getParquetReadOptionsBuilder(conf)
+                        .withRange(0, context.fileSize())
+                        .build();
+        ParquetInputStream inputStream = inputFile.newStream();
+        try {
+            ParquetMetadata footer =
+                    ParquetFileReader.readFooter(inputFile, footerReadOptions, inputStream);
+            MessageType fileSchema = footer.getFileMetaData().getSchema();
+            FilterCompat.Filter actualFilter =
+                    predicates == null
+                            ? filter
+                            : ParquetFilters.convert(predicates, fileSchema, caseSensitive);
+            ParquetReadOptions readOptions =
+                    ParquetUtil.getParquetReadOptionsBuilder(conf)
+                            .withRecordFilter(actualFilter)
+                            .withRange(0, context.fileSize())
+                            .build();
+            return new ParquetFileReader(
+                    inputFile, footer, readOptions, inputStream, context.selection());
+        } catch (IOException | RuntimeException | Error e) {
+            try {
+                inputStream.close();
+            } catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw e;
+        }
     }
 
     private RequestedSchema getOrCreateRequestedSchema(MessageType fileSchema) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -86,7 +86,6 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     private final RowType readType;
     private final int batchSize;
     private final boolean caseSensitive;
-    @Nullable private final FilterCompat.Filter filter;
     @Nullable private final List<Predicate> predicates;
 
     /**
@@ -103,26 +102,11 @@ public class ParquetReaderFactory implements FormatReaderFactory {
             new ConcurrentHashMap<>();
 
     public ParquetReaderFactory(
-            Options conf, RowType readType, int batchSize, @Nullable FilterCompat.Filter filter) {
-        this(conf, readType, batchSize, filter, null);
-    }
-
-    public static ParquetReaderFactory create(
             Options conf, RowType readType, int batchSize, @Nullable List<Predicate> predicates) {
-        return new ParquetReaderFactory(conf, readType, batchSize, null, predicates);
-    }
-
-    private ParquetReaderFactory(
-            Options conf,
-            RowType readType,
-            int batchSize,
-            @Nullable FilterCompat.Filter filter,
-            @Nullable List<Predicate> predicates) {
         this.conf = conf;
         this.readType = readType;
         this.batchSize = batchSize;
         this.caseSensitive = conf.getOptional(CatalogOptions.CASE_SENSITIVE).orElse(true);
-        this.filter = filter;
         this.predicates = predicates;
     }
 
@@ -134,8 +118,22 @@ public class ParquetReaderFactory implements FormatReaderFactory {
     @Override
     public FileRecordReader<InternalRow> createReader(FormatReaderFactory.Context context)
             throws IOException {
-        ParquetFileReader reader = createParquetFileReader(context);
-        MessageType fileSchema = reader.getFileMetaData().getSchema();
+        ParquetInputFile inputFile =
+                ParquetInputFile.fromPath(context.fileIO(), context.filePath(), context.fileSize());
+        ParquetReadOptions.Builder readOptionsBuilder =
+                ParquetUtil.getParquetReadOptionsBuilder(conf).withRange(0, context.fileSize());
+        ParquetInputStream inputStream = inputFile.newStream();
+        ParquetMetadata footer =
+                ParquetFileReader.readFooter(
+                        inputFile, readOptionsBuilder.build(), inputStream, true);
+
+        MessageType fileSchema = footer.getFileMetaData().getSchema();
+        FilterCompat.Filter filter = ParquetFilters.convert(predicates, fileSchema, caseSensitive);
+        ParquetReadOptions readOptions = readOptionsBuilder.withRecordFilter(filter).build();
+        ParquetFileReader reader =
+                new ParquetFileReader(
+                        inputFile, footer, readOptions, inputStream, context.selection());
+
         ShreddingReadPlan readPlan =
                 ShreddingReadPlanFactories.createReadPlan(
                         readType,
@@ -177,40 +175,6 @@ public class ParquetReaderFactory implements FormatReaderFactory {
         return readPlan.isIdentity()
                 ? parquetReader
                 : new ShreddingFormatReader(parquetReader, readPlan);
-    }
-
-    private ParquetFileReader createParquetFileReader(FormatReaderFactory.Context context)
-            throws IOException {
-        ParquetInputFile inputFile =
-                ParquetInputFile.fromPath(context.fileIO(), context.filePath(), context.fileSize());
-        ParquetReadOptions footerReadOptions =
-                ParquetUtil.getParquetReadOptionsBuilder(conf)
-                        .withRange(0, context.fileSize())
-                        .build();
-        ParquetInputStream inputStream = inputFile.newStream();
-        try {
-            ParquetMetadata footer =
-                    ParquetFileReader.readFooter(inputFile, footerReadOptions, inputStream);
-            MessageType fileSchema = footer.getFileMetaData().getSchema();
-            FilterCompat.Filter actualFilter =
-                    predicates == null
-                            ? filter
-                            : ParquetFilters.convert(predicates, fileSchema, caseSensitive);
-            ParquetReadOptions readOptions =
-                    ParquetUtil.getParquetReadOptionsBuilder(conf)
-                            .withRecordFilter(actualFilter)
-                            .withRange(0, context.fileSize())
-                            .build();
-            return new ParquetFileReader(
-                    inputFile, footer, readOptions, inputStream, context.selection());
-        } catch (IOException | RuntimeException | Error e) {
-            try {
-                inputStream.close();
-            } catch (IOException closeException) {
-                e.addSuppressed(closeException);
-            }
-            throw e;
-        }
     }
 
     private RequestedSchema getOrCreateRequestedSchema(MessageType fileSchema) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/ParquetReaderFactory.java
@@ -128,11 +128,22 @@ public class ParquetReaderFactory implements FormatReaderFactory {
                         inputFile, readOptionsBuilder.build(), inputStream, true);
 
         MessageType fileSchema = footer.getFileMetaData().getSchema();
-        FilterCompat.Filter filter = ParquetFilters.convert(predicates, fileSchema, caseSensitive);
-        ParquetReadOptions readOptions = readOptionsBuilder.withRecordFilter(filter).build();
-        ParquetFileReader reader =
-                new ParquetFileReader(
-                        inputFile, footer, readOptions, inputStream, context.selection());
+        ParquetFileReader reader;
+        try {
+            FilterCompat.Filter filter =
+                    ParquetFilters.convert(predicates, fileSchema, caseSensitive);
+            ParquetReadOptions readOptions = readOptionsBuilder.withRecordFilter(filter).build();
+            reader =
+                    new ParquetFileReader(
+                            inputFile, footer, readOptions, inputStream, context.selection());
+        } catch (Throwable t) {
+            try {
+                inputStream.close();
+            } catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
+            throw t;
+        }
 
         ShreddingReadPlan readPlan =
                 ShreddingReadPlanFactories.createReadPlan(

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -66,16 +66,13 @@ import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /** Convert {@link Predicate} to {@link FilterCompat.Filter}. */
 public class ParquetFilters {
 
     private ParquetFilters() {}
-
-    public static FilterCompat.Filter convert(List<Predicate> predicates) {
-        return convert(predicates, null, true);
-    }
 
     public static FilterCompat.Filter convert(
             List<Predicate> predicates, MessageType fileSchema, boolean caseSensitive) {
@@ -105,7 +102,7 @@ public class ParquetFilters {
         private final boolean caseSensitive;
 
         private ConvertFilterToParquet(MessageType fileSchema, boolean caseSensitive) {
-            this.fileSchema = fileSchema;
+            this.fileSchema = Objects.requireNonNull(fileSchema, "fileSchema");
             this.caseSensitive = caseSensitive;
         }
 
@@ -275,93 +272,70 @@ public class ParquetFilters {
         }
 
         private Operators.Column<?> toParquetColumn(FieldRef fieldRef) {
-            if (!(fieldRef.type() instanceof DecimalType)) {
-                return fieldRef.type().accept(new ConvertToColumnTypeVisitor(fieldRef.name()));
-            }
-
-            PrimitiveType primitiveType = decimalPrimitiveType(fieldRef);
-            switch (primitiveType.getPrimitiveTypeName()) {
-                case INT32:
-                    return FilterApi.intColumn(fieldRef.name());
-                case INT64:
-                    return FilterApi.longColumn(fieldRef.name());
-                case BINARY:
-                case FIXED_LEN_BYTE_ARRAY:
-                    return FilterApi.binaryColumn(fieldRef.name());
-                default:
-                    throw new UnsupportedOperationException();
-            }
+            return fieldRef.type()
+                    .accept(new ConvertToColumnTypeVisitor(fieldRef, fileSchema, caseSensitive));
         }
 
         private Comparable<?> toParquetObject(Object value, FieldRef fieldRef) {
-            if (!(fieldRef.type() instanceof DecimalType)) {
-                return ParquetFilters.toParquetObject(value, fieldRef.type());
-            }
             if (value == null) {
                 return null;
             }
-            if (!(value instanceof Decimal)) {
-                throw new UnsupportedOperationException();
-            }
 
-            DecimalType decimalType = (DecimalType) fieldRef.type();
-            Decimal decimal = normalizeDecimal((Decimal) value, decimalType);
-            PrimitiveType primitiveType = decimalPrimitiveType(fieldRef);
-            switch (primitiveType.getPrimitiveTypeName()) {
-                case INT32:
-                    long intValue = toUnscaledLong(decimal);
-                    if (intValue < Integer.MIN_VALUE || intValue > Integer.MAX_VALUE) {
+            org.apache.paimon.types.DataType type = fieldRef.type();
+            if (type instanceof DecimalType) {
+                DecimalType decimalType = (DecimalType) fieldRef.type();
+                Decimal decimal = normalizeDecimal((Decimal) value, decimalType);
+                PrimitiveType primitiveType =
+                        decimalPrimitiveType(fieldRef, fileSchema, caseSensitive);
+                switch (primitiveType.getPrimitiveTypeName()) {
+                    case INT32:
+                        long intValue = toUnscaledLong(decimal);
+                        if (intValue < Integer.MIN_VALUE || intValue > Integer.MAX_VALUE) {
+                            throw new UnsupportedOperationException();
+                        }
+                        return (int) intValue;
+                    case INT64:
+                        return toUnscaledLong(decimal);
+                    case BINARY:
+                        return Binary.fromConstantByteArray(decimal.toUnscaledBytes());
+                    case FIXED_LEN_BYTE_ARRAY:
+                        return decimalToBinary(decimal, primitiveType.getTypeLength());
+                    default:
                         throw new UnsupportedOperationException();
-                    }
-                    return (int) intValue;
-                case INT64:
-                    return toUnscaledLong(decimal);
-                case BINARY:
-                    return Binary.fromConstantByteArray(decimal.toUnscaledBytes());
-                case FIXED_LEN_BYTE_ARRAY:
-                    return decimalToBinary(decimal, primitiveType.getTypeLength());
-                default:
-                    throw new UnsupportedOperationException();
-            }
-        }
-
-        private PrimitiveType decimalPrimitiveType(FieldRef fieldRef) {
-            if (fileSchema == null) {
-                throw new UnsupportedOperationException();
-            }
-
-            Type matched = null;
-            for (Type field : fileSchema.getFields()) {
-                boolean nameMatches =
-                        caseSensitive
-                                ? field.getName().equals(fieldRef.name())
-                                : field.getName().equalsIgnoreCase(fieldRef.name());
-                if (nameMatches) {
-                    if (matched != null) {
-                        throw new UnsupportedOperationException();
-                    }
-                    matched = field;
                 }
             }
-            if (matched == null || !matched.isPrimitive()) {
+
+            if (value instanceof Number) {
+                if (value instanceof Byte) {
+                    return ((Byte) value).intValue();
+                } else if (value instanceof Short) {
+                    return ((Short) value).intValue();
+                }
+                return (Comparable<?>) value;
+            } else if (value instanceof String) {
+                return Binary.fromString((String) value);
+            } else if (value instanceof BinaryString) {
+                return Binary.fromString(value.toString());
+            } else if (value instanceof byte[]) {
+                return Binary.fromReusedByteArray((byte[]) value);
+            } else if (value instanceof Timestamp) {
+                Timestamp timestamp = (Timestamp) value;
+                int precision = getTimestampPrecision(type);
+                if (precision <= 3) {
+                    // milliseconds
+                    return timestamp.getMillisecond();
+                } else if (precision <= 6) {
+                    // microseconds
+                    return timestamp.toMicros();
+                }
+                // precision > 6 uses INT96, not supported
                 throw new UnsupportedOperationException();
             }
 
-            PrimitiveType primitiveType = matched.asPrimitiveType();
-            LogicalTypeAnnotation logicalType = primitiveType.getLogicalTypeAnnotation();
-            if (!(logicalType instanceof DecimalLogicalTypeAnnotation)) {
-                throw new UnsupportedOperationException();
-            }
-
-            DecimalLogicalTypeAnnotation decimalLogicalType =
-                    (DecimalLogicalTypeAnnotation) logicalType;
-            if (decimalLogicalType.getScale() != ((DecimalType) fieldRef.type()).getScale()) {
-                throw new UnsupportedOperationException();
-            }
-            return primitiveType;
+            throw new UnsupportedOperationException();
         }
 
-        private static Decimal normalizeDecimal(Decimal decimal, DecimalType fieldType) {
+        private Decimal normalizeDecimal(Decimal decimal, DecimalType fieldType) {
             try {
                 BigDecimal normalized =
                         decimal.toBigDecimal()
@@ -378,13 +352,65 @@ public class ParquetFilters {
             }
         }
 
-        private static long toUnscaledLong(Decimal decimal) {
+        private long toUnscaledLong(Decimal decimal) {
             try {
                 return decimal.toUnscaledLong();
             } catch (ArithmeticException e) {
                 throw new UnsupportedOperationException(e);
             }
         }
+
+        private Binary decimalToBinary(Decimal decimal, int numBytes) {
+            byte[] unscaledBytes = decimal.toUnscaledBytes();
+            if (unscaledBytes.length > numBytes) {
+                throw new UnsupportedOperationException();
+            }
+            if (unscaledBytes.length == numBytes) {
+                return Binary.fromConstantByteArray(unscaledBytes);
+            }
+
+            byte[] paddedBytes = new byte[numBytes];
+            Arrays.fill(paddedBytes, unscaledBytes[0] < 0 ? (byte) -1 : (byte) 0);
+            System.arraycopy(
+                    unscaledBytes,
+                    0,
+                    paddedBytes,
+                    numBytes - unscaledBytes.length,
+                    unscaledBytes.length);
+            return Binary.fromConstantByteArray(paddedBytes);
+        }
+    }
+
+    private static PrimitiveType decimalPrimitiveType(
+            FieldRef fieldRef, MessageType fileSchema, boolean caseSensitive) {
+        Type matched = null;
+        // Paimon predicates currently reference top-level fields only. Nested field
+        // predicates are rejected before reaching the format reader.
+        for (Type field : fileSchema.getFields()) {
+            if (caseSensitive
+                    ? field.getName().equals(fieldRef.name())
+                    : field.getName().equalsIgnoreCase(fieldRef.name())) {
+                matched = field;
+                break;
+            }
+        }
+
+        if (matched == null || !matched.isPrimitive()) {
+            throw new UnsupportedOperationException();
+        }
+
+        PrimitiveType primitiveType = matched.asPrimitiveType();
+        LogicalTypeAnnotation logicalType = primitiveType.getLogicalTypeAnnotation();
+        if (!(logicalType instanceof DecimalLogicalTypeAnnotation)) {
+            throw new UnsupportedOperationException();
+        }
+
+        DecimalLogicalTypeAnnotation decimalLogicalType =
+                (DecimalLogicalTypeAnnotation) logicalType;
+        if (decimalLogicalType.getScale() != ((DecimalType) fieldRef.type()).getScale()) {
+            throw new UnsupportedOperationException();
+        }
+        return primitiveType;
     }
 
     private static int getTimestampPrecision(org.apache.paimon.types.DataType type) {
@@ -396,71 +422,20 @@ public class ParquetFilters {
         throw new IllegalArgumentException("Not a timestamp type: " + type);
     }
 
-    private static Comparable<?> toParquetObject(
-            Object value, org.apache.paimon.types.DataType type) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value instanceof Number) {
-            if (value instanceof Byte) {
-                return ((Byte) value).intValue();
-            } else if (value instanceof Short) {
-                return ((Short) value).intValue();
-            }
-            return (Comparable<?>) value;
-        } else if (value instanceof String) {
-            return Binary.fromString((String) value);
-        } else if (value instanceof BinaryString) {
-            return Binary.fromString(value.toString());
-        } else if (value instanceof byte[]) {
-            return Binary.fromReusedByteArray((byte[]) value);
-        } else if (value instanceof Decimal) {
-            throw new UnsupportedOperationException();
-        } else if (value instanceof Timestamp) {
-            Timestamp timestamp = (Timestamp) value;
-            int precision = getTimestampPrecision(type);
-            if (precision <= 3) {
-                // milliseconds
-                return timestamp.getMillisecond();
-            } else if (precision <= 6) {
-                // microseconds
-                return timestamp.toMicros();
-            }
-            // precision > 6 uses INT96, not supported
-            throw new UnsupportedOperationException();
-        }
-
-        throw new UnsupportedOperationException();
-    }
-
-    private static Binary decimalToBinary(Decimal decimal, int numBytes) {
-        byte[] unscaledBytes = decimal.toUnscaledBytes();
-        if (unscaledBytes.length > numBytes) {
-            throw new UnsupportedOperationException();
-        }
-        if (unscaledBytes.length == numBytes) {
-            return Binary.fromConstantByteArray(unscaledBytes);
-        }
-
-        byte[] paddedBytes = new byte[numBytes];
-        Arrays.fill(paddedBytes, unscaledBytes[0] < 0 ? (byte) -1 : (byte) 0);
-        System.arraycopy(
-                unscaledBytes,
-                0,
-                paddedBytes,
-                numBytes - unscaledBytes.length,
-                unscaledBytes.length);
-        return Binary.fromConstantByteArray(paddedBytes);
-    }
-
     private static class ConvertToColumnTypeVisitor
             implements DataTypeVisitor<Operators.Column<?>> {
 
+        private final FieldRef fieldRef;
         private final String name;
+        private final MessageType fileSchema;
+        private final boolean caseSensitive;
 
-        public ConvertToColumnTypeVisitor(String name) {
-            this.name = name;
+        public ConvertToColumnTypeVisitor(
+                FieldRef fieldRef, MessageType fileSchema, boolean caseSensitive) {
+            this.fieldRef = fieldRef;
+            this.name = fieldRef.name();
+            this.fileSchema = fileSchema;
+            this.caseSensitive = caseSensitive;
         }
 
         @Override
@@ -530,7 +505,18 @@ public class ParquetFilters {
 
         @Override
         public Operators.Column<?> visit(DecimalType decimalType) {
-            throw new UnsupportedOperationException();
+            PrimitiveType primitiveType = decimalPrimitiveType(fieldRef, fileSchema, caseSensitive);
+            switch (primitiveType.getPrimitiveTypeName()) {
+                case INT32:
+                    return FilterApi.intColumn(fieldRef.name());
+                case INT64:
+                    return FilterApi.longColumn(fieldRef.name());
+                case BINARY:
+                case FIXED_LEN_BYTE_ARRAY:
+                    return FilterApi.binaryColumn(fieldRef.name());
+                default:
+                    throw new UnsupportedOperationException();
+            }
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -21,7 +21,6 @@ package org.apache.parquet.filter2.predicate;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.format.parquet.ParquetSchemaConverter;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.FunctionVisitor;
 import org.apache.paimon.predicate.LeafPredicate;
@@ -55,8 +54,15 @@ import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.FloatColumn;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -65,16 +71,20 @@ import java.util.Set;
 /** Convert {@link Predicate} to {@link FilterCompat.Filter}. */
 public class ParquetFilters {
 
-    private static final ConvertFilterToParquet CONVERTER = new ConvertFilterToParquet();
-
     private ParquetFilters() {}
 
     public static FilterCompat.Filter convert(List<Predicate> predicates) {
+        return convert(predicates, null, true);
+    }
+
+    public static FilterCompat.Filter convert(
+            List<Predicate> predicates, MessageType fileSchema, boolean caseSensitive) {
+        ConvertFilterToParquet converter = new ConvertFilterToParquet(fileSchema, caseSensitive);
         FilterPredicate result = null;
         if (predicates != null) {
             for (Predicate predicate : predicates) {
                 try {
-                    FilterPredicate parquetFilter = predicate.visit(CONVERTER);
+                    FilterPredicate parquetFilter = predicate.visit(converter);
                     if (result == null) {
                         result = parquetFilter;
                     } else {
@@ -90,6 +100,14 @@ public class ParquetFilters {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private static class ConvertFilterToParquet implements FunctionVisitor<FilterPredicate> {
+
+        private final MessageType fileSchema;
+        private final boolean caseSensitive;
+
+        private ConvertFilterToParquet(MessageType fileSchema, boolean caseSensitive) {
+            this.fileSchema = fileSchema;
+            this.caseSensitive = caseSensitive;
+        }
 
         @Override
         public FilterPredicate visitIsNotNull(FieldRef fieldRef) {
@@ -115,38 +133,35 @@ public class ParquetFilters {
 
         @Override
         public FilterPredicate visitLessThan(FieldRef fieldRef, Object literal) {
-            return new Operators.Lt(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+            return new Operators.Lt(toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
         public FilterPredicate visitGreaterOrEqual(FieldRef fieldRef, Object literal) {
             return new Operators.GtEq(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
         public FilterPredicate visitNotEqual(FieldRef fieldRef, Object literal) {
             return new Operators.NotEq(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
         public FilterPredicate visitLessOrEqual(FieldRef fieldRef, Object literal) {
             return new Operators.LtEq(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
         public FilterPredicate visitEqual(FieldRef fieldRef, Object literal) {
-            return new Operators.Eq(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+            return new Operators.Eq(toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
         public FilterPredicate visitGreaterThan(FieldRef fieldRef, Object literal) {
-            return new Operators.Gt(
-                    toParquetColumn(fieldRef), toParquetObject(literal, fieldRef.type()));
+            return new Operators.Gt(toParquetColumn(fieldRef), toParquetObject(literal, fieldRef));
         }
 
         @Override
@@ -190,22 +205,25 @@ public class ParquetFilters {
         @Override
         public FilterPredicate visitIn(FieldRef fieldRef, List<Object> literals) {
             Operators.Column<?> column = toParquetColumn(fieldRef);
-            org.apache.paimon.types.DataType type = fieldRef.type();
             if (column instanceof Operators.LongColumn) {
                 return FilterApi.in(
-                        (Operators.LongColumn) column, convertSets(literals, Long.class, type));
+                        (Operators.LongColumn) column, convertSets(literals, Long.class, fieldRef));
             } else if (column instanceof Operators.IntColumn) {
                 return FilterApi.in(
-                        (Operators.IntColumn) column, convertSets(literals, Integer.class, type));
+                        (Operators.IntColumn) column,
+                        convertSets(literals, Integer.class, fieldRef));
             } else if (column instanceof Operators.DoubleColumn) {
                 return FilterApi.in(
-                        (Operators.DoubleColumn) column, convertSets(literals, Double.class, type));
+                        (Operators.DoubleColumn) column,
+                        convertSets(literals, Double.class, fieldRef));
             } else if (column instanceof Operators.FloatColumn) {
                 return FilterApi.in(
-                        (Operators.FloatColumn) column, convertSets(literals, Float.class, type));
+                        (Operators.FloatColumn) column,
+                        convertSets(literals, Float.class, fieldRef));
             } else if (column instanceof Operators.BinaryColumn) {
                 return FilterApi.in(
-                        (Operators.BinaryColumn) column, convertSets(literals, Binary.class, type));
+                        (Operators.BinaryColumn) column,
+                        convertSets(literals, Binary.class, fieldRef));
             }
 
             throw new UnsupportedOperationException();
@@ -214,22 +232,25 @@ public class ParquetFilters {
         @Override
         public FilterPredicate visitNotIn(FieldRef fieldRef, List<Object> literals) {
             Operators.Column<?> column = toParquetColumn(fieldRef);
-            org.apache.paimon.types.DataType type = fieldRef.type();
             if (column instanceof Operators.LongColumn) {
                 return FilterApi.notIn(
-                        (Operators.LongColumn) column, convertSets(literals, Long.class, type));
+                        (Operators.LongColumn) column, convertSets(literals, Long.class, fieldRef));
             } else if (column instanceof Operators.IntColumn) {
                 return FilterApi.notIn(
-                        (Operators.IntColumn) column, convertSets(literals, Integer.class, type));
+                        (Operators.IntColumn) column,
+                        convertSets(literals, Integer.class, fieldRef));
             } else if (column instanceof Operators.DoubleColumn) {
                 return FilterApi.notIn(
-                        (Operators.DoubleColumn) column, convertSets(literals, Double.class, type));
+                        (Operators.DoubleColumn) column,
+                        convertSets(literals, Double.class, fieldRef));
             } else if (column instanceof Operators.FloatColumn) {
                 return FilterApi.notIn(
-                        (Operators.FloatColumn) column, convertSets(literals, Float.class, type));
+                        (Operators.FloatColumn) column,
+                        convertSets(literals, Float.class, fieldRef));
             } else if (column instanceof Operators.BinaryColumn) {
                 return FilterApi.notIn(
-                        (Operators.BinaryColumn) column, convertSets(literals, Binary.class, type));
+                        (Operators.BinaryColumn) column,
+                        convertSets(literals, Binary.class, fieldRef));
             }
 
             throw new UnsupportedOperationException();
@@ -239,20 +260,131 @@ public class ParquetFilters {
         public FilterPredicate visitNonFieldLeaf(LeafPredicate predicate) {
             throw new UnsupportedOperationException();
         }
-    }
 
-    private static <T> Set<T> convertSets(
-            List<Object> values, Class<T> kclass, org.apache.paimon.types.DataType type) {
-        Set<T> converted = new HashSet<>();
-        for (Object value : values) {
-            Comparable<?> cmp = toParquetObject(value, type);
-            if (kclass.isInstance(cmp)) {
-                converted.add((T) cmp);
-            } else {
-                throw new UnsupportedOperationException();
+        private <T> Set<T> convertSets(List<Object> values, Class<T> kclass, FieldRef fieldRef) {
+            Set<T> converted = new HashSet<>();
+            for (Object value : values) {
+                Comparable<?> cmp = toParquetObject(value, fieldRef);
+                if (kclass.isInstance(cmp)) {
+                    converted.add((T) cmp);
+                } else {
+                    throw new UnsupportedOperationException();
+                }
+            }
+            return converted;
+        }
+
+        private Operators.Column<?> toParquetColumn(FieldRef fieldRef) {
+            if (!(fieldRef.type() instanceof DecimalType)) {
+                return fieldRef.type().accept(new ConvertToColumnTypeVisitor(fieldRef.name()));
+            }
+
+            PrimitiveType primitiveType = decimalPrimitiveType(fieldRef);
+            switch (primitiveType.getPrimitiveTypeName()) {
+                case INT32:
+                    return FilterApi.intColumn(fieldRef.name());
+                case INT64:
+                    return FilterApi.longColumn(fieldRef.name());
+                case BINARY:
+                case FIXED_LEN_BYTE_ARRAY:
+                    return FilterApi.binaryColumn(fieldRef.name());
+                default:
+                    throw new UnsupportedOperationException();
             }
         }
-        return converted;
+
+        private Comparable<?> toParquetObject(Object value, FieldRef fieldRef) {
+            if (!(fieldRef.type() instanceof DecimalType)) {
+                return ParquetFilters.toParquetObject(value, fieldRef.type());
+            }
+            if (value == null) {
+                return null;
+            }
+            if (!(value instanceof Decimal)) {
+                throw new UnsupportedOperationException();
+            }
+
+            DecimalType decimalType = (DecimalType) fieldRef.type();
+            Decimal decimal = normalizeDecimal((Decimal) value, decimalType);
+            PrimitiveType primitiveType = decimalPrimitiveType(fieldRef);
+            switch (primitiveType.getPrimitiveTypeName()) {
+                case INT32:
+                    long intValue = toUnscaledLong(decimal);
+                    if (intValue < Integer.MIN_VALUE || intValue > Integer.MAX_VALUE) {
+                        throw new UnsupportedOperationException();
+                    }
+                    return (int) intValue;
+                case INT64:
+                    return toUnscaledLong(decimal);
+                case BINARY:
+                    return Binary.fromConstantByteArray(decimal.toUnscaledBytes());
+                case FIXED_LEN_BYTE_ARRAY:
+                    return decimalToBinary(decimal, primitiveType.getTypeLength());
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        private PrimitiveType decimalPrimitiveType(FieldRef fieldRef) {
+            if (fileSchema == null) {
+                throw new UnsupportedOperationException();
+            }
+
+            Type matched = null;
+            for (Type field : fileSchema.getFields()) {
+                boolean nameMatches =
+                        caseSensitive
+                                ? field.getName().equals(fieldRef.name())
+                                : field.getName().equalsIgnoreCase(fieldRef.name());
+                if (nameMatches) {
+                    if (matched != null) {
+                        throw new UnsupportedOperationException();
+                    }
+                    matched = field;
+                }
+            }
+            if (matched == null || !matched.isPrimitive()) {
+                throw new UnsupportedOperationException();
+            }
+
+            PrimitiveType primitiveType = matched.asPrimitiveType();
+            LogicalTypeAnnotation logicalType = primitiveType.getLogicalTypeAnnotation();
+            if (!(logicalType instanceof DecimalLogicalTypeAnnotation)) {
+                throw new UnsupportedOperationException();
+            }
+
+            DecimalLogicalTypeAnnotation decimalLogicalType =
+                    (DecimalLogicalTypeAnnotation) logicalType;
+            if (decimalLogicalType.getScale() != ((DecimalType) fieldRef.type()).getScale()) {
+                throw new UnsupportedOperationException();
+            }
+            return primitiveType;
+        }
+
+        private static Decimal normalizeDecimal(Decimal decimal, DecimalType fieldType) {
+            try {
+                BigDecimal normalized =
+                        decimal.toBigDecimal()
+                                .setScale(fieldType.getScale(), RoundingMode.UNNECESSARY);
+                Decimal result =
+                        Decimal.fromBigDecimal(
+                                normalized, fieldType.getPrecision(), fieldType.getScale());
+                if (result == null) {
+                    throw new UnsupportedOperationException();
+                }
+                return result;
+            } catch (ArithmeticException e) {
+                throw new UnsupportedOperationException(e);
+            }
+        }
+
+        private static long toUnscaledLong(Decimal decimal) {
+            try {
+                return decimal.toUnscaledLong();
+            } catch (ArithmeticException e) {
+                throw new UnsupportedOperationException(e);
+            }
+        }
     }
 
     private static int getTimestampPrecision(org.apache.paimon.types.DataType type) {
@@ -262,10 +394,6 @@ public class ParquetFilters {
             return ((LocalZonedTimestampType) type).getPrecision();
         }
         throw new IllegalArgumentException("Not a timestamp type: " + type);
-    }
-
-    private static Operators.Column<?> toParquetColumn(FieldRef fieldRef) {
-        return fieldRef.type().accept(new ConvertToColumnTypeVisitor(fieldRef.name()));
     }
 
     private static Comparable<?> toParquetObject(
@@ -288,15 +416,7 @@ public class ParquetFilters {
         } else if (value instanceof byte[]) {
             return Binary.fromReusedByteArray((byte[]) value);
         } else if (value instanceof Decimal) {
-            Decimal decimal = (Decimal) value;
-            int precision = ((DecimalType) type).getPrecision();
-            if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                return (int) decimal.toUnscaledLong();
-            } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
-                return decimal.toUnscaledLong();
-            } else {
-                return decimalToBinary(decimal, precision);
-            }
+            throw new UnsupportedOperationException();
         } else if (value instanceof Timestamp) {
             Timestamp timestamp = (Timestamp) value;
             int precision = getTimestampPrecision(type);
@@ -314,9 +434,11 @@ public class ParquetFilters {
         throw new UnsupportedOperationException();
     }
 
-    private static Binary decimalToBinary(Decimal decimal, int precision) {
-        int numBytes = ParquetSchemaConverter.computeMinBytesForDecimalPrecision(precision);
+    private static Binary decimalToBinary(Decimal decimal, int numBytes) {
         byte[] unscaledBytes = decimal.toUnscaledBytes();
+        if (unscaledBytes.length > numBytes) {
+            throw new UnsupportedOperationException();
+        }
         if (unscaledBytes.length == numBytes) {
             return Binary.fromConstantByteArray(unscaledBytes);
         }
@@ -408,14 +530,7 @@ public class ParquetFilters {
 
         @Override
         public Operators.Column<?> visit(DecimalType decimalType) {
-            int precision = decimalType.getPrecision();
-            if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                return FilterApi.intColumn(name);
-            } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
-                return FilterApi.longColumn(name);
-            } else {
-                return FilterApi.binaryColumn(name);
-            }
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
+++ b/paimon-format/src/main/java/org/apache/parquet/filter2/predicate/ParquetFilters.java
@@ -57,6 +57,7 @@ import org.apache.parquet.filter2.predicate.Operators.FloatColumn;
 import org.apache.parquet.io.api.Binary;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -288,13 +289,13 @@ public class ParquetFilters {
             return Binary.fromReusedByteArray((byte[]) value);
         } else if (value instanceof Decimal) {
             Decimal decimal = (Decimal) value;
-            int precision = decimal.precision();
+            int precision = ((DecimalType) type).getPrecision();
             if (ParquetSchemaConverter.is32BitDecimal(precision)) {
                 return (int) decimal.toUnscaledLong();
             } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
                 return decimal.toUnscaledLong();
             } else {
-                return Binary.fromConstantByteArray(decimal.toUnscaledBytes());
+                return decimalToBinary(decimal, precision);
             }
         } else if (value instanceof Timestamp) {
             Timestamp timestamp = (Timestamp) value;
@@ -311,6 +312,24 @@ public class ParquetFilters {
         }
 
         throw new UnsupportedOperationException();
+    }
+
+    private static Binary decimalToBinary(Decimal decimal, int precision) {
+        int numBytes = ParquetSchemaConverter.computeMinBytesForDecimalPrecision(precision);
+        byte[] unscaledBytes = decimal.toUnscaledBytes();
+        if (unscaledBytes.length == numBytes) {
+            return Binary.fromConstantByteArray(unscaledBytes);
+        }
+
+        byte[] paddedBytes = new byte[numBytes];
+        Arrays.fill(paddedBytes, unscaledBytes[0] < 0 ? (byte) -1 : (byte) 0);
+        System.arraycopy(
+                unscaledBytes,
+                0,
+                paddedBytes,
+                numBytes - unscaledBytes.length,
+                unscaledBytes.length);
+        return Binary.fromConstantByteArray(paddedBytes);
     }
 
     private static class ConvertToColumnTypeVisitor

--- a/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/paimon-format/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -136,7 +136,7 @@ public class ParquetFileReader implements Closeable {
         return readFooter(file, options, f, /*closeStreamOnFailure*/ false);
     }
 
-    private static final ParquetMetadata readFooter(
+    public static final ParquetMetadata readFooter(
             InputFile file,
             ParquetReadOptions options,
             SeekableInputStream f,

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetCaseInsensitiveReadTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetCaseInsensitiveReadTest.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
-import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
@@ -134,8 +133,7 @@ class ParquetCaseInsensitiveReadTest {
             throws Exception {
         Options options = new Options();
         options.set(CatalogOptions.CASE_SENSITIVE, caseSensitive);
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(options, readType, 1024, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(options, readType, 1024, null);
         LocalFileIO fileIO = new LocalFileIO();
         List<InternalRow> rows = new ArrayList<>();
         try (RecordReader<InternalRow> reader =

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetColumnVectorTest.java
@@ -38,7 +38,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.StringUtils;
 
-import org.apache.parquet.filter2.compat.FilterCompat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -593,7 +592,7 @@ public class ParquetColumnVectorTest {
         writer.close();
 
         ParquetReaderFactory readerFactory =
-                new ParquetReaderFactory(new Options(), rowType, 1024, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), rowType, 1024, null);
 
         RecordReader<InternalRow> reader =
                 readerFactory.createReader(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -49,6 +49,7 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
@@ -292,6 +293,8 @@ class ParquetFiltersTest {
         // precision <= 9 uses INT32
         int precision = 9;
         int scale = 2;
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.INT32, 0, precision, scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -304,14 +307,18 @@ class ParquetFiltersTest {
         Decimal value = Decimal.fromBigDecimal(new BigDecimal("123.45"), precision, scale);
         int expectedIntVal = (int) value.toUnscaledLong(); // 12345
 
-        test(builder.isNull(0), "eq(decimal1, null)", true);
-        test(builder.isNotNull(0), "noteq(decimal1, null)", true);
-        test(builder.equal(0, value), "eq(decimal1, " + expectedIntVal + ")", true);
-        test(builder.notEqual(0, value), "noteq(decimal1, " + expectedIntVal + ")", true);
-        test(builder.lessThan(0, value), "lt(decimal1, " + expectedIntVal + ")", true);
-        test(builder.lessOrEqual(0, value), "lteq(decimal1, " + expectedIntVal + ")", true);
-        test(builder.greaterThan(0, value), "gt(decimal1, " + expectedIntVal + ")", true);
-        test(builder.greaterOrEqual(0, value), "gteq(decimal1, " + expectedIntVal + ")", true);
+        test(schema, builder.isNull(0), "eq(decimal1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(decimal1, null)", true);
+        test(schema, builder.equal(0, value), "eq(decimal1, " + expectedIntVal + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(decimal1, " + expectedIntVal + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(decimal1, " + expectedIntVal + ")", true);
+        test(schema, builder.lessOrEqual(0, value), "lteq(decimal1, " + expectedIntVal + ")", true);
+        test(schema, builder.greaterThan(0, value), "gt(decimal1, " + expectedIntVal + ")", true);
+        test(
+                schema,
+                builder.greaterOrEqual(0, value),
+                "gteq(decimal1, " + expectedIntVal + ")",
+                true);
     }
 
     @Test
@@ -319,6 +326,8 @@ class ParquetFiltersTest {
         // 9 < precision <= 18 uses INT64
         int precision = 18;
         int scale = 4;
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.INT64, 0, precision, scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -332,14 +341,22 @@ class ParquetFiltersTest {
                 Decimal.fromBigDecimal(new BigDecimal("12345678901234.5678"), precision, scale);
         long expectedLongVal = value.toUnscaledLong();
 
-        test(builder.isNull(0), "eq(decimal1, null)", true);
-        test(builder.isNotNull(0), "noteq(decimal1, null)", true);
-        test(builder.equal(0, value), "eq(decimal1, " + expectedLongVal + ")", true);
-        test(builder.notEqual(0, value), "noteq(decimal1, " + expectedLongVal + ")", true);
-        test(builder.lessThan(0, value), "lt(decimal1, " + expectedLongVal + ")", true);
-        test(builder.lessOrEqual(0, value), "lteq(decimal1, " + expectedLongVal + ")", true);
-        test(builder.greaterThan(0, value), "gt(decimal1, " + expectedLongVal + ")", true);
-        test(builder.greaterOrEqual(0, value), "gteq(decimal1, " + expectedLongVal + ")", true);
+        test(schema, builder.isNull(0), "eq(decimal1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(decimal1, null)", true);
+        test(schema, builder.equal(0, value), "eq(decimal1, " + expectedLongVal + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(decimal1, " + expectedLongVal + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(decimal1, " + expectedLongVal + ")", true);
+        test(
+                schema,
+                builder.lessOrEqual(0, value),
+                "lteq(decimal1, " + expectedLongVal + ")",
+                true);
+        test(schema, builder.greaterThan(0, value), "gt(decimal1, " + expectedLongVal + ")", true);
+        test(
+                schema,
+                builder.greaterOrEqual(0, value),
+                "gteq(decimal1, " + expectedLongVal + ")",
+                true);
     }
 
     @Test
@@ -348,6 +365,13 @@ class ParquetFiltersTest {
         int fieldPrecision = 20;
         int literalPrecision = 8;
         int scale = 0;
+        MessageType schema =
+                decimalSchema(
+                        "decimal1",
+                        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+                        9,
+                        fieldPrecision,
+                        scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -378,25 +402,30 @@ class ParquetFiltersTest {
                             (byte) 0xD5
                         });
 
-        test(builder.isNull(0), "eq(decimal1, null)", true);
-        test(builder.isNotNull(0), "noteq(decimal1, null)", true);
+        test(schema, builder.isNull(0), "eq(decimal1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(decimal1, null)", true);
         test(
+                schema,
                 builder.equal(0, positive),
                 FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
+                schema,
                 builder.notEqual(0, positive),
                 FilterApi.notEq(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
+                schema,
                 builder.lessThan(0, positive),
                 FilterApi.lt(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
+                schema,
                 builder.greaterThan(0, positive),
                 FilterApi.gt(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
+                schema,
                 builder.equal(0, negative),
                 FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedNegative),
                 true);
@@ -406,6 +435,7 @@ class ParquetFiltersTest {
                         new BigDecimal("99999999999999999999"), fieldPrecision, scale);
         assertThat(fullWidth.toUnscaledBytes()).hasSize(9);
         test(
+                schema,
                 builder.equal(0, fullWidth),
                 FilterApi.eq(
                         FilterApi.binaryColumn("decimal1"),
@@ -417,6 +447,9 @@ class ParquetFiltersTest {
     public void testDecimalBinaryMaxPrecision() {
         int precision = 38;
         int scale = 10;
+        MessageType schema =
+                decimalSchema(
+                        "decimal1", PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 16, precision, scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -450,6 +483,7 @@ class ParquetFiltersTest {
                         });
 
         test(
+                schema,
                 builder.equal(0, value),
                 FilterApi.eq(FilterApi.binaryColumn("decimal1"), expected),
                 true);
@@ -459,6 +493,13 @@ class ParquetFiltersTest {
     public void testInFilterDecimalBinary() {
         int fieldPrecision = 20;
         int scale = 0;
+        MessageType schema =
+                decimalSchema(
+                        "decimal1",
+                        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+                        9,
+                        fieldPrecision,
+                        scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -489,10 +530,12 @@ class ParquetFiltersTest {
                         .collect(Collectors.toSet());
 
         test(
+                schema,
                 builder.in(0, literals),
                 FilterApi.in(FilterApi.binaryColumn("decimal1"), expected),
                 true);
         test(
+                schema,
                 builder.notIn(0, literals),
                 FilterApi.notIn(FilterApi.binaryColumn("decimal1"), expected),
                 true);
@@ -551,6 +594,8 @@ class ParquetFiltersTest {
                         .length(9)
                         .as(LogicalTypeAnnotation.decimalType(scale, fieldPrecision))
                         .named("decimal1");
+        MessageType schema =
+                new MessageType("paimon_schema", Collections.singletonList(primitiveType));
         EncodingStats encodingStats =
                 new EncodingStats.Builder()
                         .addDictEncoding(Encoding.PLAIN)
@@ -574,28 +619,142 @@ class ParquetFiltersTest {
 
         assertThat(
                         DictionaryFilter.canDrop(
-                                convert(builder.equal(0, positive)),
+                                convert(schema, builder.equal(0, positive)),
                                 Collections.singletonList(metadata),
                                 dictionaries))
                 .isFalse();
         assertThat(
                         DictionaryFilter.canDrop(
-                                convert(builder.equal(0, negative)),
+                                convert(schema, builder.equal(0, negative)),
                                 Collections.singletonList(metadata),
                                 dictionaries))
                 .isFalse();
         assertThat(
                         DictionaryFilter.canDrop(
-                                convert(builder.equal(0, missing)),
+                                convert(schema, builder.equal(0, missing)),
                                 Collections.singletonList(metadata),
                                 dictionaries))
                 .isTrue();
     }
 
     @Test
+    public void testDecimalWithoutFileSchema() {
+        int precision = 20;
+        int scale = 0;
+        PredicateBuilder builder = decimalPredicateBuilder(precision, scale);
+        Decimal value = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
+
+        test(builder.equal(0, value), "", false);
+    }
+
+    @Test
+    public void testDecimalLiteralOutsideFieldDomain() {
+        int fieldPrecision = 9;
+        int scale = 0;
+        PredicateBuilder builder = decimalPredicateBuilder(fieldPrecision, scale);
+        Decimal value = Decimal.fromBigDecimal(new BigDecimal("4294967297"), 10, scale);
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.INT32, 0, fieldPrecision, scale);
+
+        test(schema, builder.equal(0, value), "", false);
+    }
+
+    @Test
+    public void testDecimalLiteralWiderThanPhysicalWidth() {
+        int fieldPrecision = 20;
+        int scale = 0;
+        PredicateBuilder builder = decimalPredicateBuilder(fieldPrecision, scale);
+        Decimal value = Decimal.fromBigDecimal(new BigDecimal("3000000000"), 10, scale);
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 4, 9, scale);
+
+        test(schema, builder.equal(0, value), "", false);
+    }
+
+    @Test
+    public void testDecimalLiteralWiderThanFieldDomain() {
+        int fieldPrecision = 20;
+        int scale = 0;
+        PredicateBuilder builder = decimalPredicateBuilder(fieldPrecision, scale);
+        Decimal value =
+                Decimal.fromBigDecimal(
+                        new BigDecimal("99999999999999999999999999999999999999"), 38, scale);
+        MessageType schema =
+                decimalSchema(
+                        "decimal1",
+                        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+                        9,
+                        fieldPrecision,
+                        scale);
+
+        test(schema, builder.equal(0, value), "", false);
+    }
+
+    @Test
+    public void testDecimalScaleNormalization() {
+        int fieldPrecision = 20;
+        int fieldScale = 2;
+        PredicateBuilder builder = decimalPredicateBuilder(fieldPrecision, fieldScale);
+        MessageType schema =
+                decimalSchema(
+                        "decimal1",
+                        PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
+                        9,
+                        fieldPrecision,
+                        fieldScale);
+        Decimal exact = Decimal.fromBigDecimal(new BigDecimal("100"), 3, 0);
+        Decimal inexact = Decimal.fromBigDecimal(new BigDecimal("100.001"), 6, 3);
+        Binary expected =
+                Binary.fromConstantByteArray(new byte[] {0, 0, 0, 0, 0, 0, 0, 0x27, 0x10});
+
+        test(
+                schema,
+                builder.equal(0, exact),
+                FilterApi.eq(FilterApi.binaryColumn("decimal1"), expected),
+                true);
+        test(schema, builder.equal(0, inexact), "", false);
+    }
+
+    @Test
+    public void testDecimalPhysicalTypes() {
+        int precision = 9;
+        int scale = 2;
+        PredicateBuilder builder = decimalPredicateBuilder(precision, scale);
+        Decimal value = Decimal.fromBigDecimal(new BigDecimal("12.34"), precision, scale);
+
+        test(
+                decimalSchema("decimal1", PrimitiveTypeName.INT32, 0, precision, scale),
+                builder.equal(0, value),
+                FilterApi.eq(FilterApi.intColumn("decimal1"), 1234),
+                true);
+        test(
+                decimalSchema("decimal1", PrimitiveTypeName.INT64, 0, precision, scale),
+                builder.equal(0, value),
+                FilterApi.eq(FilterApi.longColumn("decimal1"), 1234L),
+                true);
+        test(
+                decimalSchema("decimal1", PrimitiveTypeName.BINARY, 0, precision, scale),
+                builder.equal(0, value),
+                FilterApi.eq(
+                        FilterApi.binaryColumn("decimal1"),
+                        Binary.fromConstantByteArray(new byte[] {0x04, (byte) 0xD2})),
+                true);
+        test(
+                decimalSchema(
+                        "decimal1", PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 4, precision, scale),
+                builder.equal(0, value),
+                FilterApi.eq(
+                        FilterApi.binaryColumn("decimal1"),
+                        Binary.fromConstantByteArray(new byte[] {0, 0, 0x04, (byte) 0xD2})),
+                true);
+    }
+
+    @Test
     public void testInFilterDecimal32Bit() {
         int precision = 9;
         int scale = 2;
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.INT32, 0, precision, scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -611,6 +770,7 @@ class ParquetFiltersTest {
 
         // For less than 21 elements, it expands to or(eq, eq, eq)
         test(
+                schema,
                 builder.in(0, Arrays.asList(v1, v2, v3)),
                 "or(or(eq(decimal1, "
                         + (int) v1.toUnscaledLong()
@@ -622,6 +782,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(0, Arrays.asList(v1, v2, v3)),
                 "and(and(noteq(decimal1, "
                         + (int) v1.toUnscaledLong()
@@ -637,6 +798,8 @@ class ParquetFiltersTest {
     public void testInFilterDecimal64Bit() {
         int precision = 18;
         int scale = 4;
+        MessageType schema =
+                decimalSchema("decimal1", PrimitiveTypeName.INT64, 0, precision, scale);
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -652,6 +815,7 @@ class ParquetFiltersTest {
 
         // For less than 21 elements, it expands to or(eq, eq, eq)
         test(
+                schema,
                 builder.in(0, Arrays.asList(v1, v2, v3)),
                 "or(or(eq(decimal1, "
                         + v1.toUnscaledLong()
@@ -663,6 +827,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(0, Arrays.asList(v1, v2, v3)),
                 "and(and(noteq(decimal1, "
                         + v1.toUnscaledLong()
@@ -842,6 +1007,61 @@ class ParquetFiltersTest {
                         + micros3
                         + "))",
                 true);
+    }
+
+    private void test(
+            MessageType schema,
+            Predicate predicate,
+            FilterPredicate parquetPredicate,
+            boolean canPushDown) {
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(PredicateBuilder.splitAnd(predicate), schema, true);
+        if (canPushDown) {
+            FilterPredicateCompat compat = (FilterPredicateCompat) filter;
+            assertThat(compat.getFilterPredicate()).isEqualTo(parquetPredicate);
+        } else {
+            assertThat(filter).isEqualTo(FilterCompat.NOOP);
+        }
+    }
+
+    private FilterPredicate convert(MessageType schema, Predicate predicate) {
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(PredicateBuilder.splitAnd(predicate), schema, true);
+        return ((FilterPredicateCompat) filter).getFilterPredicate();
+    }
+
+    private void test(
+            MessageType schema, Predicate predicate, String expected, boolean canPushDown) {
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(PredicateBuilder.splitAnd(predicate), schema, true);
+        if (canPushDown) {
+            FilterPredicateCompat compat = (FilterPredicateCompat) filter;
+            assertThat(compat.getFilterPredicate().toString()).isEqualTo(expected);
+        } else {
+            assertThat(filter).isEqualTo(FilterCompat.NOOP);
+        }
+    }
+
+    private static PredicateBuilder decimalPredicateBuilder(int precision, int scale) {
+        return new PredicateBuilder(
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "decimal1", new DecimalType(precision, scale)))));
+    }
+
+    private static MessageType decimalSchema(
+            String fieldName,
+            PrimitiveTypeName physicalType,
+            int fixedLength,
+            int precision,
+            int scale) {
+        Types.PrimitiveBuilder<PrimitiveType> builder = Types.required(physicalType);
+        if (physicalType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
+            builder.length(fixedLength);
+        }
+        PrimitiveType type =
+                builder.as(LogicalTypeAnnotation.decimalType(scale, precision)).named(fieldName);
+        return new MessageType("paimon_schema", Collections.singletonList(type));
     }
 
     private void test(Predicate predicate, FilterPredicate parquetPredicate, boolean canPushDown) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -20,9 +20,6 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.Timestamp;
-import org.apache.paimon.predicate.CompoundPredicate;
-import org.apache.paimon.predicate.FieldRef;
-import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.BigIntType;
@@ -63,7 +60,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -75,28 +71,29 @@ class ParquetFiltersTest {
 
     @Test
     public void testLong() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "long1", new BigIntType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "long1", new BigIntType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
-        test(builder.isNull(0), "eq(long1, null)", true);
+        test(schema, builder.isNull(0), "eq(long1, null)", true);
 
-        test(builder.isNotNull(0), "noteq(long1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(long1, null)", true);
 
-        test(builder.lessThan(0, 5L), "lt(long1, 5)", true);
+        test(schema, builder.lessThan(0, 5L), "lt(long1, 5)", true);
 
-        test(builder.greaterThan(0, 5L), "gt(long1, 5)", true);
+        test(schema, builder.greaterThan(0, 5L), "gt(long1, 5)", true);
 
         test(
+                schema,
                 builder.in(0, Arrays.asList(1L, 2L, 3L)),
                 "or(or(eq(long1, 1), eq(long1, 2)), eq(long1, 3))",
                 true);
 
-        test(builder.between(0, 1L, 3L), "and(gteq(long1, 1), lteq(long1, 3))", true);
+        test(schema, builder.between(0, 1L, 3L), "and(gteq(long1, 1), lteq(long1, 3))", true);
 
         test(
+                schema,
                 builder.notIn(0, Arrays.asList(1L, 2L, 3L)),
                 "and(and(noteq(long1, 1), noteq(long1, 2)), noteq(long1, 3))",
                 true);
@@ -104,20 +101,22 @@ class ParquetFiltersTest {
 
     @Test
     public void testString() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "string1", new VarCharType()))));
-        test(builder.isNull(0), "eq(string1, null)", true);
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(new DataField(0, "string1", new VarCharType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        test(schema, builder.isNull(0), "eq(string1, null)", true);
 
-        test(builder.isNotNull(0), "noteq(string1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(string1, null)", true);
 
         test(
+                schema,
                 builder.in(0, Arrays.asList("1", "2", "3")),
                 "or(or(eq(string1, Binary{\"1\"}), eq(string1, Binary{\"2\"})), eq(string1, Binary{\"3\"}))",
                 true);
         test(
+                schema,
                 builder.notIn(0, Arrays.asList("1", "2", "3")),
                 "and(and(noteq(string1, Binary{\"1\"}), noteq(string1, Binary{\"2\"})), noteq(string1, Binary{\"3\"}))",
                 true);
@@ -125,12 +124,12 @@ class ParquetFiltersTest {
 
     @Test
     public void testInFilterLong() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "col1", new BigIntType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "col1", new BigIntType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
         test(
+                schema,
                 builder.in(0, LongStream.range(1L, 22L).boxed().collect(Collectors.toList())),
                 FilterApi.in(
                         FilterApi.longColumn("col1"),
@@ -138,6 +137,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(0, LongStream.range(1L, 22L).boxed().collect(Collectors.toList())),
                 FilterApi.notIn(
                         FilterApi.longColumn("col1"),
@@ -147,12 +147,12 @@ class ParquetFiltersTest {
 
     @Test
     public void testInFilterDouble() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "col1", new DoubleType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "col1", new DoubleType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
         test(
+                schema,
                 builder.in(
                         0,
                         LongStream.range(1L, 22L)
@@ -168,6 +168,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(
                         0,
                         LongStream.range(1L, 22L)
@@ -185,12 +186,12 @@ class ParquetFiltersTest {
 
     @Test
     public void testInFilterString() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "col1", new VarCharType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "col1", new VarCharType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
         test(
+                schema,
                 builder.in(
                         0,
                         LongStream.range(1L, 22L)
@@ -206,6 +207,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(
                         0,
                         LongStream.range(1L, 22L)
@@ -223,16 +225,14 @@ class ParquetFiltersTest {
 
     @Test
     public void testIsNaNDouble() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "d1", new DoubleType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "d1", new DoubleType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Predicate predicate = builder.isNaN(0);
         FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        Collections.singletonList(predicate), messageType(predicate), true);
+                ParquetFilters.convert(Collections.singletonList(predicate), schema, true);
         FilterPredicateCompat compat = (FilterPredicateCompat) filter;
         assertThat(compat.getFilterPredicate().toString())
                 .contains(
@@ -241,16 +241,14 @@ class ParquetFiltersTest {
 
     @Test
     public void testIsNaNFloat() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "f1", new FloatType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "f1", new FloatType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Predicate predicate = builder.isNaN(0);
         FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        Collections.singletonList(predicate), messageType(predicate), true);
+                ParquetFilters.convert(Collections.singletonList(predicate), schema, true);
         FilterPredicateCompat compat = (FilterPredicateCompat) filter;
         assertThat(compat.getFilterPredicate().toString())
                 .contains(
@@ -259,13 +257,13 @@ class ParquetFiltersTest {
 
     @Test
     public void testInFilterFloat() {
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "col1", new FloatType()))));
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "col1", new FloatType())));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         test(
+                schema,
                 builder.in(
                         0,
                         LongStream.range(1L, 22L)
@@ -281,6 +279,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(
                         0,
                         LongStream.range(1L, 22L)
@@ -841,110 +840,110 @@ class ParquetFiltersTest {
     public void testTimestampMillis() {
         // precision <= 3 uses milliseconds (INT64)
         int precision = 3;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "ts1", new TimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new TimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp value = Timestamp.fromEpochMillis(1704067200000L); // 2024-01-01 00:00:00
         long expectedMillis = value.getMillisecond();
 
-        test(builder.isNull(0), "eq(ts1, null)", true);
-        test(builder.isNotNull(0), "noteq(ts1, null)", true);
-        test(builder.equal(0, value), "eq(ts1, " + expectedMillis + ")", true);
-        test(builder.notEqual(0, value), "noteq(ts1, " + expectedMillis + ")", true);
-        test(builder.lessThan(0, value), "lt(ts1, " + expectedMillis + ")", true);
-        test(builder.lessOrEqual(0, value), "lteq(ts1, " + expectedMillis + ")", true);
-        test(builder.greaterThan(0, value), "gt(ts1, " + expectedMillis + ")", true);
-        test(builder.greaterOrEqual(0, value), "gteq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.isNull(0), "eq(ts1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(ts1, null)", true);
+        test(schema, builder.equal(0, value), "eq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.lessOrEqual(0, value), "lteq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.greaterThan(0, value), "gt(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.greaterOrEqual(0, value), "gteq(ts1, " + expectedMillis + ")", true);
     }
 
     @Test
     public void testTimestampMicros() {
         // 3 < precision <= 6 uses microseconds (INT64)
         int precision = 6;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "ts1", new TimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new TimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp value = Timestamp.fromEpochMillis(1704067200123L, 456000); // with nanos
         long expectedMicros = value.getMillisecond() * 1000 + value.getNanoOfMillisecond() / 1000;
 
-        test(builder.isNull(0), "eq(ts1, null)", true);
-        test(builder.isNotNull(0), "noteq(ts1, null)", true);
-        test(builder.equal(0, value), "eq(ts1, " + expectedMicros + ")", true);
-        test(builder.notEqual(0, value), "noteq(ts1, " + expectedMicros + ")", true);
-        test(builder.lessThan(0, value), "lt(ts1, " + expectedMicros + ")", true);
-        test(builder.lessOrEqual(0, value), "lteq(ts1, " + expectedMicros + ")", true);
-        test(builder.greaterThan(0, value), "gt(ts1, " + expectedMicros + ")", true);
-        test(builder.greaterOrEqual(0, value), "gteq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.isNull(0), "eq(ts1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(ts1, null)", true);
+        test(schema, builder.equal(0, value), "eq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.lessOrEqual(0, value), "lteq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.greaterThan(0, value), "gt(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.greaterOrEqual(0, value), "gteq(ts1, " + expectedMicros + ")", true);
     }
 
     @Test
     public void testLocalZonedTimestampMillis() {
         // precision <= 3 uses milliseconds (INT64)
         int precision = 3;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(
-                                                0,
-                                                "ts1",
-                                                new LocalZonedTimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new LocalZonedTimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp value = Timestamp.fromEpochMillis(1704067200000L);
         long expectedMillis = value.getMillisecond();
 
-        test(builder.isNull(0), "eq(ts1, null)", true);
-        test(builder.isNotNull(0), "noteq(ts1, null)", true);
-        test(builder.equal(0, value), "eq(ts1, " + expectedMillis + ")", true);
-        test(builder.notEqual(0, value), "noteq(ts1, " + expectedMillis + ")", true);
-        test(builder.lessThan(0, value), "lt(ts1, " + expectedMillis + ")", true);
-        test(builder.greaterThan(0, value), "gt(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.isNull(0), "eq(ts1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(ts1, null)", true);
+        test(schema, builder.equal(0, value), "eq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(ts1, " + expectedMillis + ")", true);
+        test(schema, builder.greaterThan(0, value), "gt(ts1, " + expectedMillis + ")", true);
     }
 
     @Test
     public void testLocalZonedTimestampMicros() {
         // 3 < precision <= 6 uses microseconds (INT64)
         int precision = 6;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(
-                                                0,
-                                                "ts1",
-                                                new LocalZonedTimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new LocalZonedTimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp value = Timestamp.fromEpochMillis(1704067200123L, 456000);
         long expectedMicros = value.getMillisecond() * 1000 + value.getNanoOfMillisecond() / 1000;
 
-        test(builder.isNull(0), "eq(ts1, null)", true);
-        test(builder.isNotNull(0), "noteq(ts1, null)", true);
-        test(builder.equal(0, value), "eq(ts1, " + expectedMicros + ")", true);
-        test(builder.notEqual(0, value), "noteq(ts1, " + expectedMicros + ")", true);
-        test(builder.lessThan(0, value), "lt(ts1, " + expectedMicros + ")", true);
-        test(builder.greaterThan(0, value), "gt(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.isNull(0), "eq(ts1, null)", true);
+        test(schema, builder.isNotNull(0), "noteq(ts1, null)", true);
+        test(schema, builder.equal(0, value), "eq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.notEqual(0, value), "noteq(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.lessThan(0, value), "lt(ts1, " + expectedMicros + ")", true);
+        test(schema, builder.greaterThan(0, value), "gt(ts1, " + expectedMicros + ")", true);
     }
 
     @Test
     public void testInFilterTimestampMillis() {
         int precision = 3;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "ts1", new TimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new TimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp v1 = Timestamp.fromEpochMillis(1704067200000L);
         Timestamp v2 = Timestamp.fromEpochMillis(1704153600000L);
         Timestamp v3 = Timestamp.fromEpochMillis(1704240000000L);
 
         test(
+                schema,
                 builder.in(0, Arrays.asList(v1, v2, v3)),
                 "or(or(eq(ts1, "
                         + v1.getMillisecond()
@@ -956,6 +955,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(0, Arrays.asList(v1, v2, v3)),
                 "and(and(noteq(ts1, "
                         + v1.getMillisecond()
@@ -970,11 +970,12 @@ class ParquetFiltersTest {
     @Test
     public void testInFilterTimestampMicros() {
         int precision = 6;
-        PredicateBuilder builder =
-                new PredicateBuilder(
-                        new RowType(
-                                Collections.singletonList(
-                                        new DataField(0, "ts1", new TimestampType(precision)))));
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(0, "ts1", new TimestampType(precision))));
+        MessageType schema = ParquetSchemaConverter.convertToParquetMessageType(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
 
         Timestamp v1 = Timestamp.fromEpochMillis(1704067200000L, 123000);
         Timestamp v2 = Timestamp.fromEpochMillis(1704153600000L, 456000);
@@ -985,6 +986,7 @@ class ParquetFiltersTest {
         long micros3 = v3.getMillisecond() * 1000 + v3.getNanoOfMillisecond() / 1000;
 
         test(
+                schema,
                 builder.in(0, Arrays.asList(v1, v2, v3)),
                 "or(or(eq(ts1, "
                         + micros1
@@ -996,6 +998,7 @@ class ParquetFiltersTest {
                 true);
 
         test(
+                schema,
                 builder.notIn(0, Arrays.asList(v1, v2, v3)),
                 "and(and(noteq(ts1, "
                         + micros1
@@ -1060,56 +1063,5 @@ class ParquetFiltersTest {
         PrimitiveType type =
                 builder.as(LogicalTypeAnnotation.decimalType(scale, precision)).named(fieldName);
         return new MessageType("paimon_schema", Collections.singletonList(type));
-    }
-
-    private void test(Predicate predicate, FilterPredicate parquetPredicate, boolean canPushDown) {
-        FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        PredicateBuilder.splitAnd(predicate), messageType(predicate), true);
-        if (canPushDown) {
-            FilterPredicateCompat compat = (FilterPredicateCompat) filter;
-            assertThat(compat.getFilterPredicate()).isEqualTo(parquetPredicate);
-        } else {
-            assertThat(filter).isEqualTo(FilterCompat.NOOP);
-        }
-    }
-
-    private void test(Predicate predicate, String expected, boolean canPushDown) {
-        FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        PredicateBuilder.splitAnd(predicate), messageType(predicate), true);
-        if (canPushDown) {
-            FilterPredicateCompat compat = (FilterPredicateCompat) filter;
-            assertThat(compat.getFilterPredicate().toString()).isEqualTo(expected);
-        } else {
-            assertThat(filter).isEqualTo(FilterCompat.NOOP);
-        }
-    }
-
-    private static MessageType messageType(Predicate predicate) {
-        FieldRef fieldRef = fieldRef(predicate);
-        RowType rowType =
-                new RowType(
-                        Collections.singletonList(
-                                new DataField(fieldRef.index(), fieldRef.name(), fieldRef.type())));
-        return ParquetSchemaConverter.convertToParquetMessageType(rowType);
-    }
-
-    private static FieldRef fieldRef(Predicate predicate) {
-        return findFieldRef(predicate)
-                .orElseThrow(() -> new IllegalArgumentException("Predicate has no field"));
-    }
-
-    private static Optional<FieldRef> findFieldRef(Predicate predicate) {
-        if (predicate instanceof LeafPredicate) {
-            return ((LeafPredicate) predicate).fieldRefOptional();
-        }
-        for (Predicate child : ((CompoundPredicate) predicate).children()) {
-            Optional<FieldRef> fieldRef = findFieldRef(child);
-            if (fieldRef.isPresent()) {
-                return fieldRef;
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -327,8 +327,8 @@ class ParquetFiltersTest {
     @Test
     public void testDecimalBinary() {
         // precision > 18 uses Binary
-        int precision = 38;
-        int scale = 10;
+        int precision = 20;
+        int scale = 0;
         PredicateBuilder builder =
                 new PredicateBuilder(
                         new RowType(
@@ -338,28 +338,46 @@ class ParquetFiltersTest {
                                                 "decimal1",
                                                 new DecimalType(precision, scale)))));
 
-        Decimal value =
-                Decimal.fromBigDecimal(
-                        new BigDecimal("12345678901234567890.1234567890"), precision, scale);
-        Binary expectedBinary = Binary.fromConstantByteArray(value.toUnscaledBytes());
+        Decimal positive = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
+        Binary expectedPositive =
+                Binary.fromConstantByteArray(
+                        new byte[] {0, 0, 0, 0, 0, 0, (byte) 0x98, (byte) 0x9A, 0x2B});
+        Decimal negative = Decimal.fromBigDecimal(new BigDecimal("-10000939"), precision, scale);
+        Binary expectedNegative =
+                Binary.fromConstantByteArray(
+                        new byte[] {
+                            (byte) 0xFF,
+                            (byte) 0xFF,
+                            (byte) 0xFF,
+                            (byte) 0xFF,
+                            (byte) 0xFF,
+                            (byte) 0xFF,
+                            0x67,
+                            0x65,
+                            (byte) 0xD5
+                        });
 
         test(builder.isNull(0), "eq(decimal1, null)", true);
         test(builder.isNotNull(0), "noteq(decimal1, null)", true);
         test(
-                builder.equal(0, value),
-                FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedBinary),
+                builder.equal(0, positive),
+                FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
-                builder.notEqual(0, value),
-                FilterApi.notEq(FilterApi.binaryColumn("decimal1"), expectedBinary),
+                builder.notEqual(0, positive),
+                FilterApi.notEq(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
-                builder.lessThan(0, value),
-                FilterApi.lt(FilterApi.binaryColumn("decimal1"), expectedBinary),
+                builder.lessThan(0, positive),
+                FilterApi.lt(FilterApi.binaryColumn("decimal1"), expectedPositive),
                 true);
         test(
-                builder.greaterThan(0, value),
-                FilterApi.gt(FilterApi.binaryColumn("decimal1"), expectedBinary),
+                builder.greaterThan(0, positive),
+                FilterApi.gt(FilterApi.binaryColumn("decimal1"), expectedPositive),
+                true);
+        test(
+                builder.equal(0, negative),
+                FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedNegative),
                 true);
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -20,6 +20,9 @@ package org.apache.paimon.format.parquet;
 
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.predicate.CompoundPredicate;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.types.BigIntType;
@@ -60,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -225,8 +229,10 @@ class ParquetFiltersTest {
                                 Collections.singletonList(
                                         new DataField(0, "d1", new DoubleType()))));
 
+        Predicate predicate = builder.isNaN(0);
         FilterCompat.Filter filter =
-                ParquetFilters.convert(Collections.singletonList(builder.isNaN(0)));
+                ParquetFilters.convert(
+                        Collections.singletonList(predicate), messageType(predicate), true);
         FilterPredicateCompat compat = (FilterPredicateCompat) filter;
         assertThat(compat.getFilterPredicate().toString())
                 .contains(
@@ -241,8 +247,10 @@ class ParquetFiltersTest {
                                 Collections.singletonList(
                                         new DataField(0, "f1", new FloatType()))));
 
+        Predicate predicate = builder.isNaN(0);
         FilterCompat.Filter filter =
-                ParquetFilters.convert(Collections.singletonList(builder.isNaN(0)));
+                ParquetFilters.convert(
+                        Collections.singletonList(predicate), messageType(predicate), true);
         FilterPredicateCompat compat = (FilterPredicateCompat) filter;
         assertThat(compat.getFilterPredicate().toString())
                 .contains(
@@ -635,16 +643,6 @@ class ParquetFiltersTest {
                                 Collections.singletonList(metadata),
                                 dictionaries))
                 .isTrue();
-    }
-
-    @Test
-    public void testDecimalWithoutFileSchema() {
-        int precision = 20;
-        int scale = 0;
-        PredicateBuilder builder = decimalPredicateBuilder(precision, scale);
-        Decimal value = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
-
-        test(builder.equal(0, value), "", false);
     }
 
     @Test
@@ -1065,7 +1063,9 @@ class ParquetFiltersTest {
     }
 
     private void test(Predicate predicate, FilterPredicate parquetPredicate, boolean canPushDown) {
-        FilterCompat.Filter filter = ParquetFilters.convert(PredicateBuilder.splitAnd(predicate));
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(
+                        PredicateBuilder.splitAnd(predicate), messageType(predicate), true);
         if (canPushDown) {
             FilterPredicateCompat compat = (FilterPredicateCompat) filter;
             assertThat(compat.getFilterPredicate()).isEqualTo(parquetPredicate);
@@ -1074,18 +1074,42 @@ class ParquetFiltersTest {
         }
     }
 
-    private FilterPredicate convert(Predicate predicate) {
-        FilterCompat.Filter filter = ParquetFilters.convert(PredicateBuilder.splitAnd(predicate));
-        return ((FilterPredicateCompat) filter).getFilterPredicate();
-    }
-
     private void test(Predicate predicate, String expected, boolean canPushDown) {
-        FilterCompat.Filter filter = ParquetFilters.convert(PredicateBuilder.splitAnd(predicate));
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(
+                        PredicateBuilder.splitAnd(predicate), messageType(predicate), true);
         if (canPushDown) {
             FilterPredicateCompat compat = (FilterPredicateCompat) filter;
             assertThat(compat.getFilterPredicate().toString()).isEqualTo(expected);
         } else {
             assertThat(filter).isEqualTo(FilterCompat.NOOP);
         }
+    }
+
+    private static MessageType messageType(Predicate predicate) {
+        FieldRef fieldRef = fieldRef(predicate);
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(fieldRef.index(), fieldRef.name(), fieldRef.type())));
+        return ParquetSchemaConverter.convertToParquetMessageType(rowType);
+    }
+
+    private static FieldRef fieldRef(Predicate predicate) {
+        return findFieldRef(predicate)
+                .orElseThrow(() -> new IllegalArgumentException("Predicate has no field"));
+    }
+
+    private static Optional<FieldRef> findFieldRef(Predicate predicate) {
+        if (predicate instanceof LeafPredicate) {
+            return ((LeafPredicate) predicate).fieldRefOptional();
+        }
+        for (Predicate child : ((CompoundPredicate) predicate).children()) {
+            Optional<FieldRef> fieldRef = findFieldRef(child);
+            if (fieldRef.isPresent()) {
+                return fieldRef;
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetFiltersTest.java
@@ -32,18 +32,36 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.DictionaryPageReadStore;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.FilterCompat.FilterPredicateCompat;
+import org.apache.parquet.filter2.dictionarylevel.DictionaryFilter;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.ParquetFilters;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -327,7 +345,8 @@ class ParquetFiltersTest {
     @Test
     public void testDecimalBinary() {
         // precision > 18 uses Binary
-        int precision = 20;
+        int fieldPrecision = 20;
+        int literalPrecision = 8;
         int scale = 0;
         PredicateBuilder builder =
                 new PredicateBuilder(
@@ -336,13 +355,15 @@ class ParquetFiltersTest {
                                         new DataField(
                                                 0,
                                                 "decimal1",
-                                                new DecimalType(precision, scale)))));
+                                                new DecimalType(fieldPrecision, scale)))));
 
-        Decimal positive = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
+        Decimal positive =
+                Decimal.fromBigDecimal(new BigDecimal("10000939"), literalPrecision, scale);
         Binary expectedPositive =
                 Binary.fromConstantByteArray(
                         new byte[] {0, 0, 0, 0, 0, 0, (byte) 0x98, (byte) 0x9A, 0x2B});
-        Decimal negative = Decimal.fromBigDecimal(new BigDecimal("-10000939"), precision, scale);
+        Decimal negative =
+                Decimal.fromBigDecimal(new BigDecimal("-10000939"), literalPrecision, scale);
         Binary expectedNegative =
                 Binary.fromConstantByteArray(
                         new byte[] {
@@ -379,6 +400,196 @@ class ParquetFiltersTest {
                 builder.equal(0, negative),
                 FilterApi.eq(FilterApi.binaryColumn("decimal1"), expectedNegative),
                 true);
+
+        Decimal fullWidth =
+                Decimal.fromBigDecimal(
+                        new BigDecimal("99999999999999999999"), fieldPrecision, scale);
+        assertThat(fullWidth.toUnscaledBytes()).hasSize(9);
+        test(
+                builder.equal(0, fullWidth),
+                FilterApi.eq(
+                        FilterApi.binaryColumn("decimal1"),
+                        Binary.fromConstantByteArray(fullWidth.toUnscaledBytes())),
+                true);
+    }
+
+    @Test
+    public void testDecimalBinaryMaxPrecision() {
+        int precision = 38;
+        int scale = 10;
+        PredicateBuilder builder =
+                new PredicateBuilder(
+                        new RowType(
+                                Collections.singletonList(
+                                        new DataField(
+                                                0,
+                                                "decimal1",
+                                                new DecimalType(precision, scale)))));
+        Decimal value =
+                Decimal.fromBigDecimal(
+                        new BigDecimal("12345678901234567890.1234567890"), precision, scale);
+        Binary expected =
+                Binary.fromConstantByteArray(
+                        new byte[] {
+                            0,
+                            0,
+                            0,
+                            1,
+                            (byte) 0x8E,
+                            (byte) 0xE9,
+                            0x0F,
+                            (byte) 0xF6,
+                            (byte) 0xC3,
+                            0x73,
+                            (byte) 0xE0,
+                            (byte) 0xEE,
+                            0x4E,
+                            0x3F,
+                            0x0A,
+                            (byte) 0xD2
+                        });
+
+        test(
+                builder.equal(0, value),
+                FilterApi.eq(FilterApi.binaryColumn("decimal1"), expected),
+                true);
+    }
+
+    @Test
+    public void testInFilterDecimalBinary() {
+        int fieldPrecision = 20;
+        int scale = 0;
+        PredicateBuilder builder =
+                new PredicateBuilder(
+                        new RowType(
+                                Collections.singletonList(
+                                        new DataField(
+                                                0,
+                                                "decimal1",
+                                                new DecimalType(fieldPrecision, scale)))));
+
+        List<Object> literals =
+                IntStream.rangeClosed(1, 21)
+                        .mapToObj(
+                                value ->
+                                        (Object)
+                                                Decimal.fromBigDecimal(
+                                                        BigDecimal.valueOf(value),
+                                                        fieldPrecision,
+                                                        scale))
+                        .collect(Collectors.toList());
+        Set<Binary> expected =
+                IntStream.rangeClosed(1, 21)
+                        .mapToObj(
+                                value -> {
+                                    byte[] bytes = new byte[9];
+                                    bytes[8] = (byte) value;
+                                    return Binary.fromConstantByteArray(bytes);
+                                })
+                        .collect(Collectors.toSet());
+
+        test(
+                builder.in(0, literals),
+                FilterApi.in(FilterApi.binaryColumn("decimal1"), expected),
+                true);
+        test(
+                builder.notIn(0, literals),
+                FilterApi.notIn(FilterApi.binaryColumn("decimal1"), expected),
+                true);
+    }
+
+    @Test
+    public void testDecimalDictionaryFilter() {
+        int fieldPrecision = 20;
+        int scale = 0;
+        PredicateBuilder builder =
+                new PredicateBuilder(
+                        new RowType(
+                                Collections.singletonList(
+                                        new DataField(
+                                                0,
+                                                "decimal1",
+                                                new DecimalType(fieldPrecision, scale)))));
+        Decimal positive =
+                Decimal.fromBigDecimal(new BigDecimal("10000939"), fieldPrecision, scale);
+        Decimal negative =
+                Decimal.fromBigDecimal(new BigDecimal("-10000939"), fieldPrecision, scale);
+        Decimal missing = Decimal.fromBigDecimal(new BigDecimal("10000940"), fieldPrecision, scale);
+
+        byte[] positiveBytes = new byte[] {0, 0, 0, 0, 0, 0, (byte) 0x98, (byte) 0x9A, 0x2B};
+        byte[] negativeBytes =
+                new byte[] {
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    (byte) 0xFF,
+                    0x67,
+                    0x65,
+                    (byte) 0xD5
+                };
+        DictionaryPage dictionaryPage =
+                new DictionaryPage(
+                        BytesInput.concat(
+                                BytesInput.from(positiveBytes), BytesInput.from(negativeBytes)),
+                        2,
+                        Encoding.PLAIN);
+        DictionaryPageReadStore dictionaries =
+                new DictionaryPageReadStore() {
+                    @Override
+                    public DictionaryPage readDictionaryPage(ColumnDescriptor descriptor) {
+                        return dictionaryPage;
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        PrimitiveType primitiveType =
+                Types.required(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+                        .length(9)
+                        .as(LogicalTypeAnnotation.decimalType(scale, fieldPrecision))
+                        .named("decimal1");
+        EncodingStats encodingStats =
+                new EncodingStats.Builder()
+                        .addDictEncoding(Encoding.PLAIN)
+                        .addDataEncoding(Encoding.RLE_DICTIONARY)
+                        .build();
+        Set<Encoding> encodings =
+                new HashSet<>(Arrays.asList(Encoding.PLAIN, Encoding.RLE_DICTIONARY, Encoding.RLE));
+        ColumnChunkMetaData metadata =
+                ColumnChunkMetaData.get(
+                        ColumnPath.get("decimal1"),
+                        primitiveType,
+                        CompressionCodecName.UNCOMPRESSED,
+                        encodingStats,
+                        encodings,
+                        null,
+                        0,
+                        0,
+                        2,
+                        0,
+                        0);
+
+        assertThat(
+                        DictionaryFilter.canDrop(
+                                convert(builder.equal(0, positive)),
+                                Collections.singletonList(metadata),
+                                dictionaries))
+                .isFalse();
+        assertThat(
+                        DictionaryFilter.canDrop(
+                                convert(builder.equal(0, negative)),
+                                Collections.singletonList(metadata),
+                                dictionaries))
+                .isFalse();
+        assertThat(
+                        DictionaryFilter.canDrop(
+                                convert(builder.equal(0, missing)),
+                                Collections.singletonList(metadata),
+                                dictionaries))
+                .isTrue();
     }
 
     @Test
@@ -641,6 +852,11 @@ class ParquetFiltersTest {
         } else {
             assertThat(filter).isEqualTo(FilterCompat.NOOP);
         }
+    }
+
+    private FilterPredicate convert(Predicate predicate) {
+        FilterCompat.Filter filter = ParquetFilters.convert(PredicateBuilder.splitAnd(predicate));
+        return ((FilterPredicateCompat) filter).getFilterPredicate();
     }
 
     private void test(Predicate predicate, String expected, boolean canPushDown) {

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -58,10 +58,12 @@ import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.ParquetFilters;
+import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
@@ -257,6 +259,38 @@ public class ParquetReadWriteTest {
         }
 
         innerTestTypes(folder, values, rowGroupSize);
+    }
+
+    @Test
+    void testDecimalDictionaryFilterWithFixedLengthBinary() throws IOException {
+        int precision = 20;
+        int scale = 0;
+        RowType rowType = RowType.of(new DecimalType(precision, scale));
+        Decimal positive = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
+        Decimal negative = Decimal.fromBigDecimal(new BigDecimal("-10000939"), precision, scale);
+
+        List<InternalRow> rows = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            rows.add(GenericRow.of(i % 2 == 0 ? positive : negative));
+        }
+
+        Path path = new Path(folder.getPath(), UUID.randomUUID().toString());
+        Options writeOptions = new Options();
+        writeOptions.set("parquet.enable.dictionary", "true");
+        writeOptions.setInteger("parquet.block.size", 1024 * 1024);
+        ParquetWriterFactory writerFactory =
+                new ParquetWriterFactory(new RowDataParquetBuilder(rowType, writeOptions));
+        FormatWriter writer =
+                writerFactory.create(new LocalFileIO().newOutputStream(path, false), "snappy");
+        for (InternalRow row : rows) {
+            writer.addElement(row);
+        }
+        writer.close();
+
+        assertThat(filteredRowGroupCount(path, rowType, positive)).isEqualTo(1);
+        assertThat(filteredRowGroupCount(path, rowType, negative)).isEqualTo(1);
+        Decimal missing = Decimal.fromBigDecimal(new BigDecimal("10000940"), precision, scale);
+        assertThat(filteredRowGroupCount(path, rowType, missing)).isZero();
     }
 
     @ParameterizedTest
@@ -799,6 +833,31 @@ public class ParquetReadWriteTest {
 
     private static void assertVector(InternalVector vector, float[] expected) {
         Assertions.assertArrayEquals(expected, vector.toFloatArray());
+    }
+
+    private int filteredRowGroupCount(Path path, RowType rowType, Decimal literal)
+            throws IOException {
+        PredicateBuilder predicateBuilder = new PredicateBuilder(rowType);
+        FilterCompat.Filter filter =
+                ParquetFilters.convert(
+                        PredicateBuilder.splitAnd(predicateBuilder.equal(0, literal)));
+        Options readOptions = new Options();
+        readOptions.set("parquet.filter.stats.enabled", "false");
+        readOptions.set("parquet.filter.dictionary.enabled", "true");
+        LocalFileIO fileIO = new LocalFileIO();
+        long fileSize = fileIO.getFileSize(path);
+        ParquetReadOptions parquetReadOptions =
+                ParquetUtil.getParquetReadOptionsBuilder(readOptions)
+                        .withRecordFilter(filter)
+                        .withRange(0, fileSize)
+                        .build();
+        try (ParquetFileReader reader =
+                new ParquetFileReader(
+                        ParquetInputFile.fromPath(fileIO, path, fileSize),
+                        parquetReadOptions,
+                        null)) {
+            return reader.getRowGroups().size();
+        }
     }
 
     private Path createTempParquetFileByPaimon(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -498,8 +498,14 @@ public class ParquetReadWriteTest {
         int number = new Random().nextInt(1000) + 100;
         Path path = createDecimalFile(number, folder, 10);
 
+        PredicateBuilder builder = new PredicateBuilder(DECIMAL_TYPE);
+        Decimal filterValue = Decimal.fromBigDecimal(new BigDecimal("1234567.67"), 9, 2);
         ParquetReaderFactory format =
-                new ParquetReaderFactory(new Options(), DECIMAL_TYPE, 500, FilterCompat.NOOP);
+                ParquetReaderFactory.create(
+                        new Options(),
+                        DECIMAL_TYPE,
+                        500,
+                        Collections.singletonList(builder.equal(2, filterValue)));
         RecordReader<InternalRow> reader =
                 format.createReader(
                         new FormatReaderContext(
@@ -507,6 +513,7 @@ public class ParquetReadWriteTest {
         List<InternalRow> results = new ArrayList<>(number);
         InternalRowSerializer internalRowSerializer = new InternalRowSerializer(DECIMAL_TYPE);
         reader.forEachRemaining(row -> results.add(internalRowSerializer.copy(row)));
+        assertThat(results).hasSize(number);
 
         BigDecimal decimalValue0 = new BigDecimal("123.67");
         BigDecimal decimalValue1 = new BigDecimal("12345.67");

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -60,8 +60,6 @@ import org.apache.paimon.types.VarCharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
-import org.apache.parquet.filter2.compat.FilterCompat;
-import org.apache.parquet.filter2.predicate.ParquetFilters;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
@@ -309,7 +307,7 @@ public class ParquetReadWriteTest {
                                 .fields(fieldTypes, new String[] {"f7", "f2", "f4"})
                                 .build(),
                         500,
-                        FilterCompat.NOOP);
+                        null);
 
         AtomicInteger cnt = new AtomicInteger(0);
         RecordReader<InternalRow> reader =
@@ -353,7 +351,7 @@ public class ParquetReadWriteTest {
                                 .fields(fieldTypes, new String[] {"f7", "f2", "f4", "f99"})
                                 .build(),
                         500,
-                        FilterCompat.NOOP);
+                        null);
 
         AtomicInteger cnt = new AtomicInteger(0);
         RecordReader<InternalRow> reader =
@@ -392,7 +390,7 @@ public class ParquetReadWriteTest {
                         new Options(),
                         RowType.builder().fields(fieldTypes, new String[] {"f7"}).build(),
                         batchSize,
-                        FilterCompat.NOOP);
+                        null);
 
         AtomicInteger cnt = new AtomicInteger(0);
         try (RecordReader<InternalRow> reader =
@@ -434,15 +432,12 @@ public class ParquetReadWriteTest {
                 new PredicateBuilder(
                         new RowType(
                                 Collections.singletonList(new DataField(0, "f4", new IntType()))));
-        FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        PredicateBuilder.splitAnd(builder.greaterThan(0, randomStart)));
         ParquetReaderFactory format =
                 new ParquetReaderFactory(
                         new Options(),
                         RowType.builder().fields(fieldTypes, new String[] {"f4"}).build(),
                         batchSize,
-                        filter);
+                        PredicateBuilder.splitAnd(builder.greaterThan(0, randomStart)));
 
         AtomicBoolean isFirst = new AtomicBoolean(true);
         try (RecordReader<InternalRow> reader =
@@ -480,8 +475,7 @@ public class ParquetReadWriteTest {
             throw new RuntimeException("Unknown writer type.");
         }
         ParquetReaderFactory format =
-                new ParquetReaderFactory(
-                        new Options(), NESTED_ARRAY_MAP_TYPE, 500, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), NESTED_ARRAY_MAP_TYPE, 500, null);
         RecordReader<InternalRow> reader =
                 format.createReader(
                         new FormatReaderContext(
@@ -501,7 +495,7 @@ public class ParquetReadWriteTest {
         PredicateBuilder builder = new PredicateBuilder(DECIMAL_TYPE);
         Decimal filterValue = Decimal.fromBigDecimal(new BigDecimal("1234567.67"), 9, 2);
         ParquetReaderFactory format =
-                ParquetReaderFactory.create(
+                new ParquetReaderFactory(
                         new Options(),
                         DECIMAL_TYPE,
                         500,
@@ -666,7 +660,7 @@ public class ParquetReadWriteTest {
                         .build();
 
         ParquetReaderFactory format =
-                new ParquetReaderFactory(new Options(), paimonRowType, 500, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), paimonRowType, 500, null);
 
         RecordReader<InternalRow> reader =
                 format.createReader(
@@ -730,7 +724,7 @@ public class ParquetReadWriteTest {
                         .fields(new TimestampType(9), new ArrayType(new TimestampType(9)))
                         .build();
         ParquetReaderFactory format =
-                new ParquetReaderFactory(new Options(), paimonRowType, 500, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), paimonRowType, 500, null);
         AtomicInteger count = new AtomicInteger(0);
         try (RecordReader<InternalRow> reader =
                 format.createReader(
@@ -762,8 +756,7 @@ public class ParquetReadWriteTest {
                         GenericRow.of(2, BinaryVector.fromPrimitiveArray(new float[] {4, 5, 6})));
 
         Path path = createTempParquetFileByPaimon(folder, rows, 1024, rowType);
-        ParquetReaderFactory format =
-                new ParquetReaderFactory(new Options(), rowType, 500, FilterCompat.NOOP);
+        ParquetReaderFactory format = new ParquetReaderFactory(new Options(), rowType, 500, null);
 
         RecordReader<InternalRow> reader =
                 format.createReader(
@@ -833,8 +826,7 @@ public class ParquetReadWriteTest {
     }
 
     private int testReadingFile(List<Integer> expected, Path path) throws IOException {
-        ParquetReaderFactory format =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory format = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         RecordReader<InternalRow> reader =
                 format.createReader(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetReadWriteTest.java
@@ -58,12 +58,10 @@ import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.ParquetFilters;
-import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
@@ -259,38 +257,6 @@ public class ParquetReadWriteTest {
         }
 
         innerTestTypes(folder, values, rowGroupSize);
-    }
-
-    @Test
-    void testDecimalDictionaryFilterWithFixedLengthBinary() throws IOException {
-        int precision = 20;
-        int scale = 0;
-        RowType rowType = RowType.of(new DecimalType(precision, scale));
-        Decimal positive = Decimal.fromBigDecimal(new BigDecimal("10000939"), precision, scale);
-        Decimal negative = Decimal.fromBigDecimal(new BigDecimal("-10000939"), precision, scale);
-
-        List<InternalRow> rows = new ArrayList<>();
-        for (int i = 0; i < 1000; i++) {
-            rows.add(GenericRow.of(i % 2 == 0 ? positive : negative));
-        }
-
-        Path path = new Path(folder.getPath(), UUID.randomUUID().toString());
-        Options writeOptions = new Options();
-        writeOptions.set("parquet.enable.dictionary", "true");
-        writeOptions.setInteger("parquet.block.size", 1024 * 1024);
-        ParquetWriterFactory writerFactory =
-                new ParquetWriterFactory(new RowDataParquetBuilder(rowType, writeOptions));
-        FormatWriter writer =
-                writerFactory.create(new LocalFileIO().newOutputStream(path, false), "snappy");
-        for (InternalRow row : rows) {
-            writer.addElement(row);
-        }
-        writer.close();
-
-        assertThat(filteredRowGroupCount(path, rowType, positive)).isEqualTo(1);
-        assertThat(filteredRowGroupCount(path, rowType, negative)).isEqualTo(1);
-        Decimal missing = Decimal.fromBigDecimal(new BigDecimal("10000940"), precision, scale);
-        assertThat(filteredRowGroupCount(path, rowType, missing)).isZero();
     }
 
     @ParameterizedTest
@@ -833,31 +799,6 @@ public class ParquetReadWriteTest {
 
     private static void assertVector(InternalVector vector, float[] expected) {
         Assertions.assertArrayEquals(expected, vector.toFloatArray());
-    }
-
-    private int filteredRowGroupCount(Path path, RowType rowType, Decimal literal)
-            throws IOException {
-        PredicateBuilder predicateBuilder = new PredicateBuilder(rowType);
-        FilterCompat.Filter filter =
-                ParquetFilters.convert(
-                        PredicateBuilder.splitAnd(predicateBuilder.equal(0, literal)));
-        Options readOptions = new Options();
-        readOptions.set("parquet.filter.stats.enabled", "false");
-        readOptions.set("parquet.filter.dictionary.enabled", "true");
-        LocalFileIO fileIO = new LocalFileIO();
-        long fileSize = fileIO.getFileSize(path);
-        ParquetReadOptions parquetReadOptions =
-                ParquetUtil.getParquetReadOptionsBuilder(readOptions)
-                        .withRecordFilter(filter)
-                        .withRange(0, fileSize)
-                        .build();
-        try (ParquetFileReader reader =
-                new ParquetFileReader(
-                        ParquetInputFile.fromPath(fileIO, path, fileSize),
-                        parquetReadOptions,
-                        null)) {
-            return reader.getRowGroups().size();
-        }
     }
 
     private Path createTempParquetFileByPaimon(

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSchemaCacheTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/ParquetSchemaCacheTest.java
@@ -30,7 +30,6 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
-import org.apache.parquet.filter2.compat.FilterCompat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -61,8 +60,7 @@ public class ParquetSchemaCacheTest {
 
     @Test
     void testCacheIsEmptyBeforeFirstRead() throws Exception {
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         assertThat(getSchemaCacheSize(factory)).isEqualTo(0);
     }
@@ -71,8 +69,7 @@ public class ParquetSchemaCacheTest {
     void testCacheIsPopulatedAfterFirstRead() throws Exception {
         Path path = writeSingleFile();
 
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         readAll(factory, path);
 
@@ -89,8 +86,7 @@ public class ParquetSchemaCacheTest {
         Path path2 = writeSingleFile();
         Path path3 = writeSingleFile();
 
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         readAll(factory, path1);
         readAll(factory, path2);
@@ -108,8 +104,7 @@ public class ParquetSchemaCacheTest {
     void testDataReadCorrectlyOnFirstRead() throws Exception {
         Path path = writeSingleFile();
 
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         assertThat(countRows(factory, path)).isEqualTo(3);
     }
@@ -118,8 +113,7 @@ public class ParquetSchemaCacheTest {
     void testDataReadCorrectlyOnSubsequentCachedReads() throws Exception {
         Path path = writeSingleFile();
 
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         assertThat(countRows(factory, path)).isEqualTo(3);
         assertThat(countRows(factory, path)).isEqualTo(3);
@@ -131,8 +125,7 @@ public class ParquetSchemaCacheTest {
         Path path1 = writeSingleFile();
         Path path2 = writeSingleFile();
 
-        ParquetReaderFactory factory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+        ParquetReaderFactory factory = new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         assertThat(countRows(factory, path1)).isEqualTo(3);
         assertThat(countRows(factory, path2)).isEqualTo(3);
@@ -147,9 +140,9 @@ public class ParquetSchemaCacheTest {
         Path path = writeSingleFile();
 
         ParquetReaderFactory factory1 =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
         ParquetReaderFactory factory2 =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), ROW_TYPE, 500, null);
 
         readAll(factory1, path);
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/ParquetInt96RowSelectionTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/ParquetInt96RowSelectionTest.java
@@ -37,7 +37,6 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.RoaringBitmap32;
 
-import org.apache.parquet.filter2.compat.FilterCompat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -78,7 +77,7 @@ public class ParquetInt96RowSelectionTest {
                         fileIO.getFileSize(file),
                         RoaringBitmap32.bitmapOf(SELECTED_POSITIONS));
         ParquetReaderFactory readerFactory =
-                new ParquetReaderFactory(new Options(), ROW_TYPE, BATCH_SIZE, FilterCompat.NOOP);
+                new ParquetReaderFactory(new Options(), ROW_TYPE, BATCH_SIZE, null);
 
         try (RecordReader<InternalRow> reader = readerFactory.createReader(context)) {
             int expectedIndex = 0;


### PR DESCRIPTION
### Purpose
Fix problem of #7175.

Fix incorrect Parquet dictionary filtering for high-precision decimals.
Decimal literals for FIXED_LEN_BYTE_ARRAY columns are now sign-extended to the physical Parquet width, matching the writer encoding. This prevents valid row groups from being incorrectly pruned when the literal and dictionary value represent the same number with different byte lengths.

Added regression tests for positive, negative, IN, and dictionary-filter cases.
### Tests
