### PR TITLE
[hive] Fix timestamp inspector for pre-epoch timestamps in Hive 3.1

### DIFF
--- a/paimon-hive/paimon-hive-connector-3.1/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspector.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/main/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspector.java
@@ -40,7 +40,10 @@ public class PaimonTimestampObjectInspector extends AbstractPrimitiveJavaObjectI
 
         org.apache.paimon.data.Timestamp timestamp = (org.apache.paimon.data.Timestamp) o;
         long millis = timestamp.getMillisecond();
-        int nanos = (int) (millis % 1000 * 1_000_000) + timestamp.getNanoOfMillisecond();
+        // Math.floorMod keeps the sub-second nanos in [0, 999_999_999] for negative (pre-1970)
+        // millis too, so Hive's Timestamp.ofEpochMilli does not reject a negative nano-of-second.
+        int nanos =
+                (int) (Math.floorMod(millis, 1000L) * 1_000_000) + timestamp.getNanoOfMillisecond();
         return Timestamp.ofEpochMilli(millis, nanos);
     }
 

--- a/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspectorTest.java
+++ b/paimon-hive/paimon-hive-connector-3.1/src/test/java/org/apache/paimon/hive/objectinspector/PaimonTimestampObjectInspectorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.hive.objectinspector;
+
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PaimonTimestampObjectInspector}. */
+public class PaimonTimestampObjectInspectorTest {
+
+    /**
+     * Builds the expected Hive {@link Timestamp} from a {@link LocalDateTime} through an
+     * independent path (epoch-second + nano-of-second, both interpreted at UTC just like Hive's
+     * {@code ofEpochSecond}), so the assertion is derived rather than a copy of the production
+     * arithmetic under test.
+     */
+    private static Timestamp hiveTimestampOf(LocalDateTime localDateTime) {
+        Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+        return Timestamp.ofEpochSecond(instant.getEpochSecond(), instant.getNano());
+    }
+
+    @Test
+    public void testGetPrimitiveJavaObjectPreEpochWithFraction() {
+        PaimonTimestampObjectInspector oi = new PaimonTimestampObjectInspector();
+
+        // Pre-1970 value with a fractional second: Paimon stores a negative millisecond, so the
+        // old `millis % 1000` produced a negative nano-of-second and Hive's ofEpochMilli threw
+        // DateTimeException. This must now round-trip without throwing.
+        LocalDateTime localDateTime = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 500_000_000);
+        org.apache.paimon.data.Timestamp input =
+                org.apache.paimon.data.Timestamp.fromLocalDateTime(localDateTime);
+
+        assertThat(oi.getPrimitiveJavaObject(input)).isEqualTo(hiveTimestampOf(localDateTime));
+    }
+
+    @Test
+    public void testGetPrimitiveJavaObjectPostEpochWithFraction() {
+        PaimonTimestampObjectInspector oi = new PaimonTimestampObjectInspector();
+
+        // Post-1970 fractional value: positive path is unchanged by the fix.
+        LocalDateTime localDateTime = LocalDateTime.of(2023, 1, 2, 3, 4, 5, 123_456_789);
+        org.apache.paimon.data.Timestamp input =
+                org.apache.paimon.data.Timestamp.fromLocalDateTime(localDateTime);
+
+        assertThat(oi.getPrimitiveJavaObject(input)).isEqualTo(hiveTimestampOf(localDateTime));
+    }
+
+    @Test
+    public void testGetPrimitiveJavaObjectNull() {
+        PaimonTimestampObjectInspector oi = new PaimonTimestampObjectInspector();
+
+        assertThat(oi.getPrimitiveJavaObject(null)).isNull();
+    }
+}


### PR DESCRIPTION
### Purpose

fix #8644

- `PaimonTimestampObjectInspector.getPrimitiveJavaObject()` (Hive 3.1) computed nano-of-second with `millis % 1000`, negative for pre-1970 timestamps that Paimon stores as a negative `millisecond`.
- The negative `nanos` made Hive 3.1 `Timestamp.ofEpochMilli(long,int)` throw `DateTimeException` via `LocalDateTime.withNano`, so a valid `SELECT` of a pre-epoch fractional TIMESTAMP crashed.
- Use `Math.floorMod(millis, 1000L)` to keep sub-second nanos in `[0, 999_999_999]`; the positive path is unchanged (`floorMod == %` for non-negative millis).
- Matches `paimon-hive-connector-common`, which delegates to `java.sql.Timestamp` and already handles negative millis.

### Tests

- Added `PaimonTimestampObjectInspectorTest` covering the pre-epoch regression, the unchanged post-1970 path, and null; expected Hive `Timestamp` values are derived from the source `LocalDateTime` via an independent epoch-second path.
- `mvn -pl paimon-hive/paimon-hive-connector-3.1 clean install` (JDK 11) — 3 new unit tests pass, checkstyle/spotless/rat clean. The module `*ITCase` tests need a HiveServer and are covered by CI.
