### PR TITLE
[hive] Correct column.name.delimiter property key in HiveSchema

### DIFF
--- a/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
+++ b/paimon-hive/paimon-hive-connector-common/src/main/java/org/apache/paimon/hive/HiveSchema.java
@@ -116,7 +116,7 @@ public class HiveSchema {
                 properties.getProperty(
                         // serdeConstants.COLUMN_NAME_DELIMITER is not defined in earlier Hive
                         // versions, so we use a constant string instead
-                        "column.name.delimite", String.valueOf(SerDeUtils.COMMA));
+                        "column.name.delimiter", String.valueOf(SerDeUtils.COMMA));
 
         List<String> columnNames = Arrays.asList(columnProperty.split(columnNameDelimiter));
         String columnTypes =

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveTableSchemaTest.java
@@ -102,6 +102,29 @@ public class HiveTableSchemaTest {
     }
 
     @Test
+    public void testExtractSchemaWithCustomColumnNameDelimiter() {
+        // Column names are split with a custom delimiter (not the default comma).
+        // This requires the "column.name.delimiter" property key to be honored.
+        List<String> columns = Arrays.asList("a", "b", "c");
+        Properties properties = new Properties();
+        properties.setProperty("columns", String.join(";", columns));
+        properties.setProperty("column.name.delimiter", ";");
+        properties.setProperty(
+                "columns.types",
+                String.join(
+                        ":",
+                        Arrays.asList(
+                                TypeInfoFactory.intTypeInfo.getTypeName(),
+                                TypeInfoFactory.stringTypeInfo.getTypeName(),
+                                TypeInfoFactory.getDecimalTypeInfo(5, 3).getTypeName())));
+        properties.setProperty("columns.comments", "\0\0");
+        properties.setProperty("location", tempDir.toString());
+
+        HiveSchema schema = HiveSchema.extract(null, properties);
+        assertThat(schema.fieldNames()).isEqualTo(columns);
+    }
+
+    @Test
     public void testExtractSchemaWithExistsDDLAndExistsPaimonTable() throws Exception {
         // create a paimon table
         createSchema();


### PR DESCRIPTION
### Purpose

fix #8640

- `HiveSchema.extract()` read the Hive column-name delimiter with a misspelled key `"column.name.delimite"` (missing trailing `r`), so a custom `column.name.delimiter` was ignored and column names were always split on the default comma.
- Correct the key to `"column.name.delimiter"`, matching Hive's `serdeConstants.COLUMN_NAME_DELIMITER`.
- Completes merged PR #8545, which fixed the same key in the sibling `PaimonRecordReader.getHiveColumns()` (`mapred/PaimonRecordReader.java`) but missed `HiveSchema`.

### Tests

- Added `HiveTableSchemaTest#testExtractSchemaWithCustomColumnNameDelimiter` splitting `a;b;c` with delimiter `;` and asserting field names `[a, b, c]`; fails before the fix (single field), passes after.
- `mvn -pl paimon-hive/paimon-hive-connector-common test` passed.
