### PR TITLE
[hive] Fix malformed error message for unknown client pool cache key

### DIFF
--- a/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/main/java/org/apache/paimon/hive/pool/CachedClientPool.java
@@ -176,7 +176,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
                         types.add(type);
                         break;
                     default:
-                        throw new RuntimeException("Unknown key element %s" + trimmed);
+                        throw new RuntimeException("Unknown key element " + trimmed);
                 }
             }
         }

--- a/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
+++ b/paimon-hive/paimon-hive-catalog/src/test/java/org/apache/paimon/hive/pool/TestCachedClientPool.java
@@ -42,9 +42,22 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORECONNECTURLKEY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CachedClientPool}. */
 public class TestCachedClientPool {
+
+    @Test
+    public void testExtractKeyUnknownElementErrorMessage() {
+        assertThatThrownBy(
+                        () ->
+                                CachedClientPool.extractKey(
+                                        HiveMetaStoreClient.class.getName(),
+                                        "conf",
+                                        new Configuration()))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Unknown key element conf");
+    }
 
     @Test
     public void testCacheKeyNotSame() {


### PR DESCRIPTION
### Purpose

fix #8638

- `CachedClientPool.extractKey()` threw `new RuntimeException("Unknown key element %s" + trimmed)`; `RuntimeException(String)` does no `%s` substitution, so users saw a garbled message like `Unknown key element %sconf`.
- Reached on a normal misconfiguration: `client-pool-cache.keys=conf` (missing the `conf:` prefix) hits the `switch` default.
- Drop the literal `%s` and concatenate `trimmed` directly. Sibling checks (lines 162-165, 172-175) use `Preconditions.checkArgument` where `%s` is a real placeholder.

### Tests

- Added `TestCachedClientPool#testExtractKeyUnknownElementErrorMessage` asserting the message is exactly `Unknown key element conf` (proves the literal `%s` is gone).
- `mvn -pl paimon-hive/paimon-hive-catalog clean install` (JDK 11) passed: checkstyle, spotless, rat, and `TestCachedClientPool` (14 tests) green.
