### PR TITLE
[python] Make write_pandas respect write_cols and add to_duckdb parallelism

### DIFF
--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -522,11 +522,19 @@ class TableRead:
         return arrow_table.to_pandas()
 
     def to_duckdb(self, splits: List[Split], table_name: str,
-                  connection: Optional["DuckDBPyConnection"] = None) -> "DuckDBPyConnection":
+                  connection: Optional["DuckDBPyConnection"] = None,
+                  parallelism: Optional[int] = None,
+                  blob_parallelism: Optional[int] = None) -> "DuckDBPyConnection":
+        """Materialize ``splits`` into an in-memory table registered with DuckDB.
+
+        See :meth:`to_arrow` for the semantics of ``parallelism`` and
+        ``blob_parallelism``.
+        """
         import duckdb
 
         con = connection or duckdb.connect(database=":memory:")
-        con.register(table_name, self.to_arrow(splits))
+        con.register(table_name, self.to_arrow(
+            splits, parallelism=parallelism, blob_parallelism=blob_parallelism))
         return con
 
     def to_ray(

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -523,18 +523,15 @@ class TableRead:
 
     def to_duckdb(self, splits: List[Split], table_name: str,
                   connection: Optional["DuckDBPyConnection"] = None,
-                  parallelism: Optional[int] = None,
-                  blob_parallelism: Optional[int] = None) -> "DuckDBPyConnection":
+                  parallelism: Optional[int] = None) -> "DuckDBPyConnection":
         """Materialize ``splits`` into an in-memory table registered with DuckDB.
 
-        See :meth:`to_arrow` for the semantics of ``parallelism`` and
-        ``blob_parallelism``.
+        See :meth:`to_arrow` for the semantics of ``parallelism``.
         """
         import duckdb
 
         con = connection or duckdb.connect(database=":memory:")
-        con.register(table_name, self.to_arrow(
-            splits, parallelism=parallelism, blob_parallelism=blob_parallelism))
+        con.register(table_name, self.to_arrow(splits, parallelism=parallelism))
         return con
 
     def to_ray(

--- a/paimon-python/pypaimon/tests/reader_base_test.py
+++ b/paimon-python/pypaimon/tests/reader_base_test.py
@@ -364,6 +364,44 @@ class ReaderBasicTest(unittest.TestCase):
         expect = pd.DataFrame(self.raw_data)
         pd.testing.assert_frame_equal(actual.reset_index(drop=True), expect.reset_index(drop=True))
 
+    def test_reader_duckDB_parallelism(self):
+        # A dedicated partitioned table with rows across multiple partitions so
+        # scan planning yields >= 2 splits, exercising the real parallel fan-out
+        # path (``_should_run_parallel`` requires parallelism >= 2 AND
+        # splits >= 2).
+        schema = Schema.from_pyarrow_schema(self.pa_schema, partition_keys=['dt'])
+        self.catalog.create_table('default.test_duckdb_parallel', schema, False)
+        table = self.catalog.get_table('default.test_duckdb_parallel')
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_arrow(pa.Table.from_pydict({
+            'user_id': [1, 2, 3, 4, 5, 6],
+            'item_id': [1001, 1002, 1003, 1004, 1005, 1006],
+            'behavior': ['a', 'b', 'c', 'd', 'e', 'f'],
+            'dt': ['p1', 'p1', 'p2', 'p2', 'p3', 'p3'],
+        }, schema=self.pa_schema))
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        read_builder = table.new_read_builder()
+        splits = read_builder.new_scan().plan().splits()
+        self.assertGreaterEqual(len(splits), 2)
+
+        serial = read_builder.new_read().to_duckdb(
+            splits, 'duckdb_serial', parallelism=1)
+        parallel = read_builder.new_read().to_duckdb(
+            splits, 'duckdb_parallel', parallelism=4)
+
+        serial_df = serial.query(
+            "SELECT * FROM duckdb_serial ORDER BY item_id").fetchdf()
+        parallel_df = parallel.query(
+            "SELECT * FROM duckdb_parallel ORDER BY item_id").fetchdf()
+        pd.testing.assert_frame_equal(
+            serial_df.reset_index(drop=True),
+            parallel_df.reset_index(drop=True))
+
     def test_mixed_add_and_delete_entries_compute_stats(self):
         """Test record_count calculation with mixed ADD/DELETE entries in same partition."""
         pa_schema = pa.schema([

--- a/paimon-python/pypaimon/tests/write/table_write_test.py
+++ b/paimon-python/pypaimon/tests/write/table_write_test.py
@@ -587,6 +587,71 @@ class TableWriteTest(unittest.TestCase):
         self.assertTrue(str(e.exception).startswith(
             "Input schema isn't consistent with table schema and write cols."))
 
+    def test_write_pandas_respects_write_cols(self):
+        import pandas as pd
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+            ('score', pa.int64()),
+        ])
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table(
+            'default.test_write_pandas_write_cols', schema, False)
+        table = self.catalog.get_table(
+            'default.test_write_pandas_write_cols')
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write().with_write_type(['id', 'name'])
+        table_commit = write_builder.new_commit()
+        # DataFrame only carries the written subset; missing ``score`` is
+        # padded with null on read.
+        table_write.write_pandas(pd.DataFrame({
+            'id': [1, 2],
+            'name': ['a', 'b'],
+        }))
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        expected = pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['a', 'b'],
+            'score': [None, None],
+        }, schema=pa_schema)
+        actual = self._read_sorted(table, 'id')
+        self.assertEqual(expected, actual)
+
+    def test_write_pandas_full_columns_unchanged(self):
+        import pandas as pd
+
+        pa_schema = pa.schema([
+            ('id', pa.int32()),
+            ('name', pa.string()),
+        ])
+        schema = Schema.from_pyarrow_schema(pa_schema)
+        self.catalog.create_table(
+            'default.test_write_pandas_full', schema, False)
+        table = self.catalog.get_table('default.test_write_pandas_full')
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        table_write.write_pandas(pd.DataFrame({
+            'id': [1, 2],
+            'name': ['a', 'b'],
+        }))
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+
+        expected = pa.Table.from_pydict({
+            'id': [1, 2],
+            'name': ['a', 'b'],
+        }, schema=pa_schema)
+        actual = self._read_sorted(table, 'id')
+        self.assertEqual(expected, actual)
+
     def test_validate_schema_allows_binary_family_for_write_cols(self):
         pa_schema = pa.schema([
             ('id', pa.int32()),

--- a/paimon-python/pypaimon/write/table_write.py
+++ b/paimon-python/pypaimon/write/table_write.py
@@ -75,7 +75,14 @@ class TableWrite:
         self.file_store_write.write_row(partition, bucket, row, values_by_name)
 
     def write_pandas(self, dataframe):
-        pa_schema = PyarrowFieldParser.from_paimon_schema(self.table.table_schema.fields)
+        write_cols = self.file_store_write.write_cols
+        if write_cols is not None:
+            # Column-subset write (append-only ``with_write_type``): build the
+            # RecordBatch against the subset schema so the input only needs the
+            # written columns, mirroring the ``write_arrow`` path.
+            pa_schema = self._write_cols_pyarrow_schema(write_cols)
+        else:
+            pa_schema = self.table_pyarrow_schema
         record_batch = pa.RecordBatch.from_pandas(dataframe, schema=pa_schema)
         return self.write_arrow_batch(record_batch)
 


### PR DESCRIPTION
### Purpose

Two small pypaimon read/write consistency fixes:

- `write_pandas` built the RecordBatch against the full table schema, so a column-subset write set up via `with_write_type` raised `KeyError` on the missing columns — column-subset writes only worked through `write_arrow`. It now builds the batch against the `write_cols` subset schema when one is set (reusing `_write_cols_pyarrow_schema`, matching the `write_arrow_batch` validation path). Full-column writes are unchanged.
- `to_duckdb` now forwards `parallelism` and `blob_parallelism` to `to_arrow`, matching `to_pandas`/`to_arrow`.

### Tests

New unit/integration tests in `table_write_test.py` (column-subset and full-column `write_pandas`) and `reader_base_test.py` (`to_duckdb` parallel vs serial parity over a multi-split table).