### PR TITLE
[hive] Fix Hive timestamp mapped to Paimon millisecond precision

### DIFF
--- a/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
+++ b/paimon-hive/paimon-hive-common/src/main/java/org/apache/paimon/hive/HiveTypeUtils.java
@@ -310,7 +310,7 @@ public class HiveTypeUtils {
             } else if (TypeInfoFactory.dateTypeInfo.equals(atomic)) {
                 return DataTypes.DATE();
             } else if (TypeInfoFactory.timestampTypeInfo.equals(atomic)) {
-                return DataTypes.TIMESTAMP_MILLIS();
+                return DataTypes.TIMESTAMP();
             }
 
             throw new UnsupportedOperationException(

--- a/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/HiveTypeUtilsTest.java
+++ b/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/HiveTypeUtilsTest.java
@@ -20,8 +20,11 @@ package org.apache.paimon.hive;
 
 import org.apache.paimon.types.CharType;
 import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.IntType;
+import org.apache.paimon.types.LocalZonedTimestampType;
+import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
@@ -103,5 +106,24 @@ public class HiveTypeUtilsTest {
         TypeInfo timestampWithLocalZoneTypeInfo =
                 HiveTypeUtils.toTypeInfo(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE());
         assertThat(timestampWithLocalZoneTypeInfo.getTypeName()).isEqualTo("timestamp");
+    }
+
+    @Test
+    public void testToPaimonTypeTimestampPrecision() {
+        // Hive `timestamp` maps to Paimon TIMESTAMP with the default precision, not the
+        // millisecond precision (3) which silently truncates sub-millisecond values when a
+        // Hive schema is inferred into Paimon (migrate/clone/CREATE via Hive).
+        DataType timestamp = HiveTypeUtils.toPaimonType("timestamp");
+        assertThat(timestamp).isEqualTo(DataTypes.TIMESTAMP());
+        assertThat(((TimestampType) timestamp).getPrecision())
+                .isEqualTo(TimestampType.DEFAULT_PRECISION);
+
+        // Parity: the sibling local-zoned timestamp reverse path returns
+        // DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(), which carries the same default
+        // precision (SparkTypeUtils maps timestamp to precision 6 as well).
+        assertThat(((TimestampType) timestamp).getPrecision())
+                .isEqualTo(LocalZonedTimestampType.DEFAULT_PRECISION);
+        assertThat(((TimestampType) timestamp).getPrecision())
+                .isEqualTo(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE().getPrecision());
     }
 }

--- a/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
+++ b/paimon-hive/paimon-hive-connector-common/src/test/java/org/apache/paimon/hive/HiveCatalogFormatTableITCaseBase.java
@@ -213,7 +213,7 @@ public abstract class HiveCatalogFormatTableITCaseBase {
         assertThat(descResult)
                 .containsExactly(
                         "+I[a, INT, true, null, null, null, comment a]",
-                        "+I[b, TIMESTAMP(3), true, null, null, null, comment b]");
+                        "+I[b, TIMESTAMP(6), true, null, null, null, comment b]");
         hiveShell.execute(
                 String.format(
                         "INSERT INTO %s VALUES (1, '2025-03-17 10:15:30'), (2, '2025-03-18 10:15:30')",


### PR DESCRIPTION

### Purpose

fix #8642

- `HiveTypeUtils.HiveToPaimonTypeVisitor.atomic()` mapped Hive `timestamp` to `DataTypes.TIMESTAMP_MILLIS()` (precision 3), silently truncating sub-millisecond values when a Hive schema is inferred into Paimon (migrate/clone/CREATE via Hive).
- Change it to `DataTypes.TIMESTAMP()` (default precision 6) for parity with the same-file local-zoned reverse path (`TIMESTAMP_WITH_LOCAL_TIME_ZONE()`, precision 6) and `SparkTypeUtils.java:436` (`new TimestampType()`, precision 6).
- Existing persisted schemas are unchanged — only newly inferred migrate/clone/CREATE schemas move from precision 3 to 6.

### Tests

- Added `HiveTypeUtilsTest#testToPaimonTypeTimestampPrecision` asserting `toPaimonType("timestamp")` equals `DataTypes.TIMESTAMP()` and its precision equals the local-zoned reverse-path precision.
- `mvn -pl paimon-hive/paimon-hive-common -am clean install` (JDK 11) — HiveTypeUtilsTest: 2 tests passed.


