### PR TITLE
[format] Fix isNaN filter push-down failure on ORC tables

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/orc/filter/OrcPredicateFunctionVisitor.java
@@ -61,6 +61,13 @@ public class OrcPredicateFunctionVisitor
     }
 
     @Override
+    public Optional<OrcFilters.Predicate> visitIsNaN(FieldRef fieldRef) {
+        // ORC SearchArgument has no isNaN leaf, so skip push-down and let the engine
+        // evaluate the filter (consistent with the Parquet path).
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<OrcFilters.Predicate> visitStartsWith(FieldRef fieldRef, Object literal) {
         return Optional.empty();
     }

--- a/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/orc/filter/OrcFilterConverterTest.java
@@ -236,6 +236,23 @@ public class OrcFilterConverterTest {
                 true);
     }
 
+    @Test
+    public void testIsNaN() {
+        PredicateBuilder builder =
+                new PredicateBuilder(
+                        new RowType(
+                                Arrays.asList(
+                                        new DataField(0, "floatField", new FloatType()),
+                                        new DataField(1, "doubleField", new DoubleType()))));
+
+        // ORC has no isNaN SearchArgument leaf, so the visitor must skip push-down and
+        // return Optional.empty() instead of throwing UnsupportedOperationException.
+        assertThat(builder.isNaN(0).visit(OrcPredicateFunctionVisitor.VISITOR))
+                .isEqualTo(Optional.empty());
+        assertThat(builder.isNaN(1).visit(OrcPredicateFunctionVisitor.VISITOR))
+                .isEqualTo(Optional.empty());
+    }
+
     private void test(Predicate predicate, OrcFilters.Predicate orcPredicate, boolean canPushDown) {
         Optional<OrcFilters.Predicate> optionalPredicate =
                 predicate.visit(OrcPredicateFunctionVisitor.VISITOR);


### PR DESCRIPTION

### Purpose

fix #8626

- `OrcPredicateFunctionVisitor` did not override `visitIsNaN`, so the `FunctionVisitor.visitIsNaN` default threw `UnsupportedOperationException`.
- `OrcFileFormat.createReaderFactory()` calls `pred.visit(VISITOR)` without a try/catch, so an `isNaN` filter (e.g. Spark `WHERE c = float('nan')`) crashed ORC reader creation.
- Override `visitIsNaN` to return `Optional.empty()`, matching the sibling unsupported ops (`visitStartsWith`/`visitEndsWith`/`visitContains`/`visitLike`). ORC SearchArgument has no isNaN leaf, so the engine evaluates the filter — consistent with the Parquet path, where `ParquetFilters.convert` already catches the exception and skips push-down.

### Tests

- Added `OrcFilterConverterTest#testIsNaN` asserting `isNaN` on Float/Double fields returns `Optional.empty()` (previously threw).
- `mvn -pl paimon-format -am -DfailIfNoTests=false clean install` — `OrcFilterConverterTest`: 21 tests passed. JDK 11, no engine profiles.
