### PR TITLE
[format] Support narrowing Parquet reads for TINYINT and SMALLINT

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/ParquetVectorUpdaterFactory.java
@@ -147,12 +147,24 @@ public class ParquetVectorUpdaterFactory {
 
         @Override
         public UpdaterFactory visit(TinyIntType tinyIntType) {
-            return c -> new ByteUpdater();
+            return c -> {
+                if (c.getPrimitiveType().getPrimitiveTypeName()
+                        == PrimitiveType.PrimitiveTypeName.INT64) {
+                    return new ByteFromLongUpdater();
+                }
+                return new ByteUpdater();
+            };
         }
 
         @Override
         public UpdaterFactory visit(SmallIntType smallIntType) {
-            return c -> new ShortUpdater();
+            return c -> {
+                if (c.getPrimitiveType().getPrimitiveTypeName()
+                        == PrimitiveType.PrimitiveTypeName.INT64) {
+                    return new ShortFromLongUpdater();
+                }
+                return new ShortUpdater();
+            };
         }
 
         @Override
@@ -417,6 +429,41 @@ public class ParquetVectorUpdaterFactory {
         }
     }
 
+    private static class ByteFromLongUpdater implements ParquetVectorUpdater<WritableByteVector> {
+        @Override
+        public void readValues(
+                int total,
+                int offset,
+                WritableByteVector values,
+                VectorizedValuesReader valuesReader) {
+            for (int i = 0; i < total; i++) {
+                values.setByte(offset + i, (byte) Math.toIntExact(valuesReader.readLong()));
+            }
+        }
+
+        @Override
+        public void skipValues(int total, VectorizedValuesReader valuesReader) {
+            valuesReader.skipLongs(total);
+        }
+
+        @Override
+        public void readValue(
+                int offset, WritableByteVector values, VectorizedValuesReader valuesReader) {
+            values.setByte(offset, (byte) Math.toIntExact(valuesReader.readLong()));
+        }
+
+        @Override
+        public void decodeSingleDictionaryId(
+                int offset,
+                WritableByteVector values,
+                WritableIntVector dictionaryIds,
+                Dictionary dictionary) {
+            values.setByte(
+                    offset,
+                    (byte) Math.toIntExact(dictionary.decodeToLong(dictionaryIds.getInt(offset))));
+        }
+    }
+
     private static class ShortUpdater implements ParquetVectorUpdater<WritableShortVector> {
         @Override
         public void readValues(
@@ -447,6 +494,41 @@ public class ParquetVectorUpdaterFactory {
             values.setShort(
                     offset,
                     (short) dictionary.decodeToInt(((HeapIntVector) dictionaryIds).getInt(offset)));
+        }
+    }
+
+    private static class ShortFromLongUpdater implements ParquetVectorUpdater<WritableShortVector> {
+        @Override
+        public void readValues(
+                int total,
+                int offset,
+                WritableShortVector values,
+                VectorizedValuesReader valuesReader) {
+            for (int i = 0; i < total; i++) {
+                values.setShort(offset + i, (short) Math.toIntExact(valuesReader.readLong()));
+            }
+        }
+
+        @Override
+        public void skipValues(int total, VectorizedValuesReader valuesReader) {
+            valuesReader.skipLongs(total);
+        }
+
+        @Override
+        public void readValue(
+                int offset, WritableShortVector values, VectorizedValuesReader valuesReader) {
+            values.setShort(offset, (short) Math.toIntExact(valuesReader.readLong()));
+        }
+
+        @Override
+        public void decodeSingleDictionaryId(
+                int offset,
+                WritableShortVector values,
+                WritableIntVector dictionaryIds,
+                Dictionary dictionary) {
+            values.setShort(
+                    offset,
+                    (short) Math.toIntExact(dictionary.decodeToLong(dictionaryIds.getInt(offset))));
         }
     }
 

--- a/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/parquet/reader/FileTypeNotMatchReadTypeTest.java
@@ -238,6 +238,84 @@ public class FileTypeNotMatchReadTypeTest {
     }
 
     @Test
+    public void testReadByteFromInt64() throws Exception {
+        String fileName = "test.parquet";
+        String fileWholePath = tempDir + "/" + fileName;
+
+        RowType rowTypeWrite = RowType.of(new DataField(0, "byte_col", DataTypes.BIGINT()));
+        RowType rowTypeRead = RowType.of(new DataField(0, "byte_col", DataTypes.TINYINT()));
+        MessageType messageType = Util.convertToParquetMessageType(rowTypeWrite);
+        ParquetRowDataBuilderForTest parquetRowDataBuilder =
+                new ParquetRowDataBuilderForTest(
+                                new LocalOutputFile(new File(fileWholePath).toPath()),
+                                rowTypeWrite,
+                                messageType)
+                        .enableDictionaryEncoding();
+        ParquetWriter<InternalRow> parquetWriter = parquetRowDataBuilder.build();
+
+        for (int i = 0; i < 100; i++) {
+            parquetWriter.write(GenericRow.of((long) i));
+        }
+        parquetWriter.close();
+
+        ParquetReaderFactory parquetReaderFactory =
+                new ParquetReaderFactory(new Options(), rowTypeRead, 100, null);
+
+        File file = new File(fileWholePath);
+        FileRecordReader<InternalRow> fileRecordReader =
+                parquetReaderFactory.createReader(
+                        new FormatReaderContext(
+                                LocalFileIO.create(),
+                                new org.apache.paimon.fs.Path(tempDir.toString(), fileName),
+                                file.length()));
+
+        FileRecordIterator<InternalRow> batch = fileRecordReader.readBatch();
+        for (int i = 0; i < 100; i++) {
+            assertThat(batch.next().getByte(0)).isEqualTo((byte) i);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testReadShortFromInt64() throws Exception {
+        String fileName = "test.parquet";
+        String fileWholePath = tempDir + "/" + fileName;
+
+        RowType rowTypeWrite = RowType.of(new DataField(0, "short_col", DataTypes.BIGINT()));
+        RowType rowTypeRead = RowType.of(new DataField(0, "short_col", DataTypes.SMALLINT()));
+        MessageType messageType = Util.convertToParquetMessageType(rowTypeWrite);
+        ParquetRowDataBuilderForTest parquetRowDataBuilder =
+                new ParquetRowDataBuilderForTest(
+                                new LocalOutputFile(new File(fileWholePath).toPath()),
+                                rowTypeWrite,
+                                messageType)
+                        .enableDictionaryEncoding();
+        ParquetWriter<InternalRow> parquetWriter = parquetRowDataBuilder.build();
+
+        for (int i = 0; i < 100; i++) {
+            parquetWriter.write(GenericRow.of((long) i));
+        }
+        parquetWriter.close();
+
+        ParquetReaderFactory parquetReaderFactory =
+                new ParquetReaderFactory(new Options(), rowTypeRead, 100, null);
+
+        File file = new File(fileWholePath);
+        FileRecordReader<InternalRow> fileRecordReader =
+                parquetReaderFactory.createReader(
+                        new FormatReaderContext(
+                                LocalFileIO.create(),
+                                new org.apache.paimon.fs.Path(tempDir.toString(), fileName),
+                                file.length()));
+
+        FileRecordIterator<InternalRow> batch = fileRecordReader.readBatch();
+        for (int i = 0; i < 100; i++) {
+            assertThat(batch.next().getShort(0)).isEqualTo((short) i);
+        }
+        file.delete();
+    }
+
+    @Test
     public void testArray() throws Exception {
         String fileName = "test.parquet";
         String fileWholePath = tempDir + "/" + fileName;


### PR DESCRIPTION

### Purpose

fix #8628

- `ParquetVectorUpdaterFactory.visit(TinyIntType)` / `visit(SmallIntType)` had no INT64 branch, so reading a TINYINT/SMALLINT column from an INT64 (BIGINT) physical Parquet column threw `UnsupportedOperationException` via `dictionary.decodeToInt` on a `PlainLongDictionary`.
- Add an INT64 branch selecting new `ByteFromLongUpdater` / `ShortFromLongUpdater` that read via `readLong()` and narrow with `Math.toIntExact`, mirroring `IntegerFromLongUpdater`.
- Completes the narrowing pattern merged PR #8505 added for `IntType`←INT64 and `FloatType`←DOUBLE, for the symmetric TINYINT/SMALLINT cases.

### Tests

- Added `FileTypeNotMatchReadTypeTest#testReadByteFromInt64` and `#testReadShortFromInt64` covering dictionary-encoded INT64→TINYINT/SMALLINT reads.
- `mvn -pl paimon-format -am -DfailIfNoTests=false clean install` — BUILD SUCCESS (JDK 11, no engine profiles). `FileTypeNotMatchReadTypeTest`: 9 tests passed.
