### PR TITLE
[rest][spark] Support read-via authorization context

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTCatalogOptions.java
@@ -113,6 +113,13 @@ public class RESTCatalogOptions {
                                     + "'openapi' (for DlfNext/2026-01-18). "
                                     + "If not set, will be automatically selected based on endpoint host.");
 
+    public static final ConfigOption<Boolean> READ_VIA_ENABLED =
+            ConfigOptions.key("read-via.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to propagate the outermost View or table as authorization context when reading referenced tables.");
+
     public static final ConfigOption<Boolean> IO_CACHE_ENABLED =
             ConfigOptions.key("io-cache.enabled")
                     .booleanType()

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTReadVia.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTReadVia.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.catalog.Identifier;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A table identifier and its optional outermost read authorization entry point. */
+public final class RESTReadVia {
+
+    public static final String MARKER = "$via_";
+
+    private final Identifier identifier;
+    private final @Nullable Identifier readVia;
+
+    private RESTReadVia(Identifier identifier, @Nullable Identifier readVia) {
+        this.identifier = identifier;
+        this.readVia = readVia;
+    }
+
+    public static RESTReadVia parse(Identifier identifier) {
+        String objectName = identifier.getObjectName();
+        int markerPos = objectName.lastIndexOf(MARKER);
+        if (markerPos < 0) {
+            return new RESTReadVia(identifier, null);
+        }
+
+        checkArgument(
+                markerPos > 0 && objectName.indexOf(MARKER) == markerPos,
+                "Invalid REST read-via identifier: " + identifier);
+        String viaName = objectName.substring(markerPos + MARKER.length());
+        int databaseSeparator = viaName.indexOf('.');
+        checkArgument(
+                databaseSeparator > 0
+                        && databaseSeparator < viaName.length() - 1
+                        && !viaName.substring(0, databaseSeparator).trim().isEmpty()
+                        && !viaName.substring(databaseSeparator + 1).trim().isEmpty(),
+                "Invalid REST read-via identifier: " + identifier);
+        return new RESTReadVia(
+                Identifier.create(identifier.getDatabaseName(), objectName.substring(0, markerPos)),
+                Identifier.fromString(viaName));
+    }
+
+    public static Identifier withReadVia(Identifier identifier, Identifier readVia) {
+        if (parse(identifier).readVia().isPresent()) {
+            return identifier;
+        }
+        return Identifier.create(
+                identifier.getDatabaseName(),
+                identifier.getObjectName() + MARKER + readVia.getFullName());
+    }
+
+    public Identifier identifier() {
+        return identifier;
+    }
+
+    public Optional<Identifier> readVia() {
+        return Optional.ofNullable(readVia);
+    }
+}

--- a/paimon-api/src/test/java/org/apache/paimon/rest/RESTReadViaTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/rest/RESTReadViaTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the REST read-via identifier protocol. */
+public class RESTReadViaTest {
+
+    @Test
+    public void testReadViaDisabledByDefault() {
+        assertThat(new Options().get(RESTCatalogOptions.READ_VIA_ENABLED)).isFalse();
+    }
+
+    @Test
+    public void testIdentifierRoundTrip() {
+        Identifier table = Identifier.create("db_table", "my_table");
+        Identifier view = Identifier.create("db_view", "my_view");
+
+        Identifier marked = RESTReadVia.withReadVia(table, view);
+        RESTReadVia parsed = RESTReadVia.parse(marked);
+
+        assertThat(marked.getFullName()).isEqualTo("db_table.my_table$via_db_view.my_view");
+        assertThat(parsed.identifier()).isEqualTo(table);
+        assertThat(parsed.readVia()).contains(view);
+    }
+
+    @Test
+    public void testOrdinaryIdentifierHasNoReadVia() {
+        Identifier table = Identifier.create("db", "my_table");
+
+        RESTReadVia parsed = RESTReadVia.parse(table);
+
+        assertThat(parsed.identifier()).isEqualTo(table);
+        assertThat(parsed.readVia()).isEmpty();
+    }
+
+    @Test
+    public void testBranchAndSystemTableRoundTrip() {
+        Identifier table = Identifier.create("db", "my_table$branch_dev$files");
+        Identifier view = Identifier.create("db", "my_view");
+
+        Identifier marked = RESTReadVia.withReadVia(table, view);
+        RESTReadVia parsed = RESTReadVia.parse(marked);
+
+        assertThat(marked.getFullName()).isEqualTo("db.my_table$branch_dev$files$via_db.my_view");
+        assertThat(parsed.identifier()).isEqualTo(table);
+        assertThat(parsed.readVia()).contains(view);
+    }
+
+    @Test
+    public void testWithReadViaKeepsOutermostRoot() {
+        Identifier table = Identifier.create("db", "my_table");
+        Identifier outerView = Identifier.create("db", "outer_view");
+        Identifier innerView = Identifier.create("db", "inner_view");
+
+        Identifier marked = RESTReadVia.withReadVia(table, outerView);
+
+        assertThat(RESTReadVia.withReadVia(marked, innerView)).isEqualTo(marked);
+    }
+
+    @Test
+    public void testRejectMultipleReadViaMarkers() {
+        Identifier identifier =
+                Identifier.create("db", "my_table$via_db.outer_view$via_db.inner_view");
+
+        assertThatThrownBy(() -> RESTReadVia.parse(identifier))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid REST read-via identifier");
+    }
+
+    @Test
+    public void testRejectEmptyReadViaRoot() {
+        Identifier identifier = Identifier.create("db", "my_table$via_");
+
+        assertThatThrownBy(() -> RESTReadVia.parse(identifier))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid REST read-via identifier");
+    }
+
+    @Test
+    public void testRejectIncompleteReadViaRoot() {
+        Identifier identifier = Identifier.create("db", "my_table$via_db.");
+
+        assertThatThrownBy(() -> RESTReadVia.parse(identifier))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid REST read-via identifier");
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -214,12 +214,21 @@ public class RESTTokenFileIO implements FileIO {
             apiInstance = new RESTApi(catalogContext.options(), false);
         }
         Identifier tableIdentifier = identifier;
-        if (identifier.isSystemTable()) {
+        Identifier readVia = null;
+        if (catalogContext.options().get(RESTCatalogOptions.READ_VIA_ENABLED)) {
+            RESTReadVia parsed = RESTReadVia.parse(identifier);
+            tableIdentifier = parsed.identifier();
+            readVia = parsed.readVia().orElse(null);
+        }
+        if (tableIdentifier.isSystemTable()) {
             tableIdentifier =
                     new Identifier(
-                            identifier.getDatabaseName(),
-                            identifier.getTableName(),
-                            identifier.getBranchName());
+                            tableIdentifier.getDatabaseName(),
+                            tableIdentifier.getTableName(),
+                            tableIdentifier.getBranchName());
+        }
+        if (readVia != null) {
+            tableIdentifier = RESTReadVia.withReadVia(tableIdentifier, readVia);
         }
         GetTableTokenResponse response = apiInstance.loadTableToken(tableIdentifier);
         LOG.info(

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -25,6 +25,8 @@ import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.partition.PartitionStatistics;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.FileStoreTable;
@@ -243,6 +245,11 @@ public class CachingCatalog extends DelegateCatalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
+        if (options.get(RESTCatalogOptions.READ_VIA_ENABLED)
+                && RESTReadVia.parse(identifier).readVia().isPresent()) {
+            return getCachedTable(identifier);
+        }
+
         // For system table, do not cache it directly. Instead, cache the origin table and then wrap
         // it to generate the system table.
         if (identifier.isSystemTable()) {
@@ -263,6 +270,10 @@ public class CachingCatalog extends DelegateCatalog {
             return table;
         }
 
+        return getCachedTable(identifier);
+    }
+
+    private Table getCachedTable(Identifier identifier) throws TableNotExistException {
         try {
             return tableCache.get(identifier, this::loadTable);
         } catch (TableLoadingException e) {
@@ -361,8 +372,12 @@ public class CachingCatalog extends DelegateCatalog {
         }
         // clear all branches of this table
         for (Identifier i : tableCache.asMap().keySet()) {
-            if (identifier.getTableName().equals(i.getTableName())
-                    && identifier.getDatabaseName().equals(i.getDatabaseName())) {
+            Identifier cachedIdentifier =
+                    options.get(RESTCatalogOptions.READ_VIA_ENABLED)
+                            ? RESTReadVia.parse(i).identifier()
+                            : i;
+            if (identifier.getTableName().equals(cachedIdentifier.getTableName())
+                    && identifier.getDatabaseName().equals(cachedIdentifier.getDatabaseName())) {
                 tableCache.invalidate(i);
             }
         }

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -293,6 +293,31 @@ public class CatalogUtils {
             @Nullable CatalogContext catalogContext,
             boolean isRestCatalog)
             throws Catalog.TableNotExistException {
+        return loadTable(
+                catalog,
+                identifier,
+                internalFileIO,
+                externalFileIO,
+                metadataLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                null,
+                isRestCatalog);
+    }
+
+    public static Table loadTable(
+            Catalog catalog,
+            Identifier identifier,
+            Function<Path, FileIO> internalFileIO,
+            Function<Path, FileIO> externalFileIO,
+            TableMetadata.Loader metadataLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            @Nullable Identifier readVia,
+            boolean isRestCatalog)
+            throws Catalog.TableNotExistException {
         if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
             return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
         }
@@ -331,6 +356,7 @@ public class CatalogUtils {
         CatalogEnvironment catalogEnv =
                 new CatalogEnvironment(
                         tableIdentifier,
+                        readVia,
                         metadata.uuid(),
                         isRestCatalog && metadata.isExternal() ? null : catalog.catalogLoader(),
                         isRestCatalog ? null : lockFactory,

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -101,6 +101,7 @@ public class RESTCatalog implements Catalog {
     private final RESTApi api;
     private final CatalogContext context;
     private final boolean dataTokenEnabled;
+    private final boolean readViaEnabled;
     protected final Map<String, String> tableDefaultOptions;
     private final @Nullable LocalCacheManager cacheManager;
 
@@ -117,6 +118,7 @@ public class RESTCatalog implements Catalog {
                         context.preferIO(),
                         context.fallbackIO());
         this.dataTokenEnabled = api.options().get(RESTTokenFileIO.DATA_TOKEN_ENABLED);
+        this.readViaEnabled = api.options().get(RESTCatalogOptions.READ_VIA_ENABLED);
         this.tableDefaultOptions = CatalogUtils.tableDefaultOptions(this.context.options().toMap());
         this.cacheManager = CachingFileIO.createCacheManager(this.context);
     }
@@ -355,6 +357,21 @@ public class RESTCatalog implements Catalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
+        if (readViaEnabled) {
+            RESTReadVia readVia = RESTReadVia.parse(identifier);
+            Identifier tableIdentifier = readVia.identifier();
+            return CatalogUtils.loadTable(
+                    this,
+                    tableIdentifier,
+                    path -> fileIOForData(path, identifier),
+                    this::fileIOFromOptions,
+                    i -> loadTableMetadata(i, readVia.readVia().orElse(null)),
+                    null,
+                    null,
+                    context,
+                    readVia.readVia().orElse(null),
+                    true);
+        }
         return CatalogUtils.loadTable(
                 this,
                 identifier,
@@ -506,6 +523,11 @@ public class RESTCatalog implements Catalog {
     }
 
     private TableMetadata loadTableMetadata(Identifier identifier) throws TableNotExistException {
+        return loadTableMetadata(identifier, null);
+    }
+
+    private TableMetadata loadTableMetadata(Identifier identifier, @Nullable Identifier readVia)
+            throws TableNotExistException {
         // if the table is system table, we need to load table metadata from the system table's data
         // table
         Identifier loadTableIdentifier =
@@ -515,6 +537,9 @@ public class RESTCatalog implements Catalog {
                                 identifier.getTableName(),
                                 identifier.getBranchName())
                         : identifier;
+        if (readVia != null) {
+            loadTableIdentifier = RESTReadVia.withReadVia(loadTableIdentifier, readVia);
+        }
 
         GetTableResponse response;
         try {
@@ -662,7 +687,9 @@ public class RESTCatalog implements Catalog {
     @Override
     public TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException {
-        checkNotSystemTable(identifier, "authTable");
+        checkNotSystemTable(
+                readViaEnabled ? RESTReadVia.parse(identifier).identifier() : identifier,
+                "authTable");
         try {
             AuthTableQueryResponse response = api.authTableQuery(identifier, select);
             return new TableQueryAuthResult(response.filter(), response.columnMasking());

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -132,6 +132,7 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                         providerFactories,
                         schema(),
                         catalogEnvironment.catalogContext(),
+                        catalogEnvironment.readRootForReferences(),
                         () -> new AppendTableRead(providerFactories, schema()))
                 : new AppendTableRead(providerFactories, schema());
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -30,6 +30,8 @@ import org.apache.paimon.catalog.RenamingSnapshotCommit;
 import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.catalog.TableRollback;
 import org.apache.paimon.operation.Lock;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.table.source.TableQueryAuth;
 import org.apache.paimon.tag.SnapshotLoaderImpl;
 import org.apache.paimon.utils.SnapshotLoader;
@@ -47,6 +49,7 @@ public class CatalogEnvironment implements Serializable {
     private static final long serialVersionUID = 2L;
 
     @Nullable private final Identifier identifier;
+    @Nullable private final Identifier readVia;
     @Nullable private final String uuid;
     @Nullable private final CatalogLoader catalogLoader;
     @Nullable private final CatalogLockFactory lockFactory;
@@ -64,7 +67,30 @@ public class CatalogEnvironment implements Serializable {
             @Nullable CatalogContext catalogContext,
             boolean supportsVersionManagement,
             boolean supportsPartitionModification) {
+        this(
+                identifier,
+                null,
+                uuid,
+                catalogLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                supportsVersionManagement,
+                supportsPartitionModification);
+    }
+
+    public CatalogEnvironment(
+            @Nullable Identifier identifier,
+            @Nullable Identifier readVia,
+            @Nullable String uuid,
+            @Nullable CatalogLoader catalogLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            boolean supportsVersionManagement,
+            boolean supportsPartitionModification) {
         this.identifier = identifier;
+        this.readVia = readVia;
         this.uuid = uuid;
         this.catalogLoader = catalogLoader;
         this.lockFactory = lockFactory;
@@ -81,6 +107,31 @@ public class CatalogEnvironment implements Serializable {
     @Nullable
     public Identifier identifier() {
         return identifier;
+    }
+
+    public Optional<Identifier> readVia() {
+        return Optional.ofNullable(readVia);
+    }
+
+    @Nullable
+    public Identifier readIdentifier() {
+        return identifier == null || readVia == null
+                ? identifier
+                : RESTReadVia.withReadVia(identifier, readVia);
+    }
+
+    @Nullable
+    public Identifier readRoot() {
+        return readVia == null ? identifier : readVia;
+    }
+
+    @Nullable
+    public Identifier readRootForReferences() {
+        if (catalogContext == null
+                || !catalogContext.options().get(RESTCatalogOptions.READ_VIA_ENABLED)) {
+            return null;
+        }
+        return readRoot();
     }
 
     @Nullable
@@ -173,7 +224,7 @@ public class CatalogEnvironment implements Serializable {
         if (catalogLoader == null) {
             return null;
         }
-        return new SnapshotLoaderImpl(catalogLoader, identifier);
+        return new SnapshotLoaderImpl(catalogLoader, readIdentifier(), identifier);
     }
 
     @Nullable
@@ -199,6 +250,7 @@ public class CatalogEnvironment implements Serializable {
     public CatalogEnvironment copy(Identifier identifier) {
         return new CatalogEnvironment(
                 identifier,
+                readVia,
                 uuid,
                 catalogLoader,
                 lockFactory,
@@ -214,7 +266,7 @@ public class CatalogEnvironment implements Serializable {
         }
         return select -> {
             try (Catalog catalog = catalogLoader.load()) {
-                return catalog.authTableQuery(identifier, select);
+                return catalog.authTableQuery(readIdentifier(), select);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
@@ -50,15 +51,18 @@ import java.util.function.Supplier;
 public class DataEvolutionTableRead extends AppendTableRead {
 
     @Nullable private final CatalogContext catalogContext;
+    @Nullable private final Identifier readRoot;
     @Nullable private final Supplier<InnerTableRead> readFactory;
 
     public DataEvolutionTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
             TableSchema schema,
             @Nullable CatalogContext catalogContext,
+            @Nullable Identifier readRoot,
             @Nullable Supplier<InnerTableRead> readFactory) {
         super(providerFactories, schema);
         this.catalogContext = catalogContext;
+        this.readRoot = readRoot;
         this.readFactory = readFactory;
     }
 
@@ -134,7 +138,8 @@ public class DataEvolutionTableRead extends AppendTableRead {
         }
 
         BlobViewResolver resolver =
-                BlobViewLookup.createResolver(catalogContext, new ArrayList<>(viewStructs));
+                BlobViewLookup.createResolver(
+                        catalogContext, new ArrayList<>(viewStructs), readRoot);
 
         RecordReader<InternalRow> reader = createDataReader(split, authResult);
         Set<Integer> blobViewFieldSet = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/tag/SnapshotLoaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/SnapshotLoaderImpl.java
@@ -22,6 +22,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.utils.SnapshotLoader;
@@ -33,17 +34,24 @@ import java.util.Optional;
 public class SnapshotLoaderImpl implements SnapshotLoader {
 
     private final CatalogLoader catalogLoader;
-    private final Identifier identifier;
+    private final Identifier readIdentifier;
+    private final Identifier mutationIdentifier;
 
     public SnapshotLoaderImpl(CatalogLoader catalogLoader, Identifier identifier) {
+        this(catalogLoader, identifier, identifier);
+    }
+
+    public SnapshotLoaderImpl(
+            CatalogLoader catalogLoader, Identifier readIdentifier, Identifier mutationIdentifier) {
         this.catalogLoader = catalogLoader;
-        this.identifier = identifier;
+        this.readIdentifier = readIdentifier;
+        this.mutationIdentifier = mutationIdentifier;
     }
 
     @Override
     public Optional<Snapshot> load() throws IOException {
         try (Catalog catalog = catalogLoader.load()) {
-            return catalog.loadSnapshot(identifier).map(TableSnapshot::snapshot);
+            return catalog.loadSnapshot(readIdentifier).map(TableSnapshot::snapshot);
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -54,7 +62,7 @@ public class SnapshotLoaderImpl implements SnapshotLoader {
     @Override
     public void rollback(Instant instant) throws IOException {
         try (Catalog catalog = catalogLoader.load()) {
-            catalog.rollbackTo(identifier, instant);
+            catalog.rollbackTo(mutationIdentifier, instant);
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -66,6 +74,21 @@ public class SnapshotLoaderImpl implements SnapshotLoader {
     public SnapshotLoader copyWithBranch(String branch) {
         return new SnapshotLoaderImpl(
                 catalogLoader,
-                new Identifier(identifier.getDatabaseName(), identifier.getTableName(), branch));
+                copyWithBranch(readIdentifier, branch),
+                copyWithBranch(mutationIdentifier, branch));
+    }
+
+    private static Identifier copyWithBranch(Identifier identifier, String branch) {
+        RESTReadVia parsed = RESTReadVia.parse(identifier);
+        Identifier base = parsed.identifier();
+        Identifier copied =
+                new Identifier(
+                        base.getDatabaseName(),
+                        base.getTableName(),
+                        branch,
+                        base.getSystemTableName());
+        return parsed.readVia()
+                .map(readVia -> RESTReadVia.withReadVia(copied, readVia))
+                .orElse(copied);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
@@ -31,11 +31,14 @@ import org.apache.paimon.data.BlobViewResolver;
 import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -67,7 +70,14 @@ public class BlobViewLookup {
 
     public static BlobViewResolver createResolver(
             CatalogContext catalogContext, List<BlobViewStruct> viewStructs) {
-        return createResolver(catalogContext, viewStructs, CatalogFactory::createCatalog);
+        return createResolver(catalogContext, viewStructs, null, CatalogFactory::createCatalog);
+    }
+
+    public static BlobViewResolver createResolver(
+            CatalogContext catalogContext,
+            List<BlobViewStruct> viewStructs,
+            @Nullable Identifier readRoot) {
+        return createResolver(catalogContext, viewStructs, readRoot, CatalogFactory::createCatalog);
     }
 
     @VisibleForTesting
@@ -75,7 +85,17 @@ public class BlobViewLookup {
             CatalogContext catalogContext,
             List<BlobViewStruct> viewStructs,
             CatalogLoader catalogLoader) {
-        PreloadedBlobViews cached = preloadDescriptors(catalogContext, viewStructs, catalogLoader);
+        return createResolver(catalogContext, viewStructs, null, catalogLoader);
+    }
+
+    @VisibleForTesting
+    static BlobViewResolver createResolver(
+            CatalogContext catalogContext,
+            List<BlobViewStruct> viewStructs,
+            @Nullable Identifier readRoot,
+            CatalogLoader catalogLoader) {
+        PreloadedBlobViews cached =
+                preloadDescriptors(catalogContext, viewStructs, readRoot, catalogLoader);
         return new BlobViewResolver() {
 
             private final Map<Identifier, UriReader> cache = new HashMap<>();
@@ -97,7 +117,8 @@ public class BlobViewLookup {
                                 identifier -> {
                                     try (Catalog catalog = catalogLoader.create(catalogContext)) {
                                         return UriReader.fromFile(
-                                                catalog.getTable(identifier).fileIO());
+                                                catalog.getTable(withReadRoot(identifier, readRoot))
+                                                        .fileIO());
                                     } catch (Exception e) {
                                         throw new RuntimeException(e);
                                     }
@@ -133,6 +154,7 @@ public class BlobViewLookup {
     private static PreloadedBlobViews preloadDescriptors(
             CatalogContext catalogContext,
             List<BlobViewStruct> viewStructs,
+            @Nullable Identifier readRoot,
             CatalogLoader catalogLoader) {
         if (viewStructs.isEmpty()) {
             return PreloadedBlobViews.empty();
@@ -141,7 +163,11 @@ public class BlobViewLookup {
         Map<Identifier, TableReferences> grouped = groupReferencesByTable(viewStructs);
         try {
             return loadReferencedDescriptors(
-                    catalogContext, grouped.values(), PRELOAD_DESCRIPTOR_EXECUTOR, catalogLoader);
+                    catalogContext,
+                    grouped.values(),
+                    readRoot,
+                    PRELOAD_DESCRIPTOR_EXECUTOR,
+                    catalogLoader);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Failed to preload blob descriptors.", e);
@@ -182,12 +208,14 @@ public class BlobViewLookup {
     private static PreloadedBlobViews loadReferencedDescriptors(
             CatalogContext catalogContext,
             Collection<TableReferences> grouped,
+            @Nullable Identifier readRoot,
             ExecutorService executor,
             CatalogLoader catalogLoader)
             throws Exception {
         List<TableReadPlan> plans = new ArrayList<>(grouped.size());
         for (TableReferences tableReferences : grouped) {
-            plans.add(createTableReadPlan(catalogContext, tableReferences, catalogLoader));
+            plans.add(
+                    createTableReadPlan(catalogContext, tableReferences, readRoot, catalogLoader));
         }
         long targetRowsPerTask = targetRowsPerTask(plans);
 
@@ -211,6 +239,7 @@ public class BlobViewLookup {
                                                 plan.fields,
                                                 plan.readType,
                                                 rangeChunk,
+                                                readRoot,
                                                 catalogLoader);
                                     } finally {
                                         Thread.currentThread()
@@ -237,11 +266,12 @@ public class BlobViewLookup {
     private static TableReadPlan createTableReadPlan(
             CatalogContext catalogContext,
             TableReferences tableReferences,
+            @Nullable Identifier readRoot,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             List<FieldRead> fields = new ArrayList<>(tableReferences.referencesByField.size());
-            Table table = catalog.getTable(tableReferences.identifier);
+            Table table = catalog.getTable(withReadRoot(tableReferences.identifier, readRoot));
             for (Map.Entry<Integer, List<BlobViewStruct>> entry :
                     tableReferences.referencesByField.entrySet()) {
                 int fieldId = entry.getKey();
@@ -280,12 +310,13 @@ public class BlobViewLookup {
             List<FieldRead> fields,
             RowType readType,
             List<Range> rowRanges,
+            @Nullable Identifier readRoot,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             PreloadedBlobViews resolved = new PreloadedBlobViews();
             Table table =
-                    catalog.getTable(identifier)
+                    catalog.getTable(withReadRoot(identifier, readRoot))
                             .copy(
                                     Collections.singletonMap(
                                             CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true"));
@@ -325,6 +356,10 @@ public class BlobViewLookup {
 
             return resolved;
         }
+    }
+
+    private static Identifier withReadRoot(Identifier identifier, @Nullable Identifier readRoot) {
+        return readRoot == null ? identifier : RESTReadVia.withReadVia(identifier, readRoot);
     }
 
     private static List<List<Range>> splitRowRanges(List<Range> rowRanges, long targetRowsPerTask) {

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -25,6 +25,8 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.Table;
@@ -215,6 +217,63 @@ class CachingCatalogTest extends CatalogTestBase {
             releaseLoad.countDown();
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    public void testCacheReadViaTableInsteadOfTreatingItAsSystemTable() throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        Options options = new Options();
+        options.set(RESTCatalogOptions.READ_VIA_ENABLED, true);
+        CachingCatalog catalog = new CachingCatalog(wrapped, options);
+        Identifier marked =
+                RESTReadVia.withReadVia(
+                        Identifier.create("db", "tbl"), Identifier.create("db", "view"));
+        Table table = Mockito.mock(Table.class);
+        when(wrapped.getTable(marked)).thenReturn(table);
+
+        assertThat(catalog.getTable(marked)).isSameAs(table);
+        assertThat(catalog.getTable(marked)).isSameAs(table);
+        Mockito.verify(wrapped, Mockito.times(1)).getTable(marked);
+    }
+
+    @Test
+    public void testCacheReadViaTableByTargetAndRoot() throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        Options options = new Options();
+        options.set(RESTCatalogOptions.READ_VIA_ENABLED, true);
+        CachingCatalog catalog = new CachingCatalog(wrapped, options);
+        Identifier target = Identifier.create("db", "tbl");
+        Identifier viaView1 = RESTReadVia.withReadVia(target, Identifier.create("db", "view1"));
+        Identifier viaView2 = RESTReadVia.withReadVia(target, Identifier.create("db", "view2"));
+        Table table1 = Mockito.mock(Table.class);
+        Table table2 = Mockito.mock(Table.class);
+        when(wrapped.getTable(viaView1)).thenReturn(table1);
+        when(wrapped.getTable(viaView2)).thenReturn(table2);
+
+        assertThat(catalog.getTable(viaView1)).isSameAs(table1);
+        assertThat(catalog.getTable(viaView2)).isSameAs(table2);
+        assertThat(catalog.getTable(viaView1)).isSameAs(table1);
+        assertThat(catalog.getTable(viaView2)).isSameAs(table2);
+        Mockito.verify(wrapped, Mockito.times(1)).getTable(viaView1);
+        Mockito.verify(wrapped, Mockito.times(1)).getTable(viaView2);
+    }
+
+    @Test
+    public void testInvalidateReadViaSystemTableWithBaseTable() throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        Options options = new Options();
+        options.set(RESTCatalogOptions.READ_VIA_ENABLED, true);
+        CachingCatalog catalog = new CachingCatalog(wrapped, options);
+        Identifier table = Identifier.create("db", "tbl");
+        Identifier markedSystemTable =
+                RESTReadVia.withReadVia(
+                        Identifier.create("db", "tbl$files"), Identifier.create("db", "view"));
+        when(wrapped.getTable(markedSystemTable)).thenReturn(Mockito.mock(Table.class));
+
+        catalog.getTable(markedSystemTable);
+        catalog.invalidateTable(table);
+
+        assertThat(catalog.tableCache().asMap()).doesNotContainKey(markedSystemTable);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -45,6 +45,7 @@ import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
 import org.apache.paimon.rest.responses.ConfigResponse;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.JsonSerdeUtil;
@@ -212,6 +213,69 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         assertEquals(
                 restCatalog.getTable(identifier).options().get(catalogConfigInServerKey),
                 "default-value");
+    }
+
+    @Test
+    void testGetTableWithReadVia() throws Exception {
+        RESTCatalog catalog =
+                initCatalog(
+                        false,
+                        Collections.singletonMap(
+                                RESTCatalogOptions.READ_VIA_ENABLED.key(), "true"));
+        Identifier tableIdentifier = Identifier.create("db_table", "my_table");
+        Identifier viewIdentifier = Identifier.create("db_view", "my_view");
+        Identifier readIdentifier = RESTReadVia.withReadVia(tableIdentifier, viewIdentifier);
+        catalog.createDatabase(tableIdentifier.getDatabaseName(), true);
+        catalog.createTable(tableIdentifier, DEFAULT_TABLE_SCHEMA, false);
+        restCatalogServer.clearReceivedTableIdentifiers();
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(readIdentifier);
+
+        assertThat(restCatalogServer.getReceivedTableIdentifiers()).containsExactly(readIdentifier);
+        assertThat(table.catalogEnvironment().identifier()).isEqualTo(tableIdentifier);
+        assertThat(table.catalogEnvironment().readVia()).contains(viewIdentifier);
+    }
+
+    @Test
+    void testReadOperationsWithReadVia() throws Exception {
+        RESTCatalog catalog =
+                initCatalog(
+                        false,
+                        Collections.singletonMap(
+                                RESTCatalogOptions.READ_VIA_ENABLED.key(), "true"));
+        Identifier tableIdentifier = Identifier.create("db_table", "my_table");
+        Identifier readIdentifier =
+                RESTReadVia.withReadVia(tableIdentifier, Identifier.create("db_view", "my_view"));
+        catalog.createDatabase(tableIdentifier.getDatabaseName(), true);
+        catalog.createTable(tableIdentifier, DEFAULT_TABLE_SCHEMA, false);
+        restCatalogServer.clearReceivedTableIdentifiers();
+
+        assertThat(catalog.loadSnapshot(readIdentifier)).isEmpty();
+        assertThat(catalog.loadSnapshot(readIdentifier, "LATEST")).isEmpty();
+        catalog.authTableQuery(readIdentifier, null);
+
+        assertThat(restCatalogServer.getReceivedTableIdentifiers())
+                .containsExactly(readIdentifier, readIdentifier, readIdentifier);
+    }
+
+    @Test
+    void testDataTokenWithReadVia() throws Exception {
+        RESTCatalog catalog =
+                initCatalog(
+                        true,
+                        Collections.singletonMap(
+                                RESTCatalogOptions.READ_VIA_ENABLED.key(), "true"));
+        Identifier tableIdentifier = Identifier.create("db_table", "my_table");
+        Identifier readIdentifier =
+                RESTReadVia.withReadVia(tableIdentifier, Identifier.create("db_view", "my_view"));
+        catalog.createDatabase(tableIdentifier.getDatabaseName(), true);
+        catalog.createTable(tableIdentifier, DEFAULT_TABLE_SCHEMA, false);
+        FileStoreTable table = (FileStoreTable) catalog.getTable(readIdentifier);
+        restCatalogServer.clearReceivedTableIdentifiers();
+
+        ((RESTTokenFileIO) table.fileIO()).validToken();
+
+        assertThat(restCatalogServer.getReceivedTableIdentifiers()).containsExactly(readIdentifier);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -206,6 +206,8 @@ public class RESTCatalogServer {
     private final ResourcePaths resourcePaths;
 
     private final List<Map<String, String>> receivedHeaders = new ArrayList<>();
+    private final List<Identifier> receivedTableIdentifiers =
+            Collections.synchronizedList(new ArrayList<>());
 
     public RESTCatalogServer(
             String dataPath, AuthProvider authProvider, ConfigResponse config, String warehouse) {
@@ -462,13 +464,19 @@ public class RESTCatalogServer {
                                 resources.length >= 5
                                         && ResourcePaths.TABLES.equals(resources[1])
                                         && ResourcePaths.TAGS.equals(resources[3]);
-                        Identifier identifier =
+                        Identifier requestIdentifier =
                                 resources.length >= 3
                                                 && !"rename".equals(resources[2])
                                                 && !"commit".equals(resources[2])
                                         ? Identifier.create(
                                                 databaseName, RESTUtil.decodeString(resources[2]))
                                         : null;
+                        Identifier identifier = requestIdentifier;
+                        if (requestIdentifier != null
+                                && ResourcePaths.TABLES.equals(resources[1])) {
+                            receivedTableIdentifiers.add(requestIdentifier);
+                            identifier = RESTReadVia.parse(requestIdentifier).identifier();
+                        }
                         if (identifier != null && ResourcePaths.TABLES.equals(resources[1])) {
                             if (!identifier.isSystemTable()
                                     && !tableMetadataStore.containsKey(identifier.getFullName())) {
@@ -2880,5 +2888,13 @@ public class RESTCatalogServer {
 
     public void clearReceivedHeaders() {
         receivedHeaders.clear();
+    }
+
+    public List<Identifier> getReceivedTableIdentifiers() {
+        return receivedTableIdentifiers;
+    }
+
+    public void clearReceivedTableIdentifiers() {
+        receivedTableIdentifiers.clear();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTReadVia;
+import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.SnapshotLoader;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link CatalogEnvironment}. */
+public class CatalogEnvironmentTest {
+
+    @Test
+    public void testKeepRealIdentifierAndReadViaSeparately() {
+        Identifier table = Identifier.create("db_table", "my_table");
+        Identifier view = Identifier.create("db_view", "my_view");
+
+        CatalogEnvironment environment =
+                new CatalogEnvironment(table, view, null, null, null, null, null, false, false);
+
+        assertThat(environment.identifier()).isEqualTo(table);
+        assertThat(environment.readVia()).contains(view);
+        assertThat(environment.readIdentifier()).isEqualTo(RESTReadVia.withReadVia(table, view));
+        assertThat(environment.readRoot()).isEqualTo(view);
+    }
+
+    @Test
+    public void testReadOperationsUseReadIdentifier() throws Exception {
+        Identifier table = Identifier.create("db_table", "my_table");
+        Identifier view = Identifier.create("db_view", "my_view");
+        Identifier readIdentifier = RESTReadVia.withReadVia(table, view);
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.loadSnapshot(readIdentifier)).thenReturn(Optional.empty());
+
+        CatalogEnvironment environment =
+                new CatalogEnvironment(
+                        table, view, null, () -> catalog, null, null, null, true, false);
+
+        SnapshotLoader snapshotLoader = environment.snapshotLoader();
+        assertThat(snapshotLoader).isNotNull();
+        snapshotLoader.load();
+        environment
+                .tableQueryAuth(
+                        CoreOptions.fromMap(
+                                Collections.singletonMap(
+                                        CoreOptions.QUERY_AUTH_ENABLED.key(), "true")))
+                .auth(null);
+        Instant instant = Instant.snapshot(1L);
+        snapshotLoader.rollback(instant);
+
+        verify(catalog).loadSnapshot(readIdentifier);
+        verify(catalog).authTableQuery(readIdentifier, null);
+        verify(catalog).rollbackTo(table, instant);
+        verify(catalog, never()).rollbackTo(readIdentifier, instant);
+    }
+
+    @Test
+    public void testDirectReadUsesTableAsRoot() {
+        Identifier table = Identifier.create("db", "my_table");
+        CatalogEnvironment environment =
+                new CatalogEnvironment(table, null, null, null, null, null, false, false);
+
+        assertThat(environment.readVia()).isEmpty();
+        assertThat(environment.readIdentifier()).isEqualTo(table);
+        assertThat(environment.readRoot()).isEqualTo(table);
+    }
+
+    @Test
+    public void testCopyAndSerializationPreserveReadVia() throws Exception {
+        Identifier table = Identifier.create("db", "my_table");
+        Identifier view = Identifier.create("db", "my_view");
+        Identifier branchTable = new Identifier("db", "my_table", "branch1");
+        CatalogEnvironment environment =
+                new CatalogEnvironment(table, view, null, null, null, null, null, false, false);
+
+        CatalogEnvironment copied = environment.copy(branchTable);
+        CatalogEnvironment restored = InstantiationUtil.clone(copied);
+
+        assertThat(restored.identifier()).isEqualTo(branchTable);
+        assertThat(restored.readVia()).contains(view);
+        assertThat(restored.readIdentifier()).isEqualTo(RESTReadVia.withReadVia(branchTable, view));
+    }
+
+    @Test
+    public void testSnapshotLoaderBranchCopyPreservesReadVia() throws Exception {
+        Identifier table = Identifier.create("db", "my_table");
+        Identifier view = Identifier.create("db", "my_view");
+        Identifier branchTable = new Identifier("db", "my_table", "branch1");
+        Identifier branchReadIdentifier = RESTReadVia.withReadVia(branchTable, view);
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.loadSnapshot(branchReadIdentifier)).thenReturn(Optional.empty());
+        CatalogEnvironment environment =
+                new CatalogEnvironment(
+                        table, view, null, () -> catalog, null, null, null, true, false);
+
+        SnapshotLoader branchLoader = environment.snapshotLoader().copyWithBranch("branch1");
+        branchLoader.load();
+        Instant instant = Instant.snapshot(1L);
+        branchLoader.rollback(instant);
+
+        verify(catalog).loadSnapshot(branchReadIdentifier);
+        verify(catalog).rollbackTo(branchTable, instant);
+    }
+
+    @Test
+    public void testReferenceReadRootOnlyWhenEnabled() {
+        Identifier table = Identifier.create("db", "my_table");
+        Identifier view = Identifier.create("db", "my_view");
+        Options enabled = new Options();
+        enabled.set(RESTCatalogOptions.READ_VIA_ENABLED, true);
+        CatalogEnvironment direct =
+                new CatalogEnvironment(
+                        table,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        CatalogContext.create(enabled),
+                        false,
+                        false);
+        CatalogEnvironment throughView =
+                new CatalogEnvironment(
+                        table,
+                        view,
+                        null,
+                        null,
+                        null,
+                        null,
+                        CatalogContext.create(enabled),
+                        false,
+                        false);
+        CatalogEnvironment disabled =
+                new CatalogEnvironment(
+                        table,
+                        view,
+                        null,
+                        null,
+                        null,
+                        null,
+                        CatalogContext.create(new Options()),
+                        false,
+                        false);
+
+        assertThat(direct.readRootForReferences()).isEqualTo(table);
+        assertThat(throughView.readRootForReferences()).isEqualTo(view);
+        assertThat(disabled.readRootForReferences()).isNull();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobView;
+import org.apache.paimon.data.BlobViewResolver;
+import org.apache.paimon.data.BlobViewStruct;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.rest.RESTReadVia;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link BlobViewLookup}. */
+public class BlobViewLookupTest {
+
+    @Test
+    public void testUseReadRootForAllReferencedTableLoads() throws Exception {
+        Identifier upstream = Identifier.create("db_upstream", "upstream_table");
+        Identifier root = Identifier.create("db_downstream", "downstream_table");
+        Identifier expected = RESTReadVia.withReadVia(upstream, root);
+        int fieldId = 5;
+        long rowId = 7L;
+        BlobViewStruct viewStruct = new BlobViewStruct(upstream, fieldId, rowId);
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(fieldId, "blob_field", DataTypes.BLOB())));
+
+        BlobDescriptor descriptor = new BlobDescriptor("file:///blob", 0L, 1L);
+        Blob blob = mock(Blob.class);
+        when(blob.toDescriptor()).thenReturn(descriptor);
+        InternalRow row = mock(InternalRow.class);
+        when(row.getLong(1)).thenReturn(rowId);
+        when(row.isNullAt(0)).thenReturn(false);
+        when(row.getBlob(0)).thenReturn(blob);
+
+        RecordReader.RecordIterator<InternalRow> iterator = mock(RecordReader.RecordIterator.class);
+        when(iterator.next()).thenReturn(row, null);
+        RecordReader<InternalRow> reader = mock(RecordReader.class);
+        when(reader.readBatch()).thenReturn(iterator, null);
+        TableScan.Plan plan = mock(TableScan.Plan.class);
+        TableScan scan = mock(TableScan.class);
+        when(scan.plan()).thenReturn(plan);
+        TableRead read = mock(TableRead.class);
+        when(read.createReader(plan)).thenReturn(reader);
+        ReadBuilder readBuilder = mock(ReadBuilder.class);
+        when(readBuilder.withReadType(any(RowType.class))).thenReturn(readBuilder);
+        when(readBuilder.withRowRanges(any())).thenReturn(readBuilder);
+        when(readBuilder.newRead()).thenReturn(read);
+        when(readBuilder.newScan()).thenReturn(scan);
+
+        Table table = mock(Table.class);
+        when(table.rowType()).thenReturn(rowType);
+        when(table.copy(any())).thenReturn(table);
+        when(table.newReadBuilder()).thenReturn(readBuilder);
+        when(table.fileIO()).thenReturn(mock(FileIO.class));
+        List<Identifier> loadedIdentifiers = Collections.synchronizedList(new ArrayList<>());
+        Catalog catalog = mock(Catalog.class);
+        when(catalog.getTable(any(Identifier.class)))
+                .thenAnswer(
+                        invocation -> {
+                            loadedIdentifiers.add(invocation.getArgument(0));
+                            return table;
+                        });
+
+        BlobViewResolver resolver =
+                BlobViewLookup.createResolver(
+                        CatalogContext.create(new Options()),
+                        Collections.singletonList(viewStruct),
+                        root,
+                        ignored -> catalog);
+        BlobView blobView = new BlobView(viewStruct);
+        resolver.resolve(blobView);
+
+        assertThat(blobView.isResolved()).isTrue();
+        assertThat(loadedIdentifiers).containsExactly(expected, expected, expected);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -28,6 +28,8 @@ import org.apache.paimon.function.Function;
 import org.apache.paimon.function.FunctionDefinition;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.rest.RESTCatalog;
+import org.apache.paimon.rest.RESTCatalogOptions;
+import org.apache.paimon.rest.RESTReadVia;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.spark.catalog.FormatTableCatalog;
@@ -798,9 +800,18 @@ public class SparkCatalog extends SparkBaseCatalog
     protected org.apache.spark.sql.connector.catalog.Table loadSparkTable(
             Identifier ident, Map<String, String> extraOptions) throws NoSuchTableException {
         try {
-            org.apache.paimon.catalog.Identifier tblIdent =
-                    withBranchFromOptions(
-                            catalogName, toIdentifier(ident, catalogName), extraOptions);
+            org.apache.paimon.catalog.Identifier tblIdent = toIdentifier(ident, catalogName);
+            if (Boolean.parseBoolean(
+                    catalog.options()
+                            .getOrDefault(RESTCatalogOptions.READ_VIA_ENABLED.key(), "false"))) {
+                RESTReadVia readVia = RESTReadVia.parse(tblIdent);
+                tblIdent = withBranchFromOptions(catalogName, readVia.identifier(), extraOptions);
+                if (readVia.readVia().isPresent()) {
+                    tblIdent = RESTReadVia.withReadVia(tblIdent, readVia.readVia().get());
+                }
+            } else {
+                tblIdent = withBranchFromOptions(catalogName, tblIdent, extraOptions);
+            }
             org.apache.paimon.table.Table table =
                     copyWithSQLConf(
                             catalog.getTable(tblIdent), catalogName, tblIdent, extraOptions);

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonViewResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonViewResolver.scala
@@ -18,9 +18,12 @@
 
 package org.apache.paimon.spark.catalyst.analysis
 
+import org.apache.paimon.catalog.{Identifier => PaimonIdentifier}
 import org.apache.paimon.catalog.Catalog.ViewNotExistException
+import org.apache.paimon.rest.{RESTCatalogOptions, RESTReadVia}
 import org.apache.paimon.spark.SparkTypeUtils
 import org.apache.paimon.spark.catalog.SupportView
+import org.apache.paimon.spark.utils.CatalogUtils.toIdentifier
 import org.apache.paimon.view.View
 
 import org.apache.spark.sql.{PaimonUtils, SparkSession}
@@ -42,9 +45,11 @@ case class PaimonViewResolver(spark: SparkSession)
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
     case u @ UnresolvedRelation(parts @ CatalogAndIdentifier(catalog: SupportView, ident), _, _) =>
+      val (viewIdent, inheritedRoot) = realViewIdentifier(catalog, ident)
       try {
-        val view = catalog.loadView(ident)
-        createViewRelation(parts, view)
+        val view = catalog.loadView(viewIdent)
+        val realParts = parts.dropRight(1) :+ viewIdent.name()
+        createViewRelation(realParts, catalog, viewIdent, inheritedRoot, view)
       } catch {
         case _: ViewNotExistException =>
           u
@@ -60,13 +65,24 @@ case class PaimonViewResolver(spark: SparkSession)
       }
   }
 
-  private def createViewRelation(nameParts: Seq[String], view: View): LogicalPlan = {
+  private def createViewRelation(
+      nameParts: Seq[String],
+      catalog: SupportView,
+      viewIdent: Identifier,
+      inheritedRoot: Option[PaimonIdentifier],
+      view: View): LogicalPlan = {
     val parsedPlan =
       parseViewText(nameParts.toArray.mkString("."), view.query(SupportView.DIALECT))
 
     // Apply early analysis rules that won't re-run for plans injected during Resolution batch.
     val earlyRules = SparkShimLoader.shim.earlyBatchRules()
-    val rewritten = earlyRules.foldLeft(parsedPlan)((plan, rule) => rule.apply(plan))
+    val earlyRewritten = earlyRules.foldLeft(parsedPlan)((plan, rule) => rule.apply(plan))
+    val rewritten = if (readViaEnabled(catalog)) {
+      val readRoot = inheritedRoot.getOrElse(toIdentifier(viewIdent, catalog.paimonCatalogName()))
+      markRelations(earlyRewritten, catalog, readRoot)
+    } else {
+      earlyRewritten
+    }
 
     // Spark internally replaces CharType/VarcharType with StringType during V2 table resolution,
     // so the view's schema must also use StringType to avoid UpCast failures
@@ -82,6 +98,52 @@ case class PaimonViewResolver(spark: SparkSession)
     }
 
     SubqueryAlias(nameParts, Project(aliases, rewritten))
+  }
+
+  private def realViewIdentifier(
+      catalog: SupportView,
+      identifier: Identifier): (Identifier, Option[PaimonIdentifier]) = {
+    if (!readViaEnabled(catalog)) {
+      return (identifier, None)
+    }
+
+    val parsed = RESTReadVia.parse(toIdentifier(identifier, catalog.paimonCatalogName()))
+    val realIdentifier = Identifier.of(identifier.namespace(), parsed.identifier().getObjectName)
+    val inheritedRoot = if (parsed.readVia().isPresent) {
+      Some(parsed.readVia().get())
+    } else {
+      None
+    }
+    (realIdentifier, inheritedRoot)
+  }
+
+  private def markRelations(
+      plan: LogicalPlan,
+      viewCatalog: SupportView,
+      readRoot: PaimonIdentifier): LogicalPlan = {
+    plan.resolveOperators {
+      case relation @ UnresolvedRelation(
+            parts @ CatalogAndIdentifier(referenceCatalog: SupportView, identifier),
+            _,
+            _) =>
+        if (referenceCatalog ne viewCatalog) {
+          throw new IllegalArgumentException(
+            s"REST read-via does not support references across Paimon catalogs: " +
+              s"${viewCatalog.paimonCatalogName()} -> ${referenceCatalog.paimonCatalogName()}")
+        }
+        val marked = RESTReadVia.withReadVia(
+          toIdentifier(identifier, referenceCatalog.paimonCatalogName()),
+          readRoot)
+        relation.copy(multipartIdentifier = parts.dropRight(1) :+ marked.getObjectName)
+    }
+  }
+
+  private def readViaEnabled(catalog: SupportView): Boolean = {
+    java.lang.Boolean.parseBoolean(
+      catalog
+        .paimonCatalog()
+        .options()
+        .getOrDefault(RESTCatalogOptions.READ_VIA_ENABLED.key(), "false"))
   }
 
   private def parseViewText(name: String, viewText: String): LogicalPlan = {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestWithRestCatalogBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonSparkTestWithRestCatalogBase.scala
@@ -32,7 +32,7 @@ import java.util.UUID
 
 class PaimonSparkTestWithRestCatalogBase extends PaimonSparkTestBase {
 
-  private var restCatalogServer: RESTCatalogServer = _
+  protected var restCatalogServer: RESTCatalogServer = _
   private var serverUrl: String = _
   protected var warehouse: String = _
   private val initToken = "init_token"

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonReadViaTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonReadViaTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql
+
+import org.apache.paimon.catalog.Identifier
+import org.apache.paimon.rest.{RESTCatalogOptions, RESTReadVia}
+import org.apache.paimon.spark.PaimonSparkTestWithRestCatalogBase
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+
+import scala.collection.JavaConverters._
+
+/** Tests for REST read-via propagation while resolving Paimon Views. */
+class PaimonReadViaTest extends PaimonSparkTestWithRestCatalogBase {
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set(s"spark.sql.catalog.paimon.${RESTCatalogOptions.READ_VIA_ENABLED.key}", "true")
+  }
+
+  test("read a table via a Paimon View") {
+    withTable("source_table") {
+      withView("read_view") {
+        sql("CREATE TABLE source_table (id INT) USING paimon")
+        sql("INSERT INTO source_table VALUES (1), (2)")
+        sql("CREATE VIEW read_view AS SELECT * FROM source_table")
+        restCatalogServer.clearReceivedTableIdentifiers()
+
+        checkAnswer(sql("SELECT * FROM read_view"), Seq(Row(1), Row(2)))
+
+        val expected = RESTReadVia.withReadVia(
+          Identifier.create(dbName0, "source_table"),
+          Identifier.create(dbName0, "read_view"))
+        assert(restCatalogServer.getReceivedTableIdentifiers.asScala.contains(expected))
+      }
+    }
+  }
+
+  test("preserve the outermost Paimon View") {
+    withTable("nested_source") {
+      withView("inner_view", "outer_view") {
+        sql("CREATE TABLE nested_source (id INT) USING paimon")
+        sql("INSERT INTO nested_source VALUES (1), (2)")
+        sql("CREATE VIEW inner_view AS SELECT * FROM nested_source")
+        sql("CREATE VIEW outer_view AS SELECT * FROM inner_view")
+        restCatalogServer.clearReceivedTableIdentifiers()
+
+        checkAnswer(sql("SELECT * FROM outer_view"), Seq(Row(1), Row(2)))
+
+        val source = Identifier.create(dbName0, "nested_source")
+        val outer = Identifier.create(dbName0, "outer_view")
+        val inner = Identifier.create(dbName0, "inner_view")
+        val loaded = restCatalogServer.getReceivedTableIdentifiers.asScala
+        assert(loaded.contains(RESTReadVia.withReadVia(source, outer)))
+        assert(!loaded.contains(RESTReadVia.withReadVia(source, inner)))
+      }
+    }
+  }
+
+  test("mark relations in CTEs, joins, subqueries, and repeated references") {
+    withTable("left_table", "right_table") {
+      withView("complex_view") {
+        sql("CREATE TABLE left_table (id INT) USING paimon")
+        sql("CREATE TABLE right_table (id INT) USING paimon")
+        sql("INSERT INTO left_table VALUES (1), (2)")
+        sql("INSERT INTO right_table VALUES (1), (2)")
+        sql("""
+              |CREATE VIEW complex_view AS
+              |WITH filtered AS (SELECT * FROM left_table WHERE id > 0)
+              |SELECT f.id
+              |FROM filtered f JOIN right_table r ON f.id = r.id
+              |WHERE EXISTS (SELECT 1 FROM right_table r2 WHERE r2.id = f.id)
+              |""".stripMargin)
+        restCatalogServer.clearReceivedTableIdentifiers()
+
+        checkAnswer(sql("SELECT * FROM complex_view"), Seq(Row(1), Row(2)))
+
+        val root = Identifier.create(dbName0, "complex_view")
+        val loaded = restCatalogServer.getReceivedTableIdentifiers.asScala
+        assert(
+          loaded.contains(RESTReadVia.withReadVia(Identifier.create(dbName0, "left_table"), root)))
+        assert(
+          loaded.contains(RESTReadVia.withReadVia(Identifier.create(dbName0, "right_table"), root)))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- Add the opt-in REST Catalog option `read-via.enabled`, disabled by default.
- Add a `$via_` identifier protocol such as `my_table$via_db_view.my_view`.
- Propagate the outermost Paimon Catalog View while Spark resolves referenced tables, including nested views, CTEs, joins, and subqueries.
- Propagate the same authorization root when BlobView/BlobRef resolution loads referenced tables and obtains their FileIO.
- Keep real table identifiers separate from read authorization context so commits, rollback, schema changes, and other mutations never inherit view permissions.
- Isolate catalog cache entries by target and authorization root, while invalidating all variants with the real table.

## Why

Spark Catalog View expansion and BlobView resolution load referenced tables independently. Those loads previously lost the authorized entry point, so a REST service could only evaluate direct permission on the referenced table. With this option enabled, read-related REST requests carry the outermost view or downstream table as explicit authorization context.

The marker is context only. The REST service must still validate the principal, entry-point permission, and dependency between the entry point and target table.

## User impact

Existing behavior is unchanged by default. When `read-via.enabled=true`, metadata loads, snapshot loads, query authorization, and data-token requests for referenced tables use the marked identifier. Write and metadata-changing operations continue to use the real identifier.

## Validation

- `RESTReadViaTest`: 8 tests passed.
- Focused API/Core regression: 173 tests passed, including the full `MockRESTCatalogTest` suite.
- BlobView end-to-end regression: 2 tests passed.
- `PaimonReadViaTest`: 3 Spark 3 tests passed.
- Affected modules compiled successfully with Spotless, Checkstyle, and Enforcer enabled.
- `git diff --check` passed.
