### PR TITLE
[rest] Add server-issued dependency graph grants

### DIFF
--- a/docs/static/rest-catalog-open-api.yaml
+++ b/docs/static/rest-catalog-open-api.yaml
@@ -104,6 +104,7 @@ paths:
           schema:
             type: string
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -438,6 +439,8 @@ paths:
                 $ref: '#/components/schemas/GetTableResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/ForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
@@ -464,6 +467,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       responses:
         "200":
           description: OK
@@ -473,6 +477,8 @@ paths:
                 $ref: '#/components/schemas/GetTableResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
@@ -574,6 +580,48 @@ paths:
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "409":
           $ref: '#/components/responses/TableAlreadyExistErrorResponse'
+        "500":
+          $ref: '#/components/responses/ServerErrorResponse'
+  /v1/{prefix}/read-grant:
+    post:
+      tags:
+        - read-grant
+      summary: Authorize candidate dependencies of a table or view read
+      operationId: getReadGrant
+      description: >
+        Authorizes typed TABLE/VIEW dependency targets discovered while reading a TABLE or VIEW
+        root, including dependencies discovered dynamically from blob view data. Loading the root
+        itself does not require a grant. The root identity and requested targets are untrusted;
+        the server must independently authenticate the caller, recheck permission on the root,
+        and decide whether every requested target belongs to the root's dependency closure. A
+        successful grant is bound to the authenticated principal, outermost root type and
+        identifier, server-approved typed targets, and expiry. Local system-table projections are
+        constructed from their origin table and use the origin TABLE as the authorized target.
+      parameters:
+        - name: prefix
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateReadGrantRequest'
+      responses:
+        "200":
+          description: Read grant bound to the exact dependencies approved by the server
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetReadGrantResponse'
+        "401":
+          $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/ForbiddenErrorResponse'
+        "404":
+          description: The requested TABLE or VIEW authorization root does not exist
         "500":
           $ref: '#/components/responses/ServerErrorResponse'
   /v1/{prefix}/databases/{database}/tables/{table}/commit:
@@ -711,6 +759,11 @@ paths:
         - table
       summary: Get table token
       operationId: getTableToken
+      description: >
+        When REST data tokens are enabled and X-Paimon-Read-Grant is present, the storage
+        backend must enforce the returned credential as read-only and scoped to the requested
+        table. Its lifetime must not exceed the read grant and should be substantially shorter
+        so revocation is bounded by a small storage-credential window.
       parameters:
         - name: prefix
           in: path
@@ -727,6 +780,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       responses:
         "200":
           description: DataToken for visit data.
@@ -736,6 +790,8 @@ paths:
                 $ref: '#/components/schemas/GetTableDataTokenResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
@@ -762,6 +818,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       requestBody:
         content:
           application/json:
@@ -777,7 +834,7 @@ paths:
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
         "403":
-          $ref: '#/components/responses/ForbiddenErrorResponse'
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         404:
           description:
             Not Found
@@ -813,6 +870,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       responses:
         "200":
           description: OK
@@ -822,6 +880,8 @@ paths:
                 $ref: '#/components/schemas/GetTableSnapshotResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         404:
           description:
             Not Found
@@ -865,6 +925,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       responses:
         "200":
           description: OK
@@ -874,6 +935,8 @@ paths:
                 $ref: '#/components/schemas/GetVersionSnapshotResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         404:
           description:
             Not Found
@@ -956,6 +1019,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
         - name: maxResults
           in: query
           schema:
@@ -979,6 +1043,8 @@ paths:
                 $ref: '#/components/schemas/ListPartitionsResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
@@ -1125,6 +1191,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       requestBody:
         content:
           application/json:
@@ -1141,6 +1208,8 @@ paths:
           $ref: '#/components/responses/BadRequestErrorResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/GrantAwareForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/TableNotExistErrorResponse'
         "500":
@@ -1838,6 +1907,7 @@ paths:
           required: true
           schema:
             type: string
+        - $ref: '#/components/parameters/ReadGrantHeader'
       responses:
         "200":
           description: OK
@@ -1847,6 +1917,8 @@ paths:
                 $ref: '#/components/schemas/GetViewResponse'
         "401":
           $ref: '#/components/responses/UnauthorizedErrorResponse'
+        "403":
+          $ref: '#/components/responses/ForbiddenErrorResponse'
         "404":
           $ref: '#/components/responses/ViewNotExistErrorResponse'
         "500":
@@ -2218,6 +2290,28 @@ paths:
           $ref: '#/components/responses/ServerErrorResponse'
 
 components:
+  ##############################
+  # Reusable Request Parameters #
+  ##############################
+  parameters:
+    ReadGrantHeader:
+      name: X-Paimon-Read-Grant
+      in: header
+      required: false
+      description: >
+        Opaque short-lived grant issued by the generic read-grant endpoint. The server must
+        verify its integrity, audience, authenticated principal, expiry, outermost root type and
+        identifier, requested typed target, server-approved dependency relation, and graph limits
+        before honoring it. Authentication identity must come from the server authentication layer
+        rather than this or another client-controlled header. This header is read-only and must
+        never authorize mutations. Local system-table projections use the grant for their origin
+        table. When REST data tokens are used for a grant-backed read, returned storage credentials
+        must be read-only, target-scoped, and must not outlive the grant. An expired grant must
+        return 403 with resourceType READ_GRANT; clients retry only that error once through the
+        read-grant endpoint.
+      schema:
+        type: string
+
   #############################
   # Reusable Response Objects #
   #############################
@@ -2255,6 +2349,26 @@ components:
             "message": "Table has no permission",
             "code": 403
           }
+    GrantAwareForbiddenErrorResponse:
+      description: >
+        Used for 403 errors on a grant-aware endpoint. Only resourceType READ_GRANT
+        means that a correctly signed grant expired and may be renewed once. Every
+        other 403 is terminal for the current read.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            Forbidden:
+              value:
+                message: Table has no permission
+                resourceType: TABLE
+                code: 403
+            ReadGrantExpired:
+              value:
+                message: Read grant has expired
+                resourceType: READ_GRANT
+                code: 403
     ResourceNotExistErrorResponse:
       description:
         Used for 404 errors, which means the resource does not exist.
@@ -2601,7 +2715,7 @@ components:
         resourceType:
           type: string
           nullable: true
-          enum: [ "DATABASE", "TABLE", "PARTITION", "COLUMN", "SNAPSHOT", "BRANCH", "TAG", "VIEW", "DIALECT", "UNKNOWN" ]
+          enum: [ "DATABASE", "TABLE", "PARTITION", "COLUMN", "SNAPSHOT", "BRANCH", "TAG", "VIEW", "READ_GRANT", "DIALECT", "UNKNOWN" ]
         resourceName:
           type: string
           nullable: true
@@ -2629,6 +2743,37 @@ components:
           $ref: '#/components/schemas/Identifier'
         schema:
           $ref: '#/components/schemas/ViewSchema'
+    CreateReadGrantRequest:
+      type: object
+      description: Request to issue, extend, or renew a grant for candidate dependency targets.
+      required:
+        - rootType
+        - rootIdentifier
+        - targets
+      properties:
+        rootType:
+          type: string
+          enum:
+            - TABLE
+            - VIEW
+          description: Untrusted type of the outermost resource which caused dependency reads.
+        rootIdentifier:
+          $ref: '#/components/schemas/Identifier'
+        targets:
+          type: array
+          description: >
+            Untrusted dependency targets requested by the engine. The server must recover the
+            previously approved graph from previousReadGrant, search the root and its authorized
+            nodes for a valid source-to-target relationship, and either approve every target or
+            reject the request. This array may be empty only when renewing a previous grant.
+          items:
+            $ref: '#/components/schemas/ReadAuthorizationResource'
+        previousReadGrant:
+          type: string
+          description: >
+            An opaque active or expired grant to renew or extend. The server recovers the
+            previously approved dependency state from this value or from server-side state.
+            Omit when requesting the first dependency grant for this root read.
     AlterViewRequest:
       type: object
       properties:
@@ -2822,6 +2967,7 @@ components:
         - $ref: '#/components/schemas/AddDialect'
         - $ref: '#/components/schemas/UpdateDialect'
         - $ref: '#/components/schemas/DropDialect'
+        - $ref: '#/components/schemas/UpdateDependencies'
     BaseViewChange:
       discriminator:
         propertyName: action
@@ -2832,6 +2978,7 @@ components:
           addDialect: '#/components/schemas/AddDialect'
           updateDialect: '#/components/schemas/UpdateDialect'
           dropDialect: '#/components/schemas/DropDialect'
+          updateDependencies: '#/components/schemas/UpdateDependencies'
       type: object
       required:
         - action
@@ -2898,6 +3045,17 @@ components:
           const: "dropDialect"
         dialect:
           type: string
+    UpdateDependencies:
+      allOf:
+        - $ref: '#/components/schemas/BaseViewChange'
+      properties:
+        action:
+          type: string
+          const: "updateDependencies"
+        dependencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Identifier'
     DataField:
       type: object
       properties:
@@ -2966,6 +3124,19 @@ components:
           type: string
         object:
           type: string
+    ReadAuthorizationResource:
+      type: object
+      required:
+        - type
+        - identifier
+      properties:
+        type:
+          type: string
+          enum:
+            - TABLE
+            - VIEW
+        identifier:
+          $ref: '#/components/schemas/Identifier'
     Schema:
       type: object
       properties:
@@ -3341,7 +3512,7 @@ components:
           type: object
           additionalProperties:
             type: string
-        expiresAt:
+        expiresAtMillis:
           type: integer
           format: int64
     GetTableSnapshotResponse:
@@ -3591,6 +3762,21 @@ components:
           format: int64
         updatedBy:
           type: string
+    GetReadGrantResponse:
+      type: object
+      description: >
+        A successful response approves every dependency target submitted in the corresponding
+        request. The client retains those targets locally; the response does not echo the graph.
+      required:
+        - readGrant
+        - expiresAtMillis
+      properties:
+        readGrant:
+          type: string
+          description: Opaque tamper-resistant bearer credential.
+        expiresAtMillis:
+          type: integer
+          format: int64
     ListViewsResponse:
       type: object
       properties:
@@ -3731,6 +3917,14 @@ components:
           type: object
           additionalProperties:
             type: string
+        dependencies:
+          type: array
+          description: >
+            Direct dependencies associated with the view definition. A REST server must
+            treat values received from clients as untrusted until trusted server-side logic
+            validates them against the query; unverified dependencies cannot issue a read grant.
+          items:
+            $ref: '#/components/schemas/Identifier'
     Partition:
       type: object
       properties:

--- a/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationContext.java
+++ b/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationContext.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.annotation.Public;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Authorization context which lazily obtains grants for discovered dependency resources. */
+@Public
+public final class ReadAuthorizationContext implements Serializable {
+
+    private static final long serialVersionUID = 4L;
+
+    private static final ReadAuthorizationContext DIRECT =
+            new ReadAuthorizationContext(null, GrantState.empty());
+
+    @Nullable private final ReadAuthorizationResource authorizationRoot;
+    private volatile GrantState grantState;
+
+    private ReadAuthorizationContext(
+            @Nullable ReadAuthorizationResource authorizationRoot, GrantState grantState) {
+        this.authorizationRoot = authorizationRoot;
+        this.grantState = Objects.requireNonNull(grantState, "grantState");
+    }
+
+    /** Returns a context for reading a resource directly. */
+    public static ReadAuthorizationContext direct() {
+        return DIRECT;
+    }
+
+    /** Returns a pending context for dependencies discovered while reading a view. */
+    public static ReadAuthorizationContext forView(Identifier authorizationRoot) {
+        return forRoot(ReadAuthorizationResource.view(authorizationRoot));
+    }
+
+    /** Returns a pending context for dependencies discovered while reading a table. */
+    public static ReadAuthorizationContext forTable(Identifier authorizationRoot) {
+        return forRoot(ReadAuthorizationResource.table(authorizationRoot));
+    }
+
+    private static ReadAuthorizationContext forRoot(ReadAuthorizationResource root) {
+        Objects.requireNonNull(root, "root");
+        return new ReadAuthorizationContext(root, GrantState.empty());
+    }
+
+    /** Returns a context initialized from a server-issued response. */
+    public static ReadAuthorizationContext granted(
+            ReadAuthorizationRootType authorizationRootType,
+            Identifier authorizationRoot,
+            List<ReadAuthorizationResource> authorizedResources,
+            String readGrant,
+            long expiresAtMillis) {
+        ReadAuthorizationContext context =
+                forRoot(new ReadAuthorizationResource(authorizationRootType, authorizationRoot));
+        context.updateGrant(authorizedResources, readGrant, expiresAtMillis);
+        return context;
+    }
+
+    public boolean isDirect() {
+        return authorizationRoot == null;
+    }
+
+    /** Returns the type of the outermost resource which caused dependencies to be read. */
+    public Optional<ReadAuthorizationRootType> authorizationRootType() {
+        return authorizationRoot == null ? Optional.empty() : Optional.of(authorizationRoot.type());
+    }
+
+    /** Returns the outermost resource which caused dependencies to be read. */
+    public Optional<Identifier> authorizationRoot() {
+        return authorizationRoot == null
+                ? Optional.empty()
+                : Optional.of(authorizationRoot.identifier());
+    }
+
+    /**
+     * Derive a context for dependencies discovered inside an already authorized resource.
+     *
+     * <p>The outermost root and current signed grant are preserved. The returned context has an
+     * independent grant snapshot so parallel dependency branches cannot overwrite each other.
+     */
+    public ReadAuthorizationContext forDependenciesOf(
+            ReadAuthorizationRootType type, Identifier identifier) {
+        if (isDirect()) {
+            throw new IllegalStateException(
+                    "A direct read context has no dependency authorization root");
+        }
+        ReadAuthorizationResource resource = new ReadAuthorizationResource(type, identifier);
+        if (!resource.equals(authorizationRoot) && !authorizes(resource)) {
+            throw new SecurityException(
+                    "Cannot enter a resource which is not authorized by the current read grant");
+        }
+        return new ReadAuthorizationContext(authorizationRoot, grantState);
+    }
+
+    /** Returns the dependency resources approved by the current grant. */
+    public List<ReadAuthorizationResource> authorizedResources() {
+        return grantState.authorizedResources;
+    }
+
+    /** Returns whether the current server-issued grant reaches {@code resource}. */
+    public boolean authorizes(ReadAuthorizationResource resource) {
+        Objects.requireNonNull(resource, "resource");
+        return grantState.authorizedResources.contains(resource);
+    }
+
+    /** Returns whether the current server-issued grant reaches the exact typed resource. */
+    public boolean authorizes(ReadAuthorizationRootType type, Identifier identifier) {
+        return authorizes(new ReadAuthorizationResource(type, identifier));
+    }
+
+    /** Returns the opaque server-issued bearer credential. */
+    public Optional<String> readGrant() {
+        return Optional.ofNullable(grantState.readGrant);
+    }
+
+    public long expiresAtMillis() {
+        return grantState.expiresAtMillis;
+    }
+
+    /**
+     * Compare the server timestamp for diagnostics only. REST authorization must use the server's
+     * clock; clients must not reject a request solely from this local comparison.
+     */
+    public boolean isExpired(long nowMillis) {
+        return !isDirect()
+                && (grantState.readGrant == null || nowMillis >= grantState.expiresAtMillis);
+    }
+
+    /** Install a server-issued grant and merge the dependency targets accepted by its request. */
+    public synchronized void updateGrant(
+            List<ReadAuthorizationResource> additionalResources,
+            String updatedReadGrant,
+            long updatedExpiresAtMillis) {
+        if (isDirect()) {
+            throw new IllegalStateException("A direct read context cannot contain a grant");
+        }
+        if (updatedExpiresAtMillis <= 0) {
+            throw new IllegalArgumentException("expiresAtMillis must be positive");
+        }
+        List<ReadAuthorizationResource> validatedResources = validateResources(additionalResources);
+
+        GrantState previous = grantState;
+        if (previous.readGrant == null && validatedResources.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "An initial read grant must authorize at least one dependency resource");
+        }
+        List<ReadAuthorizationResource> mergedResources =
+                new ArrayList<>(previous.authorizedResources);
+        for (ReadAuthorizationResource resource : validatedResources) {
+            if (!mergedResources.contains(resource)) {
+                mergedResources.add(resource);
+            }
+        }
+
+        this.grantState =
+                new GrantState(
+                        Collections.unmodifiableList(mergedResources),
+                        Objects.requireNonNull(updatedReadGrant, "updatedReadGrant"),
+                        updatedExpiresAtMillis);
+    }
+
+    private static List<ReadAuthorizationResource> validateResources(
+            List<ReadAuthorizationResource> resources) {
+        Objects.requireNonNull(resources, "resources");
+        List<ReadAuthorizationResource> validated = new ArrayList<>(resources.size());
+        for (ReadAuthorizationResource resource : resources) {
+            validateResource(Objects.requireNonNull(resource, "resource"));
+            if (validated.contains(resource)) {
+                throw new IllegalArgumentException(
+                        "Read-grant dependency resources must not contain duplicates");
+            }
+            validated.add(resource);
+        }
+        return validated;
+    }
+
+    private static void validateResource(ReadAuthorizationResource resource) {
+        Objects.requireNonNull(resource, "resource");
+        Identifier identifier = resource.identifier();
+        if (identifier.getDatabaseName() == null
+                || identifier.getDatabaseName().isEmpty()
+                || Identifier.UNKNOWN_DATABASE.equals(identifier.getDatabaseName())
+                || identifier.getObjectName() == null
+                || identifier.getObjectName().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Read-grant resources must contain an exact database and object name");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ReadAuthorizationContext that = (ReadAuthorizationContext) o;
+        return Objects.equals(authorizationRoot, that.authorizationRoot)
+                && Objects.equals(grantState, that.grantState);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authorizationRoot, grantState);
+    }
+
+    @Override
+    public String toString() {
+        GrantState state = grantState;
+        return isDirect()
+                ? "ReadAuthorizationContext{direct}"
+                : String.format(
+                        "ReadAuthorizationContext{authorizationRoot=%s, authorizedResources=%s, expiresAtMillis=%s}",
+                        authorizationRoot, state.authorizedResources, state.expiresAtMillis);
+    }
+
+    /** Immutable holder so readers observe grant updates atomically. */
+    private static final class GrantState implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final List<ReadAuthorizationResource> authorizedResources;
+        @Nullable private final String readGrant;
+        private final long expiresAtMillis;
+
+        private GrantState(
+                List<ReadAuthorizationResource> authorizedResources,
+                @Nullable String readGrant,
+                long expiresAtMillis) {
+            this.authorizedResources =
+                    Collections.unmodifiableList(new ArrayList<>(authorizedResources));
+            this.readGrant = readGrant;
+            this.expiresAtMillis = expiresAtMillis;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            GrantState that = (GrantState) o;
+            return expiresAtMillis == that.expiresAtMillis
+                    && authorizedResources.equals(that.authorizedResources)
+                    && Objects.equals(readGrant, that.readGrant);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(authorizedResources, readGrant, expiresAtMillis);
+        }
+
+        private static GrantState empty() {
+            return new GrantState(Collections.<ReadAuthorizationResource>emptyList(), null, 0L);
+        }
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationResource.java
+++ b/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationResource.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.annotation.Public;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** An exact table or view participating in a dependency read. */
+@Public
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ReadAuthorizationResource implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String FIELD_TYPE = "type";
+    private static final String FIELD_IDENTIFIER = "identifier";
+
+    private final ReadAuthorizationRootType type;
+    private final Identifier identifier;
+
+    @JsonCreator
+    public ReadAuthorizationResource(
+            @JsonProperty(FIELD_TYPE) ReadAuthorizationRootType type,
+            @JsonProperty(FIELD_IDENTIFIER) Identifier identifier) {
+        this.type = Objects.requireNonNull(type, "type");
+        this.identifier = Objects.requireNonNull(identifier, "identifier");
+    }
+
+    public static ReadAuthorizationResource table(Identifier identifier) {
+        return new ReadAuthorizationResource(ReadAuthorizationRootType.TABLE, identifier);
+    }
+
+    public static ReadAuthorizationResource view(Identifier identifier) {
+        return new ReadAuthorizationResource(ReadAuthorizationRootType.VIEW, identifier);
+    }
+
+    @JsonGetter(FIELD_TYPE)
+    public ReadAuthorizationRootType type() {
+        return type;
+    }
+
+    @JsonGetter(FIELD_IDENTIFIER)
+    public Identifier identifier() {
+        return identifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ReadAuthorizationResource that = (ReadAuthorizationResource) o;
+        return type == that.type && identifier.equals(that.identifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, identifier);
+    }
+
+    @Override
+    public String toString() {
+        return type + ":" + identifier.getFullName();
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationRootType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/catalog/ReadAuthorizationRootType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.apache.paimon.annotation.Public;
+
+/** Type of a table or view participating in dependency-read authorization. */
+@Public
+public enum ReadAuthorizationRootType {
+    TABLE,
+    VIEW
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/DefaultErrorHandler.java
@@ -25,6 +25,7 @@ import org.apache.paimon.rest.exceptions.NoSuchResourceException;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
 import org.apache.paimon.rest.exceptions.RESTException;
+import org.apache.paimon.rest.exceptions.ReadGrantExpiredException;
 import org.apache.paimon.rest.exceptions.ServiceFailureException;
 import org.apache.paimon.rest.exceptions.ServiceUnavailableException;
 import org.apache.paimon.rest.responses.ErrorResponse;
@@ -56,6 +57,9 @@ public class DefaultErrorHandler extends ErrorHandler {
             case 401:
                 throw new NotAuthorizedException("Not authorized: %s", message);
             case 403:
+                if (ErrorResponse.RESOURCE_TYPE_READ_GRANT.equals(error.getResourceType())) {
+                    throw new ReadGrantExpiredException("Read grant expired: %s", message);
+                }
                 throw new ForbiddenException("Forbidden: %s", message);
             case 404:
                 throw new NoSuchResourceException(

--- a/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/RESTApi.java
@@ -23,6 +23,9 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
+import org.apache.paimon.catalog.ReadAuthorizationResource;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
 import org.apache.paimon.consumer.ConsumerInfo;
 import org.apache.paimon.function.FunctionChange;
 import org.apache.paimon.options.Options;
@@ -33,6 +36,7 @@ import org.apache.paimon.rest.auth.RESTAuthFunction;
 import org.apache.paimon.rest.exceptions.AlreadyExistsException;
 import org.apache.paimon.rest.exceptions.ForbiddenException;
 import org.apache.paimon.rest.exceptions.NoSuchResourceException;
+import org.apache.paimon.rest.exceptions.ReadGrantExpiredException;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterFunctionRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
@@ -43,6 +47,7 @@ import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreateFunctionRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
+import org.apache.paimon.rest.requests.CreateReadGrantRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateTagRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
@@ -66,6 +71,7 @@ import org.apache.paimon.rest.responses.DropPartitionsResponse;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.GetDatabaseResponse;
 import org.apache.paimon.rest.responses.GetFunctionResponse;
+import org.apache.paimon.rest.responses.GetReadGrantResponse;
 import org.apache.paimon.rest.responses.GetTableResponse;
 import org.apache.paimon.rest.responses.GetTableSnapshotResponse;
 import org.apache.paimon.rest.responses.GetTableTokenResponse;
@@ -106,6 +112,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -150,6 +157,7 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public class RESTApi {
 
     public static final String HEADER_PREFIX = "header.";
+    public static final String READ_GRANT_HEADER = "X-Paimon-Read-Grant";
     public static final String MAX_RESULTS = "maxResults";
     public static final String PAGE_TOKEN = "pageToken";
 
@@ -511,6 +519,23 @@ public class RESTApi {
                 restAuthFunction);
     }
 
+    /** Get table metadata with the authorization context of the originating read. */
+    public GetTableResponse getTable(Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return getTable(identifier);
+        }
+        return executeRead(
+                identifier,
+                readContext,
+                auth ->
+                        client.get(
+                                resourcePaths.table(
+                                        identifier.getDatabaseName(), identifier.getObjectName()),
+                                GetTableResponse.class,
+                                auth));
+    }
+
     /**
      * Get table by tableId.
      *
@@ -544,6 +569,26 @@ public class RESTApi {
         return response.getSnapshot();
     }
 
+    /** Load the latest snapshot with the authorization context of the originating read. */
+    public TableSnapshot loadSnapshot(Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadSnapshot(identifier);
+        }
+        GetTableSnapshotResponse response =
+                executeRead(
+                        identifier,
+                        readContext,
+                        auth ->
+                                client.get(
+                                        resourcePaths.tableSnapshot(
+                                                identifier.getDatabaseName(),
+                                                identifier.getObjectName()),
+                                        GetTableSnapshotResponse.class,
+                                        auth));
+        return response.getSnapshot();
+    }
+
     /**
      * Return the snapshot of table for given version. Version parsing order is:
      *
@@ -569,6 +614,28 @@ public class RESTApi {
                                 identifier.getDatabaseName(), identifier.getObjectName(), version),
                         GetVersionSnapshotResponse.class,
                         restAuthFunction);
+        return response.getSnapshot();
+    }
+
+    /** Load a versioned snapshot with the authorization context of the originating read. */
+    public Snapshot loadSnapshot(
+            Identifier identifier, String version, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadSnapshot(identifier, version);
+        }
+        GetVersionSnapshotResponse response =
+                executeRead(
+                        identifier,
+                        readContext,
+                        auth ->
+                                client.get(
+                                        resourcePaths.tableSnapshot(
+                                                identifier.getDatabaseName(),
+                                                identifier.getObjectName(),
+                                                version),
+                                        GetVersionSnapshotResponse.class,
+                                        auth));
         return response.getSnapshot();
     }
 
@@ -821,6 +888,28 @@ public class RESTApi {
                 restAuthFunction);
     }
 
+    /** Authorize a table query with the authorization context of the originating read. */
+    public AuthTableQueryResponse authTableQuery(
+            Identifier identifier,
+            @Nullable List<String> select,
+            ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return authTableQuery(identifier, select);
+        }
+        AuthTableQueryRequest request = new AuthTableQueryRequest(select);
+        return executeRead(
+                identifier,
+                readContext,
+                auth ->
+                        client.post(
+                                resourcePaths.authTable(
+                                        identifier.getDatabaseName(), identifier.getObjectName()),
+                                request,
+                                AuthTableQueryResponse.class,
+                                auth));
+    }
+
     /**
      * Drop table.
      *
@@ -911,6 +1000,28 @@ public class RESTApi {
                                 restAuthFunction));
     }
 
+    /** List partitions with the authorization context of the originating read. */
+    public List<Partition> listPartitions(
+            Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitions(identifier);
+        }
+        return listDataFromPageApi(
+                queryParams ->
+                        executeRead(
+                                identifier,
+                                readContext,
+                                auth ->
+                                        client.get(
+                                                resourcePaths.partitions(
+                                                        identifier.getDatabaseName(),
+                                                        identifier.getObjectName()),
+                                                queryParams,
+                                                ListPartitionsResponse.class,
+                                                auth)));
+    }
+
     /**
      * List partitions for a table.
      *
@@ -952,6 +1063,41 @@ public class RESTApi {
         return new PagedList<>(partitions, response.getNextPageToken());
     }
 
+    /** List paged partitions with the authorization context of the originating read. */
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String partitionNamePattern,
+            ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
+        }
+        ListPartitionsResponse response =
+                executeRead(
+                        identifier,
+                        readContext,
+                        auth ->
+                                client.get(
+                                        resourcePaths.partitions(
+                                                identifier.getDatabaseName(),
+                                                identifier.getObjectName()),
+                                        buildPagedQueryParams(
+                                                maxResults,
+                                                pageToken,
+                                                Pair.of(
+                                                        PARTITION_NAME_PATTERN,
+                                                        partitionNamePattern)),
+                                        ListPartitionsResponse.class,
+                                        auth));
+        List<Partition> partitions = response.getPartitions();
+        if (partitions == null) {
+            return new PagedList<>(emptyList(), null);
+        }
+        return new PagedList<>(partitions, response.getNextPageToken());
+    }
+
     /**
      * List partitions by partition names for table.
      *
@@ -977,6 +1123,39 @@ public class RESTApi {
                         request,
                         ListPartitionsResponse.class,
                         restAuthFunction);
+        List<Partition> partitions = response.getPartitions();
+        if (partitions == null) {
+            return emptyList();
+        }
+        return partitions;
+    }
+
+    /** List named partitions with the authorization context of the originating read. */
+    public List<Partition> listPartitionsByNames(
+            Identifier identifier,
+            List<Map<String, String>> partitionSpecs,
+            ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitionsByNames(identifier, partitionSpecs);
+        }
+        checkArgument(
+                partitionSpecs.size() <= 1000,
+                "The number of partition specs must not exceed 1000, but got %s",
+                partitionSpecs.size());
+        ListPartitionsByNamesRequest request = new ListPartitionsByNamesRequest(partitionSpecs);
+        ListPartitionsResponse response =
+                executeRead(
+                        identifier,
+                        readContext,
+                        auth ->
+                                client.post(
+                                        resourcePaths.listPartitionsByNames(
+                                                identifier.getDatabaseName(),
+                                                identifier.getObjectName()),
+                                        request,
+                                        ListPartitionsResponse.class,
+                                        auth));
         List<Partition> partitions = response.getPartitions();
         if (partitions == null) {
             return emptyList();
@@ -1420,6 +1599,30 @@ public class RESTApi {
                 restAuthFunction);
     }
 
+    /** Get a dependency view with the authorization context of the originating read. */
+    public GetViewResponse getView(Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return getView(identifier);
+        }
+        return executeRead(
+                ReadAuthorizationResource.view(identifier),
+                readContext,
+                auth ->
+                        client.get(
+                                resourcePaths.view(
+                                        identifier.getDatabaseName(), identifier.getObjectName()),
+                                GetViewResponse.class,
+                                auth));
+    }
+
+    /** Ask the server to authorize candidate dependencies for a table or view read. */
+    public GetReadGrantResponse getReadGrant(CreateReadGrantRequest request) {
+        Objects.requireNonNull(request, "request");
+        return client.post(
+                resourcePaths.readGrant(), request, GetReadGrantResponse.class, restAuthFunction);
+    }
+
     /**
      * Drop view.
      *
@@ -1630,6 +1833,124 @@ public class RESTApi {
                 resourcePaths.tableToken(identifier.getDatabaseName(), identifier.getObjectName()),
                 GetTableTokenResponse.class,
                 restAuthFunction);
+    }
+
+    /** Load a data token with the authorization context of the originating read. */
+    public GetTableTokenResponse loadTableToken(
+            Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadTableToken(identifier);
+        }
+        return executeRead(
+                identifier,
+                readContext,
+                auth ->
+                        client.get(
+                                resourcePaths.tableToken(
+                                        identifier.getDatabaseName(), identifier.getObjectName()),
+                                GetTableTokenResponse.class,
+                                auth));
+    }
+
+    private RESTAuthFunction authFunction(ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return restAuthFunction;
+        }
+        return restAuthFunction.withHeaders(
+                ImmutableMap.of(READ_GRANT_HEADER, readContext.readGrant().get()));
+    }
+
+    private <T> T executeRead(
+            Identifier target,
+            ReadAuthorizationContext readContext,
+            Function<RESTAuthFunction, T> request) {
+        return executeRead(ReadAuthorizationResource.table(target), readContext, request);
+    }
+
+    private <T> T executeRead(
+            ReadAuthorizationResource target,
+            ReadAuthorizationContext readContext,
+            Function<RESTAuthFunction, T> request) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return request.apply(restAuthFunction);
+        }
+
+        ensureReadGrant(target, readContext);
+        String failedGrant = readContext.readGrant().get();
+        try {
+            return request.apply(authFunction(readContext));
+        } catch (ReadGrantExpiredException firstFailure) {
+            renewReadGrant(readContext, failedGrant);
+            return request.apply(authFunction(readContext));
+        }
+    }
+
+    private void ensureReadGrant(
+            ReadAuthorizationResource target, ReadAuthorizationContext readContext) {
+        if (readContext.authorizes(target) && readContext.readGrant().isPresent()) {
+            return;
+        }
+        synchronized (readContext) {
+            if (readContext.authorizes(target) && readContext.readGrant().isPresent()) {
+                return;
+            }
+            Identifier root = authorizationRoot(readContext);
+            CreateReadGrantRequest request =
+                    new CreateReadGrantRequest(
+                            authorizationRootType(readContext),
+                            root,
+                            Collections.singletonList(target),
+                            readContext.readGrant().orElse(null));
+            installReadGrant(readContext, request, requestReadGrant(request));
+        }
+    }
+
+    private void renewReadGrant(ReadAuthorizationContext readContext, String failedGrant) {
+        synchronized (readContext) {
+            if (!readContext.readGrant().filter(failedGrant::equals).isPresent()) {
+                return;
+            }
+            Identifier root = authorizationRoot(readContext);
+            CreateReadGrantRequest request =
+                    new CreateReadGrantRequest(
+                            authorizationRootType(readContext),
+                            root,
+                            Collections.emptyList(),
+                            failedGrant);
+            installReadGrant(readContext, request, requestReadGrant(request));
+        }
+    }
+
+    private GetReadGrantResponse requestReadGrant(CreateReadGrantRequest request) {
+        try {
+            return getReadGrant(request);
+        } catch (NoSuchResourceException e) {
+            throw new ForbiddenException("Unable to authorize dependencies for the root read");
+        }
+    }
+
+    private static ReadAuthorizationRootType authorizationRootType(
+            ReadAuthorizationContext readContext) {
+        return readContext
+                .authorizationRootType()
+                .orElseThrow(() -> new SecurityException("Read authorization has no root type"));
+    }
+
+    private static Identifier authorizationRoot(ReadAuthorizationContext readContext) {
+        return readContext
+                .authorizationRoot()
+                .orElseThrow(() -> new SecurityException("Read authorization has no root"));
+    }
+
+    private static void installReadGrant(
+            ReadAuthorizationContext readContext,
+            CreateReadGrantRequest request,
+            GetReadGrantResponse response) {
+        readContext.updateGrant(
+                request.targets(), response.getReadGrant(), response.getExpiresAtMillis());
     }
 
     /** Util method to deserialize object from json. */

--- a/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/ResourcePaths.java
@@ -38,6 +38,7 @@ public class ResourcePaths {
     protected static final String VIEWS = "views";
     protected static final String TABLE_DETAILS = "table-details";
     protected static final String VIEW_DETAILS = "view-details";
+    protected static final String READ_GRANT = "read-grant";
     protected static final String ROLLBACK = "rollback";
     protected static final String REGISTER = "register";
     protected static final String FUNCTIONS = "functions";
@@ -358,6 +359,10 @@ public class ResourcePaths {
     public String view(String databaseName, String viewName) {
         return SLASH.join(
                 V1, prefix, DATABASES, encodeString(databaseName), VIEWS, encodeString(viewName));
+    }
+
+    public String readGrant() {
+        return SLASH.join(V1, prefix, READ_GRANT);
     }
 
     public String renameView() {

--- a/paimon-api/src/main/java/org/apache/paimon/rest/auth/RESTAuthFunction.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/auth/RESTAuthFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.rest.auth;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -30,6 +31,13 @@ public class RESTAuthFunction implements Function<RESTAuthParameter, Map<String,
     public RESTAuthFunction(Map<String, String> initHeader, AuthProvider authProvider) {
         this.initHeader = initHeader;
         this.authProvider = authProvider;
+    }
+
+    /** Return an auth function with additional headers included in request signing. */
+    public RESTAuthFunction withHeaders(Map<String, String> headers) {
+        Map<String, String> merged = new HashMap<>(initHeader);
+        merged.putAll(headers);
+        return new RESTAuthFunction(merged, authProvider);
     }
 
     @Override

--- a/paimon-api/src/main/java/org/apache/paimon/rest/exceptions/ReadGrantExpiredException.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/exceptions/ReadGrantExpiredException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.exceptions;
+
+/** Exception thrown when a valid dependency read grant has expired and may be renewed. */
+public class ReadGrantExpiredException extends ForbiddenException {
+
+    public ReadGrantExpiredException(String message, Object... args) {
+        super(message, args);
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreateReadGrantRequest.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/requests/CreateReadGrantRequest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.requests;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationResource;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
+import org.apache.paimon.rest.RESTRequest;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Request for authorizing candidate dependency targets of a table or view read. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateReadGrantRequest implements RESTRequest {
+
+    private static final String FIELD_ROOT_TYPE = "rootType";
+    private static final String FIELD_ROOT_IDENTIFIER = "rootIdentifier";
+    private static final String FIELD_TARGETS = "targets";
+    private static final String FIELD_PREVIOUS_READ_GRANT = "previousReadGrant";
+
+    private final ReadAuthorizationRootType rootType;
+    private final Identifier rootIdentifier;
+    private final List<ReadAuthorizationResource> targets;
+    @Nullable private final String previousReadGrant;
+
+    @JsonCreator
+    public CreateReadGrantRequest(
+            @JsonProperty(FIELD_ROOT_TYPE) ReadAuthorizationRootType rootType,
+            @JsonProperty(FIELD_ROOT_IDENTIFIER) Identifier rootIdentifier,
+            @JsonProperty(FIELD_TARGETS) List<ReadAuthorizationResource> targets,
+            @Nullable @JsonProperty(FIELD_PREVIOUS_READ_GRANT) String previousReadGrant) {
+        this.rootType = Objects.requireNonNull(rootType, "rootType");
+        this.rootIdentifier = Objects.requireNonNull(rootIdentifier, "rootIdentifier");
+        this.targets =
+                Collections.unmodifiableList(
+                        new ArrayList<>(Objects.requireNonNull(targets, "targets")));
+        this.previousReadGrant = previousReadGrant;
+    }
+
+    @JsonGetter(FIELD_ROOT_TYPE)
+    public ReadAuthorizationRootType rootType() {
+        return rootType;
+    }
+
+    @JsonGetter(FIELD_ROOT_IDENTIFIER)
+    public Identifier rootIdentifier() {
+        return rootIdentifier;
+    }
+
+    @JsonGetter(FIELD_TARGETS)
+    public List<ReadAuthorizationResource> targets() {
+        return targets;
+    }
+
+    @Nullable
+    @JsonGetter(FIELD_PREVIOUS_READ_GRANT)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String previousReadGrant() {
+        return previousReadGrant;
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/ErrorResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/ErrorResponse.java
@@ -47,6 +47,8 @@ public class ErrorResponse implements RESTResponse {
 
     public static final String RESOURCE_TYPE_VIEW = "VIEW";
 
+    public static final String RESOURCE_TYPE_READ_GRANT = "READ_GRANT";
+
     public static final String RESOURCE_TYPE_DIALECT = "DIALECT";
 
     public static final String RESOURCE_TYPE_FUNCTION = "FUNCTION";

--- a/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetReadGrantResponse.java
+++ b/paimon-api/src/main/java/org/apache/paimon/rest/responses/GetReadGrantResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest.responses;
+
+import org.apache.paimon.rest.RESTResponse;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Response containing a grant bound to server-approved dependencies of a table or view.
+ *
+ * <p>A successful response approves every dependency target in its corresponding request. The
+ * client keeps those targets locally instead of requiring the server to echo the complete graph.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GetReadGrantResponse implements RESTResponse {
+
+    private static final String FIELD_READ_GRANT = "readGrant";
+    private static final String FIELD_EXPIRES_AT_MILLIS = "expiresAtMillis";
+
+    private final String readGrant;
+    private final long expiresAtMillis;
+
+    @JsonCreator
+    public GetReadGrantResponse(
+            @JsonProperty(FIELD_READ_GRANT) String readGrant,
+            @JsonProperty(FIELD_EXPIRES_AT_MILLIS) long expiresAtMillis) {
+        this.readGrant = Objects.requireNonNull(readGrant, "readGrant");
+        this.expiresAtMillis = expiresAtMillis;
+    }
+
+    @JsonGetter(FIELD_READ_GRANT)
+    public String getReadGrant() {
+        return readGrant;
+    }
+
+    @JsonGetter(FIELD_EXPIRES_AT_MILLIS)
+    public long getExpiresAtMillis() {
+        return expiresAtMillis;
+    }
+}

--- a/paimon-api/src/main/java/org/apache/paimon/view/View.java
+++ b/paimon-api/src/main/java/org/apache/paimon/view/View.java
@@ -18,8 +18,11 @@
 
 package org.apache.paimon.view;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.types.RowType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -51,6 +54,16 @@ public interface View {
 
     /** Options of this view. */
     Map<String, String> options();
+
+    /**
+     * Direct dependencies resolved when this view was created or updated.
+     *
+     * <p>A REST server must independently validate client-provided values against the view query
+     * before treating them as authoritative for authorization.
+     */
+    default List<Identifier> dependencies() {
+        return Collections.emptyList();
+    }
 
     /** Copy this view with adding dynamic options. */
     View copy(Map<String, String> dynamicOptions);

--- a/paimon-api/src/main/java/org/apache/paimon/view/ViewChange.java
+++ b/paimon-api/src/main/java/org/apache/paimon/view/ViewChange.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.view;
 
 import org.apache.paimon.annotation.Public;
+import org.apache.paimon.catalog.Identifier;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonGetter;
@@ -29,6 +30,9 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonTyp
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /** Dialect change to view. */
@@ -55,7 +59,10 @@ import java.util.Objects;
             name = ViewChange.Actions.UPDATE_DIALECT_ACTION),
     @JsonSubTypes.Type(
             value = ViewChange.DropDialect.class,
-            name = ViewChange.Actions.DROP_DIALECT_ACTION)
+            name = ViewChange.Actions.DROP_DIALECT_ACTION),
+    @JsonSubTypes.Type(
+            value = ViewChange.UpdateDependencies.class,
+            name = ViewChange.Actions.UPDATE_DEPENDENCIES_ACTION)
 })
 public interface ViewChange extends Serializable {
 
@@ -81,6 +88,55 @@ public interface ViewChange extends Serializable {
 
     static ViewChange dropDialect(String dialect) {
         return new DropDialect(dialect);
+    }
+
+    /** Replace direct dependencies resolved from the view query. */
+    static ViewChange updateDependencies(List<Identifier> dependencies) {
+        return new UpdateDependencies(dependencies);
+    }
+
+    /**
+     * Replace direct dependencies resolved from the view query.
+     *
+     * <p>REST servers must independently validate this client-provided change before using it for
+     * authorization.
+     */
+    final class UpdateDependencies implements ViewChange {
+
+        private static final long serialVersionUID = 1L;
+        private static final String FIELD_DEPENDENCIES = "dependencies";
+
+        @JsonProperty(FIELD_DEPENDENCIES)
+        private final List<Identifier> dependencies;
+
+        @JsonCreator
+        public UpdateDependencies(@JsonProperty(FIELD_DEPENDENCIES) List<Identifier> dependencies) {
+            this.dependencies =
+                    Collections.unmodifiableList(
+                            new ArrayList<>(Objects.requireNonNull(dependencies, "dependencies")));
+        }
+
+        @JsonGetter(FIELD_DEPENDENCIES)
+        public List<Identifier> dependencies() {
+            return dependencies;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+            UpdateDependencies that = (UpdateDependencies) object;
+            return Objects.equals(dependencies, that.dependencies);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dependencies);
+        }
     }
 
     /** set a view option for view change. */
@@ -348,6 +404,7 @@ public interface ViewChange extends Serializable {
         public static final String SET_OPTION_ACTION = "setOption";
         public static final String REMOVE_OPTION_ACTION = "removeOption";
         public static final String UPDATE_COMMENT_ACTION = "updateComment";
+        public static final String UPDATE_DEPENDENCIES_ACTION = "updateDependencies";
 
         private Actions() {}
     }

--- a/paimon-api/src/main/java/org/apache/paimon/view/ViewImpl.java
+++ b/paimon-api/src/main/java/org/apache/paimon/view/ViewImpl.java
@@ -26,6 +26,7 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonIgn
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +47,19 @@ public class ViewImpl implements View {
             Map<String, String> dialects,
             @Nullable String comment,
             Map<String, String> options) {
+        this(identifier, fields, query, dialects, comment, options, Collections.emptyList());
+    }
+
+    public ViewImpl(
+            Identifier identifier,
+            List<DataField> fields,
+            String query,
+            Map<String, String> dialects,
+            @Nullable String comment,
+            Map<String, String> options,
+            List<Identifier> dependencies) {
         this.identifier = identifier;
-        this.viewSchema = new ViewSchema(fields, query, dialects, comment, options);
+        this.viewSchema = new ViewSchema(fields, query, dialects, comment, options, dependencies);
     }
 
     @Override
@@ -86,6 +98,11 @@ public class ViewImpl implements View {
     }
 
     @Override
+    public List<Identifier> dependencies() {
+        return this.viewSchema.dependencies();
+    }
+
+    @Override
     public View copy(Map<String, String> dynamicOptions) {
         Map<String, String> newOptions = new HashMap<>(options());
         newOptions.putAll(dynamicOptions);
@@ -95,7 +112,8 @@ public class ViewImpl implements View {
                 query(),
                 dialects(),
                 viewSchema.comment(),
-                newOptions);
+                newOptions,
+                dependencies());
     }
 
     @Override

--- a/paimon-api/src/main/java/org/apache/paimon/view/ViewSchema.java
+++ b/paimon-api/src/main/java/org/apache/paimon/view/ViewSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.view;
 
+import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.types.DataField;
 
 import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +29,8 @@ import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.annotation.JsonPro
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,6 +44,7 @@ public class ViewSchema {
     private static final String FIELD_DIALECTS = "dialects";
     private static final String FIELD_COMMENT = "comment";
     private static final String FIELD_OPTIONS = "options";
+    private static final String FIELD_DEPENDENCIES = "dependencies";
 
     @JsonProperty(FIELD_FIELDS)
     private final List<DataField> fields;
@@ -59,18 +63,36 @@ public class ViewSchema {
     @JsonProperty(FIELD_OPTIONS)
     private final Map<String, String> options;
 
+    @JsonProperty(FIELD_DEPENDENCIES)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<Identifier> dependencies;
+
+    public ViewSchema(
+            List<DataField> fields,
+            String query,
+            Map<String, String> dialects,
+            @Nullable String comment,
+            Map<String, String> options) {
+        this(fields, query, dialects, comment, options, Collections.emptyList());
+    }
+
     @JsonCreator
     public ViewSchema(
             @JsonProperty(FIELD_FIELDS) List<DataField> fields,
             @JsonProperty(FIELD_QUERY) String query,
             @JsonProperty(FIELD_DIALECTS) Map<String, String> dialects,
             @Nullable @JsonProperty(FIELD_COMMENT) String comment,
-            @JsonProperty(FIELD_OPTIONS) Map<String, String> options) {
+            @JsonProperty(FIELD_OPTIONS) Map<String, String> options,
+            @Nullable @JsonProperty(FIELD_DEPENDENCIES) List<Identifier> dependencies) {
         this.fields = fields;
         this.query = query;
         this.dialects = dialects;
         this.options = options;
         this.comment = comment;
+        this.dependencies =
+                dependencies == null
+                        ? Collections.emptyList()
+                        : Collections.unmodifiableList(new ArrayList<>(dependencies));
     }
 
     @JsonGetter(FIELD_FIELDS)
@@ -99,6 +121,11 @@ public class ViewSchema {
         return options;
     }
 
+    @JsonGetter(FIELD_DEPENDENCIES)
+    public List<Identifier> dependencies() {
+        return dependencies;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {
@@ -109,11 +136,12 @@ public class ViewSchema {
                 && Objects.equals(query, that.query)
                 && Objects.equals(dialects, that.dialects)
                 && Objects.equals(comment, that.comment)
-                && Objects.equals(options, that.options);
+                && Objects.equals(options, that.options)
+                && Objects.equals(dependencies, that.dependencies);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fields, query, dialects, comment, options);
+        return Objects.hash(fields, query, dialects, comment, options, dependencies);
     }
 }

--- a/paimon-api/src/test/java/org/apache/paimon/catalog/ReadAuthorizationContextTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/catalog/ReadAuthorizationContextTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link ReadAuthorizationContext}. */
+class ReadAuthorizationContextTest {
+
+    private static final Identifier ROOT = Identifier.create("db", "view");
+    private static final Identifier TABLE = Identifier.create("db", "table");
+    private static final Identifier SECOND_TABLE = Identifier.create("db", "second_table");
+
+    private static ReadAuthorizationResource resource(Identifier table) {
+        return ReadAuthorizationResource.table(table);
+    }
+
+    @Test
+    void testPendingContextDoesNotAuthorizeByItself() {
+        ReadAuthorizationContext context = ReadAuthorizationContext.forView(ROOT);
+
+        assertThat(context.isDirect()).isFalse();
+        assertThat(context.authorizationRootType()).contains(ReadAuthorizationRootType.VIEW);
+        assertThat(context.authorizationRoot()).contains(ROOT);
+        assertThat(context.readGrant()).isEmpty();
+        assertThat(context.authorizedResources()).isEmpty();
+        assertThat(context.authorizes(ReadAuthorizationRootType.TABLE, TABLE)).isFalse();
+        assertThat(context.isExpired(0L)).isTrue();
+    }
+
+    @Test
+    void testExtendAndSerializeLease() throws Exception {
+        ReadAuthorizationContext context = ReadAuthorizationContext.forView(ROOT);
+        context.updateGrant(Collections.singletonList(resource(TABLE)), "grant-1", 100L);
+        context.updateGrant(Collections.singletonList(resource(SECOND_TABLE)), "grant-2", 200L);
+        context.updateGrant(Collections.emptyList(), "grant-3", 300L);
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(context);
+        }
+        ReadAuthorizationContext restored;
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            restored = (ReadAuthorizationContext) input.readObject();
+        }
+
+        assertThat(restored).isEqualTo(context);
+        assertThat(restored.authorizationRoot()).contains(ROOT);
+        assertThat(restored.authorizedResources())
+                .containsExactly(resource(TABLE), resource(SECOND_TABLE));
+        assertThat(restored.authorizes(ReadAuthorizationRootType.TABLE, SECOND_TABLE)).isTrue();
+        assertThat(restored.readGrant()).contains("grant-3");
+        assertThat(restored.expiresAtMillis()).isEqualTo(300L);
+
+        ReadAuthorizationContext tableContext =
+                restored.forDependenciesOf(ReadAuthorizationRootType.TABLE, SECOND_TABLE);
+        assertThat(tableContext.authorizationRoot()).contains(ROOT);
+        assertThat(tableContext).isEqualTo(restored);
+        tableContext.updateGrant(Collections.emptyList(), "branch-grant", 400L);
+        assertThat(tableContext).isNotEqualTo(restored);
+        assertThat(tableContext.readGrant()).contains("branch-grant");
+        assertThat(restored.readGrant()).contains("grant-3");
+    }
+
+    @Test
+    void testInitialUpdateRequiresDependency() {
+        assertThatThrownBy(
+                        () ->
+                                ReadAuthorizationContext.forView(ROOT)
+                                        .updateGrant(Collections.emptyList(), "new-grant", 200L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("initial");
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -20,6 +20,7 @@ package org.apache.paimon.rest;
 
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
@@ -57,6 +58,7 @@ import static org.apache.paimon.rest.RESTCatalogOptions.IO_CACHE_ENABLED;
 public class RESTTokenFileIO implements FileIO {
 
     private static final long serialVersionUID = 2L;
+    private static final long READ_TOKEN_REFRESH_SAFETY_MILLIS = 5_000L;
 
     public static final ConfigOption<Boolean> DATA_TOKEN_ENABLED =
             ConfigOptions.key("data-token.enabled")
@@ -81,6 +83,7 @@ public class RESTTokenFileIO implements FileIO {
 
     private final CatalogContext catalogContext;
     private final Identifier identifier;
+    private final ReadAuthorizationContext readContext;
     private final Path path;
 
     // Api instance before serialization, it will become null after serialization, then we should
@@ -93,9 +96,19 @@ public class RESTTokenFileIO implements FileIO {
 
     public RESTTokenFileIO(
             CatalogContext catalogContext, RESTApi apiInstance, Identifier identifier, Path path) {
+        this(catalogContext, apiInstance, identifier, ReadAuthorizationContext.direct(), path);
+    }
+
+    public RESTTokenFileIO(
+            CatalogContext catalogContext,
+            RESTApi apiInstance,
+            Identifier identifier,
+            ReadAuthorizationContext readContext,
+            Path path) {
         this.catalogContext = catalogContext;
         this.apiInstance = apiInstance;
         this.identifier = identifier;
+        this.readContext = readContext;
         this.path = path;
     }
 
@@ -203,6 +216,11 @@ public class RESTTokenFileIO implements FileIO {
     }
 
     private boolean shouldRefresh() {
+        if (!readContext().isDirect()) {
+            return token == null
+                    || token.expireAtMillis() - System.currentTimeMillis()
+                            < READ_TOKEN_REFRESH_SAFETY_MILLIS;
+        }
         return token == null
                 || token.expireAtMillis() - System.currentTimeMillis()
                         < TOKEN_EXPIRATION_SAFE_TIME_MILLIS;
@@ -221,7 +239,16 @@ public class RESTTokenFileIO implements FileIO {
                             identifier.getTableName(),
                             identifier.getBranchName());
         }
-        GetTableTokenResponse response = apiInstance.loadTableToken(tableIdentifier);
+        ReadAuthorizationContext authorizationContext = readContext();
+        GetTableTokenResponse response =
+                authorizationContext.isDirect()
+                        ? apiInstance.loadTableToken(tableIdentifier)
+                        : apiInstance.loadTableToken(tableIdentifier, authorizationContext);
+        if (!authorizationContext.isDirect()) {
+            if (response.getExpiresAtMillis() > authorizationContext.expiresAtMillis()) {
+                throw new SecurityException("Data token outlives the view read grant");
+            }
+        }
         LOG.info(
                 "end refresh data token for identifier [{}] expiresAtMillis [{}]",
                 identifier,
@@ -231,6 +258,11 @@ public class RESTTokenFileIO implements FileIO {
                 new RESTToken(
                         mergeTokenWithCatalogOptions(response.getToken()),
                         response.getExpiresAtMillis());
+    }
+
+    private ReadAuthorizationContext readContext() {
+        // The field is null when deserializing instances written before read contexts existed.
+        return readContext == null ? ReadAuthorizationContext.direct() : readContext;
     }
 
     private Map<String, String> mergeTokenWithCatalogOptions(Map<String, String> token) {

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CachingCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.MemorySize;
@@ -44,6 +45,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static org.apache.paimon.options.CatalogOptions.CACHE_DV_MAX_NUM;
@@ -270,6 +272,38 @@ public class CachingCatalog extends DelegateCatalog {
         }
     }
 
+    @Override
+    public Table getTable(Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return getTable(identifier);
+        }
+        // Grant-backed tables are deliberately not cached. Grants are renewable mutable leases,
+        // and caching every random grant nonce would retain an unbounded number of table objects.
+        if (identifier.isSystemTable()) {
+            Identifier originIdentifier =
+                    new Identifier(
+                            identifier.getDatabaseName(),
+                            identifier.getTableName(),
+                            identifier.getBranchName(),
+                            null);
+            Table originTable = getTable(originIdentifier, readContext);
+            Table table =
+                    SystemTableLoader.load(
+                            checkNotNull(identifier.getSystemTableName()),
+                            (FileStoreTable) originTable);
+            if (table == null) {
+                throw new TableNotExistException(identifier);
+            }
+            return table;
+        }
+
+        Table table = wrapped.getTable(identifier, readContext);
+        configureTableCache(table);
+        return table;
+    }
+
     private Table loadTable(Identifier identifier) {
         Table table;
         try {
@@ -278,6 +312,11 @@ public class CachingCatalog extends DelegateCatalog {
             throw new TableLoadingException(e);
         }
 
+        configureTableCache(table);
+        return table;
+    }
+
+    private void configureTableCache(Table table) {
         if (table instanceof FileStoreTable) {
             FileStoreTable storeTable = (FileStoreTable) table;
             storeTable.setSnapshotCache(
@@ -303,8 +342,6 @@ public class CachingCatalog extends DelegateCatalog {
                 storeTable.setDVMetaCache(dvMetaCache);
             }
         }
-
-        return table;
     }
 
     private static class TableLoadingException extends RuntimeException {
@@ -333,6 +370,39 @@ public class CachingCatalog extends DelegateCatalog {
             partitionCache.put(identifier, result);
         }
         return result;
+    }
+
+    @Override
+    public List<Partition> listPartitions(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        return readContext.isDirect()
+                ? listPartitions(identifier)
+                : wrapped.listPartitions(identifier, readContext);
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String partitionNamePattern,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        return wrapped.listPartitionsPaged(
+                identifier, maxResults, pageToken, partitionNamePattern, readContext);
+    }
+
+    @Override
+    public List<Partition> listPartitionsByNames(
+            Identifier identifier,
+            List<Map<String, String>> partitions,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        return wrapped.listPartitionsByNames(identifier, partitions, readContext);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/Catalog.java
@@ -159,6 +159,23 @@ public interface Catalog extends AutoCloseable {
     Table getTable(Identifier identifier) throws TableNotExistException;
 
     /**
+     * Return a {@link Table} with an authorization context which is preserved for all subsequent
+     * read operations.
+     *
+     * <p>The context only authorizes reads. Implementations must not use it for writes or metadata
+     * mutations.
+     *
+     * @param identifier Path of the target table
+     * @param readContext authorization context for this read
+     * @return The requested table
+     * @throws TableNotExistException if the target does not exist
+     */
+    default Table getTable(Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return getTable(identifier);
+    }
+
+    /**
      * Return a {@link Table} identified by the given tableId.
      *
      * @param tableId Id of the table
@@ -399,6 +416,13 @@ public interface Catalog extends AutoCloseable {
      */
     List<Partition> listPartitions(Identifier identifier) throws TableNotExistException;
 
+    /** List partitions with the authorization context of the originating read. */
+    default List<Partition> listPartitions(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return listPartitions(identifier);
+    }
+
     /**
      * Get paged partition list of the table, the partition list will be returned in descending
      * order.
@@ -423,6 +447,17 @@ public interface Catalog extends AutoCloseable {
             @Nullable String pageToken,
             @Nullable String partitionNamePattern)
             throws TableNotExistException;
+
+    /** List paged partitions with the authorization context of the originating read. */
+    default PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String partitionNamePattern,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
+    }
 
     /**
      * Get a page of partitions using {@code predicate} as a best-effort filter.
@@ -463,6 +498,15 @@ public interface Catalog extends AutoCloseable {
             Identifier identifier, List<Map<String, String>> partitions)
             throws TableNotExistException;
 
+    /** List named partitions with the authorization context of the originating read. */
+    default List<Partition> listPartitionsByNames(
+            Identifier identifier,
+            List<Map<String, String>> partitions,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return listPartitionsByNames(identifier, partitions);
+    }
+
     // ======================= view methods ===============================
 
     /**
@@ -474,6 +518,18 @@ public interface Catalog extends AutoCloseable {
      */
     default View getView(Identifier identifier) throws ViewNotExistException {
         throw new ViewNotExistException(identifier);
+    }
+
+    /**
+     * Return a dependency view with the authorization context of the originating read.
+     *
+     * <p>After this succeeds, callers resolving dependencies inside the returned view must pass a
+     * context derived with {@link ReadAuthorizationContext#forDependenciesOf} so each traversal
+     * branch keeps an independent grant snapshot while the outermost root remains unchanged.
+     */
+    default View getView(Identifier identifier, ReadAuthorizationContext readContext)
+            throws ViewNotExistException {
+        return getView(identifier);
     }
 
     /**
@@ -750,6 +806,13 @@ public interface Catalog extends AutoCloseable {
     Optional<TableSnapshot> loadSnapshot(Identifier identifier)
             throws Catalog.TableNotExistException;
 
+    /** Return the latest snapshot with the authorization context of the originating read. */
+    default Optional<TableSnapshot> loadSnapshot(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws Catalog.TableNotExistException {
+        return loadSnapshot(identifier);
+    }
+
     /**
      * Return the snapshot of table for given version. Version parsing order is:
      *
@@ -769,6 +832,13 @@ public interface Catalog extends AutoCloseable {
      */
     Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
             throws Catalog.TableNotExistException;
+
+    /** Return a versioned snapshot with the authorization context of the originating read. */
+    default Optional<Snapshot> loadSnapshot(
+            Identifier identifier, String version, ReadAuthorizationContext readContext)
+            throws Catalog.TableNotExistException {
+        return loadSnapshot(identifier, version);
+    }
 
     /**
      * Get paged snapshot list of the table, the snapshot list will be returned in descending order.
@@ -1261,6 +1331,23 @@ public interface Catalog extends AutoCloseable {
      */
     TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException;
+
+    /**
+     * Authorize a table query with the authorization context of the originating read.
+     *
+     * @param identifier path of the target table
+     * @param select selected fields, null if select all
+     * @param readContext authorization context for this read
+     * @return additional filter for row level access control and column masking rules
+     * @throws TableNotExistException if the table does not exist
+     */
+    default TableQueryAuthResult authTableQuery(
+            Identifier identifier,
+            @Nullable List<String> select,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return authTableQuery(identifier, select);
+    }
 
     // ==================== Catalog Information ==========================
 

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/CatalogUtils.java
@@ -329,15 +329,47 @@ public class CatalogUtils {
             @Nullable CatalogContext catalogContext,
             boolean isRestCatalog)
             throws Catalog.TableNotExistException {
-        if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
-            return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
-        }
+        return loadTable(
+                catalog,
+                identifier,
+                internalFileIO,
+                externalFileIO,
+                metadataLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                ReadAuthorizationContext.direct(),
+                isRestCatalog);
+    }
 
+    public static Table loadTable(
+            Catalog catalog,
+            Identifier identifier,
+            Function<Path, FileIO> internalFileIO,
+            Function<Path, FileIO> externalFileIO,
+            TableMetadata.Loader metadataLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            ReadAuthorizationContext readContext,
+            boolean isRestCatalog)
+            throws Catalog.TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (SYSTEM_DATABASE_NAME.equals(identifier.getDatabaseName())) {
+            if (readContext.isDirect()) {
+                return CatalogUtils.createGlobalSystemTable(identifier.getTableName(), catalog);
+            }
+            // System tables are constructed locally and may expose metadata beyond one exact data
+            // table, so there is no safe target REST request on which a server can validate the
+            // grant. A grant for one dependency must never authorize these broader local reads.
+            throw new Catalog.TableNoPermissionException(identifier);
+        }
         TableMetadata metadata = metadataLoader.load(identifier);
         TableSchema schema = metadata.schema();
         CoreOptions options = CoreOptions.fromMap(schema.options());
 
-        Function<Path, FileIO> dataFileIO = metadata.isExternal() ? externalFileIO : internalFileIO;
+        Function<Path, FileIO> dataFileIO =
+                readContext.isDirect() && metadata.isExternal() ? externalFileIO : internalFileIO;
 
         if (options.type() == TableType.FORMAT_TABLE) {
             FormatTablePartitionManager partitionManager = null;
@@ -378,6 +410,12 @@ public class CatalogUtils {
                             identifier.getBranchName());
         }
 
+        ReadAuthorizationContext resourceReadContext =
+                readContext.isDirect()
+                        ? readContext
+                        : readContext.forDependenciesOf(
+                                ReadAuthorizationRootType.TABLE, tableIdentifier);
+
         CatalogEnvironment catalogEnv =
                 new CatalogEnvironment(
                         tableIdentifier,
@@ -387,7 +425,8 @@ public class CatalogUtils {
                         isRestCatalog ? null : lockContext,
                         catalogContext,
                         catalog.supportsVersionManagement(),
-                        catalog.supportsPartitionModification());
+                        catalog.supportsPartitionModification(),
+                        resourceReadContext);
         Path path = new Path(schema.options().get(PATH.key()));
         FileStoreTable table =
                 FileStoreTableFactory.create(dataFileIO.apply(path), path, schema, catalogEnv);

--- a/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/catalog/DelegateCatalog.java
@@ -211,9 +211,23 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public Optional<TableSnapshot> loadSnapshot(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.loadSnapshot(identifier, readContext);
+    }
+
+    @Override
     public Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
             throws TableNotExistException {
         return wrapped.loadSnapshot(identifier, version);
+    }
+
+    @Override
+    public Optional<Snapshot> loadSnapshot(
+            Identifier identifier, String version, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.loadSnapshot(identifier, version, readContext);
     }
 
     @Override
@@ -384,8 +398,20 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public Table getTable(Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.getTable(identifier, readContext);
+    }
+
+    @Override
     public View getView(Identifier identifier) throws ViewNotExistException {
         return wrapped.getView(identifier);
+    }
+
+    @Override
+    public View getView(Identifier identifier, ReadAuthorizationContext readContext)
+            throws ViewNotExistException {
+        return wrapped.getView(identifier, readContext);
     }
 
     @Override
@@ -447,6 +473,13 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public List<Partition> listPartitions(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.listPartitions(identifier, readContext);
+    }
+
+    @Override
     public PagedList<Partition> listPartitionsPaged(
             Identifier identifier,
             Integer maxResults,
@@ -454,6 +487,18 @@ public abstract class DelegateCatalog implements Catalog {
             String partitionNamePattern)
             throws TableNotExistException {
         return wrapped.listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            Integer maxResults,
+            String pageToken,
+            String partitionNamePattern,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.listPartitionsPaged(
+                identifier, maxResults, pageToken, partitionNamePattern, readContext);
     }
 
     @Override
@@ -476,9 +521,27 @@ public abstract class DelegateCatalog implements Catalog {
     }
 
     @Override
+    public List<Partition> listPartitionsByNames(
+            Identifier identifier,
+            List<Map<String, String>> partitions,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.listPartitionsByNames(identifier, partitions, readContext);
+    }
+
+    @Override
     public TableQueryAuthResult authTableQuery(Identifier identifier, @Nullable List<String> select)
             throws TableNotExistException {
         return wrapped.authTableQuery(identifier, select);
+    }
+
+    @Override
+    public TableQueryAuthResult authTableQuery(
+            Identifier identifier,
+            @Nullable List<String> select,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapped.authTableQuery(identifier, select, readContext);
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/jdbc/JdbcCatalog.java
@@ -1044,7 +1044,8 @@ public class JdbcCatalog extends AbstractCatalog {
                     viewSchema.query(),
                     viewSchema.dialects(),
                     viewSchema.comment(),
-                    viewSchema.options());
+                    viewSchema.options(),
+                    viewSchema.dependencies());
         } catch (SQLException | InterruptedException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
@@ -1066,7 +1067,8 @@ public class JdbcCatalog extends AbstractCatalog {
                         view.query(),
                         view.dialects(),
                         view.comment().orElse(null),
-                        view.options());
+                        view.options(),
+                        view.dependencies());
         String viewSchemaJson = JsonSerdeUtil.toJson(viewSchema);
 
         // Insert view
@@ -1295,6 +1297,9 @@ public class JdbcCatalog extends AbstractCatalog {
                         Map<String, String> newOptions = new HashMap<>(existingView.options());
                         String newComment = existingView.comment().orElse(null);
                         Map<String, String> newDialects = new HashMap<>(existingView.dialects());
+                        List<Identifier> newDependencies = existingView.dependencies();
+                        boolean queryChanged = false;
+                        boolean dependenciesUpdated = false;
                         for (ViewChange change : changes) {
                             if (change instanceof ViewChange.SetViewOption) {
                                 ViewChange.SetViewOption setOption =
@@ -1315,6 +1320,7 @@ public class JdbcCatalog extends AbstractCatalog {
                                             identifier, addDialect.dialect());
                                 }
                                 newDialects.put(addDialect.dialect(), addDialect.query());
+                                queryChanged = true;
                             } else if (change instanceof ViewChange.UpdateDialect) {
                                 ViewChange.UpdateDialect updateDialect =
                                         (ViewChange.UpdateDialect) change;
@@ -1323,6 +1329,7 @@ public class JdbcCatalog extends AbstractCatalog {
                                             identifier, updateDialect.dialect());
                                 }
                                 newDialects.put(updateDialect.dialect(), updateDialect.query());
+                                queryChanged = true;
                             } else if (change instanceof ViewChange.DropDialect) {
                                 ViewChange.DropDialect dropDialect =
                                         (ViewChange.DropDialect) change;
@@ -1331,7 +1338,15 @@ public class JdbcCatalog extends AbstractCatalog {
                                             identifier, dropDialect.dialect());
                                 }
                                 newDialects.remove(dropDialect.dialect());
+                                queryChanged = true;
+                            } else if (change instanceof ViewChange.UpdateDependencies) {
+                                newDependencies =
+                                        ((ViewChange.UpdateDependencies) change).dependencies();
+                                dependenciesUpdated = true;
                             }
+                        }
+                        if (queryChanged && !dependenciesUpdated) {
+                            newDependencies = Collections.emptyList();
                         }
 
                         ViewSchema updatedSchema =
@@ -1340,7 +1355,8 @@ public class JdbcCatalog extends AbstractCatalog {
                                         existingView.query(),
                                         newDialects,
                                         newComment,
-                                        newOptions);
+                                        newOptions,
+                                        newDependencies);
                         String viewSchemaJson = JsonSerdeUtil.toJson(updatedSchema);
                         JdbcUtils.updateView(
                                 connections,

--- a/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/privilege/PrivilegedCatalog.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.DelegateCatalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.ConfigOptions;
 import org.apache.paimon.options.Options;
@@ -149,7 +150,16 @@ public class PrivilegedCatalog extends DelegateCatalog {
 
     @Override
     public Table getTable(Identifier identifier) throws TableNotExistException {
-        Table table = wrapped.getTable(identifier);
+        return wrapTable(wrapped.getTable(identifier), identifier);
+    }
+
+    @Override
+    public Table getTable(Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        return wrapTable(wrapped.getTable(identifier, readContext), identifier);
+    }
+
+    private Table wrapTable(Table table, Identifier identifier) {
         if (table instanceof FileStoreTable) {
             return PrivilegedFileStoreTable.wrap(
                     (FileStoreTable) table, privilegeManager.getPrivilegeChecker(), identifier);

--- a/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
+++ b/paimon-core/src/main/java/org/apache/paimon/rest/RESTCatalog.java
@@ -29,6 +29,7 @@ import org.apache.paimon.catalog.CatalogUtils;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.catalog.TableMetadata;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.consumer.ConsumerInfo;
@@ -374,6 +375,26 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public Table getTable(Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return getTable(identifier);
+        }
+        return CatalogUtils.loadTable(
+                this,
+                identifier,
+                path -> fileIOForData(path, identifier, readContext),
+                this::fileIOFromOptions,
+                i -> loadTableMetadata(i, readContext),
+                null,
+                null,
+                context,
+                readContext,
+                true);
+    }
+
+    @Override
     public Optional<TableSnapshot> loadSnapshot(Identifier identifier)
             throws TableNotExistException {
         try {
@@ -389,10 +410,50 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public Optional<TableSnapshot> loadSnapshot(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadSnapshot(identifier);
+        }
+        try {
+            return Optional.ofNullable(api.loadSnapshot(identifier, readContext));
+        } catch (NoSuchResourceException e) {
+            if (StringUtils.equals(e.resourceType(), ErrorResponse.RESOURCE_TYPE_SNAPSHOT)) {
+                return Optional.empty();
+            }
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        }
+    }
+
+    @Override
     public Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
             throws TableNotExistException {
         try {
             return Optional.ofNullable(api.loadSnapshot(identifier, version));
+        } catch (NoSuchResourceException e) {
+            if (StringUtils.equals(e.resourceType(), ErrorResponse.RESOURCE_TYPE_SNAPSHOT)) {
+                return Optional.empty();
+            }
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        }
+    }
+
+    @Override
+    public Optional<Snapshot> loadSnapshot(
+            Identifier identifier, String version, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadSnapshot(identifier, version);
+        }
+        try {
+            return Optional.ofNullable(api.loadSnapshot(identifier, version, readContext));
         } catch (NoSuchResourceException e) {
             if (StringUtils.equals(e.resourceType(), ErrorResponse.RESOURCE_TYPE_SNAPSHOT)) {
                 return Optional.empty();
@@ -525,6 +586,35 @@ public class RESTCatalog implements Catalog {
         GetTableResponse response;
         try {
             response = api.getTable(loadTableIdentifier);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        }
+
+        return toTableMetadata(identifier.getDatabaseName(), response);
+    }
+
+    private TableMetadata loadTableMetadata(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return loadTableMetadata(identifier);
+        }
+        // if the table is system table, we need to load table metadata from the system table's data
+        // table
+        Identifier loadTableIdentifier =
+                identifier.isSystemTable()
+                        ? new Identifier(
+                                identifier.getDatabaseName(),
+                                identifier.getTableName(),
+                                identifier.getBranchName())
+                        : identifier;
+
+        GetTableResponse response;
+        try {
+            response = api.getTable(loadTableIdentifier, readContext);
         } catch (NoSuchResourceException e) {
             throw new TableNotExistException(identifier);
         } catch (ForbiddenException e) {
@@ -695,6 +785,33 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public TableQueryAuthResult authTableQuery(
+            Identifier identifier,
+            @Nullable List<String> select,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return authTableQuery(identifier, select);
+        }
+        checkNotSystemTable(identifier, "authTable");
+        try {
+            AuthTableQueryResponse response = api.authTableQuery(identifier, select, readContext);
+            return new TableQueryAuthResult(response.filter(), response.columnMasking());
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (ServiceFailureException e) {
+            throw new IllegalStateException(e.getMessage());
+        } catch (NotImplementedException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        } catch (BadRequestException e) {
+            throw new RuntimeException(new IllegalArgumentException(e.getMessage()));
+        }
+    }
+
+    @Override
     public void dropTable(Identifier identifier, boolean ignoreIfNotExists)
             throws TableNotExistException {
         checkNotBranch(identifier, "dropTable");
@@ -811,6 +928,29 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public List<Partition> listPartitions(
+            Identifier identifier, ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitions(identifier);
+        }
+        try {
+            return api.listPartitions(identifier, readContext);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (NotImplementedException e) {
+            Table table = getTable(identifier, readContext);
+            if (hasCatalogManagedPartitions(table)) {
+                throw e;
+            }
+            return listPartitionsFromFileSystem(table);
+        }
+    }
+
+    @Override
     public PagedList<Partition> listPartitionsPaged(
             Identifier identifier,
             @Nullable Integer maxResults,
@@ -825,6 +965,34 @@ public class RESTCatalog implements Catalog {
             throw new TableNoPermissionException(identifier, e);
         } catch (NotImplementedException e) {
             Table table = getTable(identifier);
+            if (hasCatalogManagedPartitions(table)) {
+                throw e;
+            }
+            return new PagedList<>(listPartitionsFromFileSystem(table), null);
+        }
+    }
+
+    @Override
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String partitionNamePattern,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
+        }
+        try {
+            return api.listPartitionsPaged(
+                    identifier, maxResults, pageToken, partitionNamePattern, readContext);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (NotImplementedException e) {
+            Table table = getTable(identifier, readContext);
             if (hasCatalogManagedPartitions(table)) {
                 throw e;
             }
@@ -870,6 +1038,31 @@ public class RESTCatalog implements Catalog {
             throw new TableNoPermissionException(identifier, e);
         } catch (NotImplementedException e) {
             Table table = getTable(identifier);
+            if (hasCatalogManagedPartitions(table)) {
+                throw e;
+            }
+            return listPartitionsFromFileSystem(table, partitions);
+        }
+    }
+
+    @Override
+    public List<Partition> listPartitionsByNames(
+            Identifier identifier,
+            List<Map<String, String>> partitions,
+            ReadAuthorizationContext readContext)
+            throws TableNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return listPartitionsByNames(identifier, partitions);
+        }
+        try {
+            return api.listPartitionsByNames(identifier, partitions, readContext);
+        } catch (NoSuchResourceException e) {
+            throw new TableNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new TableNoPermissionException(identifier, e);
+        } catch (NotImplementedException e) {
+            Table table = getTable(identifier, readContext);
             if (hasCatalogManagedPartitions(table)) {
                 throw e;
             }
@@ -1076,6 +1269,23 @@ public class RESTCatalog implements Catalog {
     }
 
     @Override
+    public View getView(Identifier identifier, ReadAuthorizationContext readContext)
+            throws ViewNotExistException {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return getView(identifier);
+        }
+        try {
+            GetViewResponse response = api.getView(identifier, readContext);
+            return toView(identifier.getDatabaseName(), response);
+        } catch (NoSuchResourceException e) {
+            throw new ViewNotExistException(identifier);
+        } catch (ForbiddenException e) {
+            throw new ViewNoPermissionException(identifier, e);
+        }
+    }
+
+    @Override
     public void dropView(Identifier identifier, boolean ignoreIfNotExists)
             throws ViewNotExistException {
         try {
@@ -1099,7 +1309,8 @@ public class RESTCatalog implements Catalog {
                             view.query(),
                             view.dialects(),
                             view.comment().orElse(null),
-                            view.options());
+                            view.options(),
+                            view.dependencies());
             api.createView(identifier, schema);
         } catch (NoSuchResourceException e) {
             throw new DatabaseNotExistException(identifier.getDatabaseName());
@@ -1187,7 +1398,8 @@ public class RESTCatalog implements Catalog {
                 schema.query(),
                 schema.dialects(),
                 schema.comment(),
-                options);
+                options,
+                schema.dependencies());
     }
 
     @Override
@@ -1375,6 +1587,20 @@ public class RESTCatalog implements Catalog {
         return CachingFileIO.wrapWithCachingIfNeeded(
                 dataTokenEnabled
                         ? new RESTTokenFileIO(context, api, identifier, path)
+                        : fileIOFromOptions(path),
+                context,
+                cacheManager);
+    }
+
+    private FileIO fileIOForData(
+            Path path, Identifier identifier, ReadAuthorizationContext readContext) {
+        Objects.requireNonNull(readContext, "readContext");
+        if (readContext.isDirect()) {
+            return fileIOForData(path, identifier);
+        }
+        return CachingFileIO.wrapWithCachingIfNeeded(
+                dataTokenEnabled
+                        ? new RESTTokenFileIO(context, api, identifier, readContext, path)
                         : fileIOFromOptions(path),
                 context,
                 cacheManager);

--- a/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/AppendOnlyFileStoreTable.java
@@ -132,7 +132,8 @@ public class AppendOnlyFileStoreTable extends AbstractFileStoreTable {
                         providerFactories,
                         schema(),
                         catalogEnvironment.catalogContext(),
-                        () -> new AppendTableRead(providerFactories, schema()))
+                        () -> new AppendTableRead(providerFactories, schema()),
+                        catalogEnvironment.dependencyReadContext())
                 : new AppendTableRead(providerFactories, schema());
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/CatalogEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.paimon.catalog.CatalogLockContext;
 import org.apache.paimon.catalog.CatalogLockFactory;
 import org.apache.paimon.catalog.CatalogSnapshotCommit;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.catalog.RenamingSnapshotCommit;
 import org.apache.paimon.catalog.SnapshotCommit;
 import org.apache.paimon.catalog.TableRollback;
@@ -47,6 +48,7 @@ public class CatalogEnvironment implements Serializable {
     private static final long serialVersionUID = 2L;
 
     @Nullable private final Identifier identifier;
+    @Nullable private final ReadAuthorizationContext readContext;
     @Nullable private final String uuid;
     @Nullable private final CatalogLoader catalogLoader;
     @Nullable private final CatalogLockFactory lockFactory;
@@ -64,7 +66,30 @@ public class CatalogEnvironment implements Serializable {
             @Nullable CatalogContext catalogContext,
             boolean supportsVersionManagement,
             boolean supportsPartitionModification) {
+        this(
+                identifier,
+                uuid,
+                catalogLoader,
+                lockFactory,
+                lockContext,
+                catalogContext,
+                supportsVersionManagement,
+                supportsPartitionModification,
+                ReadAuthorizationContext.direct());
+    }
+
+    public CatalogEnvironment(
+            @Nullable Identifier identifier,
+            @Nullable String uuid,
+            @Nullable CatalogLoader catalogLoader,
+            @Nullable CatalogLockFactory lockFactory,
+            @Nullable CatalogLockContext lockContext,
+            @Nullable CatalogContext catalogContext,
+            boolean supportsVersionManagement,
+            boolean supportsPartitionModification,
+            ReadAuthorizationContext readContext) {
         this.identifier = identifier;
+        this.readContext = readContext;
         this.uuid = uuid;
         this.catalogLoader = catalogLoader;
         this.lockFactory = lockFactory;
@@ -81,6 +106,27 @@ public class CatalogEnvironment implements Serializable {
     @Nullable
     public Identifier identifier() {
         return identifier;
+    }
+
+    /** Authorization context used only by read operations. */
+    public ReadAuthorizationContext readContext() {
+        return readContext == null ? ReadAuthorizationContext.direct() : readContext;
+    }
+
+    /**
+     * Context for tables discovered while reading this table.
+     *
+     * <p>A directly loaded table becomes the authorization root for its runtime dependencies. A
+     * table already reached through another root preserves that outermost context. A new table-root
+     * context is created for every read so principal-bound grants are never retained in cached
+     * table objects.
+     */
+    public ReadAuthorizationContext dependencyReadContext() {
+        ReadAuthorizationContext current = readContext();
+        if (!current.isDirect() || identifier == null) {
+            return current;
+        }
+        return ReadAuthorizationContext.forTable(identifier);
     }
 
     @Nullable
@@ -173,7 +219,7 @@ public class CatalogEnvironment implements Serializable {
         if (catalogLoader == null) {
             return null;
         }
-        return new SnapshotLoaderImpl(catalogLoader, identifier);
+        return new SnapshotLoaderImpl(catalogLoader, identifier, readContext());
     }
 
     @Nullable
@@ -205,7 +251,8 @@ public class CatalogEnvironment implements Serializable {
                 lockContext,
                 catalogContext,
                 supportsVersionManagement,
-                supportsPartitionModification);
+                supportsPartitionModification,
+                readContext());
     }
 
     public TableQueryAuth tableQueryAuth(CoreOptions options) {
@@ -214,7 +261,7 @@ public class CatalogEnvironment implements Serializable {
         }
         return select -> {
             try (Catalog catalog = catalogLoader.load()) {
-                return catalog.authTableQuery(identifier, select);
+                return catalog.authTableQuery(identifier, select, readContext());
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionTableRead.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.source;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
@@ -42,6 +43,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -51,15 +53,18 @@ public class DataEvolutionTableRead extends AppendTableRead {
 
     @Nullable private final CatalogContext catalogContext;
     @Nullable private final Supplier<InnerTableRead> readFactory;
+    private final ReadAuthorizationContext readContext;
 
     public DataEvolutionTableRead(
             List<Function<SplitReadConfig, SplitReadProvider>> providerFactories,
             TableSchema schema,
             @Nullable CatalogContext catalogContext,
-            @Nullable Supplier<InnerTableRead> readFactory) {
+            @Nullable Supplier<InnerTableRead> readFactory,
+            ReadAuthorizationContext readContext) {
         super(providerFactories, schema);
         this.catalogContext = catalogContext;
         this.readFactory = readFactory;
+        this.readContext = Objects.requireNonNull(readContext, "readContext");
     }
 
     @Override
@@ -134,7 +139,8 @@ public class DataEvolutionTableRead extends AppendTableRead {
         }
 
         BlobViewResolver resolver =
-                BlobViewLookup.createResolver(catalogContext, new ArrayList<>(viewStructs));
+                BlobViewLookup.createResolver(
+                        catalogContext, new ArrayList<>(viewStructs), readContext);
 
         RecordReader<InternalRow> reader = createDataReader(split, authResult);
         Set<Integer> blobViewFieldSet = new HashSet<>();

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/PartitionsTable.java
@@ -421,7 +421,8 @@ public class PartitionsTable implements ReadonlyTable {
                 } else {
                     identifier = baseIdentifier;
                 }
-                return catalog.listPartitions(identifier);
+                return catalog.listPartitions(
+                        identifier, fileStoreTable.catalogEnvironment().readContext());
             } catch (Exception e) {
                 return listPartitionEntries();
             }

--- a/paimon-core/src/main/java/org/apache/paimon/tag/SnapshotLoaderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/tag/SnapshotLoaderImpl.java
@@ -22,6 +22,7 @@ import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.utils.SnapshotLoader;
@@ -32,18 +33,29 @@ import java.util.Optional;
 /** Implementation of {@link SnapshotLoader}. */
 public class SnapshotLoaderImpl implements SnapshotLoader {
 
+    private static final long serialVersionUID = 3096335741107585269L;
+
     private final CatalogLoader catalogLoader;
     private final Identifier identifier;
+    private final ReadAuthorizationContext readContext;
 
     public SnapshotLoaderImpl(CatalogLoader catalogLoader, Identifier identifier) {
+        this(catalogLoader, identifier, ReadAuthorizationContext.direct());
+    }
+
+    public SnapshotLoaderImpl(
+            CatalogLoader catalogLoader,
+            Identifier identifier,
+            ReadAuthorizationContext readContext) {
         this.catalogLoader = catalogLoader;
         this.identifier = identifier;
+        this.readContext = readContext;
     }
 
     @Override
     public Optional<Snapshot> load() throws IOException {
         try (Catalog catalog = catalogLoader.load()) {
-            return catalog.loadSnapshot(identifier).map(TableSnapshot::snapshot);
+            return catalog.loadSnapshot(identifier, readContext()).map(TableSnapshot::snapshot);
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -66,6 +78,12 @@ public class SnapshotLoaderImpl implements SnapshotLoader {
     public SnapshotLoader copyWithBranch(String branch) {
         return new SnapshotLoaderImpl(
                 catalogLoader,
-                new Identifier(identifier.getDatabaseName(), identifier.getTableName(), branch));
+                new Identifier(identifier.getDatabaseName(), identifier.getTableName(), branch),
+                readContext());
+    }
+
+    private ReadAuthorizationContext readContext() {
+        // The field is null when deserializing instances written before read contexts existed.
+        return readContext == null ? ReadAuthorizationContext.direct() : readContext;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/BlobViewLookup.java
@@ -24,6 +24,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobView;
@@ -46,6 +47,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -67,7 +69,19 @@ public class BlobViewLookup {
 
     public static BlobViewResolver createResolver(
             CatalogContext catalogContext, List<BlobViewStruct> viewStructs) {
-        return createResolver(catalogContext, viewStructs, CatalogFactory::createCatalog);
+        return createResolver(
+                catalogContext,
+                viewStructs,
+                ReadAuthorizationContext.direct(),
+                CatalogFactory::createCatalog);
+    }
+
+    public static BlobViewResolver createResolver(
+            CatalogContext catalogContext,
+            List<BlobViewStruct> viewStructs,
+            ReadAuthorizationContext readContext) {
+        return createResolver(
+                catalogContext, viewStructs, readContext, CatalogFactory::createCatalog);
     }
 
     @VisibleForTesting
@@ -75,7 +89,19 @@ public class BlobViewLookup {
             CatalogContext catalogContext,
             List<BlobViewStruct> viewStructs,
             CatalogLoader catalogLoader) {
-        PreloadedBlobViews cached = preloadDescriptors(catalogContext, viewStructs, catalogLoader);
+        return createResolver(
+                catalogContext, viewStructs, ReadAuthorizationContext.direct(), catalogLoader);
+    }
+
+    @VisibleForTesting
+    static BlobViewResolver createResolver(
+            CatalogContext catalogContext,
+            List<BlobViewStruct> viewStructs,
+            ReadAuthorizationContext readContext,
+            CatalogLoader catalogLoader) {
+        Objects.requireNonNull(readContext, "readContext");
+        PreloadedBlobViews cached =
+                preloadDescriptors(catalogContext, viewStructs, readContext, catalogLoader);
         return new BlobViewResolver() {
 
             private final Map<Identifier, UriReader> cache = new HashMap<>();
@@ -97,7 +123,7 @@ public class BlobViewLookup {
                                 identifier -> {
                                     try (Catalog catalog = catalogLoader.create(catalogContext)) {
                                         return UriReader.fromFile(
-                                                catalog.getTable(identifier).fileIO());
+                                                catalog.getTable(identifier, readContext).fileIO());
                                     } catch (Exception e) {
                                         throw new RuntimeException(e);
                                     }
@@ -133,6 +159,7 @@ public class BlobViewLookup {
     private static PreloadedBlobViews preloadDescriptors(
             CatalogContext catalogContext,
             List<BlobViewStruct> viewStructs,
+            ReadAuthorizationContext readContext,
             CatalogLoader catalogLoader) {
         if (viewStructs.isEmpty()) {
             return PreloadedBlobViews.empty();
@@ -141,7 +168,11 @@ public class BlobViewLookup {
         Map<Identifier, TableReferences> grouped = groupReferencesByTable(viewStructs);
         try {
             return loadReferencedDescriptors(
-                    catalogContext, grouped.values(), PRELOAD_DESCRIPTOR_EXECUTOR, catalogLoader);
+                    catalogContext,
+                    grouped.values(),
+                    PRELOAD_DESCRIPTOR_EXECUTOR,
+                    readContext,
+                    catalogLoader);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Failed to preload blob descriptors.", e);
@@ -183,11 +214,14 @@ public class BlobViewLookup {
             CatalogContext catalogContext,
             Collection<TableReferences> grouped,
             ExecutorService executor,
+            ReadAuthorizationContext readContext,
             CatalogLoader catalogLoader)
             throws Exception {
         List<TableReadPlan> plans = new ArrayList<>(grouped.size());
         for (TableReferences tableReferences : grouped) {
-            plans.add(createTableReadPlan(catalogContext, tableReferences, catalogLoader));
+            plans.add(
+                    createTableReadPlan(
+                            catalogContext, tableReferences, readContext, catalogLoader));
         }
         long targetRowsPerTask = targetRowsPerTask(plans);
 
@@ -211,6 +245,7 @@ public class BlobViewLookup {
                                                 plan.fields,
                                                 plan.readType,
                                                 rangeChunk,
+                                                readContext,
                                                 catalogLoader);
                                     } finally {
                                         Thread.currentThread()
@@ -237,11 +272,12 @@ public class BlobViewLookup {
     private static TableReadPlan createTableReadPlan(
             CatalogContext catalogContext,
             TableReferences tableReferences,
+            ReadAuthorizationContext readContext,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             List<FieldRead> fields = new ArrayList<>(tableReferences.referencesByField.size());
-            Table table = catalog.getTable(tableReferences.identifier);
+            Table table = catalog.getTable(tableReferences.identifier, readContext);
             for (Map.Entry<Integer, List<BlobViewStruct>> entry :
                     tableReferences.referencesByField.entrySet()) {
                 int fieldId = entry.getKey();
@@ -280,12 +316,13 @@ public class BlobViewLookup {
             List<FieldRead> fields,
             RowType readType,
             List<Range> rowRanges,
+            ReadAuthorizationContext readContext,
             CatalogLoader catalogLoader)
             throws Exception {
         try (Catalog catalog = catalogLoader.create(catalogContext)) {
             PreloadedBlobViews resolved = new PreloadedBlobViews();
             Table table =
-                    catalog.getTable(identifier)
+                    catalog.getTable(identifier, readContext)
                             .copy(
                                     Collections.singletonMap(
                                             CoreOptions.BLOB_AS_DESCRIPTOR.key(), "true"));

--- a/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/catalog/CachingCatalogTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.catalog;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.PagedList;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
@@ -84,6 +85,10 @@ class CachingCatalogTest extends CatalogTestBase {
 
     private static final Duration EXPIRATION_TTL = Duration.ofMinutes(5);
     private static final Duration HALF_OF_EXPIRATION = EXPIRATION_TTL.dividedBy(2);
+
+    private static ReadAuthorizationResource resource(Identifier table) {
+        return ReadAuthorizationResource.table(table);
+    }
 
     private FakeTicker ticker;
 
@@ -217,6 +222,46 @@ class CachingCatalogTest extends CatalogTestBase {
             releaseLoad.countDown();
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    public void testReadContextTablesAreNotCached() throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        CachingCatalog catalog = new CachingCatalog(wrapped, new Options());
+        Identifier tableIdentifier = Identifier.create("db", "tbl");
+        ReadAuthorizationContext firstContext =
+                ReadAuthorizationContext.granted(
+                        ReadAuthorizationRootType.VIEW,
+                        Identifier.create("db", "view1"),
+                        Collections.singletonList(resource(tableIdentifier)),
+                        "grant-1",
+                        Long.MAX_VALUE);
+        ReadAuthorizationContext secondContext =
+                ReadAuthorizationContext.granted(
+                        ReadAuthorizationRootType.VIEW,
+                        Identifier.create("db", "view2"),
+                        Collections.singletonList(resource(tableIdentifier)),
+                        "grant-2",
+                        Long.MAX_VALUE);
+        Table directTable = Mockito.mock(Table.class);
+        Table firstContextTable = Mockito.mock(Table.class);
+        Table secondFirstContextTable = Mockito.mock(Table.class);
+        Table secondContextTable = Mockito.mock(Table.class);
+
+        when(wrapped.getTable(tableIdentifier)).thenReturn(directTable);
+        when(wrapped.getTable(tableIdentifier, firstContext))
+                .thenReturn(firstContextTable, secondFirstContextTable);
+        when(wrapped.getTable(tableIdentifier, secondContext)).thenReturn(secondContextTable);
+
+        assertThat(catalog.getTable(tableIdentifier)).isSameAs(directTable);
+        assertThat(catalog.getTable(tableIdentifier, firstContext)).isSameAs(firstContextTable);
+        assertThat(catalog.getTable(tableIdentifier, firstContext))
+                .isSameAs(secondFirstContextTable);
+        assertThat(catalog.getTable(tableIdentifier, secondContext)).isSameAs(secondContextTable);
+        Mockito.verify(wrapped).getTable(tableIdentifier);
+        Mockito.verify(wrapped, Mockito.times(2)).getTable(tableIdentifier, firstContext);
+        Mockito.verify(wrapped).getTable(tableIdentifier, secondContext);
+        assertThat(catalog.estimatedCacheSizes().tableCacheSize()).isEqualTo(1L);
     }
 
     @Test
@@ -366,6 +411,56 @@ class CachingCatalogTest extends CatalogTestBase {
         catalog.createPartitions(identifier, singletonList(spec), false);
 
         assertThat(catalog.listPartitions(identifier)).containsExactly(created);
+    }
+
+    @Test
+    public void testReadContextPartitionsAreNotCached() throws Exception {
+        Catalog wrapped = Mockito.mock(Catalog.class);
+        Options options = new Options();
+        options.set(CACHE_PARTITION_MAX_NUM, 10L);
+        CachingCatalog catalog = new CachingCatalog(wrapped, options);
+        Identifier tableIdentifier = Identifier.create("db", "tbl");
+        ReadAuthorizationContext readContext =
+                ReadAuthorizationContext.granted(
+                        ReadAuthorizationRootType.VIEW,
+                        Identifier.create("db", "view"),
+                        Collections.singletonList(resource(tableIdentifier)),
+                        "grant",
+                        Long.MAX_VALUE);
+        Partition directPartition = Mockito.mock(Partition.class);
+        Partition firstContextPartition = Mockito.mock(Partition.class);
+        Partition secondContextPartition = Mockito.mock(Partition.class);
+        List<Map<String, String>> partitionSpecs =
+                singletonList(Collections.singletonMap("f0", "value"));
+        PagedList<Partition> paged = new PagedList<>(singletonList(firstContextPartition), null);
+
+        when(wrapped.listPartitions(tableIdentifier)).thenReturn(singletonList(directPartition));
+        when(wrapped.listPartitions(tableIdentifier, readContext))
+                .thenReturn(
+                        singletonList(firstContextPartition),
+                        singletonList(secondContextPartition));
+        when(wrapped.listPartitionsPaged(tableIdentifier, 10, null, null, readContext))
+                .thenReturn(paged);
+        when(wrapped.listPartitionsByNames(tableIdentifier, partitionSpecs, readContext))
+                .thenReturn(singletonList(firstContextPartition));
+
+        assertThat(catalog.listPartitions(tableIdentifier)).containsExactly(directPartition);
+        assertThat(catalog.listPartitions(tableIdentifier)).containsExactly(directPartition);
+        assertThat(catalog.listPartitions(tableIdentifier, readContext))
+                .containsExactly(firstContextPartition);
+        assertThat(catalog.listPartitions(tableIdentifier, readContext))
+                .containsExactly(secondContextPartition);
+        assertThat(catalog.listPartitionsPaged(tableIdentifier, 10, null, null, readContext))
+                .isSameAs(paged);
+        assertThat(catalog.listPartitionsByNames(tableIdentifier, partitionSpecs, readContext))
+                .containsExactly(firstContextPartition);
+
+        Mockito.verify(wrapped).listPartitions(tableIdentifier);
+        Mockito.verify(wrapped, Mockito.times(2)).listPartitions(tableIdentifier, readContext);
+        Mockito.verify(wrapped).listPartitionsPaged(tableIdentifier, 10, null, null, readContext);
+        Mockito.verify(wrapped).listPartitionsByNames(tableIdentifier, partitionSpecs, readContext);
+        assertThat(catalog.partitionCache.asMap())
+                .containsEntry(tableIdentifier, singletonList(directPartition));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/jdbc/JdbcCatalogTest.java
@@ -800,7 +800,17 @@ public class JdbcCatalogTest extends CatalogTestBase {
     public void testCreateViewStoresViewSchemaWithoutResolvingReferencedTable() throws Exception {
         String databaseName = "view_schema_db";
         Identifier identifier = Identifier.create(databaseName, "view_on_missing_table");
-        View view = createView(identifier);
+        Identifier dependency = Identifier.create(databaseName, "missing_table");
+        View baseView = createView(identifier);
+        View view =
+                new ViewImpl(
+                        identifier,
+                        baseView.rowType().getFields(),
+                        baseView.query(),
+                        baseView.dialects(),
+                        baseView.comment().orElse(null),
+                        baseView.options(),
+                        Collections.singletonList(dependency));
 
         catalog.createDatabase(databaseName, false);
         catalog.createView(identifier, view, false);
@@ -809,6 +819,7 @@ public class JdbcCatalogTest extends CatalogTestBase {
                 fetchViewSchema((JdbcCatalog) catalog, databaseName, "view_on_missing_table");
         assertThat(viewSchemaJson).contains("\"query\"").contains("\"SELECT * FROM OTHER_TABLE\"");
         assertThat(catalog.getView(identifier).query()).isEqualTo("SELECT * FROM OTHER_TABLE");
+        assertThat(catalog.getView(identifier).dependencies()).containsExactly(dependency);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/privilege/PrivilegedCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/privilege/PrivilegedCatalogTest.java
@@ -21,12 +21,16 @@ package org.apache.paimon.privilege;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.FileSystemCatalogTest;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
+import org.apache.paimon.catalog.ReadAuthorizationResource;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
 import org.apache.paimon.table.FileStoreTable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,12 +63,22 @@ public class PrivilegedCatalogTest extends FileSystemCatalogTest {
         PrivilegedCatalog rootCatalog = ((PrivilegedCatalog) catalog);
         rootCatalog.createPrivilegedUser(USERNAME_TEST_USER, PASSWORD_TEST_USER);
         Catalog userCatalog = create(rootCatalog.wrapped(), USERNAME_TEST_USER, PASSWORD_TEST_USER);
+        ReadAuthorizationContext readContext =
+                ReadAuthorizationContext.granted(
+                        ReadAuthorizationRootType.VIEW,
+                        Identifier.create("test_db", "authorized_view"),
+                        Collections.singletonList(ReadAuthorizationResource.table(identifier)),
+                        "signed-read-grant",
+                        System.currentTimeMillis() + 60_000L);
 
         FileStoreTable dataTable = (FileStoreTable) userCatalog.getTable(identifier);
 
         assertNoPrivilege(dataTable::snapshotManager);
         assertNoPrivilege(dataTable::latestSnapshot);
         assertNoPrivilege(() -> dataTable.snapshot(0));
+        FileStoreTable unverifiedContextTable =
+                (FileStoreTable) userCatalog.getTable(identifier, readContext);
+        assertNoPrivilege(unverifiedContextTable::newScan);
 
         rootCatalog.grantPrivilegeOnTable(USERNAME_TEST_USER, identifier, PrivilegeType.SELECT);
         userCatalog = create(rootCatalog.wrapped(), USERNAME_TEST_USER, PASSWORD_TEST_USER);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/HttpClientTest.java
@@ -23,7 +23,9 @@ import org.apache.paimon.rest.auth.BearTokenAuthProvider;
 import org.apache.paimon.rest.auth.RESTAuthFunction;
 import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.exceptions.BadRequestException;
+import org.apache.paimon.rest.exceptions.ForbiddenException;
 import org.apache.paimon.rest.exceptions.RESTException;
+import org.apache.paimon.rest.exceptions.ReadGrantExpiredException;
 import org.apache.paimon.rest.responses.ErrorResponse;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
@@ -175,6 +177,20 @@ public class HttpClientTest {
                         RESTException.class,
                         () -> httpClient.get(MOCK_PATH, MockRESTData.class, restAuthFunction));
         assertFalse(e.getMessage().contains(secret));
+    }
+
+    @Test
+    public void testForbiddenErrorCompatibility() {
+        server.enqueueResponse("{\"message\":\"legacy forbidden\",\"code\":403}", 403);
+        assertThrows(
+                ForbiddenException.class,
+                () -> httpClient.get(MOCK_PATH, MockRESTData.class, restAuthFunction));
+
+        server.enqueueResponse(
+                "{\"message\":\"expired\",\"resourceType\":\"READ_GRANT\",\"code\":403}", 403);
+        assertThrows(
+                ReadGrantExpiredException.class,
+                () -> httpClient.get(MOCK_PATH, MockRESTData.class, restAuthFunction));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTCatalogTest.java
@@ -25,6 +25,9 @@ import org.apache.paimon.TableType;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
+import org.apache.paimon.catalog.ReadAuthorizationResource;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
 import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -47,6 +50,7 @@ import org.apache.paimon.rest.auth.DLFTokenLoaderFactory;
 import org.apache.paimon.rest.auth.RESTAuthParameter;
 import org.apache.paimon.rest.exceptions.NotAuthorizedException;
 import org.apache.paimon.rest.exceptions.NotImplementedException;
+import org.apache.paimon.rest.requests.CreateReadGrantRequest;
 import org.apache.paimon.rest.responses.ConfigResponse;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FormatTable;
@@ -55,6 +59,9 @@ import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.JsonSerdeUtil;
+import org.apache.paimon.view.View;
+import org.apache.paimon.view.ViewChange;
+import org.apache.paimon.view.ViewImpl;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 
@@ -198,6 +205,99 @@ class MockRESTCatalogTest extends RESTCatalogTest {
         RESTCatalog restCatalog2 = restCatalog.catalogLoader().load();
         Map<String, String> headers2 = restCatalog2.api().authFunction().apply(restAuthParameter);
         assertEquals(headers2.get("User-Agent"), "test");
+    }
+
+    @Test
+    void testViewDependenciesRoundTrip() throws Exception {
+        Identifier viewIdentifier = Identifier.create("view_dependencies_db", "my_view");
+        Identifier initialDependency =
+                Identifier.create(viewIdentifier.getDatabaseName(), "initial_table");
+        Identifier updatedDependency =
+                Identifier.create(viewIdentifier.getDatabaseName(), "updated_table");
+        catalog.createDatabase(viewIdentifier.getDatabaseName(), false);
+
+        View baseView = createView(viewIdentifier);
+        View view =
+                new ViewImpl(
+                        viewIdentifier,
+                        baseView.rowType().getFields(),
+                        baseView.query(),
+                        baseView.dialects(),
+                        baseView.comment().orElse(null),
+                        baseView.options(),
+                        Collections.singletonList(initialDependency));
+        catalog.createView(viewIdentifier, view, false);
+
+        assertThat(catalog.getView(viewIdentifier).dependencies())
+                .containsExactly(initialDependency);
+        List<View> listedViews =
+                catalog.listViewDetailsPaged(viewIdentifier.getDatabaseName(), null, null, null)
+                        .getElements();
+        assertThat(listedViews).hasSize(1);
+        assertThat(listedViews.get(0).dependencies()).containsExactly(initialDependency);
+
+        catalog.alterView(
+                viewIdentifier,
+                Collections.singletonList(
+                        ViewChange.updateDependencies(
+                                Collections.singletonList(updatedDependency))),
+                false);
+
+        assertThat(catalog.getView(viewIdentifier).dependencies())
+                .containsExactly(updatedDependency);
+        listedViews =
+                catalog.listViewDetailsPaged(viewIdentifier.getDatabaseName(), null, null, null)
+                        .getElements();
+        assertThat(listedViews).hasSize(1);
+        assertThat(listedViews.get(0).dependencies()).containsExactly(updatedDependency);
+    }
+
+    @Test
+    void testReadGrantEndpointAndGrantBackedTableRead() throws Exception {
+        String database = "read_grant_db";
+        Identifier root = Identifier.create(database, "root_view");
+        Identifier dependency = Identifier.create(database, "dependency_table");
+        catalog.createDatabase(database, false);
+        catalog.createTable(dependency, DEFAULT_TABLE_SCHEMA, false);
+
+        View baseView = createView(root);
+        catalog.createView(
+                root,
+                new ViewImpl(
+                        root,
+                        baseView.rowType().getFields(),
+                        baseView.query(),
+                        baseView.dialects(),
+                        baseView.comment().orElse(null),
+                        baseView.options(),
+                        Collections.singletonList(dependency)),
+                false);
+
+        restCatalogServer.clearReceivedHeaders();
+        restCatalogServer.clearReceivedReadGrantRequests();
+        assertThat(catalog.getView(root).dependencies()).containsExactly(dependency);
+        assertThat(restCatalogServer.getReceivedReadGrantRequests()).isEmpty();
+
+        ReadAuthorizationContext readContext = ReadAuthorizationContext.forView(root);
+        catalog.getTable(dependency, readContext);
+
+        List<CreateReadGrantRequest> requests = restCatalogServer.getReceivedReadGrantRequests();
+        assertThat(requests).hasSize(1);
+        CreateReadGrantRequest request = requests.get(0);
+        assertThat(request.rootType()).isEqualTo(ReadAuthorizationRootType.VIEW);
+        assertThat(request.rootIdentifier()).isEqualTo(root);
+        assertThat(request.targets()).containsExactly(ReadAuthorizationResource.table(dependency));
+        assertThat(request.previousReadGrant()).isNull();
+
+        String readGrant =
+                readContext
+                        .readGrant()
+                        .orElseThrow(() -> new AssertionError("No read grant was installed"));
+        assertThat(readContext.authorizedResources())
+                .containsExactly(ReadAuthorizationResource.table(dependency));
+        assertThat(restCatalogServer.getReceivedHeaders())
+                .extracting(headers -> headers.get(RESTApi.READ_GRANT_HEADER.toLowerCase()))
+                .contains(readGrant);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/MockRESTMessage.java
@@ -270,7 +270,7 @@ public class MockRESTMessage {
 
     public static GetTableTokenResponse getTableCredentialsResponse() {
         return new GetTableTokenResponse(
-                ImmutableMap.of("key", "value"), System.currentTimeMillis());
+                ImmutableMap.of("key", "value"), System.currentTimeMillis() + 1_000L);
     }
 
     public static RollbackTableRequest rollbackTableRequestBySnapshot(long snapshotId) {

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTApiJsonTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.paimon.rest;
 
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationResource;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
 import org.apache.paimon.rest.requests.AlterDatabaseRequest;
 import org.apache.paimon.rest.requests.AlterFunctionRequest;
 import org.apache.paimon.rest.requests.AlterTableRequest;
@@ -25,6 +28,7 @@ import org.apache.paimon.rest.requests.AlterViewRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreateFunctionRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
+import org.apache.paimon.rest.requests.CreateReadGrantRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
 import org.apache.paimon.rest.requests.DropPartitionsRequest;
@@ -39,6 +43,7 @@ import org.apache.paimon.rest.responses.DropPartitionsResponse;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.GetDatabaseResponse;
 import org.apache.paimon.rest.responses.GetFunctionResponse;
+import org.apache.paimon.rest.responses.GetReadGrantResponse;
 import org.apache.paimon.rest.responses.GetTableResponse;
 import org.apache.paimon.rest.responses.GetTableTokenResponse;
 import org.apache.paimon.rest.responses.GetViewResponse;
@@ -336,6 +341,44 @@ public class RESTApiJsonTest {
         assertEquals(response.getId(), parseData.getId());
         assertEquals(response.getName(), parseData.getName());
         assertEquals(response.getSchema(), parseData.getSchema());
+    }
+
+    @Test
+    public void readGrantRequestAndResponseParseTest() throws Exception {
+        Identifier dependency = Identifier.create("db", "table");
+        Identifier root = Identifier.create("db", "root");
+        ReadAuthorizationResource target = ReadAuthorizationResource.table(dependency);
+        CreateReadGrantRequest initialRequest =
+                new CreateReadGrantRequest(
+                        ReadAuthorizationRootType.TABLE,
+                        root,
+                        Collections.singletonList(target),
+                        null);
+        CreateReadGrantRequest renewalRequest =
+                new CreateReadGrantRequest(
+                        ReadAuthorizationRootType.TABLE,
+                        root,
+                        Collections.emptyList(),
+                        "expired-grant");
+        String initialRequestJson = RESTApi.toJson(initialRequest);
+        CreateReadGrantRequest parsedInitialRequest =
+                RESTApi.fromJson(initialRequestJson, CreateReadGrantRequest.class);
+        CreateReadGrantRequest parsedRequest =
+                RESTApi.fromJson(RESTApi.toJson(renewalRequest), CreateReadGrantRequest.class);
+        assertEquals(Collections.singletonList(target), parsedInitialRequest.targets());
+        assertTrue(initialRequestJson.contains("\"targets\""));
+        assertFalse(initialRequestJson.contains("\"source\""));
+        assertFalse(initialRequestJson.contains("\"dependencies\""));
+        assertEquals(ReadAuthorizationRootType.TABLE, parsedRequest.rootType());
+        assertEquals(root, parsedRequest.rootIdentifier());
+        assertEquals(Collections.emptyList(), parsedRequest.targets());
+        assertEquals("expired-grant", parsedRequest.previousReadGrant());
+
+        GetReadGrantResponse response = new GetReadGrantResponse("read-grant", 123L);
+        GetReadGrantResponse parsedResponse =
+                RESTApi.fromJson(RESTApi.toJson(response), GetReadGrantResponse.class);
+        assertEquals("read-grant", parsedResponse.getReadGrant());
+        assertEquals(123L, parsedResponse.getExpiresAtMillis());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogServer.java
@@ -59,6 +59,7 @@ import org.apache.paimon.rest.requests.CreateBranchRequest;
 import org.apache.paimon.rest.requests.CreateDatabaseRequest;
 import org.apache.paimon.rest.requests.CreateFunctionRequest;
 import org.apache.paimon.rest.requests.CreatePartitionsRequest;
+import org.apache.paimon.rest.requests.CreateReadGrantRequest;
 import org.apache.paimon.rest.requests.CreateTableRequest;
 import org.apache.paimon.rest.requests.CreateTagRequest;
 import org.apache.paimon.rest.requests.CreateViewRequest;
@@ -80,6 +81,7 @@ import org.apache.paimon.rest.responses.DropPartitionsResponse;
 import org.apache.paimon.rest.responses.ErrorResponse;
 import org.apache.paimon.rest.responses.GetDatabaseResponse;
 import org.apache.paimon.rest.responses.GetFunctionResponse;
+import org.apache.paimon.rest.responses.GetReadGrantResponse;
 import org.apache.paimon.rest.responses.GetTableResponse;
 import org.apache.paimon.rest.responses.GetTableSnapshotResponse;
 import org.apache.paimon.rest.responses.GetTableTokenResponse;
@@ -226,6 +228,8 @@ public class RESTCatalogServer {
     private final ResourcePaths resourcePaths;
 
     private final List<Map<String, String>> receivedHeaders = new ArrayList<>();
+    private final Queue<CreateReadGrantRequest> receivedReadGrantRequests =
+            new ConcurrentLinkedQueue<>();
 
     private volatile boolean partitionListingSupported = true;
 
@@ -380,6 +384,9 @@ public class RESTCatalogServer {
                                     .queryParameter(WAREHOUSE.key())
                                     .equals(warehouse)) {
                         return mockResponse(configResponse, 200);
+                    } else if ("POST".equals(request.getMethod())
+                            && resourcePaths.readGrant().equals(resourcePath)) {
+                        return readGrantHandle(data);
                     } else if (databaseUri.equals(request.getPath())
                             || request.getPath().contains(databaseUri + "?")) {
                         return databasesApiHandler(restAuthParameter.method(), data, parameters);
@@ -534,7 +541,10 @@ public class RESTCatalogServer {
                             }
                         }
                         // validate partition
-                        if (isPartitions || isMarkDonePartitions || isDropPartitions) {
+                        if (isPartitions
+                                || isMarkDonePartitions
+                                || isDropPartitions
+                                || isListPartitionsByNames) {
                             String tableName = RESTUtil.decodeString(resources[2]);
                             Optional<MockResponse> error =
                                     checkTablePartitioned(
@@ -854,6 +864,18 @@ public class RESTCatalogServer {
         return new MockResponse()
                 .setResponseCode(200)
                 .setBody(RESTApi.toJson(getTableTokenResponse));
+    }
+
+    private MockResponse readGrantHandle(String data) throws Exception {
+        // Protocol-only mock: production servers must validate root permission and dependency
+        // reachability before issuing a grant.
+        CreateReadGrantRequest request = RESTApi.fromJson(data, CreateReadGrantRequest.class);
+        receivedReadGrantRequests.add(request);
+        GetReadGrantResponse response =
+                new GetReadGrantResponse(
+                        "mock-read-grant-" + UUID.randomUUID(),
+                        System.currentTimeMillis() + Duration.ofMinutes(5).toMillis());
+        return mockResponse(response, 200);
     }
 
     private MockResponse snapshotHandle(Identifier identifier) throws Exception {
@@ -2387,7 +2409,8 @@ public class RESTCatalogServer {
                                 schema.query(),
                                 schema.dialects(),
                                 schema.comment(),
-                                schema.options());
+                                schema.options(),
+                                schema.dependencies());
                 if (viewStore.containsKey(identifier.getFullName())) {
                     throw new Catalog.ViewAlreadyExistException(identifier);
                 }
@@ -2483,7 +2506,8 @@ public class RESTCatalogServer {
                                             view.query(),
                                             view.dialects(),
                                             view.comment().orElse(null),
-                                            view.options());
+                                            view.options(),
+                                            view.dependencies());
                             return new GetViewResponse(
                                     "id",
                                     identifier.getTableName(),
@@ -2590,7 +2614,8 @@ public class RESTCatalogServer {
                                         view.query(),
                                         view.dialects(),
                                         view.comment().orElse(null),
-                                        view.options());
+                                        view.options(),
+                                        view.dependencies());
                         response =
                                 new GetViewResponse(
                                         "id",
@@ -2614,6 +2639,7 @@ public class RESTCatalogServer {
                         ViewImpl view = (ViewImpl) viewStore.get(identifier.getFullName());
                         HashMap<String, String> newDialects = new HashMap<>(view.dialects());
                         Map<String, String> newOptions = new HashMap<>(view.options());
+                        List<Identifier> newDependencies = view.dependencies();
                         String newComment = view.comment().orElse(null);
                         for (ViewChange viewChange : request.viewChanges()) {
                             if (viewChange instanceof ViewChange.SetViewOption) {
@@ -2657,6 +2683,9 @@ public class RESTCatalogServer {
                                     throw new Catalog.DialectNotExistException(
                                             identifier, dropDialect.dialect());
                                 }
+                            } else if (viewChange instanceof ViewChange.UpdateDependencies) {
+                                newDependencies =
+                                        ((ViewChange.UpdateDependencies) viewChange).dependencies();
                             }
                         }
                         view =
@@ -2666,7 +2695,8 @@ public class RESTCatalogServer {
                                         view.query(),
                                         newDialects,
                                         newComment,
-                                        newOptions);
+                                        newOptions,
+                                        newDependencies);
                         viewStore.put(identifier.getFullName(), view);
                         return new MockResponse().setResponseCode(200);
                     } else {
@@ -3104,5 +3134,13 @@ public class RESTCatalogServer {
 
     public void clearReceivedHeaders() {
         receivedHeaders.clear();
+    }
+
+    public List<CreateReadGrantRequest> getReceivedReadGrantRequests() {
+        return new ArrayList<>(receivedReadGrantRequests);
+    }
+
+    public void clearReceivedReadGrantRequests() {
+        receivedReadGrantRequests.clear();
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/CatalogEnvironmentTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
+import org.apache.paimon.catalog.ReadAuthorizationRootType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CatalogEnvironment}. */
+class CatalogEnvironmentTest {
+
+    private static final Identifier TABLE = Identifier.create("db", "table");
+    private static final Identifier VIEW = Identifier.create("db", "view");
+
+    @Test
+    void testDirectTableCreatesFreshDependencyContextPerRead() {
+        CatalogEnvironment environment =
+                new CatalogEnvironment(TABLE, null, null, null, null, null, false, false);
+
+        ReadAuthorizationContext first = environment.dependencyReadContext();
+        ReadAuthorizationContext second = environment.dependencyReadContext();
+
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.authorizationRootType()).contains(ReadAuthorizationRootType.TABLE);
+        assertThat(first.authorizationRoot()).contains(TABLE);
+        assertThat(first.readGrant()).isEmpty();
+    }
+
+    @Test
+    void testDependencyReachedThroughViewPreservesOutermostRoot() {
+        ReadAuthorizationContext viewContext = ReadAuthorizationContext.forView(VIEW);
+        CatalogEnvironment environment =
+                new CatalogEnvironment(
+                        TABLE, null, null, null, null, null, false, false, viewContext);
+
+        assertThat(environment.dependencyReadContext()).isSameAs(viewContext);
+    }
+
+    @Test
+    void testEnvironmentWithoutIdentifierRemainsDirect() {
+        assertThat(CatalogEnvironment.empty().dependencyReadContext().isDirect()).isTrue();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/tag/SnapshotLoaderImplCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/tag/SnapshotLoaderImplCompatibilityTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.tag;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ObjectStreamClass;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Serialization compatibility tests for {@link SnapshotLoaderImpl}. */
+class SnapshotLoaderImplCompatibilityTest {
+
+    @Test
+    void testSerialVersionUidMatchesPreReadContextImplementation() {
+        assertThat(ObjectStreamClass.lookup(SnapshotLoaderImpl.class).getSerialVersionUID())
+                .isEqualTo(3096335741107585269L);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/utils/BlobViewLookupTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.ReadAuthorizationContext;
+import org.apache.paimon.data.BlobViewStruct;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link BlobViewLookup}. */
+class BlobViewLookupTest {
+
+    @Test
+    void testUpstreamTablesUseOriginatingReadAuthorization() throws Exception {
+        Identifier root = Identifier.create("db", "blob_table");
+        Identifier upstream = Identifier.create("db", "upstream");
+        ReadAuthorizationContext readContext = ReadAuthorizationContext.forTable(root);
+        Catalog catalog = mock(Catalog.class);
+        Table table = mock(Table.class);
+        ReadBuilder readBuilder = mock(ReadBuilder.class);
+        TableScan scan = mock(TableScan.class);
+        TableScan.Plan plan = mock(TableScan.Plan.class);
+        TableRead read = mock(TableRead.class);
+        @SuppressWarnings("unchecked")
+        RecordReader<InternalRow> reader = mock(RecordReader.class);
+
+        when(catalog.getTable(upstream, readContext)).thenReturn(table);
+        when(table.rowType())
+                .thenReturn(
+                        new RowType(
+                                Collections.singletonList(
+                                        new DataField(7, "blob", DataTypes.BLOB()))));
+        when(table.copy(any())).thenReturn(table);
+        when(table.newReadBuilder()).thenReturn(readBuilder);
+        when(readBuilder.withReadType(any())).thenReturn(readBuilder);
+        when(readBuilder.withRowRanges(any())).thenReturn(readBuilder);
+        when(readBuilder.newScan()).thenReturn(scan);
+        when(scan.plan()).thenReturn(plan);
+        when(readBuilder.newRead()).thenReturn(read);
+        when(read.createReader(plan)).thenReturn(reader);
+        when(reader.readBatch()).thenReturn(null);
+
+        BlobViewLookup.createResolver(
+                CatalogContext.create(new Options()),
+                Collections.singletonList(new BlobViewStruct(upstream, 7, 1L)),
+                readContext,
+                ignored -> catalog);
+
+        verify(catalog, atLeast(2)).getTable(upstream, readContext);
+        verify(catalog, never()).getTable(upstream);
+    }
+}


### PR DESCRIPTION
## Purpose

Prevent dependency-permission penetration without assuming that every dependency is known when a root resource is loaded. Views and ordinary tables can discover TABLE or VIEW dependencies at runtime; nested views and Blob View data are the motivating cases.

This is the core/REST protocol PR split from the discussion in #8112. Apache Paimon does not contain a deployable production REST server, so this PR defines the reusable client protocol and the authorization responsibilities of a server. The mock REST server only exercises the wire flow; it is not a production authorization implementation.

## Changes

- Add `ReadAuthorizationContext` with typed TABLE/VIEW resources.
- Keep initial root loading unchanged: direct `getView(root)` and `getTable(root)` do not request a grant.
- Lazily request or extend a grant only when the engine reads a discovered dependency.
- Use one generic `POST /v1/{prefix}/read-grant` endpoint for table and view roots. The request carries the outermost root, newly discovered typed targets, and an optional opaque previous grant.
- Treat the root and targets supplied by the client as untrusted. A server must independently authenticate the principal, recheck root permission, and decide whether each requested target belongs to the root's dependency closure before issuing a grant.
- Keep the outermost authorization root across nested reads, supporting chains such as `view1 -> view2 -> view3 -> tableA` and ordinary-table Blob dependencies.
- Return only an opaque short-lived grant and its expiry. The client records targets approved by the corresponding request and renews once when the server returns `403` with `resourceType: READ_GRANT`.
- Preserve view dependencies across REST create/get/list/alter operations and support `ViewChange.UpdateDependencies`.
- Authorize local system-table projections through their origin TABLE grant because the projection is constructed locally.
- When REST data tokens are enabled for a grant-backed read, require the returned storage credential to be read-only, target-scoped, and no longer-lived than the grant. Direct FileIO behavior is unchanged when REST data tokens are not used.
- Add a minimal test-only read-grant endpoint and integration coverage for dependency round trips, lazy grant acquisition, and grant-header propagation.

## Security contract

- A root identifier or client-declared dependency grants no access by itself.
- The deployable REST server is responsible for authenticating the principal, authorizing the root, validating dependency reachability according to its trusted policy, enforcing graph limits, and binding the issued grant to the principal, root, approved typed targets, and expiry.
- Read grants authorize reads only and must never authorize mutations.
- Client-side target tracking is an optimization and protocol state, not an authorization decision.
- This protocol does not require root/intermediate versions, semantic fingerprints, or table metadata epochs. Servers may apply stricter internal invalidation policies without changing the wire contract.

## Validation

- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=BlobDescriptorReaderFactoryTest test` — 4 tests passed
- `mvn -pl paimon-core -am -Pfast-build -DfailIfNoTests=false -DwildcardSuites=none -Dtest=MockRESTCatalogTest,RESTApiJsonTest test` — 154 tests passed
- `mvn -pl paimon-core -am -DskipTests compile` passed with checkstyle, Spotless, and enforcer enabled
- OpenAPI YAML parsing and `git diff --check` passed
