### PR TITLE
[format] Support Map<X, Blob> type for Blob File Format

### DIFF
--- a/docs/docs/concepts/spec/fileformat.md
+++ b/docs/docs/concepts/spec/fileformat.md
@@ -849,9 +849,9 @@ BLOB files use the `.blob` extension and have the following structure:
 +------------------+
 ```
 
-Each physical BLOB file stores one logical field. The field can be either `BLOB` or
-`ARRAY<BLOB>`. For `ARRAY<BLOB>`, the variable-length data area in an entry uses the
-following nested payload:
+Each physical BLOB file stores one logical field. The field can be `BLOB`,
+`ARRAY<BLOB>`, or `MAP<K, BLOB>`. For `ARRAY<BLOB>`, the variable-length data area in
+an entry uses the following nested payload:
 
 ```
 +----------------------+-----------------------------------------------+
@@ -864,10 +864,33 @@ following nested payload:
 +----------------------+-----------------------------------------------+
 ```
 
-An element length of `-1` represents a null array element. At the outer file index
-level, `-1` represents a null field and `-2` represents a field placeholder used by
-data evolution. An empty array is encoded with an element count of zero and an empty
-element index; it is distinct from a null array.
+An element length of `-1` represents a null array element. An empty array is encoded
+with an element count of zero and an empty element index; it is distinct from a null
+array.
+
+For `MAP<K, BLOB>`, the variable-length data area uses the following nested payload:
+
+```
++----------------------+-----------------------------------------------+
+| Map Magic Number     | 4 bytes (1296188226, Little Endian)           |
+| Map Version          | 1 byte                                        |
+| Entry Count          | 4 bytes (Little Endian)                       |
+| Key Data             | Concatenated bytes of all non-null keys       |
+| Blob Data            | Concatenated bytes of all non-null values     |
+| Key Length Index     | Delta-Varint compressed key lengths           |
+| Blob Length Index    | Delta-Varint compressed Blob lengths          |
+| Key Index Length     | 4 bytes (Little Endian)                       |
+| Blob Index Length    | 4 bytes (Little Endian)                       |
++----------------------+-----------------------------------------------+
+```
+
+The key and Blob length indexes are aligned by entry position. A length of `-1`
+represents null, while zero represents an empty key or Blob. Supported key types are
+the integer family, `CHAR`, and `VARCHAR`. An empty map has an entry count of zero and
+is distinct from a null map.
+
+At the outer file index level, `-1` represents a null field and `-2` represents a
+field placeholder used by data evolution.
 
 Key features:
 - **CRC32 Checksums**: Each blob entry has a CRC32 checksum for data integrity verification
@@ -875,7 +898,7 @@ Key features:
 - **Delta-Varint Compression**: The index uses delta-varint compression for space efficiency
 
 Limitations:
-1. BLOB format only supports a single `BLOB` or `ARRAY<BLOB>` field per physical file.
+1. BLOB format only supports a single `BLOB`, `ARRAY<BLOB>`, or `MAP<K, BLOB>` field per physical file.
 2. BLOB format does not support predicate pushdown.
 3. Statistics collection is not supported for BLOB columns.
 

--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -29,7 +29,7 @@ under the License.
 
 ## Overview
 
-The `BLOB` (Binary Large Object) type is a data type designed for storing multimodal data such as images, videos, audio files, and other large binary objects in Paimon tables. Unlike traditional `BYTES` type which stores binary data inline with other columns, `BLOB` type stores large binary data in separate files and maintains references to them, providing better performance for large objects. A field can also use `ARRAY<BLOB>` to store an ordered collection of blobs, including null arrays and null elements.
+The `BLOB` (Binary Large Object) type is a data type designed for storing multimodal data such as images, videos, audio files, and other large binary objects in Paimon tables. Unlike traditional `BYTES` type which stores binary data inline with other columns, `BLOB` type stores large binary data in separate files and maintains references to them, providing better performance for large objects. A field can also use `ARRAY<BLOB>` for an ordered collection or `MAP<K, BLOB>` for keyed blobs.
 
 The Blob Storage is based on Data Evolution mode.
 
@@ -76,7 +76,7 @@ Paimon supports three storage modes for BLOB fields, selected via **comment dire
 
 1. **Default blob storage** (`__BLOB_FIELD`)
    Blob bytes are written to Paimon-managed `.blob` files under the table path.
-   This mode supports both `BLOB` and `ARRAY<BLOB>` fields.
+   This mode supports `BLOB`, `ARRAY<BLOB>`, and `MAP<K, BLOB>` fields.
 
 2. **Descriptor-only storage** (`__BLOB_DESCRIPTOR_FIELD`)
    Only serialized `BlobDescriptor` bytes are stored inline in data files. Paimon does not write `.blob` files for these fields, and writes must provide descriptor-based input.
@@ -85,8 +85,10 @@ Paimon supports three storage modes for BLOB fields, selected via **comment dire
    Serialized `BlobViewStruct` bytes are stored inline. The struct points to a BLOB value in an upstream table by table identifier, BLOB field, and row id. The actual blob bytes are resolved from the upstream table at read time.
 
 This allows one table to mix different storage modes for different BLOB columns.
-`ARRAY<BLOB>` is supported only by `__BLOB_FIELD`; descriptor-only and blob-view
-comment directives accept scalar BLOB fields only.
+`ARRAY<BLOB>` and `MAP<K, BLOB>` are supported only by `__BLOB_FIELD`;
+descriptor-only and blob-view comment directives accept scalar BLOB fields only.
+Map keys support the integer family, `CHAR`, and `VARCHAR`. Use non-null keys for
+compatibility across Flink, Spark, and Python.
 
 ## Table Options
 
@@ -173,7 +175,7 @@ CREATE TABLE image_table (
 
 ## Creating a Table
 
-The recommended way to create a blob table in SQL is to use the **comment directive** `__BLOB_FIELD`, `__BLOB_DESCRIPTOR_FIELD`, or `__BLOB_VIEW_FIELD` on the column. Paimon automatically converts the column type to `BLOB` and registers it in the corresponding option.
+The recommended way to create a blob table in SQL is to use the **comment directive** `__BLOB_FIELD`, `__BLOB_DESCRIPTOR_FIELD`, or `__BLOB_VIEW_FIELD` on the column. Paimon automatically converts the column to the corresponding BLOB type and registers it in the corresponding option.
 
 <Tabs groupId="blob-create-table">
 
@@ -243,7 +245,7 @@ Schema schema = Schema.newBuilder()
 import pyarrow as pa
 from pypaimon import Schema
 
-# pa.large_binary() and list_(large_binary()) are recognized as blob types.
+# Scalar, list, and map types with large_binary() values are recognized as blob types.
 pa_schema = pa.schema([
     ('id', pa.int32()),
     ('name', pa.string()),
@@ -264,13 +266,13 @@ schema = Schema.from_pyarrow_schema(
 
 </Tabs>
 
-The comment directive format is `__DIRECTIVE; optional user comment`. Paimon converts `BYTES`/`BINARY` to `BLOB` and `ARRAY<BYTES>`/`ARRAY<BINARY>` to `ARRAY<BLOB>`, registers the field in the corresponding option, and stores the text after `;` as the column's real comment.
+The comment directive format is `__DIRECTIVE; optional user comment`. Paimon converts `BYTES`/`BINARY` to `BLOB`, `ARRAY<BYTES>`/`ARRAY<BINARY>` to `ARRAY<BLOB>`, and `MAP<K, BYTES>`/`MAP<K, BINARY>` to `MAP<K, BLOB>`. It registers the field in the corresponding option and stores the text after `;` as the column's real comment.
 
 Supported directives:
 
 | Directive | Storage mode | Option |
 |-----------|-------------|--------|
-| `__BLOB_FIELD` | Raw scalar or array elements in `.blob` files | `blob-field` |
+| `__BLOB_FIELD` | Raw scalar, array elements, or map values in `.blob` files | `blob-field` |
 | `__BLOB_DESCRIPTOR_FIELD` | Descriptor bytes inline | `blob-descriptor-field` |
 | `__BLOB_VIEW_FIELD` | View reference inline | `blob-view-field` |
 
@@ -600,12 +602,12 @@ For the Python equivalent, see [Blob Storage in pypaimon](../pypaimon/blob).
 
 ## Limitations
 
-1. **Append Table Only**: Blob type is designed for append-only tables. Primary key tables are not supported.
+1. **Primary Key Tables**: Managed BLOB storage in primary-key tables has additional requirements; see [Primary-Key BLOB Storage](../primary-key-table/blob-storage).
 2. **No Predicate Pushdown**: Blob columns cannot be used in filter predicates.
 3. **No Statistics**: Statistics collection is not supported for blob columns.
-4. **Required Options**: `row-tracking.enabled` and `data-evolution.enabled` must be set to `true`.
+4. **Append Table Options**: For append tables, `row-tracking.enabled` and `data-evolution.enabled` must be set to `true`.
 5. **Blob View Dependency**: Blob view fields depend on the referenced upstream table and row. If the upstream data is removed or no longer readable, the view cannot be resolved.
-6. **Array Storage Mode**: `ARRAY<BLOB>` is supported only for raw managed blob storage (`__BLOB_FIELD`), not for `__BLOB_DESCRIPTOR_FIELD` or `__BLOB_VIEW_FIELD`.
+6. **Collection Storage Mode**: `ARRAY<BLOB>` and `MAP<K, BLOB>` are supported only for raw managed blob storage (`__BLOB_FIELD`), not for `__BLOB_DESCRIPTOR_FIELD` or `__BLOB_VIEW_FIELD`.
 
 ## Best Practices
 

--- a/docs/docs/primary-key-table/blob-storage.md
+++ b/docs/docs/primary-key-table/blob-storage.md
@@ -24,13 +24,14 @@ under the License.
 
 # BLOB Storage
 
-Primary-key tables can store top-level `BLOB` and `ARRAY<BLOB>` payloads in table-managed files. Unlike the positional
-BLOB files used by append tables, managed BLOB payloads have stable descriptors. MergeTree sorting, deduplication, and
-compaction can therefore reorder or remove rows without rewriting the surviving payload bytes.
+Primary-key tables can store top-level `BLOB`, `ARRAY<BLOB>`, and `MAP<K, BLOB>` payloads in table-managed files.
+Unlike the positional BLOB files used by append tables, managed BLOB payloads have stable descriptors. MergeTree
+sorting, deduplication, and compaction can therefore reorder or remove rows without rewriting the surviving payload
+bytes.
 
 This mode stores:
 
-- a serialized `BlobDescriptor` for each scalar value or non-null array element;
+- a serialized `BlobDescriptor` for each scalar value, non-null array element, or non-null map value;
 - the payload in an immutable `.managed.blob` pack; and
 - one `.blobref` sidecar for every data file, containing the exact managed packs referenced by that file.
 
@@ -38,7 +39,7 @@ For general BLOB concepts and read options, see [BLOB Storage](../multimodal-tab
 
 ## Create a Table
 
-Use `blob-field` to mark scalar or array fields whose payloads should be stored in managed BLOB files.
+Use `blob-field` to mark scalar, array, or map fields whose payloads should be stored in managed BLOB files.
 `blob-descriptor-field` and `blob-view-field` are inline forms: their serialized descriptor or view metadata stays in
 the normal data file and is not materialized into a managed BLOB file.
 
@@ -50,6 +51,7 @@ CREATE TABLE media (
     name STRING,
     content BYTES COMMENT '__BLOB_FIELD; media content',
     attachments ARRAY<BYTES> COMMENT '__BLOB_FIELD; related files',
+    renditions MAP<STRING, BYTES> COMMENT '__BLOB_FIELD; named renditions',
     PRIMARY KEY (id) NOT ENFORCED
 ) WITH (
     'merge-engine' = 'deduplicate',
@@ -58,7 +60,7 @@ CREATE TABLE media (
 );
 
 INSERT INTO media VALUES
-    (1, 'logo', X'89504E470D0A1A0A', ARRAY[X'25504446', NULL]);
+    (1, 'logo', X'89504E470D0A1A0A', ARRAY[X'25504446', NULL], MAP['thumbnail', X'89504E47']);
 ```
 
 For a primary-key table, every non-null `Blob` value in a `blob-field` is externalized before it enters the MergeTree
@@ -90,6 +92,10 @@ including external tables in REST catalogs, are not supported. When this option 
 array order, a null array, and null elements are preserved. An empty array writes no payload. `ARRAY<BLOB>` uses
 `blob-field`; `blob-descriptor-field` and `blob-view-field` remain scalar-only declarations.
 
+`MAP<K, BLOB>` is externalized value by value. Keys remain in the normal data file and every non-null value is replaced
+with a descriptor to managed storage. A null map, an empty map, and null values are preserved. Supported key types are
+the integer family, `CHAR`, and `VARCHAR`; `blob-descriptor-field` and `blob-view-field` remain scalar-only declarations.
+
 `blob.target-file-size` controls when a writer rolls to a new managed payload pack. A pack can contain payloads from
 multiple rows, and a row descriptor records its URI, offset, and length.
 
@@ -107,7 +113,7 @@ Primary-key managed BLOB storage has the following requirements:
 
 | Item | Requirement |
 |------|-------------|
-| Managed BLOB declaration | Scalar `BLOB` and `ARRAY<BLOB>` use `blob-field`; `blob-descriptor-field` remains inline |
+| Managed BLOB declaration | `BLOB`, `ARRAY<BLOB>`, and `MAP<K, BLOB>` use `blob-field`; `blob-descriptor-field` remains inline |
 | Merge engine | `deduplicate` only |
 | Changelog producer | `none` only |
 | Key usage | A managed BLOB column cannot be a primary, partition, bucket, or sequence key |
@@ -118,9 +124,9 @@ Primary-key managed BLOB storage has the following requirements:
 
 ## Update, Delete, and Compaction
 
-An update writes a new descriptor and managed payload when a scalar value or array element changes. A delete record does
-not write a new payload. Deduplication determines the final rows of each data file, and its `.blobref` sidecar contains
-only the managed packs referenced by those rows.
+An update writes a new descriptor and managed payload when a scalar value, array element, or map value changes. A delete
+record does not write a new payload. Deduplication determines the final rows of each data file, and its `.blobref`
+sidecar contains only the managed packs referenced by those rows.
 
 Compaction preserves descriptors for surviving values and creates new `.blobref` sidecars from the compacted output.
 It does not copy the referenced payload bytes into new `.managed.blob` packs. This keeps ordinary compaction cost

--- a/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
@@ -118,6 +118,25 @@ public final class BlobType extends DataType {
         if (type.getTypeRoot() == DataTypeRoot.ARRAY) {
             return ((ArrayType) type).getElementType().getTypeRoot() == DataTypeRoot.BLOB;
         }
+        if (type.getTypeRoot() == DataTypeRoot.MAP) {
+            MapType mapType = (MapType) type;
+            return mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB
+                    && isSupportedMapBlobKeyType(mapType.getKeyType());
+        }
         return false;
+    }
+
+    private static boolean isSupportedMapBlobKeyType(DataType keyType) {
+        switch (keyType.getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case CHAR:
+            case VARCHAR:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/BlobType.java
@@ -119,24 +119,8 @@ public final class BlobType extends DataType {
             return ((ArrayType) type).getElementType().getTypeRoot() == DataTypeRoot.BLOB;
         }
         if (type.getTypeRoot() == DataTypeRoot.MAP) {
-            MapType mapType = (MapType) type;
-            return mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB
-                    && isSupportedMapBlobKeyType(mapType.getKeyType());
+            return ((MapType) type).getValueType().getTypeRoot() == DataTypeRoot.BLOB;
         }
         return false;
-    }
-
-    private static boolean isSupportedMapBlobKeyType(DataType keyType) {
-        switch (keyType.getTypeRoot()) {
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-            case CHAR:
-            case VARCHAR:
-                return true;
-            default:
-                return false;
-        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobMapPlaceholder.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobMapPlaceholder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data;
+
+import java.io.Serializable;
+
+/**
+ * Placeholder for a map blob field in data-evolution blob files. It should never be exposed to
+ * users.
+ */
+public final class BlobMapPlaceholder implements InternalMap, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final BlobMapPlaceholder INSTANCE = new BlobMapPlaceholder();
+
+    private BlobMapPlaceholder() {}
+
+    private Object readResolve() {
+        return INSTANCE;
+    }
+
+    private static UnsupportedOperationException unsupported() {
+        return new UnsupportedOperationException(
+                "Should never call this method for placeholder blob map.");
+    }
+
+    @Override
+    public int size() {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalArray keyArray() {
+        throw unsupported();
+    }
+
+    @Override
+    public InternalArray valueArray() {
+        throw unsupported();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
@@ -160,7 +160,11 @@ public final class ColumnarArray implements InternalArray, DataSetters, Serializ
 
     @Override
     public InternalMap getMap(int pos) {
-        return ((MapColumnVector) data).getMap(offset + pos);
+        InternalMap map = ((MapColumnVector) data).getMap(offset + pos);
+        if (map instanceof ColumnarMap) {
+            ((ColumnarMap) map).setFileIO(fileIO);
+        }
+        return map;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarMap.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarMap.java
@@ -20,6 +20,7 @@ package org.apache.paimon.data.columnar;
 
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.fs.FileIO;
 
 import java.io.Serializable;
 
@@ -32,6 +33,7 @@ public final class ColumnarMap implements InternalMap, Serializable {
     private final ColumnVector valueColumnVector;
     private final int offset;
     private final int numElements;
+    private FileIO fileIO;
 
     public ColumnarMap(
             ColumnVector keyColumnVector,
@@ -44,6 +46,10 @@ public final class ColumnarMap implements InternalMap, Serializable {
         this.numElements = numElements;
     }
 
+    void setFileIO(FileIO fileIO) {
+        this.fileIO = fileIO;
+    }
+
     @Override
     public int size() {
         return numElements;
@@ -51,12 +57,16 @@ public final class ColumnarMap implements InternalMap, Serializable {
 
     @Override
     public InternalArray keyArray() {
-        return new ColumnarArray(keyColumnVector, offset, numElements);
+        ColumnarArray array = new ColumnarArray(keyColumnVector, offset, numElements);
+        array.setFileIO(fileIO);
+        return array;
     }
 
     @Override
     public InternalArray valueArray() {
-        return new ColumnarArray(valueColumnVector, offset, numElements);
+        ColumnarArray array = new ColumnarArray(valueColumnVector, offset, numElements);
+        array.setFileIO(fileIO);
+        return array;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarRow.java
@@ -180,7 +180,11 @@ public final class ColumnarRow implements InternalRow, DataSetters, Serializable
 
     @Override
     public InternalMap getMap(int pos) {
-        return vectorizedColumnBatch.getMap(rowId, pos);
+        InternalMap map = vectorizedColumnBatch.getMap(rowId, pos);
+        if (map instanceof ColumnarMap) {
+            ((ColumnarMap) map).setFileIO(fileIO);
+        }
+        return map;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalMapSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/InternalMapSerializer.java
@@ -22,6 +22,8 @@ import org.apache.paimon.data.BinaryArray;
 import org.apache.paimon.data.BinaryArrayWriter;
 import org.apache.paimon.data.BinaryMap;
 import org.apache.paimon.data.BinaryWriter;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.io.DataInputView;
@@ -29,9 +31,11 @@ import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySegmentUtils;
 import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Serializer for {@link InternalMap}. */
@@ -88,9 +92,25 @@ public class InternalMapSerializer implements Serializer<InternalMap> {
     public InternalMap copy(InternalMap from) {
         if (from instanceof BinaryMap) {
             return ((BinaryMap) from).copy();
+        } else if (valueType.getTypeRoot() == DataTypeRoot.BLOB) {
+            return copyBlobMap(from);
         } else {
             return toBinaryMap(from);
         }
+    }
+
+    private GenericMap copyBlobMap(InternalMap map) {
+        Map<Object, Object> copied = new LinkedHashMap<>();
+        InternalArray keys = map.keyArray();
+        InternalArray values = map.valueArray();
+        for (int i = 0; i < map.size(); i++) {
+            Object key = keyGetter.getElementOrNull(keys, i);
+            Blob value = (Blob) valueGetter.getElementOrNull(values, i);
+            copied.put(
+                    key == null ? null : keySerializer.copy(key),
+                    value == null ? null : valueSerializer.copy(value));
+        }
+        return new GenericMap(copied);
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/InternalMapSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/InternalMapSerializerTest.java
@@ -22,19 +22,32 @@ import org.apache.paimon.data.BinaryArray;
 import org.apache.paimon.data.BinaryArrayWriter;
 import org.apache.paimon.data.BinaryMap;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.columnar.ColumnarArray;
+import org.apache.paimon.data.columnar.heap.HeapBytesVector;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.paimon.data.serializer.InternalMapSerializer.convertToJavaMap;
+import static org.apache.paimon.types.DataTypes.BLOB;
 import static org.apache.paimon.types.DataTypes.INT;
 import static org.apache.paimon.types.DataTypes.STRING;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link InternalMapSerializer}. */
 public class InternalMapSerializerTest extends SerializerTestBase<InternalMap> {
@@ -84,6 +97,48 @@ public class InternalMapSerializerTest extends SerializerTestBase<InternalMap> {
     protected InternalMap[] getSerializableTestData() {
         InternalMap[] testData = getTestData();
         return Arrays.copyOfRange(testData, 0, testData.length - 1);
+    }
+
+    @Test
+    void testCopyColumnarBlobMapPreservesReader(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        byte[] payload = "blob-payload".getBytes(StandardCharsets.UTF_8);
+        Path path = new Path(tempDir.resolve("blob.data").toUri());
+        try (PositionOutputStream out = fileIO.newOutputStream(path, false)) {
+            out.write(payload);
+        }
+
+        byte[] descriptor = new BlobDescriptor(path.toString(), 0, payload.length).serialize();
+        HeapBytesVector values = new HeapBytesVector(2);
+        values.putByteArray(0, descriptor, 0, descriptor.length);
+        values.setNullAt(1);
+        ColumnarArray valueArray = new ColumnarArray(values, 0, 2);
+        valueArray.setFileIO(fileIO);
+        InternalMap map =
+                new InternalMap() {
+                    @Override
+                    public int size() {
+                        return 2;
+                    }
+
+                    @Override
+                    public InternalArray keyArray() {
+                        return new GenericArray(new Object[] {1, 2});
+                    }
+
+                    @Override
+                    public InternalArray valueArray() {
+                        return valueArray;
+                    }
+                };
+
+        InternalMap copied = new InternalMapSerializer(INT(), BLOB()).copy(map);
+
+        assertThat(copied).isInstanceOf(GenericMap.class);
+        assertThat(copied.keyArray().getInt(0)).isEqualTo(1);
+        assertThat(copied.valueArray().getBlob(0).toData()).isEqualTo(payload);
+        assertThat(copied.valueArray().isNullAt(1)).isTrue();
     }
 
     private static BinaryArray createArray(int... vs) {

--- a/paimon-core/src/main/java/org/apache/paimon/blob/ManagedBlobReferenceCollector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/blob/ManagedBlobReferenceCollector.java
@@ -22,6 +22,7 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.types.DataTypeRoot;
@@ -34,7 +35,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.paimon.types.BlobType.isBlobFileField;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Collects exact managed BLOB dependencies from the final rows of one data file. */
@@ -43,7 +43,7 @@ public class ManagedBlobReferenceCollector {
     private final FileIO fileIO;
     private final Path sidecar;
     private final int[] blobFieldIndexes;
-    private final boolean[] blobArrayFields;
+    private final DataTypeRoot[] blobFieldTypeRoots;
     private final Set<String> descriptorUris;
 
     private boolean closed;
@@ -53,26 +53,19 @@ public class ManagedBlobReferenceCollector {
         this.fileIO = fileIO;
         this.sidecar = ManagedBlobReferenceFile.sidecarPath(dataFile);
         List<Integer> indexes = new ArrayList<>();
-        List<Boolean> arrayFields = new ArrayList<>();
+        List<DataTypeRoot> typeRoots = new ArrayList<>();
         for (int i = 0; i < valueType.getFieldCount(); i++) {
             if (!managedBlobFields.contains(valueType.getFieldNames().get(i))) {
                 continue;
             }
             DataTypeRoot typeRoot = valueType.getTypeAt(i).getTypeRoot();
-            checkArgument(
-                    typeRoot != DataTypeRoot.MAP,
-                    "Primary-key managed MAP<X, BLOB> field '%s' is not supported.",
-                    valueType.getFieldNames().get(i));
             if (isBlobFileField(valueType.getTypeAt(i))) {
                 indexes.add(i);
-                arrayFields.add(typeRoot == DataTypeRoot.ARRAY);
+                typeRoots.add(typeRoot);
             }
         }
         this.blobFieldIndexes = indexes.stream().mapToInt(Integer::intValue).toArray();
-        this.blobArrayFields = new boolean[arrayFields.size()];
-        for (int i = 0; i < arrayFields.size(); i++) {
-            blobArrayFields[i] = arrayFields.get(i);
-        }
+        this.blobFieldTypeRoots = typeRoots.toArray(new DataTypeRoot[0]);
         this.descriptorUris = new HashSet<>();
     }
 
@@ -87,11 +80,19 @@ public class ManagedBlobReferenceCollector {
             if (keyValue.value().isNullAt(fieldIndex)) {
                 continue;
             }
-            if (blobArrayFields[i]) {
+            if (blobFieldTypeRoots[i] == DataTypeRoot.ARRAY) {
                 InternalArray array = keyValue.value().getArray(fieldIndex);
                 for (int j = 0; j < array.size(); j++) {
                     if (!array.isNullAt(j)) {
                         collect(array.getBlob(j));
+                    }
+                }
+            } else if (blobFieldTypeRoots[i] == DataTypeRoot.MAP) {
+                InternalMap map = keyValue.value().getMap(fieldIndex);
+                InternalArray values = map.valueArray();
+                for (int j = 0; j < map.size(); j++) {
+                    if (!values.isNullAt(j)) {
+                        collect(values.getBlob(j));
                     }
                 }
             } else {

--- a/paimon-core/src/main/java/org/apache/paimon/blob/ManagedBlobReferenceCollector.java
+++ b/paimon-core/src/main/java/org/apache/paimon/blob/ManagedBlobReferenceCollector.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.paimon.types.BlobType.isBlobFileField;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Collects exact managed BLOB dependencies from the final rows of one data file. */
@@ -58,6 +59,10 @@ public class ManagedBlobReferenceCollector {
                 continue;
             }
             DataTypeRoot typeRoot = valueType.getTypeAt(i).getTypeRoot();
+            checkArgument(
+                    typeRoot != DataTypeRoot.MAP,
+                    "Primary-key managed MAP<X, BLOB> field '%s' is not supported.",
+                    valueType.getFieldNames().get(i));
             if (isBlobFileField(valueType.getTypeAt(i))) {
                 indexes.add(i);
                 arrayFields.add(typeRoot == DataTypeRoot.ARRAY);

--- a/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
@@ -22,8 +22,10 @@ import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobFetchMetricReporter;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.blob.BlobFormatWriter;
 import org.apache.paimon.fs.FileIO;
@@ -32,30 +34,51 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.io.DataFilePathFactory;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.InternalRowUtils;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Externalizes primary-key BLOB values before they enter the MergeTree write buffer. */
 public class PrimaryKeyBlobExternalizer {
 
+    private static final RowType BLOB_ROW_TYPE = RowType.of(DataTypes.BLOB());
+
     private final FileIO fileIO;
     private final RowDataToObjectArrayConverter rowConverter;
-    private final int[] blobFieldIndexes;
-    private final boolean[] blobArrayFields;
-    private final ManagedBlobPackWriter[] packWriters;
+    private final ManagedBlobField[] blobFields;
     private final List<Path> uncommittedPacks;
+
+    public PrimaryKeyBlobExternalizer(
+            FileIO fileIO,
+            RowType valueType,
+            Set<String> managedBlobFields,
+            DataFilePathFactory pathFactory,
+            long targetFileSize) {
+        this(
+                fileIO,
+                valueType,
+                managedBlobFields,
+                pathFactory,
+                targetFileSize,
+                BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+    }
 
     public PrimaryKeyBlobExternalizer(
             FileIO fileIO,
@@ -69,9 +92,7 @@ public class PrimaryKeyBlobExternalizer {
         this.rowConverter = new RowDataToObjectArrayConverter(valueType);
         this.uncommittedPacks = new ArrayList<>();
 
-        List<Integer> indexes = new ArrayList<>();
-        List<Boolean> arrayFields = new ArrayList<>();
-        List<ManagedBlobPackWriter> writers = new ArrayList<>();
+        List<ManagedBlobField> blobFields = new ArrayList<>();
         Set<String> unknownFields = new TreeSet<>(managedBlobFields);
         for (int i = 0; i < valueType.getFieldCount(); i++) {
             DataField field = valueType.getFields().get(i);
@@ -84,42 +105,37 @@ public class PrimaryKeyBlobExternalizer {
                     field.type().getTypeRoot() == DataTypeRoot.ARRAY
                             && ((ArrayType) field.type()).getElementType().getTypeRoot()
                                     == DataTypeRoot.BLOB;
+            boolean blobMap =
+                    field.type().getTypeRoot() == DataTypeRoot.MAP && isBlobFileField(field.type());
             checkArgument(
-                    field.type().getTypeRoot() != DataTypeRoot.MAP,
-                    "Primary-key managed MAP<X, BLOB> field '%s' is not supported.",
-                    field.name());
-            checkArgument(
-                    blob || blobArray,
-                    "Managed BLOB field '%s' must be BLOB or ARRAY<BLOB>, but was %s.",
+                    blob || blobArray || blobMap,
+                    "Managed BLOB field '%s' must be BLOB, ARRAY<BLOB> or MAP<X, BLOB>, but was %s.",
                     field.name(),
                     field.type());
-            indexes.add(i);
-            arrayFields.add(blobArray);
-            writers.add(
-                    new ManagedBlobPackWriter(
-                            fileIO,
-                            blobArray
-                                    ? RowType.of(((ArrayType) field.type()).getElementType())
-                                    : new RowType(Collections.singletonList(field)),
-                            pathFactory,
-                            targetFileSize,
-                            uncommittedPacks,
-                            copyBufferSize));
+            blobFields.add(
+                    new ManagedBlobField(
+                            i,
+                            field.type(),
+                            blobMap
+                                    ? InternalArray.createElementGetter(
+                                            ((MapType) field.type()).getKeyType())
+                                    : null,
+                            new ManagedBlobPackWriter(
+                                    fileIO,
+                                    pathFactory,
+                                    targetFileSize,
+                                    uncommittedPacks,
+                                    copyBufferSize)));
         }
         checkArgument(
                 unknownFields.isEmpty(),
                 "Managed BLOB fields do not exist in value type: %s.",
                 unknownFields);
-        this.blobFieldIndexes = indexes.stream().mapToInt(Integer::intValue).toArray();
-        this.blobArrayFields = new boolean[arrayFields.size()];
-        for (int i = 0; i < arrayFields.size(); i++) {
-            blobArrayFields[i] = arrayFields.get(i);
-        }
-        this.packWriters = writers.toArray(new ManagedBlobPackWriter[0]);
+        this.blobFields = blobFields.toArray(new ManagedBlobField[0]);
     }
 
     public boolean enabled() {
-        return blobFieldIndexes.length > 0;
+        return blobFields.length > 0;
     }
 
     public InternalRow externalize(RowKind valueKind, InternalRow value) throws IOException {
@@ -129,8 +145,8 @@ public class PrimaryKeyBlobExternalizer {
 
         GenericRow result = null;
         try {
-            for (int i = 0; i < blobFieldIndexes.length; i++) {
-                int fieldIndex = blobFieldIndexes[i];
+            for (ManagedBlobField blobField : blobFields) {
+                int fieldIndex = blobField.index;
                 if (value.isNullAt(fieldIndex)) {
                     continue;
                 }
@@ -140,9 +156,24 @@ public class PrimaryKeyBlobExternalizer {
                         result = copy(value);
                     }
                     result.setField(fieldIndex, null);
-                } else if (blobArrayFields[i]) {
+                } else if (blobField.type.getTypeRoot() == DataTypeRoot.ARRAY) {
                     InternalArray array = value.getArray(fieldIndex);
-                    GenericArray externalized = externalizeArray(array, packWriters[i]);
+                    GenericArray externalized = externalizeArray(array, blobField.packWriter);
+                    if (externalized != null) {
+                        if (result == null) {
+                            result = copy(value);
+                        }
+                        result.setField(fieldIndex, externalized);
+                    }
+                } else if (blobField.type.getTypeRoot() == DataTypeRoot.MAP) {
+                    InternalMap map = value.getMap(fieldIndex);
+                    MapType mapType = (MapType) blobField.type;
+                    GenericMap externalized =
+                            externalizeMap(
+                                    map,
+                                    mapType.getKeyType(),
+                                    blobField.mapKeyGetter,
+                                    blobField.packWriter);
                     if (externalized != null) {
                         if (result == null) {
                             result = copy(value);
@@ -154,7 +185,7 @@ public class PrimaryKeyBlobExternalizer {
                     if (result == null) {
                         result = copy(value);
                     }
-                    BlobDescriptor descriptor = packWriters[i].write(blob);
+                    BlobDescriptor descriptor = blobField.packWriter.write(blob);
                     result.setField(
                             fieldIndex,
                             Blob.fromFile(
@@ -195,10 +226,55 @@ public class PrimaryKeyBlobExternalizer {
         return elements == null ? null : new GenericArray(elements);
     }
 
+    private GenericMap externalizeMap(
+            InternalMap map,
+            DataType keyType,
+            InternalArray.ElementGetter keyGetter,
+            ManagedBlobPackWriter packWriter)
+            throws IOException {
+        InternalArray keys = map.keyArray();
+        InternalArray values = map.valueArray();
+        checkArgument(
+                keys.size() == map.size() && values.size() == map.size(),
+                "MAP<X, BLOB> key/value array size does not match map size.");
+
+        Map<Object, Blob> blobs = new LinkedHashMap<>();
+        for (int i = 0; i < map.size(); i++) {
+            Object key = InternalRowUtils.copy(keyGetter.getElementOrNull(keys, i), keyType);
+            blobs.put(key, values.isNullAt(i) ? null : values.getBlob(i));
+        }
+
+        boolean hasBlob = false;
+        for (Blob blob : blobs.values()) {
+            if (blob != null) {
+                hasBlob = true;
+                break;
+            }
+        }
+        if (!hasBlob) {
+            return blobs.size() == map.size() ? null : new GenericMap(blobs);
+        }
+
+        Map<Object, Object> externalized = new LinkedHashMap<>();
+        for (Map.Entry<Object, Blob> entry : blobs.entrySet()) {
+            Blob blob = entry.getValue();
+            if (blob == null) {
+                externalized.put(entry.getKey(), null);
+                continue;
+            }
+            BlobDescriptor descriptor = packWriter.write(blob);
+            externalized.put(
+                    entry.getKey(),
+                    Blob.fromFile(
+                            fileIO, descriptor.uri(), descriptor.offset(), descriptor.length()));
+        }
+        return new GenericMap(externalized);
+    }
+
     public void prepareCommit() throws IOException {
         try {
-            for (ManagedBlobPackWriter packWriter : packWriters) {
-                packWriter.closeCurrent();
+            for (ManagedBlobField blobField : blobFields) {
+                blobField.packWriter.closeCurrent();
             }
             uncommittedPacks.clear();
         } catch (IOException e) {
@@ -208,8 +284,8 @@ public class PrimaryKeyBlobExternalizer {
     }
 
     public void abort() {
-        for (ManagedBlobPackWriter packWriter : packWriters) {
-            packWriter.abortCurrent();
+        for (ManagedBlobField blobField : blobFields) {
+            blobField.packWriter.abortCurrent();
         }
         for (Path path : uncommittedPacks) {
             fileIO.deleteQuietly(path);
@@ -223,10 +299,28 @@ public class PrimaryKeyBlobExternalizer {
         return row;
     }
 
+    private static class ManagedBlobField {
+
+        private final int index;
+        private final DataType type;
+        private final InternalArray.ElementGetter mapKeyGetter;
+        private final ManagedBlobPackWriter packWriter;
+
+        private ManagedBlobField(
+                int index,
+                DataType type,
+                InternalArray.ElementGetter mapKeyGetter,
+                ManagedBlobPackWriter packWriter) {
+            this.index = index;
+            this.type = type;
+            this.mapKeyGetter = mapKeyGetter;
+            this.packWriter = packWriter;
+        }
+    }
+
     private static class ManagedBlobPackWriter {
 
         private final FileIO fileIO;
-        private final RowType blobType;
         private final DataFilePathFactory pathFactory;
         private final long targetFileSize;
         private final List<Path> uncommittedPacks;
@@ -239,13 +333,11 @@ public class PrimaryKeyBlobExternalizer {
 
         private ManagedBlobPackWriter(
                 FileIO fileIO,
-                RowType blobType,
                 DataFilePathFactory pathFactory,
                 long targetFileSize,
                 List<Path> uncommittedPacks,
                 int copyBufferSize) {
             this.fileIO = fileIO;
-            this.blobType = blobType;
             this.pathFactory = pathFactory;
             this.targetFileSize = targetFileSize;
             this.uncommittedPacks = uncommittedPacks;
@@ -281,7 +373,7 @@ public class PrimaryKeyBlobExternalizer {
                                 lastDescriptor = descriptor;
                                 return false;
                             },
-                            blobType,
+                            BLOB_ROW_TYPE,
                             false,
                             false,
                             BlobFetchMetricReporter.NOOP,

--- a/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
@@ -70,21 +70,6 @@ public class PrimaryKeyBlobExternalizer {
             RowType valueType,
             Set<String> managedBlobFields,
             DataFilePathFactory pathFactory,
-            long targetFileSize) {
-        this(
-                fileIO,
-                valueType,
-                managedBlobFields,
-                pathFactory,
-                targetFileSize,
-                BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
-    }
-
-    public PrimaryKeyBlobExternalizer(
-            FileIO fileIO,
-            RowType valueType,
-            Set<String> managedBlobFields,
-            DataFilePathFactory pathFactory,
             long targetFileSize,
             int copyBufferSize) {
         checkArgument(targetFileSize > 0, "Managed BLOB target file size must be positive.");

--- a/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizer.java
@@ -85,6 +85,10 @@ public class PrimaryKeyBlobExternalizer {
                             && ((ArrayType) field.type()).getElementType().getTypeRoot()
                                     == DataTypeRoot.BLOB;
             checkArgument(
+                    field.type().getTypeRoot() != DataTypeRoot.MAP,
+                    "Primary-key managed MAP<X, BLOB> field '%s' is not supported.",
+                    field.name());
+            checkArgument(
                     blob || blobArray,
                     "Managed BLOB field '%s' must be BLOB or ARRAY<BLOB>, but was %s.",
                     field.name(),

--- a/paimon-core/src/main/java/org/apache/paimon/operation/AllPlaceholdersRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AllPlaceholdersRecordReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.operation;
 
 import org.apache.paimon.data.BlobArrayPlaceholder;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -60,14 +61,24 @@ class AllPlaceholdersRecordReader implements FileRecordReader<InternalRow> {
         this.firstRowId = firstRowId;
         this.fieldCount = readRowType.getFieldCount();
         this.blobIndex = blobIndex;
-        this.blobPlaceholder =
-                readRowType.getTypeAt(blobIndex).getTypeRoot() == DataTypeRoot.ARRAY
-                        ? BlobArrayPlaceholder.INSTANCE
-                        : BlobPlaceholder.INSTANCE;
+        this.blobPlaceholder = blobPlaceholder(readRowType.getTypeAt(blobIndex).getTypeRoot());
         this.rowIdIndex = readRowType.getFieldIndex(SpecialFields.ROW_ID.name());
         this.seqNumIndex = readRowType.getFieldIndex(SpecialFields.SEQUENCE_NUMBER.name());
         this.sequenceNumber = sequenceNumber;
         this.selectedRanges = selectedRanges(firstRowId, rowCount, rowRanges);
+    }
+
+    private static Object blobPlaceholder(DataTypeRoot typeRoot) {
+        switch (typeRoot) {
+            case ARRAY:
+                return BlobArrayPlaceholder.INSTANCE;
+            case MAP:
+                return BlobMapPlaceholder.INSTANCE;
+            case BLOB:
+                return BlobPlaceholder.INSTANCE;
+            default:
+                throw new UnsupportedOperationException("Unsupported BlobType: " + typeRoot);
+        }
     }
 
     @Nullable

--- a/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/BlobFallbackRecordReader.java
@@ -20,6 +20,7 @@ package org.apache.paimon.operation;
 
 import org.apache.paimon.append.ForceSingleBatchReader;
 import org.apache.paimon.data.BlobArrayPlaceholder;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -226,9 +227,17 @@ public class BlobFallbackRecordReader implements RecordReader<InternalRow> {
     }
 
     private static Object blobPlaceholder(RowType rowType, int blobIndex) {
-        return rowType.getTypeAt(blobIndex).getTypeRoot() == DataTypeRoot.ARRAY
-                ? BlobArrayPlaceholder.INSTANCE
-                : BlobPlaceholder.INSTANCE;
+        DataTypeRoot typeRoot = rowType.getTypeAt(blobIndex).getTypeRoot();
+        switch (typeRoot) {
+            case ARRAY:
+                return BlobArrayPlaceholder.INSTANCE;
+            case MAP:
+                return BlobMapPlaceholder.INSTANCE;
+            case BLOB:
+                return BlobPlaceholder.INSTANCE;
+            default:
+                throw new UnsupportedOperationException("Unsupported Blob Type: " + typeRoot);
+        }
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
@@ -26,6 +26,7 @@ import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.VectorType;
 import org.apache.paimon.utils.Preconditions;
 import org.apache.paimon.utils.StringUtils;
@@ -240,10 +241,39 @@ public final class ColumnDirectiveUtils {
                 return new ArrayType(
                         sourceType.isNullable(), new BlobType(elementType.isNullable()));
             }
+            if (root == DataTypeRoot.MAP) {
+                Preconditions.checkArgument(
+                        CoreOptions.BLOB_FIELD.key().equals(directive.optionKey()),
+                        "Column %s declared with '%s' must be of BYTES, BINARY or BLOB type, but was %s. "
+                                + "MAP<X, BLOB> is only supported by '%s'.",
+                        fieldName,
+                        directive.optionKey(),
+                        sourceType,
+                        CoreOptions.BLOB_FIELD.key());
+                MapType mapType = (MapType) sourceType;
+                Preconditions.checkArgument(
+                        isBlobSourceRoot(mapType.getValueType().getTypeRoot()),
+                        "Column %s declared with a BLOB directive must have a BINARY, "
+                                + "VARBINARY or BLOB map value type, but was %s.",
+                        fieldName,
+                        sourceType);
+                MapType result =
+                        new MapType(
+                                sourceType.isNullable(),
+                                mapType.getKeyType(),
+                                new BlobType(mapType.getValueType().isNullable()));
+                Preconditions.checkArgument(
+                        BlobType.isBlobFileField(result),
+                        "Unsupported key type [%s] for MAP<X, BLOB> field '%s'.",
+                        mapType.getKeyType(),
+                        fieldName);
+                return result;
+            }
             Preconditions.checkArgument(
                     isBlobSourceRoot(root),
                     "Column %s declared with a BLOB directive must be of BYTES, BINARY, "
-                            + "BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type, but was %s.",
+                            + "BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> type, or a "
+                            + "supported MAP<X, BYTES/BINARY/BLOB> type, but was %s.",
                     fieldName,
                     sourceType);
             return new BlobType(sourceType.isNullable());
@@ -303,7 +333,7 @@ public final class ColumnDirectiveUtils {
 
     /**
      * Remove directive-managed options when a BLOB or VECTOR column is dropped. Only acts on BLOB,
-     * {@code ARRAY<BLOB>} or VECTOR type columns; other types are ignored.
+     * {@code ARRAY<BLOB>}, {@code MAP<X, BLOB>} or VECTOR type columns; other types are ignored.
      */
     public static void removeDroppedDirectiveOptions(
             String fieldName, DataType type, Map<String, String> options) {

--- a/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
@@ -257,17 +257,10 @@ public final class ColumnDirectiveUtils {
                                 + "VARBINARY or BLOB map value type, but was %s.",
                         fieldName,
                         sourceType);
-                MapType result =
-                        new MapType(
-                                sourceType.isNullable(),
-                                mapType.getKeyType(),
-                                new BlobType(mapType.getValueType().isNullable()));
-                Preconditions.checkArgument(
-                        BlobType.isBlobFileField(result),
-                        "Unsupported key type [%s] for MAP<X, BLOB> field '%s'.",
+                return new MapType(
+                        sourceType.isNullable(),
                         mapType.getKeyType(),
-                        fieldName);
-                return result;
+                        new BlobType(mapType.getValueType().isNullable()));
             }
             Preconditions.checkArgument(
                     isBlobSourceRoot(root),

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1402,17 +1402,6 @@ public class SchemaValidation {
             return;
         }
 
-        List<String> mapBlobFields =
-                schema.fields().stream()
-                        .filter(field -> managedBlobFields.contains(field.name()))
-                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.MAP)
-                        .map(DataField::name)
-                        .collect(Collectors.toList());
-        checkArgument(
-                mapBlobFields.isEmpty(),
-                "Primary-key managed MAP<X, BLOB> fields are not supported: %s.",
-                mapBlobFields);
-
         List<String> primaryKeyBlobFields =
                 managedBlobFields.stream()
                         .filter(schema.primaryKeys()::contains)

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1292,7 +1292,6 @@ public class SchemaValidation {
     }
 
     private static void validateBlobFields(RowType rowType, CoreOptions options) {
-        validateMapBlobKeyTypes(rowType.getFields());
         validateBlobNesting(rowType.getFields(), options);
         Set<String> blobFieldNames =
                 rowType.getFields().stream()
@@ -1325,23 +1324,6 @@ public class SchemaValidation {
                             + "top-level BLOB, ARRAY<BLOB>, or MAP<X, BLOB> field.",
                     field.name(),
                     type);
-        }
-    }
-
-    private static void validateMapBlobKeyTypes(List<DataField> fields) {
-        for (DataField field : fields) {
-            DataType type = field.type();
-            if (type.getTypeRoot() != DataTypeRoot.MAP) {
-                continue;
-            }
-            MapType mapType = (MapType) type;
-            if (mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB) {
-                checkArgument(
-                        isBlobFileField(type),
-                        "Unsupported key type [%s] for MAP<X, BLOB> field '%s'.",
-                        mapType.getKeyType(),
-                        field.name());
-            }
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -1263,14 +1263,14 @@ public class SchemaValidation {
             if (!primaryKeyManagedBlob) {
                 checkArgument(
                         options.dataEvolutionEnabled(),
-                        "Data evolution config must enabled for table with BLOB or ARRAY<BLOB> type column.");
+                        "Data evolution config must enabled for table with BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column.");
             }
             checkArgument(
                     fields.size() > blobNames.size(),
-                    "Table with BLOB or ARRAY<BLOB> type column must have other normal columns.");
+                    "Table with BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column must have other normal columns.");
             checkArgument(
                     blobNames.stream().noneMatch(schema.partitionKeys()::contains),
-                    "The BLOB or ARRAY<BLOB> type column can not be part of partition keys.");
+                    "The BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column can not be part of partition keys.");
         }
 
         FileFormat vectorFileFormat = vectorFileFormat(options);
@@ -1292,6 +1292,8 @@ public class SchemaValidation {
     }
 
     private static void validateBlobFields(RowType rowType, CoreOptions options) {
+        validateMapBlobKeyTypes(rowType.getFields());
+        validateBlobNesting(rowType.getFields(), options);
         Set<String> blobFieldNames =
                 rowType.getFields().stream()
                         .filter(field -> isBlobFileField(field.type()))
@@ -1303,9 +1305,43 @@ public class SchemaValidation {
         for (String field : configured) {
             checkArgument(
                     blobFieldNames.contains(field),
-                    "Field '%s' in '%s' must be a BLOB field or ARRAY<BLOB> field in table schema.",
+                    "Field '%s' in '%s' must be a BLOB, ARRAY<BLOB> or MAP<X, BLOB> field in table schema.",
                     field,
                     CoreOptions.BLOB_FIELD.key());
+        }
+    }
+
+    private static void validateBlobNesting(List<DataField> fields, CoreOptions options) {
+        for (DataField field : fields) {
+            // Preserve the more specific shared-shredding validation errors below.
+            if (options.mapStorageLayout(field.name()) == MapStorageLayout.SHARED_SHREDDING) {
+                continue;
+            }
+            DataType type = field.type();
+            checkArgument(
+                    isBlobFileField(type)
+                            || !containsType(type, nested -> nested.is(DataTypeRoot.BLOB)),
+                    "Field '%s' has unsupported nested BLOB type %s. BLOB is only supported as a "
+                            + "top-level BLOB, ARRAY<BLOB>, or MAP<X, BLOB> field.",
+                    field.name(),
+                    type);
+        }
+    }
+
+    private static void validateMapBlobKeyTypes(List<DataField> fields) {
+        for (DataField field : fields) {
+            DataType type = field.type();
+            if (type.getTypeRoot() != DataTypeRoot.MAP) {
+                continue;
+            }
+            MapType mapType = (MapType) type;
+            if (mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB) {
+                checkArgument(
+                        isBlobFileField(type),
+                        "Unsupported key type [%s] for MAP<X, BLOB> field '%s'.",
+                        mapType.getKeyType(),
+                        field.name());
+            }
         }
     }
 
@@ -1320,7 +1356,7 @@ public class SchemaValidation {
             checkArgument(
                     blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema. "
-                            + "ARRAY<BLOB> is only supported by '%s'.",
+                            + "ARRAY<BLOB> and MAP<X, BLOB> are only supported by '%s'.",
                     field,
                     CoreOptions.BLOB_DESCRIPTOR_FIELD.key(),
                     CoreOptions.BLOB_FIELD.key());
@@ -1340,7 +1376,7 @@ public class SchemaValidation {
             checkArgument(
                     blobFieldNames.contains(field),
                     "Field '%s' in '%s' must be a BLOB field in table schema. "
-                            + "ARRAY<BLOB> is only supported by '%s'.",
+                            + "ARRAY<BLOB> and MAP<X, BLOB> are only supported by '%s'.",
                     field,
                     CoreOptions.BLOB_VIEW_FIELD.key(),
                     CoreOptions.BLOB_FIELD.key());
@@ -1365,6 +1401,17 @@ public class SchemaValidation {
         if (managedBlobFields.isEmpty()) {
             return;
         }
+
+        List<String> mapBlobFields =
+                schema.fields().stream()
+                        .filter(field -> managedBlobFields.contains(field.name()))
+                        .filter(field -> field.type().getTypeRoot() == DataTypeRoot.MAP)
+                        .map(DataField::name)
+                        .collect(Collectors.toList());
+        checkArgument(
+                mapBlobFields.isEmpty(),
+                "Primary-key managed MAP<X, BLOB> fields are not supported: %s.",
+                mapBlobFields);
 
         List<String> primaryKeyBlobFields =
                 managedBlobFields.stream()

--- a/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/JavaPyE2ETest.java
@@ -30,8 +30,10 @@ import org.apache.paimon.data.BinaryVector;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.DataFormatTestUtil;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.variant.GenericVariant;
 import org.apache.paimon.deletionvectors.BitmapDeletionVector;
@@ -95,6 +97,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -1419,6 +1422,94 @@ public class JavaPyE2ETest {
         assertThat(rows.get(3)).isNull();
         assertThat(rows.get(4)).hasSize(1);
         assertThat(rows.get(4).get(0)).isEqualTo(lastValue.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Java writes a MAP&lt;INT, BLOB&gt; table for Python to read. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaWriteMapBlobTable() throws Exception {
+        Identifier identifier = identifier("map_blob_java_test");
+        catalog.dropTable(identifier, true);
+        Schema schema =
+                Schema.newBuilder()
+                        .column("id", DataTypes.INT())
+                        .column("payloads", DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB()))
+                        .option(ROW_TRACKING_ENABLED.key(), "true")
+                        .option(DATA_EVOLUTION_ENABLED.key(), "true")
+                        .option(BUCKET.key(), "-1")
+                        .build();
+        catalog.createTable(identifier, schema, false);
+
+        Map<Object, Object> first = new LinkedHashMap<>();
+        first.put(1, new BlobData("java-alpha".getBytes(StandardCharsets.UTF_8)));
+        first.put(2, null);
+        first.put(3, new BlobData(new byte[0]));
+        Map<Object, Object> last = new LinkedHashMap<>();
+        last.put(4, new BlobData("java-omega".getBytes(StandardCharsets.UTF_8)));
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            write.write(GenericRow.of(1, new GenericMap(first)));
+            write.write(GenericRow.of(2, new GenericMap(Collections.emptyMap())));
+            write.write(GenericRow.of(3, null));
+            write.write(GenericRow.of(4, new GenericMap(last)));
+            commit.commit(write.prepareCommit());
+        }
+
+        assertMapBlobRows(readMapBlobRows(table), "java-alpha", "java-omega");
+    }
+
+    /** Java reads a MAP&lt;INT, BLOB&gt; table written by Python. */
+    @Test
+    @EnabledIfSystemProperty(named = "run.e2e.tests", matches = "true")
+    public void testJavaReadMapBlobTable() throws Exception {
+        FileStoreTable table =
+                (FileStoreTable) catalog.getTable(identifier("map_blob_python_test"));
+        assertMapBlobRows(readMapBlobRows(table), "python-alpha", "python-omega");
+    }
+
+    private Map<Integer, Map<Integer, byte[]>> readMapBlobRows(FileStoreTable table)
+            throws Exception {
+        Map<Integer, Map<Integer, byte[]>> rows = new HashMap<>();
+        List<Split> splits = new ArrayList<>(table.newSnapshotReader().read().dataSplits());
+        try (org.apache.paimon.reader.RecordReader<InternalRow> reader =
+                table.newRead().createReader(splits)) {
+            reader.forEachRemaining(
+                    row -> {
+                        int id = row.getInt(0);
+                        if (row.isNullAt(1)) {
+                            rows.put(id, null);
+                            return;
+                        }
+
+                        InternalMap map = row.getMap(1);
+                        InternalArray keys = map.keyArray();
+                        InternalArray values = map.valueArray();
+                        Map<Integer, byte[]> converted = new HashMap<>();
+                        for (int i = 0; i < map.size(); i++) {
+                            converted.put(
+                                    keys.getInt(i),
+                                    values.isNullAt(i) ? null : values.getBlob(i).toData());
+                        }
+                        rows.put(id, converted);
+                    });
+        }
+        return rows;
+    }
+
+    private void assertMapBlobRows(
+            Map<Integer, Map<Integer, byte[]>> rows, String firstValue, String lastValue) {
+        assertThat(rows).containsOnlyKeys(1, 2, 3, 4);
+        assertThat(rows.get(1)).containsOnlyKeys(1, 2, 3);
+        assertThat(rows.get(1).get(1)).isEqualTo(firstValue.getBytes(StandardCharsets.UTF_8));
+        assertThat(rows.get(1).get(2)).isNull();
+        assertThat(rows.get(1).get(3)).isEmpty();
+        assertThat(rows.get(2)).isEmpty();
+        assertThat(rows.get(3)).isNull();
+        assertThat(rows.get(4)).containsOnlyKeys(4);
+        assertThat(rows.get(4).get(4)).isEqualTo(lastValue.getBytes(StandardCharsets.UTF_8));
     }
 
     /** Java writes a VARIANT-column table for Python to read (Java→Python E2E). */

--- a/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/append/BlobTableTest.java
@@ -27,12 +27,15 @@ import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.serializer.InternalRowSerializer;
 import org.apache.paimon.fs.FileIO;
@@ -78,6 +81,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -247,6 +251,111 @@ public class BlobTableTest extends TableTestBase {
         InternalArray third = actual.get(2);
         assertThat(third.size()).isEqualTo(1);
         assertThat(third.getBlob(0).toData()).isEqualTo(blob2);
+    }
+
+    @Test
+    public void testMapBlobField() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
+        schemaBuilder.option(CoreOptions.TARGET_FILE_SIZE.key(), "1 GB");
+        schemaBuilder.option(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "25 MB");
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        byte[] blob0 = "blob-0".getBytes();
+        byte[] empty = new byte[0];
+        writeDataDefault(
+                Arrays.asList(
+                        GenericRow.of(
+                                0,
+                                blobMap(
+                                        "a",
+                                        new BlobData(blob0),
+                                        "b",
+                                        null,
+                                        "c",
+                                        new BlobData(empty))),
+                        GenericRow.of(1, null),
+                        GenericRow.of(2, blobMap())));
+
+        FileStoreTable table = getTableDefault();
+        List<DataFileMeta> filesMetas =
+                table.store().newScan().plan().files().stream()
+                        .map(ManifestEntry::file)
+                        .collect(Collectors.toList());
+        List<DataEvolutionSplitRead.FieldBunch> fieldGroups =
+                DataEvolutionSplitRead.splitFieldBunches(filesMetas, file -> table.rowType());
+        assertThat(fieldGroups.size()).isEqualTo(2);
+        assertThat(countFilesWithSuffix(table.fileIO(), table.location(), ".blob")).isEqualTo(1);
+        assertMapBlobRows(blob0, null);
+
+        byte[] updated = "updated".getBytes();
+        RowType blobWriteType = table.schema().logicalRowType().project("f1");
+        BatchWriteBuilder builder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = builder.newWrite().withWriteType(blobWriteType);
+                BatchTableCommit commit = builder.newCommit()) {
+            write.write(GenericRow.of(BlobMapPlaceholder.INSTANCE));
+            write.write(GenericRow.of(blobMap("updated", new BlobData(updated))));
+            write.write(GenericRow.of(BlobMapPlaceholder.INSTANCE));
+
+            List<CommitMessage> commitMessages = write.prepareCommit();
+            assignFirstRowId(commitMessages, 0L);
+            commit.commit(commitMessages);
+        }
+        assertMapBlobRows(blob0, updated);
+
+        DataEvolutionCompactCoordinator coordinator =
+                new DataEvolutionCompactCoordinator(
+                        table, true, false, table.latestSnapshot().get());
+        List<DataEvolutionCompactTask> tasks = coordinator.plan();
+        assertThat(tasks.stream().anyMatch(task -> task.type() == BLOB)).isTrue();
+        List<CommitMessage> compactMessages = new ArrayList<>();
+        for (DataEvolutionCompactTask task : tasks) {
+            compactMessages.add(task.doCompact(table, commitUser));
+        }
+        commitDefault(compactMessages);
+        assertMapBlobRows(blob0, updated);
+    }
+
+    private void assertMapBlobRows(byte[] blob0, byte[] updated) throws Exception {
+        Map<Integer, InternalMap> actual = new HashMap<>();
+        readDefault(row -> actual.put(row.getInt(0), row.getMap(1)));
+
+        assertThat(actual.size()).isEqualTo(3);
+        Map<String, byte[]> first = blobMapData(actual.get(0));
+        assertThat(new ArrayList<>(first.keySet())).isEqualTo(Arrays.asList("a", "b", "c"));
+        assertThat(first.get("a")).isEqualTo(blob0);
+        assertThat(first.get("b")).isNull();
+        assertThat(first.get("c")).isEmpty();
+
+        if (updated == null) {
+            assertThat(actual.get(1)).isNull();
+        } else {
+            assertThat(blobMapData(actual.get(1)).get("updated")).isEqualTo(updated);
+        }
+        assertThat(actual.get(2).size()).isZero();
+    }
+
+    private static GenericMap blobMap(Object... keyValues) {
+        Map<BinaryString, Blob> values = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            values.put(BinaryString.fromString((String) keyValues[i]), (Blob) keyValues[i + 1]);
+        }
+        return new GenericMap(values);
+    }
+
+    private static Map<String, byte[]> blobMapData(InternalMap map) {
+        Map<String, byte[]> result = new LinkedHashMap<>();
+        InternalArray keys = map.keyArray();
+        InternalArray values = map.valueArray();
+        for (int i = 0; i < map.size(); i++) {
+            result.put(
+                    keys.getString(i).toString(),
+                    values.isNullAt(i) ? null : values.getBlob(i).toData());
+        }
+        return result;
     }
 
     @Test
@@ -618,7 +727,7 @@ public class BlobTableTest extends TableTestBase {
                 .hasRootCauseMessage(
                         "Field 'f1' in '"
                                 + optionKey
-                                + "' must be a BLOB field in table schema. ARRAY<BLOB> is only supported by '"
+                                + "' must be a BLOB field in table schema. ARRAY<BLOB> and MAP<X, BLOB> are only supported by '"
                                 + CoreOptions.BLOB_FIELD.key()
                                 + "'.");
     }

--- a/paimon-core/src/test/java/org/apache/paimon/blob/ManagedBlobReferenceCollectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/blob/ManagedBlobReferenceCollectorTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.blob;
 import org.apache.paimon.KeyValue;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -32,9 +33,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ManagedBlobReferenceCollector}. */
 class ManagedBlobReferenceCollectorTest {
@@ -154,20 +156,51 @@ class ManagedBlobReferenceCollectorTest {
     }
 
     @Test
-    void testRejectsManagedMapBlobField() {
+    void testCollectManagedReferencesFromBlobMap() throws Exception {
         LocalFileIO fileIO = LocalFileIO.create();
-        Path dataFile = new Path(tempDir.resolve("data-a.avro").toUri());
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        Path otherBucketPath = new Path(tempDir.resolve("bucket-1").toUri());
+        fileIO.mkdirs(bucketPath);
+        Path dataFile = new Path(bucketPath, "data-a.avro");
+        Path first = new Path(bucketPath, "data-b.managed.blob");
+        Path second = new Path(otherBucketPath, "data-c.managed.blob");
+        Path ordinary = new Path(tempDir.resolve("external/data-d.blob").toUri());
+        ManagedBlobReferenceCollector collector =
+                new ManagedBlobReferenceCollector(
+                        fileIO,
+                        dataFile,
+                        RowType.of(
+                                DataTypes.INT(), DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                        Collections.singleton("f1"));
+        Map<Object, Object> values = new LinkedHashMap<>();
+        values.put(1, Blob.fromFile(fileIO, first.toString()));
+        values.put(2, null);
+        values.put(3, Blob.fromFile(fileIO, ordinary.toString()));
+        values.put(4, Blob.fromFile(fileIO, first.toString()));
+        values.put(5, Blob.fromFile(fileIO, second.toString()));
 
-        assertThatThrownBy(
-                        () ->
-                                new ManagedBlobReferenceCollector(
-                                        fileIO,
-                                        dataFile,
-                                        RowType.of(
-                                                DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
-                                        Collections.singleton("f0")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Primary-key managed MAP<X, BLOB> field 'f0' is not supported.");
+        collector.write(
+                new KeyValue()
+                        .replace(
+                                GenericRow.of(1),
+                                RowKind.INSERT,
+                                GenericRow.of(1, new GenericMap(values))));
+        collector.write(
+                new KeyValue()
+                        .replace(
+                                GenericRow.of(2),
+                                RowKind.DELETE,
+                                GenericRow.of(2, new GenericMap(values))));
+        collector.close();
+
+        assertThat(
+                        ManagedBlobReferenceFile.read(
+                                fileIO, ManagedBlobReferenceFile.sidecarPath(dataFile)))
+                .containsExactly(
+                        new ManagedBlobReferenceFile.Reference(
+                                bucketPath.toString(), first.getName()),
+                        new ManagedBlobReferenceFile.Reference(
+                                otherBucketPath.toString(), second.getName()));
     }
 
     private KeyValue keyValue(RowKind kind, Blob blob) {

--- a/paimon-core/src/test/java/org/apache/paimon/blob/ManagedBlobReferenceCollectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/blob/ManagedBlobReferenceCollectorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ManagedBlobReferenceCollector}. */
 class ManagedBlobReferenceCollectorTest {
@@ -150,6 +151,23 @@ class ManagedBlobReferenceCollectorTest {
                 .containsExactly(
                         new ManagedBlobReferenceFile.Reference(
                                 bucketPath.toString(), managed.getName()));
+    }
+
+    @Test
+    void testRejectsManagedMapBlobField() {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path dataFile = new Path(tempDir.resolve("data-a.avro").toUri());
+
+        assertThatThrownBy(
+                        () ->
+                                new ManagedBlobReferenceCollector(
+                                        fileIO,
+                                        dataFile,
+                                        RowType.of(
+                                                DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                                        Collections.singleton("f0")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Primary-key managed MAP<X, BLOB> field 'f0' is not supported.");
     }
 
     private KeyValue keyValue(RowKind kind, Blob blob) {

--- a/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
@@ -132,7 +132,7 @@ class PrimaryKeyBlobExternalizerTest {
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
 
         PrimaryKeyBlobExternalizer externalizer =
-                new PrimaryKeyBlobExternalizer(
+                newExternalizer(
                         fileIO,
                         RowType.of(
                                 DataTypes.INT(), DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
@@ -403,7 +403,7 @@ class PrimaryKeyBlobExternalizerTest {
                 new DataFilePathFactory(
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
         PrimaryKeyBlobExternalizer externalizer =
-                new PrimaryKeyBlobExternalizer(
+                newExternalizer(
                         fileIO,
                         RowType.of(
                                 DataTypes.INT(),
@@ -451,7 +451,7 @@ class PrimaryKeyBlobExternalizerTest {
                 new DataFilePathFactory(
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
         PrimaryKeyBlobExternalizer externalizer =
-                new PrimaryKeyBlobExternalizer(
+                newExternalizer(
                         fileIO,
                         RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
                         Collections.singleton("f0"),
@@ -502,7 +502,7 @@ class PrimaryKeyBlobExternalizerTest {
                 new DataFilePathFactory(
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
         PrimaryKeyBlobExternalizer externalizer =
-                new PrimaryKeyBlobExternalizer(
+                newExternalizer(
                         fileIO,
                         RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
                         Collections.singleton("f0"),
@@ -548,7 +548,7 @@ class PrimaryKeyBlobExternalizerTest {
                 new DataFilePathFactory(
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
         PrimaryKeyBlobExternalizer externalizer =
-                new PrimaryKeyBlobExternalizer(
+                newExternalizer(
                         fileIO,
                         RowType.of(
                                 DataTypes.INT(), DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),

--- a/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
@@ -18,12 +18,16 @@
 
 package org.apache.paimon.blob;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobArrayPlaceholder;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.blob.BlobFormatWriter;
 import org.apache.paimon.fs.Path;
@@ -41,6 +45,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -112,11 +118,12 @@ class PrimaryKeyBlobExternalizerTest {
                                         pathFactory,
                                         1024L))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Managed BLOB field 'f0' must be BLOB or ARRAY<BLOB>, but was INT.");
+                .hasMessage(
+                        "Managed BLOB field 'f0' must be BLOB, ARRAY<BLOB> or MAP<X, BLOB>, but was INT.");
     }
 
     @Test
-    void testRejectsManagedMapBlobField() throws Exception {
+    void testExternalizeBlobMapValues() throws Exception {
         LocalFileIO fileIO = LocalFileIO.create();
         Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
         fileIO.mkdirs(bucketPath);
@@ -124,17 +131,39 @@ class PrimaryKeyBlobExternalizerTest {
                 new DataFilePathFactory(
                         bucketPath, "avro", "data-", "changelog-", false, null, null);
 
-        assertThatThrownBy(
-                        () ->
-                                new PrimaryKeyBlobExternalizer(
-                                        fileIO,
-                                        RowType.of(
-                                                DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
-                                        Collections.singleton("f0"),
-                                        pathFactory,
-                                        1024L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Primary-key managed MAP<X, BLOB> field 'f0' is not supported.");
+        PrimaryKeyBlobExternalizer externalizer =
+                new PrimaryKeyBlobExternalizer(
+                        fileIO,
+                        RowType.of(
+                                DataTypes.INT(), DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                        Collections.singleton("f1"),
+                        pathFactory,
+                        1024L);
+        byte[] first = "first-map-value".getBytes(StandardCharsets.UTF_8);
+        byte[] second = "second-map-value".getBytes(StandardCharsets.UTF_8);
+        Map<Object, Object> input = new LinkedHashMap<>();
+        input.put(1, Blob.fromData(first));
+        input.put(2, null);
+        input.put(3, Blob.fromData(second));
+
+        InternalMap result =
+                externalizer
+                        .externalize(RowKind.INSERT, GenericRow.of(1, new GenericMap(input)))
+                        .getMap(1);
+        InternalArray keys = result.keyArray();
+        InternalArray values = result.valueArray();
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(keys.getInt(0)).isEqualTo(1);
+        assertThat(keys.getInt(1)).isEqualTo(2);
+        assertThat(keys.getInt(2)).isEqualTo(3);
+        assertThat(values.getBlob(0)).isInstanceOf(BlobRef.class);
+        assertThat(values.isNullAt(1)).isTrue();
+        assertThat(values.getBlob(2)).isInstanceOf(BlobRef.class);
+
+        externalizer.prepareCommit();
+        assertThat(values.getBlob(0).toData()).isEqualTo(first);
+        assertThat(values.getBlob(2).toData()).isEqualTo(second);
     }
 
     @Test
@@ -363,6 +392,192 @@ class PrimaryKeyBlobExternalizerTest {
                 .endsWith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX);
         externalizer.prepareCommit();
         assertThat(result.getBlob(1).toData()).isEqualTo(expected);
+    }
+
+    @Test
+    void testRematerializesBlobRefMapValueWithRange() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        fileIO.mkdirs(bucketPath);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(
+                        bucketPath, "avro", "data-", "changelog-", false, null, null);
+        PrimaryKeyBlobExternalizer externalizer =
+                new PrimaryKeyBlobExternalizer(
+                        fileIO,
+                        RowType.of(
+                                DataTypes.INT(),
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())),
+                        Collections.singleton("f1"),
+                        pathFactory,
+                        1024L);
+        byte[] expected = "ranged-map-value".getBytes(StandardCharsets.UTF_8);
+        byte[] prefix = "prefix".getBytes(StandardCharsets.UTF_8);
+        byte[] suffix = "suffix".getBytes(StandardCharsets.UTF_8);
+        Path source = new Path(tempDir.resolve("external-map.blob").toUri());
+        try (org.apache.paimon.fs.PositionOutputStream out =
+                fileIO.newOutputStream(source, false)) {
+            out.write(prefix);
+            out.write(expected);
+            out.write(suffix);
+        }
+        Blob ranged = Blob.fromFile(fileIO, source.toString(), prefix.length, expected.length);
+        Map<Object, Object> input = new LinkedHashMap<>();
+        input.put(BinaryString.fromString("slice"), ranged);
+
+        Blob result =
+                externalizer
+                        .externalize(RowKind.INSERT, GenericRow.of(1, new GenericMap(input)))
+                        .getMap(1)
+                        .valueArray()
+                        .getBlob(0);
+
+        assertThat(result).isInstanceOf(BlobRef.class);
+        assertThat(result.toDescriptor().uri())
+                .isNotEqualTo(source.toString())
+                .endsWith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX);
+        assertThat(result.toDescriptor().offset()).isPositive();
+        assertThat(result.toDescriptor().length()).isEqualTo(expected.length);
+        externalizer.prepareCommit();
+        assertThat(result.toData()).isEqualTo(expected);
+    }
+
+    @Test
+    void testDuplicateMapKeyUsesLastValueWithoutWritingOverriddenBlob() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        fileIO.mkdirs(bucketPath);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(
+                        bucketPath, "avro", "data-", "changelog-", false, null, null);
+        PrimaryKeyBlobExternalizer externalizer =
+                new PrimaryKeyBlobExternalizer(
+                        fileIO,
+                        RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                        Collections.singleton("f0"),
+                        pathFactory,
+                        1L);
+        byte[] expected = "last".getBytes(StandardCharsets.UTF_8);
+        InternalMap duplicateKeys =
+                new InternalMap() {
+                    @Override
+                    public int size() {
+                        return 2;
+                    }
+
+                    @Override
+                    public InternalArray keyArray() {
+                        return new GenericArray(new Object[] {1, 1});
+                    }
+
+                    @Override
+                    public InternalArray valueArray() {
+                        return new GenericArray(
+                                new Object[] {
+                                    Blob.fromData("overridden".getBytes(StandardCharsets.UTF_8)),
+                                    Blob.fromData(expected)
+                                });
+                    }
+                };
+
+        InternalMap result =
+                externalizer.externalize(RowKind.INSERT, GenericRow.of(duplicateKeys)).getMap(0);
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.keyArray().getInt(0)).isEqualTo(1);
+        assertThat(result.valueArray().getBlob(0).toData()).isEqualTo(expected);
+        assertThat(fileIO.listStatus(bucketPath))
+                .singleElement()
+                .extracting(status -> status.getPath().getName())
+                .asString()
+                .endsWith(ManagedBlobReferenceFile.MANAGED_BLOB_SUFFIX);
+    }
+
+    @Test
+    void testDuplicateMapKeyUsesLastNullWithoutWritingBlob() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        fileIO.mkdirs(bucketPath);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(
+                        bucketPath, "avro", "data-", "changelog-", false, null, null);
+        PrimaryKeyBlobExternalizer externalizer =
+                new PrimaryKeyBlobExternalizer(
+                        fileIO,
+                        RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                        Collections.singleton("f0"),
+                        pathFactory,
+                        1024L);
+        InternalMap duplicateKeys =
+                new InternalMap() {
+                    @Override
+                    public int size() {
+                        return 2;
+                    }
+
+                    @Override
+                    public InternalArray keyArray() {
+                        return new GenericArray(new Object[] {1, 1});
+                    }
+
+                    @Override
+                    public InternalArray valueArray() {
+                        return new GenericArray(
+                                new Object[] {
+                                    Blob.fromData("overridden".getBytes(StandardCharsets.UTF_8)),
+                                    null
+                                });
+                    }
+                };
+
+        InternalMap result =
+                externalizer.externalize(RowKind.INSERT, GenericRow.of(duplicateKeys)).getMap(0);
+
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.keyArray().getInt(0)).isEqualTo(1);
+        assertThat(result.valueArray().isNullAt(0)).isTrue();
+        assertThat(fileIO.listStatus(bucketPath)).isEmpty();
+    }
+
+    @Test
+    void testBlobMapNullEmptyRetractAndPlaceholder() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        fileIO.mkdirs(bucketPath);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(
+                        bucketPath, "avro", "data-", "changelog-", false, null, null);
+        PrimaryKeyBlobExternalizer externalizer =
+                new PrimaryKeyBlobExternalizer(
+                        fileIO,
+                        RowType.of(
+                                DataTypes.INT(), DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                        Collections.singleton("f1"),
+                        pathFactory,
+                        1024L);
+
+        GenericRow nullMap = GenericRow.of(1, null);
+        GenericRow emptyMap = GenericRow.of(2, new GenericMap(new LinkedHashMap<>()));
+        Map<Object, Object> nullValue = new LinkedHashMap<>();
+        nullValue.put(1, null);
+        GenericRow allNullMap = GenericRow.of(3, new GenericMap(nullValue));
+        assertThat(externalizer.externalize(RowKind.INSERT, nullMap)).isSameAs(nullMap);
+        assertThat(externalizer.externalize(RowKind.INSERT, emptyMap)).isSameAs(emptyMap);
+        assertThat(externalizer.externalize(RowKind.INSERT, allNullMap)).isSameAs(allNullMap);
+
+        InternalRow retract =
+                externalizer.externalize(
+                        RowKind.DELETE, GenericRow.of(4, BlobMapPlaceholder.INSTANCE));
+        assertThat(retract.isNullAt(1)).isTrue();
+
+        assertThatThrownBy(
+                        () ->
+                                externalizer.externalize(
+                                        RowKind.INSERT,
+                                        GenericRow.of(5, BlobMapPlaceholder.INSTANCE)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("placeholder blob map");
+        assertThat(fileIO.listStatus(bucketPath)).isEmpty();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/blob/PrimaryKeyBlobExternalizerTest.java
@@ -116,6 +116,28 @@ class PrimaryKeyBlobExternalizerTest {
     }
 
     @Test
+    void testRejectsManagedMapBlobField() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());
+        fileIO.mkdirs(bucketPath);
+        DataFilePathFactory pathFactory =
+                new DataFilePathFactory(
+                        bucketPath, "avro", "data-", "changelog-", false, null, null);
+
+        assertThatThrownBy(
+                        () ->
+                                new PrimaryKeyBlobExternalizer(
+                                        fileIO,
+                                        RowType.of(
+                                                DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                                        Collections.singleton("f0"),
+                                        pathFactory,
+                                        1024L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Primary-key managed MAP<X, BLOB> field 'f0' is not supported.");
+    }
+
+    @Test
     void testRejectsUnknownManagedField() throws Exception {
         LocalFileIO fileIO = LocalFileIO.create();
         Path bucketPath = new Path(tempDir.resolve("bucket-0").toUri());

--- a/paimon-core/src/test/java/org/apache/paimon/operation/BlobFallbackRecordReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/BlobFallbackRecordReaderTest.java
@@ -18,12 +18,16 @@
 
 package org.apache.paimon.operation;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.deletionvectors.ApplyDeletionVectorReader;
@@ -49,7 +53,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,6 +88,16 @@ public class BlobFallbackRecordReaderTest {
                     Arrays.asList(
                             new DataField(
                                     BLOB_INDEX, BLOB_FIELD, DataTypes.ARRAY(DataTypes.BLOB())),
+                            new DataField(1, SpecialFields.ROW_ID.name(), DataTypes.BIGINT()),
+                            new DataField(
+                                    2, SpecialFields.SEQUENCE_NUMBER.name(), DataTypes.BIGINT())));
+    private static final RowType READ_MAP_ROW_TYPE =
+            new RowType(
+                    Arrays.asList(
+                            new DataField(
+                                    BLOB_INDEX,
+                                    BLOB_FIELD,
+                                    DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())),
                             new DataField(1, SpecialFields.ROW_ID.name(), DataTypes.BIGINT()),
                             new DataField(
                                     2, SpecialFields.SEQUENCE_NUMBER.name(), DataTypes.BIGINT())));
@@ -304,6 +320,40 @@ public class BlobFallbackRecordReaderTest {
         }
     }
 
+    @Test
+    public void testMapBlobFallbackRecordReader() throws Exception {
+        DataFileMeta newFile = blobFile("new-map-file", 0, 3, 2);
+        DataFileMeta oldFile = blobFile("old-map-file", 0, 5, 1);
+        Set<String> placeholderRows = placeholderRows(newFile, 1);
+
+        try (RecordReader<InternalRow> reader =
+                new BlobFallbackRecordReader(
+                        Arrays.asList(newFile, oldFile),
+                        file -> oneRowPerBatchReader(file, mapFileRows(file, placeholderRows)),
+                        (placeholderReader, range) -> placeholderReader,
+                        null,
+                        READ_MAP_ROW_TYPE,
+                        BLOB_INDEX)) {
+            List<Long> rowIds = new ArrayList<>();
+            List<Long> sequenceNumbers = new ArrayList<>();
+
+            RecordIterator<InternalRow> batch;
+            while ((batch = reader.readBatch()) != null) {
+                InternalRow row;
+                while ((row = batch.next()) != null) {
+                    InternalMap map = row.getMap(BLOB_INDEX);
+                    assertThat(map).isNotSameAs(BlobMapPlaceholder.INSTANCE);
+                    rowIds.add(row.getLong(1));
+                    sequenceNumbers.add(row.getLong(2));
+                }
+                batch.releaseBatch();
+            }
+
+            assertThat(rowIds).containsExactly(0L, 1L, 2L, 3L, 4L);
+            assertThat(sequenceNumbers).containsExactly(2L, 1L, 2L, 1L, 1L);
+        }
+    }
+
     private static ReadResult readFallback(
             List<DataFileMeta> files, List<Range> rowRanges, Set<String> placeholderRows)
             throws Exception {
@@ -420,6 +470,19 @@ public class BlobFallbackRecordReaderTest {
         return rows;
     }
 
+    private static List<InternalRow> mapFileRows(DataFileMeta file, Set<String> placeholderRows) {
+        List<InternalRow> rows = new ArrayList<>();
+        long lastRowId = file.nonNullFirstRowId() + file.rowCount() - 1;
+        for (long rowId = file.nonNullFirstRowId(); rowId <= lastRowId; rowId++) {
+            rows.add(
+                    mapBlobRow(
+                            rowId,
+                            file.maxSequenceNumber(),
+                            placeholderRows.contains(rowKey(file, rowId))));
+        }
+        return rows;
+    }
+
     private static boolean selected(long rowId, List<Range> rowRanges) {
         if (rowRanges == null) {
             return true;
@@ -496,6 +559,17 @@ public class BlobFallbackRecordReaderTest {
                 placeholder
                         ? BlobArrayPlaceholder.INSTANCE
                         : new GenericArray(new Object[] {new BlobData(new byte[] {(byte) rowId})}));
+        row.setField(1, rowId);
+        row.setField(2, sequenceNumber);
+        return row;
+    }
+
+    private static InternalRow mapBlobRow(long rowId, long sequenceNumber, boolean placeholder) {
+        GenericRow row = new GenericRow(3);
+        Map<BinaryString, BlobData> values = new LinkedHashMap<>();
+        values.put(BinaryString.fromString("key"), new BlobData(new byte[] {(byte) rowId}));
+        row.setField(
+                BLOB_INDEX, placeholder ? BlobMapPlaceholder.INSTANCE : new GenericMap(values));
         row.setField(1, rowId);
         row.setField(2, sequenceNumber);
         return row;

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyManagedBlobStoreTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyManagedBlobStoreTest.java
@@ -23,10 +23,13 @@ import org.apache.paimon.KeyValue;
 import org.apache.paimon.TestFileStore;
 import org.apache.paimon.blob.ManagedBlobReferenceFile;
 import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
@@ -57,6 +60,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -118,6 +122,40 @@ class PrimaryKeyManagedBlobStoreTest {
         KeyValue read =
                 store.readKvsFromSnapshot(store.snapshotManager().latestSnapshotId()).get(0);
         assertThat(read.value().getArray(1).getBlob(0).toData()).isEqualTo(expected);
+    }
+
+    @Test
+    void testPostponeBucketExternalizesBlobMap() throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        TestFileStore store =
+                createStore(
+                        fileIO,
+                        "pictures",
+                        DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()),
+                        BucketMode.POSTPONE_BUCKET);
+        byte[] expected = "postpone-bucket-blob-map".getBytes(StandardCharsets.UTF_8);
+        KeyValue keyValue =
+                new KeyValue()
+                        .replace(
+                                GenericRow.of(1),
+                                RowKind.INSERT,
+                                GenericRow.of(1, blobMap("picture", Blob.fromData(expected))));
+
+        store.commitData(
+                Collections.singletonList(keyValue),
+                ignored -> BinaryRow.EMPTY_ROW,
+                ignored -> BucketMode.POSTPONE_BUCKET);
+
+        ManifestEntry entry = store.newScan().plan().files().get(0);
+        assertThat(entry.bucket()).isEqualTo(BucketMode.POSTPONE_BUCKET);
+        assertThat(references(fileIO, store, entry)).hasSize(1);
+        InternalMap result =
+                store.readKvsFromSnapshot(store.snapshotManager().latestSnapshotId())
+                        .get(0)
+                        .value()
+                        .getMap(1);
+        assertThat(result.keyArray().getString(0).toString()).isEqualTo("picture");
+        assertThat(result.valueArray().getBlob(0).toData()).isEqualTo(expected);
     }
 
     @Test
@@ -220,6 +258,52 @@ class PrimaryKeyManagedBlobStoreTest {
     }
 
     @Test
+    void testExternalizeAndReadBlobMap() throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        TestFileStore store = createMapStore(fileIO);
+        byte[] expected = "map-payload".getBytes(StandardCharsets.UTF_8);
+        byte[] second = "second-map-payload".getBytes(StandardCharsets.UTF_8);
+        Path source = new Path(tempDir.resolve("external-map.blob").toUri());
+        try (org.apache.paimon.fs.PositionOutputStream out =
+                fileIO.newOutputStream(source, false)) {
+            out.write(second);
+        }
+        Map<Object, Object> input = new LinkedHashMap<>();
+        input.put(BinaryString.fromString("first"), Blob.fromData(expected));
+        input.put(BinaryString.fromString("null"), null);
+        input.put(BinaryString.fromString("second"), Blob.fromFile(fileIO, source.toString()));
+
+        store.commitData(
+                Collections.singletonList(
+                        new KeyValue()
+                                .replace(
+                                        GenericRow.of(1),
+                                        RowKind.INSERT,
+                                        GenericRow.of(1, new GenericMap(input)))),
+                ignored -> BinaryRow.EMPTY_ROW,
+                ignored -> 0);
+
+        ManifestEntry entry = store.newScan().plan().files().get(0);
+        assertThat(references(fileIO, store, entry)).hasSize(2);
+        InternalMap blobs =
+                store.readKvsFromSnapshot(store.snapshotManager().latestSnapshotId())
+                        .get(0)
+                        .value()
+                        .getMap(1);
+        Map<String, Blob> actual = new HashMap<>();
+        InternalArray keys = blobs.keyArray();
+        InternalArray values = blobs.valueArray();
+        for (int i = 0; i < blobs.size(); i++) {
+            actual.put(keys.getString(i).toString(), values.isNullAt(i) ? null : values.getBlob(i));
+        }
+        assertThat(actual).containsOnlyKeys("first", "null", "second");
+        assertThat(actual.get("first").toData()).isEqualTo(expected);
+        assertThat(actual.get("null")).isNull();
+        assertThat(actual.get("second").toDescriptor().uri()).isNotEqualTo(source.toString());
+        assertThat(actual.get("second").toData()).isEqualTo(second);
+    }
+
+    @Test
     void testCompactionRebuildsExactBlobReferences() throws Exception {
         FileIO fileIO = LocalFileIO.create();
         TestFileStore store = createStore(fileIO);
@@ -296,12 +380,54 @@ class PrimaryKeyManagedBlobStoreTest {
                 .isEqualTo("new".getBytes(StandardCharsets.UTF_8));
     }
 
+    @Test
+    void testBlobMapCompactionRebuildsExactReferences() throws Exception {
+        FileIO fileIO = LocalFileIO.create();
+        TestFileStore store = createMapStore(fileIO);
+
+        store.commitData(
+                Arrays.asList(
+                        mapKeyValue(1, RowKind.INSERT, "old"),
+                        mapKeyValue(2, RowKind.INSERT, "deleted")),
+                ignored -> BinaryRow.EMPTY_ROW,
+                ignored -> 0);
+        List<ManagedBlobReferenceFile.Reference> oldReferences = new java.util.ArrayList<>();
+        for (ManifestEntry file : store.newScan().plan().files()) {
+            oldReferences.addAll(references(fileIO, store, file));
+        }
+        assertThat(oldReferences).hasSize(2);
+
+        store.commitData(
+                Arrays.asList(
+                        mapKeyValue(1, RowKind.UPDATE_AFTER, "new"),
+                        mapKeyValue(2, RowKind.DELETE, "must-not-be-written")),
+                ignored -> BinaryRow.EMPTY_ROW,
+                ignored -> 0);
+        forceFullCompaction(store);
+
+        List<ManifestEntry> files = store.newScan().plan().files();
+        assertThat(files).hasSize(1);
+        assertThat(references(fileIO, store, files.get(0)))
+                .hasSize(1)
+                .doesNotContainAnyElementsOf(oldReferences);
+        List<KeyValue> rows = store.readKvsFromSnapshot(store.snapshotManager().latestSnapshotId());
+        assertThat(rows).hasSize(1);
+        InternalMap result = rows.get(0).value().getMap(1);
+        assertThat(result.keyArray().getString(0).toString()).isEqualTo("key");
+        assertThat(result.valueArray().getBlob(0).toData())
+                .isEqualTo("new".getBytes(StandardCharsets.UTF_8));
+    }
+
     private TestFileStore createStore(FileIO fileIO) throws Exception {
         return createStore(fileIO, "payload", DataTypes.BLOB());
     }
 
     private TestFileStore createArrayStore(FileIO fileIO) throws Exception {
         return createStore(fileIO, "payloads", DataTypes.ARRAY(DataTypes.BLOB()));
+    }
+
+    private TestFileStore createMapStore(FileIO fileIO) throws Exception {
+        return createStore(fileIO, "payloads", DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
     }
 
     private TestFileStore createStore(FileIO fileIO, String payloadName, DataType payloadType)
@@ -410,5 +536,23 @@ class PrimaryKeyManagedBlobStoreTest {
                                         new Object[] {
                                             Blob.fromData(value.getBytes(StandardCharsets.UTF_8))
                                         })));
+    }
+
+    private KeyValue mapKeyValue(int id, RowKind kind, String value) {
+        return new KeyValue()
+                .replace(
+                        GenericRow.of(id),
+                        kind,
+                        GenericRow.of(
+                                id,
+                                blobMap(
+                                        "key",
+                                        Blob.fromData(value.getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    private GenericMap blobMap(String key, Blob value) {
+        Map<Object, Object> map = new LinkedHashMap<>();
+        map.put(BinaryString.fromString(key), value);
+        return new GenericMap(map);
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
@@ -247,15 +247,15 @@ public class ColumnDirectiveUtilsTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("MAP<X, BLOB> is only supported by 'blob-field'");
 
-        assertThatThrownBy(
-                        () ->
-                                ColumnDirectiveUtils.applyAddColumnDirective(
-                                        "__BLOB_FIELD",
-                                        "images",
-                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BYTES()),
-                                        new HashMap<>()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported key type [BOOLEAN]");
+        ColumnDirectiveUtils.ConvertedColumn result =
+                ColumnDirectiveUtils.applyAddColumnDirective(
+                        "__BLOB_FIELD",
+                        "images",
+                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BYTES()),
+                        new HashMap<>());
+        MapType mapType = (MapType) result.type();
+        assertThat(mapType.getKeyType()).isEqualTo(DataTypes.BOOLEAN());
+        assertThat(mapType.getValueType()).isEqualTo(DataTypes.BLOB());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/ColumnDirectiveUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VectorType;
 
@@ -180,6 +181,25 @@ public class ColumnDirectiveUtilsTest {
         assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "images");
     }
 
+    @Test
+    public void testBlobDirectiveWithMapSourceType() {
+        Map<String, String> opts = new HashMap<>();
+        ColumnDirectiveUtils.ConvertedColumn result =
+                ColumnDirectiveUtils.applyAddColumnDirective(
+                        "__BLOB_FIELD",
+                        "images",
+                        new MapType(
+                                false, DataTypes.INT().copy(false), DataTypes.BYTES().copy(false)),
+                        opts);
+
+        assertThat(result).isNotNull();
+        MapType mapType = (MapType) result.type();
+        assertThat(mapType.isNullable()).isFalse();
+        assertThat(mapType.getKeyType()).isEqualTo(DataTypes.INT().copy(false));
+        assertThat(mapType.getValueType()).isEqualTo(DataTypes.BLOB().copy(false));
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "images");
+    }
+
     // -- applyAddColumnDirective error cases --
 
     @Test
@@ -213,6 +233,29 @@ public class ColumnDirectiveUtilsTest {
                                         new HashMap<>()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("ARRAY<BLOB> is only supported by 'blob-field'");
+    }
+
+    @Test
+    public void testMapBlobDirectiveValidation() {
+        assertThatThrownBy(
+                        () ->
+                                ColumnDirectiveUtils.applyAddColumnDirective(
+                                        "__BLOB_DESCRIPTOR_FIELD",
+                                        "images",
+                                        DataTypes.MAP(DataTypes.INT(), DataTypes.BYTES()),
+                                        new HashMap<>()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MAP<X, BLOB> is only supported by 'blob-field'");
+
+        assertThatThrownBy(
+                        () ->
+                                ColumnDirectiveUtils.applyAddColumnDirective(
+                                        "__BLOB_FIELD",
+                                        "images",
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BYTES()),
+                                        new HashMap<>()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported key type [BOOLEAN]");
     }
 
     @Test
@@ -376,6 +419,17 @@ public class ColumnDirectiveUtilsTest {
 
         ColumnDirectiveUtils.removeDroppedDirectiveOptions(
                 "images", DataTypes.ARRAY(DataTypes.BLOB()), opts);
+
+        assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "other");
+    }
+
+    @Test
+    public void testRemoveDroppedMapBlobOptions() {
+        Map<String, String> opts = new HashMap<>();
+        opts.put(CoreOptions.BLOB_FIELD.key(), "images,other");
+
+        ColumnDirectiveUtils.removeDroppedDirectiveOptions(
+                "images", DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()), opts);
 
         assertThat(opts).containsEntry(CoreOptions.BLOB_FIELD.key(), "other");
     }

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -149,14 +149,14 @@ class SchemaValidationTest {
         options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         assertThatThrownBy(() -> validateBlobSchema(options, emptyList()))
                 .hasMessage(
-                        "Data evolution config must enabled for table with BLOB or ARRAY<BLOB> type column.");
+                        "Data evolution config must enabled for table with BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column.");
 
         options.clear();
         options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
         options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
         assertThatThrownBy(() -> validateBlobSchema(options, singletonList("f2")))
                 .hasMessage(
-                        "The BLOB or ARRAY<BLOB> type column can not be part of partition keys.");
+                        "The BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column can not be part of partition keys.");
 
         assertThatThrownBy(
                         () -> {
@@ -171,7 +171,93 @@ class SchemaValidationTest {
                                             ""));
                         })
                 .hasMessage(
-                        "Table with BLOB or ARRAY<BLOB> type column must have other normal columns.");
+                        "Table with BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column must have other normal columns.");
+    }
+
+    @Test
+    public void testMapBlobSchemaValidation() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(
+                                1,
+                                "payloads",
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+        Map<String, String> options = new HashMap<>();
+        options.put(BUCKET.key(), "-1");
+        options.put(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        options.put(CoreOptions.BLOB_FIELD.key(), "payloads");
+
+        TableSchema schema = new TableSchema(1, fields, 10, emptyList(), emptyList(), options, "");
+        assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
+
+        List<DataField> unsupportedFields =
+                Arrays.asList(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(
+                                1,
+                                "payloads",
+                                DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BLOB())));
+        TableSchema unsupported =
+                new TableSchema(1, unsupportedFields, 10, emptyList(), emptyList(), options, "");
+        assertThatThrownBy(() -> validateTableSchema(unsupported))
+                .hasMessageContaining("Unsupported key type [BOOLEAN]");
+    }
+
+    @Test
+    public void testUnsupportedNestedBlobTypes() {
+        DataType rowBlob = DataTypes.ROW(DataTypes.FIELD(2, "nested_blob", DataTypes.BLOB()));
+        List<DataType> unsupportedTypes =
+                Arrays.asList(
+                        DataTypes.MAP(DataTypes.BLOB(), DataTypes.INT()),
+                        rowBlob,
+                        DataTypes.ARRAY(rowBlob),
+                        DataTypes.MAP(DataTypes.STRING(), rowBlob),
+                        DataTypes.MAP(DataTypes.STRING(), DataTypes.ARRAY(DataTypes.BLOB())),
+                        DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BLOB())),
+                        DataTypes.ROW(
+                                DataTypes.FIELD(
+                                        2,
+                                        "nested_map",
+                                        DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB()))),
+                        DataTypes.MULTISET(DataTypes.BLOB()),
+                        DataTypes.MAP(
+                                DataTypes.STRING(),
+                                DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())));
+
+        for (DataType unsupportedType : unsupportedTypes) {
+            List<DataField> fields =
+                    Arrays.asList(
+                            new DataField(0, "id", DataTypes.INT()),
+                            new DataField(1, "payload", unsupportedType));
+            TableSchema schema =
+                    new TableSchema(1, fields, 10, emptyList(), emptyList(), new HashMap<>(), "");
+
+            assertThatThrownBy(() -> validateTableSchema(schema))
+                    .as("type %s", unsupportedType)
+                    .hasMessageContaining("Field 'payload' has unsupported nested BLOB type")
+                    .hasMessageContaining(
+                            "BLOB is only supported as a top-level BLOB, ARRAY<BLOB>, or MAP<X, BLOB> field.");
+        }
+    }
+
+    @Test
+    public void testPrimaryKeyMapBlobIsRejected() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(
+                                1, "payloads", DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())));
+        Map<String, String> options = new HashMap<>();
+        options.put(BUCKET.key(), "1");
+        options.put(CoreOptions.BLOB_FIELD.key(), "payloads");
+
+        TableSchema schema =
+                new TableSchema(1, fields, 10, emptyList(), singletonList("id"), options, "");
+        assertThatThrownBy(() -> validateTableSchema(schema))
+                .hasMessage(
+                        "Primary-key managed MAP<X, BLOB> fields are not supported: [payloads].");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -243,7 +243,7 @@ class SchemaValidationTest {
     }
 
     @Test
-    public void testPrimaryKeyMapBlobIsRejected() {
+    public void testPrimaryKeyMapBlobField() {
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "id", DataTypes.INT()),
@@ -255,9 +255,24 @@ class SchemaValidationTest {
 
         TableSchema schema =
                 new TableSchema(1, fields, 10, emptyList(), singletonList("id"), options, "");
-        assertThatThrownBy(() -> validateTableSchema(schema))
-                .hasMessage(
-                        "Primary-key managed MAP<X, BLOB> fields are not supported: [payloads].");
+        assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testPrimaryKeyMapBlobManagedByType() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "id", DataTypes.INT()),
+                        new DataField(
+                                1,
+                                "payloads",
+                                DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+        Map<String, String> options = new HashMap<>();
+        options.put(BUCKET.key(), "1");
+
+        TableSchema schema =
+                new TableSchema(1, fields, 10, emptyList(), singletonList("id"), options, "");
+        assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaValidationTest.java
@@ -192,17 +192,16 @@ class SchemaValidationTest {
         TableSchema schema = new TableSchema(1, fields, 10, emptyList(), emptyList(), options, "");
         assertThatCode(() -> validateTableSchema(schema)).doesNotThrowAnyException();
 
-        List<DataField> unsupportedFields =
+        List<DataField> booleanKeyFields =
                 Arrays.asList(
                         new DataField(0, "id", DataTypes.INT()),
                         new DataField(
                                 1,
                                 "payloads",
                                 DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BLOB())));
-        TableSchema unsupported =
-                new TableSchema(1, unsupportedFields, 10, emptyList(), emptyList(), options, "");
-        assertThatThrownBy(() -> validateTableSchema(unsupported))
-                .hasMessageContaining("Unsupported key type [BOOLEAN]");
+        TableSchema booleanKeySchema =
+                new TableSchema(1, booleanKeyFields, 10, emptyList(), emptyList(), options, "");
+        assertThatCode(() -> validateTableSchema(booleanKeySchema)).doesNotThrowAnyException();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
@@ -152,6 +152,7 @@ public class FlinkRowData implements RowData {
         return new BinaryVariant(variant.value(), variant.metadata());
     }
 
+    /** {@link ArrayData} backed by an {@link InternalArray}. */
     protected static class FlinkArrayData implements ArrayData {
 
         private final InternalArray array;

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowData.java
@@ -152,11 +152,11 @@ public class FlinkRowData implements RowData {
         return new BinaryVariant(variant.value(), variant.metadata());
     }
 
-    private static class FlinkArrayData implements ArrayData {
+    protected static class FlinkArrayData implements ArrayData {
 
         private final InternalArray array;
 
-        private FlinkArrayData(InternalArray array) {
+        protected FlinkArrayData(InternalArray array) {
             this.array = array;
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/FlinkRowDataWithBlob.java
@@ -21,10 +21,12 @@ package org.apache.paimon.flink;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobView;
 import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.MapData;
 
 import java.util.Set;
 
@@ -54,14 +56,55 @@ public class FlinkRowDataWithBlob extends FlinkRowData {
     public ArrayData getArray(int pos) {
         if (blobFields.contains(pos)) {
             InternalArray array = row.getArray(pos);
-            Object[] elements = new Object[array.size()];
-            for (int i = 0; i < array.size(); i++) {
-                elements[i] = array.isNullAt(i) ? null : blobToBytes(array.getBlob(i));
-            }
-            return new GenericArrayData(elements);
+            return toFlinkBlobArray(array);
         } else {
             return super.getArray(pos);
         }
+    }
+
+    @Override
+    public MapData getMap(int pos) {
+        if (!blobFields.contains(pos)) {
+            return super.getMap(pos);
+        }
+
+        InternalMap map = row.getMap(pos);
+        InternalArray keys = map.keyArray();
+
+        // Keys should never be null in FlinkMap, but Paimon could. Check here.
+        for (int i = 0; i < map.size(); i++) {
+            if (keys.isNullAt(i)) {
+                throw new IllegalArgumentException(
+                        "Flink MAP<X, BLOB> does not support null keys.");
+            }
+        }
+
+        return new MapData() {
+            @Override
+            public int size() {
+                return map.size();
+            }
+
+            @Override
+            public ArrayData keyArray() {
+                return new FlinkArrayData(keys);
+            }
+
+            @Override
+            public ArrayData valueArray() {
+                return toFlinkBlobArray(map.valueArray());
+            }
+        };
+    }
+
+    private ArrayData toFlinkBlobArray(InternalArray array) {
+        Object[] elements = new Object[array.size()];
+
+        for (int i = 0; i < array.size(); i++) {
+            elements[i] = array.isNullAt(i) ? null : blobToBytes(array.getBlob(i));
+        }
+
+        return new GenericArrayData(elements);
     }
 
     private byte[] blobToBytes(Blob blob) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
@@ -50,10 +50,10 @@ public class LogicalTypeConversion {
         return toBlobType(logicalType, true);
     }
 
-    public static DataType toBlobType(LogicalType logicalType, boolean allowArray) {
+    public static DataType toBlobType(LogicalType logicalType, boolean allowNested) {
         if (logicalType instanceof org.apache.flink.table.types.logical.ArrayType) {
             checkArgument(
-                    allowArray,
+                    allowNested,
                     "ARRAY<BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
             LogicalType elementType =
                     ((org.apache.flink.table.types.logical.ArrayType) logicalType).getElementType();
@@ -65,10 +65,32 @@ public class LogicalTypeConversion {
             return new org.apache.paimon.types.ArrayType(
                     logicalType.isNullable(), new BlobType(elementType.isNullable()));
         }
+        if (logicalType instanceof org.apache.flink.table.types.logical.MapType) {
+            checkArgument(
+                    allowNested,
+                    "MAP<X, BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
+            org.apache.flink.table.types.logical.MapType mapType =
+                    (org.apache.flink.table.types.logical.MapType) logicalType;
+            LogicalType valueType = mapType.getValueType();
+            checkArgument(
+                    isBinaryType(valueType),
+                    "The value type of a MAP<X, BLOB> field must be BinaryType or "
+                            + "VarBinaryType, but got: "
+                            + logicalType);
+            org.apache.paimon.types.MapType result =
+                    new org.apache.paimon.types.MapType(
+                            logicalType.isNullable(),
+                            toDataType(mapType.getKeyType()),
+                            new BlobType(valueType.isNullable()));
+            checkArgument(
+                    BlobType.isBlobFileField(result),
+                    "Unsupported key type for MAP<X, BLOB>: " + mapType.getKeyType());
+            return result;
+        }
         checkArgument(
                 isBinaryType(logicalType),
-                "Expected BinaryType, VarBinaryType or ArrayType with BinaryType or "
-                        + "VarBinaryType element, but got: "
+                "Expected BinaryType, VarBinaryType, ArrayType with binary element, or "
+                        + "MapType with binary value, but got: "
                         + logicalType);
         return new BlobType(logicalType.isNullable());
     }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/LogicalTypeConversion.java
@@ -77,15 +77,10 @@ public class LogicalTypeConversion {
                     "The value type of a MAP<X, BLOB> field must be BinaryType or "
                             + "VarBinaryType, but got: "
                             + logicalType);
-            org.apache.paimon.types.MapType result =
-                    new org.apache.paimon.types.MapType(
-                            logicalType.isNullable(),
-                            toDataType(mapType.getKeyType()),
-                            new BlobType(valueType.isNullable()));
-            checkArgument(
-                    BlobType.isBlobFileField(result),
-                    "Unsupported key type for MAP<X, BLOB>: " + mapType.getKeyType());
-            return result;
+            return new org.apache.paimon.types.MapType(
+                    logicalType.isNullable(),
+                    toDataType(mapType.getKeyType()),
+                    new BlobType(valueType.isNullable()));
         }
         checkArgument(
                 isBinaryType(logicalType),

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoAction.java
@@ -503,7 +503,7 @@ public class DataEvolutionMergeIntoAction extends TableActionBase {
                 if (BlobType.isBlobFileField(targetField.type())
                         && !updatableBlobFields.contains(flinkColumn.getName())) {
                     throw new IllegalStateException(
-                            "Should not append/update raw-data BLOB or ARRAY<BLOB> column '"
+                            "Should not append/update raw-data BLOB, ARRAY<BLOB> or MAP<X, BLOB> column '"
                                     + flinkColumn.getName()
                                     + "' through MERGE INTO. "
                                     + "Only descriptor-based BLOB columns (configured via '"

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BlobDescriptorResolvingRow.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/BlobDescriptorResolvingRow.java
@@ -20,7 +20,9 @@ package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.InternalArray;
@@ -70,7 +72,27 @@ final class BlobDescriptorResolvingRow extends PartialRow {
 
     @Override
     public InternalArray getArray(int pos) {
-        return new BlobDescriptorResolvingArray(super.getArray(pos), uriReaderFactory);
+        return withReader(super.getArray(pos), uriReaderFactory);
+    }
+
+    @Override
+    public InternalMap getMap(int pos) {
+        return withReader(super.getMap(pos), uriReaderFactory);
+    }
+
+    private static InternalArray withReader(
+            InternalArray array, UriReaderFactory uriReaderFactory) {
+        if (array == BlobArrayPlaceholder.INSTANCE) {
+            return array;
+        }
+        return new BlobDescriptorResolvingArray(array, uriReaderFactory);
+    }
+
+    private static InternalMap withReader(InternalMap map, UriReaderFactory uriReaderFactory) {
+        if (map == BlobMapPlaceholder.INSTANCE) {
+            return map;
+        }
+        return new BlobDescriptorResolvingMap(map, uriReaderFactory);
     }
 
     private static final class BlobDescriptorResolvingArray implements InternalArray {
@@ -161,7 +183,7 @@ final class BlobDescriptorResolvingRow extends PartialRow {
 
         @Override
         public InternalArray getArray(int pos) {
-            return new BlobDescriptorResolvingArray(wrapped.getArray(pos), uriReaderFactory);
+            return withReader(wrapped.getArray(pos), uriReaderFactory);
         }
 
         @Override
@@ -171,7 +193,7 @@ final class BlobDescriptorResolvingRow extends PartialRow {
 
         @Override
         public InternalMap getMap(int pos) {
-            return wrapped.getMap(pos);
+            return withReader(wrapped.getMap(pos), uriReaderFactory);
         }
 
         @Override
@@ -212,6 +234,32 @@ final class BlobDescriptorResolvingRow extends PartialRow {
         @Override
         public double[] toDoubleArray() {
             return wrapped.toDoubleArray();
+        }
+    }
+
+    private static final class BlobDescriptorResolvingMap implements InternalMap {
+
+        private final InternalMap wrapped;
+        private final UriReaderFactory uriReaderFactory;
+
+        private BlobDescriptorResolvingMap(InternalMap wrapped, UriReaderFactory uriReaderFactory) {
+            this.wrapped = wrapped;
+            this.uriReaderFactory = uriReaderFactory;
+        }
+
+        @Override
+        public int size() {
+            return wrapped.size();
+        }
+
+        @Override
+        public InternalArray keyArray() {
+            return wrapped.keyArray();
+        }
+
+        @Override
+        public InternalArray valueArray() {
+            return withReader(wrapped.valueArray(), uriReaderFactory);
         }
     }
 }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -42,7 +42,9 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import static org.apache.paimon.flink.LogicalTypeConversion.toLogicalType;
@@ -62,6 +64,7 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 "CREATE TABLE IF NOT EXISTS blob_table_descriptor (id INT, data STRING, picture BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='picture', 'blob-as-descriptor'='true')",
                 "CREATE TABLE IF NOT EXISTS multiple_blob_table (id INT, data STRING, pic1 BYTES, pic2 BYTES) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pic1,pic2')",
                 "CREATE TABLE IF NOT EXISTS array_blob_table (id INT, data STRING, pictures ARRAY<BYTES>) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pictures')",
+                "CREATE TABLE IF NOT EXISTS map_blob_table (id INT, data STRING, pictures MAP<STRING, BYTES>) WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-compaction.enabled'='true', 'blob-field'='pictures')",
                 "CREATE TABLE IF NOT EXISTS mixed_blob_table"
                         + " (id INT, data STRING, raw_pic BYTES, desc_pic BYTES)"
                         + " WITH ('row-tracking.enabled'='true', 'data-evolution.enabled'='true',"
@@ -144,6 +147,54 @@ public class BlobTableITCase extends CatalogITCaseBase {
         assertThat(
                         batchSql(
                                 "SELECT COUNT(*) > 0 FROM `array_blob_table$files` WHERE file_path LIKE '%%.blob'"))
+                .containsExactly(Row.of(true));
+    }
+
+    @Test
+    public void testMapBlobField() throws Exception {
+        org.apache.paimon.types.MapType mapType =
+                (org.apache.paimon.types.MapType)
+                        paimonTable("map_blob_table").rowType().getTypeAt(2);
+        assertThat(mapType.getKeyType().getTypeRoot()).isEqualTo(DataTypeRoot.VARCHAR);
+        assertThat(mapType.getValueType().getTypeRoot()).isEqualTo(DataTypeRoot.BLOB);
+
+        Map<String, byte[]> firstMap = new LinkedHashMap<>();
+        firstMap.put("first", new byte[] {72, 101, 108, 108, 111});
+        firstMap.put("null", null);
+        firstMap.put("second", new byte[] {89, 69});
+        Map<String, byte[]> emptyMap = new LinkedHashMap<>();
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(1, "paimon", firstMap),
+                                Row.of(2, "empty", emptyMap),
+                                Row.of(3, "null-map", null)));
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE map_blob_source "
+                                        + "(id INT, data STRING, pictures MAP<STRING, BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+        batchSql("INSERT INTO map_blob_table SELECT * FROM map_blob_source");
+
+        assertThat(
+                        batchSql(
+                                "SELECT id, CARDINALITY(pictures), pictures['first'], "
+                                        + "pictures['null'], pictures['second'] "
+                                        + "FROM map_blob_table ORDER BY id"))
+                .containsExactly(
+                        Row.of(
+                                1,
+                                3,
+                                new byte[] {72, 101, 108, 108, 111},
+                                null,
+                                new byte[] {89, 69}),
+                        Row.of(2, 0, null, null, null),
+                        Row.of(3, null, null, null, null));
+        assertThat(
+                        batchSql(
+                                "SELECT COUNT(*) > 0 FROM `map_blob_table$files` WHERE file_path LIKE '%%.blob'"))
                 .containsExactly(Row.of(true));
     }
 
@@ -237,6 +288,72 @@ public class BlobTableITCase extends CatalogITCaseBase {
                         batchSql(
                                 "SELECT pictures[1], pictures[2] "
                                         + "FROM array_blob_descriptor_table"))
+                .containsExactly(Row.of(blobData, new byte[] {89, 69}));
+    }
+
+    @Test
+    public void testMapBlobFieldWithDescriptorValues() throws Exception {
+        byte[] blobData = new byte[1024];
+        RANDOM.nextBytes(blobData);
+        FileIO fileIO = new LocalFileIO();
+        String uri = "file://" + warehouse + "/external_map_blob";
+        try (OutputStream outputStream =
+                fileIO.newOutputStream(new org.apache.paimon.fs.Path(uri), true)) {
+            outputStream.write(blobData);
+        }
+
+        tEnv.executeSql(
+                        "CREATE TABLE map_blob_descriptor_table "
+                                + "(id INT, data STRING, pictures MAP<STRING, BYTES>) "
+                                + "WITH ('row-tracking.enabled'='true', "
+                                + "'data-evolution.enabled'='true', "
+                                + "'blob-field'='pictures', "
+                                + "'blob-as-descriptor'='true')")
+                .await();
+        Map<String, byte[]> pictures = new LinkedHashMap<>();
+        pictures.put("external", new BlobDescriptor(uri, 0, blobData.length).serialize());
+        pictures.put("inline", new byte[] {89, 69});
+        String dataId =
+                TestValuesTableFactory.registerData(Arrays.asList(Row.of(1, "paimon", pictures)));
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE map_blob_descriptor_source "
+                                        + "(id INT, data STRING, pictures MAP<STRING, BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+        batchSql("INSERT INTO map_blob_descriptor_table SELECT * FROM map_blob_descriptor_source");
+
+        Row descriptorRow =
+                batchSql(
+                                "SELECT pictures['external'], pictures['inline'] "
+                                        + "FROM map_blob_descriptor_table")
+                        .get(0);
+        BlobDescriptor firstDescriptor =
+                BlobDescriptor.deserialize((byte[]) descriptorRow.getField(0));
+        BlobDescriptor secondDescriptor =
+                BlobDescriptor.deserialize((byte[]) descriptorRow.getField(1));
+        Options options = new Options();
+        options.set("warehouse", warehouse.toString());
+        UriReaderFactory uriReaderFactory = new UriReaderFactory(CatalogContext.create(options));
+        assertThat(
+                        Blob.fromDescriptor(
+                                        uriReaderFactory.create(firstDescriptor.uri()),
+                                        firstDescriptor)
+                                .toData())
+                .isEqualTo(blobData);
+        assertThat(
+                        Blob.fromDescriptor(
+                                        uriReaderFactory.create(secondDescriptor.uri()),
+                                        secondDescriptor)
+                                .toData())
+                .isEqualTo(new byte[] {89, 69});
+
+        batchSql("ALTER TABLE map_blob_descriptor_table SET ('blob-as-descriptor'='false')");
+        assertThat(
+                        batchSql(
+                                "SELECT pictures['external'], pictures['inline'] "
+                                        + "FROM map_blob_descriptor_table"))
                 .containsExactly(Row.of(blobData, new byte[] {89, 69}));
     }
 
@@ -600,6 +717,53 @@ public class BlobTableITCase extends CatalogITCaseBase {
                 "array_blob_descriptor_reject", "'blob-descriptor-field'='pictures'");
         assertArrayBlobInlineFieldRejected(
                 "array_blob_view_reject", "'blob-view-field'='pictures'");
+    }
+
+    @Test
+    public void testMapBlobValidation() {
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                                "CREATE TABLE map_blob_descriptor_reject "
+                                                        + "(id INT, pictures MAP<STRING, BYTES>) "
+                                                        + "WITH ('row-tracking.enabled'='true', "
+                                                        + "'data-evolution.enabled'='true', "
+                                                        + "'blob-descriptor-field'='pictures')")
+                                        .await())
+                .hasRootCauseMessage("MAP<X, BLOB> is only supported by 'blob-field'.");
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                                "CREATE TABLE map_blob_view_reject "
+                                                        + "(id INT, pictures MAP<STRING, BYTES>) "
+                                                        + "WITH ('row-tracking.enabled'='true', "
+                                                        + "'data-evolution.enabled'='true', "
+                                                        + "'blob-view-field'='pictures')")
+                                        .await())
+                .hasRootCauseMessage("MAP<X, BLOB> is only supported by 'blob-field'.");
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                                "CREATE TABLE map_blob_unsupported_key "
+                                                        + "(id INT, pictures MAP<BOOLEAN, BYTES>) "
+                                                        + "WITH ('row-tracking.enabled'='true', "
+                                                        + "'data-evolution.enabled'='true', "
+                                                        + "'blob-field'='pictures')")
+                                        .await())
+                .hasRootCauseMessage("Unsupported key type for MAP<X, BLOB>: BOOLEAN");
+
+        assertThatThrownBy(
+                        () ->
+                                tEnv.executeSql(
+                                                "CREATE TABLE pk_map_blob_reject "
+                                                        + "(id INT, pictures MAP<STRING, BYTES>, "
+                                                        + "PRIMARY KEY (id) NOT ENFORCED) "
+                                                        + "WITH ('bucket'='1', 'blob-field'='pictures')")
+                                        .await())
+                .hasRootCauseMessage(
+                        "Primary-key managed MAP<X, BLOB> fields are not supported: [pictures].");
     }
 
     private void assertArrayBlobInlineFieldRejected(String tableName, String blobOptions) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -775,7 +775,7 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
-    public void testMapBlobValidation() {
+    public void testMapBlobValidation() throws Exception {
         assertThatThrownBy(
                         () ->
                                 tEnv.executeSql(
@@ -798,16 +798,13 @@ public class BlobTableITCase extends CatalogITCaseBase {
                                         .await())
                 .hasRootCauseMessage("MAP<X, BLOB> is only supported by 'blob-field'.");
 
-        assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                                "CREATE TABLE map_blob_unsupported_key "
-                                                        + "(id INT, pictures MAP<BOOLEAN, BYTES>) "
-                                                        + "WITH ('row-tracking.enabled'='true', "
-                                                        + "'data-evolution.enabled'='true', "
-                                                        + "'blob-field'='pictures')")
-                                        .await())
-                .hasRootCauseMessage("Unsupported key type for MAP<X, BLOB>: BOOLEAN");
+        tEnv.executeSql(
+                        "CREATE TABLE map_blob_boolean_key "
+                                + "(id INT, pictures MAP<BOOLEAN, BYTES>) "
+                                + "WITH ('row-tracking.enabled'='true', "
+                                + "'data-evolution.enabled'='true', "
+                                + "'blob-field'='pictures')")
+                .await();
     }
 
     private void assertArrayBlobInlineFieldRejected(String tableName, String blobOptions) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -239,6 +239,61 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testPrimaryKeyMapBlobField() throws Exception {
+        batchSql(
+                "CREATE TABLE pk_map_blob_table ("
+                        + "id INT, pictures MAP<STRING, BYTES>, "
+                        + "PRIMARY KEY (id) NOT ENFORCED) "
+                        + "WITH ('bucket'='1', 'blob-field'='pictures')");
+        Map<String, byte[]> pictures = new LinkedHashMap<>();
+        pictures.put("first", new byte[] {72, 101, 108, 108, 111});
+        pictures.put("null", null);
+        pictures.put("second", new byte[] {89, 69});
+        String dataId = TestValuesTableFactory.registerData(Arrays.asList(Row.of(1, pictures)));
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE pk_map_blob_source "
+                                        + "(id INT, pictures MAP<STRING, BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+
+        batchSql("INSERT INTO pk_map_blob_table SELECT * FROM pk_map_blob_source");
+
+        assertThat(
+                        batchSql(
+                                "SELECT id, CARDINALITY(pictures), pictures['first'], "
+                                        + "pictures['null'], pictures['second'] "
+                                        + "FROM pk_map_blob_table"))
+                .containsExactly(
+                        Row.of(
+                                1,
+                                3,
+                                new byte[] {72, 101, 108, 108, 111},
+                                null,
+                                new byte[] {89, 69}));
+
+        Map<String, byte[]> updated = new LinkedHashMap<>();
+        updated.put("first", new byte[] {78, 69, 87});
+        String updateDataId =
+                TestValuesTableFactory.registerData(Arrays.asList(Row.of(1, updated)));
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE pk_map_blob_update_source "
+                                        + "(id INT, pictures MAP<STRING, BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                updateDataId))
+                .await();
+        batchSql("INSERT INTO pk_map_blob_table SELECT * FROM pk_map_blob_update_source");
+
+        assertThat(
+                        batchSql(
+                                "SELECT id, CARDINALITY(pictures), pictures['first'] "
+                                        + "FROM pk_map_blob_table"))
+                .containsExactly(Row.of(1, 1, new byte[] {78, 69, 87}));
+    }
+
+    @Test
     public void testArrayBlobFieldWithDescriptorElements() throws Exception {
         byte[] blobData = new byte[1024];
         RANDOM.nextBytes(blobData);
@@ -753,17 +808,6 @@ public class BlobTableITCase extends CatalogITCaseBase {
                                                         + "'blob-field'='pictures')")
                                         .await())
                 .hasRootCauseMessage("Unsupported key type for MAP<X, BLOB>: BOOLEAN");
-
-        assertThatThrownBy(
-                        () ->
-                                tEnv.executeSql(
-                                                "CREATE TABLE pk_map_blob_reject "
-                                                        + "(id INT, pictures MAP<STRING, BYTES>, "
-                                                        + "PRIMARY KEY (id) NOT ENFORCED) "
-                                                        + "WITH ('bucket'='1', 'blob-field'='pictures')")
-                                        .await())
-                .hasRootCauseMessage(
-                        "Primary-key managed MAP<X, BLOB> fields are not supported: [pictures].");
     }
 
     private void assertArrayBlobInlineFieldRejected(String tableName, String blobOptions) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowDataWithBlobTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/FlinkRowDataWithBlobTest.java
@@ -19,20 +19,26 @@
 package org.apache.paimon.flink;
 
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobViewStruct;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.utils.UriReader;
 
 import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.MapData;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link FlinkRowDataWithBlob}. */
 public class FlinkRowDataWithBlobTest {
@@ -79,6 +85,48 @@ public class FlinkRowDataWithBlobTest {
 
         assertThat(rowData.getBinary(0)).isEqualTo(rawDescriptor.serialize());
         assertThat(rowData.getArray(1).getBinary(0)).isEqualTo(arrayDescriptor.serialize());
+    }
+
+    @Test
+    public void testMapBlobAsDataAndDescriptor() {
+        byte[] first = new byte[] {1, 2};
+        BlobDescriptor descriptor = new BlobDescriptor("file:///map", 3, 4);
+        Map<Object, Object> map = new LinkedHashMap<>();
+        map.put(BinaryString.fromString("first"), Blob.fromData(first));
+        map.put(BinaryString.fromString("null"), null);
+
+        FlinkRowDataWithBlob dataRow =
+                new FlinkRowDataWithBlob(
+                        GenericRow.of(new GenericMap(map)), new HashSet<>(Arrays.asList(0)), false);
+        MapData dataMap = dataRow.getMap(0);
+        assertThat(dataMap.size()).isEqualTo(2);
+        assertThat(dataMap.keyArray().getString(0).toString()).isEqualTo("first");
+        assertThat(dataMap.valueArray().getBinary(0)).isEqualTo(first);
+        assertThat(dataMap.keyArray().getString(1).toString()).isEqualTo("null");
+        assertThat(dataMap.valueArray().isNullAt(1)).isTrue();
+
+        map.clear();
+        map.put(
+                BinaryString.fromString("descriptor"),
+                Blob.fromDescriptor(UriReader.fromHttp(), descriptor));
+        FlinkRowDataWithBlob descriptorRow =
+                new FlinkRowDataWithBlob(
+                        GenericRow.of(new GenericMap(map)), new HashSet<>(Arrays.asList(0)), true);
+        assertThat(descriptorRow.getMap(0).valueArray().getBinary(0))
+                .isEqualTo(descriptor.serialize());
+    }
+
+    @Test
+    public void testMapBlobRejectsNullKey() {
+        Map<Object, Object> map = new LinkedHashMap<>();
+        map.put(null, Blob.fromData(new byte[] {1}));
+        FlinkRowDataWithBlob rowData =
+                new FlinkRowDataWithBlob(
+                        GenericRow.of(new GenericMap(map)), new HashSet<>(Arrays.asList(0)), false);
+
+        assertThatThrownBy(() -> rowData.getMap(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Flink MAP<X, BLOB> does not support null keys.");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/LookupJoinITCase.java
@@ -31,7 +31,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -1664,6 +1666,66 @@ public class LookupJoinITCase extends CatalogITCaseBase {
         String query =
                 "SELECT T.i, D.name, D.pictures[1], D.pictures[2] FROM T "
                         + "LEFT JOIN ARRAY_BLOB_DIM for system_time as of T.proctime AS D "
+                        + "ON T.i = D.id";
+        BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
+
+        sql("INSERT INTO T VALUES (1), (2), (3)");
+        List<Row> result = iterator.collect(3);
+        assertThat(result).hasSize(3);
+
+        Row first = result.stream().filter(row -> row.getField(0).equals(1)).findFirst().get();
+        assertThat(first.getField(1)).isEqualTo("cat");
+        assertThat(BlobDescriptor.deserialize((byte[]) first.getField(2)).length()).isEqualTo(5);
+        assertThat(BlobDescriptor.deserialize((byte[]) first.getField(3)).length()).isEqualTo(2);
+
+        Row second = result.stream().filter(row -> row.getField(0).equals(2)).findFirst().get();
+        assertThat(second.getField(1)).isEqualTo("dog");
+        assertThat(BlobDescriptor.deserialize((byte[]) second.getField(2)).length()).isEqualTo(5);
+        assertThat(second.getField(3)).isNull();
+
+        Row missing = result.stream().filter(row -> row.getField(0).equals(3)).findFirst().get();
+        assertThat(missing.getField(1)).isNull();
+        assertThat(missing.getField(2)).isNull();
+        assertThat(missing.getField(3)).isNull();
+
+        iterator.close();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = LookupCacheMode.class,
+            names = {"FULL", "MEMORY"})
+    public void testLookupMapBlobAsDescriptorOnNormalBlobTable(LookupCacheMode mode)
+            throws Exception {
+        sql(
+                "CREATE TABLE MAP_BLOB_DIM (id INT, name STRING, pictures MAP<INT, BYTES>) WITH ("
+                        + "'row-tracking.enabled'='true', "
+                        + "'data-evolution.enabled'='true', "
+                        + "'blob-field'='pictures', "
+                        + "'lookup.blob-as-descriptor'='true', "
+                        + "'lookup.cache'='%s', "
+                        + "'continuous.discovery-interval'='1 ms')",
+                mode);
+
+        Map<Integer, byte[]> firstPictures = new LinkedHashMap<>();
+        firstPictures.put(1, new byte[] {72, 101, 108, 108, 111});
+        firstPictures.put(2, new byte[] {89, 69});
+        Map<Integer, byte[]> secondPictures = new LinkedHashMap<>();
+        secondPictures.put(1, new byte[] {87, 111, 114, 108, 100});
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(1, "cat", firstPictures), Row.of(2, "dog", secondPictures)));
+        sql(
+                "CREATE TEMPORARY TABLE MAP_BLOB_SOURCE "
+                        + "(id INT, name STRING, pictures MAP<INT, BYTES>) WITH ("
+                        + "'connector'='values', 'bounded'='true', 'data-id'='%s')",
+                dataId);
+        sql("INSERT INTO MAP_BLOB_DIM SELECT * FROM MAP_BLOB_SOURCE");
+
+        String query =
+                "SELECT T.i, D.name, D.pictures[1], D.pictures[2] FROM T "
+                        + "LEFT JOIN MAP_BLOB_DIM for system_time as of T.proctime AS D "
                         + "ON T.i = D.id";
         BlockingIterator<Row, Row> iterator = BlockingIterator.of(sEnv.executeSql(query).collect());
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/action/DataEvolutionMergeIntoActionITCase.java
@@ -39,7 +39,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -718,9 +720,48 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
 
         Throwable t = Assertions.assertThrows(IllegalStateException.class, () -> action.run());
         Assertions.assertTrue(
-                t.getMessage().contains("raw-data BLOB or ARRAY<BLOB> column"),
-                "Expected error about raw-data BLOB or ARRAY<BLOB> column but got: "
+                t.getMessage().contains("raw-data BLOB, ARRAY<BLOB> or MAP<X, BLOB> column"),
+                "Expected error about raw-data BLOB, ARRAY<BLOB> or MAP<X, BLOB> column but got: "
                         + t.getMessage());
+    }
+
+    @Test
+    public void testUpdateRawMapBlobColumnThrowsError() throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_MAP_BLOB_T",
+                        Arrays.asList("id INT", "pictures MAP<STRING, BYTES>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put("blob-field", "pictures");
+                            }
+                        }));
+        insertInto("RAW_MAP_BLOB_T", "(1, MAP['old', X'4F4C44'])");
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_MAP_BLOB_S",
+                        Arrays.asList("id INT", "pictures MAP<STRING, BYTES>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyMap()));
+        insertInto("RAW_MAP_BLOB_S", "(1, MAP['new', X'4E4557'])");
+
+        DataEvolutionMergeIntoAction action =
+                builder(warehouse, database, "RAW_MAP_BLOB_T")
+                        .withMergeCondition("RAW_MAP_BLOB_T.id=RAW_MAP_BLOB_S.id")
+                        .withMatchedUpdateSet("RAW_MAP_BLOB_T.pictures=RAW_MAP_BLOB_S.pictures")
+                        .withSourceTable("RAW_MAP_BLOB_S")
+                        .withSinkParallelism(1)
+                        .build();
+
+        Throwable t = Assertions.assertThrows(IllegalStateException.class, () -> action.run());
+        Assertions.assertTrue(
+                t.getMessage().contains("raw-data BLOB, ARRAY<BLOB> or MAP<X, BLOB> column"),
+                "Expected error about raw-data MAP<X, BLOB> column but got: " + t.getMessage());
     }
 
     @Test
@@ -850,6 +891,83 @@ public class DataEvolutionMergeIntoActionITCase extends ActionITCaseBase {
         testBatchRead(
                 "SELECT id, name, pictures[1], pictures[2] "
                         + "FROM RAW_ARRAY_BLOB_SPLIT_T ORDER BY id",
+                expected);
+    }
+
+    @Test
+    public void testUpdateNonBlobColumnOnRawMapBlobTableWithSplitFiles() throws Exception {
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_MAP_BLOB_SPLIT_T",
+                        Arrays.asList("id INT", "name STRING", "pictures MAP<STRING, BYTES>"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        new HashMap<String, String>() {
+                            {
+                                put(ROW_TRACKING_ENABLED.key(), "true");
+                                put(DATA_EVOLUTION_ENABLED.key(), "true");
+                                put("blob-field", "pictures");
+                                put(CoreOptions.BLOB_TARGET_FILE_SIZE.key(), "1 b");
+                                put("sink.parallelism", "1");
+                            }
+                        }));
+        Map<String, byte[]> firstPictures = new LinkedHashMap<>();
+        firstPictures.put("first", new byte[] {72, 101, 108, 108, 111});
+        firstPictures.put("second", new byte[] {89, 69});
+        Map<String, byte[]> secondPictures = new LinkedHashMap<>();
+        secondPictures.put("first", new byte[] {65, 66, 67});
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(1, "name1", firstPictures),
+                                Row.of(2, "name2", secondPictures),
+                                Row.of(3, "name3", null)));
+        sEnv.executeSql(
+                        String.format(
+                                "CREATE TEMPORARY TABLE RAW_MAP_BLOB_SPLIT_SOURCE "
+                                        + "(id INT, name STRING, pictures MAP<STRING, BYTES>) "
+                                        + "WITH ('connector'='values', 'bounded'='true', 'data-id'='%s')",
+                                dataId))
+                .await();
+        sEnv.executeSql(
+                        "INSERT INTO RAW_MAP_BLOB_SPLIT_T "
+                                + "SELECT * FROM RAW_MAP_BLOB_SPLIT_SOURCE")
+                .await();
+        testBatchRead(
+                "SELECT COUNT(*) > 1 FROM `RAW_MAP_BLOB_SPLIT_T$files` "
+                        + "WHERE file_path LIKE '%.blob'",
+                Collections.singletonList(changelogRow("+I", true)));
+
+        sEnv.executeSql(
+                buildDdl(
+                        "RAW_MAP_BLOB_SPLIT_S",
+                        Arrays.asList("id INT", "name STRING"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyMap()));
+        insertInto("RAW_MAP_BLOB_SPLIT_S", "(1, 'updated_name1')");
+
+        builder(warehouse, database, "RAW_MAP_BLOB_SPLIT_T")
+                .withMergeCondition("RAW_MAP_BLOB_SPLIT_T.id=RAW_MAP_BLOB_SPLIT_S.id")
+                .withMatchedUpdateSet("RAW_MAP_BLOB_SPLIT_T.name=RAW_MAP_BLOB_SPLIT_S.name")
+                .withSourceTable("RAW_MAP_BLOB_SPLIT_S")
+                .withSinkParallelism(1)
+                .build()
+                .run();
+
+        List<Row> expected =
+                Arrays.asList(
+                        changelogRow(
+                                "+I",
+                                1,
+                                "updated_name1",
+                                new byte[] {72, 101, 108, 108, 111},
+                                new byte[] {89, 69}),
+                        changelogRow("+I", 2, "name2", new byte[] {65, 66, 67}, null),
+                        changelogRow("+I", 3, "name3", null, null));
+        testBatchRead(
+                "SELECT id, name, pictures['first'], pictures['second'] "
+                        + "FROM RAW_MAP_BLOB_SPLIT_T ORDER BY id",
                 expected);
     }
 

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BlobDescriptorResolvingRowTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/BlobDescriptorResolvingRowTest.java
@@ -19,8 +19,12 @@
 package org.apache.paimon.flink.sink;
 
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.flink.utils.InternalRowTypeSerializer;
 import org.apache.paimon.fs.local.LocalFileIO;
@@ -34,7 +38,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static org.apache.paimon.data.BinaryString.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link BlobDescriptorResolvingRow}. */
@@ -62,6 +69,40 @@ class BlobDescriptorResolvingRowTest {
                         serialized, UriReaderFactory.fromFileIO(LocalFileIO.create()));
 
         assertThat(resolvingRow.getArray(0).getBlob(0).toData()).isEqualTo(expected);
+    }
+
+    @Test
+    void testMapBlobAfterFlinkSerialization() throws Exception {
+        byte[] expected = new byte[] {1, 2, 3};
+        java.nio.file.Path blobPath = tempPath.resolve("map-blob");
+        Files.write(blobPath, expected);
+
+        RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
+        Map<Object, Object> values = new LinkedHashMap<>();
+        values.put(
+                fromString("key"),
+                Blob.fromFile(LocalFileIO.create(), blobPath.toUri().toString()));
+        InternalRow serialized =
+                serializeAndDeserialize(GenericRow.of(new GenericMap(values)), rowType);
+
+        BlobDescriptorResolvingRow resolvingRow =
+                new BlobDescriptorResolvingRow(
+                        serialized, UriReaderFactory.fromFileIO(LocalFileIO.create()));
+
+        InternalMap map = resolvingRow.getMap(0);
+        assertThat(map.keyArray().getString(0)).isEqualTo(fromString("key"));
+        assertThat(map.valueArray().getBlob(0).toData()).isEqualTo(expected);
+    }
+
+    @Test
+    void testBlobPlaceholdersArePreserved() {
+        BlobDescriptorResolvingRow resolvingRow =
+                new BlobDescriptorResolvingRow(
+                        GenericRow.of(BlobArrayPlaceholder.INSTANCE, BlobMapPlaceholder.INSTANCE),
+                        UriReaderFactory.fromFileIO(LocalFileIO.create()));
+
+        assertThat(resolvingRow.getArray(0)).isSameAs(BlobArrayPlaceholder.INSTANCE);
+        assertThat(resolvingRow.getMap(1)).isSameAs(BlobMapPlaceholder.INSTANCE);
     }
 
     private static InternalRow serializeAndDeserialize(InternalRow row, RowType rowType)

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementReader.java
@@ -23,6 +23,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -47,8 +48,8 @@ abstract class AbstractBlobElementReader implements BlobElementSerializer.Reader
         this.blobAsDescriptor = blobAsDescriptor;
     }
 
-    protected final @Nullable SeekableInputStream inputStream() {
-        return in;
+    protected final SeekableInputStream inputStream() {
+        return Preconditions.checkNotNull(in, "Input stream must be available for blob reading.");
     }
 
     protected final boolean blobAsDescriptor() {
@@ -56,14 +57,15 @@ abstract class AbstractBlobElementReader implements BlobElementSerializer.Reader
     }
 
     protected final Blob readBlob(long position, long length) {
-        if (in != null && !blobAsDescriptor) {
-            return Blob.fromData(readInlineBlob(position, length));
+        if (blobAsDescriptor) {
+            return Blob.fromFile(fileIO, filePath, position, length);
         }
-        return Blob.fromFile(fileIO, filePath, position, length);
+        return Blob.fromData(readInlineBlob(position, length));
     }
 
     protected final byte[] readInlineBlob(long position, long length) {
         byte[] blobData = new byte[(int) length];
+        SeekableInputStream in = inputStream();
         try {
             in.seek(position);
             IOUtils.readFully(in, blobData);

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementReader.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.utils.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** Common reader functionality shared by blob element formats. */
+abstract class AbstractBlobElementReader implements BlobElementSerializer.Reader {
+
+    private final FileIO fileIO;
+    private final String filePath;
+    private final @Nullable SeekableInputStream in;
+    private final boolean blobAsDescriptor;
+
+    AbstractBlobElementReader(
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor) {
+        this.fileIO = fileIO;
+        this.filePath = filePath.toString();
+        this.in = in;
+        this.blobAsDescriptor = blobAsDescriptor;
+    }
+
+    protected final @Nullable SeekableInputStream inputStream() {
+        return in;
+    }
+
+    protected final boolean blobAsDescriptor() {
+        return blobAsDescriptor;
+    }
+
+    protected final Blob readBlob(long position, long length) {
+        if (in != null && !blobAsDescriptor) {
+            return Blob.fromData(readInlineBlob(position, length));
+        }
+        return Blob.fromFile(fileIO, filePath, position, length);
+    }
+
+    protected final byte[] readInlineBlob(long position, long length) {
+        byte[] blobData = new byte[(int) length];
+        try {
+            in.seek(position);
+            IOUtils.readFully(in, blobData);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return blobData;
+    }
+
+    @Override
+    public void close() {
+        IOUtils.closeQuietly(in);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/AbstractBlobElementWriter.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.BlobRef;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.rest.HttpClientUtils;
+import org.apache.paimon.utils.SensitiveConfigUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.StreamUtils.intToLittleEndian;
+import static org.apache.paimon.utils.StreamUtils.longToLittleEndian;
+
+/** Common writer functionality shared by blob element formats. */
+abstract class AbstractBlobElementWriter implements BlobElementSerializer.Writer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBlobElementWriter.class);
+
+    private final PositionOutputStream out;
+    private final String blobFieldName;
+    private final @Nullable BlobConsumer writeConsumer;
+    private final boolean writeNullOnMissingFile;
+    private final boolean writeNullOnFetchFailure;
+    private final BlobFetchMetricReporter blobFetchMetricReporter;
+    private final CRC32 crc32;
+    private final byte[] copyBuffer;
+
+    private String pathString;
+
+    AbstractBlobElementWriter(
+            PositionOutputStream out,
+            String blobFieldName,
+            @Nullable BlobConsumer writeConsumer,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize) {
+        checkArgument(
+                copyBufferSize > 0,
+                "BLOB copy buffer size must be positive, but was %s.",
+                copyBufferSize);
+        this.out = out;
+        this.blobFieldName = blobFieldName;
+        this.writeConsumer = writeConsumer;
+        this.writeNullOnMissingFile = writeNullOnMissingFile;
+        this.writeNullOnFetchFailure = writeNullOnFetchFailure;
+        this.blobFetchMetricReporter = blobFetchMetricReporter;
+        this.crc32 = new CRC32();
+        this.copyBuffer = new byte[copyBufferSize];
+    }
+
+    @Override
+    public final void setFile(Path file) {
+        this.pathString = file.toString();
+    }
+
+    protected final long startRecord() throws IOException {
+        long position = out.getPos();
+        crc32.reset();
+        write(BlobFormatWriter.MAGIC_NUMBER_BYTES);
+        return position;
+    }
+
+    protected final long finishRecord(long recordPosition) throws IOException {
+        long recordLength = out.getPos() - recordPosition + 12;
+        write(longToLittleEndian(recordLength));
+        out.write(intToLittleEndian((int) crc32.getValue()));
+        return recordLength;
+    }
+
+    protected final long writeNullElement() throws IOException {
+        if (writeConsumer != null) {
+            writeConsumer.accept(blobFieldName, null);
+        }
+        return BlobFormatWriter.NULL_LENGTH;
+    }
+
+    protected final long writePlaceholderElement() {
+        return BlobFormatWriter.PLACE_HOLDER_LENGTH;
+    }
+
+    protected final BlobFetchResult getBlob(BlobGetter getter) {
+        try {
+            return new BlobFetchResult(getter.get(), false);
+        } catch (RuntimeException e) {
+            if (shouldWriteNullOnFetchFailure(e)) {
+                logWriteNullOnFetchFailure(e, null);
+                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
+                return new BlobFetchResult(null, true);
+            }
+            blobFetchMetricReporter.recordFetchFailure(e);
+            throw e;
+        }
+    }
+
+    protected final @Nullable SeekableInputStream openBlobInputStream(Blob blob)
+            throws IOException {
+        try {
+            return blob.newInputStream();
+        } catch (IOException | RuntimeException e) {
+            if (writeNullOnMissingFile && HttpClientUtils.isNotFoundError(e)) {
+                LOG.warn(
+                        "Failed to open blob from {} (HTTP 404), writing NULL for BLOB field {}.",
+                        blobUri(blob),
+                        blobFieldName,
+                        e);
+                blobFetchMetricReporter.recordMissingFileNullWritten(true);
+                return null;
+            }
+            if (shouldWriteNullOnFetchFailure(e)) {
+                logWriteNullOnFetchFailure(e, blob);
+                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
+                return null;
+            }
+            blobFetchMetricReporter.recordFetchFailure(e);
+            throw e;
+        }
+    }
+
+    protected final BlobDescriptor writeBlobData(SeekableInputStream in) throws IOException {
+        long blobPosition = out.getPos();
+        try (SeekableInputStream stream = in) {
+            int bytesRead = stream.read(copyBuffer);
+            while (bytesRead >= 0) {
+                write(copyBuffer, bytesRead);
+                bytesRead = stream.read(copyBuffer);
+            }
+        } catch (IOException | RuntimeException e) {
+            blobFetchMetricReporter.recordFetchFailure(e);
+            throw e;
+        }
+        return new BlobDescriptor(pathString, blobPosition, out.getPos() - blobPosition);
+    }
+
+    protected final boolean accept(BlobDescriptor descriptor) throws IOException {
+        return writeConsumer != null && writeConsumer.accept(blobFieldName, descriptor);
+    }
+
+    protected final void flush() throws IOException {
+        out.flush();
+    }
+
+    protected final void recordSuccess(long length) {
+        blobFetchMetricReporter.recordSuccess(length);
+    }
+
+    protected final void recordPreCheckedMissingFileNull(InternalRow row) {
+        if (!writeNullOnMissingFile) {
+            return;
+        }
+        Blob blob = row.getBlob(0);
+        if (blob instanceof BlobRef) {
+            BlobDescriptor descriptor = ((BlobRef) blob).toDescriptor();
+            blobFetchMetricReporter.recordMissingFileNullWritten(isHttpUri(descriptor.uri()));
+        }
+    }
+
+    protected final void write(byte[] bytes) throws IOException {
+        write(bytes, bytes.length);
+    }
+
+    private void write(byte[] bytes, int length) throws IOException {
+        crc32.update(bytes, 0, length);
+        out.write(bytes, 0, length);
+    }
+
+    private boolean shouldWriteNullOnFetchFailure(Throwable e) {
+        return writeNullOnFetchFailure && !HttpClientUtils.isNotFoundError(e);
+    }
+
+    private void logWriteNullOnFetchFailure(Throwable e, @Nullable Blob blob) {
+        Integer statusCode = HttpClientUtils.getHttpStatusCode(e);
+        if (statusCode != null) {
+            LOG.warn(
+                    "Failed to open blob from {} (HTTP {}), writing NULL for BLOB field {}.",
+                    blobUri(blob),
+                    statusCode,
+                    blobFieldName,
+                    e);
+        } else if (HttpClientUtils.isInvalidUriException(e)) {
+            LOG.warn(
+                    "Invalid blob URI {} while opening blob, writing NULL for BLOB field {}.",
+                    blobUri(blob),
+                    blobFieldName,
+                    e);
+        } else {
+            LOG.warn(
+                    "Failed to open blob from {} due to fetch failure, writing NULL for BLOB field {}.",
+                    blobUri(blob),
+                    blobFieldName,
+                    e);
+        }
+    }
+
+    private static String blobUri(@Nullable Blob blob) {
+        if (blob instanceof BlobRef) {
+            // Sanitize: a signed URL carries token/signature in its query.
+            return SensitiveConfigUtils.sanitizeUri(((BlobRef) blob).toDescriptor().uri());
+        }
+        return "unknown";
+    }
+
+    private static boolean isHttpUri(String uri) {
+        return uri.regionMatches(true, 0, "http://", 0, "http://".length())
+                || uri.regionMatches(true, 0, "https://", 0, "https://".length());
+    }
+
+    /** Lazily gets a Blob from a row or array. */
+    interface BlobGetter {
+        Blob get();
+    }
+
+    /** Result of getting a Blob, preserving whether a null came from fetch fallback. */
+    static final class BlobFetchResult {
+
+        private final @Nullable Blob blob;
+        private final boolean fetchFailure;
+
+        private BlobFetchResult(@Nullable Blob blob, boolean fetchFailure) {
+            this.blob = blob;
+            this.fetchFailure = fetchFailure;
+        }
+
+        @Nullable
+        Blob blob() {
+            return blob;
+        }
+
+        boolean fetchFailure() {
+            return fetchFailure;
+        }
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/ArrayBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/ArrayBlobElementSerializer.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
+import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.utils.DeltaVarintCompressor;
+import org.apache.paimon.utils.IOUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.apache.paimon.utils.StreamUtils.intToLittleEndian;
+
+/** Element serializer for an ARRAY&lt;BLOB&gt; field. */
+final class ArrayBlobElementSerializer implements BlobElementSerializer {
+
+    static final byte VERSION = 1;
+    static final int MAGIC_NUMBER = 1094861634;
+    static final byte[] MAGIC_NUMBER_BYTES = intToLittleEndian(MAGIC_NUMBER);
+    static final long NULL_ELEMENT_LENGTH = -1L;
+
+    private static final int HEADER_LENGTH = 9;
+    private static final int INDEX_LENGTH_SIZE = Integer.BYTES;
+    private static final int MIN_PAYLOAD_LENGTH = HEADER_LENGTH + INDEX_LENGTH_SIZE;
+
+    @Override
+    public BlobElementSerializer.Writer createWriter(
+            PositionOutputStream out,
+            String blobFieldName,
+            @Nullable BlobConsumer writeConsumer,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize) {
+        return new Writer(
+                out,
+                blobFieldName,
+                writeConsumer,
+                writeNullOnMissingFile,
+                writeNullOnFetchFailure,
+                blobFetchMetricReporter,
+                copyBufferSize);
+    }
+
+    @Override
+    public BlobElementSerializer.Reader createReader(
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor) {
+        return new Reader(fileIO, filePath, in, blobAsDescriptor);
+    }
+
+    /** Writer for an ARRAY&lt;BLOB&gt; field. */
+    static final class Writer extends AbstractBlobElementWriter {
+
+        Writer(
+                PositionOutputStream out,
+                String blobFieldName,
+                @Nullable BlobConsumer writeConsumer,
+                boolean writeNullOnMissingFile,
+                boolean writeNullOnFetchFailure,
+                BlobFetchMetricReporter blobFetchMetricReporter,
+                int copyBufferSize) {
+            super(
+                    out,
+                    blobFieldName,
+                    writeConsumer,
+                    writeNullOnMissingFile,
+                    writeNullOnFetchFailure,
+                    blobFetchMetricReporter,
+                    copyBufferSize);
+        }
+
+        @Override
+        public long write(InternalRow row) throws IOException {
+            if (row.isNullAt(0)) {
+                return writeNullElement();
+            }
+
+            InternalArray array = row.getArray(0);
+            if (array == BlobArrayPlaceholder.INSTANCE) {
+                return writePlaceholderElement();
+            }
+
+            long recordPosition = startRecord();
+            write(MAGIC_NUMBER_BYTES);
+            write(new byte[] {VERSION});
+            write(intToLittleEndian(array.size()));
+
+            long[] elementLengths = new long[array.size()];
+            boolean flush = false;
+            for (int i = 0; i < array.size(); i++) {
+                if (array.isNullAt(i)) {
+                    elementLengths[i] = NULL_ELEMENT_LENGTH;
+                    continue;
+                }
+
+                final int position = i;
+                BlobFetchResult fetchResult = getBlob(() -> array.getBlob(position));
+                Blob blob = fetchResult.blob();
+                if (fetchResult.fetchFailure() || blob == null) {
+                    elementLengths[i] = NULL_ELEMENT_LENGTH;
+                    continue;
+                }
+                SeekableInputStream in = openBlobInputStream(blob);
+                if (in == null) {
+                    elementLengths[i] = NULL_ELEMENT_LENGTH;
+                    continue;
+                }
+                BlobDescriptor descriptor = writeBlobData(in);
+                elementLengths[i] = descriptor.length();
+                flush |= accept(descriptor);
+                recordSuccess(descriptor.length());
+            }
+
+            byte[] indexBytes = DeltaVarintCompressor.compress(elementLengths);
+            write(indexBytes);
+            write(intToLittleEndian(indexBytes.length));
+
+            long recordLength = finishRecord(recordPosition);
+            if (flush) {
+                flush();
+            }
+            return recordLength;
+        }
+    }
+
+    /** Reader for an ARRAY&lt;BLOB&gt; field. */
+    static final class Reader extends AbstractBlobElementReader {
+
+        Reader(
+                FileIO fileIO,
+                Path filePath,
+                @Nullable SeekableInputStream in,
+                boolean blobAsDescriptor) {
+            super(fileIO, filePath, in, blobAsDescriptor);
+        }
+
+        @Override
+        public Object read(long payloadPosition, long payloadLength) {
+            SeekableInputStream in = inputStream();
+            if (in == null) {
+                throw new IllegalStateException("Input stream must be available for ARRAY<BLOB>.");
+            }
+            if (payloadPosition < 0
+                    || payloadLength < MIN_PAYLOAD_LENGTH
+                    || payloadPosition > Long.MAX_VALUE - payloadLength) {
+                throw new IllegalArgumentException(
+                        "Invalid ARRAY<BLOB> payload position or length: "
+                                + payloadPosition
+                                + ", "
+                                + payloadLength);
+            }
+
+            try {
+                byte[] header = new byte[HEADER_LENGTH];
+                in.seek(payloadPosition);
+                IOUtils.readFully(in, header);
+                ByteBuffer headerBuffer = littleEndianBuffer(header);
+                int magic = headerBuffer.getInt();
+                if (magic != MAGIC_NUMBER) {
+                    throw new IllegalArgumentException(
+                            "Invalid ARRAY<BLOB> payload magic number: " + magic);
+                }
+                byte version = headerBuffer.get();
+                if (version != VERSION) {
+                    throw new UnsupportedOperationException(
+                            "Unsupported ARRAY<BLOB> payload version: " + version);
+                }
+                int elementCount = headerBuffer.getInt();
+                if (elementCount < 0) {
+                    throw new IllegalArgumentException(
+                            "Invalid ARRAY<BLOB> element count: " + elementCount);
+                }
+
+                long payloadEnd = payloadPosition + payloadLength;
+                long elementDataStart = payloadPosition + HEADER_LENGTH;
+                long indexLengthPosition = payloadEnd - INDEX_LENGTH_SIZE;
+                byte[] indexLengthBytes = new byte[INDEX_LENGTH_SIZE];
+                in.seek(indexLengthPosition);
+                IOUtils.readFully(in, indexLengthBytes);
+                int indexLength = littleEndianBuffer(indexLengthBytes).getInt();
+                long maximumIndexLength = payloadLength - MIN_PAYLOAD_LENGTH;
+                if (indexLength < 0 || indexLength > maximumIndexLength) {
+                    throw new IllegalArgumentException(
+                            "Invalid ARRAY<BLOB> element index length: " + indexLength);
+                }
+                if (elementCount > indexLength) {
+                    throw new IllegalArgumentException(
+                            "ARRAY<BLOB> element count exceeds element index length.");
+                }
+
+                byte[] indexBytes = new byte[indexLength];
+                long indexStart = indexLengthPosition - indexLength;
+                in.seek(indexStart);
+                IOUtils.readFully(in, indexBytes);
+                long[] elementLengths;
+                try {
+                    elementLengths = DeltaVarintCompressor.decompress(indexBytes);
+                } catch (RuntimeException e) {
+                    throw new IllegalArgumentException("Invalid ARRAY<BLOB> element index.", e);
+                }
+                if (elementLengths.length != elementCount) {
+                    throw new IllegalArgumentException(
+                            "ARRAY<BLOB> element count does not match element index length.");
+                }
+
+                long elementDataLength = indexStart - elementDataStart;
+                long totalElementLength = 0;
+                for (long elementLength : elementLengths) {
+                    if (elementLength == NULL_ELEMENT_LENGTH) {
+                        continue;
+                    }
+                    if (elementLength < 0) {
+                        throw new IllegalArgumentException(
+                                "Invalid ARRAY<BLOB> element length: " + elementLength);
+                    }
+                    if (!blobAsDescriptor() && elementLength > Integer.MAX_VALUE) {
+                        throw new IllegalArgumentException(
+                                "ARRAY<BLOB> inline element is too large: " + elementLength);
+                    }
+                    if (elementLength > elementDataLength - totalElementLength) {
+                        throw new IllegalArgumentException(
+                                "ARRAY<BLOB> element lengths exceed the payload data length.");
+                    }
+                    totalElementLength += elementLength;
+                }
+                if (totalElementLength != elementDataLength) {
+                    throw new IllegalArgumentException(
+                            "ARRAY<BLOB> element lengths do not match the payload data length.");
+                }
+
+                Object[] blobs = new Object[elementCount];
+                long elementOffset = elementDataStart;
+                for (int i = 0; i < elementCount; i++) {
+                    long elementLength = elementLengths[i];
+                    if (elementLength == NULL_ELEMENT_LENGTH) {
+                        blobs[i] = null;
+                    } else {
+                        blobs[i] = readBlob(elementOffset, elementLength);
+                        elementOffset += elementLength;
+                    }
+                }
+                return new GenericArray(blobs);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean requiresInputStream() {
+            return true;
+        }
+
+        @Override
+        public Object placeholder() {
+            return BlobArrayPlaceholder.INSTANCE;
+        }
+    }
+
+    private static ByteBuffer littleEndianBuffer(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/ArrayBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/ArrayBlobElementSerializer.java
@@ -73,6 +73,11 @@ final class ArrayBlobElementSerializer implements BlobElementSerializer {
     }
 
     @Override
+    public boolean requiresReadInputStream(boolean blobAsDescriptor) {
+        return true;
+    }
+
+    @Override
     public BlobElementSerializer.Reader createReader(
             FileIO fileIO,
             Path filePath,
@@ -170,9 +175,6 @@ final class ArrayBlobElementSerializer implements BlobElementSerializer {
         @Override
         public Object read(long payloadPosition, long payloadLength) {
             SeekableInputStream in = inputStream();
-            if (in == null) {
-                throw new IllegalStateException("Input stream must be available for ARRAY<BLOB>.");
-            }
             if (payloadPosition < 0
                     || payloadLength < MIN_PAYLOAD_LENGTH
                     || payloadPosition > Long.MAX_VALUE - payloadLength) {
@@ -276,11 +278,6 @@ final class ArrayBlobElementSerializer implements BlobElementSerializer {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }
-
-        @Override
-        public boolean requiresInputStream() {
-            return true;
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/** Creates file-lifetime readers and writers for one blob field format. */
+interface BlobElementSerializer {
+
+    Writer createWriter(
+            PositionOutputStream out,
+            String blobFieldName,
+            @Nullable BlobConsumer writeConsumer,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize);
+
+    Reader createReader(
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor);
+
+    /** Writer used for the lifetime of one output file. */
+    interface Writer {
+
+        long write(InternalRow row) throws IOException;
+
+        void setFile(Path file);
+    }
+
+    /** Reader used for the lifetime of one input file. */
+    interface Reader extends Closeable {
+
+        Object placeholder();
+
+        Object read(long payloadPosition, long payloadLength);
+
+        boolean requiresInputStream();
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializer.java
@@ -25,6 +25,7 @@ import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.utils.IOUtils;
 
 import javax.annotation.Nullable;
 
@@ -43,11 +44,31 @@ interface BlobElementSerializer {
             BlobFetchMetricReporter blobFetchMetricReporter,
             int copyBufferSize);
 
+    boolean requiresReadInputStream(boolean blobAsDescriptor);
+
+    /** Creates a reader which owns and closes the input stream when non-null. */
     Reader createReader(
             FileIO fileIO,
             Path filePath,
             @Nullable SeekableInputStream in,
             boolean blobAsDescriptor);
+
+    /** Helper method to close InputStream early if element reader doesn't need it. */
+    static BlobElementSerializer.Reader createReader(
+            BlobElementSerializer elementSerializer,
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor) {
+        boolean requiresInputStream = elementSerializer.requiresReadInputStream(blobAsDescriptor);
+
+        if (!requiresInputStream) {
+            IOUtils.closeQuietly(in);
+            in = null;
+        }
+
+        return elementSerializer.createReader(fileIO, filePath, in, blobAsDescriptor);
+    }
 
     /** Writer used for the lifetime of one output file. */
     interface Writer {
@@ -63,7 +84,5 @@ interface BlobElementSerializer {
         Object placeholder();
 
         Object read(long payloadPosition, long payloadLength);
-
-        boolean requiresInputStream();
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.types.DataTypeRoot;
+import org.apache.paimon.types.MapType;
+import org.apache.paimon.utils.Preconditions;
+
+/** Selects a blob element serializer for a field type. */
+final class BlobElementSerializerFactory {
+
+    private BlobElementSerializerFactory() {}
+
+    static boolean supports(DataType dataType) {
+        switch (dataType.getTypeRoot()) {
+            case BLOB:
+                return true;
+            case ARRAY:
+                return ((ArrayType) dataType).getElementType().getTypeRoot() == DataTypeRoot.BLOB;
+            case MAP:
+                MapType mapType = (MapType) dataType;
+                return MapBlobElementSerializer.supportKeyType(mapType.getKeyType())
+                        && mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB;
+            default:
+                return false;
+        }
+    }
+
+    static BlobElementSerializer create(DataType dataType) {
+        switch (dataType.getTypeRoot()) {
+            case BLOB:
+                return new RawBlobElementSerializer();
+            case ARRAY:
+                ArrayType arrayType = (ArrayType) dataType;
+                Preconditions.checkArgument(
+                        arrayType.getElementType().getTypeRoot() == DataTypeRoot.BLOB);
+                return new ArrayBlobElementSerializer();
+            case MAP:
+                MapType mapType = (MapType) dataType;
+                Preconditions.checkArgument(
+                        MapBlobElementSerializer.supportKeyType(mapType.getKeyType()),
+                        "Unsupported key type [%s] for nested Map-Blob type.",
+                        mapType.getKeyType());
+                Preconditions.checkArgument(
+                        mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB,
+                        "Map-Blob value type must be BLOB, but is [%s].",
+                        mapType.getValueType());
+                return new MapBlobElementSerializer(mapType.getKeyType());
+            default:
+                throw new RuntimeException("Unsupported Element Type for Blob File Format");
+        }
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
@@ -46,10 +46,6 @@ final class BlobElementSerializerFactory {
             case MAP:
                 MapType mapType = (MapType) dataType;
                 Preconditions.checkArgument(
-                        supportsMapKey(mapType.getKeyType()),
-                        "Unsupported key type [%s] for nested Map-Blob type.",
-                        mapType.getKeyType());
-                Preconditions.checkArgument(
                         mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB,
                         "Map-Blob value type must be BLOB, but is [%s].",
                         mapType.getValueType());
@@ -57,9 +53,5 @@ final class BlobElementSerializerFactory {
             default:
                 throw new RuntimeException("Unsupported Element Type for Blob File Format");
         }
-    }
-
-    private static boolean supportsMapKey(DataType keyType) {
-        return BlobType.isBlobFileField(new MapType(keyType, new BlobType()));
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobElementSerializerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.types.ArrayType;
+import org.apache.paimon.types.BlobType;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.MapType;
@@ -30,18 +31,7 @@ final class BlobElementSerializerFactory {
     private BlobElementSerializerFactory() {}
 
     static boolean supports(DataType dataType) {
-        switch (dataType.getTypeRoot()) {
-            case BLOB:
-                return true;
-            case ARRAY:
-                return ((ArrayType) dataType).getElementType().getTypeRoot() == DataTypeRoot.BLOB;
-            case MAP:
-                MapType mapType = (MapType) dataType;
-                return MapBlobElementSerializer.supportKeyType(mapType.getKeyType())
-                        && mapType.getValueType().getTypeRoot() == DataTypeRoot.BLOB;
-            default:
-                return false;
-        }
+        return BlobType.isBlobFileField(dataType);
     }
 
     static BlobElementSerializer create(DataType dataType) {
@@ -56,7 +46,7 @@ final class BlobElementSerializerFactory {
             case MAP:
                 MapType mapType = (MapType) dataType;
                 Preconditions.checkArgument(
-                        MapBlobElementSerializer.supportKeyType(mapType.getKeyType()),
+                        supportsMapKey(mapType.getKeyType()),
                         "Unsupported key type [%s] for nested Map-Blob type.",
                         mapType.getKeyType());
                 Preconditions.checkArgument(
@@ -67,5 +57,9 @@ final class BlobElementSerializerFactory {
             default:
                 throw new RuntimeException("Unsupported Element Type for Blob File Format");
         }
+    }
+
+    private static boolean supportsMapKey(DataType keyType) {
+        return BlobType.isBlobFileField(new MapType(keyType, new BlobType()));
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -168,22 +168,19 @@ public class BlobFileFormat extends FileFormat {
         public FileRecordReader<InternalRow> createReader(Context context) throws IOException {
             FileIO fileIO = context.fileIO();
             Path filePath = context.filePath();
-            SeekableInputStream in = null;
-            boolean elementReaderOwnsInputStream = false;
+            SeekableInputStream in = fileIO.newInputStream(filePath);
+            BlobFileMeta fileMeta;
             try {
-                in = fileIO.newInputStream(filePath);
-                BlobFileMeta fileMeta =
-                        new BlobFileMeta(in, context.fileSize(), context.selection());
-                BlobElementSerializer.Reader elementReader =
-                        elementSerializer.createReader(fileIO, filePath, in, blobAsDescriptor);
-                elementReaderOwnsInputStream = elementReader.requiresInputStream();
-                return new BlobFormatReader(
-                        filePath, fileMeta, fieldCount, blobIndex, elementReader);
-            } finally {
-                if (!elementReaderOwnsInputStream) {
-                    IOUtils.closeQuietly(in);
-                }
+                fileMeta = new BlobFileMeta(in, context.fileSize(), context.selection());
+            } catch (Exception e) {
+                IOUtils.closeQuietly(in);
+                throw e;
             }
+
+            BlobElementSerializer.Reader elementReader =
+                    BlobElementSerializer.createReader(
+                            elementSerializer, fileIO, filePath, in, blobAsDescriptor);
+            return new BlobFormatReader(filePath, fileMeta, fieldCount, blobIndex, elementReader);
         }
 
         private static int findBlobFieldIndex(RowType rowType) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -58,14 +58,6 @@ public class BlobFileFormat extends FileFormat {
 
     @Nullable public BlobConsumer writeConsumer;
 
-    public BlobFileFormat() {
-        this(false);
-    }
-
-    public BlobFileFormat(boolean blobAsDescriptor) {
-        this(blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
-    }
-
     public BlobFileFormat(boolean blobAsDescriptor, int copyBufferSize) {
         super(BlobFileFormatFactory.IDENTIFIER);
         this.blobAsDescriptor = blobAsDescriptor;
@@ -122,27 +114,23 @@ public class BlobFileFormat extends FileFormat {
 
     private class BlobFormatWriterFactory implements FormatWriterFactory {
 
-        private final String blobFieldName;
-        private final BlobElementSerializer elementSerializer;
+        private final RowType type;
 
         private BlobFormatWriterFactory(RowType type) {
             checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
-            this.blobFieldName = type.getFieldNames().get(0);
-            this.elementSerializer = BlobElementSerializerFactory.create(type.getTypeAt(0));
+            this.type = type;
         }
 
         @Override
         public FormatWriter create(PositionOutputStream out, String compression) {
-            BlobElementSerializer.Writer elementWriter =
-                    elementSerializer.createWriter(
-                            out,
-                            blobFieldName,
-                            writeConsumer,
-                            writeNullOnMissingFile,
-                            writeNullOnFetchFailure,
-                            blobFetchMetricReporter,
-                            copyBufferSize);
-            return new BlobFormatWriter(out, writeConsumer, elementWriter);
+            return new BlobFormatWriter(
+                    out,
+                    writeConsumer,
+                    type,
+                    writeNullOnMissingFile,
+                    writeNullOnFetchFailure,
+                    blobFetchMetricReporter,
+                    copyBufferSize);
         }
     }
 
@@ -151,7 +139,7 @@ public class BlobFileFormat extends FileFormat {
         private final boolean blobAsDescriptor;
         private final int fieldCount;
         private final int blobIndex;
-        private final BlobElementSerializer elementSerializer;
+        private final DataType blobFieldType;
 
         public BlobFormatReaderFactory(boolean blobAsDescriptor, RowType projectedRowType) {
             this.blobAsDescriptor = blobAsDescriptor;
@@ -160,8 +148,7 @@ public class BlobFileFormat extends FileFormat {
             Preconditions.checkState(
                     this.blobIndex >= 0,
                     "Read type of a blob format does not contain any blob field.");
-            DataType blobFieldType = projectedRowType.getTypeAt(this.blobIndex);
-            this.elementSerializer = BlobElementSerializerFactory.create(blobFieldType);
+            this.blobFieldType = projectedRowType.getTypeAt(this.blobIndex);
         }
 
         @Override
@@ -177,10 +164,15 @@ public class BlobFileFormat extends FileFormat {
                 throw e;
             }
 
-            BlobElementSerializer.Reader elementReader =
-                    BlobElementSerializer.createReader(
-                            elementSerializer, fileIO, filePath, in, blobAsDescriptor);
-            return new BlobFormatReader(filePath, fileMeta, fieldCount, blobIndex, elementReader);
+            return new BlobFormatReader(
+                    fileIO,
+                    filePath,
+                    fileMeta,
+                    in,
+                    fieldCount,
+                    blobIndex,
+                    blobFieldType,
+                    blobAsDescriptor);
         }
 
         private static int findBlobFieldIndex(RowType rowType) {

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileFormat.java
@@ -35,7 +35,6 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.statistics.SimpleColStatsCollector;
 import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Preconditions;
@@ -46,7 +45,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.paimon.types.BlobType.isBlobFileField;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** {@link FileFormat} for blob file. */
@@ -59,6 +57,14 @@ public class BlobFileFormat extends FileFormat {
     private BlobFetchMetricReporter blobFetchMetricReporter = BlobFetchMetricReporter.NOOP;
 
     @Nullable public BlobConsumer writeConsumer;
+
+    public BlobFileFormat() {
+        this(false);
+    }
+
+    public BlobFileFormat(boolean blobAsDescriptor) {
+        this(blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+    }
 
     public BlobFileFormat(boolean blobAsDescriptor, int copyBufferSize) {
         super(BlobFileFormatFactory.IDENTIFIER);
@@ -103,8 +109,8 @@ public class BlobFileFormat extends FileFormat {
     public void validateDataFields(RowType rowType) {
         checkArgument(rowType.getFieldCount() == 1, "BlobFileFormat only support one field.");
         checkArgument(
-                isBlobFileField(rowType.getField(0).type()),
-                "BlobFileFormat only support blob type or array of blob type.");
+                BlobElementSerializerFactory.supports(rowType.getField(0).type()),
+                "BlobFileFormat only supports BLOB, ARRAY<BLOB>, or supported MAP<X, BLOB> types.");
     }
 
     @Override
@@ -116,22 +122,27 @@ public class BlobFileFormat extends FileFormat {
 
     private class BlobFormatWriterFactory implements FormatWriterFactory {
 
-        private final RowType type;
+        private final String blobFieldName;
+        private final BlobElementSerializer elementSerializer;
 
         private BlobFormatWriterFactory(RowType type) {
-            this.type = type;
+            checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
+            this.blobFieldName = type.getFieldNames().get(0);
+            this.elementSerializer = BlobElementSerializerFactory.create(type.getTypeAt(0));
         }
 
         @Override
         public FormatWriter create(PositionOutputStream out, String compression) {
-            return new BlobFormatWriter(
-                    out,
-                    writeConsumer,
-                    type,
-                    writeNullOnMissingFile,
-                    writeNullOnFetchFailure,
-                    blobFetchMetricReporter,
-                    copyBufferSize);
+            BlobElementSerializer.Writer elementWriter =
+                    elementSerializer.createWriter(
+                            out,
+                            blobFieldName,
+                            writeConsumer,
+                            writeNullOnMissingFile,
+                            writeNullOnFetchFailure,
+                            blobFetchMetricReporter,
+                            copyBufferSize);
+            return new BlobFormatWriter(out, writeConsumer, elementWriter);
         }
     }
 
@@ -140,7 +151,7 @@ public class BlobFileFormat extends FileFormat {
         private final boolean blobAsDescriptor;
         private final int fieldCount;
         private final int blobIndex;
-        private final DataType blobFieldType;
+        private final BlobElementSerializer elementSerializer;
 
         public BlobFormatReaderFactory(boolean blobAsDescriptor, RowType projectedRowType) {
             this.blobAsDescriptor = blobAsDescriptor;
@@ -149,7 +160,8 @@ public class BlobFileFormat extends FileFormat {
             Preconditions.checkState(
                     this.blobIndex >= 0,
                     "Read type of a blob format does not contain any blob field.");
-            this.blobFieldType = projectedRowType.getTypeAt(this.blobIndex);
+            DataType blobFieldType = projectedRowType.getTypeAt(this.blobIndex);
+            this.elementSerializer = BlobElementSerializerFactory.create(blobFieldType);
         }
 
         @Override
@@ -157,31 +169,26 @@ public class BlobFileFormat extends FileFormat {
             FileIO fileIO = context.fileIO();
             Path filePath = context.filePath();
             SeekableInputStream in = null;
-            BlobFileMeta fileMeta;
+            boolean elementReaderOwnsInputStream = false;
             try {
                 in = fileIO.newInputStream(filePath);
-                fileMeta = new BlobFileMeta(in, context.fileSize(), context.selection());
+                BlobFileMeta fileMeta =
+                        new BlobFileMeta(in, context.fileSize(), context.selection());
+                BlobElementSerializer.Reader elementReader =
+                        elementSerializer.createReader(fileIO, filePath, in, blobAsDescriptor);
+                elementReaderOwnsInputStream = elementReader.requiresInputStream();
+                return new BlobFormatReader(
+                        filePath, fileMeta, fieldCount, blobIndex, elementReader);
             } finally {
-                if (blobAsDescriptor && blobFieldType.getTypeRoot() != DataTypeRoot.ARRAY) {
+                if (!elementReaderOwnsInputStream) {
                     IOUtils.closeQuietly(in);
-                    in = null;
                 }
             }
-
-            return new BlobFormatReader(
-                    fileIO,
-                    filePath,
-                    fileMeta,
-                    in,
-                    fieldCount,
-                    blobIndex,
-                    blobFieldType,
-                    blobAsDescriptor);
         }
 
         private static int findBlobFieldIndex(RowType rowType) {
             for (int i = 0; i < rowType.getFieldCount(); i++) {
-                if (isBlobFileField(rowType.getTypeAt(i))) {
+                if (BlobElementSerializerFactory.supports(rowType.getTypeAt(i))) {
                     return i;
                 }
             }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileMeta.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFileMeta.java
@@ -42,7 +42,7 @@ public class BlobFileMeta {
         byte[] header = new byte[5];
         IOUtils.readFully(in, header);
         byte version = header[4];
-        if (version != 1) {
+        if (version != BlobFormatWriter.VERSION) {
             throw new IOException("Unsupported version: " + version);
         }
         int indexLength = BytesUtils.getInt(header, 0);

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -18,10 +18,6 @@
 
 package org.apache.paimon.format.blob;
 
-import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobArrayPlaceholder;
-import org.apache.paimon.data.BlobPlaceholder;
-import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
@@ -30,34 +26,19 @@ import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.types.DataType;
-import org.apache.paimon.types.DataTypeRoot;
-import org.apache.paimon.utils.DeltaVarintCompressor;
-import org.apache.paimon.utils.IOUtils;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /** {@link FileRecordReader} for blob file. */
 public class BlobFormatReader implements FileRecordReader<InternalRow> {
 
-    private static final int ARRAY_HEADER_LENGTH = 9;
-    private static final int ARRAY_INDEX_LENGTH_SIZE = Integer.BYTES;
-    private static final int MIN_ARRAY_PAYLOAD_LENGTH =
-            ARRAY_HEADER_LENGTH + ARRAY_INDEX_LENGTH_SIZE;
-
-    private final FileIO fileIO;
     private final Path filePath;
-    private final String filePathString;
     private final BlobFileMeta fileMeta;
-    private final @Nullable SeekableInputStream in;
     private final int fieldCount;
     private final int blobIndex;
-    private final DataType blobFieldType;
-    private final Object blobPlaceholder;
-    private final boolean blobAsDescriptor;
+    private final BlobElementSerializer.Reader elementReader;
 
     private boolean returned;
 
@@ -70,19 +51,26 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
             int blobIndex,
             DataType blobFieldType,
             boolean blobAsDescriptor) {
-        this.fileIO = fileIO;
+        this(
+                filePath,
+                fileMeta,
+                fieldCount,
+                blobIndex,
+                BlobElementSerializerFactory.create(blobFieldType)
+                        .createReader(fileIO, filePath, in, blobAsDescriptor));
+    }
+
+    BlobFormatReader(
+            Path filePath,
+            BlobFileMeta fileMeta,
+            int fieldCount,
+            int blobIndex,
+            BlobElementSerializer.Reader elementReader) {
         this.filePath = filePath;
-        this.filePathString = filePath.toString();
         this.fileMeta = fileMeta;
-        this.in = in;
         this.fieldCount = fieldCount;
         this.blobIndex = blobIndex;
-        this.blobFieldType = blobFieldType;
-        this.blobPlaceholder =
-                blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY
-                        ? BlobArrayPlaceholder.INSTANCE
-                        : BlobPlaceholder.INSTANCE;
-        this.blobAsDescriptor = blobAsDescriptor;
+        this.elementReader = elementReader;
         this.returned = false;
     }
 
@@ -119,15 +107,11 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                 if (fileMeta.isNull(currentPosition)) {
                     field = null;
                 } else if (fileMeta.isPlaceHolder(currentPosition)) {
-                    field = blobPlaceholder;
+                    field = elementReader.placeholder();
                 } else {
-                    long offset = fileMeta.blobOffset(currentPosition) + 4;
-                    long length = fileMeta.blobLength(currentPosition) - 16;
-                    if (blobFieldType.getTypeRoot() == DataTypeRoot.ARRAY) {
-                        field = readBlobArray(in, offset, length);
-                    } else {
-                        field = readBlob(in, offset, length);
-                    }
+                    long payloadPosition = fileMeta.blobOffset(currentPosition) + 4;
+                    long payloadLength = fileMeta.blobLength(currentPosition) - 16;
+                    field = elementReader.read(payloadPosition, payloadLength);
                 }
                 currentPosition++;
                 GenericRow row = new GenericRow(fieldCount);
@@ -140,140 +124,8 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
         };
     }
 
-    private Blob readBlob(@Nullable SeekableInputStream in, long position, long length) {
-        if (in != null && !blobAsDescriptor) {
-            return Blob.fromData(readInlineBlob(in, position, length));
-        }
-        return Blob.fromFile(fileIO, filePathString, position, length);
-    }
-
     @Override
     public void close() throws IOException {
-        IOUtils.closeQuietly(in);
-    }
-
-    private static byte[] readInlineBlob(SeekableInputStream in, long position, long length) {
-        byte[] blobData = new byte[(int) length];
-        try {
-            in.seek(position);
-            IOUtils.readFully(in, blobData);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return blobData;
-    }
-
-    private GenericArray readBlobArray(SeekableInputStream in, long position, long length) {
-        if (in == null) {
-            throw new IllegalStateException("Input stream must be available for ARRAY<BLOB>.");
-        }
-        if (position < 0
-                || length < MIN_ARRAY_PAYLOAD_LENGTH
-                || position > Long.MAX_VALUE - length) {
-            throw new IllegalArgumentException(
-                    "Invalid ARRAY<BLOB> payload position or length: " + position + ", " + length);
-        }
-
-        try {
-            byte[] header = new byte[ARRAY_HEADER_LENGTH];
-            in.seek(position);
-            IOUtils.readFully(in, header);
-            ByteBuffer headerBuffer = littleEndianBuffer(header);
-            int magic = headerBuffer.getInt();
-            if (magic != BlobFormatWriter.ARRAY_MAGIC_NUMBER) {
-                throw new IllegalArgumentException(
-                        "Invalid ARRAY<BLOB> payload magic number: " + magic);
-            }
-            byte version = headerBuffer.get();
-            if (version != BlobFormatWriter.ARRAY_VERSION) {
-                throw new UnsupportedOperationException(
-                        "Unsupported ARRAY<BLOB> payload version: " + version);
-            }
-            int elementCount = headerBuffer.getInt();
-            if (elementCount < 0) {
-                throw new IllegalArgumentException(
-                        "Invalid ARRAY<BLOB> element count: " + elementCount);
-            }
-
-            long payloadEnd = position + length;
-            long elementDataStart = position + ARRAY_HEADER_LENGTH;
-            long elementIndexLengthPosition = payloadEnd - ARRAY_INDEX_LENGTH_SIZE;
-            byte[] indexLengthBytes = new byte[ARRAY_INDEX_LENGTH_SIZE];
-            in.seek(elementIndexLengthPosition);
-            IOUtils.readFully(in, indexLengthBytes);
-            int elementIndexLength = littleEndianBuffer(indexLengthBytes).getInt();
-            long maximumIndexLength = length - MIN_ARRAY_PAYLOAD_LENGTH;
-            if (elementIndexLength < 0 || elementIndexLength > maximumIndexLength) {
-                throw new IllegalArgumentException(
-                        "Invalid ARRAY<BLOB> element index length: " + elementIndexLength);
-            }
-            if (elementCount > elementIndexLength) {
-                throw new IllegalArgumentException(
-                        "ARRAY<BLOB> element count exceeds element index length.");
-            }
-
-            byte[] elementIndexBytes = new byte[elementIndexLength];
-            long elementIndexStart = elementIndexLengthPosition - elementIndexLength;
-            in.seek(elementIndexStart);
-            IOUtils.readFully(in, elementIndexBytes);
-            long[] elementLengths;
-            try {
-                elementLengths = DeltaVarintCompressor.decompress(elementIndexBytes);
-            } catch (RuntimeException e) {
-                throw new IllegalArgumentException("Invalid ARRAY<BLOB> element index.", e);
-            }
-            if (elementLengths.length != elementCount) {
-                throw new IllegalArgumentException(
-                        "ARRAY<BLOB> element count does not match element index length.");
-            }
-
-            long elementDataLength = elementIndexStart - elementDataStart;
-            long totalElementLength = 0;
-            for (long elementLength : elementLengths) {
-                if (elementLength == BlobFormatWriter.ARRAY_NULL_ELEMENT_LENGTH) {
-                    continue;
-                }
-                if (elementLength < 0) {
-                    throw new IllegalArgumentException(
-                            "Invalid ARRAY<BLOB> element length: " + elementLength);
-                }
-                if (!blobAsDescriptor && elementLength > Integer.MAX_VALUE) {
-                    throw new IllegalArgumentException(
-                            "ARRAY<BLOB> inline element is too large: " + elementLength);
-                }
-                if (elementLength > elementDataLength - totalElementLength) {
-                    throw new IllegalArgumentException(
-                            "ARRAY<BLOB> element lengths exceed the payload data length.");
-                }
-                totalElementLength += elementLength;
-            }
-            if (totalElementLength != elementDataLength) {
-                throw new IllegalArgumentException(
-                        "ARRAY<BLOB> element lengths do not match the payload data length.");
-            }
-
-            Object[] blobs = new Object[elementCount];
-            long elementOffset = elementDataStart;
-            for (int i = 0; i < elementCount; i++) {
-                long elementLength = elementLengths[i];
-                if (elementLength == BlobFormatWriter.ARRAY_NULL_ELEMENT_LENGTH) {
-                    blobs[i] = null;
-                } else if (blobAsDescriptor) {
-                    blobs[i] = Blob.fromFile(fileIO, filePathString, elementOffset, elementLength);
-                    elementOffset += elementLength;
-                } else {
-                    blobs[i] = Blob.fromData(readInlineBlob(in, elementOffset, elementLength));
-                    elementOffset += elementLength;
-                }
-            }
-
-            return new GenericArray(blobs);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static ByteBuffer littleEndianBuffer(byte[] bytes) {
-        return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        elementReader.close();
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -56,8 +56,12 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
                 fileMeta,
                 fieldCount,
                 blobIndex,
-                BlobElementSerializerFactory.create(blobFieldType)
-                        .createReader(fileIO, filePath, in, blobAsDescriptor));
+                BlobElementSerializer.createReader(
+                        BlobElementSerializerFactory.create(blobFieldType),
+                        fileIO,
+                        filePath,
+                        in,
+                        blobAsDescriptor));
     }
 
     BlobFormatReader(

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatReader.java
@@ -51,30 +51,17 @@ public class BlobFormatReader implements FileRecordReader<InternalRow> {
             int blobIndex,
             DataType blobFieldType,
             boolean blobAsDescriptor) {
-        this(
-                filePath,
-                fileMeta,
-                fieldCount,
-                blobIndex,
+        this.filePath = filePath;
+        this.fileMeta = fileMeta;
+        this.fieldCount = fieldCount;
+        this.blobIndex = blobIndex;
+        this.elementReader =
                 BlobElementSerializer.createReader(
                         BlobElementSerializerFactory.create(blobFieldType),
                         fileIO,
                         filePath,
                         in,
-                        blobAsDescriptor));
-    }
-
-    BlobFormatReader(
-            Path filePath,
-            BlobFileMeta fileMeta,
-            int fieldCount,
-            int blobIndex,
-            BlobElementSerializer.Reader elementReader) {
-        this.filePath = filePath;
-        this.fileMeta = fileMeta;
-        this.fieldCount = fieldCount;
-        this.blobIndex = blobIndex;
-        this.elementReader = elementReader;
+                        blobAsDescriptor);
         this.returned = false;
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -42,14 +42,8 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     public static final byte VERSION = 1;
     public static final int MAGIC_NUMBER = 1481511375;
     public static final byte[] MAGIC_NUMBER_BYTES = intToLittleEndian(MAGIC_NUMBER);
-    public static final byte ARRAY_VERSION = ArrayBlobElementSerializer.VERSION;
-    public static final int ARRAY_MAGIC_NUMBER = ArrayBlobElementSerializer.MAGIC_NUMBER;
-    public static final byte[] ARRAY_MAGIC_NUMBER_BYTES =
-            ArrayBlobElementSerializer.MAGIC_NUMBER_BYTES;
     public static final long NULL_LENGTH = -1L;
     public static final long PLACE_HOLDER_LENGTH = -2L;
-    public static final long ARRAY_NULL_ELEMENT_LENGTH =
-            ArrayBlobElementSerializer.NULL_ELEMENT_LENGTH;
     public static final int DEFAULT_COPY_BUFFER_SIZE = 4 * 1024;
 
     private final PositionOutputStream out;

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -52,54 +52,6 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
     private final LongArrayList lengths;
 
     public BlobFormatWriter(
-            PositionOutputStream out, @Nullable BlobConsumer writeConsumer, RowType type) {
-        this(out, writeConsumer, type, false, false);
-    }
-
-    public BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            RowType type,
-            boolean writeNullOnMissingFile) {
-        this(out, writeConsumer, type, writeNullOnMissingFile, false);
-    }
-
-    public BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            RowType type,
-            boolean writeNullOnMissingFile,
-            boolean writeNullOnFetchFailure) {
-        this(
-                out,
-                writeConsumer,
-                type,
-                writeNullOnMissingFile,
-                writeNullOnFetchFailure,
-                BlobFetchMetricReporter.NOOP);
-    }
-
-    public BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            RowType type,
-            boolean writeNullOnMissingFile,
-            boolean writeNullOnFetchFailure,
-            BlobFetchMetricReporter blobFetchMetricReporter) {
-        this(
-                out,
-                writeConsumer,
-                createElementWriter(
-                        out,
-                        writeConsumer,
-                        type,
-                        writeNullOnMissingFile,
-                        writeNullOnFetchFailure,
-                        blobFetchMetricReporter,
-                        DEFAULT_COPY_BUFFER_SIZE));
-    }
-
-    public BlobFormatWriter(
             PositionOutputStream out,
             @Nullable BlobConsumer writeConsumer,
             RowType type,
@@ -107,9 +59,9 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             boolean writeNullOnFetchFailure,
             BlobFetchMetricReporter blobFetchMetricReporter,
             int copyBufferSize) {
-        this(
-                out,
-                writeConsumer,
+        this.out = out;
+        this.deleteFileUponAbort = writeConsumer == null;
+        this.elementWriter =
                 createElementWriter(
                         out,
                         writeConsumer,
@@ -117,16 +69,7 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
                         writeNullOnMissingFile,
                         writeNullOnFetchFailure,
                         blobFetchMetricReporter,
-                        copyBufferSize));
-    }
-
-    BlobFormatWriter(
-            PositionOutputStream out,
-            @Nullable BlobConsumer writeConsumer,
-            BlobElementSerializer.Writer elementWriter) {
-        this.out = out;
-        this.deleteFileUponAbort = writeConsumer == null;
-        this.elementWriter = elementWriter;
+                        copyBufferSize);
         this.lengths = new LongArrayList(16);
     }
 

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/BlobFormatWriter.java
@@ -18,67 +18,92 @@
 
 package org.apache.paimon.format.blob;
 
-import org.apache.paimon.data.Blob;
-import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobConsumer;
-import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobFetchMetricReporter;
-import org.apache.paimon.data.BlobPlaceholder;
-import org.apache.paimon.data.BlobRef;
-import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.format.FileAwareFormatWriter;
 import org.apache.paimon.format.FormatWriter;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.PositionOutputStream;
-import org.apache.paimon.fs.SeekableInputStream;
-import org.apache.paimon.rest.HttpClientUtils;
-import org.apache.paimon.types.DataTypeRoot;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DeltaVarintCompressor;
 import org.apache.paimon.utils.LongArrayList;
-import org.apache.paimon.utils.SensitiveConfigUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.zip.CRC32;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.StreamUtils.intToLittleEndian;
-import static org.apache.paimon.utils.StreamUtils.longToLittleEndian;
 
 /** {@link FormatWriter} for blob file. */
 public class BlobFormatWriter implements FileAwareFormatWriter {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BlobFormatWriter.class);
-
     public static final byte VERSION = 1;
     public static final int MAGIC_NUMBER = 1481511375;
     public static final byte[] MAGIC_NUMBER_BYTES = intToLittleEndian(MAGIC_NUMBER);
-    public static final byte ARRAY_VERSION = 1;
-    public static final int ARRAY_MAGIC_NUMBER = 1094861634;
-    public static final byte[] ARRAY_MAGIC_NUMBER_BYTES = intToLittleEndian(ARRAY_MAGIC_NUMBER);
+    public static final byte ARRAY_VERSION = ArrayBlobElementSerializer.VERSION;
+    public static final int ARRAY_MAGIC_NUMBER = ArrayBlobElementSerializer.MAGIC_NUMBER;
+    public static final byte[] ARRAY_MAGIC_NUMBER_BYTES =
+            ArrayBlobElementSerializer.MAGIC_NUMBER_BYTES;
     public static final long NULL_LENGTH = -1L;
     public static final long PLACE_HOLDER_LENGTH = -2L;
-    public static final long ARRAY_NULL_ELEMENT_LENGTH = -1L;
+    public static final long ARRAY_NULL_ELEMENT_LENGTH =
+            ArrayBlobElementSerializer.NULL_ELEMENT_LENGTH;
     public static final int DEFAULT_COPY_BUFFER_SIZE = 4 * 1024;
 
     private final PositionOutputStream out;
-    @Nullable private final BlobConsumer writeConsumer;
-    private final BlobFetchMetricReporter blobFetchMetricReporter;
-    private final String blobFieldName;
-    private final boolean writeNullOnMissingFile;
-    private final boolean writeNullOnFetchFailure;
-    private final BlobElementWriter elementWriter;
-    private final CRC32 crc32;
-    private final byte[] tmpBuffer;
+    private final boolean deleteFileUponAbort;
+    private final BlobElementSerializer.Writer elementWriter;
     private final LongArrayList lengths;
 
-    private String pathString;
+    public BlobFormatWriter(
+            PositionOutputStream out, @Nullable BlobConsumer writeConsumer, RowType type) {
+        this(out, writeConsumer, type, false, false);
+    }
+
+    public BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
+            boolean writeNullOnMissingFile) {
+        this(out, writeConsumer, type, writeNullOnMissingFile, false);
+    }
+
+    public BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure) {
+        this(
+                out,
+                writeConsumer,
+                type,
+                writeNullOnMissingFile,
+                writeNullOnFetchFailure,
+                BlobFetchMetricReporter.NOOP);
+    }
+
+    public BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter) {
+        this(
+                out,
+                writeConsumer,
+                createElementWriter(
+                        out,
+                        writeConsumer,
+                        type,
+                        writeNullOnMissingFile,
+                        writeNullOnFetchFailure,
+                        blobFetchMetricReporter,
+                        DEFAULT_COPY_BUFFER_SIZE));
+    }
 
     public BlobFormatWriter(
             PositionOutputStream out,
@@ -88,297 +113,43 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
             boolean writeNullOnFetchFailure,
             BlobFetchMetricReporter blobFetchMetricReporter,
             int copyBufferSize) {
-        checkArgument(
-                copyBufferSize > 0,
-                "BLOB copy buffer size must be positive, but was %s.",
-                copyBufferSize);
+        this(
+                out,
+                writeConsumer,
+                createElementWriter(
+                        out,
+                        writeConsumer,
+                        type,
+                        writeNullOnMissingFile,
+                        writeNullOnFetchFailure,
+                        blobFetchMetricReporter,
+                        copyBufferSize));
+    }
+
+    BlobFormatWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            BlobElementSerializer.Writer elementWriter) {
         this.out = out;
-        this.writeConsumer = writeConsumer;
-        this.blobFetchMetricReporter = blobFetchMetricReporter;
-        this.writeNullOnMissingFile = writeNullOnMissingFile;
-        this.writeNullOnFetchFailure = writeNullOnFetchFailure;
-        checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
-        this.blobFieldName = type.getFieldNames().get(0);
-        this.elementWriter =
-                type.getTypeAt(0).getTypeRoot() == DataTypeRoot.ARRAY
-                        ? new ArrayBlobElementWriter()
-                        : new RawBlobElementWriter();
-        this.crc32 = new CRC32();
-        this.tmpBuffer = new byte[copyBufferSize];
+        this.deleteFileUponAbort = writeConsumer == null;
+        this.elementWriter = elementWriter;
         this.lengths = new LongArrayList(16);
     }
 
     @Override
     public void setFile(Path file) {
-        this.pathString = file.toString();
+        elementWriter.setFile(file);
     }
 
     @Override
     public boolean deleteFileUponAbort() {
-        return writeConsumer == null;
+        return deleteFileUponAbort;
     }
 
     @Override
     public void addElement(InternalRow element) throws IOException {
         checkArgument(element.getFieldCount() == 1, "BlobFormatWriter only support one field.");
-        elementWriter.addElement(element);
-    }
-
-    private interface BlobElementWriter {
-        void addElement(InternalRow element) throws IOException;
-    }
-
-    private class RawBlobElementWriter implements BlobElementWriter {
-
-        @Override
-        public void addElement(InternalRow element) throws IOException {
-            if (element.isNullAt(0)) {
-                recordPreCheckedMissingFileNull(element);
-                writeNullElement();
-                return;
-            }
-
-            Blob blob;
-            try {
-                blob = element.getBlob(0);
-            } catch (RuntimeException e) {
-                if (shouldWriteNullOnFetchFailure(e)) {
-                    logWriteNullOnFetchFailure(e, null);
-                    blobFetchMetricReporter.recordFetchFailureNullWritten(e);
-                    writeNullElement();
-                    return;
-                }
-                blobFetchMetricReporter.recordFetchFailure(e);
-                throw e;
-            }
-            if (blob == BlobPlaceholder.INSTANCE) {
-                lengths.add(PLACE_HOLDER_LENGTH);
-                return;
-            }
-
-            addBlob(blob);
-        }
-    }
-
-    private class ArrayBlobElementWriter implements BlobElementWriter {
-
-        @Override
-        public void addElement(InternalRow element) throws IOException {
-            if (element.isNullAt(0)) {
-                writeNullElement();
-                return;
-            }
-
-            InternalArray array = element.getArray(0);
-            if (array == BlobArrayPlaceholder.INSTANCE) {
-                lengths.add(PLACE_HOLDER_LENGTH);
-                return;
-            }
-
-            addBlobArray(array);
-        }
-    }
-
-    private void addBlob(Blob blob) throws IOException {
-        SeekableInputStream in = openBlobInputStream(blob);
-        if (in == null) {
-            writeNullElement();
-            return;
-        }
-        long previousPos = out.getPos();
-        crc32.reset();
-        write(MAGIC_NUMBER_BYTES);
-
-        BlobDescriptor descriptor = writeBlobData(in);
-
-        long binLength = out.getPos() - previousPos + 12;
-        lengths.add(binLength);
-        byte[] lenBytes = longToLittleEndian(binLength);
-        write(lenBytes);
-        int crcValue = (int) crc32.getValue();
-        out.write(intToLittleEndian(crcValue));
-
-        if (writeConsumer != null) {
-            boolean flush = writeConsumer.accept(blobFieldName, descriptor);
-            if (flush) {
-                out.flush();
-            }
-        }
-        blobFetchMetricReporter.recordSuccess(descriptor.length());
-    }
-
-    private void addBlobArray(InternalArray array) throws IOException {
-        long previousPos = out.getPos();
-        crc32.reset();
-
-        write(MAGIC_NUMBER_BYTES);
-
-        write(ARRAY_MAGIC_NUMBER_BYTES);
-        write(new byte[] {ARRAY_VERSION});
-        write(intToLittleEndian(array.size()));
-
-        long[] elementLengths = new long[array.size()];
-        boolean flush = false;
-        for (int i = 0; i < array.size(); i++) {
-            if (array.isNullAt(i)) {
-                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
-                continue;
-            }
-
-            Blob blob = getArrayBlob(array, i);
-            if (blob == null) {
-                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
-                continue;
-            }
-            SeekableInputStream in = openBlobInputStream(blob);
-            if (in == null) {
-                elementLengths[i] = ARRAY_NULL_ELEMENT_LENGTH;
-                continue;
-            }
-            BlobDescriptor descriptor = writeBlobData(in);
-            elementLengths[i] = descriptor.length();
-            if (writeConsumer != null) {
-                flush |= writeConsumer.accept(blobFieldName, descriptor);
-            }
-            blobFetchMetricReporter.recordSuccess(descriptor.length());
-        }
-
-        byte[] elementIndexBytes = DeltaVarintCompressor.compress(elementLengths);
-        write(elementIndexBytes);
-        write(intToLittleEndian(elementIndexBytes.length));
-
-        long binLength = out.getPos() - previousPos + 12;
-        lengths.add(binLength);
-        write(longToLittleEndian(binLength));
-        int crcValue = (int) crc32.getValue();
-        out.write(intToLittleEndian(crcValue));
-
-        if (flush) {
-            out.flush();
-        }
-    }
-
-    @Nullable
-    private Blob getArrayBlob(InternalArray array, int pos) {
-        try {
-            return array.getBlob(pos);
-        } catch (RuntimeException e) {
-            if (shouldWriteNullOnFetchFailure(e)) {
-                logWriteNullOnFetchFailure(e, null);
-                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
-                return null;
-            }
-            blobFetchMetricReporter.recordFetchFailure(e);
-            throw e;
-        }
-    }
-
-    @Nullable
-    private SeekableInputStream openBlobInputStream(Blob blob) throws IOException {
-        try {
-            return blob.newInputStream();
-        } catch (IOException | RuntimeException e) {
-            if (writeNullOnMissingFile && HttpClientUtils.isNotFoundError(e)) {
-                LOG.warn(
-                        "Failed to open blob from {} (HTTP 404), writing NULL for BLOB field {}.",
-                        blobUri(blob),
-                        blobFieldName,
-                        e);
-                blobFetchMetricReporter.recordMissingFileNullWritten(true);
-                return null;
-            }
-            if (shouldWriteNullOnFetchFailure(e)) {
-                logWriteNullOnFetchFailure(e, blob);
-                blobFetchMetricReporter.recordFetchFailureNullWritten(e);
-                return null;
-            }
-            blobFetchMetricReporter.recordFetchFailure(e);
-            throw e;
-        }
-    }
-
-    private BlobDescriptor writeBlobData(SeekableInputStream in) throws IOException {
-        long blobPos = out.getPos();
-        try (SeekableInputStream stream = in) {
-            int bytesRead = stream.read(tmpBuffer);
-            while (bytesRead >= 0) {
-                write(tmpBuffer, bytesRead);
-                bytesRead = stream.read(tmpBuffer);
-            }
-        } catch (IOException | RuntimeException e) {
-            blobFetchMetricReporter.recordFetchFailure(e);
-            throw e;
-        }
-
-        return new BlobDescriptor(pathString, blobPos, out.getPos() - blobPos);
-    }
-
-    private boolean shouldWriteNullOnFetchFailure(Throwable e) {
-        return writeNullOnFetchFailure && !HttpClientUtils.isNotFoundError(e);
-    }
-
-    private void logWriteNullOnFetchFailure(Throwable e, @Nullable Blob blob) {
-        Integer statusCode = HttpClientUtils.getHttpStatusCode(e);
-        if (statusCode != null) {
-            LOG.warn(
-                    "Failed to open blob from {} (HTTP {}), writing NULL for BLOB field {}.",
-                    blobUri(blob),
-                    statusCode,
-                    blobFieldName,
-                    e);
-        } else if (HttpClientUtils.isInvalidUriException(e)) {
-            LOG.warn(
-                    "Invalid blob URI {} while opening blob, writing NULL for BLOB field {}.",
-                    blobUri(blob),
-                    blobFieldName,
-                    e);
-        } else {
-            LOG.warn(
-                    "Failed to open blob from {} due to fetch failure, writing NULL for BLOB field {}.",
-                    blobUri(blob),
-                    blobFieldName,
-                    e);
-        }
-    }
-
-    private void recordPreCheckedMissingFileNull(InternalRow element) {
-        if (!writeNullOnMissingFile) {
-            return;
-        }
-        Blob blob = element.getBlob(0);
-        if (blob instanceof BlobRef) {
-            BlobDescriptor descriptor = ((BlobRef) blob).toDescriptor();
-            blobFetchMetricReporter.recordMissingFileNullWritten(isHttpUri(descriptor.uri()));
-        }
-    }
-
-    private void writeNullElement() throws IOException {
-        lengths.add(NULL_LENGTH);
-        if (writeConsumer != null) {
-            writeConsumer.accept(blobFieldName, null);
-        }
-    }
-
-    private static String blobUri(@Nullable Blob blob) {
-        if (blob instanceof BlobRef) {
-            // Sanitize: a signed URL carries token/signature in its query.
-            return SensitiveConfigUtils.sanitizeUri(((BlobRef) blob).toDescriptor().uri());
-        }
-        return "unknown";
-    }
-
-    private static boolean isHttpUri(String uri) {
-        return uri.regionMatches(true, 0, "http://", 0, "http://".length())
-                || uri.regionMatches(true, 0, "https://", 0, "https://".length());
-    }
-
-    private void write(byte[] bytes) throws IOException {
-        write(bytes, bytes.length);
-    }
-
-    private void write(byte[] bytes, int length) throws IOException {
-        crc32.update(bytes, 0, length);
-        out.write(bytes, 0, length);
+        lengths.add(elementWriter.write(element));
     }
 
     @Override
@@ -390,11 +161,29 @@ public class BlobFormatWriter implements FileAwareFormatWriter {
 
     @Override
     public void close() throws IOException {
-        // index
         byte[] indexBytes = DeltaVarintCompressor.compress(lengths.toArray());
         out.write(indexBytes);
-        // header
         out.write(intToLittleEndian(indexBytes.length));
         out.write(VERSION);
+    }
+
+    private static BlobElementSerializer.Writer createElementWriter(
+            PositionOutputStream out,
+            @Nullable BlobConsumer writeConsumer,
+            RowType type,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize) {
+        checkArgument(type.getFieldCount() == 1, "BlobFormatWriter only support one field.");
+        return BlobElementSerializerFactory.create(type.getTypeAt(0))
+                .createWriter(
+                        out,
+                        type.getFieldNames().get(0),
+                        writeConsumer,
+                        writeNullOnMissingFile,
+                        writeNullOnFetchFailure,
+                        blobFetchMetricReporter,
+                        copyBufferSize);
     }
 }

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
@@ -129,6 +129,11 @@ final class MapBlobElementSerializer implements BlobElementSerializer {
     }
 
     @Override
+    public boolean requiresReadInputStream(boolean blobAsDescriptor) {
+        return true;
+    }
+
+    @Override
     public BlobElementSerializer.Reader createReader(
             FileIO fileIO,
             Path filePath,
@@ -261,9 +266,6 @@ final class MapBlobElementSerializer implements BlobElementSerializer {
         @Override
         public Object read(long payloadPosition, long payloadLength) {
             SeekableInputStream in = inputStream();
-            if (in == null) {
-                throw new IllegalStateException("Input stream must be available for MAP<X, BLOB>.");
-            }
             if (payloadPosition < 0
                     || payloadLength < MIN_PAYLOAD_LENGTH
                     || payloadPosition > Long.MAX_VALUE - payloadLength) {
@@ -377,11 +379,6 @@ final class MapBlobElementSerializer implements BlobElementSerializer {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }
-
-        @Override
-        public boolean requiresInputStream() {
-            return true;
         }
 
         @Override

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
@@ -93,20 +93,6 @@ final class MapBlobElementSerializer implements BlobElementSerializer {
         this.keySerializer = createKeySerializer(keyType);
     }
 
-    static boolean supportKeyType(DataType keyType) {
-        switch (keyType.getTypeRoot()) {
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-            case CHAR:
-            case VARCHAR:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     @Override
     public BlobElementSerializer.Writer createWriter(
             PositionOutputStream out,

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/MapBlobElementSerializer.java
@@ -1,0 +1,608 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.BlobMapPlaceholder;
+import org.apache.paimon.data.GenericMap;
+import org.apache.paimon.data.InternalArray;
+import org.apache.paimon.data.InternalMap;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+import org.apache.paimon.types.DataType;
+import org.apache.paimon.utils.DeltaVarintCompressor;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.apache.paimon.utils.StreamUtils.intToLittleEndian;
+import static org.apache.paimon.utils.StreamUtils.longToLittleEndian;
+
+/**
+ * Element serializer for a MAP&lt;X, BLOB&gt; field.
+ *
+ * <p>The element payload, excluding the common record framing, is laid out as follows:
+ *
+ * <pre>
+ * +-------------------+-------------+-----------------+
+ * | map magic (4 B)   | version (1) | entry count (4) |
+ * +-------------------+-------------+-----------------+
+ * | concatenated non-null key bytes                   |
+ * +---------------------------------------------------+
+ * | concatenated non-null Blob bytes                  |
+ * +---------------------------------------------------+
+ * | delta-varint compressed key lengths               |
+ * +---------------------------------------------------+
+ * | delta-varint compressed Blob lengths              |
+ * +------------------------+--------------------------+
+ * |  key index size (4 B)  |  Blob index size (4 B)   |
+ * +------------------------+--------------------------+
+ * </pre>
+ *
+ * <p>The key and Blob length arrays are aligned by entry ordinal. A length of {@code -1} represents
+ * null; zero represents an empty key or Blob.
+ */
+final class MapBlobElementSerializer implements BlobElementSerializer {
+
+    static final byte VERSION = 1;
+    static final int MAGIC_NUMBER = 0x4D424342;
+    static final byte[] MAGIC_NUMBER_BYTES = intToLittleEndian(MAGIC_NUMBER);
+    static final long NULL_VALUE_LENGTH = -1L;
+
+    private static final int HEADER_LENGTH = 9;
+    private static final int INDEX_LENGTH_SIZE = Integer.BYTES;
+    private static final int INDEX_LENGTHS_SIZE = INDEX_LENGTH_SIZE * 2;
+    private static final long NULL_KEY_LENGTH = -1L;
+    private static final int MIN_PAYLOAD_LENGTH = HEADER_LENGTH + INDEX_LENGTHS_SIZE;
+
+    private final InternalArray.ElementGetter keyGetter;
+    private final KeySerializer keySerializer;
+
+    MapBlobElementSerializer(DataType keyType) {
+        this.keyGetter = InternalArray.createElementGetter(keyType);
+        this.keySerializer = createKeySerializer(keyType);
+    }
+
+    static boolean supportKeyType(DataType keyType) {
+        switch (keyType.getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case CHAR:
+            case VARCHAR:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public BlobElementSerializer.Writer createWriter(
+            PositionOutputStream out,
+            String blobFieldName,
+            @Nullable BlobConsumer writeConsumer,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize) {
+        return new Writer(
+                out,
+                blobFieldName,
+                writeConsumer,
+                writeNullOnMissingFile,
+                writeNullOnFetchFailure,
+                blobFetchMetricReporter,
+                copyBufferSize,
+                keyGetter,
+                keySerializer);
+    }
+
+    @Override
+    public BlobElementSerializer.Reader createReader(
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor) {
+        return new Reader(fileIO, filePath, in, blobAsDescriptor, keySerializer);
+    }
+
+    /** Writer for a MAP&lt;X, BLOB&gt; field. */
+    static final class Writer extends AbstractBlobElementWriter {
+
+        private final InternalArray.ElementGetter keyGetter;
+        private final KeySerializer keySerializer;
+
+        Writer(
+                PositionOutputStream out,
+                String blobFieldName,
+                @Nullable BlobConsumer writeConsumer,
+                boolean writeNullOnMissingFile,
+                boolean writeNullOnFetchFailure,
+                BlobFetchMetricReporter blobFetchMetricReporter,
+                int copyBufferSize,
+                InternalArray.ElementGetter keyGetter,
+                KeySerializer keySerializer) {
+            super(
+                    out,
+                    blobFieldName,
+                    writeConsumer,
+                    writeNullOnMissingFile,
+                    writeNullOnFetchFailure,
+                    blobFetchMetricReporter,
+                    copyBufferSize);
+            this.keyGetter = keyGetter;
+            this.keySerializer = keySerializer;
+        }
+
+        @Override
+        public long write(InternalRow row) throws IOException {
+            if (row.isNullAt(0)) {
+                return writeNullElement();
+            }
+
+            InternalMap map = row.getMap(0);
+            if (map == BlobMapPlaceholder.INSTANCE) {
+                return writePlaceholderElement();
+            }
+
+            InternalArray keys = map.keyArray();
+            InternalArray values = map.valueArray();
+            if (keys.size() != map.size() || values.size() != map.size()) {
+                throw new IllegalArgumentException(
+                        "MAP<X, BLOB> key/value array size does not match map size.");
+            }
+
+            long recordPosition = startRecord();
+            // 1. Write meta
+            write(MAGIC_NUMBER_BYTES);
+            write(new byte[] {VERSION});
+            write(intToLittleEndian(map.size()));
+
+            // 2. Write key array
+            long[] keyLengths = new long[map.size()];
+            for (int i = 0; i < map.size(); i++) {
+                if (keys.isNullAt(i)) {
+                    keyLengths[i] = NULL_KEY_LENGTH;
+                } else {
+                    byte[] keyBytes = keySerializer.serialize(keyGetter.getElementOrNull(keys, i));
+                    keyLengths[i] = keyBytes.length;
+                    write(keyBytes);
+                }
+            }
+
+            // 3. Write values(blobs) array, same as ArrayBlobElementWriter
+            long[] valueLengths = new long[map.size()];
+            boolean flush = false;
+            for (int i = 0; i < map.size(); i++) {
+                if (values.isNullAt(i)) {
+                    valueLengths[i] = NULL_VALUE_LENGTH;
+                    continue;
+                }
+
+                final int position = i;
+                BlobFetchResult fetchResult = getBlob(() -> values.getBlob(position));
+                Blob blob = fetchResult.blob();
+                if (fetchResult.fetchFailure() || blob == null) {
+                    valueLengths[i] = NULL_VALUE_LENGTH;
+                    continue;
+                }
+                SeekableInputStream in = openBlobInputStream(blob);
+                if (in == null) {
+                    valueLengths[i] = NULL_VALUE_LENGTH;
+                    continue;
+                }
+                BlobDescriptor descriptor = writeBlobData(in);
+                valueLengths[i] = descriptor.length();
+                flush |= accept(descriptor);
+                recordSuccess(descriptor.length());
+            }
+
+            byte[] keyIndexBytes = DeltaVarintCompressor.compress(keyLengths);
+            byte[] valueIndexBytes = DeltaVarintCompressor.compress(valueLengths);
+            write(keyIndexBytes);
+            write(valueIndexBytes);
+            write(intToLittleEndian(keyIndexBytes.length));
+            write(intToLittleEndian(valueIndexBytes.length));
+
+            long recordLength = finishRecord(recordPosition);
+            if (flush) {
+                flush();
+            }
+            return recordLength;
+        }
+    }
+
+    /** Reader for a MAP&lt;X, BLOB&gt; field. */
+    static final class Reader extends AbstractBlobElementReader {
+
+        private final KeySerializer keySerializer;
+
+        Reader(
+                FileIO fileIO,
+                Path filePath,
+                @Nullable SeekableInputStream in,
+                boolean blobAsDescriptor,
+                KeySerializer keySerializer) {
+            super(fileIO, filePath, in, blobAsDescriptor);
+            this.keySerializer = keySerializer;
+        }
+
+        @Override
+        public Object read(long payloadPosition, long payloadLength) {
+            SeekableInputStream in = inputStream();
+            if (in == null) {
+                throw new IllegalStateException("Input stream must be available for MAP<X, BLOB>.");
+            }
+            if (payloadPosition < 0
+                    || payloadLength < MIN_PAYLOAD_LENGTH
+                    || payloadPosition > Long.MAX_VALUE - payloadLength) {
+                throw new IllegalArgumentException(
+                        "Invalid MAP<X, BLOB> payload position or length: "
+                                + payloadPosition
+                                + ", "
+                                + payloadLength);
+            }
+
+            try {
+                byte[] header = new byte[HEADER_LENGTH];
+                in.seek(payloadPosition);
+                IOUtils.readFully(in, header);
+                ByteBuffer headerBuffer = littleEndianBuffer(header);
+                int magic = headerBuffer.getInt();
+                if (magic != MAGIC_NUMBER) {
+                    throw new IllegalArgumentException(
+                            "Invalid MAP<X, BLOB> payload magic number: " + magic);
+                }
+                byte version = headerBuffer.get();
+                if (version != VERSION) {
+                    throw new UnsupportedOperationException(
+                            "Unsupported MAP<X, BLOB> payload version: " + version);
+                }
+                int entryCount = headerBuffer.getInt();
+                if (entryCount < 0) {
+                    throw new IllegalArgumentException(
+                            "Invalid MAP<X, BLOB> entry count: " + entryCount);
+                }
+
+                long payloadEnd = payloadPosition + payloadLength;
+                long dataStart = payloadPosition + HEADER_LENGTH;
+                long indexLengthsPosition = payloadEnd - INDEX_LENGTHS_SIZE;
+                byte[] indexLengthBytes = new byte[INDEX_LENGTHS_SIZE];
+                in.seek(indexLengthsPosition);
+                IOUtils.readFully(in, indexLengthBytes);
+
+                // key index lengths and value index lengths
+                ByteBuffer indexLengthBuffer = littleEndianBuffer(indexLengthBytes);
+                int keyIndexLength = indexLengthBuffer.getInt();
+                int valueIndexLength = indexLengthBuffer.getInt();
+                checkIndexLengths(keyIndexLength, valueIndexLength, payloadLength, entryCount);
+
+                // 1. deserialize key indexes and value indexes
+                long valueIndexStart = indexLengthsPosition - valueIndexLength;
+                long keyIndexStart = valueIndexStart - keyIndexLength;
+
+                byte[] keyIndexBytes = new byte[keyIndexLength];
+                in.seek(keyIndexStart);
+                IOUtils.readFully(in, keyIndexBytes);
+
+                byte[] valueIndexBytes = new byte[valueIndexLength];
+                in.seek(valueIndexStart);
+                IOUtils.readFully(in, valueIndexBytes);
+
+                long[] keyLengths;
+                try {
+                    keyLengths = DeltaVarintCompressor.decompress(keyIndexBytes);
+                } catch (RuntimeException e) {
+                    throw new IllegalArgumentException("Invalid MAP<X, BLOB> key index.", e);
+                }
+
+                long[] valueLengths;
+                try {
+                    valueLengths = DeltaVarintCompressor.decompress(valueIndexBytes);
+                } catch (RuntimeException e) {
+                    throw new IllegalArgumentException("Invalid MAP<X, BLOB> value index.", e);
+                }
+                long dataLength = keyIndexStart - dataStart;
+                long keyDataLength = checkKeyLengths(keyLengths, dataLength, entryCount);
+                checkBlobLengths(valueLengths, dataLength - keyDataLength, entryCount);
+
+                // 2. deserialize keys
+                Object[] keys = new Object[entryCount];
+                long keyOffset = dataStart;
+                for (int i = 0; i < entryCount; i++) {
+                    long keyLength = keyLengths[i];
+                    Object key;
+                    if (keyLength == NULL_KEY_LENGTH) {
+                        key = null;
+                    } else {
+                        byte[] keyBytes = new byte[(int) keyLength];
+                        in.seek(keyOffset);
+                        IOUtils.readFully(in, keyBytes);
+                        try {
+                            key = keySerializer.deserialize(keyBytes);
+                        } catch (RuntimeException e) {
+                            throw new IllegalArgumentException("Invalid MAP<X, BLOB> key.", e);
+                        }
+                        keyOffset += keyLength;
+                    }
+                    keys[i] = key;
+                }
+
+                // 3. deserialize values and construct map
+                Map<Object, Object> map = new LinkedHashMap<>();
+                long valueOffset = dataStart + keyDataLength;
+                for (int i = 0; i < entryCount; i++) {
+                    long valueLength = valueLengths[i];
+                    Object value =
+                            valueLength == NULL_VALUE_LENGTH
+                                    ? null
+                                    : readBlob(valueOffset, valueLength);
+                    if (valueLength != NULL_VALUE_LENGTH) {
+                        valueOffset += valueLength;
+                    }
+                    map.put(keys[i], value);
+                }
+                return new GenericMap(map);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public boolean requiresInputStream() {
+            return true;
+        }
+
+        @Override
+        public Object placeholder() {
+            return BlobMapPlaceholder.INSTANCE;
+        }
+
+        private void checkIndexLengths(
+                int keyIndexLength, int valueIndexLength, long payloadLength, int entryCount) {
+            long maximumIndexesLength = payloadLength - MIN_PAYLOAD_LENGTH;
+            Preconditions.checkState(
+                    keyIndexLength >= 0 && keyIndexLength <= maximumIndexesLength,
+                    "Invalid MAP<X, BLOB> key index length: %s",
+                    keyIndexLength);
+            Preconditions.checkState(
+                    valueIndexLength >= 0 && valueIndexLength <= maximumIndexesLength,
+                    "Invalid MAP<X, BLOB> value index length: %s",
+                    valueIndexLength);
+            Preconditions.checkState(
+                    (long) keyIndexLength + valueIndexLength <= maximumIndexesLength,
+                    "MAP<X, BLOB> indexes exceed the payload length.");
+            Preconditions.checkState(
+                    entryCount <= keyIndexLength,
+                    "MAP<X, BLOB> entry count exceeds key index length.");
+            Preconditions.checkState(
+                    entryCount <= valueIndexLength,
+                    "MAP<X, BLOB> entry count exceeds value index length.");
+        }
+
+        private long checkKeyLengths(long[] keyLengths, long maxDataLength, int entryCount) {
+            Preconditions.checkState(
+                    keyLengths.length == entryCount,
+                    "MAP<X, BLOB> entry count does not match key index length.");
+
+            long keyDataLength = 0;
+            int fixedKeyLength = keySerializer.fixedLength();
+            for (long keyLength : keyLengths) {
+                if (keyLength == NULL_KEY_LENGTH) {
+                    continue;
+                }
+                Preconditions.checkState(
+                        keyLength >= 0, "Invalid MAP<X, BLOB> key length: %s", keyLength);
+                Preconditions.checkState(
+                        keyLength <= Integer.MAX_VALUE,
+                        "MAP<X, BLOB> key is too large: %s",
+                        keyLength);
+                Preconditions.checkState(
+                        fixedKeyLength < 0 || keyLength == fixedKeyLength,
+                        "Invalid MAP<X, BLOB> fixed-width key length: %s",
+                        keyLength);
+                Preconditions.checkState(
+                        keyLength <= maxDataLength - keyDataLength,
+                        "MAP<X, BLOB> key lengths exceed the payload data length.");
+                keyDataLength += keyLength;
+            }
+            return keyDataLength;
+        }
+
+        private void checkBlobLengths(long[] blobLengths, long maxDataLength, int entryCount) {
+            Preconditions.checkState(
+                    blobLengths.length == entryCount,
+                    "MAP<X, BLOB> entry count does not match value index length.");
+
+            long valueDataLength = 0;
+            for (long valueLength : blobLengths) {
+                if (valueLength == NULL_VALUE_LENGTH) {
+                    continue;
+                }
+                Preconditions.checkState(
+                        valueLength >= 0, "Invalid MAP<X, BLOB> value length: %s", valueLength);
+                Preconditions.checkState(
+                        blobAsDescriptor() || valueLength <= Integer.MAX_VALUE,
+                        "MAP<X, BLOB> inline value is too large: %s",
+                        valueLength);
+                Preconditions.checkState(
+                        valueLength <= maxDataLength - valueDataLength,
+                        "MAP<X, BLOB> value lengths exceed the payload data length.");
+                valueDataLength += valueLength;
+            }
+            Preconditions.checkState(
+                    valueDataLength == maxDataLength,
+                    "MAP<X, BLOB> key/value lengths do not match the payload data length.");
+        }
+    }
+
+    private static KeySerializer createKeySerializer(DataType keyType) {
+        switch (keyType.getTypeRoot()) {
+            case TINYINT:
+                return new TinyIntKeySerializer();
+            case SMALLINT:
+                return new SmallIntKeySerializer();
+            case INTEGER:
+                return new IntKeySerializer();
+            case BIGINT:
+                return new BigIntKeySerializer();
+            case CHAR:
+            case VARCHAR:
+                return new StringKeySerializer();
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported key type for MAP<X, BLOB>: " + keyType);
+        }
+    }
+
+    private static void checkKeyLength(byte[] bytes, int expectedLength) {
+        if (bytes.length != expectedLength) {
+            throw new IllegalArgumentException(
+                    "Expected " + expectedLength + " key bytes, but found " + bytes.length + '.');
+        }
+    }
+
+    /** Key serializer for Map-Blob type. */
+    private interface KeySerializer {
+
+        byte[] serialize(Object key);
+
+        Object deserialize(byte[] bytes);
+
+        int fixedLength();
+    }
+
+    /** {@link KeySerializer} for Tiny Int Type. */
+    private static final class TinyIntKeySerializer implements KeySerializer {
+
+        @Override
+        public byte[] serialize(Object key) {
+            return new byte[] {(Byte) key};
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) {
+            checkKeyLength(bytes, Byte.BYTES);
+            return bytes[0];
+        }
+
+        @Override
+        public int fixedLength() {
+            return Byte.BYTES;
+        }
+    }
+
+    /** {@link KeySerializer} for Small Int Type. */
+    private static final class SmallIntKeySerializer implements KeySerializer {
+
+        @Override
+        public byte[] serialize(Object key) {
+            return littleEndianBuffer(new byte[Short.BYTES]).putShort((Short) key).array();
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) {
+            checkKeyLength(bytes, Short.BYTES);
+            return littleEndianBuffer(bytes).getShort();
+        }
+
+        @Override
+        public int fixedLength() {
+            return Short.BYTES;
+        }
+    }
+
+    /** {@link KeySerializer} for Int Type. */
+    private static final class IntKeySerializer implements KeySerializer {
+
+        @Override
+        public byte[] serialize(Object key) {
+            return intToLittleEndian((Integer) key);
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) {
+            checkKeyLength(bytes, Integer.BYTES);
+            return littleEndianBuffer(bytes).getInt();
+        }
+
+        @Override
+        public int fixedLength() {
+            return Integer.BYTES;
+        }
+    }
+
+    /** {@link KeySerializer} for Big Int Type. */
+    private static final class BigIntKeySerializer implements KeySerializer {
+
+        @Override
+        public byte[] serialize(Object key) {
+            return longToLittleEndian((Long) key);
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) {
+            checkKeyLength(bytes, Long.BYTES);
+            return littleEndianBuffer(bytes).getLong();
+        }
+
+        @Override
+        public int fixedLength() {
+            return Long.BYTES;
+        }
+    }
+
+    /** {@link KeySerializer} for String Type. */
+    private static final class StringKeySerializer implements KeySerializer {
+
+        @Override
+        public byte[] serialize(Object key) {
+            return ((BinaryString) key).toBytes();
+        }
+
+        @Override
+        public Object deserialize(byte[] bytes) {
+            return BinaryString.fromBytes(bytes);
+        }
+
+        @Override
+        public int fixedLength() {
+            return -1;
+        }
+    }
+
+    private static ByteBuffer littleEndianBuffer(byte[] bytes) {
+        return ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/RawBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/RawBlobElementSerializer.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.format.blob;
+
+import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobConsumer;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.BlobPlaceholder;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.SeekableInputStream;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/** Element serializer for a raw BLOB field. */
+final class RawBlobElementSerializer implements BlobElementSerializer {
+
+    @Override
+    public BlobElementSerializer.Writer createWriter(
+            PositionOutputStream out,
+            String blobFieldName,
+            @Nullable BlobConsumer writeConsumer,
+            boolean writeNullOnMissingFile,
+            boolean writeNullOnFetchFailure,
+            BlobFetchMetricReporter blobFetchMetricReporter,
+            int copyBufferSize) {
+        return new Writer(
+                out,
+                blobFieldName,
+                writeConsumer,
+                writeNullOnMissingFile,
+                writeNullOnFetchFailure,
+                blobFetchMetricReporter,
+                copyBufferSize);
+    }
+
+    @Override
+    public BlobElementSerializer.Reader createReader(
+            FileIO fileIO,
+            Path filePath,
+            @Nullable SeekableInputStream in,
+            boolean blobAsDescriptor) {
+        return new Reader(fileIO, filePath, in, blobAsDescriptor);
+    }
+
+    /** Writer for a raw BLOB field. */
+    static final class Writer extends AbstractBlobElementWriter {
+
+        Writer(
+                PositionOutputStream out,
+                String blobFieldName,
+                @Nullable BlobConsumer writeConsumer,
+                boolean writeNullOnMissingFile,
+                boolean writeNullOnFetchFailure,
+                BlobFetchMetricReporter blobFetchMetricReporter,
+                int copyBufferSize) {
+            super(
+                    out,
+                    blobFieldName,
+                    writeConsumer,
+                    writeNullOnMissingFile,
+                    writeNullOnFetchFailure,
+                    blobFetchMetricReporter,
+                    copyBufferSize);
+        }
+
+        @Override
+        public long write(InternalRow row) throws IOException {
+            if (row.isNullAt(0)) {
+                recordPreCheckedMissingFileNull(row);
+                return writeNullElement();
+            }
+
+            BlobFetchResult fetchResult = getBlob(() -> row.getBlob(0));
+            if (fetchResult.fetchFailure()) {
+                return writeNullElement();
+            }
+            Blob blob = fetchResult.blob();
+            if (blob == BlobPlaceholder.INSTANCE) {
+                return writePlaceholderElement();
+            }
+
+            SeekableInputStream in = openBlobInputStream(blob);
+            if (in == null) {
+                return writeNullElement();
+            }
+
+            long recordPosition = startRecord();
+            BlobDescriptor descriptor = writeBlobData(in);
+            long recordLength = finishRecord(recordPosition);
+            if (accept(descriptor)) {
+                flush();
+            }
+            recordSuccess(descriptor.length());
+            return recordLength;
+        }
+    }
+
+    /** Reader for a raw BLOB field. */
+    static final class Reader extends AbstractBlobElementReader {
+
+        Reader(
+                FileIO fileIO,
+                Path filePath,
+                @Nullable SeekableInputStream in,
+                boolean blobAsDescriptor) {
+            super(fileIO, filePath, in, blobAsDescriptor);
+        }
+
+        @Override
+        public Object read(long payloadPosition, long payloadLength) {
+            return readBlob(payloadPosition, payloadLength);
+        }
+
+        @Override
+        public boolean requiresInputStream() {
+            return !blobAsDescriptor();
+        }
+
+        @Override
+        public Object placeholder() {
+            return BlobPlaceholder.INSTANCE;
+        }
+    }
+}

--- a/paimon-format/src/main/java/org/apache/paimon/format/blob/RawBlobElementSerializer.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/blob/RawBlobElementSerializer.java
@@ -56,6 +56,11 @@ final class RawBlobElementSerializer implements BlobElementSerializer {
     }
 
     @Override
+    public boolean requiresReadInputStream(boolean blobAsDescriptor) {
+        return !blobAsDescriptor;
+    }
+
+    @Override
     public BlobElementSerializer.Reader createReader(
             FileIO fileIO,
             Path filePath,
@@ -131,11 +136,6 @@ final class RawBlobElementSerializer implements BlobElementSerializer {
         @Override
         public Object read(long payloadPosition, long payloadLength) {
             return readBlob(payloadPosition, payloadLength);
-        }
-
-        @Override
-        public boolean requiresInputStream() {
-            return !blobAsDescriptor();
         }
 
         @Override

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -91,7 +91,8 @@ public class BlobFileFormatTest {
 
     @Test
     public void testRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
-        BlobFileFormat format = new BlobFileFormat(true);
+        BlobFileFormat format =
+                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -116,7 +117,8 @@ public class BlobFileFormatTest {
 
     @Test
     public void testPublicRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
-        BlobFileFormat format = new BlobFileFormat(true);
+        BlobFileFormat format =
+                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -147,7 +149,8 @@ public class BlobFileFormatTest {
 
     @Test
     public void testArrayDescriptorReaderOwnsInputStream() throws IOException {
-        BlobFileFormat format = new BlobFileFormat(true);
+        BlobFileFormat format =
+                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -194,7 +197,8 @@ public class BlobFileFormatTest {
         }
 
         TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
-        BlobFileFormat format = new BlobFileFormat(true);
+        BlobFileFormat format =
+                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
         FormatReaderContext context =
@@ -250,7 +254,8 @@ public class BlobFileFormatTest {
 
     @Test
     public void testWriteMapBlobPlaceholderWithProjectedRow() throws IOException {
-        BlobFileFormat format = new BlobFileFormat();
+        BlobFileFormat format =
+                new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
 
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
@@ -449,7 +454,9 @@ public class BlobFileFormatTest {
         entries.put(BinaryString.fromString("a"), new BlobData("first".getBytes()));
         entries.put(BinaryString.fromString("b"), new BlobData("second".getBytes()));
 
-        BlobFileFormat format = new BlobFileFormat(blobAsDescriptor);
+        BlobFileFormat format =
+                new BlobFileFormat(
+                        blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -511,13 +518,16 @@ public class BlobFileFormatTest {
             entries.put(keys[i], new BlobData("value".getBytes()));
             try (PositionOutputStream out = fileIO.newOutputStream(mapFile, false)) {
                 FormatWriter writer =
-                        new BlobFileFormat().createWriterFactory(rowType).create(out, null);
+                        new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE)
+                                .createWriterFactory(rowType)
+                                .create(out, null);
                 writer.addElement(GenericRow.of(new GenericMap(entries)));
                 writer.close();
             }
 
             FormatReaderFactory readerFactory =
-                    new BlobFileFormat().createReaderFactory(null, rowType, null);
+                    new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE)
+                            .createReaderFactory(null, rowType, null);
             FormatReaderContext context =
                     new FormatReaderContext(fileIO, mapFile, fileIO.getFileSize(mapFile));
             List<InternalRow> rows = new ArrayList<>();
@@ -675,7 +685,8 @@ public class BlobFileFormatTest {
     private void assertMalformedMapPayload(
             RowType rowType, GenericMap map, MapPayloadCorruptor corruptor, String expectedMessage)
             throws IOException {
-        BlobFileFormat format = new BlobFileFormat();
+        BlobFileFormat format =
+                new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
             writer.addElement(GenericRow.of(map));
@@ -804,7 +815,9 @@ public class BlobFileFormatTest {
     }
 
     private void innerTestMap(boolean blobAsDescriptor) throws IOException {
-        BlobFileFormat format = new BlobFileFormat(blobAsDescriptor);
+        BlobFileFormat format =
+                new BlobFileFormat(
+                        blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
 
         Map<Object, Object> firstEntries = new LinkedHashMap<>();

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -542,6 +542,12 @@ public class BlobFileFormatTest {
                                         DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("value type must be BLOB");
+        assertThatThrownBy(
+                        () ->
+                                BlobElementSerializerFactory.create(
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.STRING())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported key type");
     }
 
     private void innerTest(boolean blobAsDescriptor) throws IOException {

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -90,6 +90,121 @@ public class BlobFileFormatTest {
     }
 
     @Test
+    public void testRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
+        BlobFileFormat format = new BlobFileFormat(true);
+        RowType rowType = RowType.of(DataTypes.BLOB());
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(GenericRow.of(new BlobData("blob".getBytes())));
+            writer.close();
+        }
+
+        TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(trackingFileIO, file, trackingFileIO.getFileSize(file));
+        TrackingSeekableInputStream trackingInputStream;
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(context)) {
+            trackingInputStream = trackingFileIO.lastInputStream;
+            assertThat(trackingInputStream).isNotNull();
+            assertThat(trackingInputStream.closeCount).isOne();
+            assertThat(reader.readBatch().next().getBlob(0)).isInstanceOf(BlobRef.class);
+            assertThat(trackingInputStream.closeCount).isOne();
+        }
+        assertThat(trackingInputStream.closeCount).isOne();
+    }
+
+    @Test
+    public void testPublicRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
+        BlobFileFormat format = new BlobFileFormat(true);
+        RowType rowType = RowType.of(DataTypes.BLOB());
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(GenericRow.of(new BlobData("blob".getBytes())));
+            writer.close();
+        }
+
+        TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
+        TrackingSeekableInputStream trackingInputStream =
+                (TrackingSeekableInputStream) trackingFileIO.newInputStream(file);
+        BlobFileMeta fileMeta =
+                new BlobFileMeta(trackingInputStream, trackingFileIO.getFileSize(file), null);
+        try (BlobFormatReader reader =
+                new BlobFormatReader(
+                        trackingFileIO,
+                        file,
+                        fileMeta,
+                        trackingInputStream,
+                        1,
+                        0,
+                        DataTypes.BLOB(),
+                        true)) {
+            assertThat(trackingInputStream.closeCount).isOne();
+            assertThat(reader.readBatch().next().getBlob(0)).isInstanceOf(BlobRef.class);
+        }
+        assertThat(trackingInputStream.closeCount).isOne();
+    }
+
+    @Test
+    public void testArrayDescriptorReaderOwnsInputStream() throws IOException {
+        BlobFileFormat format = new BlobFileFormat(true);
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(
+                    GenericRow.of(
+                            new GenericArray(new Object[] {new BlobData("blob".getBytes())})));
+            writer.close();
+        }
+
+        TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(trackingFileIO, file, trackingFileIO.getFileSize(file));
+        TrackingSeekableInputStream trackingInputStream;
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(context)) {
+            trackingInputStream = trackingFileIO.lastInputStream;
+            assertThat(trackingInputStream.closeCount).isZero();
+            assertThat(reader.readBatch().next().getArray(0).getBlob(0))
+                    .isInstanceOf(BlobRef.class);
+            assertThat(trackingInputStream.closeCount).isZero();
+        }
+        assertThat(trackingInputStream.closeCount).isOne();
+    }
+
+    @Test
+    public void testElementSerializerReadInputStreamRequirements() {
+        BlobElementSerializer raw = new RawBlobElementSerializer();
+        assertThat(raw.requiresReadInputStream(false)).isTrue();
+        assertThat(raw.requiresReadInputStream(true)).isFalse();
+
+        BlobElementSerializer array = new ArrayBlobElementSerializer();
+        assertThat(array.requiresReadInputStream(false)).isTrue();
+        assertThat(array.requiresReadInputStream(true)).isTrue();
+
+        BlobElementSerializer map = new MapBlobElementSerializer(DataTypes.STRING());
+        assertThat(map.requiresReadInputStream(false)).isTrue();
+        assertThat(map.requiresReadInputStream(true)).isTrue();
+    }
+
+    @Test
+    public void testReaderCreationFailureClosesInputStream() throws IOException {
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            out.write(1);
+        }
+
+        TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
+        BlobFileFormat format = new BlobFileFormat(true);
+        RowType rowType = RowType.of(DataTypes.BLOB());
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(trackingFileIO, file, trackingFileIO.getFileSize(file));
+
+        assertThatThrownBy(() -> readerFactory.createReader(context));
+        assertThat(trackingFileIO.lastInputStream.closeCount).isOne();
+    }
+
+    @Test
     public void testArrayBlobAsDescriptor() throws IOException {
         innerTestArray(true);
     }
@@ -791,6 +906,53 @@ public class BlobFileFormatTest {
             }
         }
         result.add(bytes);
+    }
+
+    private static class TrackingLocalFileIO extends LocalFileIO {
+
+        private TrackingSeekableInputStream lastInputStream;
+
+        @Override
+        public SeekableInputStream newInputStream(Path path) throws IOException {
+            this.lastInputStream = new TrackingSeekableInputStream(super.newInputStream(path));
+            return lastInputStream;
+        }
+    }
+
+    private static class TrackingSeekableInputStream extends SeekableInputStream {
+
+        private final SeekableInputStream delegate;
+        private int closeCount;
+
+        private TrackingSeekableInputStream(SeekableInputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void seek(long desired) throws IOException {
+            delegate.seek(desired);
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return delegate.getPos();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length) throws IOException {
+            return delegate.read(bytes, offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCount++;
+            delegate.close();
+        }
     }
 
     private interface ArrayPayloadCorruptor {

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -552,7 +552,7 @@ public class BlobFileFormatTest {
                                 BlobElementSerializerFactory.create(
                                         DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.STRING())))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported key type");
+                .hasMessageContaining("value type must be BLOB");
     }
 
     private void innerTest(boolean blobAsDescriptor) throws IOException {

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -91,8 +91,7 @@ public class BlobFileFormatTest {
 
     @Test
     public void testRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
-        BlobFileFormat format =
-                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        BlobFileFormat format = new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -117,8 +116,7 @@ public class BlobFileFormatTest {
 
     @Test
     public void testPublicRawDescriptorReaderDoesNotOwnInputStream() throws IOException {
-        BlobFileFormat format =
-                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        BlobFileFormat format = new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -149,8 +147,7 @@ public class BlobFileFormatTest {
 
     @Test
     public void testArrayDescriptorReaderOwnsInputStream() throws IOException {
-        BlobFileFormat format =
-                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        BlobFileFormat format = new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.BLOB()));
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -197,8 +194,7 @@ public class BlobFileFormatTest {
         }
 
         TrackingLocalFileIO trackingFileIO = new TrackingLocalFileIO();
-        BlobFileFormat format =
-                new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+        BlobFileFormat format = new BlobFileFormat(true, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.BLOB());
         FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
         FormatReaderContext context =
@@ -455,8 +451,7 @@ public class BlobFileFormatTest {
         entries.put(BinaryString.fromString("b"), new BlobData("second".getBytes()));
 
         BlobFileFormat format =
-                new BlobFileFormat(
-                        blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+                new BlobFileFormat(blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
         try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
@@ -816,8 +811,7 @@ public class BlobFileFormatTest {
 
     private void innerTestMap(boolean blobAsDescriptor) throws IOException {
         BlobFileFormat format =
-                new BlobFileFormat(
-                        blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
+                new BlobFileFormat(blobAsDescriptor, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
         RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
 
         Map<Object, Object> firstEntries = new LinkedHashMap<>();

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFileFormatTest.java
@@ -18,12 +18,15 @@
 
 package org.apache.paimon.format.blob;
 
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobData;
+import org.apache.paimon.data.BlobMapPlaceholder;
 import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
@@ -37,6 +40,7 @@ import org.apache.paimon.fs.PositionOutputStream;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.reader.FileRecordReader;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ProjectedRow;
@@ -51,7 +55,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,6 +100,16 @@ public class BlobFileFormatTest {
     }
 
     @Test
+    public void testMapBlobAsDescriptor() throws IOException {
+        innerTestMap(true);
+    }
+
+    @Test
+    public void testReadMapBlobInlineBytes() throws IOException {
+        innerTestMap(false);
+    }
+
+    @Test
     public void testWriteArrayBlobPlaceholderWithProjectedRow() throws IOException {
         BlobFileFormat format =
                 new BlobFileFormat(false, BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
@@ -115,6 +131,29 @@ public class BlobFileFormatTest {
 
         assertThat(rows).hasSize(1);
         assertThat(rows.get(0).getArray(0)).isSameAs(BlobArrayPlaceholder.INSTANCE);
+    }
+
+    @Test
+    public void testWriteMapBlobPlaceholderWithProjectedRow() throws IOException {
+        BlobFileFormat format = new BlobFileFormat();
+        RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
+
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter formatWriter = format.createWriterFactory(rowType).create(out, null);
+            ProjectedRow projectedRow = ProjectedRow.from(new int[] {1});
+            formatWriter.addElement(
+                    projectedRow.replaceRow(GenericRow.of(0, BlobMapPlaceholder.INSTANCE)));
+            formatWriter.close();
+        }
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        List<InternalRow> rows = new ArrayList<>();
+        readerFactory.createReader(context).forEachRemaining(rows::add);
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getMap(0)).isSameAs(BlobMapPlaceholder.INSTANCE);
     }
 
     @Test
@@ -160,6 +199,234 @@ public class BlobFileFormatTest {
         assertMalformedArrayPayload(
                 (bytes, position, length) -> bytes[position + length - Integer.BYTES - 1] = 4,
                 "element lengths exceed the payload data length");
+    }
+
+    @Test
+    public void testRejectUnsupportedMapBlobPayloadVersion() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[position + Integer.BYTES] = 0,
+                "Unsupported MAP<X, BLOB> payload version");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobPayloadMagic() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[position] = 0,
+                "Invalid MAP<X, BLOB> payload magic number");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobEntryCount() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> {
+                    int countPosition = position + Integer.BYTES + 1;
+                    Arrays.fill(bytes, countPosition, countPosition + Integer.BYTES, (byte) 0xff);
+                },
+                "Invalid MAP<X, BLOB> entry count");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobIndexLength() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> {
+                    int indexLengthPosition = position + length - Integer.BYTES;
+                    Arrays.fill(
+                            bytes,
+                            indexLengthPosition,
+                            indexLengthPosition + Integer.BYTES,
+                            (byte) 0xff);
+                },
+                "Invalid MAP<X, BLOB> value index length");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobKeyIndexLength() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> {
+                    int indexLengthPosition = position + length - 2 * Integer.BYTES;
+                    Arrays.fill(
+                            bytes,
+                            indexLengthPosition,
+                            indexLengthPosition + Integer.BYTES,
+                            (byte) 0xff);
+                },
+                "Invalid MAP<X, BLOB> key index length");
+    }
+
+    @Test
+    public void testRejectMapBlobIndexesOutsidePayload() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> {
+                    writeLittleEndianInt(bytes, position + length - 2 * Integer.BYTES, 3);
+                    writeLittleEndianInt(bytes, position + length - Integer.BYTES, 3);
+                },
+                "indexes exceed the payload length");
+    }
+
+    @Test
+    public void testRejectMapBlobEntryCountIndexMismatch() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> {
+                    int countPosition = position + Integer.BYTES + 1;
+                    Arrays.fill(bytes, countPosition, countPosition + Integer.BYTES, (byte) 0);
+                },
+                "entry count does not match key index length");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobKeyLength() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[keyIndexPosition(bytes, position, length)] = 3,
+                "Invalid MAP<X, BLOB> key length");
+    }
+
+    @Test
+    public void testRejectMapBlobKeyOutsidePayload() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[keyIndexPosition(bytes, position, length)] = 6,
+                "key lengths exceed the payload data length");
+    }
+
+    @Test
+    public void testRejectInvalidFixedWidthMapBlobKey() throws IOException {
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(7, new BlobData("a".getBytes()));
+        assertMalformedMapPayload(
+                RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB())),
+                new GenericMap(entries),
+                (bytes, position, length) -> bytes[keyIndexPosition(bytes, position, length)] = 6,
+                "Invalid MAP<X, BLOB> fixed-width key length");
+    }
+
+    @Test
+    public void testRejectInvalidMapBlobValueLength() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[valueIndexPosition(bytes, position, length)] = 3,
+                "Invalid MAP<X, BLOB> value length");
+    }
+
+    @Test
+    public void testRejectMapBlobDataLengthMismatch() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[valueIndexPosition(bytes, position, length)] = 4,
+                "value lengths exceed the payload data length");
+    }
+
+    @Test
+    public void testRejectTrailingMapBlobEntryData() throws IOException {
+        assertMalformedMapPayload(
+                (bytes, position, length) -> bytes[valueIndexPosition(bytes, position, length)] = 0,
+                "key/value lengths do not match the payload data length");
+    }
+
+    @Test
+    public void testDuplicateMapBlobKeyLastWinsInline() throws IOException {
+        assertDuplicateMapBlobKeyLastWins(false);
+    }
+
+    @Test
+    public void testDuplicateMapBlobKeyLastWinsAsDescriptor() throws IOException {
+        assertDuplicateMapBlobKeyLastWins(true);
+    }
+
+    private void assertDuplicateMapBlobKeyLastWins(boolean blobAsDescriptor) throws IOException {
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(BinaryString.fromString("a"), new BlobData("first".getBytes()));
+        entries.put(BinaryString.fromString("b"), new BlobData("second".getBytes()));
+
+        BlobFileFormat format = new BlobFileFormat(blobAsDescriptor);
+        RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(GenericRow.of(new GenericMap(entries)));
+            writer.close();
+        }
+
+        int payloadPosition;
+        try (SeekableInputStream input = fileIO.newInputStream(file)) {
+            BlobFileMeta fileMeta = new BlobFileMeta(input, fileIO.getFileSize(file), null);
+            payloadPosition = Math.toIntExact(fileMeta.blobOffset(0) + Integer.BYTES);
+        }
+
+        java.nio.file.Path localFile = Paths.get(file.toUri());
+        byte[] bytes = Files.readAllBytes(localFile);
+        bytes[payloadPosition + 10] = 'a';
+        Files.write(localFile, bytes);
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        List<InternalRow> rows = new ArrayList<>();
+        try (FileRecordReader<InternalRow> reader = readerFactory.createReader(context)) {
+            reader.forEachRemaining(rows::add);
+        }
+
+        assertThat(rows).hasSize(1);
+        GenericMap result = (GenericMap) rows.get(0).getMap(0);
+        assertThat(result.size()).isOne();
+        assertMapBlob(
+                result.get(BinaryString.fromString("a")), blobAsDescriptor, "second".getBytes());
+    }
+
+    @Test
+    public void testMapBlobSupportedKeyTypes() throws IOException {
+        DataType[] keyTypes =
+                new DataType[] {
+                    DataTypes.TINYINT(),
+                    DataTypes.SMALLINT(),
+                    DataTypes.INT(),
+                    DataTypes.BIGINT(),
+                    DataTypes.CHAR(10),
+                    DataTypes.VARCHAR(10)
+                };
+        Object[] keys =
+                new Object[] {
+                    (byte) 1,
+                    (short) 2,
+                    3,
+                    4L,
+                    BinaryString.fromString("char"),
+                    BinaryString.fromString("varchar")
+                };
+
+        for (int i = 0; i < keyTypes.length; i++) {
+            Path mapFile = new Path(parent, UUID.randomUUID().toString());
+            RowType rowType = RowType.of(DataTypes.MAP(keyTypes[i], DataTypes.BLOB()));
+            Map<Object, Object> entries = new LinkedHashMap<>();
+            entries.put(keys[i], new BlobData("value".getBytes()));
+            try (PositionOutputStream out = fileIO.newOutputStream(mapFile, false)) {
+                FormatWriter writer =
+                        new BlobFileFormat().createWriterFactory(rowType).create(out, null);
+                writer.addElement(GenericRow.of(new GenericMap(entries)));
+                writer.close();
+            }
+
+            FormatReaderFactory readerFactory =
+                    new BlobFileFormat().createReaderFactory(null, rowType, null);
+            FormatReaderContext context =
+                    new FormatReaderContext(fileIO, mapFile, fileIO.getFileSize(mapFile));
+            List<InternalRow> rows = new ArrayList<>();
+            readerFactory.createReader(context).forEachRemaining(rows::add);
+            GenericMap result = (GenericMap) rows.get(0).getMap(0);
+            assertThat(result.contains(keys[i])).isTrue();
+            assertThat(((Blob) result.get(keys[i])).toData()).isEqualTo("value".getBytes());
+        }
+    }
+
+    @Test
+    public void testRejectUnsupportedMapBlobTypes() {
+        assertThatThrownBy(
+                        () ->
+                                BlobElementSerializerFactory.create(
+                                        DataTypes.MAP(DataTypes.BOOLEAN(), DataTypes.BLOB())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported key type");
+        assertThatThrownBy(
+                        () ->
+                                BlobElementSerializerFactory.create(
+                                        DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("value type must be BLOB");
     }
 
     private void innerTest(boolean blobAsDescriptor) throws IOException {
@@ -244,6 +511,53 @@ public class BlobFileFormatTest {
             FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
             writer.addElement(
                     GenericRow.of(new GenericArray(new Object[] {new BlobData("a".getBytes())})));
+            writer.close();
+        }
+
+        int payloadPosition;
+        int payloadLength;
+        try (SeekableInputStream input = fileIO.newInputStream(file)) {
+            BlobFileMeta fileMeta = new BlobFileMeta(input, fileIO.getFileSize(file), null);
+            payloadPosition = Math.toIntExact(fileMeta.blobOffset(0) + Integer.BYTES);
+            payloadLength = Math.toIntExact(fileMeta.blobLength(0) - 16);
+        }
+
+        java.nio.file.Path localFile = Paths.get(file.toUri());
+        byte[] bytes = Files.readAllBytes(localFile);
+        corruptor.corrupt(bytes, payloadPosition, payloadLength);
+        Files.write(localFile, bytes);
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        assertThatThrownBy(
+                        () -> {
+                            try (FileRecordReader<InternalRow> reader =
+                                    readerFactory.createReader(context)) {
+                                reader.forEachRemaining(ignored -> {});
+                            }
+                        })
+                .hasMessageContaining(expectedMessage);
+    }
+
+    private void assertMalformedMapPayload(MapPayloadCorruptor corruptor, String expectedMessage)
+            throws IOException {
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(BinaryString.fromString("a"), new BlobData("a".getBytes()));
+        assertMalformedMapPayload(
+                RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())),
+                new GenericMap(entries),
+                corruptor,
+                expectedMessage);
+    }
+
+    private void assertMalformedMapPayload(
+            RowType rowType, GenericMap map, MapPayloadCorruptor corruptor, String expectedMessage)
+            throws IOException {
+        BlobFileFormat format = new BlobFileFormat();
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter writer = format.createWriterFactory(rowType).create(out, null);
+            writer.addElement(GenericRow.of(map));
             writer.close();
         }
 
@@ -368,6 +682,93 @@ public class BlobFileFormatTest {
         assertThat((byte[]) result.get(0)).isEqualTo("hello".getBytes());
     }
 
+    private void innerTestMap(boolean blobAsDescriptor) throws IOException {
+        BlobFileFormat format = new BlobFileFormat(blobAsDescriptor);
+        RowType rowType = RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()));
+
+        Map<Object, Object> firstEntries = new LinkedHashMap<>();
+        firstEntries.put(null, new BlobData("null-key".getBytes()));
+        firstEntries.put(BinaryString.fromString("null-value"), null);
+        firstEntries.put(BinaryString.fromString("hello"), new BlobData("world".getBytes()));
+        firstEntries.put(BinaryString.fromString("empty"), new BlobData(new byte[0]));
+        GenericMap first = new GenericMap(firstEntries);
+        GenericMap empty = new GenericMap(new LinkedHashMap<>());
+        List<Object> maps = Arrays.asList(first, null, BlobMapPlaceholder.INSTANCE, empty);
+
+        try (PositionOutputStream out = fileIO.newOutputStream(file, false)) {
+            FormatWriter formatWriter = format.createWriterFactory(rowType).create(out, null);
+            for (Object map : maps) {
+                formatWriter.addElement(GenericRow.of(map));
+            }
+            formatWriter.close();
+        }
+
+        FormatReaderFactory readerFactory = format.createReaderFactory(null, rowType, null);
+        FormatReaderContext context =
+                new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        List<InternalRow> rows = new ArrayList<>();
+        readerFactory.createReader(context).forEachRemaining(rows::add);
+
+        assertThat(rows).hasSize(4);
+        GenericMap result = (GenericMap) rows.get(0).getMap(0);
+        assertMapBlob(result.get(null), blobAsDescriptor, "null-key".getBytes());
+        assertThat(result.get(BinaryString.fromString("null-value"))).isNull();
+        assertMapBlob(
+                result.get(BinaryString.fromString("hello")), blobAsDescriptor, "world".getBytes());
+        assertMapBlob(result.get(BinaryString.fromString("empty")), blobAsDescriptor, new byte[0]);
+        assertThat(rows.get(1).isNullAt(0)).isTrue();
+        assertThat(rows.get(2).getMap(0)).isSameAs(BlobMapPlaceholder.INSTANCE);
+        assertThat(rows.get(3).getMap(0).size()).isZero();
+
+        RoaringBitmap32 selection = new RoaringBitmap32();
+        selection.add(0);
+        context = new FormatReaderContext(fileIO, file, fileIO.getFileSize(file), selection);
+        rows.clear();
+        readerFactory.createReader(context).forEachRemaining(rows::add);
+        assertThat(rows).hasSize(1);
+        assertThat(((GenericMap) rows.get(0).getMap(0)).contains(null)).isTrue();
+
+        RowType projectedRowType = RowType.of(DataTypes.BIGINT(), rowType.getTypeAt(0));
+        readerFactory = format.createReaderFactory(null, projectedRowType, null);
+        context = new FormatReaderContext(fileIO, file, fileIO.getFileSize(file));
+        rows.clear();
+        readerFactory.createReader(context).forEachRemaining(rows::add);
+        assertThat(rows.get(0).isNullAt(0)).isTrue();
+        assertThat(rows.get(0).getMap(1)).isInstanceOf(GenericMap.class);
+    }
+
+    private static void assertMapBlob(
+            Object value, boolean blobAsDescriptor, byte[] expectedBytes) {
+        assertThat(value).isInstanceOf(blobAsDescriptor ? BlobRef.class : BlobData.class);
+        assertThat(((Blob) value).toData()).isEqualTo(expectedBytes);
+    }
+
+    private static int keyIndexPosition(byte[] bytes, int payloadPosition, int payloadLength) {
+        int keyIndexLength =
+                readLittleEndianInt(bytes, payloadPosition + payloadLength - 2 * Integer.BYTES);
+        return valueIndexPosition(bytes, payloadPosition, payloadLength) - keyIndexLength;
+    }
+
+    private static int valueIndexPosition(byte[] bytes, int payloadPosition, int payloadLength) {
+        int valueIndexLength =
+                readLittleEndianInt(bytes, payloadPosition + payloadLength - Integer.BYTES);
+        return payloadPosition + payloadLength - 2 * Integer.BYTES - valueIndexLength;
+    }
+
+    private static int readLittleEndianInt(byte[] bytes, int offset) {
+        return (bytes[offset] & 0xff)
+                | ((bytes[offset + 1] & 0xff) << 8)
+                | ((bytes[offset + 2] & 0xff) << 16)
+                | ((bytes[offset + 3] & 0xff) << 24);
+    }
+
+    private static void writeLittleEndianInt(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) value;
+        bytes[offset + 1] = (byte) (value >>> 8);
+        bytes[offset + 2] = (byte) (value >>> 16);
+        bytes[offset + 3] = (byte) (value >>> 24);
+    }
+
     private static void addArrayBlobResult(
             InternalRow row, boolean blobAsDescriptor, List<Object> result) {
         InternalArray array = row.getArray(0);
@@ -393,6 +794,10 @@ public class BlobFileFormatTest {
     }
 
     private interface ArrayPayloadCorruptor {
+        void corrupt(byte[] bytes, int position, int length);
+    }
+
+    private interface MapPayloadCorruptor {
         void corrupt(byte[] bytes, int position, int length);
     }
 }

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
@@ -69,7 +69,15 @@ public class BlobFormatWriterTest {
 
         try (PositionOutputStream out =
                 new LocalFileIO.LocalPositionOutputStream(outputFile.toFile())) {
-            BlobFormatWriter writer = new BlobFormatWriter(out, null, RowType.of(DataTypes.BLOB()));
+            BlobFormatWriter writer =
+                    new BlobFormatWriter(
+                            out,
+                            null,
+                            RowType.of(DataTypes.BLOB()),
+                            false,
+                            false,
+                            BlobFetchMetricReporter.NOOP,
+                            BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
             writer.addElement(GenericRow.of(Blob.fromData("inline".getBytes())));
             writer.addElement(GenericRow.of(Blob.fromLocal(sourceFile.toString())));
             writer.addElement(GenericRow.of((Object) null));
@@ -93,7 +101,14 @@ public class BlobFormatWriterTest {
         try (PositionOutputStream out =
                 new LocalFileIO.LocalPositionOutputStream(outputFile.toFile())) {
             BlobFormatWriter writer =
-                    new BlobFormatWriter(out, null, RowType.of(DataTypes.ARRAY(DataTypes.BLOB())));
+                    new BlobFormatWriter(
+                            out,
+                            null,
+                            RowType.of(DataTypes.ARRAY(DataTypes.BLOB())),
+                            false,
+                            false,
+                            BlobFetchMetricReporter.NOOP,
+                            BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
             writer.addElement(GenericRow.of(new GenericArray(new Object[0])));
             writer.addElement(
                     GenericRow.of(
@@ -134,7 +149,11 @@ public class BlobFormatWriterTest {
                     new BlobFormatWriter(
                             out,
                             null,
-                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())),
+                            false,
+                            false,
+                            BlobFetchMetricReporter.NOOP,
+                            BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
             writer.addElement(GenericRow.of(new GenericMap(new LinkedHashMap<>())));
             writer.addElement(GenericRow.of(new GenericMap(entries)));
             writer.addElement(GenericRow.of((Object) null));
@@ -716,7 +735,8 @@ public class BlobFormatWriterTest {
                         rowType,
                         true,
                         true,
-                        metricReporter);
+                        metricReporter,
+                        BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
 
         Map<Object, Object> entries = new LinkedHashMap<>();
         entries.put(1, Blob.fromData("image".getBytes()));
@@ -761,7 +781,11 @@ public class BlobFormatWriterTest {
                                 descriptors.add(descriptor);
                                 return descriptors.size() == 1;
                             },
-                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())),
+                            false,
+                            false,
+                            BlobFetchMetricReporter.NOOP,
+                            BlobFormatWriter.DEFAULT_COPY_BUFFER_SIZE);
             writer.setFile(blobFile);
             Map<Object, Object> entries = new LinkedHashMap<>();
             entries.put(BinaryString.fromString("a"), Blob.fromData("x".getBytes()));

--- a/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
+++ b/paimon-format/src/test/java/org/apache/paimon/format/blob/BlobFormatWriterTest.java
@@ -19,15 +19,22 @@
 package org.apache.paimon.format.blob;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.Blob;
+import org.apache.paimon.data.BlobArrayPlaceholder;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.BlobFetchMetricReporter;
+import org.apache.paimon.data.BlobMapPlaceholder;
+import org.apache.paimon.data.BlobPlaceholder;
 import org.apache.paimon.data.BlobRef;
 import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.PositionOutputStreamWrapper;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
@@ -53,6 +60,95 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link BlobFormatWriter}. */
 public class BlobFormatWriterTest {
+
+    @Test
+    public void testRawBlobGoldenBytes(@TempDir java.nio.file.Path tempDir) throws Exception {
+        java.nio.file.Path sourceFile = tempDir.resolve("source.bin");
+        Files.write(sourceFile, "descriptor".getBytes());
+        java.nio.file.Path outputFile = tempDir.resolve("blob.out");
+
+        try (PositionOutputStream out =
+                new LocalFileIO.LocalPositionOutputStream(outputFile.toFile())) {
+            BlobFormatWriter writer = new BlobFormatWriter(out, null, RowType.of(DataTypes.BLOB()));
+            writer.addElement(GenericRow.of(Blob.fromData("inline".getBytes())));
+            writer.addElement(GenericRow.of(Blob.fromLocal(sourceFile.toString())));
+            writer.addElement(GenericRow.of((Object) null));
+            writer.addElement(GenericRow.of(BlobPlaceholder.INSTANCE));
+            writer.close();
+        }
+
+        assertThat(toHex(Files.readAllBytes(outputFile)))
+                .isEqualTo(
+                        "cf114e58696e6c696e6516000000000000002960c8e9"
+                                + "cf114e5864657363726970746f721a000000000000003f69146b"
+                                + "2c0835010400000001");
+    }
+
+    @Test
+    public void testArrayBlobGoldenBytes(@TempDir java.nio.file.Path tempDir) throws Exception {
+        java.nio.file.Path sourceFile = tempDir.resolve("source.bin");
+        Files.write(sourceFile, "descriptor".getBytes());
+        java.nio.file.Path outputFile = tempDir.resolve("blob.out");
+
+        try (PositionOutputStream out =
+                new LocalFileIO.LocalPositionOutputStream(outputFile.toFile())) {
+            BlobFormatWriter writer =
+                    new BlobFormatWriter(out, null, RowType.of(DataTypes.ARRAY(DataTypes.BLOB())));
+            writer.addElement(GenericRow.of(new GenericArray(new Object[0])));
+            writer.addElement(
+                    GenericRow.of(
+                            new GenericArray(
+                                    new Object[] {
+                                        Blob.fromData("inline".getBytes()),
+                                        null,
+                                        Blob.fromData(new byte[0]),
+                                        Blob.fromLocal(sourceFile.toString())
+                                    })));
+            writer.addElement(GenericRow.of((Object) null));
+            writer.addElement(GenericRow.of(BlobArrayPlaceholder.INSTANCE));
+            writer.close();
+        }
+
+        assertThat(toHex(Files.readAllBytes(outputFile)))
+                .isEqualTo(
+                        "cf114e58424342410100000000000000001d000000000000009bd49157"
+                                + "cf114e58424342410104000000696e6c696e6564657363726970746f72"
+                                + "0c0d0214040000003100000000000000d08307713a2863010400000001");
+    }
+
+    @Test
+    public void testMapBlobGoldenBytes(@TempDir java.nio.file.Path tempDir) throws Exception {
+        java.nio.file.Path sourceFile = tempDir.resolve("source.bin");
+        Files.write(sourceFile, "descriptor".getBytes());
+        java.nio.file.Path outputFile = tempDir.resolve("blob.out");
+
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(null, null);
+        entries.put(BinaryString.fromString(""), Blob.fromData(new byte[0]));
+        entries.put(BinaryString.fromString("inline"), Blob.fromData("data".getBytes()));
+        entries.put(BinaryString.fromString("descriptor"), Blob.fromLocal(sourceFile.toString()));
+
+        try (PositionOutputStream out =
+                new LocalFileIO.LocalPositionOutputStream(outputFile.toFile())) {
+            BlobFormatWriter writer =
+                    new BlobFormatWriter(
+                            out,
+                            null,
+                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+            writer.addElement(GenericRow.of(new GenericMap(new LinkedHashMap<>())));
+            writer.addElement(GenericRow.of(new GenericMap(entries)));
+            writer.addElement(GenericRow.of((Object) null));
+            writer.addElement(GenericRow.of(BlobMapPlaceholder.INSTANCE));
+            writer.close();
+        }
+
+        assertThat(toHex(Files.readAllBytes(outputFile)))
+                .isEqualTo(
+                        "cf114e584243424d010000000000000000000000002100000000000000"
+                                + "8360591ecf114e584243424d0104000000696e6c696e65646573637269"
+                                + "70746f726461746164657363726970746f7201020c080102080c040000"
+                                + "000400000047000000000000006c9f5981424c8f01010500000001");
+    }
 
     @Test
     public void testTwoConsecutiveBlobsPreserveReadback(@TempDir java.nio.file.Path tempDir)
@@ -607,12 +703,94 @@ public class BlobFormatWriterTest {
         public void close() {}
     }
 
+    @Test
+    public void testMapBlobFetchMetricReporter(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        RowType rowType = RowType.of(DataTypes.MAP(DataTypes.INT(), DataTypes.BLOB()));
+        TestingBlobFetchMetricReporter metricReporter = new TestingBlobFetchMetricReporter();
+        BlobFormatWriter writer =
+                new BlobFormatWriter(
+                        new LocalFileIO.LocalPositionOutputStream(
+                                tempDir.resolve("blob.out").toFile()),
+                        null,
+                        rowType,
+                        true,
+                        true,
+                        metricReporter);
+
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(1, Blob.fromData("image".getBytes()));
+        entries.put(
+                2,
+                new BlobRef(
+                        failingHttpReader(500),
+                        new BlobDescriptor("https://example.com/error.jpg", 0, -1)));
+        entries.put(
+                3,
+                new BlobRef(
+                        failingHttpReader(404),
+                        new BlobDescriptor("https://example.com/missing.jpg", 0, -1)));
+        entries.put(4, null);
+        writer.addElement(GenericRow.of(new GenericMap(entries)));
+        writer.addElement(GenericRow.of((Object) null));
+        writer.close();
+
+        assertThat(metricReporter.success).isEqualTo(1);
+        assertThat(metricReporter.successBytes).isEqualTo(5);
+        assertThat(metricReporter.missingFileNullWritten).isEqualTo(1);
+        assertThat(metricReporter.httpNotFound).isEqualTo(1);
+        assertThat(metricReporter.fetchFailureNullWritten).isEqualTo(1);
+        assertThat(metricReporter.failure).isEqualTo(0);
+    }
+
+    @Test
+    public void testMapBlobConsumerDescriptorsAndFlush(@TempDir java.nio.file.Path tempDir)
+            throws Exception {
+        java.nio.file.Path outputFile = tempDir.resolve("blob.out");
+        Path blobFile = new Path(outputFile.toUri());
+        List<BlobDescriptor> descriptors = new ArrayList<>();
+
+        try (CountingPositionOutputStream out =
+                new CountingPositionOutputStream(
+                        new LocalFileIO.LocalPositionOutputStream(outputFile.toFile()))) {
+            BlobFormatWriter writer =
+                    new BlobFormatWriter(
+                            out,
+                            (fieldName, descriptor) -> {
+                                assertThat(fieldName).isEqualTo("f0");
+                                descriptors.add(descriptor);
+                                return descriptors.size() == 1;
+                            },
+                            RowType.of(DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB())));
+            writer.setFile(blobFile);
+            Map<Object, Object> entries = new LinkedHashMap<>();
+            entries.put(BinaryString.fromString("a"), Blob.fromData("x".getBytes()));
+            entries.put(BinaryString.fromString("b"), Blob.fromData("yz".getBytes()));
+            writer.addElement(GenericRow.of(new GenericMap(entries)));
+            writer.close();
+
+            assertThat(out.flushCount).isEqualTo(1);
+        }
+
+        assertThat(descriptors).hasSize(2);
+        assertThat(descriptors.get(0)).isEqualTo(new BlobDescriptor(blobFile.toString(), 15, 1));
+        assertThat(descriptors.get(1)).isEqualTo(new BlobDescriptor(blobFile.toString(), 16, 2));
+    }
+
     private static void assertBlobPayload(Blob blob, byte[] expected) throws Exception {
         try (SeekableInputStream blobIn = blob.newInputStream()) {
             byte[] actual = new byte[expected.length];
             org.apache.paimon.utils.IOUtils.readFully(blobIn, actual);
             assertThat(actual).isEqualTo(expected);
         }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder result = new StringBuilder(bytes.length * 2);
+        for (byte value : bytes) {
+            result.append(String.format("%02x", value & 0xff));
+        }
+        return result.toString();
     }
 
     private static UriReader failingHttpReader(int statusCode) {
@@ -779,6 +957,21 @@ public class BlobFormatWriterTest {
         @Override
         public void recordFetchFailure(Throwable throwable) {
             failure++;
+        }
+    }
+
+    private static final class CountingPositionOutputStream extends PositionOutputStreamWrapper {
+
+        private int flushCount;
+
+        private CountingPositionOutputStream(PositionOutputStream out) {
+            super(out);
+        }
+
+        @Override
+        public void flush() throws java.io.IOException {
+            flushCount++;
+            super.flush();
         }
     }
 

--- a/paimon-python/dev/run_mixed_tests.sh
+++ b/paimon-python/dev/run_mixed_tests.sh
@@ -109,6 +109,7 @@ run_batched_java_write_tests() {
     core_tests="${core_tests}+testBlobCompactConflictWriteBase"
     core_tests="${core_tests}+testBlobWriteAlterCompact"
     core_tests="${core_tests}+testJavaWriteArrayBlobTable"
+    core_tests="${core_tests}+testJavaWriteMapBlobTable"
     core_tests="${core_tests}+testDataEvolutionWrite"
     core_tests="${core_tests}+testJavaWriteRowAppendTable"
     if [[ "$PYTHON_MINOR" -ge 7 ]]; then
@@ -972,6 +973,43 @@ run_array_blob_interop_test() {
     echo -e "${GREEN}✓ Java ARRAY<BLOB> read test completed successfully${NC}"
 }
 
+run_map_blob_interop_test() {
+    echo -e "${YELLOW}=== Running MAP<INT, BLOB> Test (Java Write → Python Read, Python Write → Java Read) ===${NC}"
+
+    if ! skip_batched_java_write; then
+        cd "$PROJECT_ROOT"
+        echo "Running Maven test for JavaPyE2ETest.testJavaWriteMapBlobTable..."
+        if ! mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaWriteMapBlobTable -pl paimon-core -q -Drun.e2e.tests=true; then
+            echo -e "${RED}✗ Java MAP<INT, BLOB> write test failed${NC}"
+            return 1
+        fi
+        echo -e "${GREEN}✓ Java MAP<INT, BLOB> write test completed successfully${NC}"
+    fi
+
+    cd "$PAIMON_PYTHON_DIR"
+    echo "Running Python MAP<INT, BLOB> read test..."
+    if ! python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_read_map_blob_written_by_java -v; then
+        echo -e "${RED}✗ Python MAP<INT, BLOB> read test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Python MAP<INT, BLOB> read test completed successfully${NC}"
+
+    echo "Running Python MAP<INT, BLOB> write test..."
+    if ! python -m pytest java_py_read_write_test.py::JavaPyReadWriteTest::test_write_map_blob_for_java -v; then
+        echo -e "${RED}✗ Python MAP<INT, BLOB> write test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Python MAP<INT, BLOB> write test completed successfully${NC}"
+
+    cd "$PROJECT_ROOT"
+    echo "Running Maven test for JavaPyE2ETest.testJavaReadMapBlobTable..."
+    if ! mvn test -Dtest=org.apache.paimon.JavaPyE2ETest#testJavaReadMapBlobTable -pl paimon-core -q -Drun.e2e.tests=true; then
+        echo -e "${RED}✗ Java MAP<INT, BLOB> read test failed${NC}"
+        return 1
+    fi
+    echo -e "${GREEN}✓ Java MAP<INT, BLOB> read test completed successfully${NC}"
+}
+
 # Function to run VARIANT test (Java write, Python read)
 run_java_variant_write_py_read_test() {
     echo -e "${YELLOW}=== Running VARIANT Test (Java Write, Python Read) ===${NC}"
@@ -1089,6 +1127,7 @@ main() {
     local blob_compact_conflict_result=0
     local blob_alter_compact_result=0
     local array_blob_interop_result=0
+    local map_blob_interop_result=0
     local data_evolution_result=0
     local data_evolution_deletion_vector_result=0
     local data_evolution_py_write_result=0
@@ -1327,6 +1366,12 @@ main() {
 
     echo ""
 
+    if ! run_map_blob_interop_test; then
+        map_blob_interop_result=1
+    fi
+
+    echo ""
+
     # Run data evolution test (Java write, Python read). Lance variant skips
     # itself on <3.8 (get_file_format_params + gated Java lance read).
     if ! run_data_evolution_test; then
@@ -1521,6 +1566,12 @@ main() {
         echo -e "${RED}✗ ARRAY<BLOB> Interoperability Test (Java ↔ Python): FAILED${NC}"
     fi
 
+    if [[ $map_blob_interop_result -eq 0 ]]; then
+        echo -e "${GREEN}✓ MAP<INT, BLOB> Interoperability Test (Java ↔ Python): PASSED${NC}"
+    else
+        echo -e "${RED}✗ MAP<INT, BLOB> Interoperability Test (Java ↔ Python): FAILED${NC}"
+    fi
+
     if [[ $data_evolution_result -eq 0 ]]; then
         echo -e "${GREEN}✓ Data Evolution Test (Java Write, Python Read): PASSED${NC}"
     else
@@ -1562,7 +1613,7 @@ main() {
     # Clean up warehouse directory after all tests
     cleanup_warehouse
 
-    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $btree_raw_fallback_result -eq 0 && $bitmap_index_result -eq 0 && $compressed_global_index_result -eq 0 && $compressed_text_result -eq 0 && $native_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $vindex_vector_result -eq 0 && $vindex_vector_raw_fallback_result -eq 0 && $compact_conflict_result -eq 0 && $blob_compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $array_blob_interop_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_deletion_vector_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
+    if [[ $java_write_result -eq 0 && $python_read_result -eq 0 && $python_write_result -eq 0 && $java_read_result -eq 0 && $pk_dv_result -eq 0 && $btree_index_result -eq 0 && $btree_raw_fallback_result -eq 0 && $bitmap_index_result -eq 0 && $compressed_global_index_result -eq 0 && $compressed_text_result -eq 0 && $native_fulltext_result -eq 0 && $lumina_vector_result -eq 0 && $lumina_vector_btree_result -eq 0 && $vindex_vector_result -eq 0 && $vindex_vector_raw_fallback_result -eq 0 && $compact_conflict_result -eq 0 && $blob_compact_conflict_result -eq 0 && $blob_alter_compact_result -eq 0 && $array_blob_interop_result -eq 0 && $map_blob_interop_result -eq 0 && $data_evolution_result -eq 0 && $data_evolution_deletion_vector_result -eq 0 && $data_evolution_py_write_result -eq 0 && $java_variant_write_py_read_result -eq 0 && $py_variant_write_java_read_result -eq 0 && $vector_append_table_result -eq 0 && $vector_dedicated_java_write_result -eq 0 && $vector_dedicated_py_write_result -eq 0 && $multi_vector_dedicated_java_write_result -eq 0 && $multi_vector_dedicated_py_write_result -eq 0 && $row_format_result -eq 0 ]]; then
         echo -e "${GREEN}🎉 All tests passed! Java-Python interoperability verified.${NC}"
         return 0
     else

--- a/paimon-python/pypaimon/common/map_blob_key_serializer.py
+++ b/paimon-python/pypaimon/common/map_blob_key_serializer.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import struct
+from typing import Optional
+
+from pypaimon.schema.data_types import AtomicType, DataType
+
+
+class MapBlobKeySerializer:
+
+    def __init__(self, type_name: str, struct_format: Optional[str] = None):
+        self._type_name = type_name
+        self._struct_format = struct_format
+        self.fixed_length = -1 if struct_format is None else struct.calcsize(struct_format)
+
+    def serialize(self, key) -> bytes:
+        if self._struct_format is None:
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"MAP<X, BLOB> {self._type_name} key must be a string."
+                )
+            return key.encode('utf-8')
+
+        if not isinstance(key, int) or isinstance(key, bool):
+            raise ValueError(
+                f"MAP<X, BLOB> {self._type_name} key must be an integer."
+            )
+        try:
+            return struct.pack(self._struct_format, key)
+        except struct.error as error:
+            raise ValueError(
+                f"MAP<X, BLOB> {self._type_name} key is out of range: {key}."
+            ) from error
+
+    def deserialize(self, data: bytes):
+        if self._struct_format is None:
+            try:
+                return data.decode('utf-8')
+            except UnicodeDecodeError as error:
+                raise ValueError("Invalid MAP<X, BLOB> string key.") from error
+
+        if len(data) != self.fixed_length:
+            raise ValueError(
+                f"Expected {self.fixed_length} key bytes, but found {len(data)}."
+            )
+        return struct.unpack(self._struct_format, data)[0]
+
+
+def create_map_blob_key_serializer(data_type: DataType) -> MapBlobKeySerializer:
+    if not isinstance(data_type, AtomicType):
+        raise ValueError(f"Unsupported key type for MAP<X, BLOB>: {data_type}")
+
+    type_name = data_type.type.upper()
+    if type_name == 'TINYINT':
+        return MapBlobKeySerializer(type_name, '<b')
+    if type_name == 'SMALLINT':
+        return MapBlobKeySerializer(type_name, '<h')
+    if type_name in ('INT', 'INTEGER'):
+        return MapBlobKeySerializer(type_name, '<i')
+    if type_name == 'BIGINT':
+        return MapBlobKeySerializer(type_name, '<q')
+    if type_name == 'STRING' or type_name.startswith('CHAR') or type_name.startswith('VARCHAR'):
+        return MapBlobKeySerializer(type_name)
+    raise ValueError(f"Unsupported key type for MAP<X, BLOB>: {data_type}")

--- a/paimon-python/pypaimon/daft/daft_blob.py
+++ b/paimon-python/pypaimon/daft/daft_blob.py
@@ -129,3 +129,48 @@ def blob_array_column_to_file_array(
         else pa.list_(value_field)
     )
     return pa.array(rows, type=target_type)
+
+
+def blob_map_column_to_file_array(
+    column: pa.Array,
+    io_config_bytes: bytes | None = None,
+) -> pa.Array:
+    """Convert a map of serialized BlobDescriptors to a map of File structs."""
+    if not pa.types.is_map(column.type):
+        raise TypeError(f"Expected a map column, but got {column.type}.")
+
+    rows = []
+    for row in column:
+        if row is None or not row.is_valid:
+            rows.append(None)
+            continue
+
+        files = []
+        for key, raw in row.as_py():
+            if raw is None:
+                files.append((key, None))
+                continue
+            uri, offset, length = _deserialize_one(raw)
+            files.append((
+                key,
+                {
+                    "url": uri,
+                    "io_config": io_config_bytes,
+                    file_range_position_field(): offset,
+                    file_range_size_field(): length,
+                },
+            ))
+        rows.append(files)
+
+    item_field = pa.field(
+        column.type.item_field.name,
+        FILE_PHYSICAL_TYPE,
+        nullable=column.type.item_field.nullable,
+        metadata=column.type.item_field.metadata,
+    )
+    target_type = pa.map_(
+        column.type.key_field,
+        item_field,
+        keys_sorted=column.type.keys_sorted,
+    )
+    return pa.array(rows, type=target_type)

--- a/paimon-python/pypaimon/daft/daft_datasource.py
+++ b/paimon-python/pypaimon/daft/daft_datasource.py
@@ -50,6 +50,7 @@ from pypaimon.schema.data_types import (
     VectorType,
     is_array_blob_type,
     is_blob_type,
+    is_map_blob_type,
 )
 
 if TYPE_CHECKING:
@@ -316,6 +317,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         blob_column_names: set[str] | None = None,
         explicit_io_config_bytes: bytes | None = None,
         array_blob_column_names: set[str] | None = None,
+        map_blob_column_names: set[str] | None = None,
     ) -> None:
         self._table_catalog_options = table_catalog_options
         self._table_identifier = table_identifier
@@ -329,6 +331,7 @@ class _PaimonPKSplitTask(DataSourceTask):
         self._output_columns = output_columns
         self._blob_column_names = blob_column_names or set()
         self._array_blob_column_names = array_blob_column_names or set()
+        self._map_blob_column_names = map_blob_column_names or set()
         self._explicit_io_config_bytes = explicit_io_config_bytes
 
     @property
@@ -351,7 +354,9 @@ class _PaimonPKSplitTask(DataSourceTask):
             read_builder = read_builder.with_filter(self._predicate)
 
         has_blob_columns = bool(
-            self._blob_column_names or self._array_blob_column_names
+            self._blob_column_names
+            or self._array_blob_column_names
+            or self._map_blob_column_names
         )
         blob_io_config_bytes = (
             self._blob_io_config_bytes(table) if has_blob_columns else None
@@ -366,6 +371,7 @@ class _PaimonPKSplitTask(DataSourceTask):
                     self._blob_column_names,
                     blob_io_config_bytes,
                     self._array_blob_column_names,
+                    self._map_blob_column_names,
                 )
             batch = _promote_time32_batch_for_daft(batch)
             rb = RecordBatch.from_arrow_record_batches([batch], batch.schema)
@@ -374,6 +380,7 @@ class _PaimonPKSplitTask(DataSourceTask):
                     rb,
                     self._blob_column_names,
                     self._array_blob_column_names,
+                    self._map_blob_column_names,
                 )
             yield rb
 
@@ -407,15 +414,18 @@ def _convert_blob_columns(
     blob_column_names: set[str],
     io_config_bytes: bytes | None = None,
     array_blob_column_names: set[str] | None = None,
+    map_blob_column_names: set[str] | None = None,
 ) -> pa.RecordBatch:
     """Replace serialized BlobDescriptor columns with the File physical struct layout."""
     from pypaimon.daft.daft_blob import (
         FILE_PHYSICAL_TYPE,
         blob_array_column_to_file_array,
         blob_column_to_file_array,
+        blob_map_column_to_file_array,
     )
 
     array_blob_column_names = array_blob_column_names or set()
+    map_blob_column_names = map_blob_column_names or set()
 
     arrays = []
     fields = []
@@ -430,6 +440,18 @@ def _convert_blob_columns(
             converted = blob_array_column_to_file_array(col, io_config_bytes)
             arrays.append(converted)
             fields.append(pa.field(field.name, converted.type, nullable=field.nullable))
+        elif field.name in map_blob_column_names and pa.types.is_map(field.type):
+            converted = blob_map_column_to_file_array(col, io_config_bytes)
+            arrays.append(converted)
+            # Daft task schemas expose Map fields as nullable. PyPaimon can
+            # return a non-nullable field even when its MapArray contains null
+            # rows, which Daft rejects at the Python source boundary.
+            fields.append(pa.field(
+                field.name,
+                converted.type,
+                nullable=True,
+                metadata=field.metadata,
+            ))
         else:
             arrays.append(col)
             fields.append(field)
@@ -440,12 +462,14 @@ def _cast_blob_columns_to_file(
     rb: RecordBatch,
     blob_column_names: set[str],
     array_blob_column_names: set[str] | None = None,
+    map_blob_column_names: set[str] | None = None,
 ) -> RecordBatch:
     """Cast struct-typed blob columns in a RecordBatch to DataType.file()."""
     from daft.datatype import DataType
 
     file_dtype = DataType.file()
     array_blob_column_names = array_blob_column_names or set()
+    map_blob_column_names = map_blob_column_names or set()
     columns = {}
     for i, field in enumerate(rb.schema()):
         col = rb.get_column(i)
@@ -453,6 +477,8 @@ def _cast_blob_columns_to_file(
             col = col.cast(file_dtype)
         elif field.name in array_blob_column_names:
             col = col.cast(DataType.list(file_dtype))
+        elif field.name in map_blob_column_names:
+            col = col.cast(DataType.map(field.dtype.key_type, file_dtype))
         columns[field.name] = col
     return RecordBatch.from_pydict(columns)
 
@@ -467,7 +493,7 @@ def _blob_native_covering_files(
     native reader, or ``None`` if the split must use the pypaimon fallback.
 
     A blob table stores each column bunch in its own file: scalar columns in
-    parquet, BLOB / ARRAY<BLOB> columns in ``.blob`` files, vector columns in
+    parquet, BLOB / ARRAY<BLOB> / MAP<X, BLOB> columns in ``.blob`` files, vector columns in
     ``.vector`` files, aligned by row id. Reading the base parquet files
     natively is only correct when every projected data column lives in parquet
     files that each fully cover the projection over disjoint row-id ranges --
@@ -609,8 +635,13 @@ class PaimonDataSource(DataSource):
         self._array_blob_column_names = {
             field.name for field in table.fields if is_array_blob_type(field.type)
         }
+        self._map_blob_column_names = {
+            field.name for field in table.fields if is_map_blob_type(field.type)
+        }
         self._has_blob_columns = bool(
-            self._scalar_blob_column_names or self._array_blob_column_names
+            self._scalar_blob_column_names
+            or self._array_blob_column_names
+            or self._map_blob_column_names
         )
 
         if self._has_blob_columns:
@@ -624,6 +655,11 @@ class PaimonDataSource(DataSource):
                     fields.append((f.name, DataType.file()))
                 elif f.name in self._array_blob_column_names:
                     fields.append((f.name, DataType.list(DataType.file())))
+                elif f.name in self._map_blob_column_names:
+                    fields.append((
+                        f.name,
+                        DataType.map(f.dtype.key_type, DataType.file()),
+                    ))
                 else:
                     fields.append((f.name, f.dtype))
             self._schema = Schema.from_field_name_and_types(fields)
@@ -783,6 +819,7 @@ class PaimonDataSource(DataSource):
                     self._scalar_blob_column_names,
                     self._explicit_io_config_bytes,
                     self._array_blob_column_names,
+                    self._map_blob_column_names,
                 )
 
     def explain_scan(self, pushdowns: Pushdowns, verbose: bool = False) -> PaimonScanExplain:
@@ -967,7 +1004,11 @@ class PaimonDataSource(DataSource):
             or task_columns is None
         ):
             return None
-        blob_column_names = self._scalar_blob_column_names | self._array_blob_column_names
+        blob_column_names = (
+            self._scalar_blob_column_names
+            | self._array_blob_column_names
+            | self._map_blob_column_names
+        )
         return _blob_native_covering_files(
             files, task_columns, blob_column_names, self._table.partition_keys
         )

--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -395,14 +395,15 @@ class BlobFallbackBatchReader(RecordBatchReader):
             raise ValueError(
                 "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
             )
-        result = {}
+        result = []
         for key, blob in blob_map.items():
             if blob is None:
-                result[key] = None
+                value = None
             elif self._blob_as_descriptor:
-                result[key] = blob.to_descriptor().serialize()
+                value = blob.to_descriptor().serialize()
             else:
-                result[key] = blob.to_data()
+                value = blob.to_data()
+            result.append((key, value))
         return result
 
     def _resolve_selected_blobs(self, values: List[object]) -> List[object]:
@@ -418,13 +419,11 @@ class BlobFallbackBatchReader(RecordBatchReader):
                     raise ValueError(
                         "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
                     )
-                map_values = {}
-                for key, blob in value.items():
-                    if blob is None:
-                        map_values[key] = None
-                    else:
-                        map_values[key] = None
-                        indexed_blobs.append((row_index, key, blob))
+                map_values = []
+                for entry_index, (key, blob) in enumerate(value.items()):
+                    map_values.append((key, None))
+                    if blob is not None:
+                        indexed_blobs.append((row_index, entry_index, blob))
                 resolved.append(map_values)
             elif self._is_array_blob:
                 if value is None:
@@ -451,7 +450,8 @@ class BlobFallbackBatchReader(RecordBatchReader):
             [blob for _, _, blob in indexed_blobs], self._blob_parallelism)
         for (row_index, slot, _), body in zip(indexed_blobs, bodies):
             if self._is_map_blob:
-                resolved[row_index][slot] = body
+                key = resolved[row_index][slot][0]
+                resolved[row_index][slot] = (key, body)
             elif slot is None:
                 resolved[row_index] = body
             else:

--- a/paimon-python/pypaimon/read/reader/concat_batch_reader.py
+++ b/paimon-python/pypaimon/read/reader/concat_batch_reader.py
@@ -268,6 +268,7 @@ class BlobFallbackBatchReader(RecordBatchReader):
         self._row_ranges = Range.sort_and_merge_overlap(row_ranges) if row_ranges else None
         self._blob_as_descriptor = blob_as_descriptor
         self._is_array_blob = pa.types.is_list(output_type) or pa.types.is_large_list(output_type)
+        self._is_map_blob = pa.types.is_map(output_type)
         self._data_field = DataField(
             0,
             field_name,
@@ -323,8 +324,17 @@ class BlobFallbackBatchReader(RecordBatchReader):
                     )
                 if blob is None:
                     group[row_id] = (None, False)
-                elif blob is Blob.PLACE_HOLDER or blob is Blob.ARRAY_PLACE_HOLDER:
+                elif (
+                    blob is Blob.PLACE_HOLDER
+                    or blob is Blob.ARRAY_PLACE_HOLDER
+                    or blob is Blob.MAP_PLACE_HOLDER
+                ):
                     group[row_id] = (None, True)
+                elif self._is_map_blob:
+                    if resolve_blobs_concurrently:
+                        group[row_id] = (blob, False)
+                    else:
+                        group[row_id] = (self._map_value_for_arrow(blob), False)
                 elif self._is_array_blob:
                     if resolve_blobs_concurrently:
                         group[row_id] = (blob, False)
@@ -380,12 +390,43 @@ class BlobFallbackBatchReader(RecordBatchReader):
                 result.append(blob.to_data())
         return result
 
+    def _map_value_for_arrow(self, blob_map):
+        if None in blob_map:
+            raise ValueError(
+                "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
+            )
+        result = {}
+        for key, blob in blob_map.items():
+            if blob is None:
+                result[key] = None
+            elif self._blob_as_descriptor:
+                result[key] = blob.to_descriptor().serialize()
+            else:
+                result[key] = blob.to_data()
+        return result
+
     def _resolve_selected_blobs(self, values: List[object]) -> List[object]:
-        """Materialize selected scalar or array BLOBs with the shared FileIO."""
+        """Materialize selected scalar, array, or map BLOBs with the shared FileIO."""
         resolved = []
-        indexed_blobs: List[Tuple[int, Optional[int], Blob]] = []
+        indexed_blobs: List[Tuple[int, object, Blob]] = []
         for row_index, value in enumerate(values):
-            if self._is_array_blob:
+            if self._is_map_blob:
+                if value is None:
+                    resolved.append(None)
+                    continue
+                if None in value:
+                    raise ValueError(
+                        "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
+                    )
+                map_values = {}
+                for key, blob in value.items():
+                    if blob is None:
+                        map_values[key] = None
+                    else:
+                        map_values[key] = None
+                        indexed_blobs.append((row_index, key, blob))
+                resolved.append(map_values)
+            elif self._is_array_blob:
                 if value is None:
                     resolved.append(None)
                     continue
@@ -408,11 +449,13 @@ class BlobFallbackBatchReader(RecordBatchReader):
 
         bodies = self._file_io.read_blobs_concurrent(
             [blob for _, _, blob in indexed_blobs], self._blob_parallelism)
-        for (row_index, element_index, _), body in zip(indexed_blobs, bodies):
-            if element_index is None:
+        for (row_index, slot, _), body in zip(indexed_blobs, bodies):
+            if self._is_map_blob:
+                resolved[row_index][slot] = body
+            elif slot is None:
                 resolved[row_index] = body
             else:
-                resolved[row_index][element_index] = body
+                resolved[row_index][slot] = body
         return resolved
 
     def _compute_target_ranges(self) -> List[Range]:

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -24,12 +24,15 @@ from pyarrow import RecordBatch
 
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 from pypaimon.common.file_io import FileIO
+from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.read.reader.iface.record_batch_reader import RecordBatchReader
 from pypaimon.schema.data_types import (
     DataField,
     PyarrowFieldParser,
     AtomicType,
+    MapType,
     is_array_blob_type,
+    is_map_blob_type,
 )
 from pypaimon.table.row.blob import Blob
 from pypaimon.table.row.generic_row import GenericRow
@@ -72,13 +75,25 @@ class FormatBlobReader(RecordBatchReader):
             full_fields_map = {field.name: field for field in full_fields}
             projected_data_fields = [full_fields_map[name] for name in read_fields]
             self._data_field = projected_data_fields[0]
+            if isinstance(self._data_field.type, MapType) and not is_map_blob_type(
+                self._data_field.type
+            ):
+                raise ValueError(
+                    "Map-Blob value type must be BLOB, but is "
+                    f"{self._data_field.type.value}."
+                )
             self._is_array_blob = is_array_blob_type(self._data_field.type)
+            self._is_map_blob = is_map_blob_type(self._data_field.type)
             self._schema = PyarrowFieldParser.from_paimon_schema(projected_data_fields)
 
             # Drop the shared stream: descriptor/concurrent reads yield BlobRefs
             # that each open their own stream (one stream isn't thread-safe).
-            # ARRAY<BLOB> needs the stream to read the nested element index.
-            if not self._is_array_blob and (self._blob_as_descriptor or self._blob_parallelism > 1):
+            # Nested Blob formats need the stream to read their keys and indexes.
+            if (
+                not self._is_array_blob
+                and not self._is_map_blob
+                and (self._blob_as_descriptor or self._blob_parallelism > 1)
+            ):
                 self._input_stream.close()
                 self._input_stream = None
         except Exception:
@@ -121,7 +136,17 @@ class FormatBlobReader(RecordBatchReader):
                     break
                 blob = blob_row.values[0]
                 for field_name in self._fields:
-                    if self._is_array_blob:
+                    if self._is_map_blob:
+                        row_index = len(pydict_data[field_name])
+                        pydict_data[field_name].append(
+                            self._map_value_for_arrow(
+                                blob,
+                                field_name,
+                                row_index,
+                                blobs_to_resolve,
+                            )
+                        )
+                    elif self._is_array_blob:
                         row_index = len(pydict_data[field_name])
                         pydict_data[field_name].append(
                             self._array_value_for_arrow(
@@ -143,7 +168,7 @@ class FormatBlobReader(RecordBatchReader):
                         elif self._blob_parallelism > 1:
                             idx = len(pydict_data[field_name])
                             pydict_data[field_name].append(None)
-                            blobs_to_resolve.append((field_name, idx, None, blob))
+                            blobs_to_resolve.append((field_name, idx, 'raw', None, blob))
                         else:
                             pydict_data[field_name].append(blob.to_data())
 
@@ -180,14 +205,16 @@ class FormatBlobReader(RecordBatchReader):
                 return None
 
     def _resolve_blobs_concurrent(self, pydict_data, blobs_to_resolve):
-        blobs = [item[3] for item in blobs_to_resolve]
+        blobs = [item[4] for item in blobs_to_resolve]
         results = self._file_io.read_blobs_concurrent(blobs, self._blob_parallelism)
         for target, data in zip(blobs_to_resolve, results):
-            field_name, row_index, element_index, _ = target
-            if element_index is None:
+            field_name, row_index, container_kind, slot, _ = target
+            if container_kind == 'raw':
                 pydict_data[field_name][row_index] = data
+            elif container_kind == 'array':
+                pydict_data[field_name][row_index][slot] = data
             else:
-                pydict_data[field_name][row_index][element_index] = data
+                pydict_data[field_name][row_index][slot] = data
 
     def _array_value_for_arrow(
         self,
@@ -211,10 +238,43 @@ class FormatBlobReader(RecordBatchReader):
             elif self._blob_parallelism > 1:
                 result.append(None)
                 blobs_to_resolve.append(
-                    (field_name, row_index, element_index, blob)
+                    (field_name, row_index, 'array', element_index, blob)
                 )
             else:
                 result.append(blob.to_data())
+        return result
+
+    def _map_value_for_arrow(
+        self,
+        blob_map,
+        field_name,
+        row_index,
+        blobs_to_resolve,
+    ):
+        if blob_map is None:
+            return None
+        if blob_map is Blob.MAP_PLACE_HOLDER:
+            raise RuntimeError(
+                "Blob placeholder is not supported by FormatBlobReader yet."
+            )
+        if None in blob_map:
+            raise ValueError(
+                "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
+            )
+
+        result = {}
+        for key, blob in blob_map.items():
+            if blob is None:
+                result[key] = None
+            elif self._blob_as_descriptor:
+                result[key] = blob.to_descriptor().serialize()
+            elif self._blob_parallelism > 1:
+                result[key] = None
+                blobs_to_resolve.append(
+                    (field_name, row_index, 'map', key, blob)
+                )
+            else:
+                result[key] = blob.to_data()
         return result
 
     def close(self):
@@ -290,6 +350,14 @@ class BlobRecordIterator:
     ARRAY_NULL_ELEMENT_LENGTH = -1
     ARRAY_INDEX_LENGTH_SIZE = 4
     MIN_ARRAY_PAYLOAD_LENGTH = ARRAY_HEADER_SIZE + ARRAY_INDEX_LENGTH_SIZE
+    MAP_HEADER_SIZE = 9
+    MAP_VERSION = 1
+    MAP_MAGIC_NUMBER = 0x4D424342
+    MAP_NULL_KEY_LENGTH = -1
+    MAP_NULL_VALUE_LENGTH = -1
+    MAP_INDEX_LENGTH_SIZE = 4
+    MAP_INDEX_LENGTHS_SIZE = MAP_INDEX_LENGTH_SIZE * 2
+    MIN_MAP_PAYLOAD_LENGTH = MAP_HEADER_SIZE + MAP_INDEX_LENGTHS_SIZE
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
 
@@ -305,7 +373,17 @@ class BlobRecordIterator:
         else:
             self.field = DataField(0, field, AtomicType("BLOB"))
         self.field_name = self.field.name
+        if isinstance(self.field.type, MapType) and not is_map_blob_type(self.field.type):
+            raise ValueError(
+                f"Map-Blob value type must be BLOB, but is {self.field.type.value}."
+            )
         self.is_array_blob = is_array_blob_type(self.field.type)
+        self.is_map_blob = is_map_blob_type(self.field.type)
+        self.map_key_serializer = (
+            create_map_blob_key_serializer(self.field.type.key)
+            if self.is_map_blob
+            else None
+        )
         self.blob_as_descriptor = blob_as_descriptor
         self.blob_lengths = blob_lengths
         self.blob_offsets = blob_offsets
@@ -324,13 +402,20 @@ class BlobRecordIterator:
             return GenericRow([None], fields, RowKind.INSERT)
         if length == self.PLACE_HOLDER_LENGTH:
             self.current_position += 1
-            placeholder = Blob.ARRAY_PLACE_HOLDER if self.is_array_blob else Blob.PLACE_HOLDER
+            if self.is_map_blob:
+                placeholder = Blob.MAP_PLACE_HOLDER
+            elif self.is_array_blob:
+                placeholder = Blob.ARRAY_PLACE_HOLDER
+            else:
+                placeholder = Blob.PLACE_HOLDER
             return GenericRow([placeholder], fields, RowKind.INSERT)
         # Create blob reference for the current blob
         # Skip magic number (4 bytes) and exclude length (8 bytes) + CRC (4 bytes) = 12 bytes
         blob_offset = self.blob_offsets[self.current_position] + self.MAGIC_NUMBER_SIZE  # Skip magic number
         blob_length = length - self.METADATA_OVERHEAD
-        if self.is_array_blob:
+        if self.is_map_blob:
+            blob = self._read_blob_map(blob_offset, blob_length)
+        elif self.is_array_blob:
             blob = self._read_blob_array(blob_offset, blob_length)
         elif self.input_stream is not None and not self.blob_as_descriptor:
             blob = Blob.from_data(self._read_inline_blob(blob_offset, blob_length))
@@ -450,6 +535,220 @@ class BlobRecordIterator:
         finally:
             if close_stream:
                 stream.close()
+
+    def _read_blob_map(self, position: int, length: int):
+        if position < 0 or length < self.MIN_MAP_PAYLOAD_LENGTH:
+            raise ValueError(
+                f"Invalid MAP<X, BLOB> payload position or length: {position}, {length}"
+            )
+
+        stream = self.input_stream
+        close_stream = False
+        if stream is None:
+            stream = self.file_io.new_input_stream(self.file_path)
+            close_stream = True
+        try:
+            stream.seek(position)
+            header = self._read_fully_from(stream, self.MAP_HEADER_SIZE)
+            if len(header) != self.MAP_HEADER_SIZE:
+                raise IOError("Invalid MAP<X, BLOB> payload: cannot read header")
+            magic, version, entry_count = struct.unpack('<IBI', header)
+            if magic != self.MAP_MAGIC_NUMBER:
+                raise ValueError(f"Invalid MAP<X, BLOB> payload magic number: {magic}")
+            if version != self.MAP_VERSION:
+                raise ValueError(f"Unsupported MAP<X, BLOB> payload version: {version}")
+            if entry_count > 0x7fffffff:
+                raise ValueError(f"Invalid MAP<X, BLOB> entry count: {entry_count}")
+
+            payload_end = position + length
+            data_start = position + self.MAP_HEADER_SIZE
+            index_lengths_position = payload_end - self.MAP_INDEX_LENGTHS_SIZE
+            stream.seek(index_lengths_position)
+            index_length_bytes = self._read_fully_from(
+                stream, self.MAP_INDEX_LENGTHS_SIZE
+            )
+            if len(index_length_bytes) != self.MAP_INDEX_LENGTHS_SIZE:
+                raise IOError("Invalid MAP<X, BLOB> payload: cannot read index lengths")
+            key_index_length, value_index_length = struct.unpack('<II', index_length_bytes)
+            self._check_map_index_lengths(
+                key_index_length,
+                value_index_length,
+                length,
+                entry_count,
+            )
+
+            value_index_start = index_lengths_position - value_index_length
+            key_index_start = value_index_start - key_index_length
+            stream.seek(key_index_start)
+            key_index_bytes = self._read_fully_from(stream, key_index_length)
+            if len(key_index_bytes) != key_index_length:
+                raise IOError("Invalid MAP<X, BLOB> payload: cannot read key index")
+            stream.seek(value_index_start)
+            value_index_bytes = self._read_fully_from(stream, value_index_length)
+            if len(value_index_bytes) != value_index_length:
+                raise IOError("Invalid MAP<X, BLOB> payload: cannot read value index")
+
+            self._validate_map_index(key_index_bytes, "key")
+            self._validate_map_index(value_index_bytes, "value")
+            try:
+                key_lengths = DeltaVarintCompressor.decompress(key_index_bytes)
+            except RuntimeError as error:
+                raise ValueError("Invalid MAP<X, BLOB> key index.") from error
+            try:
+                value_lengths = DeltaVarintCompressor.decompress(value_index_bytes)
+            except RuntimeError as error:
+                raise ValueError("Invalid MAP<X, BLOB> value index.") from error
+
+            data_length = key_index_start - data_start
+            key_data_length = self._check_map_key_lengths(
+                key_lengths, data_length, entry_count
+            )
+            value_data_length = data_length - key_data_length
+            self._check_map_value_lengths(
+                value_lengths, value_data_length, entry_count
+            )
+
+            stream.seek(data_start)
+            key_data = self._read_fully_from(stream, key_data_length)
+            if len(key_data) != key_data_length:
+                raise IOError("Invalid MAP<X, BLOB> payload: cannot read key data")
+            keys = []
+            key_data_offset = 0
+            for key_length in key_lengths:
+                if key_length == self.MAP_NULL_KEY_LENGTH:
+                    keys.append(None)
+                    continue
+                serialized_key = key_data[
+                    key_data_offset:key_data_offset + key_length
+                ]
+                try:
+                    keys.append(self.map_key_serializer.deserialize(serialized_key))
+                except ValueError as error:
+                    raise ValueError("Invalid MAP<X, BLOB> key.") from error
+                key_data_offset += key_length
+
+            value_data_start = data_start + key_data_length
+            value_data = None
+            if not self.blob_as_descriptor:
+                stream.seek(value_data_start)
+                value_data = self._read_fully_from(stream, value_data_length)
+                if len(value_data) != value_data_length:
+                    raise IOError("Invalid MAP<X, BLOB> payload: cannot read value data")
+
+            result = {}
+            value_offset = value_data_start
+            value_data_offset = 0
+            for key, value_length in zip(keys, value_lengths):
+                if value_length == self.MAP_NULL_VALUE_LENGTH:
+                    value = None
+                elif self.blob_as_descriptor:
+                    value = Blob.from_file(
+                        self.file_io, self.file_path, value_offset, value_length
+                    )
+                else:
+                    value = Blob.from_data(
+                        value_data[value_data_offset:value_data_offset + value_length]
+                    )
+                if value_length != self.MAP_NULL_VALUE_LENGTH:
+                    value_offset += value_length
+                    value_data_offset += value_length
+                result[key] = value
+            return result
+        finally:
+            if close_stream:
+                stream.close()
+
+    @classmethod
+    def _check_map_index_lengths(
+        cls,
+        key_index_length: int,
+        value_index_length: int,
+        payload_length: int,
+        entry_count: int,
+    ) -> None:
+        maximum_indexes_length = payload_length - cls.MIN_MAP_PAYLOAD_LENGTH
+        if key_index_length > 0x7fffffff or key_index_length > maximum_indexes_length:
+            raise ValueError(
+                f"Invalid MAP<X, BLOB> key index length: {key_index_length}"
+            )
+        if value_index_length > 0x7fffffff or value_index_length > maximum_indexes_length:
+            raise ValueError(
+                f"Invalid MAP<X, BLOB> value index length: {value_index_length}"
+            )
+        if key_index_length + value_index_length > maximum_indexes_length:
+            raise ValueError("MAP<X, BLOB> indexes exceed the payload length.")
+        if entry_count > key_index_length:
+            raise ValueError("MAP<X, BLOB> entry count exceeds key index length.")
+        if entry_count > value_index_length:
+            raise ValueError("MAP<X, BLOB> entry count exceeds value index length.")
+
+    def _check_map_key_lengths(
+        self, key_lengths, max_data_length: int, entry_count: int
+    ) -> int:
+        if len(key_lengths) != entry_count:
+            raise ValueError(
+                "MAP<X, BLOB> entry count does not match key index length."
+            )
+
+        key_data_length = 0
+        fixed_key_length = self.map_key_serializer.fixed_length
+        for key_length in key_lengths:
+            if key_length == self.MAP_NULL_KEY_LENGTH:
+                continue
+            if key_length < 0:
+                raise ValueError(f"Invalid MAP<X, BLOB> key length: {key_length}")
+            if key_length > 0x7fffffff:
+                raise ValueError(f"MAP<X, BLOB> key is too large: {key_length}")
+            if fixed_key_length >= 0 and key_length != fixed_key_length:
+                raise ValueError(
+                    f"Invalid MAP<X, BLOB> fixed-width key length: {key_length}"
+                )
+            if key_length > max_data_length - key_data_length:
+                raise ValueError(
+                    "MAP<X, BLOB> key lengths exceed the payload data length."
+                )
+            key_data_length += key_length
+        return key_data_length
+
+    def _check_map_value_lengths(
+        self, value_lengths, max_data_length: int, entry_count: int
+    ) -> None:
+        if len(value_lengths) != entry_count:
+            raise ValueError(
+                "MAP<X, BLOB> entry count does not match value index length."
+            )
+
+        value_data_length = 0
+        for value_length in value_lengths:
+            if value_length == self.MAP_NULL_VALUE_LENGTH:
+                continue
+            if value_length < 0:
+                raise ValueError(f"Invalid MAP<X, BLOB> value length: {value_length}")
+            if not self.blob_as_descriptor and value_length > 0x7fffffff:
+                raise ValueError(
+                    f"MAP<X, BLOB> inline value is too large: {value_length}"
+                )
+            if value_length > max_data_length - value_data_length:
+                raise ValueError(
+                    "MAP<X, BLOB> value lengths exceed the payload data length."
+                )
+            value_data_length += value_length
+        if value_data_length != max_data_length:
+            raise ValueError(
+                "MAP<X, BLOB> key/value lengths do not match the payload data length."
+            )
+
+    @staticmethod
+    def _validate_map_index(index_bytes: bytes, index_name: str) -> None:
+        varint_length = 0
+        for value in index_bytes:
+            varint_length += 1
+            if varint_length > 10:
+                raise ValueError(f"Invalid MAP<X, BLOB> {index_name} index.")
+            if value & 0x80 == 0:
+                varint_length = 0
+        if varint_length != 0:
+            raise ValueError(f"Invalid MAP<X, BLOB> {index_name} index.")
 
     @staticmethod
     def _validate_array_element_index(index_bytes: bytes) -> None:

--- a/paimon-python/pypaimon/read/reader/format_blob_reader.py
+++ b/paimon-python/pypaimon/read/reader/format_blob_reader.py
@@ -213,8 +213,9 @@ class FormatBlobReader(RecordBatchReader):
                 pydict_data[field_name][row_index] = data
             elif container_kind == 'array':
                 pydict_data[field_name][row_index][slot] = data
-            else:
-                pydict_data[field_name][row_index][slot] = data
+            elif container_kind == 'map':
+                key = pydict_data[field_name][row_index][slot][0]
+                pydict_data[field_name][row_index][slot] = (key, data)
 
     def _array_value_for_arrow(
         self,
@@ -262,19 +263,20 @@ class FormatBlobReader(RecordBatchReader):
                 "MAP<X, BLOB> with null keys cannot be converted to a PyArrow Map."
             )
 
-        result = {}
-        for key, blob in blob_map.items():
+        result = []
+        for entry_index, (key, blob) in enumerate(blob_map.items()):
             if blob is None:
-                result[key] = None
+                value = None
             elif self._blob_as_descriptor:
-                result[key] = blob.to_descriptor().serialize()
+                value = blob.to_descriptor().serialize()
             elif self._blob_parallelism > 1:
-                result[key] = None
+                value = None
                 blobs_to_resolve.append(
-                    (field_name, row_index, 'map', key, blob)
+                    (field_name, row_index, 'map', entry_index, blob)
                 )
             else:
-                result[key] = blob.to_data()
+                value = blob.to_data()
+            result.append((key, value))
         return result
 
     def close(self):

--- a/paimon-python/pypaimon/schema/column_directive_utils.py
+++ b/paimon-python/pypaimon/schema/column_directive_utils.py
@@ -27,9 +27,10 @@ Mirrors Java's ColumnDirectiveUtils. Supported directives:
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.schema.data_types import (ArrayType, AtomicType, DataField,
-                                        DataType, VectorType)
+                                        DataType, MapType, VectorType)
 
 BLOB_FIELD_DIRECTIVE = "__BLOB_FIELD"
 BLOB_DESCRIPTOR_FIELD_DIRECTIVE = "__BLOB_DESCRIPTOR_FIELD"
@@ -149,6 +150,26 @@ def _convert_type(directive: ParsedDirective, field_name: str, source_type: Data
             )
         return VectorType(source_type.nullable, source_type.element, directive.vector_dim)
     else:
+        if isinstance(source_type, MapType):
+            if directive.option_key != CoreOptions.BLOB_FIELD.key():
+                raise ValueError(
+                    f"MAP<X, BLOB> is only supported by '{CoreOptions.BLOB_FIELD.key()}'."
+                )
+            create_map_blob_key_serializer(source_type.key)
+            value_type = getattr(source_type.value, 'type', None) \
+                if isinstance(source_type.value, AtomicType) else None
+            if not _is_blob_source_type(value_type):
+                raise ValueError(
+                    f"Column {field_name} declared with a BLOB directive must be of "
+                    f"BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY>, ARRAY<BLOB>, "
+                    f"MAP<X, BYTES>, MAP<X, BINARY> or MAP<X, BLOB> type, but was "
+                    f"{source_type}."
+                )
+            return MapType(
+                source_type.nullable,
+                source_type.key,
+                AtomicType('BLOB', source_type.value.nullable),
+            )
         if isinstance(source_type, ArrayType):
             if directive.option_key != CoreOptions.BLOB_FIELD.key():
                 raise ValueError(
@@ -159,8 +180,9 @@ def _convert_type(directive: ParsedDirective, field_name: str, source_type: Data
             if not _is_blob_source_type(element_type):
                 raise ValueError(
                     f"Column {field_name} declared with a BLOB directive must be of "
-                    f"BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> or ARRAY<BLOB> "
-                    f"type, but was {source_type}."
+                    f"BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY>, ARRAY<BLOB>, "
+                    f"MAP<X, BYTES>, MAP<X, BINARY> or MAP<X, BLOB> type, but was "
+                    f"{source_type}."
                 )
             return ArrayType(
                 source_type.nullable,
@@ -170,8 +192,9 @@ def _convert_type(directive: ParsedDirective, field_name: str, source_type: Data
         if not _is_blob_source_type(type_name):
             raise ValueError(
                 f"Column {field_name} declared with a BLOB directive "
-                f"must be of BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY> "
-                f"or ARRAY<BLOB> type, but was {source_type}."
+                f"must be of BYTES, BINARY, BLOB, ARRAY<BYTES>, ARRAY<BINARY>, "
+                f"ARRAY<BLOB>, MAP<X, BYTES>, MAP<X, BINARY> or MAP<X, BLOB> "
+                f"type, but was {source_type}."
             )
         return AtomicType('BLOB', source_type.nullable)
 

--- a/paimon-python/pypaimon/schema/column_directive_utils.py
+++ b/paimon-python/pypaimon/schema/column_directive_utils.py
@@ -27,7 +27,6 @@ Mirrors Java's ColumnDirectiveUtils. Supported directives:
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.schema.data_types import (ArrayType, AtomicType, DataField,
                                         DataType, MapType, VectorType)
@@ -155,7 +154,6 @@ def _convert_type(directive: ParsedDirective, field_name: str, source_type: Data
                 raise ValueError(
                     f"MAP<X, BLOB> is only supported by '{CoreOptions.BLOB_FIELD.key()}'."
                 )
-            create_map_blob_key_serializer(source_type.key)
             value_type = getattr(source_type.value, 'type', None) \
                 if isinstance(source_type.value, AtomicType) else None
             if not _is_blob_source_type(value_type):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -582,7 +582,9 @@ class DataTypeParser:
                     json_data.get("key"), field_id)
                 value = DataTypeParser.parse_data_type(
                     json_data.get("value"), field_id)
-                nullable = "NOT NULL" not in type_string
+                nullable = json_data.get("nullable")
+                if nullable is None:
+                    nullable = not type_string.rstrip().endswith(" NOT NULL")
                 return MapType(nullable, key, value)
 
             elif type_string.startswith("ROW"):

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -291,7 +291,11 @@ def is_map_blob_type(data_type: DataType) -> bool:
 
 
 def is_blob_file_type(data_type: DataType) -> bool:
-    return is_blob_type(data_type) or is_array_blob_type(data_type)
+    return (
+        is_blob_type(data_type)
+        or is_array_blob_type(data_type)
+        or is_map_blob_type(data_type)
+    )
 
 
 def is_blob_file_field(field: 'DataField') -> bool:
@@ -727,7 +731,14 @@ class PyarrowFieldParser:
         elif isinstance(data_type, MapType):
             key_type = PyarrowFieldParser.from_paimon_type(data_type.key)
             value_type = PyarrowFieldParser.from_paimon_type(data_type.value)
-            return pyarrow.map_(key_type, value_type)
+            return pyarrow.map_(
+                pyarrow.field("key", key_type, nullable=False),
+                pyarrow.field(
+                    "value",
+                    value_type,
+                    nullable=data_type.value.nullable,
+                ),
+            )
         elif isinstance(data_type, RowType):
             pa_fields = []
             for field in data_type.fields:
@@ -802,8 +813,10 @@ class PyarrowFieldParser:
             return ArrayType(nullable, element_type)
         elif types.is_map(pa_type):
             pa_type: pyarrow.MapType
-            key_type = PyarrowFieldParser.to_paimon_type(pa_type.key_type, nullable)
-            value_type = PyarrowFieldParser.to_paimon_type(pa_type.item_type, nullable)
+            key_type = PyarrowFieldParser.to_paimon_type(
+                pa_type.key_type, pa_type.key_field.nullable)
+            value_type = PyarrowFieldParser.to_paimon_type(
+                pa_type.item_type, pa_type.item_field.nullable)
             return MapType(nullable, key_type, value_type)
         elif types.is_struct(pa_type) and is_variant_struct(pa_type):
             return AtomicType('VARIANT', nullable)

--- a/paimon-python/pypaimon/schema/data_types.py
+++ b/paimon-python/pypaimon/schema/data_types.py
@@ -286,6 +286,10 @@ def is_array_blob_type(data_type: DataType) -> bool:
     return isinstance(data_type, ArrayType) and is_blob_type(data_type.element)
 
 
+def is_map_blob_type(data_type: DataType) -> bool:
+    return isinstance(data_type, MapType) and is_blob_type(data_type.value)
+
+
 def is_blob_file_type(data_type: DataType) -> bool:
     return is_blob_type(data_type) or is_array_blob_type(data_type)
 
@@ -656,7 +660,7 @@ class PyarrowFieldParser:
                 return pyarrow.int8()
             elif type_name == 'SMALLINT':
                 return pyarrow.int16()
-            elif type_name == 'INT':
+            elif type_name in ('INT', 'INTEGER'):
                 return pyarrow.int32()
             elif type_name == 'BIGINT':
                 return pyarrow.int64()

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -22,15 +22,17 @@ from pypaimon.catalog.catalog_exception import (ColumnAlreadyExistException,
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.identifier import DEFAULT_MAIN_BRANCH
 from pypaimon.common.json_util import JSON
+from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.common.options import CoreOptions, Options
 from pypaimon.schema.column_directive_utils import (
     apply_add_column_directive, apply_directives,
     remove_dropped_directive_options)
 from pypaimon.casting.data_type_casts import can_execute_cast, supports_cast
 from pypaimon.schema.data_types import (ArrayType, AtomicInteger, DataField,
-                                        MapType, RowType, is_array_blob_type,
-                                        is_blob_file_field, is_blob_file_type,
-                                        is_blob_type, reassign_field_id)
+                                        DataType, MapType, MultisetType, RowType,
+                                        is_array_blob_type, is_blob_file_field,
+                                        is_blob_file_type, is_blob_type,
+                                        is_map_blob_type, reassign_field_id)
 from pypaimon.schema.schema import Schema
 from pypaimon.schema.schema_change import (AddColumn, DropColumn, RemoveOption,
                                            RenameColumn, SchemaChange,
@@ -344,7 +346,7 @@ def _assert_not_renaming_blob_column(
     for field in new_fields:
         if field.name == field_name and is_blob_file_field(field):
             raise ValueError(
-                f"Cannot rename BLOB or ARRAY<BLOB> column: [{field_name}]"
+                f"Cannot rename BLOB, ARRAY<BLOB> or MAP<X, BLOB> column: [{field_name}]"
             )
 
 
@@ -361,10 +363,24 @@ def _validate_blob_fields(
     blob_field_names = {field.name for field in fields if is_blob_file_field(field)}
     scalar_blob_field_names = {field.name for field in fields if is_blob_type(field.type)}
     array_blob_field_names = {field.name for field in fields if is_array_blob_type(field.type)}
+    map_blob_fields = [field for field in fields if is_map_blob_type(field.type)]
+    map_blob_field_names = {field.name for field in map_blob_fields}
+
+    for field in fields:
+        if not is_blob_file_type(field.type) and _contains_blob_type(field.type):
+            raise ValueError(
+                f"Field '{field.name}' has unsupported nested BLOB type {field.type}. "
+                f"BLOB is only supported as a top-level BLOB, ARRAY<BLOB>, or "
+                f"MAP<X, BLOB> field."
+            )
+
+    for field in map_blob_fields:
+        create_map_blob_key_serializer(field.type.key)
 
     if len(fields) <= len(blob_field_names):
         raise ValueError(
-            "Table with BLOB or ARRAY<BLOB> type column must have other normal columns."
+            "Table with BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column must have "
+            "other normal columns."
         )
 
     core_options = CoreOptions(Options(options))
@@ -373,7 +389,8 @@ def _validate_blob_fields(
     for field in configured_blob_fields:
         if field not in blob_field_names:
             raise ValueError(
-                "Field '{}' in '{}' must be a BLOB field or ARRAY<BLOB> field in table schema.".format(
+                "Field '{}' in '{}' must be a BLOB, ARRAY<BLOB> or MAP<X, BLOB> "
+                "field in table schema.".format(
                     field, CoreOptions.BLOB_FIELD.key()
                 )
             )
@@ -384,11 +401,16 @@ def _validate_blob_fields(
     all_inline_fields = descriptor_fields.union(view_fields)
     non_blob_inline_fields = all_inline_fields.difference(scalar_blob_field_names)
     if non_blob_inline_fields:
-        array_inline_fields = sorted(non_blob_inline_fields.intersection(array_blob_field_names))
-        if array_inline_fields:
+        nested_inline_fields = sorted(
+            non_blob_inline_fields.intersection(
+                array_blob_field_names.union(map_blob_field_names)
+            )
+        )
+        if nested_inline_fields:
             raise ValueError(
-                "ARRAY<BLOB> is only supported by '{}'. Invalid inline blob fields: {}".format(
-                    CoreOptions.BLOB_FIELD.key(), array_inline_fields
+                "ARRAY<BLOB> and MAP<X, BLOB> are only supported by '{}'. "
+                "Invalid inline blob fields: {}".format(
+                    CoreOptions.BLOB_FIELD.key(), nested_inline_fields
                 )
             )
         raise ValueError(
@@ -416,18 +438,37 @@ def _validate_blob_fields(
 
         if missing_options:
             raise ValueError(
-                f"Schema contains BLOB or ARRAY<BLOB> type but is missing required options: "
+                f"Schema contains BLOB, ARRAY<BLOB> or MAP<X, BLOB> type but is "
+                f"missing required options: "
                 f"{', '.join(missing_options)}. "
                 f"Please add these options to the schema."
             )
 
         if primary_keys:
-            raise ValueError("BLOB or ARRAY<BLOB> type is not supported with primary key.")
+            raise ValueError(
+                "BLOB, ARRAY<BLOB> or MAP<X, BLOB> type is not supported with primary key."
+            )
 
         if blob_field_names.intersection(partition_keys):
             raise ValueError(
-                "The BLOB or ARRAY<BLOB> type column can not be part of partition keys."
+                "The BLOB, ARRAY<BLOB> or MAP<X, BLOB> type column can not be "
+                "part of partition keys."
             )
+
+
+def _contains_blob_type(data_type: DataType) -> bool:
+    if is_blob_type(data_type):
+        return True
+    if isinstance(data_type, (ArrayType, MultisetType)):
+        return _contains_blob_type(data_type.element)
+    if isinstance(data_type, MapType):
+        return (
+            _contains_blob_type(data_type.key)
+            or _contains_blob_type(data_type.value)
+        )
+    if isinstance(data_type, RowType):
+        return any(_contains_blob_type(field.type) for field in data_type.fields)
+    return False
 
 
 def _handle_rename_column(change: RenameColumn, new_fields: List[DataField]):

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -22,7 +22,6 @@ from pypaimon.catalog.catalog_exception import (ColumnAlreadyExistException,
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.identifier import DEFAULT_MAIN_BRANCH
 from pypaimon.common.json_util import JSON
-from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
 from pypaimon.common.options import CoreOptions, Options
 from pypaimon.schema.column_directive_utils import (
     apply_add_column_directive, apply_directives,
@@ -373,9 +372,6 @@ def _validate_blob_fields(
                 f"BLOB is only supported as a top-level BLOB, ARRAY<BLOB>, or "
                 f"MAP<X, BLOB> field."
             )
-
-    for field in map_blob_fields:
-        create_map_blob_key_serializer(field.type.key)
 
     if len(fields) <= len(blob_field_names):
         raise ValueError(

--- a/paimon-python/pypaimon/table/row/blob.py
+++ b/paimon-python/pypaimon/table/row/blob.py
@@ -442,6 +442,15 @@ class _PlaceholderBlobArray:
 Blob.ARRAY_PLACE_HOLDER = _PlaceholderBlobArray()
 
 
+class _PlaceholderBlobMap:
+
+    def __repr__(self) -> str:
+        return "Blob.MAP_PLACE_HOLDER"
+
+
+Blob.MAP_PLACE_HOLDER = _PlaceholderBlobMap()
+
+
 class BlobData(Blob):
 
     def __init__(self, data: Optional[Union[bytes, bytearray]] = None):

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1602,7 +1602,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         valid_data = pa.Table.from_pydict({
             'id': [1, 2, 3],
             'payloads': pa.array(
-                [{'first': b'alpha', 'empty': b''}, {}, None],
+                [[('first', b'alpha'), ('empty', b'')], [], None],
                 type=map_blob_type,
             ),
         }, schema=pa_schema)
@@ -1635,7 +1635,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
         ])
         incompatible_data = pa.Table.from_pydict({
             'id': [4],
-            'payloads': pa.array([{'bad': None}], type=nullable_map_type),
+            'payloads': pa.array([[('bad', None)]], type=nullable_map_type),
         }, schema=incompatible_schema)
         incompatible_writer = table.new_batch_write_builder().new_write()
         with self.assertRaisesRegex(ValueError, "Input schema isn't consistent"):
@@ -1644,7 +1644,7 @@ class DedicatedFormatWriterTest(unittest.TestCase):
 
         invalid_data = pa.Table.from_pydict({
             'id': [5],
-            'payloads': pa.array([{'bad': None}], type=map_blob_type),
+            'payloads': pa.array([[('bad', None)]], type=map_blob_type),
         }, schema=pa_schema)
         invalid_writer = table.new_batch_write_builder().new_write()
         with self.assertRaisesRegex(ValueError, "does not allow null values"):

--- a/paimon-python/pypaimon/tests/blob_table_test.py
+++ b/paimon-python/pypaimon/tests/blob_table_test.py
@@ -1429,6 +1429,228 @@ class DedicatedFormatWriterTest(unittest.TestCase):
             },
         )
 
+    def test_map_blob_column_write_read_and_update(self):
+        from pypaimon.read.reader.format_blob_reader import FormatBlobReader
+        from pypaimon.table.row.blob import BlobDescriptor
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        map_blob_type = pa.map_(pa.string(), pa.large_binary())
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', map_blob_type),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            },
+        )
+        table_name = 'test_db.map_blob_update_column'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        descriptor_body = b'descriptor-map-value'
+        descriptor_prefix = b'prefix-'
+        descriptor_path = os.path.join(self.temp_dir, 'map_blob_descriptor_source')
+        with open(descriptor_path, 'wb') as source:
+            source.write(descriptor_prefix + descriptor_body + b'-suffix')
+        source_descriptor = BlobDescriptor(
+            descriptor_path,
+            len(descriptor_prefix),
+            len(descriptor_body),
+        )
+
+        initial = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4, 5, 6],
+            'payloads': pa.array(
+                [
+                    [('first', b'blob-1'), ('null', None), ('empty', b'')],
+                    None,
+                    [],
+                    [('last', b'blob-4')],
+                    [('descriptor', source_descriptor.serialize())],
+                    [('duplicate', b'first'), ('duplicate', b'last')],
+                ],
+                type=map_blob_type,
+            ),
+        }, schema=pa_schema)
+
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(initial)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        read_builder = table.new_read_builder().with_projection(['id', 'payloads'])
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(
+            {
+                row['id']: None if row['payloads'] is None else dict(row['payloads'])
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: {'first': b'blob-1', 'null': None, 'empty': b''},
+                2: None,
+                3: {},
+                4: {'last': b'blob-4'},
+                5: {'descriptor': descriptor_body},
+                6: {'duplicate': b'last'},
+            },
+        )
+
+        descriptor_table = table.copy({'blob-as-descriptor': 'true'})
+        descriptor_builder = descriptor_table.new_read_builder()
+        descriptor_result = descriptor_builder.new_read().to_arrow(
+            descriptor_builder.new_scan().plan().splits())
+        descriptor_rows = {
+            row['id']: None if row['payloads'] is None else dict(row['payloads'])
+            for row in descriptor_result.select(['id', 'payloads']).to_pylist()
+        }
+        output_descriptor = BlobDescriptor.deserialize(
+            descriptor_rows[5]['descriptor']
+        )
+        self.assertNotEqual(output_descriptor.uri, descriptor_path)
+        self.assertGreater(output_descriptor.offset, 0)
+        self.assertEqual(output_descriptor.length, len(descriptor_body))
+        output_blob = Blob.from_descriptor(
+            table.file_io.uri_reader_factory.create(output_descriptor.uri),
+            output_descriptor,
+        )
+        self.assertEqual(output_blob.to_data(), descriptor_body)
+
+        row_id_builder = table.new_read_builder().with_projection(['id', '_ROW_ID'])
+        row_id_result = row_id_builder.new_read().to_arrow(
+            row_id_builder.new_scan().plan().splits())
+        row_ids_by_id = {
+            row['id']: row['_ROW_ID']
+            for row in row_id_result.select(['id', '_ROW_ID']).to_pylist()
+        }
+
+        update_builder = table.new_batch_write_builder()
+        table_update = update_builder.new_update().with_update_type(['payloads'])
+        update_data = pa.Table.from_pydict({
+            '_ROW_ID': pa.array([row_ids_by_id[2]], type=pa.int64()),
+            'payloads': pa.array(
+                [[('updated', b'updated-2'), ('null', None)]],
+                type=map_blob_type,
+            ),
+        })
+        update_messages = table_update.update_by_arrow_with_row_id(update_data)
+
+        update_files = [f for msg in update_messages for f in msg.new_files]
+        update_blob_files = [f for f in update_files if f.file_name.endswith('.blob')]
+        self.assertEqual(len(update_blob_files), 1)
+        self.assertEqual(update_blob_files[0].row_count, 2)
+        blob_fields = [field for field in table.fields if field.name == 'payloads']
+        blob_reader = FormatBlobReader(
+            file_io=table.file_io,
+            file_path=update_blob_files[0].file_path,
+            read_fields=['payloads'],
+            full_fields=blob_fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        update_blob_lengths = list(blob_reader.blob_lengths)
+        blob_reader.close()
+        self.assertEqual(
+            update_blob_lengths.count(BlobFormatWriter.PLACE_HOLDER_LENGTH),
+            1,
+        )
+
+        update_builder.new_commit().commit(update_messages)
+
+        read_builder = table.new_read_builder().with_projection(['id', 'payloads'])
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        self.assertEqual(
+            {
+                row['id']: None if row['payloads'] is None else dict(row['payloads'])
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: {'first': b'blob-1', 'null': None, 'empty': b''},
+                2: {'updated': b'updated-2', 'null': None},
+                3: {},
+                4: {'last': b'blob-4'},
+                5: {'descriptor': descriptor_body},
+                6: {'duplicate': b'last'},
+            },
+        )
+
+    def test_map_blob_value_not_null(self):
+        map_blob_type = pa.map_(
+            pa.field('key', pa.string(), nullable=False),
+            pa.field('value', pa.large_binary(), nullable=False),
+        )
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', map_blob_type),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+            },
+        )
+        table_name = 'test_db.map_blob_value_not_null'
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        valid_data = pa.Table.from_pydict({
+            'id': [1, 2, 3],
+            'payloads': pa.array(
+                [{'first': b'alpha', 'empty': b''}, {}, None],
+                type=map_blob_type,
+            ),
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        writer.write_arrow(valid_data)
+        write_builder.new_commit().commit(writer.prepare_commit())
+        writer.close()
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        self.assertFalse(result.schema.field('payloads').type.item_field.nullable)
+        self.assertEqual(
+            {
+                row['id']: None if row['payloads'] is None else dict(row['payloads'])
+                for row in result.select(['id', 'payloads']).to_pylist()
+            },
+            {
+                1: {'first': b'alpha', 'empty': b''},
+                2: {},
+                3: None,
+            },
+        )
+
+        nullable_map_type = pa.map_(pa.string(), pa.large_binary())
+        incompatible_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', nullable_map_type),
+        ])
+        incompatible_data = pa.Table.from_pydict({
+            'id': [4],
+            'payloads': pa.array([{'bad': None}], type=nullable_map_type),
+        }, schema=incompatible_schema)
+        incompatible_writer = table.new_batch_write_builder().new_write()
+        with self.assertRaisesRegex(ValueError, "Input schema isn't consistent"):
+            incompatible_writer.write_arrow(incompatible_data)
+        incompatible_writer.abort()
+
+        invalid_data = pa.Table.from_pydict({
+            'id': [5],
+            'payloads': pa.array([{'bad': None}], type=map_blob_type),
+        }, schema=pa_schema)
+        invalid_writer = table.new_batch_write_builder().new_write()
+        with self.assertRaisesRegex(ValueError, "does not allow null values"):
+            invalid_writer.write_arrow(invalid_data)
+        invalid_writer.abort()
+
     def test_array_blob_element_not_null(self):
         array_blob_type = pa.list_(
             pa.field('item', pa.large_binary(), nullable=False)
@@ -4789,7 +5011,10 @@ class DedicatedFormatWriterTest(unittest.TestCase):
                 [SchemaChange.rename_column('blob_col', 'blob_col_renamed')],
                 False
             )
-        self.assertIn('Cannot rename BLOB or ARRAY<BLOB> column', str(ctx.exception))
+        self.assertIn(
+            'Cannot rename BLOB, ARRAY<BLOB> or MAP<X, BLOB> column',
+            str(ctx.exception),
+        )
 
     def test_nested_field_named_blob_not_treated_as_blob(self):
         """Regression: a ROW field with a nested column whose name contains

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -762,6 +762,118 @@ class BlobTest(unittest.TestCase):
             [descriptor.uri for descriptor in descriptors],
         )
 
+    def test_blob_fallback_batch_reader_materializes_selected_map_values_in_parallel(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        class RecordingFileIO(LocalFileIO):
+            def __init__(self, path, options):
+                super().__init__(path, options)
+                self.calls = []
+
+            def read_blobs_concurrent(self, blobs, parallelism):
+                self.calls.append((
+                    [blob.to_descriptor() for blob in blobs],
+                    parallelism,
+                ))
+                return super().read_blobs_concurrent(blobs, parallelism)
+
+        field = DataField(
+            0,
+            "pictures",
+            MapType(True, AtomicType("STRING", False), AtomicType("BLOB")),
+        )
+        file_io = RecordingFileIO(self.temp_dir, Options({}))
+
+        def write_blob_file(name, values):
+            path = os.path.join(self.temp_dir, name)
+            with open(path, 'wb') as output:
+                writer = BlobFormatWriter(output)
+                for value in values:
+                    writer.add_element(
+                        GenericRow([value], [field], RowKind.INSERT)
+                    )
+                writer.close()
+            return path
+
+        old_path = write_blob_file(
+            "old-map.blob",
+            [
+                {"a": BlobData(b"old-0"), "null": None},
+                {"a": BlobData(b"old-1")},
+                {"a": BlobData(b"old-2a"), "b": BlobData(b"old-2b")},
+            ],
+        )
+        new_path = write_blob_file(
+            "new-map.blob",
+            [
+                Blob.MAP_PLACE_HOLDER,
+                {"a": BlobData(b"new-1a"), "b": None, "c": BlobData(b"new-1c")},
+                Blob.MAP_PLACE_HOLDER,
+            ],
+        )
+
+        def data_file(path, max_sequence_number):
+            return DataFileMeta(
+                file_name=os.path.basename(path),
+                file_size=os.path.getsize(path),
+                row_count=3,
+                min_key=None,
+                max_key=None,
+                key_stats=None,
+                value_stats=None,
+                min_sequence_number=max_sequence_number,
+                max_sequence_number=max_sequence_number,
+                schema_id=0,
+                level=0,
+                extra_files=[],
+                first_row_id=0,
+                file_path=path,
+            )
+
+        def supplier(path):
+            return lambda: FormatBlobReader(
+                file_io=file_io,
+                file_path=path,
+                read_fields=[field.name],
+                full_fields=[field],
+                push_down_predicate=None,
+                blob_as_descriptor=False,
+                blob_parallelism=4,
+            )
+
+        reader = BlobFallbackBatchReader(
+            [
+                (data_file(old_path, 1), supplier(old_path)),
+                (data_file(new_path, 2), supplier(new_path)),
+            ],
+            field.name,
+            pa.map_(pa.string(), pa.large_binary()),
+            batch_size=3,
+            blob_parallelism=4,
+        )
+        try:
+            batch = reader.read_arrow_batch()
+            self.assertEqual(
+                [
+                    {"a": b"old-0", "null": None},
+                    {"a": b"new-1a", "b": None, "c": b"new-1c"},
+                    {"a": b"old-2a", "b": b"old-2b"},
+                ],
+                [dict(value) for value in batch.column(field.name).to_pylist()],
+            )
+            self.assertIsNone(reader.read_arrow_batch())
+        finally:
+            reader.close()
+
+        self.assertEqual(1, len(file_io.calls))
+        descriptors, parallelism = file_io.calls[0]
+        self.assertEqual(4, parallelism)
+        self.assertEqual(5, len(descriptors))
+        self.assertEqual(
+            [old_path, new_path, new_path, old_path, old_path],
+            [descriptor.uri for descriptor in descriptors],
+        )
+
     def test_blob_data_interface_compliance(self):
         """Test that BlobData properly implements Blob interface."""
         test_data = b"interface test data"

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -851,6 +851,13 @@ class BlobTest(unittest.TestCase):
             batch_size=3,
             blob_parallelism=4,
         )
+        self.assertEqual(
+            [("value", b"body"), ("null", None)],
+            reader._map_value_for_arrow({
+                "value": BlobData(b"body"),
+                "null": None,
+            }),
+        )
         try:
             batch = reader.read_arrow_batch()
             self.assertEqual(
@@ -2682,6 +2689,15 @@ class BlobEndToEndTest(unittest.TestCase):
             push_down_predicate=None,
             blob_as_descriptor=False,
         )
+        self.assertEqual(
+            [("value", b"body"), ("null", None)],
+            reader._map_value_for_arrow(
+                {"value": BlobData(b"body"), "null": None},
+                "blob_map",
+                0,
+                [],
+            ),
+        )
         values = reader.read_arrow_batch().column(0).to_pylist()
         self.assertEqual(dict(values[0]), {"alpha": b"a", "null": None, "empty": b""})
         self.assertIsNone(values[1])
@@ -2758,6 +2774,21 @@ class BlobEndToEndTest(unittest.TestCase):
             blob_as_descriptor=False,
             blob_parallelism=4,
         )
+        blobs_to_resolve = []
+        self.assertEqual(
+            [("a", None), ("n", None), ("b", None)],
+            parallel_reader._map_value_for_arrow(
+                {
+                    "a": BlobData(b"x"),
+                    "n": None,
+                    "b": BlobData(b"yz"),
+                },
+                "blob_map",
+                0,
+                blobs_to_resolve,
+            ),
+        )
+        self.assertEqual([0, 2], [target[3] for target in blobs_to_resolve])
         values = dict(parallel_reader.read_arrow_batch().column(0)[0].as_py())
         self.assertEqual(values, {"a": b"x", "b": b"yz", "n": None})
         self.assertEqual(len(calls), 1)

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -35,7 +35,7 @@ from pypaimon.filesystem.local_file_io import LocalFileIO
 from pypaimon.manifest.schema.data_file_meta import DataFileMeta
 from pypaimon.read.reader.concat_batch_reader import BlobFallbackBatchReader
 from pypaimon.read.reader.format_blob_reader import BlobRecordIterator, FormatBlobReader
-from pypaimon.schema.data_types import ArrayType, AtomicType, DataField
+from pypaimon.schema.data_types import ArrayType, AtomicType, DataField, MapType
 from pypaimon.table.row.blob import Blob, BlobData, BlobRef, BlobDescriptor, BlobViewStruct, BlobView
 from pypaimon.table.row.generic_row import GenericRowDeserializer, GenericRowSerializer, GenericRow
 from pypaimon.table.row.row_kind import RowKind
@@ -2453,6 +2453,685 @@ class BlobEndToEndTest(unittest.TestCase):
             + data
             + index
             + struct.pack('<I', index_length)
+        )
+
+    def test_map_blob_golden_bytes(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        blob_file_path = os.path.join(self.temp_dir, "map_golden.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+        entries = [
+            (None, None),
+            ("", BlobData(b"")),
+            ("inline", BlobData(b"data")),
+            ("descriptor", BlobData(b"descriptor")),
+        ]
+
+        writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+        writer.add_element(GenericRow([{}], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([entries], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([None], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([Blob.MAP_PLACE_HOLDER], fields, RowKind.INSERT))
+        writer.close()
+
+        with open(blob_file_path, 'rb') as blob_file:
+            self.assertEqual(
+                blob_file.read().hex(),
+                "cf114e584243424d010000000000000000000000002100000000000000"
+                "8360591ecf114e584243424d0104000000696e6c696e65646573637269"
+                "70746f726461746164657363726970746f7201020c080102080c040000"
+                "000400000047000000000000006c9f5981424c8f01010500000001",
+            )
+
+    def test_read_java_map_blob_golden_bytes(self):
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "java_map_golden.blob")
+        java_golden_bytes = bytes.fromhex(
+            "cf114e584243424d010000000000000000000000002100000000000000"
+            "8360591ecf114e584243424d0104000000696e6c696e65646573637269"
+            "70746f726461746164657363726970746f7201020c080102080c040000"
+            "000400000047000000000000006c9f5981424c8f01010500000001"
+        )
+        with open(blob_file_path, 'wb') as blob_file:
+            blob_file.write(java_golden_bytes)
+
+        field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=[field.name],
+            full_fields=[field],
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        try:
+            self.assertEqual(reader.blob_lengths, [33, 71, -1, -2])
+            iterator = BlobRecordIterator(
+                file_io,
+                blob_file_path,
+                reader.blob_lengths,
+                reader.blob_offsets,
+                field,
+                input_stream=reader._input_stream,
+            )
+
+            self.assertEqual(next(iterator).values[0], {})
+            blob_map = next(iterator).values[0]
+            self.assertEqual(list(blob_map), [None, "", "inline", "descriptor"])
+            self.assertIsNone(blob_map[None])
+            self.assertEqual(blob_map[""].to_data(), b"")
+            self.assertEqual(blob_map["inline"].to_data(), b"data")
+            self.assertEqual(blob_map["descriptor"].to_data(), b"descriptor")
+            self.assertIsNone(next(iterator).values[0])
+            self.assertIs(next(iterator).values[0], Blob.MAP_PLACE_HOLDER)
+            with self.assertRaises(StopIteration):
+                next(iterator)
+        finally:
+            reader.close()
+
+    def test_map_blob_write_read(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "map_blob.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+
+        writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+        writer.write_value(
+            {"alpha": b"a", "null": None, "empty": b""},
+            fields,
+        )
+        writer.add_element(GenericRow([None], fields, RowKind.INSERT))
+        writer.add_element(GenericRow([{}], fields, RowKind.INSERT))
+        writer.add_element(GenericRow(
+            [{"omega": BlobData(b"last")}],
+            fields,
+            RowKind.INSERT,
+        ))
+        writer.close()
+
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        values = reader.read_arrow_batch().column(0).to_pylist()
+        self.assertEqual(dict(values[0]), {"alpha": b"a", "null": None, "empty": b""})
+        self.assertIsNone(values[1])
+        self.assertEqual(values[2], [])
+        self.assertEqual(dict(values[3]), {"omega": b"last"})
+        reader.close()
+
+        selected_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+            row_indices=[3, 0],
+        )
+        selected = selected_reader.read_arrow_batch().column(0).to_pylist()
+        self.assertEqual(dict(selected[0]), {"omega": b"last"})
+        self.assertEqual(
+            dict(selected[1]),
+            {"alpha": b"a", "null": None, "empty": b""},
+        )
+        selected_reader.close()
+
+    def test_map_blob_descriptor_and_parallel_reads(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "map_blob_descriptor.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+
+        writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+        writer.add_element(GenericRow(
+            [[("a", BlobData(b"x")), ("b", BlobData(b"yz")), ("n", None)]],
+            fields,
+            RowKind.INSERT,
+        ))
+        writer.close()
+
+        descriptor_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=True,
+        )
+        descriptors = dict(descriptor_reader.read_arrow_batch().column(0)[0].as_py())
+        descriptor_a = BlobDescriptor.deserialize(descriptors["a"])
+        descriptor_b = BlobDescriptor.deserialize(descriptors["b"])
+        self.assertEqual((descriptor_a.offset, descriptor_a.length), (16, 1))
+        self.assertEqual((descriptor_b.offset, descriptor_b.length), (17, 2))
+        self.assertIsNone(descriptors["n"])
+        descriptor_reader.close()
+
+        calls = []
+        original_read = file_io.read_blobs_concurrent
+
+        def read_blobs_concurrent(blobs, parallelism):
+            calls.append((list(blobs), parallelism))
+            return original_read(blobs, parallelism)
+
+        file_io.read_blobs_concurrent = read_blobs_concurrent
+        parallel_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+            blob_parallelism=4,
+        )
+        values = dict(parallel_reader.read_arrow_batch().column(0)[0].as_py())
+        self.assertEqual(values, {"a": b"x", "b": b"yz", "n": None})
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(calls[0][0]), 2)
+        self.assertEqual(calls[0][1], 4)
+        parallel_reader.close()
+
+    def test_map_blob_consumer_descriptors_and_flush(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        class TrackingOutput:
+            def __init__(self, path):
+                self.output = open(path, 'wb')
+                self.flush_count = 0
+
+            def write(self, data):
+                return self.output.write(data)
+
+            def flush(self):
+                self.flush_count += 1
+                return self.output.flush()
+
+            def close(self):
+                return self.output.close()
+
+        blob_file_path = os.path.join(self.temp_dir, "map_blob_consumer.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+        descriptors = []
+
+        def consumer(field_name, descriptor):
+            descriptors.append((field_name, descriptor))
+            return descriptor.length == 2
+
+        output = TrackingOutput(blob_file_path)
+        writer = BlobFormatWriter(output, consumer, blob_file_path)
+        writer.add_element(GenericRow(
+            [[("a", BlobData(b"x")), ("b", BlobData(b"yz")), (None, None)]],
+            fields,
+            RowKind.INSERT,
+        ))
+
+        self.assertEqual(output.flush_count, 1)
+        self.assertEqual(len(descriptors), 2)
+        self.assertEqual([item[0] for item in descriptors], ["blob_map", "blob_map"])
+        self.assertEqual(
+            [(item[1].offset, item[1].length) for item in descriptors],
+            [(15, 1), (16, 2)],
+        )
+        writer.close()
+
+    def test_map_blob_write_value_from_serialized_descriptor(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        source_uri = "custom://bucket/source.bin"
+        source_data = b"prefix-selected-suffix"
+        selected_data = b"selected"
+        source_descriptor = BlobDescriptor(
+            source_uri,
+            len(b"prefix-"),
+            len(selected_data),
+        )
+
+        class TrackingStream(io.BytesIO):
+
+            def __init__(self, data):
+                super().__init__(data)
+                self.close_count = 0
+
+            def close(self):
+                self.close_count += 1
+                super().close()
+
+        class TrackingUriReader:
+
+            def __init__(self):
+                self.opened_uris = []
+                self.streams = []
+
+            def new_input_stream(self, uri):
+                self.opened_uris.append(uri)
+                stream = TrackingStream(source_data)
+                self.streams.append(stream)
+                return stream
+
+        class TrackingUriReaderFactory:
+
+            def __init__(self, uri_reader):
+                self.uri_reader = uri_reader
+                self.created_uris = []
+
+            def create(self, uri):
+                self.created_uris.append(uri)
+                return self.uri_reader
+
+        output_path = os.path.join(self.temp_dir, "map_descriptor_input.blob")
+        field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )
+        consumed_descriptors = []
+
+        def consumer(field_name, descriptor):
+            consumed_descriptors.append((field_name, descriptor))
+            return False
+
+        uri_reader = TrackingUriReader()
+        uri_reader_factory = TrackingUriReaderFactory(uri_reader)
+        writer = BlobFormatWriter(
+            open(output_path, 'wb'),
+            blob_consumer=consumer,
+            file_path=output_path,
+        )
+        writer.write_value(
+            {"slice": source_descriptor.serialize()},
+            [field],
+            uri_reader_factory=uri_reader_factory,
+        )
+        writer.close()
+
+        self.assertEqual(uri_reader_factory.created_uris, [source_uri])
+        self.assertEqual(uri_reader.opened_uris, [source_uri])
+        self.assertEqual(len(uri_reader.streams), 1)
+        self.assertTrue(uri_reader.streams[0].closed)
+        self.assertEqual(uri_reader.streams[0].close_count, 1)
+        self.assertEqual(len(consumed_descriptors), 1)
+        output_descriptor = consumed_descriptors[0][1]
+        self.assertEqual(consumed_descriptors[0][0], field.name)
+        self.assertEqual(output_descriptor.uri, output_path)
+        self.assertEqual(output_descriptor.offset, 18)
+        self.assertEqual(output_descriptor.length, len(selected_data))
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=output_path,
+            read_fields=[field.name],
+            full_fields=[field],
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+        )
+        try:
+            value = dict(reader.read_arrow_batch().column(0)[0].as_py())
+            self.assertEqual(value, {"slice": selected_data})
+        finally:
+            reader.close()
+
+    def test_map_blob_placeholder_and_null_key(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "map_blob_null_key.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+
+        writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+        writer.add_element(GenericRow(
+            [[(None, BlobData(b"null-key"))]],
+            fields,
+            RowKind.INSERT,
+        ))
+        writer.add_element(GenericRow(
+            [Blob.MAP_PLACE_HOLDER],
+            fields,
+            RowKind.INSERT,
+        ))
+        lengths = list(writer.lengths)
+        writer.close()
+
+        iterator = BlobRecordIterator(
+            file_io,
+            blob_file_path,
+            lengths,
+            [0, lengths[0]],
+            fields[0],
+        )
+        result = next(iterator).values[0]
+        self.assertEqual(result[None].to_data(), b"null-key")
+        self.assertIs(next(iterator).values[0], Blob.MAP_PLACE_HOLDER)
+
+        null_key_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+            row_indices=[0],
+        )
+        with self.assertRaisesRegex(ValueError, "null keys cannot be converted"):
+            null_key_reader.read_arrow_batch()
+        null_key_reader.close()
+
+        placeholder_reader = FormatBlobReader(
+            file_io=file_io,
+            file_path=blob_file_path,
+            read_fields=["blob_map"],
+            full_fields=fields,
+            push_down_predicate=None,
+            blob_as_descriptor=False,
+            row_indices=[1],
+        )
+        with self.assertRaisesRegex(RuntimeError, "Blob placeholder is not supported"):
+            placeholder_reader.read_arrow_batch()
+        placeholder_reader.close()
+
+    def test_duplicate_map_blob_key_last_wins(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        blob_file_path = os.path.join(self.temp_dir, "map_blob_duplicate.blob")
+        fields = [DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )]
+        writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+        writer.add_element(GenericRow(
+            [[
+                ("duplicate", BlobData(b"first")),
+                ("duplicate", BlobData(b"second")),
+                ("tail", BlobData(b"third")),
+            ]],
+            fields,
+            RowKind.INSERT,
+        ))
+        record_length = writer.lengths[0]
+        writer.close()
+
+        for blob_as_descriptor in (False, True):
+            iterator = BlobRecordIterator(
+                file_io,
+                blob_file_path,
+                [record_length],
+                [0],
+                fields[0],
+                blob_as_descriptor=blob_as_descriptor,
+            )
+            result = next(iterator).values[0]
+            self.assertEqual(list(result), ["duplicate", "tail"])
+            self.assertEqual(result["duplicate"].to_data(), b"second")
+            self.assertEqual(result["tail"].to_data(), b"third")
+
+    def test_map_blob_key_types_and_rejections(self):
+        from pypaimon.write.blob_format_writer import BlobFormatWriter
+
+        file_io = LocalFileIO(self.temp_dir, Options({}))
+        cases = [
+            (AtomicType("TINYINT"), -128),
+            (AtomicType("SMALLINT"), -32768),
+            (AtomicType("INT"), -2147483648),
+            (AtomicType("INTEGER"), 0x01020304),
+            (AtomicType("BIGINT"), -9223372036854775808),
+            (AtomicType("STRING"), "string"),
+            (AtomicType("CHAR(3)"), "abc"),
+            (AtomicType("VARCHAR(10)"), "varchar"),
+        ]
+        for index, (key_type, key) in enumerate(cases):
+            with self.subTest(key_type=key_type):
+                blob_file_path = os.path.join(self.temp_dir, f"map_key_{index}.blob")
+                fields = [DataField(
+                    0,
+                    "blob_map",
+                    MapType(True, key_type, AtomicType("BLOB")),
+                )]
+                writer = BlobFormatWriter(open(blob_file_path, 'wb'))
+                writer.add_element(GenericRow(
+                    [[(key, BlobData(b"value"))]],
+                    fields,
+                    RowKind.INSERT,
+                ))
+                record_length = writer.lengths[0]
+                writer.close()
+                iterator = BlobRecordIterator(
+                    file_io,
+                    blob_file_path,
+                    [record_length],
+                    [0],
+                    fields[0],
+                )
+                result = next(iterator).values[0]
+                self.assertEqual(result[key].to_data(), b"value")
+
+                if key_type.type == "INTEGER":
+                    with open(blob_file_path, 'rb') as blob_file:
+                        blob_file.seek(BlobRecordIterator.MAGIC_NUMBER_SIZE
+                                       + BlobRecordIterator.MAP_HEADER_SIZE)
+                        self.assertEqual(blob_file.read(4), b"\x04\x03\x02\x01")
+                    reader = FormatBlobReader(
+                        file_io=file_io,
+                        file_path=blob_file_path,
+                        read_fields=["blob_map"],
+                        full_fields=fields,
+                        push_down_predicate=None,
+                        blob_as_descriptor=False,
+                    )
+                    try:
+                        value = dict(reader.read_arrow_batch().column(0)[0].as_py())
+                        self.assertEqual(value, {key: b"value"})
+                    finally:
+                        reader.close()
+
+        output = io.BytesIO()
+        unsupported_key_writer = BlobFormatWriter(output)
+        unsupported_key_field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("BOOLEAN"), AtomicType("BLOB")),
+        )
+        with self.assertRaisesRegex(ValueError, "Unsupported key type"):
+            unsupported_key_writer.add_element(GenericRow(
+                [{True: BlobData(b"value")}],
+                [unsupported_key_field],
+                RowKind.INSERT,
+            ))
+
+        invalid_value_writer = BlobFormatWriter(io.BytesIO())
+        invalid_value_field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("STRING")),
+        )
+        with self.assertRaisesRegex(ValueError, "value type must be BLOB"):
+            invalid_value_writer.add_element(GenericRow(
+                [{"key": "value"}],
+                [invalid_value_field],
+                RowKind.INSERT,
+            ))
+
+        invalid_key_writer = BlobFormatWriter(io.BytesIO())
+        int_key_field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("INT"), AtomicType("BLOB")),
+        )
+        with self.assertRaisesRegex(ValueError, "key must be an integer"):
+            invalid_key_writer.add_element(GenericRow(
+                [{"not-an-int": BlobData(b"value")}],
+                [int_key_field],
+                RowKind.INSERT,
+            ))
+
+    def test_reject_malformed_map_blob_payloads(self):
+        string_field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("STRING"), AtomicType("BLOB")),
+        )
+        int_field = DataField(
+            0,
+            "blob_map",
+            MapType(True, AtomicType("INT"), AtomicType("BLOB")),
+        )
+        cases = [
+            (
+                self._map_blob_payload(b"", b"", [], [], magic=0),
+                string_field,
+                "Invalid MAP<X, BLOB> payload magic number",
+            ),
+            (
+                self._map_blob_payload(b"", b"", [], [], version=0),
+                string_field,
+                "Unsupported MAP<X, BLOB> payload version",
+            ),
+            (
+                self._map_blob_payload(b"", b"", [], [], entry_count=0x80000000),
+                string_field,
+                "Invalid MAP<X, BLOB> entry count",
+            ),
+            (
+                self._map_blob_payload(b"", b"", [], [], key_index_length=100),
+                string_field,
+                "Invalid MAP<X, BLOB> key index length",
+            ),
+            (
+                self._map_blob_payload(b"", b"", [], [], value_index_length=100),
+                string_field,
+                "Invalid MAP<X, BLOB> value index length",
+            ),
+            (
+                self._map_blob_payload(
+                    b"", b"", [], [], key_index=b"\x80", value_index=b""
+                ),
+                string_field,
+                "Invalid MAP<X, BLOB> key index",
+            ),
+            (
+                self._map_blob_payload(
+                    b"", b"", [], [], key_index=b"", value_index=b"\x80"
+                ),
+                string_field,
+                "Invalid MAP<X, BLOB> value index",
+            ),
+            (
+                self._map_blob_payload(b"", b"", [-2], [-1]),
+                string_field,
+                "Invalid MAP<X, BLOB> key length",
+            ),
+            (
+                self._map_blob_payload(b"abc", b"", [3], [-1]),
+                int_field,
+                "Invalid MAP<X, BLOB> fixed-width key length",
+            ),
+            (
+                self._map_blob_payload(b"a", b"", [2], [-1]),
+                string_field,
+                "key lengths exceed the payload data length",
+            ),
+            (
+                self._map_blob_payload(b"a", b"", [1], [-2]),
+                string_field,
+                "Invalid MAP<X, BLOB> value length",
+            ),
+            (
+                self._map_blob_payload(b"a", b"b", [1], [2]),
+                string_field,
+                "value lengths exceed the payload data length",
+            ),
+            (
+                self._map_blob_payload(b"a", b"b", [1], [0]),
+                string_field,
+                "key/value lengths do not match the payload data length",
+            ),
+            (
+                self._map_blob_payload(
+                    b"", b"", [], [],
+                    entry_count=2,
+                    key_index=DeltaVarintCompressor.compress([128]),
+                    value_index=DeltaVarintCompressor.compress([128]),
+                ),
+                string_field,
+                "entry count does not match key index length",
+            ),
+        ]
+
+        for payload, field, expected_message in cases:
+            with self.subTest(expected_message=expected_message):
+                iterator = BlobRecordIterator(
+                    None,
+                    "unused",
+                    [],
+                    [],
+                    field,
+                    input_stream=io.BytesIO(payload),
+                )
+                with self.assertRaisesRegex(ValueError, expected_message):
+                    iterator._read_blob_map(0, len(payload))
+
+    @staticmethod
+    def _map_blob_payload(
+        key_data,
+        value_data,
+        key_lengths,
+        value_lengths,
+        magic=BlobRecordIterator.MAP_MAGIC_NUMBER,
+        version=BlobRecordIterator.MAP_VERSION,
+        entry_count=None,
+        key_index=None,
+        value_index=None,
+        key_index_length=None,
+        value_index_length=None,
+    ):
+        if key_index is None:
+            key_index = DeltaVarintCompressor.compress(key_lengths)
+        if value_index is None:
+            value_index = DeltaVarintCompressor.compress(value_lengths)
+        if entry_count is None:
+            entry_count = len(key_lengths)
+        if key_index_length is None:
+            key_index_length = len(key_index)
+        if value_index_length is None:
+            value_index_length = len(value_index)
+        return (
+            struct.pack('<IBI', magic, version, entry_count)
+            + key_data
+            + value_data
+            + key_index
+            + value_index
+            + struct.pack('<II', key_index_length, value_index_length)
         )
 
 

--- a/paimon-python/pypaimon/tests/column_directive_utils_test.py
+++ b/paimon-python/pypaimon/tests/column_directive_utils_test.py
@@ -25,7 +25,7 @@ from pypaimon.schema.column_directive_utils import (
     remove_dropped_directive_options,
 )
 from pypaimon.schema.data_types import (
-    ArrayType, AtomicType, DataField, VectorType,
+    ArrayType, AtomicType, DataField, MapType, VectorType,
 )
 
 
@@ -121,6 +121,53 @@ class TestApplyAddColumnDirective(unittest.TestCase):
                 "__BLOB_DESCRIPTOR_FIELD",
                 "pictures",
                 ArrayType(True, AtomicType("BYTES")),
+                {},
+            )
+
+    def test_blob_field_map_source_type(self):
+        opts = {}
+        result = apply_add_column_directive(
+            "__BLOB_FIELD; pictures",
+            "pictures",
+            MapType(
+                True,
+                AtomicType("STRING", False),
+                AtomicType("BYTES", False),
+            ),
+            opts,
+        )
+
+        self.assertIsInstance(result.type, MapType)
+        self.assertEqual(result.type.key, AtomicType("STRING", False))
+        self.assertEqual(result.type.value, AtomicType("BLOB", False))
+        self.assertEqual(result.comment, "pictures")
+        self.assertEqual(opts[CoreOptions.BLOB_FIELD.key()], "pictures")
+
+    def test_inline_blob_directive_rejects_map_source_type(self):
+        with self.assertRaisesRegex(ValueError, "MAP<X, BLOB> is only supported"):
+            apply_add_column_directive(
+                "__BLOB_DESCRIPTOR_FIELD",
+                "pictures",
+                MapType(
+                    True,
+                    AtomicType("INT", False),
+                    AtomicType("BYTES"),
+                ),
+                {},
+            )
+
+    def test_blob_field_map_rejects_unsupported_key_type(self):
+        with self.assertRaisesRegex(
+            ValueError, "Unsupported key type for MAP<X, BLOB>"
+        ):
+            apply_add_column_directive(
+                "__BLOB_FIELD",
+                "pictures",
+                MapType(
+                    True,
+                    AtomicType("BOOLEAN", False),
+                    AtomicType("BYTES"),
+                ),
                 {},
             )
 

--- a/paimon-python/pypaimon/tests/column_directive_utils_test.py
+++ b/paimon-python/pypaimon/tests/column_directive_utils_test.py
@@ -156,20 +156,21 @@ class TestApplyAddColumnDirective(unittest.TestCase):
                 {},
             )
 
-    def test_blob_field_map_rejects_unsupported_key_type(self):
-        with self.assertRaisesRegex(
-            ValueError, "Unsupported key type for MAP<X, BLOB>"
-        ):
-            apply_add_column_directive(
-                "__BLOB_FIELD",
-                "pictures",
-                MapType(
-                    True,
-                    AtomicType("BOOLEAN", False),
-                    AtomicType("BYTES"),
-                ),
-                {},
-            )
+    def test_blob_field_map_allows_unsupported_key_type(self):
+        result = apply_add_column_directive(
+            "__BLOB_FIELD",
+            "pictures",
+            MapType(
+                True,
+                AtomicType("BOOLEAN", False),
+                AtomicType("BYTES"),
+            ),
+            {},
+        )
+
+        self.assertIsInstance(result.type, MapType)
+        self.assertEqual(result.type.key, AtomicType("BOOLEAN", False))
+        self.assertEqual(result.type.value, AtomicType("BLOB"))
 
     def test_vector_field(self):
         opts = {}

--- a/paimon-python/pypaimon/tests/daft/daft_blob_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_blob_test.py
@@ -30,6 +30,7 @@ from daft.io import IOConfig, S3Config
 from pypaimon.daft.daft_blob import (
     blob_array_column_to_file_array,
     blob_column_to_file_array,
+    blob_map_column_to_file_array,
 )
 from pypaimon.daft.daft_compat import (
     file_range_position_field,
@@ -102,6 +103,41 @@ class BlobColumnToFileArrayTest(unittest.TestCase):
             None if value is None else value[file_range_position_field()]
             for value in files
         ], [1, None, 3])
+        self.assertFalse(converted[1].is_valid)
+        self.assertEqual(converted[2].as_py(), [])
+
+    def test_blob_map_column_to_file_array(self):
+        descriptor_a = BlobDescriptor("oss://b/a", 1, 2).serialize()
+        descriptor_b = BlobDescriptor("oss://b/b", 3, 4).serialize()
+        io_config = b"serialized-io-config"
+        column = pa.array(
+            [
+                [(1, descriptor_a), (1, None), (2, descriptor_b)],
+                None,
+                [],
+            ],
+            type=pa.map_(pa.int32(), pa.large_binary()),
+        )
+
+        converted = blob_map_column_to_file_array(column, io_config)
+
+        files = converted[0].as_py()
+        self.assertEqual([key for key, _ in files], [1, 1, 2])
+        self.assertEqual(
+            [None if value is None else value["url"] for _, value in files],
+            ["oss://b/a", None, "oss://b/b"],
+        )
+        self.assertEqual(
+            [
+                None if value is None else value[file_range_position_field()]
+                for _, value in files
+            ],
+            [1, None, 3],
+        )
+        self.assertEqual(
+            [None if value is None else value["io_config"] for _, value in files],
+            [io_config, None, io_config],
+        )
         self.assertFalse(converted[1].is_valid)
         self.assertEqual(converted[2].as_py(), [])
 

--- a/paimon-python/pypaimon/tests/daft/daft_explain_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_explain_test.py
@@ -575,6 +575,39 @@ def test_explain_scan_reports_array_blob_fallback(catalog_options):
     assert all(split.reader_mode == READER_MODE_PYPAIMON_FALLBACK for split in result.splits)
 
 
+@requires_blob
+def test_explain_scan_reports_map_blob_fallback(catalog_options):
+    map_blob_type = pa.map_(pa.string(), pa.large_binary())
+    pa_schema = pa.schema([
+        ("id", pa.int64()),
+        ("payloads", map_blob_type),
+    ])
+    _, table = _create_table(
+        catalog_options,
+        "explain_map_blob_fallback",
+        pa_schema,
+        options={
+            "bucket": "-1",
+            "file.format": "parquet",
+            "row-tracking.enabled": "true",
+            "data-evolution.enabled": "true",
+        },
+    )
+    _write_arrow(table, pa.table({
+        "id": [1],
+        "payloads": pa.array([{"key": b"hello"}], type=map_blob_type),
+    }, schema=pa_schema))
+
+    result = _explain_table(table, catalog_options=catalog_options, verbose=True)
+
+    assert result.pypaimon_fallback_split_count == result.paimon_scan.split_count
+    assert result.pypaimon_fallback_split_count > 0
+    assert result.native_parquet_split_count == 0
+    assert result.fallback_reasons["blob columns present"] == result.pypaimon_fallback_split_count
+    assert result.splits is not None
+    assert all(split.reader_mode == READER_MODE_PYPAIMON_FALLBACK for split in result.splits)
+
+
 def test_explain_scan_reports_deletion_vector_fallback(catalog_options, monkeypatch):
     pa_schema = pa.schema([
         ("id", pa.int64()),

--- a/paimon-python/pypaimon/tests/daft/daft_sink_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_sink_test.py
@@ -590,6 +590,57 @@ class TestBlobType:
         with payloads[0][2].open() as stream:
             assert stream.read() == b"world"
 
+    def test_read_map_blob_type(self, local_paimon_catalog):
+        """MAP<STRING, BLOB> values are returned as File objects."""
+        catalog, _ = local_paimon_catalog
+        map_blob_type = pa.map_(pa.string(), pa.large_binary())
+        pa_schema = pa.schema([
+            ("id", pa.int64()),
+            ("payloads", map_blob_type),
+        ])
+        paimon_schema = pypaimon.Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                "bucket": "1",
+                "file.format": "parquet",
+                "row-tracking.enabled": "true",
+                "data-evolution.enabled": "true",
+            },
+        )
+        catalog.create_table(
+            "test_db.map_blob_table",
+            paimon_schema,
+            ignore_if_exists=True,
+        )
+        table = catalog.get_table("test_db.map_blob_table")
+        _write_to_paimon(table, pa.table({
+            "id": [1, 2],
+            "payloads": pa.array(
+                [{"first": b"hello", "null": None, "second": b"world"}, None],
+                type=map_blob_type,
+            ),
+        }, schema=pa_schema))
+
+        result_df = _read_table(table).sort("id")
+        assert str(result_df.schema()["payloads"].dtype) == "Map[String: File[Unknown]]"
+
+        projected = result_df.select(
+            "id",
+            result_df["payloads"].map_get("first").alias("first"),
+            result_df["payloads"].map_get("null").alias("null"),
+            result_df["payloads"].map_get("second").alias("second"),
+        ).to_pydict()
+        assert projected["id"] == [1, 2]
+        assert projected["null"] == [None, None]
+        assert projected["first"][1] is None
+        assert projected["second"][1] is None
+        assert isinstance(projected["first"][0], daft.File)
+        assert isinstance(projected["second"][0], daft.File)
+        with projected["first"][0].open() as stream:
+            assert stream.read() == b"hello"
+        with projected["second"][0].open() as stream:
+            assert stream.read() == b"world"
+
 
 # ---------------------------------------------------------------------------
 # Truncate tests

--- a/paimon-python/pypaimon/tests/data_types_test.py
+++ b/paimon-python/pypaimon/tests/data_types_test.py
@@ -92,6 +92,25 @@ class DataTypesTest(unittest.TestCase):
         self.assertEqual(str(MapType(True, AtomicType("STRING"), AtomicType("TIMESTAMP(6)"))),
                          "MAP<STRING, TIMESTAMP(6)>")
 
+    def test_map_nullability_dict_roundtrip(self):
+        for map_nullable in (True, False):
+            for value_nullable in (True, False):
+                original = MapType(
+                    map_nullable,
+                    AtomicType("STRING", nullable=False),
+                    AtomicType("INT", nullable=value_nullable),
+                )
+
+                self.assertEqual(MapType.from_dict(original.to_dict()), original)
+
+        legacy = MapType(
+            True,
+            AtomicType("STRING", nullable=False),
+            AtomicType("INT"),
+        ).to_dict()
+        legacy.pop("nullable")
+        self.assertTrue(MapType.from_dict(legacy).nullable)
+
     def test_map_blob_value_nullability_roundtrip(self):
         for value_nullable in (True, False):
             paimon_type = MapType(

--- a/paimon-python/pypaimon/tests/data_types_test.py
+++ b/paimon-python/pypaimon/tests/data_types_test.py
@@ -20,7 +20,8 @@ from parameterized import parameterized
 import pyarrow as pa
 
 from pypaimon.schema.data_types import (DataField, AtomicType, ArrayType, MultisetType, MapType,
-                                        RowType, VectorType, PyarrowFieldParser)
+                                        RowType, VectorType, PyarrowFieldParser,
+                                        is_blob_file_type)
 
 
 class DataTypesTest(unittest.TestCase):
@@ -90,6 +91,24 @@ class DataTypesTest(unittest.TestCase):
     def test_map_type(self):
         self.assertEqual(str(MapType(True, AtomicType("STRING"), AtomicType("TIMESTAMP(6)"))),
                          "MAP<STRING, TIMESTAMP(6)>")
+
+    def test_map_blob_value_nullability_roundtrip(self):
+        for value_nullable in (True, False):
+            paimon_type = MapType(
+                True,
+                AtomicType("STRING", nullable=False),
+                AtomicType("BLOB", nullable=value_nullable),
+            )
+
+            arrow_type = PyarrowFieldParser.from_paimon_type(paimon_type)
+
+            self.assertFalse(arrow_type.key_field.nullable)
+            self.assertEqual(arrow_type.item_field.nullable, value_nullable)
+            self.assertEqual(
+                PyarrowFieldParser.to_paimon_type(arrow_type, nullable=True),
+                paimon_type,
+            )
+            self.assertTrue(is_blob_file_type(paimon_type))
 
     def test_vector_type(self):
         vector_type = VectorType(True, AtomicType("FLOAT"), 3)

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -1458,6 +1458,81 @@ class JavaPyReadWriteTest(unittest.TestCase):
             data.column('payloads').to_pylist(),
         )
 
+    def test_read_map_blob_written_by_java(self):
+        table = self.catalog.get_table('default.map_blob_java_test')
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        result = table_sort_by(result, 'id')
+
+        self.assertTrue(pa.types.is_map(result.schema.field('payloads').type))
+        self.assertEqual(result.column('id').to_pylist(), [1, 2, 3, 4])
+        self.assertEqual(
+            [None if value is None else dict(value)
+             for value in result.column('payloads').to_pylist()],
+            [
+                {1: b'java-alpha', 2: None, 3: b''},
+                {},
+                None,
+                {4: b'java-omega'},
+            ],
+        )
+
+    def test_write_map_blob_for_java(self):
+        map_blob_type = pa.map_(pa.int32(), pa.large_binary())
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('payloads', map_blob_type),
+        ])
+        schema = Schema.from_pyarrow_schema(
+            pa_schema,
+            options={
+                'row-tracking.enabled': 'true',
+                'data-evolution.enabled': 'true',
+                'bucket': '-1',
+            },
+        )
+        table_name = 'default.map_blob_python_test'
+        self.catalog.drop_table(table_name, True)
+        self.catalog.create_table(table_name, schema, False)
+        table = self.catalog.get_table(table_name)
+
+        data = pa.Table.from_pydict({
+            'id': [1, 2, 3, 4],
+            'payloads': pa.array(
+                [
+                    {1: b'python-alpha', 2: None, 3: b''},
+                    {},
+                    None,
+                    {4: b'python-omega'},
+                ],
+                type=map_blob_type,
+            ),
+        }, schema=pa_schema)
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(data)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        result = read_builder.new_read().to_arrow(
+            read_builder.new_scan().plan().splits())
+        result = table_sort_by(result, 'id')
+        self.assertEqual(result.column('id').to_pylist(), [1, 2, 3, 4])
+        self.assertEqual(
+            [None if value is None else dict(value)
+             for value in result.column('payloads').to_pylist()],
+            [
+                {1: b'python-alpha', 2: None, 3: b''},
+                {},
+                None,
+                {4: b'python-omega'},
+            ],
+        )
+
     def test_compact_conflict_shard_update(self):
         """
         1. Java writes 5 base files (testCompactConflictWriteBase)

--- a/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
+++ b/paimon-python/pypaimon/tests/e2e/java_py_read_write_test.py
@@ -1501,10 +1501,10 @@ class JavaPyReadWriteTest(unittest.TestCase):
             'id': [1, 2, 3, 4],
             'payloads': pa.array(
                 [
-                    {1: b'python-alpha', 2: None, 3: b''},
-                    {},
+                    [(1, b'python-alpha'), (2, None), (3, b'')],
+                    [],
                     None,
-                    {4: b'python-omega'},
+                    [(4, b'python-omega')],
                 ],
                 type=map_blob_type,
             ),

--- a/paimon-python/pypaimon/tests/multimodal_table_test.py
+++ b/paimon-python/pypaimon/tests/multimodal_table_test.py
@@ -184,7 +184,7 @@ class MultimodalTableTest(unittest.TestCase):
         self.assertEqual("TIMESTAMP(6)", types_by_name["created_at"])
         self.assertEqual("TIMESTAMP_LTZ(6)", types_by_name["created_ltz"])
         self.assertEqual("ARRAY<STRING>", types_by_name["tags"])
-        self.assertEqual("MAP<STRING, INT>", types_by_name["attrs"])
+        self.assertEqual("MAP<STRING NOT NULL, INT>", types_by_name["attrs"])
         self.assertEqual("ROW<rank: INT>", types_by_name["meta"])
         self.assertEqual("VECTOR<FLOAT, 3>", types_by_name["embedding"])
 

--- a/paimon-python/pypaimon/tests/schema_manager_test.py
+++ b/paimon-python/pypaimon/tests/schema_manager_test.py
@@ -150,7 +150,7 @@ class TestBlobPartitionValidation(unittest.TestCase):
         ):
             manager.commit(table_schema)
 
-    def test_create_table_rejects_unsupported_map_blob_key(self):
+    def test_create_table_allows_unsupported_map_blob_key(self):
         manager = SchemaManager(
             self.file_io,
             f"{self.temp_dir}/test_db.db/unsupported_map_key",
@@ -174,10 +174,8 @@ class TestBlobPartitionValidation(unittest.TestCase):
             },
         )
 
-        with self.assertRaisesRegex(
-            ValueError, "Unsupported key type for MAP<X, BLOB>"
-        ):
-            manager.create_table(schema)
+        table_schema = manager.create_table(schema)
+        self.assertEqual(table_schema.fields[1].type, schema.fields[1].type)
 
     def test_create_table_rejects_unsupported_nested_blob(self):
         nested_types = [

--- a/paimon-python/pypaimon/tests/schema_manager_test.py
+++ b/paimon-python/pypaimon/tests/schema_manager_test.py
@@ -23,7 +23,8 @@ from pypaimon.branch.branch_manager import BranchManager
 from pypaimon.common.identifier import DEFAULT_MAIN_BRANCH
 from pypaimon.common.file_io import FileIO
 from pypaimon.common.options.options import Options
-from pypaimon.schema.data_types import ArrayType, AtomicType, DataField
+from pypaimon.schema.data_types import (ArrayType, AtomicType, DataField,
+                                        MapType, RowType)
 from pypaimon.schema.schema import Schema
 from pypaimon.schema.schema_manager import SchemaManager
 from pypaimon.schema.table_schema import TableSchema
@@ -116,6 +117,11 @@ class TestBlobPartitionValidation(unittest.TestCase):
         blob_types = [
             AtomicType("BLOB"),
             ArrayType(True, AtomicType("BLOB")),
+            MapType(
+                True,
+                AtomicType("STRING", False),
+                AtomicType("BLOB"),
+            ),
         ]
         for index, blob_type in enumerate(blob_types):
             with self.subTest(blob_type=blob_type):
@@ -143,6 +149,99 @@ class TestBlobPartitionValidation(unittest.TestCase):
             "can not be part of partition keys",
         ):
             manager.commit(table_schema)
+
+    def test_create_table_rejects_unsupported_map_blob_key(self):
+        manager = SchemaManager(
+            self.file_io,
+            f"{self.temp_dir}/test_db.db/unsupported_map_key",
+        )
+        schema = Schema(
+            fields=[
+                DataField(0, "id", AtomicType("INT")),
+                DataField(
+                    1,
+                    "payload",
+                    MapType(
+                        True,
+                        AtomicType("BOOLEAN", False),
+                        AtomicType("BLOB"),
+                    ),
+                ),
+            ],
+            options={
+                "row-tracking.enabled": "true",
+                "data-evolution.enabled": "true",
+            },
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "Unsupported key type for MAP<X, BLOB>"
+        ):
+            manager.create_table(schema)
+
+    def test_create_table_rejects_unsupported_nested_blob(self):
+        nested_types = [
+            MapType(True, AtomicType("BLOB", False), AtomicType("INT")),
+            RowType(
+                True,
+                [DataField(2, "nested_blob", AtomicType("BLOB"))],
+            ),
+            ArrayType(True, ArrayType(True, AtomicType("BLOB"))),
+            MapType(
+                True,
+                AtomicType("STRING", False),
+                ArrayType(True, AtomicType("BLOB")),
+            ),
+        ]
+
+        for index, nested_type in enumerate(nested_types):
+            with self.subTest(nested_type=nested_type):
+                manager = SchemaManager(
+                    self.file_io,
+                    f"{self.temp_dir}/test_db.db/nested_blob_{index}",
+                )
+                schema = Schema(
+                    fields=[
+                        DataField(0, "id", AtomicType("INT")),
+                        DataField(1, "payload", nested_type),
+                    ],
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "unsupported nested BLOB type",
+                ):
+                    manager.create_table(schema)
+
+    def test_create_table_still_rejects_primary_key_map_blob(self):
+        manager = SchemaManager(
+            self.file_io,
+            f"{self.temp_dir}/test_db.db/pk_map_blob",
+        )
+        schema = Schema(
+            fields=[
+                DataField(0, "id", AtomicType("INT", False)),
+                DataField(
+                    1,
+                    "payload",
+                    MapType(
+                        True,
+                        AtomicType("STRING", False),
+                        AtomicType("BLOB"),
+                    ),
+                ),
+            ],
+            primary_keys=["id"],
+            options={
+                "row-tracking.enabled": "true",
+                "data-evolution.enabled": "true",
+            },
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "MAP<X, BLOB> type is not supported with primary key",
+        ):
+            manager.create_table(schema)
 
 
 if __name__ == '__main__':

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import struct
+from collections.abc import Mapping
 from typing import BinaryIO, List, Optional
 
 try:
@@ -23,7 +24,13 @@ try:
 except ImportError:
     import zlib as crc_backend
 
-from pypaimon.schema.data_types import is_array_blob_type, is_blob_file_type
+from pypaimon.common.map_blob_key_serializer import create_map_blob_key_serializer
+from pypaimon.schema.data_types import (
+    MapType,
+    is_array_blob_type,
+    is_blob_file_type,
+    is_map_blob_type,
+)
 from pypaimon.table.row.blob import Blob, BlobData, BlobDescriptor, BlobConsumer
 from pypaimon.common.delta_varint_compressor import DeltaVarintCompressor
 
@@ -33,9 +40,13 @@ class BlobFormatWriter:
     MAGIC_NUMBER = 1481511375
     ARRAY_VERSION = 1
     ARRAY_MAGIC_NUMBER = 1094861634
+    MAP_VERSION = 1
+    MAP_MAGIC_NUMBER = 0x4D424342
     NULL_LENGTH = -1
     PLACE_HOLDER_LENGTH = -2
     ARRAY_NULL_ELEMENT_LENGTH = -1
+    MAP_NULL_KEY_LENGTH = -1
+    MAP_NULL_VALUE_LENGTH = -1
     BUFFER_SIZE = 4096
     METADATA_SIZE = 12  # 8-byte length + 4-byte CRC
 
@@ -60,10 +71,25 @@ class BlobFormatWriter:
         blob_field_name = row.fields[0].name
         blob_field_type = row.fields[0].type
         blob_value = row.values[0]
+        if isinstance(blob_field_type, MapType) and not is_map_blob_type(blob_field_type):
+            raise ValueError(
+                f"Map-Blob value type must be BLOB, but is {blob_field_type.value}."
+            )
         if blob_value is None:
             self.lengths.append(self.NULL_LENGTH)
             if self._blob_consumer is not None:
                 self._blob_consumer(blob_field_name, None)
+            return
+
+        if is_map_blob_type(blob_field_type):
+            if blob_value is Blob.MAP_PLACE_HOLDER:
+                self.lengths.append(self.PLACE_HOLDER_LENGTH)
+                return
+            self.add_blob_map(
+                blob_field_name,
+                blob_value,
+                blob_field_type.key,
+            )
             return
 
         if is_array_blob_type(blob_field_type):
@@ -172,6 +198,77 @@ class BlobFormatWriter:
         if flush:
             self.output_stream.flush()
 
+    def add_blob_map(self, blob_field_name: str, blob_values, key_type) -> None:
+        entries = self._map_entries(blob_values)
+        if len(entries) > 0x7fffffff:
+            raise ValueError(f"Invalid MAP<X, BLOB> entry count: {len(entries)}")
+
+        key_serializer = create_map_blob_key_serializer(key_type)
+        key_bytes = []
+        for key, _ in entries:
+            if key is None:
+                key_bytes.append(None)
+                continue
+            serialized = key_serializer.serialize(key)
+            if len(serialized) > 0x7fffffff:
+                raise ValueError(f"MAP<X, BLOB> key is too large: {len(serialized)}")
+            key_bytes.append(serialized)
+
+        for _, blob_value in entries:
+            if blob_value is None:
+                continue
+            if (
+                blob_value is Blob.PLACE_HOLDER
+                or blob_value is Blob.ARRAY_PLACE_HOLDER
+                or blob_value is Blob.MAP_PLACE_HOLDER
+            ):
+                raise ValueError("MAP<X, BLOB> values do not support placeholders")
+            if not isinstance(blob_value, Blob):
+                raise ValueError("MAP<X, BLOB> values must be Blob/BlobData instances or None")
+
+        previous_pos = self.position
+        crc32 = 0
+        crc32 = self._write_with_crc(struct.pack('<I', self.MAGIC_NUMBER), crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', self.MAP_MAGIC_NUMBER), crc32)
+        crc32 = self._write_with_crc(struct.pack('<B', self.MAP_VERSION), crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', len(entries)), crc32)
+
+        key_lengths = []
+        for serialized in key_bytes:
+            if serialized is None:
+                key_lengths.append(self.MAP_NULL_KEY_LENGTH)
+            else:
+                key_lengths.append(len(serialized))
+                crc32 = self._write_with_crc(serialized, crc32)
+
+        value_lengths = []
+        flush = False
+        for _, blob_value in entries:
+            if blob_value is None:
+                value_lengths.append(self.MAP_NULL_VALUE_LENGTH)
+                continue
+            blob_pos, blob_length, crc32 = self._write_blob_data(blob_value, crc32)
+            value_lengths.append(blob_length)
+            if self._blob_consumer is not None:
+                descriptor = BlobDescriptor(self._file_path, blob_pos, blob_length)
+                flush = self._blob_consumer(blob_field_name, descriptor) or flush
+
+        key_index_bytes = DeltaVarintCompressor.compress(key_lengths)
+        value_index_bytes = DeltaVarintCompressor.compress(value_lengths)
+        crc32 = self._write_with_crc(key_index_bytes, crc32)
+        crc32 = self._write_with_crc(value_index_bytes, crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', len(key_index_bytes)), crc32)
+        crc32 = self._write_with_crc(struct.pack('<I', len(value_index_bytes)), crc32)
+
+        bin_length = self.position - previous_pos + self.METADATA_SIZE
+        self.lengths.append(bin_length)
+        crc32 = self._write_with_crc(struct.pack('<Q', bin_length), crc32)
+        self.output_stream.write(struct.pack('<I', crc32 & 0xffffffff))
+        self.position += 4
+
+        if flush:
+            self.output_stream.flush()
+
     def _write_blob_data(self, blob_value: Blob, crc32: int):
         blob_pos = self.position
 
@@ -200,7 +297,8 @@ class BlobFormatWriter:
         from pypaimon.table.row.generic_row import GenericRow
         from pypaimon.table.row.row_kind import RowKind
 
-        is_blob = is_blob_file_type(fields[0].type)
+        is_map_blob = is_map_blob_type(fields[0].type)
+        is_blob = is_blob_file_type(fields[0].type) or is_map_blob
 
         if col_data is None:
             if not is_blob:
@@ -208,7 +306,9 @@ class BlobFormatWriter:
             self.lengths.append(self.NULL_LENGTH)
             return
 
-        if is_array_blob_type(fields[0].type):
+        if is_map_blob:
+            row_values = [self._to_blob_map(col_data, uri_reader_factory)]
+        elif is_array_blob_type(fields[0].type):
             row_values = [self._to_blob_array(col_data, uri_reader_factory)]
         elif is_blob:
             row_values = [self._to_blob(col_data, uri_reader_factory)]
@@ -261,6 +361,45 @@ class BlobFormatWriter:
                 raise RuntimeError("ARRAY<BLOB> elements do not support placeholders.")
             result.append(cls._to_blob(element, uri_reader_factory))
         return result
+
+    @classmethod
+    def _to_blob_map(cls, col_data, uri_reader_factory=None):
+        if col_data is Blob.MAP_PLACE_HOLDER:
+            return Blob.MAP_PLACE_HOLDER
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if col_data is None:
+            return None
+
+        result = []
+        for key, value in cls._map_entries(col_data):
+            if value is None:
+                result.append((key, None))
+                continue
+            if (
+                value is Blob.PLACE_HOLDER
+                or value is Blob.ARRAY_PLACE_HOLDER
+                or value is Blob.MAP_PLACE_HOLDER
+            ):
+                raise RuntimeError("MAP<X, BLOB> values do not support placeholders.")
+            result.append((key, cls._to_blob(value, uri_reader_factory)))
+        return result
+
+    @staticmethod
+    def _map_entries(blob_values):
+        if isinstance(blob_values, Mapping):
+            return list(blob_values.items())
+        if isinstance(blob_values, (bytes, bytearray, str)) or not hasattr(
+            blob_values, '__iter__'
+        ):
+            raise ValueError("MAP<X, BLOB> field value must be a mapping or key/value pairs")
+
+        entries = []
+        for entry in blob_values:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                raise ValueError("MAP<X, BLOB> entries must be key/value pairs")
+            entries.append((entry[0], entry[1]))
+        return entries
 
     def reach_target_size(self, target_size: int) -> bool:
         return self.position >= target_size

--- a/paimon-python/pypaimon/write/blob_format_writer.py
+++ b/paimon-python/pypaimon/write/blob_format_writer.py
@@ -89,6 +89,7 @@ class BlobFormatWriter:
                 blob_field_name,
                 blob_value,
                 blob_field_type.key,
+                value_nullable=blob_field_type.value.nullable,
             )
             return
 
@@ -160,7 +161,11 @@ class BlobFormatWriter:
                 continue
             if not isinstance(blob_value, Blob):
                 raise ValueError("ARRAY<BLOB> elements must be Blob/BlobData instances or None")
-            if blob_value is Blob.PLACE_HOLDER or blob_value is Blob.ARRAY_PLACE_HOLDER:
+            if (
+                blob_value is Blob.PLACE_HOLDER
+                or blob_value is Blob.ARRAY_PLACE_HOLDER
+                or blob_value is Blob.MAP_PLACE_HOLDER
+            ):
                 raise ValueError("ARRAY<BLOB> elements do not support placeholders")
 
         previous_pos = self.position
@@ -198,7 +203,12 @@ class BlobFormatWriter:
         if flush:
             self.output_stream.flush()
 
-    def add_blob_map(self, blob_field_name: str, blob_values, key_type) -> None:
+    def add_blob_map(
+            self,
+            blob_field_name: str,
+            blob_values,
+            key_type,
+            value_nullable: bool = True) -> None:
         entries = self._map_entries(blob_values)
         if len(entries) > 0x7fffffff:
             raise ValueError(f"Invalid MAP<X, BLOB> entry count: {len(entries)}")
@@ -216,6 +226,10 @@ class BlobFormatWriter:
 
         for _, blob_value in entries:
             if blob_value is None:
+                if not value_nullable:
+                    raise ValueError(
+                        f"MAP<X, BLOB> field '{blob_field_name}' does not allow null values"
+                    )
                 continue
             if (
                 blob_value is Blob.PLACE_HOLDER
@@ -298,7 +312,7 @@ class BlobFormatWriter:
         from pypaimon.table.row.row_kind import RowKind
 
         is_map_blob = is_map_blob_type(fields[0].type)
-        is_blob = is_blob_file_type(fields[0].type) or is_map_blob
+        is_blob = is_blob_file_type(fields[0].type)
 
         if col_data is None:
             if not is_blob:
@@ -357,7 +371,11 @@ class BlobFormatWriter:
             if element is None:
                 result.append(None)
                 continue
-            if element is Blob.PLACE_HOLDER or element is Blob.ARRAY_PLACE_HOLDER:
+            if (
+                element is Blob.PLACE_HOLDER
+                or element is Blob.ARRAY_PLACE_HOLDER
+                or element is Blob.MAP_PLACE_HOLDER
+            ):
                 raise RuntimeError("ARRAY<BLOB> elements do not support placeholders.")
             result.append(cls._to_blob(element, uri_reader_factory))
         return result

--- a/paimon-python/pypaimon/write/row_utils.py
+++ b/paimon-python/pypaimon/write/row_utils.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from collections.abc import Mapping
 from typing import Any, Dict, Iterable, List
 
 import pyarrow as pa
@@ -78,6 +79,8 @@ def value_for_arrow(value: Any, field: DataField) -> Any:
 def _contains_blob_value(value: Any) -> bool:
     if isinstance(value, Blob):
         return True
+    if isinstance(value, Mapping):
+        return any(_contains_blob_value(item) for item in value.values())
     if isinstance(value, (list, tuple)):
         return any(_contains_blob_value(item) for item in value)
     return False

--- a/paimon-python/pypaimon/write/table_update_by_row_id.py
+++ b/paimon-python/pypaimon/write/table_update_by_row_id.py
@@ -31,6 +31,7 @@ from pypaimon.schema.data_types import (
     PyarrowFieldParser,
     is_array_blob_type,
     is_blob_file_field,
+    is_map_blob_type,
 )
 from pypaimon.table.row.blob import Blob
 from pypaimon.table.row.generic_row import GenericRow
@@ -524,6 +525,8 @@ class TableUpdateByRowId:
     def _blob_placeholder(self, column_name: str):
         for table_field in self.table.fields:
             if table_field.name == column_name:
+                if is_map_blob_type(table_field.type):
+                    return Blob.MAP_PLACE_HOLDER
                 return (
                     Blob.ARRAY_PLACE_HOLDER
                     if is_array_blob_type(table_field.type)

--- a/paimon-python/pypaimon/write/writer/blob_file_writer.py
+++ b/paimon-python/pypaimon/write/writer/blob_file_writer.py
@@ -27,6 +27,7 @@ from pypaimon.schema.data_types import (
     DataField,
     PyarrowFieldParser,
     is_array_blob_type,
+    is_map_blob_type,
 )
 
 
@@ -80,6 +81,8 @@ class BlobFileWriter:
         self.row_count += 1
 
     def _to_blob_file_value(self, col_data, field_type):
+        if is_map_blob_type(field_type):
+            return self._to_blob_map(col_data)
         if is_array_blob_type(field_type):
             return self._to_blob_array(col_data)
         return self._to_blob(col_data)
@@ -129,9 +132,35 @@ class BlobFileWriter:
             if element is None:
                 result.append(None)
                 continue
-            if element is Blob.PLACE_HOLDER or element is Blob.ARRAY_PLACE_HOLDER:
+            if (
+                element is Blob.PLACE_HOLDER
+                or element is Blob.ARRAY_PLACE_HOLDER
+                or element is Blob.MAP_PLACE_HOLDER
+            ):
                 raise ValueError("ARRAY<BLOB> elements do not support placeholders.")
             result.append(self._to_blob(element))
+        return result
+
+    def _to_blob_map(self, col_data):
+        if col_data is Blob.MAP_PLACE_HOLDER:
+            return Blob.MAP_PLACE_HOLDER
+        if hasattr(col_data, 'as_py'):
+            col_data = col_data.as_py()
+        if col_data is None:
+            return None
+
+        result = []
+        for key, value in BlobFormatWriter._map_entries(col_data):
+            if value is None:
+                result.append((key, None))
+                continue
+            if (
+                value is Blob.PLACE_HOLDER
+                or value is Blob.ARRAY_PLACE_HOLDER
+                or value is Blob.MAP_PLACE_HOLDER
+            ):
+                raise ValueError("MAP<X, BLOB> values do not support placeholders.")
+            result.append((key, self._to_blob(value)))
         return result
 
     @staticmethod

--- a/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
+++ b/paimon-python/pypaimon/write/writer/dedicated_format_writer.py
@@ -80,15 +80,15 @@ class DedicatedFormatWriter(DataWriter):
                 "Fields in 'blob-descriptor-field' must be blob fields in schema. "
                 f"Unknown fields: {sorted(unknown_descriptor_fields)}"
             )
-        inline_array_blob_fields = [
+        inline_nested_blob_fields = [
             field.name
             for field in self.table.table_schema.fields
             if field.name in self.blob_inline_fields and not is_blob_type(field.type)
         ]
-        if inline_array_blob_fields:
+        if inline_nested_blob_fields:
             raise ValueError(
-                "ARRAY<BLOB> is only supported by 'blob-field'. "
-                f"Invalid inline blob fields: {sorted(inline_array_blob_fields)}"
+                "ARRAY<BLOB> and MAP<X, BLOB> are only supported by 'blob-field'. "
+                f"Invalid inline blob fields: {sorted(inline_nested_blob_fields)}"
             )
 
         # Blob fields that should still be written to `.blob` files.

--- a/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-4.0/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -430,8 +430,12 @@ case class MergeIntoPaimonDataEvolutionTable(
     val rawBlobFieldNames = rawBlobFields
       .map(_.name())
       .toSet
-    val rawArrayBlobFieldNames = rawBlobFields
-      .filter(_.`type`().getTypeRoot == DataTypeRoot.ARRAY)
+    val rawNestedBlobFieldNames = rawBlobFields
+      .filter(
+        field => {
+          val root = field.`type`().getTypeRoot
+          root == DataTypeRoot.ARRAY || root == DataTypeRoot.MAP
+        })
       .map(_.name())
       .toSet
 
@@ -455,15 +459,15 @@ case class MergeIntoPaimonDataEvolutionTable(
       }.toSet
     }
 
-    val modifiedRawArrayBlobColumnNames = matchedActions
+    val modifiedRawNestedBlobColumnNames = matchedActions
       .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
       .flatten
-      .filter(name => rawArrayBlobFieldNames.exists(arrayBlobName => resolver(arrayBlobName, name)))
+      .filter(name => rawNestedBlobFieldNames.exists(blobName => resolver(blobName, name)))
       .toSet
-    if (modifiedRawArrayBlobColumnNames.nonEmpty) {
+    if (modifiedRawNestedBlobColumnNames.nonEmpty) {
       throw new UnsupportedOperationException(
-        "Should not append/update raw-data ARRAY<BLOB> column through MERGE INTO: " +
-          modifiedRawArrayBlobColumnNames.toSeq.sorted.mkString(", "))
+        "Should not append/update raw-data ARRAY<BLOB> or MAP<X, BLOB> column through MERGE INTO: " +
+          modifiedRawNestedBlobColumnNames.toSeq.sorted.mkString(", "))
     }
 
     val rawBlobMarkerNames =

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/AbstractSparkInternalRow.java
@@ -194,7 +194,7 @@ public abstract class AbstractSparkInternalRow extends SparkInternalRow {
 
     @Override
     public MapData getMap(int ordinal) {
-        return fromPaimon(row.getMap(ordinal), rowType.getTypeAt(ordinal));
+        return fromPaimon(row.getMap(ordinal), rowType.getTypeAt(ordinal), blobAsDescriptor);
     }
 
     @Override

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/DataConverter.java
@@ -125,6 +125,10 @@ public class DataConverter {
     }
 
     public static MapData fromPaimon(InternalMap map, DataType mapType) {
+        return fromPaimon(map, mapType, false);
+    }
+
+    public static MapData fromPaimon(InternalMap map, DataType mapType, boolean blobAsDescriptor) {
         DataType keyType;
         DataType valueType;
         if (mapType instanceof MapType) {
@@ -137,8 +141,18 @@ public class DataConverter {
             throw new UnsupportedOperationException("Unsupported type: " + mapType);
         }
 
+        if (valueType.getTypeRoot() == org.apache.paimon.types.DataTypeRoot.BLOB) {
+            InternalArray keys = map.keyArray();
+            for (int i = 0; i < keys.size(); i++) {
+                if (keys.isNullAt(i)) {
+                    throw new IllegalArgumentException(
+                            "Spark MAP<X, BLOB> does not support null keys.");
+                }
+            }
+        }
+
         return new ArrayBasedMapData(
                 fromPaimonArrayElementType(map.keyArray(), keyType),
-                fromPaimonArrayElementType(map.valueArray(), valueType));
+                fromPaimonArrayElementType(map.valueArray(), valueType, blobAsDescriptor));
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -642,14 +642,14 @@ public class SparkCatalog extends SparkBaseCatalog
         return schemaBuilder.build();
     }
 
-    private static DataType toBlobType(StructField field, boolean allowArray) {
+    private static DataType toBlobType(StructField field, boolean allowNested) {
         org.apache.spark.sql.types.DataType sparkType = field.dataType();
         if (sparkType instanceof BinaryType) {
             return new BlobType(field.nullable());
         }
         if (sparkType instanceof ArrayType) {
             checkArgument(
-                    allowArray,
+                    allowNested,
                     "ARRAY<BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
             ArrayType arrayType = (ArrayType) sparkType;
             checkArgument(
@@ -658,8 +658,27 @@ public class SparkCatalog extends SparkBaseCatalog
             return new org.apache.paimon.types.ArrayType(
                     field.nullable(), new BlobType(arrayType.containsNull()));
         }
+        if (sparkType instanceof org.apache.spark.sql.types.MapType) {
+            checkArgument(
+                    allowNested,
+                    "MAP<X, BLOB> is only supported by '" + CoreOptions.BLOB_FIELD.key() + "'.");
+            org.apache.spark.sql.types.MapType mapType =
+                    (org.apache.spark.sql.types.MapType) sparkType;
+            checkArgument(
+                    mapType.valueType() instanceof BinaryType,
+                    "The value type of a MAP<X, BLOB> field must be binary");
+            org.apache.paimon.types.MapType result =
+                    new org.apache.paimon.types.MapType(
+                            field.nullable(),
+                            toPaimonType(mapType.keyType()).copy(false),
+                            new BlobType(mapType.valueContainsNull()));
+            checkArgument(
+                    BlobType.isBlobFileField(result),
+                    "Unsupported key type for MAP<X, BLOB>: " + mapType.keyType());
+            return result;
+        }
         throw new IllegalArgumentException(
-                "The type of blob field must be binary or array of binary");
+                "The type of blob field must be binary, array of binary, or map with binary values");
     }
 
     private void validateAlterProperty(String alterKey) {

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -667,15 +667,10 @@ public class SparkCatalog extends SparkBaseCatalog
             checkArgument(
                     mapType.valueType() instanceof BinaryType,
                     "The value type of a MAP<X, BLOB> field must be binary");
-            org.apache.paimon.types.MapType result =
-                    new org.apache.paimon.types.MapType(
-                            field.nullable(),
-                            toPaimonType(mapType.keyType()).copy(false),
-                            new BlobType(mapType.valueContainsNull()));
-            checkArgument(
-                    BlobType.isBlobFileField(result),
-                    "Unsupported key type for MAP<X, BLOB>: " + mapType.keyType());
-            return result;
+            return new org.apache.paimon.types.MapType(
+                    field.nullable(),
+                    toPaimonType(mapType.keyType()).copy(false),
+                    new BlobType(mapType.valueContainsNull()));
         }
         throw new IllegalArgumentException(
                 "The type of blob field must be binary, array of binary, or map with binary values");

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/commands/MergeIntoPaimonDataEvolutionTable.scala
@@ -430,8 +430,12 @@ case class MergeIntoPaimonDataEvolutionTable(
     val rawBlobFieldNames = rawBlobFields
       .map(_.name())
       .toSet
-    val rawArrayBlobFieldNames = rawBlobFields
-      .filter(_.`type`().getTypeRoot == DataTypeRoot.ARRAY)
+    val rawNestedBlobFieldNames = rawBlobFields
+      .filter(
+        field => {
+          val root = field.`type`().getTypeRoot
+          root == DataTypeRoot.ARRAY || root == DataTypeRoot.MAP
+        })
       .map(_.name())
       .toSet
 
@@ -455,15 +459,15 @@ case class MergeIntoPaimonDataEvolutionTable(
       }.toSet
     }
 
-    val modifiedRawArrayBlobColumnNames = matchedActions
+    val modifiedRawNestedBlobColumnNames = matchedActions
       .collect { case action: UpdateAction => modifiedRawBlobNames(action) }
       .flatten
-      .filter(name => rawArrayBlobFieldNames.exists(arrayBlobName => resolver(arrayBlobName, name)))
+      .filter(name => rawNestedBlobFieldNames.exists(blobName => resolver(blobName, name)))
       .toSet
-    if (modifiedRawArrayBlobColumnNames.nonEmpty) {
+    if (modifiedRawNestedBlobColumnNames.nonEmpty) {
       throw new UnsupportedOperationException(
-        "Should not append/update raw-data ARRAY<BLOB> column through MERGE INTO: " +
-          modifiedRawArrayBlobColumnNames.toSeq.sorted.mkString(", "))
+        "Should not append/update raw-data ARRAY<BLOB> or MAP<X, BLOB> column through MERGE INTO: " +
+          modifiedRawNestedBlobColumnNames.toSeq.sorted.mkString(", "))
     }
 
     val rawBlobMarkerNames =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/write/DataEvolutionTableDataWrite.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark.write
 
 import org.apache.paimon.casting.FallbackMappingRow
-import org.apache.paimon.data.{BinaryRow, BlobArrayPlaceholder, BlobPlaceholder, GenericRow, InternalRow}
+import org.apache.paimon.data.{BinaryRow, BlobArrayPlaceholder, BlobMapPlaceholder, BlobPlaceholder, GenericRow, InternalRow}
 import org.apache.paimon.data.serializer.InternalSerializers
 import org.apache.paimon.disk.IOManager
 import org.apache.paimon.format.blob.BlobFileFormat.isBlobFile
@@ -76,6 +76,8 @@ case class DataEvolutionTableDataWrite(
     case (fieldIndex, _) =>
       if (writeType.getTypeAt(fieldIndex).getTypeRoot == DataTypeRoot.ARRAY) {
         BlobArrayPlaceholder.INSTANCE
+      } else if (writeType.getTypeAt(fieldIndex).getTypeRoot == DataTypeRoot.MAP) {
+        BlobMapPlaceholder.INSTANCE
       } else {
         BlobPlaceholder.INSTANCE
       }

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkInternalRowTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkInternalRowTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark;
 
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Blob;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
@@ -28,13 +29,13 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.spark.data.SparkInternalRow;
+import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.UriReaderFactory;
 
 import org.apache.spark.sql.catalyst.CatalystTypeConverters;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -45,6 +46,7 @@ import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.AbstractMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -56,6 +58,7 @@ import scala.collection.JavaConverters;
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.spark.SparkTypeTest.ALL_TYPES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link SparkInternalRow}. */
 public class SparkInternalRowTest {
@@ -146,7 +149,8 @@ public class SparkInternalRowTest {
         Files.write(blobFile, bytes);
         byte[] descriptor =
                 new BlobDescriptor(blobFile.toUri().toString(), 0, bytes.length).serialize();
-        StructType schema = new StructType().add("blob", DataTypes.BinaryType);
+        StructType schema =
+                new StructType().add("blob", org.apache.spark.sql.types.DataTypes.BinaryType);
 
         SparkInternalRowWrapper wrapper =
                 SparkInternalRowWrapper.fromUriReaderFactory(
@@ -157,6 +161,21 @@ public class SparkInternalRowTest {
                         .replace(new GenericInternalRow(new Object[] {descriptor}));
 
         assertThat(wrapper.getBlob(0).toData()).isEqualTo(bytes);
+    }
+
+    @Test
+    public void testMapBlobRejectsNullKey() {
+        Map<Object, Object> map = new LinkedHashMap<>();
+        map.put(null, Blob.fromData(new byte[] {1}));
+
+        assertThatThrownBy(
+                        () ->
+                                DataConverter.fromPaimon(
+                                        new GenericMap(map),
+                                        DataTypes.MAP(DataTypes.STRING(), DataTypes.BLOB()),
+                                        false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Spark MAP<X, BLOB> does not support null keys.");
     }
 
     private String sparkRowToString(org.apache.spark.sql.Row row) {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -326,19 +326,13 @@ class BlobTestBase extends PaimonSparkTestBase {
         }
     }
 
-    withTable("map_blob_unsupported_key") {
-      val error = intercept[Exception] {
-        sql(
-          "CREATE TABLE map_blob_unsupported_key " +
-            "(id INT, pictures MAP<BOOLEAN, BINARY>) TBLPROPERTIES (" +
-            "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
-            "'blob-field'='pictures')")
-      }
-      assert(
-        exceptionContains(error, "Unsupported key type for MAP<X, BLOB>: BooleanType"),
-        exceptionMessages(error))
+    withTable("map_blob_boolean_key") {
+      sql(
+        "CREATE TABLE map_blob_boolean_key " +
+          "(id INT, pictures MAP<BOOLEAN, BINARY>) TBLPROPERTIES (" +
+          "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='pictures')")
     }
-
   }
 
   test("Blob: test write blob descriptor") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -184,6 +184,33 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: test primary-key map blob") {
+    withTable("t") {
+      sql(
+        "CREATE TABLE t (id INT, pictures MAP<STRING, BINARY>) TBLPROPERTIES (" +
+          "'primary-key'='id', 'bucket'='1', 'blob-field'='pictures')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, map('first', X'48656C6C6F', 'null', CAST(NULL AS BINARY), " +
+          "'second', X'5945'))")
+
+      val row = sql(
+        "SELECT id, size(pictures), pictures['first'], pictures['null'], pictures['second'] " +
+          "FROM t").collect()(0)
+      assert(row.getInt(0) == 1)
+      assert(row.getInt(1) == 3)
+      assert(util.Arrays.equals(row.getAs[Array[Byte]](2), Array[Byte](72, 101, 108, 108, 111)))
+      assert(row.isNullAt(3))
+      assert(util.Arrays.equals(row.getAs[Array[Byte]](4), Array[Byte](89, 69)))
+
+      sql("INSERT INTO t VALUES (1, map('first', X'4E4557'))")
+      val updated = sql("SELECT id, size(pictures), pictures['first'] FROM t").collect()(0)
+      assert(updated.getInt(0) == 1)
+      assert(updated.getInt(1) == 1)
+      assert(util.Arrays.equals(updated.getAs[Array[Byte]](2), Array[Byte](78, 69, 87)))
+    }
+  }
+
   test("Blob: array blob writes descriptor elements and reads descriptors") {
     withTable("t") {
       val blobData = new Array[Byte](1024)
@@ -312,18 +339,6 @@ class BlobTestBase extends PaimonSparkTestBase {
         exceptionMessages(error))
     }
 
-    withTable("pk_map_blob_reject") {
-      val error = intercept[Exception] {
-        sql(
-          "CREATE TABLE pk_map_blob_reject (id INT, pictures MAP<STRING, BINARY>) " +
-            "TBLPROPERTIES ('primary-key'='id', 'bucket'='1', 'blob-field'='pictures')")
-      }
-      assert(
-        exceptionContains(
-          error,
-          "Primary-key managed MAP<X, BLOB> fields are not supported: [pictures]."),
-        exceptionMessages(error))
-    }
   }
 
   test("Blob: test write blob descriptor") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobTestBase.scala
@@ -129,6 +129,41 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: test map blob") {
+    withTable("t") {
+      sql("CREATE TABLE t (id INT, data STRING, pictures MAP<STRING, BINARY>) TBLPROPERTIES (" +
+        "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, 'paimon', map('first', X'48656C6C6F', 'null', CAST(NULL AS BINARY), " +
+          "'second', X'5945')), " +
+          "(2, 'empty', CAST(map() AS MAP<STRING, BINARY>)), " +
+          "(3, 'null-map', CAST(NULL AS MAP<STRING, BINARY>))")
+
+      val first = sql(
+        "SELECT id, size(pictures), pictures['first'], pictures['null'], pictures['second'] " +
+          "FROM t WHERE id = 1").collect()(0)
+      assert(first.getInt(0) == 1)
+      assert(first.getInt(1) == 3)
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](2), Array[Byte](72, 101, 108, 108, 111)))
+      assert(first.isNullAt(3))
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](4), Array[Byte](89, 69)))
+
+      checkAnswer(
+        sql("SELECT id, size(pictures) FROM t WHERE id = 2"),
+        Seq(Row(2, 0))
+      )
+      checkAnswer(
+        sql("SELECT id, pictures IS NULL FROM t WHERE id = 3"),
+        Seq(Row(3, true))
+      )
+      checkAnswer(
+        sql("SELECT COUNT(*) > 0 FROM `t$files` WHERE file_path LIKE '%.blob'"),
+        Seq(Row(true))
+      )
+    }
+  }
+
   test("Blob: test primary-key array blob") {
     withTable("t") {
       sql(
@@ -186,6 +221,47 @@ class BlobTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: map blob writes descriptor values and reads descriptors") {
+    withTable("t") {
+      val blobData = new Array[Byte](1024)
+      RANDOM.nextBytes(blobData)
+      val fileIO = new LocalFileIO
+      val uri = "file://" + tempDBDir.toString + "/external_map_blob"
+      writeFile(fileIO, uri, blobData)
+
+      sql(
+        "CREATE TABLE t (id INT, data STRING, pictures MAP<STRING, BINARY>) TBLPROPERTIES (" +
+          "'row-tracking.enabled'='true', " +
+          "'data-evolution.enabled'='true', " +
+          "'blob-field'='pictures', " +
+          "'blob-as-descriptor'='true')")
+      sql(
+        s"INSERT INTO t VALUES (1, 'paimon', " +
+          s"map('external', sys.path_to_descriptor('$uri'), 'inline', X'5945'))")
+
+      val descriptorRow =
+        sql("SELECT pictures['external'], pictures['inline'] FROM t WHERE id = 1").collect()(0)
+      val firstDescriptor = BlobDescriptor.deserialize(descriptorRow.getAs[Array[Byte]](0))
+      val secondDescriptor = BlobDescriptor.deserialize(descriptorRow.getAs[Array[Byte]](1))
+      val options = new Options()
+      options.set("warehouse", tempDBDir.toString)
+      val catalogContext = CatalogContext.create(options)
+      val uriReaderFactory = new UriReaderFactory(catalogContext)
+      val firstBlob =
+        Blob.fromDescriptor(uriReaderFactory.create(firstDescriptor.uri), firstDescriptor)
+      val secondBlob =
+        Blob.fromDescriptor(uriReaderFactory.create(secondDescriptor.uri), secondDescriptor)
+      assert(util.Arrays.equals(blobData, firstBlob.toData))
+      assert(util.Arrays.equals(Array[Byte](89, 69), secondBlob.toData))
+
+      sql("ALTER TABLE t SET TBLPROPERTIES ('blob-as-descriptor'='false')")
+      val dataRow =
+        sql("SELECT pictures['external'], pictures['inline'] FROM t WHERE id = 1").collect()(0)
+      assert(util.Arrays.equals(blobData, dataRow.getAs[Array[Byte]](0)))
+      assert(util.Arrays.equals(Array[Byte](89, 69), dataRow.getAs[Array[Byte]](1)))
+    }
+  }
+
   test("Blob: array blob inline fields are rejected") {
     Seq(
       ("array_blob_descriptor_reject", "'blob-descriptor-field'='pictures'"),
@@ -202,6 +278,51 @@ class BlobTestBase extends PaimonSparkTestBase {
             exceptionContains(error, "ARRAY<BLOB> is only supported by 'blob-field'."),
             exceptionMessages(error))
         }
+    }
+  }
+
+  test("Blob: map blob validation") {
+    Seq(
+      ("map_blob_descriptor_reject", "'blob-descriptor-field'='pictures'"),
+      ("map_blob_view_reject", "'blob-view-field'='pictures'")
+    ).foreach {
+      case (tableName, blobOptions) =>
+        withTable(tableName) {
+          val error = intercept[Exception] {
+            sql(
+              s"CREATE TABLE $tableName (id INT, pictures MAP<STRING, BINARY>) TBLPROPERTIES (" +
+                s"'row-tracking.enabled'='true', 'data-evolution.enabled'='true', $blobOptions)")
+          }
+          assert(
+            exceptionContains(error, "MAP<X, BLOB> is only supported by 'blob-field'."),
+            exceptionMessages(error))
+        }
+    }
+
+    withTable("map_blob_unsupported_key") {
+      val error = intercept[Exception] {
+        sql(
+          "CREATE TABLE map_blob_unsupported_key " +
+            "(id INT, pictures MAP<BOOLEAN, BINARY>) TBLPROPERTIES (" +
+            "'row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+            "'blob-field'='pictures')")
+      }
+      assert(
+        exceptionContains(error, "Unsupported key type for MAP<X, BLOB>: BooleanType"),
+        exceptionMessages(error))
+    }
+
+    withTable("pk_map_blob_reject") {
+      val error = intercept[Exception] {
+        sql(
+          "CREATE TABLE pk_map_blob_reject (id INT, pictures MAP<STRING, BINARY>) " +
+            "TBLPROPERTIES ('primary-key'='id', 'bucket'='1', 'blob-field'='pictures')")
+      }
+      assert(
+        exceptionContains(
+          error,
+          "Primary-key managed MAP<X, BLOB> fields are not supported: [pictures]."),
+        exceptionMessages(error))
     }
   }
 
@@ -644,6 +765,44 @@ class BlobTestBase extends PaimonSparkTestBase {
       assert(util.Arrays.equals(second.getAs[Array[Byte]](0), Array[Byte](65, 66, 67)))
       assert(second.getInt(1) == 1)
 
+      checkAnswer(
+        sql("SELECT pictures IS NULL FROM t WHERE id = 3"),
+        Seq(Row(true))
+      )
+    }
+  }
+
+  test("Blob: merge-into updates non-blob column on raw map blob table with split files") {
+    withTable("s", "t") {
+      sql(
+        "CREATE TABLE t (id INT, name STRING, pictures MAP<STRING, BINARY>) TBLPROPERTIES " +
+          "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', " +
+          "'blob-field'='pictures', 'blob.target-file-size'='1 b')")
+      sql(
+        "INSERT INTO t VALUES " +
+          "(1, 'name1', map('first', X'48656C6C6F', 'second', X'5945')), " +
+          "(2, 'name2', map('only', X'414243')), " +
+          "(3, 'name3', CAST(NULL AS MAP<STRING, BINARY>))")
+
+      checkAnswer(
+        sql("SELECT COUNT(*) > 1 FROM `t$files` WHERE file_path LIKE '%.blob'"),
+        Seq(Row(true))
+      )
+
+      sql("CREATE TABLE s (id INT, name STRING)")
+      sql("INSERT INTO s VALUES (1, 'updated_name1')")
+      sql("""
+            |MERGE INTO t
+            |USING s
+            |ON t.id = s.id
+            |WHEN MATCHED THEN UPDATE SET t.name = s.name
+            |""".stripMargin)
+
+      val first =
+        sql("SELECT name, pictures['first'], pictures['second'] FROM t WHERE id = 1").collect()(0)
+      assert(first.getString(0) == "updated_name1")
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](1), Array[Byte](72, 101, 108, 108, 111)))
+      assert(util.Arrays.equals(first.getAs[Array[Byte]](2), Array[Byte](89, 69)))
       checkAnswer(
         sql("SELECT pictures IS NULL FROM t WHERE id = 3"),
         Seq(Row(true))

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/BlobUpdateTestBase.scala
@@ -80,6 +80,27 @@ class BlobUpdateTestBase extends PaimonSparkTestBase {
     }
   }
 
+  test("Blob: merge-into rejects updating raw-data map blob column") {
+    withTable("s", "t") {
+      sql("CREATE TABLE t (id INT, name STRING, pictures MAP<STRING, BINARY>) TBLPROPERTIES " +
+        "('row-tracking.enabled'='true', 'data-evolution.enabled'='true', 'blob-field'='pictures')")
+      sql("INSERT INTO t VALUES (1, 'name1', map('old', X'48656C6C6F'))")
+
+      sql("CREATE TABLE s (id INT, pictures MAP<STRING, BINARY>)")
+      sql("INSERT INTO s VALUES (1, map('new', X'4E4557'))")
+
+      val e = intercept[UnsupportedOperationException] {
+        sql("""
+              |MERGE INTO t
+              |USING s
+              |ON t.id = s.id
+              |WHEN MATCHED THEN UPDATE SET t.pictures = s.pictures
+              |""".stripMargin)
+      }
+      assert(e.getMessage.contains("MAP<X, BLOB>"))
+    }
+  }
+
   test("Blob: merge-into updates raw-data BLOB column to null") {
     withTable("s", "s2", "t") {
       sql("CREATE TABLE t (id INT, name STRING, picture BINARY) TBLPROPERTIES " +


### PR DESCRIPTION
### Purpose
Supports writing Map<X, Blob> in BlobFormatTable, following https://github.com/apache/paimon/pull/8181

This PR only focus on Blob File Format of Java and Python module, keeping this PR reasonably small.
This PR DO NOT involes:

1. end-to-end support of Map<X, Blob> Type
2. Spark/Flink MergeInto support

Key Changes:
1. extract a new BlobElementSerializer to deal with blob elements: raw, array and map
2. implement BlobElementSerializer for Map<X, Blob>, where `X` only supports some simple non-nested type: String and Int family.

### Tests
See unit tests