### PR TITLE
[core] Support full-text search for primary-key tables

### DIFF
--- a/docs/designs/2026-07-15-pk-full-text-lsm.md
+++ b/docs/designs/2026-07-15-pk-full-text-lsm.md
@@ -1,0 +1,86 @@
+# Primary-Key Full-Text LSM Maintenance Design
+
+## Problem Statement
+
+Primary-key full-text indexes currently maintain one immutable archive for every eligible compact
+data file. This keeps writes incremental, but the number of archives and query fan-out can grow
+with the compaction history. Full-text maintenance should use the same logical LSM policy as the
+primary-key vector and sorted indexes so that similarly sized archives are consolidated and stale
+sources are reclaimed incrementally.
+
+## Chosen Approach
+
+Build multi-source full-text archives from the active compact data files selected by
+`PrimaryKeyIndexLevels`. Do not add a native archive-merge API. A merge rebuild reads the selected
+active source files in deterministic order, concatenates their physical row positions into one
+archive row-id space, and atomically replaces the selected input archives.
+
+The implementation reuses the existing per-column primary-key index compaction options:
+
+- `fields.<column>.pk-index.compaction.level-fanout`
+- `fields.<column>.pk-index.compaction.stale-ratio-threshold`
+
+No `index.type` option or full-text-specific compaction option is added.
+
+## Design Details
+
+### Multi-Source Archive Format
+
+`PrimaryKeyIndexSourceMeta.sourceFiles()` stores the ordered source files covered by an archive.
+The native archive row-id space is the concatenation of those files: the first file starts at zero
+and every following file starts at the cumulative row count of its predecessors. Existing
+single-source archives remain valid one-unit LSM segments and require no metadata migration.
+
+`PkFullTextIndexFile` accepts ordered sources, validates each reader row count, writes all rows
+with cumulative row IDs, and records the complete ordered source list plus the existing definition
+fingerprint.
+
+### LSM Maintenance
+
+`BucketedFullTextIndexMaintainer` maintains active source files and active archive segments. It:
+
+1. builds one archive for uncovered active sources;
+2. uses `PrimaryKeyIndexLevels<IndexFileMeta>` to select similarly sized or stale archives;
+3. rebuilds the selected active sources asynchronously;
+4. accepts a completed build only when all sources and input segments are still active and the
+   output does not overlap retained segments;
+5. publishes the new archive and retires its input archives in the same snapshot increment;
+6. restores state and deletes generated unpublished output if commit preparation aborts.
+
+The maintainer follows the existing Vector/Sorted `waitCompaction` behavior and exposes pending
+maintenance through the bucket coordinator.
+
+### State Restoration
+
+`PkFullTextBucketIndexState` accepts one or more ordered sources per current-definition archive,
+maps every source file to its owning archive, rejects overlapping coverage, and classifies archives
+with old definition fingerprints as stale. Active archive validation checks source row counts and
+the full concatenated row range.
+
+### Search and Deletion Vectors
+
+For every archive, search builds one include bitmap in archive-global row IDs. Each source file's
+live positions are shifted by its cumulative archive offset. Returned archive row IDs are mapped
+back to `(sourceFile, localRowPosition)` with the same ordered ranges. Deletion-vector filtering
+therefore happens before the archive-local Top-K, as it does for single-source archives.
+
+Archive-local rankings continue to be fused with RRF across active archive segments. Score and tie
+ordering remain unchanged.
+
+### Validation and Documentation
+
+Full-text columns participate in validation of the shared primary-key index compaction options.
+The primary-key full-text documentation describes multi-source LSM maintenance, asynchronous
+visibility, compatibility with single-source archives, and the shared tuning options.
+
+## Open Questions
+
+None for the first implementation. Binary native archive merging can be evaluated separately if
+source-file rebuild cost becomes a demonstrated bottleneck.
+
+## Out of Scope
+
+- Native full-text archive binary merging.
+- More than one primary-key full-text column per table.
+- Changes to Python APIs.
+- Changes to `index.type` selection.

--- a/docs/docs/flink/procedures.md
+++ b/docs/docs/flink/procedures.md
@@ -1141,6 +1141,35 @@ All available procedures are listed below.
       </td>
    </tr>
    <tr>
+      <td>full_text_search</td>
+      <td>
+         CALL [catalog.]sys.full_text_search(<br/>
+            `table` => 'identifier',<br/>
+            `column` => 'columnName',<br/>
+            query => 'queryJson',<br/>
+            top_k => topK,<br/>
+            projection => 'col1,col2,__paimon_search_score',<br/>
+            options => 'key1=value1;key2=value2')<br/>
+      </td>
+      <td>
+         To perform full-text search on a table and return deterministically ordered JSON rows. Arguments:
+            <li>table(required): the target table identifier.</li>
+            <li>column(required): the character column to search.</li>
+            <li>query(required): native full-text query JSON.</li>
+            <li>top_k(required): the maximum number of results, from 1 through 10,000.</li>
+            <li>projection(optional): comma-separated result columns. Add <code>__paimon_search_score</code> to return the primary-key RRF score.</li>
+            <li>options(optional): additional dynamic options of the table. The query authorization setting cannot be overridden.</li>
+      </td>
+      <td>
+         CALL sys.full_text_search(<br/>
+            `table` => 'default.articles',<br/>
+            `column` => 'content',<br/>
+            query => '{"match":{"query":"paimon lake"}}',<br/>
+            top_k => 10,<br/>
+            projection => 'id,title,__paimon_search_score')
+      </td>
+   </tr>
+   <tr>
       <td>vector_search</td>
       <td>
          CALL [catalog.]sys.vector_search(<br/>

--- a/docs/docs/primary-key-table/full-text-index.md
+++ b/docs/docs/primary-key-table/full-text-index.md
@@ -1,0 +1,257 @@
+---
+title: "Full-Text Index"
+sidebar_position: 10
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Full-Text Index
+
+Primary-key tables can maintain a bucket-local full-text index together with compacted data. The
+index follows the primary-key table's write and compaction lifecycle and maps search results back
+to physical rows in compact-output files. It is different from a global full-text index created by
+`create_global_index`, which uses global row IDs and is built separately from normal writes.
+
+Use a primary-key full-text index when indexed text can be updated or deleted and search results
+must follow the table's deletion vectors. For append-only or Data Evolution tables, see
+[Global Index](../multimodal-table/global-index).
+
+## Requirements
+
+A table with a primary-key full-text index must satisfy all of the following:
+
+- It is a primary-key table in fixed-bucket mode (`bucket > 0`) or postpone-bucket mode
+  (`bucket = -2`).
+- The indexed column is `CHAR`, `VARCHAR`, or `STRING`.
+- Exactly one full-text column is configured in the first release.
+- `deletion-vectors.enabled` is `true` and `deletion-vectors.merge-on-read` is `false`, except for
+  the `first-row` merge engine, where deletion vectors must remain disabled.
+- `pk-clustering-override` is disabled.
+- The `paimon-full-text` module and its native `paimon-full-text-index` dependency are available on
+  every writer, compactor, and reader classpath.
+
+A column can belong to only one source-backed primary-key index family. For example, the same
+column cannot own both a primary-key Bitmap index and a primary-key full-text index.
+
+## Create Table
+
+The full-text implementation is selected automatically. Configure the indexed column and,
+optionally, its analyzer settings.
+
+The following Flink SQL example uses the `jieba` tokenizer:
+
+```sql
+CREATE TABLE articles (
+    id BIGINT,
+    title STRING,
+    content STRING,
+    PRIMARY KEY (id) NOT ENFORCED
+) WITH (
+    'bucket' = '16',
+    'deletion-vectors.enabled' = 'true',
+    'pk-full-text.index.columns' = 'content',
+    'fields.content.pk-full-text.index.options' = '{"tokenizer":"jieba"}'
+);
+```
+
+Use the same properties in Spark SQL:
+
+```sql
+CREATE TABLE articles (
+    id BIGINT,
+    title STRING,
+    content STRING
+) USING paimon
+TBLPROPERTIES (
+    'primary-key' = 'id',
+    'bucket' = '16',
+    'deletion-vectors.enabled' = 'true',
+    'pk-full-text.index.columns' = 'content',
+    'fields.content.pk-full-text.index.options' =
+        '{"tokenizer":"jieba"}'
+);
+```
+
+### Options
+
+| Option | Required | Description |
+|---|---|---|
+| `pk-full-text.index.columns` | Yes | Indexed character column. Exactly one column is supported in the first release. |
+| `fields.<column>.pk-full-text.index.options` | No | JSON object containing native full-text analyzer options. Keys may omit the `full-text.` prefix. |
+| `fields.<column>.pk-index.compaction.level-fanout` | No | Number of similarly sized full-text archive groups which triggers an LSM rebuild and maximum row-count ratio within one size tier. Shared by source-backed primary-key indexes. Default: `5`. |
+| `fields.<column>.pk-index.compaction.stale-ratio-threshold` | No | Ratio of rows from inactive source files which triggers an archive rebuild. Shared by source-backed primary-key indexes. Default: `0.2`. |
+| `global-index.search-mode` | No | Coverage policy for search. `fast` is the default; `full` and `detail` also search uncovered compaction-visible files through temporary indexes. |
+| `global-index.thread-num` | No | Maximum concurrency shared by full-text index reads and temporary fallback builds. |
+
+Analyzer options can also be supplied as table-level `full-text.*` properties. A conflicting
+table-level and field-scoped value is rejected so that the effective index definition remains
+deterministic. Common settings include:
+
+| Analyzer option | Default | Description |
+|---|---|---|
+| `tokenizer` | `default` | `default`, `simple`, `whitespace`, `raw`, `ngram`, or `jieba`. |
+| `ngram.min-gram` | `2` | Minimum gram length for the `ngram` tokenizer. |
+| `ngram.max-gram` | `2` | Maximum gram length for the `ngram` tokenizer. |
+| `lower-case` | `true` | Whether configurable tokenizers lowercase emitted tokens. |
+| `stem` | `false` | Whether to apply stemming. |
+| `remove-stop-words` | `false` | Whether to remove built-in stop words for the configured language. |
+| `with-position` | `true` | Whether to store term positions for phrase queries. |
+
+See the [`paimon-full-text` README](https://github.com/apache/paimon/blob/master/paimon-full-text/README.md)
+for the complete native analyzer option list.
+
+## Index Maintenance and Visibility
+
+Paimon initially builds an immutable full-text archive for uncovered complete compact-output data
+files. An eligible source must have `COMPACT` source metadata and a level greater than zero. It then
+uses the same logical LSM policy as the primary-key Vector, BTree, and Bitmap indexes to consolidate
+similarly sized archives and rebuild archives containing too many inactive sources. Consolidation
+re-reads the selected active data files; it does not merge native archive bytes.
+
+An archive therefore covers one or more ordered source files. Its native row-ID space concatenates
+their physical positions: each source starts at the cumulative row count of the sources before it.
+Every physical row consumes an ordinal, including a row whose indexed value is null; null text is
+not added to the native term index. Existing single-source archives remain compatible.
+
+The data-file and archive changes are committed atomically. Updates and deletes are filtered with
+each source file's deletion vector after shifting its live positions into the archive-global row-ID
+space, so old physical versions do not reappear in search results. When compaction replaces a
+source file, maintenance first indexes uncovered replacement files and incrementally reclaims stale
+archive sources according to the configured threshold. Builds may run asynchronously when the
+calling write does not wait for index compaction; a later snapshot publishes the completed archive.
+
+This is a **compaction-visible** index:
+
+- Level-0 files created by foreground writes are not full-text sources, even when normal fixed-
+  bucket reads can already see those rows.
+- Rows become searchable after compaction publishes a complete level-1-or-higher output and its
+  archive.
+- Postpone-bucket writes remain pending until the batch compaction publishes them in a real bucket.
+- `full` and `detail` coverage do not make level-0 files eligible. They only cover eligible compact
+  files whose persistent archive is missing.
+
+Choose the search mode according to the required latency and coverage:
+
+- `fast`: search only persistent archives. This has the lowest query-time cost and is the default.
+- `full` or `detail`: build temporary per-file native archives for uncovered compaction-visible
+  files, search them with the same effective analyzer options, and delete them when the query
+  finishes. Both modes have the same fallback behavior for primary-key full-text search.
+
+## Search
+
+The native engine ranks matches within each archive segment. Paimon maps archive-global row IDs
+back to source-file positions, combines segment-local rankings with reciprocal-rank fusion (RRF),
+and applies the requested global Top-K. Therefore,
+`__paimon_search_score` is a deterministic synthetic RRF score, not the original native BM25
+score. Deletion-vector filtering happens before each segment-local Top-K.
+
+### Spark SQL
+
+Use the `full_text_search` table-valued function:
+
+```sql
+SELECT id, title, __paimon_search_score
+FROM full_text_search(
+    'articles',
+    'content',
+    '{"match":{"query":"paimon lake"}}',
+    10
+)
+ORDER BY __paimon_search_score DESC;
+```
+
+For partitioned tables, Spark can push a partition predicate before full-text ranking. Non-
+partition filters cannot be pushed before Top-K and are not supported on a full-text route.
+
+### Flink SQL
+
+Flink exposes the same search as a procedure. Each returned procedure row contains a JSON object.
+Add `__paimon_search_score` to `projection` when the RRF score is needed.
+
+```sql
+CALL sys.full_text_search(
+    `table` => 'default.articles',
+    `column` => 'content',
+    query => '{"match":{"query":"paimon lake"}}',
+    top_k => 10,
+    projection => 'id,title,__paimon_search_score'
+);
+```
+
+The optional `options` argument applies dynamic table options to this search, but it cannot
+override the table's query authorization setting. `top_k` must be between 1 and 10,000. Results are
+ordered by score descending, with deterministic JSON ordering for ties.
+
+### Java API
+
+```java
+GlobalIndexResult result = table.newFullTextSearchBuilder()
+        .withQuery("content", "{\"match\":{\"query\":\"paimon lake\"}}")
+        .withLimit(10)
+        .executeLocal();
+
+ReadBuilder readBuilder = table.newReadBuilder();
+TableScan.Plan plan = readBuilder.newScan()
+        .withGlobalIndexResult(result)
+        .plan();
+try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+    reader.forEachRemaining(row -> consume(row));
+}
+```
+
+## Hybrid Search
+
+Spark `hybrid_search` can fuse primary-key vector and full-text routes by physical data-file
+position when both indexes belong to the same table snapshot. The ranker may be `rrf`,
+`weighted_score`, or `mrr`; route weights must be positive.
+
+```sql
+SELECT id, __paimon_search_score
+FROM hybrid_search(
+    'articles',
+    array(named_struct(
+        'field', 'embedding',
+        'query_vector', array(0.1f, 0.2f, 0.3f),
+        'limit', 20,
+        'weight', 1.0f,
+        'options', map())),
+    array(named_struct(
+        'column', 'content',
+        'query', '{"match":{"query":"paimon lake"}}',
+        'limit', 20,
+        'weight', 1.0f,
+        'options', map())),
+    10,
+    'rrf'
+)
+ORDER BY __paimon_search_score DESC;
+```
+
+Hybrid search cannot mix physical primary-key routes with global row-ID routes. A full-text hybrid
+route supports partition filters but not non-partition filters before ranking. See
+[Vector Index](vector-index) for primary-key vector maintenance and search behavior.
+
+## Limitations
+
+- Exactly one primary-key full-text column is supported per table in the first release.
+- Dynamic-bucket and `pk-clustering-override` tables are not supported.
+- Search is snapshot-scoped batch reading; streaming and lateral full-text search are not
+  supported.
+- Foreground level-0 files are outside full-text coverage until compaction, in every search mode.
+- Full-text routes support partition pruning but not arbitrary row predicates before Top-K.
+- Writers, compactors, and readers all require the native full-text implementation.

--- a/docs/docs/primary-key-table/vector-index.md
+++ b/docs/docs/primary-key-table/vector-index.md
@@ -103,8 +103,8 @@ The vector comment directive converts the SQL `ARRAY<FLOAT>` column to Paimon's 
 | `fields.<column>.pk-vector.index.type` | Yes | ANN implementation, such as `ivf-flat`, `ivf-pq`, `ivf-hnsw-flat`, `ivf-hnsw-sq`, or `lumina`. |
 | `fields.<column>.pk-vector.distance.metric` | No | `l2`, `cosine`, or `inner_product`. The default is `inner_product`. |
 | `fields.<column>.pk-vector.index.options` | No | JSON object containing build options for the selected ANN implementation. Unqualified keys are scoped to that implementation. |
-| `fields.<column>.pk-index.compaction.level-fanout` | No | Number of similarly sized index groups which triggers a rebuild and maximum row-count ratio within one size tier. Shared by vector, BTree, and Bitmap primary-key indexes. Default: `5`. |
-| `fields.<column>.pk-index.compaction.stale-ratio-threshold` | No | Ratio of rows from inactive source files which triggers an index rebuild. Shared by vector, BTree, and Bitmap primary-key indexes. Default: `0.2`. |
+| `fields.<column>.pk-index.compaction.level-fanout` | No | Number of similarly sized index groups which triggers a rebuild and maximum row-count ratio within one size tier. Shared by vector, full-text, BTree, and Bitmap primary-key indexes. Default: `5`. |
+| `fields.<column>.pk-index.compaction.stale-ratio-threshold` | No | Ratio of rows from inactive source files which triggers an index rebuild. Shared by vector, full-text, BTree, and Bitmap primary-key indexes. Default: `0.2`. |
 
 For algorithm-specific build and search options, see
 [Vector Index](../multimodal-table/global-index/vector).
@@ -146,6 +146,10 @@ level-1 output. Wait for that compaction when read-after-write vector-search vis
 required. Batch writes which wait for compaction can publish the data and its index together.
 
 ## Search
+
+Primary-key vector routes can be combined with primary-key full-text routes by physical row
+position. See [Full-Text Index](full-text-index#hybrid-search) for the Spark `hybrid_search`
+syntax, score-fusion semantics, and filter restrictions.
 
 ### Exact Rerank
 

--- a/docs/plans/2026-07-15-pk-full-text-lsm.md
+++ b/docs/plans/2026-07-15-pk-full-text-lsm.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Primary-Key Full-Text LSM Maintenance
+
+## Prerequisites
+
+- [x] Work on `codex/pk-fulltext`; preserve the existing uncommitted PK full-text changes.
+- [x] Use JDK 8 syntax and the detached verification worktree at
+      `/tmp/paimon-pk-fulltext-verify-20260715`.
+- [x] Follow RED-GREEN-REFACTOR for every production change.
+
+## Tasks
+
+### Task 1: Validate shared LSM options for full-text definitions
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/schema/PrimaryKeyFullTextIndexValidationTest.java`
+  - `paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java`
+  - `paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainer.java`
+- **Changes**: Replace the existing assertion that full text ignores LSM options with validation
+  tests; verify resolved fanout/stale threshold; pass both values into the full-text maintainer.
+- **Verify**: Run the two test classes; expect all tests to pass.
+- **Dependencies**: None.
+
+### Task 2: Build one archive from ordered multiple source files
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFileTest.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFile.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexBuilder.java`
+- **Changes**: Add a lazy source abstraction, concatenate source ordinals, validate row counts, and
+  serialize ordered multi-source metadata while retaining the single-source entry point.
+- **Verify**: Run `PkFullTextIndexFileTest`; expect all tests to pass.
+- **Dependencies**: Task 1.
+
+### Task 3: Restore and validate multi-source archive state
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexStateTest.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexState.java`
+- **Changes**: Accept multi-source archives, validate cumulative row metadata, map every source to
+  its archive, reject overlapping coverage, and retain old-fingerprint retirement.
+- **Verify**: Run `PkFullTextBucketIndexStateTest`; expect all tests to pass.
+- **Dependencies**: Task 2.
+
+### Task 4: Add shared level selection and incremental archive replacement
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainerTest.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainer.java`
+- **Changes**: Replace per-file concurrent builds with one asynchronous pending build over ordered
+  sources, use `PrimaryKeyIndexLevels<IndexFileMeta>` for fanout/stale selection, atomically replace
+  inputs, and preserve cancellation, retry, and rollback semantics.
+- **Verify**: Run `BucketedFullTextIndexMaintainerTest`; expect uncovered, fanout, stale, async, and
+  abort tests to pass.
+- **Dependencies**: Tasks 2-3.
+
+### Task 5: Map search and deletion vectors across archive source ranges
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearchTest.java`
+  - `paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearch.java`
+- **Changes**: Shift per-file live-row bitmaps into archive-global offsets and map scored results
+  back to local file positions before RRF.
+- **Verify**: Run `PrimaryKeyFullTextBucketSearchTest`; expect multi-source DV and ranking tests to
+  pass.
+- **Dependencies**: Task 3.
+
+### Task 6: Verify coordinator lifecycle and compatibility
+
+- **Files**:
+  - `paimon-core/src/test/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainerTest.java`
+  - `paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexWriteTest.java`
+- **Changes**: Cover factory option propagation, non-blocking LSM completion, snapshot increment
+  routing, and restoration from existing single-source archives.
+- **Verify**: Run both test classes; expect all tests to pass.
+- **Dependencies**: Tasks 1-5.
+
+### Task 7: Update documentation and run the regression matrix
+
+- **Files**:
+  - `docs/docs/primary-key-table/full-text-index.md`
+  - `docs/docs/primary-key-table/vector-index.md`
+  - relevant changed tests and sources above
+- **Changes**: Document multi-source LSM maintenance and shared options; run core, Spark 3/4, Flink
+  1/2, formal compile, Spotless, and `git diff --check`.
+- **Verify**:
+  - Core full-text/PK-index test set passes.
+  - Spark 3 and Spark 4 full-text/hybrid suites pass.
+  - Flink 1 and Flink 2 `FullTextSearchProcedureITCase` pass.
+  - JDK 8 non-fast `paimon-core,paimon-full-text` compile passes.
+- **Dependencies**: Tasks 1-6.
+
+## Post-Implementation
+
+- [ ] Run `spotless:check` for API, Core, Full Text, Flink, and Spark modules.
+- [ ] Run `git diff --check` and inspect all untracked files.
+- [ ] Perform a focused code review of LSM state transitions, row-id offsets, and cleanup paths.
+- [ ] Do not stage, commit, push, or open a PR without explicit user instruction.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -85,6 +85,7 @@ const sidebars = {
       "primary-key-table/compaction",
       "primary-key-table/query-performance",
       "primary-key-table/vector-index",
+      "primary-key-table/full-text-index",
       "primary-key-table/chain-table",
       "primary-key-table/pk-clustering-override",
       {

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2755,6 +2755,14 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Comma-separated columns indexed by primary-key Bitmap indexes.");
 
+    public static final ConfigOption<String> PK_FULL_TEXT_INDEX_COLUMNS =
+            key("pk-full-text.index.columns")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Comma-separated character columns indexed by primary-key full-text indexes. "
+                                    + "The first release supports exactly one column.");
+
     @Immutable
     public static final ConfigOption<Boolean> PK_CLUSTERING_OVERRIDE =
             key("pk-clustering-override")
@@ -4287,6 +4295,10 @@ public class CoreOptions implements Serializable {
         return options.getOptional(PK_VECTOR_INDEX_COLUMNS).isPresent();
     }
 
+    public boolean primaryKeyFullTextIndexEnabled() {
+        return options.getOptional(PK_FULL_TEXT_INDEX_COLUMNS).isPresent();
+    }
+
     public int primaryKeyIndexCompactionLevelFanout(String column) {
         return options.getInteger(primaryKeyIndexCompactionLevelFanoutKey(column), 5);
     }
@@ -4315,6 +4327,10 @@ public class CoreOptions implements Serializable {
         return primaryKeyIndexColumns(PK_BITMAP_INDEX_COLUMNS);
     }
 
+    public List<String> primaryKeyFullTextIndexColumns() {
+        return primaryKeyIndexColumns(PK_FULL_TEXT_INDEX_COLUMNS);
+    }
+
     private List<String> primaryKeyIndexColumns(ConfigOption<String> option) {
         String columns = options.get(option);
         if (columns == null) {
@@ -4329,6 +4345,47 @@ public class CoreOptions implements Serializable {
 
     public Options primaryKeyBitmapIndexOptions(String column) {
         return primaryKeySortedIndexOptions(column, "pk-bitmap", "bitmap-index.");
+    }
+
+    public Options primaryKeyFullTextIndexOptions(String column) {
+        String optionKey = "fields." + column + ".pk-full-text.index.options";
+        TreeMap<String, String> resolved = new TreeMap<>();
+        for (Map.Entry<String, String> entry : toConfiguration().toMap().entrySet()) {
+            if (entry.getKey().startsWith("full-text.")) {
+                resolved.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        String serialized = options.get(optionKey);
+        if (serialized == null || serialized.trim().isEmpty()) {
+            return new Options(resolved);
+        }
+
+        LinkedHashMap<String, String> parsed;
+        try {
+            parsed = JsonSerdeUtil.parseJsonMap(serialized, String.class);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                    optionKey + " must be a JSON object of option key-value pairs.", e);
+        }
+
+        for (Map.Entry<String, String> entry : parsed.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            checkArgument(
+                    key != null && !key.trim().isEmpty(),
+                    "%s contains an empty option key.",
+                    optionKey);
+            checkArgument(value != null, "%s value for key %s must not be null.", optionKey, key);
+            String qualifiedKey = key.startsWith("full-text.") ? key : "full-text." + key;
+            String previous = resolved.put(qualifiedKey, value);
+            checkArgument(
+                    previous == null || previous.equals(value),
+                    "%s defines conflicting values for %s.",
+                    optionKey,
+                    qualifiedKey);
+        }
+        return new Options(resolved);
     }
 
     private Options primaryKeySortedIndexOptions(

--- a/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
+++ b/paimon-core/src/main/java/org/apache/paimon/KeyValueFileStore.java
@@ -172,6 +172,7 @@ public class KeyValueFileStore extends AbstractFileStore<KeyValue> {
         }
         BucketedPrimaryKeyIndexMaintainer.Factory primaryKeyIndexMaintainerFactory = null;
         if (options.primaryKeyVectorIndexEnabled()
+                || options.primaryKeyFullTextIndexEnabled()
                 || !options.primaryKeyBTreeIndexColumns().isEmpty()
                 || !options.primaryKeyBitmapIndexColumns().isEmpty()) {
             primaryKeyIndexMaintainerFactory =

--- a/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/IndexFileHandler.java
@@ -25,6 +25,7 @@ import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.deletionvectors.DeletionVectorsIndexFile;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
 import org.apache.paimon.index.pksorted.PkSortedIndexFile;
 import org.apache.paimon.index.pkvector.PkVectorAnnSegmentFile;
 import org.apache.paimon.manifest.IndexManifestEntry;
@@ -88,6 +89,10 @@ public class IndexFileHandler {
 
     public PkVectorAnnSegmentFile pkVectorAnnSegment(BinaryRow partition, int bucket) {
         return new PkVectorAnnSegmentFile(fileIO, pathFactories.get(partition, bucket));
+    }
+
+    public PkFullTextIndexFile pkFullTextIndex(BinaryRow partition, int bucket) {
+        return new PkFullTextIndexFile(fileIO, pathFactories.get(partition, bucket));
     }
 
     public PkSortedIndexFile pkSortedIndex(BinaryRow partition, int bucket) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainer.java
@@ -23,6 +23,10 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pkfulltext.BucketedFullTextIndexMaintainer;
+import org.apache.paimon.index.pkfulltext.PkFullTextDataFileReader;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexBuilder;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
 import org.apache.paimon.index.pksorted.BucketedSortedIndexMaintainer;
 import org.apache.paimon.index.pksorted.PkSortedDataFileReader;
 import org.apache.paimon.index.pksorted.PkSortedIndexBuilder;
@@ -50,13 +54,16 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 public final class BucketedPrimaryKeyIndexMaintainer {
 
     @Nullable private final BucketedVectorIndexMaintainer vectorMaintainer;
+    @Nullable private final BucketedFullTextIndexMaintainer fullTextMaintainer;
     private final List<BucketedSortedIndexMaintainer> sortedMaintainers;
     private int nextSortedMaintainerIndex;
 
     private BucketedPrimaryKeyIndexMaintainer(
             @Nullable BucketedVectorIndexMaintainer vectorMaintainer,
+            @Nullable BucketedFullTextIndexMaintainer fullTextMaintainer,
             List<BucketedSortedIndexMaintainer> sortedMaintainers) {
         this.vectorMaintainer = vectorMaintainer;
+        this.fullTextMaintainer = fullTextMaintainer;
         List<BucketedSortedIndexMaintainer> sorted = new ArrayList<>(sortedMaintainers);
         sorted.sort(Comparator.comparingInt(BucketedSortedIndexMaintainer::fieldId));
         this.sortedMaintainers = Collections.unmodifiableList(sorted);
@@ -64,18 +71,33 @@ public final class BucketedPrimaryKeyIndexMaintainer {
 
     public static BucketedPrimaryKeyIndexMaintainer ofVector(
             BucketedVectorIndexMaintainer vectorMaintainer) {
-        return new BucketedPrimaryKeyIndexMaintainer(vectorMaintainer, Collections.emptyList());
+        return new BucketedPrimaryKeyIndexMaintainer(
+                vectorMaintainer, null, Collections.emptyList());
+    }
+
+    public static BucketedPrimaryKeyIndexMaintainer ofFullText(
+            BucketedFullTextIndexMaintainer fullTextMaintainer) {
+        return new BucketedPrimaryKeyIndexMaintainer(
+                null, fullTextMaintainer, Collections.emptyList());
     }
 
     public static BucketedPrimaryKeyIndexMaintainer of(
             BucketedVectorIndexMaintainer vectorMaintainer,
             List<BucketedSortedIndexMaintainer> sortedMaintainers) {
-        return new BucketedPrimaryKeyIndexMaintainer(vectorMaintainer, sortedMaintainers);
+        return new BucketedPrimaryKeyIndexMaintainer(vectorMaintainer, null, sortedMaintainers);
+    }
+
+    public static BucketedPrimaryKeyIndexMaintainer of(
+            @Nullable BucketedVectorIndexMaintainer vectorMaintainer,
+            @Nullable BucketedFullTextIndexMaintainer fullTextMaintainer,
+            List<BucketedSortedIndexMaintainer> sortedMaintainers) {
+        return new BucketedPrimaryKeyIndexMaintainer(
+                vectorMaintainer, fullTextMaintainer, sortedMaintainers);
     }
 
     public static BucketedPrimaryKeyIndexMaintainer ofSorted(
             List<BucketedSortedIndexMaintainer> sortedMaintainers) {
-        return new BucketedPrimaryKeyIndexMaintainer(null, sortedMaintainers);
+        return new BucketedPrimaryKeyIndexMaintainer(null, null, sortedMaintainers);
     }
 
     public synchronized void prepareCommit(
@@ -84,11 +106,17 @@ public final class BucketedPrimaryKeyIndexMaintainer {
             boolean waitCompaction)
             throws Exception {
         BucketedVectorIndexMaintainer.VectorIndexCommit vectorCommit = null;
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit fullTextCommit = null;
         List<BucketedSortedIndexMaintainer.SortedIndexCommit> sortedCommits = new ArrayList<>();
         try {
             if (vectorMaintainer != null) {
                 vectorCommit =
                         vectorMaintainer.prepareCommit(
+                                appendIncrement, compactIncrement, waitCompaction);
+            }
+            if (fullTextMaintainer != null) {
+                fullTextCommit =
+                        fullTextMaintainer.prepareCommit(
                                 appendIncrement, compactIncrement, waitCompaction);
             }
 
@@ -101,12 +129,18 @@ public final class BucketedPrimaryKeyIndexMaintainer {
             if (vectorCommit != null) {
                 mergeVectorCommit(appendIncrement, compactIncrement, vectorCommit);
             }
+            if (fullTextCommit != null) {
+                mergeFullTextCommit(appendIncrement, compactIncrement, fullTextCommit);
+            }
             for (BucketedSortedIndexMaintainer.SortedIndexCommit sortedCommit : sortedCommits) {
                 mergeSortedCommit(appendIncrement, compactIncrement, sortedCommit);
             }
         } catch (Throwable failure) {
             for (int i = sortedCommits.size() - 1; i >= 0; i--) {
                 sortedCommits.get(i).abort(failure);
+            }
+            if (fullTextCommit != null) {
+                fullTextCommit.abort(failure);
             }
             if (vectorCommit != null) {
                 vectorCommit.abort(failure);
@@ -219,6 +253,28 @@ public final class BucketedPrimaryKeyIndexMaintainer {
                                         increment.deletedIndexFiles()));
     }
 
+    private static void mergeFullTextCommit(
+            DataIncrement appendIncrement,
+            CompactIncrement compactIncrement,
+            BucketedFullTextIndexMaintainer.FullTextIndexCommit commit) {
+        commit.appendIncrement()
+                .ifPresent(
+                        increment ->
+                                applyIndexIncrement(
+                                        appendIncrement.newIndexFiles(),
+                                        appendIncrement.deletedIndexFiles(),
+                                        increment.newIndexFiles(),
+                                        increment.deletedIndexFiles()));
+        commit.compactIncrement()
+                .ifPresent(
+                        increment ->
+                                applyIndexIncrement(
+                                        compactIncrement.newIndexFiles(),
+                                        compactIncrement.deletedIndexFiles(),
+                                        increment.newIndexFiles(),
+                                        increment.deletedIndexFiles()));
+    }
+
     private static void applyIndexIncrement(
             List<IndexFileMeta> targetNew,
             List<IndexFileMeta> targetDeleted,
@@ -232,12 +288,33 @@ public final class BucketedPrimaryKeyIndexMaintainer {
         if (vectorMaintainer != null && vectorMaintainer.buildNotCompleted()) {
             return true;
         }
+        if (fullTextMaintainer != null && fullTextMaintainer.buildNotCompleted()) {
+            return true;
+        }
         return activeSortedMaintainer() != null;
+    }
+
+    public boolean hasPendingMaintenance() {
+        if (buildNotCompleted()) {
+            return true;
+        }
+        if (fullTextMaintainer != null && fullTextMaintainer.hasPendingMaintenance()) {
+            return true;
+        }
+        for (BucketedSortedIndexMaintainer maintainer : sortedMaintainers) {
+            if (maintainer.hasPendingMaintenance()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void withExecutor(ExecutorService executor) {
         if (vectorMaintainer != null) {
             vectorMaintainer.withExecutor(executor);
+        }
+        if (fullTextMaintainer != null) {
+            fullTextMaintainer.withExecutor(executor);
         }
         for (BucketedSortedIndexMaintainer maintainer : sortedMaintainers) {
             maintainer.withExecutor(executor);
@@ -247,6 +324,9 @@ public final class BucketedPrimaryKeyIndexMaintainer {
     public void close() {
         if (vectorMaintainer != null) {
             vectorMaintainer.close();
+        }
+        if (fullTextMaintainer != null) {
+            fullTextMaintainer.close();
         }
         for (BucketedSortedIndexMaintainer maintainer : sortedMaintainers) {
             maintainer.close();
@@ -258,20 +338,23 @@ public final class BucketedPrimaryKeyIndexMaintainer {
 
         private final IndexFileHandler handler;
         @Nullable private final BucketedVectorIndexMaintainer.Factory vectorFactory;
+        @Nullable private final FullTextDefinitionFactory fullTextFactory;
         private final List<SortedDefinitionFactory> sortedFactories;
 
         private Factory(
                 IndexFileHandler handler,
                 @Nullable BucketedVectorIndexMaintainer.Factory vectorFactory,
+                @Nullable FullTextDefinitionFactory fullTextFactory,
                 List<SortedDefinitionFactory> sortedFactories) {
             this.handler = handler;
             this.vectorFactory = vectorFactory;
+            this.fullTextFactory = fullTextFactory;
             this.sortedFactories = Collections.unmodifiableList(new ArrayList<>(sortedFactories));
         }
 
         public static Factory ofVector(BucketedVectorIndexMaintainer.Factory vectorFactory) {
             return new Factory(
-                    vectorFactory.indexFileHandler(), vectorFactory, Collections.emptyList());
+                    vectorFactory.indexFileHandler(), vectorFactory, null, Collections.emptyList());
         }
 
         public static Factory create(
@@ -281,6 +364,7 @@ public final class BucketedPrimaryKeyIndexMaintainer {
             CoreOptions coreOptions = new CoreOptions(schema.options());
             Map<String, DataField> fields = schema.nameToFieldMap();
             BucketedVectorIndexMaintainer.Factory vectorFactory = null;
+            FullTextDefinitionFactory fullTextFactory = null;
             List<SortedDefinitionFactory> sortedFactories = new ArrayList<>();
             for (PrimaryKeyIndexDefinition definition :
                     PrimaryKeyIndexDefinitions.create(schema).definitions()) {
@@ -315,15 +399,28 @@ public final class BucketedPrimaryKeyIndexMaintainer {
                                         definition.compactionLevelFanout(),
                                         definition.compactionStaleRatioThreshold()));
                         break;
+                    case FULL_TEXT:
+                        checkArgument(
+                                fullTextFactory == null,
+                                "Only one primary-key full-text index is supported.");
+                        fullTextFactory =
+                                new FullTextDefinitionFactory(
+                                        readerFactoryBuilder,
+                                        field,
+                                        definition.options(),
+                                        definition.definitionFingerprint(),
+                                        definition.compactionLevelFanout(),
+                                        definition.compactionStaleRatioThreshold());
+                        break;
                     default:
                         throw new IllegalArgumentException(
                                 "Unsupported primary-key index family " + definition.family());
                 }
             }
             checkArgument(
-                    vectorFactory != null || !sortedFactories.isEmpty(),
+                    vectorFactory != null || fullTextFactory != null || !sortedFactories.isEmpty(),
                     "No primary-key index definition is configured.");
-            return new Factory(handler, vectorFactory, sortedFactories);
+            return new Factory(handler, vectorFactory, fullTextFactory, sortedFactories);
         }
 
         public IndexFileHandler indexFileHandler() {
@@ -355,6 +452,11 @@ public final class BucketedPrimaryKeyIndexMaintainer {
                             ? null
                             : vectorFactory.create(
                                     partition, bucket, dataFiles, payloads, executor);
+            BucketedFullTextIndexMaintainer fullText =
+                    fullTextFactory == null
+                            ? null
+                            : fullTextFactory.create(
+                                    handler, partition, bucket, dataFiles, payloads, executor);
             List<BucketedSortedIndexMaintainer> sorted = new ArrayList<>();
             for (SortedDefinitionFactory factory : sortedFactories) {
                 sorted.add(
@@ -362,7 +464,60 @@ public final class BucketedPrimaryKeyIndexMaintainer {
                                 handler, partition, bucket, dataFiles, payloads, executor,
                                 ioManager));
             }
-            return new BucketedPrimaryKeyIndexMaintainer(vector, sorted);
+            return new BucketedPrimaryKeyIndexMaintainer(vector, fullText, sorted);
+        }
+
+        private static final class FullTextDefinitionFactory {
+
+            private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
+            private final DataField field;
+            private final org.apache.paimon.options.Options options;
+            private final String definitionFingerprint;
+            private final int compactionLevelFanout;
+            private final double compactionStaleRatioThreshold;
+
+            private FullTextDefinitionFactory(
+                    KeyValueFileReaderFactory.Builder readerFactoryBuilder,
+                    DataField field,
+                    org.apache.paimon.options.Options options,
+                    String definitionFingerprint,
+                    int compactionLevelFanout,
+                    double compactionStaleRatioThreshold) {
+                this.readerFactoryBuilder = readerFactoryBuilder;
+                this.field = field;
+                this.options = options;
+                this.definitionFingerprint = definitionFingerprint;
+                this.compactionLevelFanout = compactionLevelFanout;
+                this.compactionStaleRatioThreshold = compactionStaleRatioThreshold;
+            }
+
+            private BucketedFullTextIndexMaintainer create(
+                    IndexFileHandler handler,
+                    BinaryRow partition,
+                    int bucket,
+                    List<DataFileMeta> restoredDataFiles,
+                    List<IndexFileMeta> restoredPayloads,
+                    ExecutorService executor) {
+                PkFullTextIndexFile indexFile = handler.pkFullTextIndex(partition, bucket);
+                PkFullTextIndexBuilder builder =
+                        new PkFullTextIndexBuilder(
+                                indexFile,
+                                new PkFullTextDataFileReader.Factory(
+                                        readerFactoryBuilder, partition, bucket, field),
+                                field,
+                                options,
+                                definitionFingerprint);
+                return new BucketedFullTextIndexMaintainer(
+                        field.id(),
+                        definitionFingerprint,
+                        indexFile,
+                        builder,
+                        compactionLevelFanout,
+                        compactionStaleRatioThreshold,
+                        restoredDataFiles,
+                        restoredPayloads,
+                        executor);
+            }
         }
 
         private static final class SortedDefinitionFactory {

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinition.java
@@ -20,6 +20,12 @@ package org.apache.paimon.index.pk;
 
 import org.apache.paimon.options.Options;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.TreeMap;
+
 /** Resolved definition of one source-backed primary-key index. */
 public class PrimaryKeyIndexDefinition {
 
@@ -27,7 +33,8 @@ public class PrimaryKeyIndexDefinition {
     public enum Family {
         VECTOR,
         BTREE,
-        BITMAP
+        BITMAP,
+        FULL_TEXT
     }
 
     private final String column;
@@ -37,6 +44,7 @@ public class PrimaryKeyIndexDefinition {
     private final Family family;
     private final int compactionLevelFanout;
     private final double compactionStaleRatioThreshold;
+    private final String definitionFingerprint;
 
     public PrimaryKeyIndexDefinition(
             String column,
@@ -53,6 +61,7 @@ public class PrimaryKeyIndexDefinition {
         this.family = family;
         this.compactionLevelFanout = compactionLevelFanout;
         this.compactionStaleRatioThreshold = compactionStaleRatioThreshold;
+        this.definitionFingerprint = definitionFingerprint(fieldId, indexType, options, family);
     }
 
     public String column() {
@@ -81,5 +90,40 @@ public class PrimaryKeyIndexDefinition {
 
     public double compactionStaleRatioThreshold() {
         return compactionStaleRatioThreshold;
+    }
+
+    public String definitionFingerprint() {
+        return definitionFingerprint;
+    }
+
+    private static String definitionFingerprint(
+            int fieldId, String indexType, Options options, Family family) {
+        StringBuilder definition = new StringBuilder();
+        append(definition, family.name());
+        append(definition, Integer.toString(fieldId));
+        append(definition, indexType);
+        for (Map.Entry<String, String> entry : new TreeMap<>(options.toMap()).entrySet()) {
+            append(definition, entry.getKey());
+            append(definition, entry.getValue());
+        }
+        try {
+            byte[] digest =
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(definition.toString().getBytes(StandardCharsets.UTF_8));
+            char[] hex = new char[digest.length * 2];
+            char[] digits = "0123456789abcdef".toCharArray();
+            for (int i = 0; i < digest.length; i++) {
+                int value = digest[i] & 0xff;
+                hex[i * 2] = digits[value >>> 4];
+                hex[i * 2 + 1] = digits[value & 0x0f];
+            }
+            return new String(hex);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 is not available.", e);
+        }
+    }
+
+    private static void append(StringBuilder target, String value) {
+        target.append(value.length()).append(':').append(value);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitions.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitions.java
@@ -46,10 +46,12 @@ public class PrimaryKeyIndexDefinitions {
         List<String> vectorColumns = options.primaryKeyVectorIndexColumns();
         List<String> btreeColumns = options.primaryKeyBTreeIndexColumns();
         List<String> bitmapColumns = options.primaryKeyBitmapIndexColumns();
+        List<String> fullTextColumns = options.primaryKeyFullTextIndexColumns();
         validateNoDuplicates(vectorColumns, CoreOptions.PK_VECTOR_INDEX_COLUMNS.key());
         validateNoDuplicates(btreeColumns, CoreOptions.PK_BTREE_INDEX_COLUMNS.key());
         validateNoDuplicates(bitmapColumns, CoreOptions.PK_BITMAP_INDEX_COLUMNS.key());
-        validateOneIndexPerColumn(vectorColumns, btreeColumns, bitmapColumns);
+        validateNoDuplicates(fullTextColumns, CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
+        validateOneIndexPerColumn(vectorColumns, btreeColumns, bitmapColumns, fullTextColumns);
         List<PrimaryKeyIndexDefinition> definitions = new ArrayList<>();
 
         for (DataField field : schema.fields()) {
@@ -84,6 +86,16 @@ public class PrimaryKeyIndexDefinitions {
                                 PrimaryKeyIndexDefinition.Family.VECTOR,
                                 options.primaryKeyIndexCompactionLevelFanout(column),
                                 options.primaryKeyIndexCompactionStaleRatioThreshold(column)));
+            } else if (fullTextColumns.contains(column)) {
+                definitions.add(
+                        new PrimaryKeyIndexDefinition(
+                                column,
+                                field.id(),
+                                "full-text",
+                                options.primaryKeyFullTextIndexOptions(column),
+                                PrimaryKeyIndexDefinition.Family.FULL_TEXT,
+                                options.primaryKeyIndexCompactionLevelFanout(column),
+                                options.primaryKeyIndexCompactionStaleRatioThreshold(column)));
             }
         }
 
@@ -102,11 +114,15 @@ public class PrimaryKeyIndexDefinitions {
     }
 
     private static void validateOneIndexPerColumn(
-            List<String> vectorColumns, List<String> btreeColumns, List<String> bitmapColumns) {
+            List<String> vectorColumns,
+            List<String> btreeColumns,
+            List<String> bitmapColumns,
+            List<String> fullTextColumns) {
         Set<String> indexedColumns = new HashSet<>();
         validateUniqueColumns(indexedColumns, vectorColumns);
         validateUniqueColumns(indexedColumns, btreeColumns);
         validateUniqueColumns(indexedColumns, bitmapColumns);
+        validateUniqueColumns(indexedColumns, fullTextColumns);
     }
 
     private static void validateUniqueColumns(Set<String> indexedColumns, List<String> columns) {

--- a/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexSourceMeta.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pk/PrimaryKeyIndexSourceMeta.java
@@ -27,23 +27,40 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Ordered source data files covered by a source-backed primary-key index payload. */
 public final class PrimaryKeyIndexSourceMeta {
 
-    private static final int VERSION = 1;
+    private static final int VERSION_1 = 1;
+    private static final int VERSION_2 = 2;
 
     private final List<PrimaryKeyIndexSourceFile> sourceFiles;
+    private final String definitionFingerprint;
 
     public PrimaryKeyIndexSourceMeta(List<PrimaryKeyIndexSourceFile> sourceFiles) {
+        this(sourceFiles, null);
+    }
+
+    public PrimaryKeyIndexSourceMeta(
+            List<PrimaryKeyIndexSourceFile> sourceFiles, String definitionFingerprint) {
         this.sourceFiles = Collections.unmodifiableList(new ArrayList<>(sourceFiles));
         checkArgument(!this.sourceFiles.isEmpty(), "An index must reference source files.");
+        checkArgument(
+                definitionFingerprint == null || !definitionFingerprint.trim().isEmpty(),
+                "Definition fingerprint must not be empty.");
+        this.definitionFingerprint = definitionFingerprint;
     }
 
     public PrimaryKeyIndexSourceMeta(PrimaryKeyIndexSourceFile sourceFile) {
         this(Collections.singletonList(sourceFile));
+    }
+
+    public PrimaryKeyIndexSourceMeta(
+            PrimaryKeyIndexSourceFile sourceFile, String definitionFingerprint) {
+        this(Collections.singletonList(sourceFile), definitionFingerprint);
     }
 
     public List<PrimaryKeyIndexSourceFile> sourceFiles() {
@@ -58,6 +75,10 @@ public final class PrimaryKeyIndexSourceMeta {
         return sourceFiles.get(0);
     }
 
+    public Optional<String> definitionFingerprint() {
+        return Optional.ofNullable(definitionFingerprint);
+    }
+
     public static PrimaryKeyIndexSourceMeta fromIndexFile(IndexFileMeta indexFile) {
         GlobalIndexMeta globalIndexMeta = indexFile.globalIndexMeta();
         checkArgument(
@@ -70,11 +91,14 @@ public final class PrimaryKeyIndexSourceMeta {
     public byte[] serialize() {
         try {
             DataOutputSerializer output = new DataOutputSerializer(128);
-            output.writeInt(VERSION);
+            output.writeInt(definitionFingerprint == null ? VERSION_1 : VERSION_2);
             output.writeInt(sourceFiles.size());
             for (PrimaryKeyIndexSourceFile sourceFile : sourceFiles) {
                 output.writeUTF(sourceFile.fileName());
                 output.writeLong(sourceFile.rowCount());
+            }
+            if (definitionFingerprint != null) {
+                output.writeUTF(definitionFingerprint);
             }
             return output.getCopyOfBuffer();
         } catch (IOException e) {
@@ -86,7 +110,10 @@ public final class PrimaryKeyIndexSourceMeta {
         try {
             DataInputDeserializer input = new DataInputDeserializer(bytes);
             int version = input.readInt();
-            checkArgument(version == VERSION, "Unsupported index source version: %s.", version);
+            checkArgument(
+                    version == VERSION_1 || version == VERSION_2,
+                    "Unsupported index source version: %s.",
+                    version);
             int sourceFileCount = input.readInt();
             checkArgument(sourceFileCount > 0, "An index must reference source files.");
             // Each entry needs at least the two-byte writeUTF length and one long.
@@ -102,9 +129,10 @@ public final class PrimaryKeyIndexSourceMeta {
             for (int i = 0; i < sourceFileCount; i++) {
                 sourceFiles.add(new PrimaryKeyIndexSourceFile(input.readUTF(), input.readLong()));
             }
+            String definitionFingerprint = version == VERSION_2 ? input.readUTF() : null;
             checkArgument(
                     input.available() == 0, "Unexpected trailing bytes in index source metadata.");
-            return new PrimaryKeyIndexSourceMeta(sourceFiles);
+            return new PrimaryKeyIndexSourceMeta(sourceFiles, definitionFingerprint);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to deserialize index source metadata.", e);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainer.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainer.java
@@ -1,0 +1,573 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexLevels;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourcePolicy;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Maintains bucket-local full-text archives with source-backed LSM consolidation. */
+public class BucketedFullTextIndexMaintainer {
+
+    private static final int DEFAULT_LEVEL_FANOUT = 5;
+    private static final double DEFAULT_STALE_RATIO_THRESHOLD = 0.2;
+
+    private final int textFieldId;
+    private final String definitionFingerprint;
+    private final PkFullTextIndexFile indexFile;
+    private final PkFullTextIndexBuilder indexBuilder;
+    private final PrimaryKeyIndexLevels<IndexFileMeta> levels;
+    private final List<IndexFileMeta> currentPayloads = new ArrayList<>();
+    private final List<IndexFileMeta> retiredPayloads = new ArrayList<>();
+    private final Map<String, DataFileMeta> activeSourceFiles = new LinkedHashMap<>();
+    private ExecutorService executor;
+    @Nullable private PendingBuild pendingBuild;
+
+    public BucketedFullTextIndexMaintainer(
+            int textFieldId,
+            String definitionFingerprint,
+            PkFullTextIndexFile indexFile,
+            PkFullTextIndexBuilder indexBuilder,
+            List<DataFileMeta> restoredDataFiles,
+            List<IndexFileMeta> restoredPayloads,
+            ExecutorService executor) {
+        this(
+                textFieldId,
+                definitionFingerprint,
+                indexFile,
+                indexBuilder,
+                DEFAULT_LEVEL_FANOUT,
+                DEFAULT_STALE_RATIO_THRESHOLD,
+                restoredDataFiles,
+                restoredPayloads,
+                executor);
+    }
+
+    public BucketedFullTextIndexMaintainer(
+            int textFieldId,
+            String definitionFingerprint,
+            PkFullTextIndexFile indexFile,
+            PkFullTextIndexBuilder indexBuilder,
+            int levelFanout,
+            double staleRatioThreshold,
+            List<DataFileMeta> restoredDataFiles,
+            List<IndexFileMeta> restoredPayloads,
+            ExecutorService executor) {
+        this.textFieldId = textFieldId;
+        this.definitionFingerprint = definitionFingerprint;
+        this.indexFile = indexFile;
+        this.indexBuilder = indexBuilder;
+        this.levels =
+                new PrimaryKeyIndexLevels<>(
+                        levelFanout,
+                        staleRatioThreshold,
+                        IndexFileMeta::fileName,
+                        payload -> sourceMeta(payload).sourceFiles());
+        this.executor = executor;
+        for (DataFileMeta file : restoredDataFiles) {
+            if (PrimaryKeyIndexSourcePolicy.shouldRead(file)) {
+                activeSourceFiles.put(file.fileName(), file);
+            }
+        }
+
+        PkFullTextBucketIndexState restoredState =
+                PkFullTextBucketIndexState.fromActivePayloads(
+                        textFieldId, definitionFingerprint, restoredPayloads);
+        currentPayloads.addAll(restoredState.currentPayloads());
+        retiredPayloads.addAll(restoredState.stalePayloads());
+        validateActiveSourceRows();
+    }
+
+    public synchronized FullTextIndexCommit prepareCommit(
+            DataIncrement appendIncrement,
+            CompactIncrement compactIncrement,
+            boolean waitCompaction)
+            throws Exception {
+        checkArgument(
+                eligibleFiles(appendIncrement.newFiles()).isEmpty(),
+                "Append files must not be primary-key full-text index sources.");
+
+        List<IndexFileMeta> originalPayloads = new ArrayList<>(currentPayloads);
+        List<IndexFileMeta> originalRetired = new ArrayList<>(retiredPayloads);
+        Map<String, DataFileMeta> originalSources = new LinkedHashMap<>(activeSourceFiles);
+        List<IndexFileMeta> generated = new ArrayList<>();
+        try {
+            applyDataTransition(compactIncrement);
+            List<IndexFileMeta> created = new ArrayList<>();
+            List<IndexFileMeta> removed = new ArrayList<>(retiredPayloads);
+            retiredPayloads.clear();
+
+            while (true) {
+                Optional<CompletedBuild> completed = finishPendingBuild(waitCompaction);
+                if (completed.isPresent()) {
+                    CompletedBuild build = completed.get();
+                    generated.add(build.payload);
+                    if (canAccept(build)) {
+                        replacePayloads(
+                                build.inputPayloads, build.payload, created, removed, generated);
+                    } else {
+                        deleteGenerated(build.payload, generated);
+                    }
+                }
+
+                if (pendingBuild == null) {
+                    List<DataFileMeta> uncovered = uncoveredFiles();
+                    if (!uncovered.isEmpty()) {
+                        startBuild(uncovered, Collections.emptyList());
+                    } else {
+                        Optional<PrimaryKeyIndexLevels.Plan<IndexFileMeta>> plan =
+                                levels.pick(currentPayloads, activeSourceFiles);
+                        if (plan.isPresent()) {
+                            if (plan.get().sourceFiles().isEmpty()) {
+                                removePayloads(
+                                        plan.get().inputUnits(), created, removed, generated);
+                                continue;
+                            }
+                            startBuild(plan.get().sourceFiles(), plan.get().inputUnits());
+                        }
+                    }
+                }
+                if (!waitCompaction || pendingBuild == null) {
+                    break;
+                }
+            }
+
+            boolean hasCompactDataTransition =
+                    !compactIncrement.compactBefore().isEmpty()
+                            || !compactIncrement.compactAfter().isEmpty();
+            boolean changed = !created.isEmpty() || !removed.isEmpty();
+            Optional<FullTextIndexIncrement> appendChange =
+                    changed && !hasCompactDataTransition
+                            ? Optional.of(new FullTextIndexIncrement(created, removed))
+                            : Optional.empty();
+            Optional<FullTextIndexIncrement> compactChange =
+                    changed && hasCompactDataTransition
+                            ? Optional.of(new FullTextIndexIncrement(created, removed))
+                            : Optional.empty();
+            return new FullTextIndexCommit(
+                    appendChange,
+                    compactChange,
+                    failure ->
+                            rollback(
+                                    originalPayloads,
+                                    originalRetired,
+                                    originalSources,
+                                    generated,
+                                    failure));
+        } catch (Throwable failure) {
+            rollback(originalPayloads, originalRetired, originalSources, generated, failure);
+            if (failure instanceof Exception) {
+                throw (Exception) failure;
+            }
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+            throw new RuntimeException(failure);
+        }
+    }
+
+    private void applyDataTransition(CompactIncrement compactIncrement) {
+        for (DataFileMeta file : compactIncrement.compactBefore()) {
+            if (!containsFile(compactIncrement.compactAfter(), file.fileName())) {
+                activeSourceFiles.remove(file.fileName());
+            }
+        }
+        for (DataFileMeta file : compactIncrement.compactAfter()) {
+            if (PrimaryKeyIndexSourcePolicy.shouldRead(file)) {
+                activeSourceFiles.put(file.fileName(), file);
+            }
+        }
+    }
+
+    private List<DataFileMeta> uncoveredFiles() {
+        Set<String> covered = coveredSources(currentPayloads);
+        List<DataFileMeta> uncovered = new ArrayList<>();
+        for (DataFileMeta source : activeSourceFiles.values()) {
+            if (!covered.contains(source.fileName())) {
+                uncovered.add(source);
+            }
+        }
+        uncovered.sort(Comparator.comparing(DataFileMeta::fileName));
+        return uncovered;
+    }
+
+    private void startBuild(List<DataFileMeta> sourceFiles, List<IndexFileMeta> inputPayloads) {
+        PendingBuild build = new PendingBuild(sourceFiles, inputPayloads);
+        build.start();
+        pendingBuild = build;
+    }
+
+    private Optional<CompletedBuild> finishPendingBuild(boolean blocking) throws Exception {
+        if (pendingBuild == null || (!blocking && !pendingBuild.isDone())) {
+            return Optional.empty();
+        }
+        PendingBuild completed = pendingBuild;
+        try {
+            IndexFileMeta payload = completed.get();
+            pendingBuild = null;
+            return Optional.of(
+                    new CompletedBuild(completed.sourceFiles, completed.inputPayloads, payload));
+        } catch (CancellationException e) {
+            pendingBuild = null;
+            return Optional.empty();
+        } catch (ExecutionException e) {
+            pendingBuild = null;
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new RuntimeException(cause);
+        }
+    }
+
+    private boolean canAccept(CompletedBuild build) {
+        if (!currentPayloads.containsAll(build.inputPayloads)) {
+            return false;
+        }
+        PkFullTextBucketIndexState outputState =
+                PkFullTextBucketIndexState.fromActivePayloads(
+                        textFieldId,
+                        definitionFingerprint,
+                        Collections.singletonList(build.payload));
+        if (outputState.currentPayloads().size() != 1) {
+            return false;
+        }
+        List<PrimaryKeyIndexSourceFile> actualSources = sourceMeta(build.payload).sourceFiles();
+        if (actualSources.size() != build.sourceFiles.size()) {
+            return false;
+        }
+
+        List<IndexFileMeta> retained = new ArrayList<>(currentPayloads);
+        retained.removeAll(build.inputPayloads);
+        Set<String> retainedSources = coveredSources(retained);
+        for (int i = 0; i < actualSources.size(); i++) {
+            PrimaryKeyIndexSourceFile actual = actualSources.get(i);
+            DataFileMeta expected = build.sourceFiles.get(i);
+            DataFileMeta active = activeSourceFiles.get(actual.fileName());
+            if (!actual.fileName().equals(expected.fileName())
+                    || actual.rowCount() != expected.rowCount()
+                    || active == null
+                    || active.rowCount() != actual.rowCount()
+                    || retainedSources.contains(actual.fileName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void replacePayloads(
+            List<IndexFileMeta> inputs,
+            IndexFileMeta output,
+            List<IndexFileMeta> created,
+            List<IndexFileMeta> removed,
+            List<IndexFileMeta> generated) {
+        removePayloads(inputs, created, removed, generated);
+        currentPayloads.add(output);
+        created.add(output);
+    }
+
+    private void removePayloads(
+            List<IndexFileMeta> inputs,
+            List<IndexFileMeta> created,
+            List<IndexFileMeta> removed,
+            List<IndexFileMeta> generated) {
+        for (IndexFileMeta input : inputs) {
+            checkArgument(
+                    currentPayloads.remove(input), "Full-text rebuild input is no longer active.");
+            if (created.remove(input)) {
+                deleteGenerated(input, generated);
+            } else {
+                removed.add(input);
+            }
+        }
+    }
+
+    private void deleteGenerated(IndexFileMeta payload, List<IndexFileMeta> generated) {
+        indexFile.delete(payload);
+        generated.remove(payload);
+    }
+
+    private synchronized void rollback(
+            List<IndexFileMeta> originalPayloads,
+            List<IndexFileMeta> originalRetired,
+            Map<String, DataFileMeta> originalSources,
+            List<IndexFileMeta> generated,
+            Throwable failure) {
+        currentPayloads.clear();
+        currentPayloads.addAll(originalPayloads);
+        retiredPayloads.clear();
+        retiredPayloads.addAll(originalRetired);
+        activeSourceFiles.clear();
+        activeSourceFiles.putAll(originalSources);
+
+        PendingBuild build = pendingBuild;
+        pendingBuild = null;
+        if (build != null) {
+            try {
+                build.cancel();
+            } catch (Throwable cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
+        }
+        for (IndexFileMeta payload : generated) {
+            try {
+                indexFile.delete(payload);
+            } catch (Throwable cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
+        }
+    }
+
+    public synchronized boolean buildNotCompleted() {
+        return pendingBuild != null;
+    }
+
+    public synchronized boolean hasPendingMaintenance() {
+        return pendingBuild != null
+                || !retiredPayloads.isEmpty()
+                || !uncoveredFiles().isEmpty()
+                || levels.pick(currentPayloads, activeSourceFiles).isPresent();
+    }
+
+    public synchronized void withExecutor(ExecutorService executor) {
+        checkArgument(pendingBuild == null, "Cannot replace executor during a full-text build.");
+        this.executor = executor;
+    }
+
+    public synchronized void close() {
+        PendingBuild build = pendingBuild;
+        pendingBuild = null;
+        if (build != null) {
+            build.cancel();
+        }
+    }
+
+    public synchronized PkFullTextBucketIndexState state() {
+        return PkFullTextBucketIndexState.fromActivePayloads(
+                textFieldId, definitionFingerprint, currentPayloads);
+    }
+
+    public synchronized List<IndexFileMeta> payloads() {
+        return Collections.unmodifiableList(new ArrayList<>(currentPayloads));
+    }
+
+    private void validateActiveSourceRows() {
+        for (IndexFileMeta payload : currentPayloads) {
+            for (PrimaryKeyIndexSourceFile source : sourceMeta(payload).sourceFiles()) {
+                DataFileMeta active = activeSourceFiles.get(source.fileName());
+                if (active != null) {
+                    checkArgument(
+                            active.rowCount() == source.rowCount(),
+                            "Full-text source %s row count does not match its active data file.",
+                            source.fileName());
+                }
+            }
+        }
+    }
+
+    private class PendingBuild {
+
+        private final List<DataFileMeta> sourceFiles;
+        private final List<IndexFileMeta> inputPayloads;
+        @Nullable private IndexFileMeta result;
+        @Nullable private Future<IndexFileMeta> future;
+        private boolean cancelled;
+
+        private PendingBuild(List<DataFileMeta> sourceFiles, List<IndexFileMeta> inputPayloads) {
+            this.sourceFiles = Collections.unmodifiableList(new ArrayList<>(sourceFiles));
+            this.inputPayloads = Collections.unmodifiableList(new ArrayList<>(inputPayloads));
+        }
+
+        private void start() {
+            future =
+                    executor.submit(
+                            () -> {
+                                IndexFileMeta payload =
+                                        sourceFiles.size() == 1
+                                                ? indexBuilder.build(sourceFiles.get(0))
+                                                : indexBuilder.build(sourceFiles);
+                                synchronized (PendingBuild.this) {
+                                    if (!cancelled) {
+                                        result = payload;
+                                        return payload;
+                                    }
+                                }
+                                indexFile.delete(payload);
+                                throw new CancellationException();
+                            });
+        }
+
+        private boolean isDone() {
+            return future.isDone();
+        }
+
+        private IndexFileMeta get() throws InterruptedException, ExecutionException {
+            return future.get();
+        }
+
+        private void cancel() {
+            Future<IndexFileMeta> buildFuture;
+            IndexFileMeta builtPayload;
+            synchronized (this) {
+                cancelled = true;
+                buildFuture = future;
+                builtPayload = result;
+                result = null;
+            }
+            if (buildFuture != null) {
+                buildFuture.cancel(true);
+            }
+            if (builtPayload != null) {
+                indexFile.delete(builtPayload);
+            }
+        }
+    }
+
+    private static final class CompletedBuild {
+
+        private final List<DataFileMeta> sourceFiles;
+        private final List<IndexFileMeta> inputPayloads;
+        private final IndexFileMeta payload;
+
+        private CompletedBuild(
+                List<DataFileMeta> sourceFiles,
+                List<IndexFileMeta> inputPayloads,
+                IndexFileMeta payload) {
+            this.sourceFiles = sourceFiles;
+            this.inputPayloads = inputPayloads;
+            this.payload = payload;
+        }
+    }
+
+    private static Set<String> coveredSources(List<IndexFileMeta> payloads) {
+        Set<String> covered = new HashSet<>();
+        for (IndexFileMeta payload : payloads) {
+            for (PrimaryKeyIndexSourceFile source : sourceMeta(payload).sourceFiles()) {
+                covered.add(source.fileName());
+            }
+        }
+        return covered;
+    }
+
+    private static List<DataFileMeta> eligibleFiles(List<DataFileMeta> files) {
+        List<DataFileMeta> eligible = new ArrayList<>();
+        for (DataFileMeta file : files) {
+            if (PrimaryKeyIndexSourcePolicy.shouldRead(file)) {
+                eligible.add(file);
+            }
+        }
+        return eligible;
+    }
+
+    private static boolean containsFile(List<DataFileMeta> files, String fileName) {
+        for (DataFileMeta file : files) {
+            if (file.fileName().equals(fileName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static PrimaryKeyIndexSourceMeta sourceMeta(IndexFileMeta payload) {
+        return PrimaryKeyIndexSourceMeta.fromIndexFile(payload);
+    }
+
+    /** Full-text changes prepared for Paimon's append snapshot or compact snapshot. */
+    public static class FullTextIndexCommit {
+
+        private final Optional<FullTextIndexIncrement> appendIncrement;
+        private final Optional<FullTextIndexIncrement> compactIncrement;
+        private final AbortAction abortAction;
+
+        private FullTextIndexCommit(
+                Optional<FullTextIndexIncrement> appendIncrement,
+                Optional<FullTextIndexIncrement> compactIncrement,
+                AbortAction abortAction) {
+            this.appendIncrement = appendIncrement;
+            this.compactIncrement = compactIncrement;
+            this.abortAction = abortAction;
+        }
+
+        public Optional<FullTextIndexIncrement> appendIncrement() {
+            return appendIncrement;
+        }
+
+        public Optional<FullTextIndexIncrement> compactIncrement() {
+            return compactIncrement;
+        }
+
+        public void abort(Throwable failure) {
+            abortAction.abort(failure);
+        }
+    }
+
+    @FunctionalInterface
+    private interface AbortAction {
+
+        void abort(Throwable failure);
+    }
+
+    /** Index-file additions and deletions emitted by one bucket state update. */
+    public static class FullTextIndexIncrement {
+
+        private final List<IndexFileMeta> newIndexFiles;
+        private final List<IndexFileMeta> deletedIndexFiles;
+
+        private FullTextIndexIncrement(
+                List<IndexFileMeta> newIndexFiles, List<IndexFileMeta> deletedIndexFiles) {
+            this.newIndexFiles = Collections.unmodifiableList(new ArrayList<>(newIndexFiles));
+            this.deletedIndexFiles =
+                    Collections.unmodifiableList(new ArrayList<>(deletedIndexFiles));
+        }
+
+        public List<IndexFileMeta> newIndexFiles() {
+            return newIndexFiles;
+        }
+
+        public List<IndexFileMeta> deletedIndexFiles() {
+            return deletedIndexFiles;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexState.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.utils.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Immutable source-aligned primary-key full-text state for one bucket and definition. */
+public final class PkFullTextBucketIndexState {
+
+    private final int textFieldId;
+    private final String definitionFingerprint;
+    private final List<IndexFileMeta> currentPayloads;
+    private final List<IndexFileMeta> stalePayloads;
+    private final Map<String, IndexFileMeta> payloadBySourceFile;
+
+    public static PkFullTextBucketIndexState fromActivePayloads(
+            int textFieldId, String definitionFingerprint, List<IndexFileMeta> activePayloads) {
+        return new PkFullTextBucketIndexState(textFieldId, definitionFingerprint, activePayloads);
+    }
+
+    public PkFullTextBucketIndexState(
+            int textFieldId, String definitionFingerprint, List<IndexFileMeta> activePayloads) {
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(definitionFingerprint),
+                "Full-text definition fingerprint must not be empty.");
+        this.textFieldId = textFieldId;
+        this.definitionFingerprint = definitionFingerprint;
+
+        List<IndexFileMeta> current = new ArrayList<>();
+        List<IndexFileMeta> stale = new ArrayList<>();
+        Map<String, IndexFileMeta> bySource = new LinkedHashMap<>();
+        Set<String> payloadNames = new HashSet<>();
+        for (IndexFileMeta payload : activePayloads) {
+            GlobalIndexMeta globalMeta = payload.globalIndexMeta();
+            if (!PkFullTextIndexFile.INDEX_TYPE.equals(payload.indexType()) || globalMeta == null) {
+                continue;
+            }
+            if (globalMeta.indexFieldId() != textFieldId) {
+                if (globalMeta.sourceMeta() != null) {
+                    stale.add(payload);
+                }
+                continue;
+            }
+            checkArgument(
+                    payloadNames.add(payload.fileName()),
+                    "Active full-text payload %s appears more than once in the index manifest.",
+                    payload.fileName());
+            PrimaryKeyIndexSourceMeta sourceMeta = PrimaryKeyIndexSourceMeta.fromIndexFile(payload);
+            long sourceRowCount = 0;
+            for (PrimaryKeyIndexSourceFile source : sourceMeta.sourceFiles()) {
+                sourceRowCount = Math.addExact(sourceRowCount, source.rowCount());
+            }
+            checkArgument(
+                    payload.rowCount() == sourceRowCount
+                            && globalMeta.rowRangeStart() == 0
+                            && globalMeta.rowRangeEnd() == sourceRowCount - 1,
+                    "Full-text archive %s row metadata does not match its source files.",
+                    payload.fileName());
+            if (sourceMeta
+                    .definitionFingerprint()
+                    .filter(definitionFingerprint::equals)
+                    .isPresent()) {
+                for (PrimaryKeyIndexSourceFile source : sourceMeta.sourceFiles()) {
+                    IndexFileMeta previous = bySource.put(source.fileName(), payload);
+                    checkArgument(
+                            previous == null,
+                            "Source data file %s is covered by both full-text archives %s and %s.",
+                            source.fileName(),
+                            previous == null ? "" : previous.fileName(),
+                            payload.fileName());
+                }
+                current.add(payload);
+            } else {
+                stale.add(payload);
+            }
+        }
+        this.currentPayloads = Collections.unmodifiableList(current);
+        this.stalePayloads = Collections.unmodifiableList(stale);
+        this.payloadBySourceFile = Collections.unmodifiableMap(bySource);
+    }
+
+    public int textFieldId() {
+        return textFieldId;
+    }
+
+    public String definitionFingerprint() {
+        return definitionFingerprint;
+    }
+
+    public List<IndexFileMeta> currentPayloads() {
+        return currentPayloads;
+    }
+
+    public List<IndexFileMeta> stalePayloads() {
+        return stalePayloads;
+    }
+
+    public Map<String, IndexFileMeta> payloadBySourceFile() {
+        return payloadBySourceFile;
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextDataFileReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextDataFileReader.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.reader.RecordReaderIterator;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.RowType;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Reads one projected text value from every physical row of a data file. */
+public class PkFullTextDataFileReader implements Closeable {
+
+    private final DataFileMeta dataFile;
+    private final RecordReaderIterator<KeyValue> iterator;
+    private long rowsRead;
+
+    public PkFullTextDataFileReader(KeyValueFileReaderFactory readerFactory, DataFileMeta dataFile)
+            throws IOException {
+        this.dataFile = dataFile;
+        this.iterator = new RecordReaderIterator<>(readerFactory.createRecordReader(dataFile));
+    }
+
+    public long rowCount() {
+        return dataFile.rowCount();
+    }
+
+    @Nullable
+    public BinaryString readNextText() {
+        checkArgument(
+                rowsRead < rowCount(), "Read past data file %s row count.", dataFile.fileName());
+        checkArgument(
+                iterator.hasNext(),
+                "Data file %s ended before its declared row count.",
+                dataFile.fileName());
+        KeyValue keyValue = iterator.next();
+        rowsRead++;
+        if (rowsRead == rowCount()) {
+            checkArgument(
+                    !iterator.hasNext(),
+                    "Data file %s contains more rows than declared.",
+                    dataFile.fileName());
+        }
+        InternalRow value = keyValue.value();
+        return value.isNullAt(0) ? null : value.getString(0);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            iterator.close();
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to close full-text reader for " + dataFile.fileName(), e);
+        }
+    }
+
+    /** Bucket-scoped factory with text-only value projection and no deletion-vector filtering. */
+    public static class Factory {
+
+        private final KeyValueFileReaderFactory readerFactory;
+
+        public Factory(
+                KeyValueFileReaderFactory.Builder readerFactoryBuilder,
+                BinaryRow partition,
+                int bucket,
+                DataField textField) {
+            this.readerFactory =
+                    readerFactoryBuilder
+                            .copyWithoutProjection()
+                            .withReadKeyType(RowType.of())
+                            .withReadValueType(RowType.of(textField))
+                            .buildWithoutDeletionVector(partition, bucket);
+        }
+
+        public PkFullTextDataFileReader create(DataFileMeta dataFile) throws IOException {
+            return new PkFullTextDataFileReader(readerFactory, dataFile);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataField;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Opens projected data-file readers and builds an ordered-source full-text archive. */
+public class PkFullTextIndexBuilder {
+
+    private final PkFullTextIndexFile indexFile;
+    private final PkFullTextDataFileReader.Factory readerFactory;
+    private final DataField textField;
+    private final Options indexOptions;
+    private final String definitionFingerprint;
+
+    public PkFullTextIndexBuilder(
+            PkFullTextIndexFile indexFile,
+            PkFullTextDataFileReader.Factory readerFactory,
+            DataField textField,
+            Options indexOptions,
+            String definitionFingerprint) {
+        this.indexFile = indexFile;
+        this.readerFactory = readerFactory;
+        this.textField = textField;
+        this.indexOptions = indexOptions;
+        this.definitionFingerprint = definitionFingerprint;
+    }
+
+    public IndexFileMeta build(DataFileMeta sourceFile) throws IOException {
+        PkFullTextDataFileReader reader = readerFactory.create(sourceFile);
+        return indexFile.build(sourceFile, reader, textField, indexOptions, definitionFingerprint);
+    }
+
+    public IndexFileMeta build(List<DataFileMeta> sourceFiles) throws IOException {
+        List<PkFullTextIndexFile.Source> sources = new ArrayList<>(sourceFiles.size());
+        try {
+            for (DataFileMeta sourceFile : sourceFiles) {
+                sources.add(
+                        new PkFullTextIndexFile.Source(
+                                sourceFile, readerFactory.create(sourceFile)));
+            }
+        } catch (IOException | RuntimeException | Error failure) {
+            for (PkFullTextIndexFile.Source source : sources) {
+                source.close();
+            }
+            throw failure;
+        }
+        return indexFile.build(sources, textField, indexOptions, definitionFingerprint);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFile.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFile.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.GlobalIndexWriter;
+import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFile;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Builds one immutable full-text archive from ordered compact primary-key data files. */
+public class PkFullTextIndexFile extends IndexFile {
+
+    public static final String INDEX_TYPE = "full-text";
+
+    public PkFullTextIndexFile(FileIO fileIO, IndexPathFactory pathFactory) {
+        super(fileIO, pathFactory);
+    }
+
+    public IndexFileMeta build(
+            DataFileMeta sourceFile,
+            PkFullTextDataFileReader textReader,
+            DataField textField,
+            Options indexOptions,
+            String definitionFingerprint)
+            throws IOException {
+        GlobalIndexer indexer;
+        try {
+            indexer = GlobalIndexer.create(INDEX_TYPE, textField, indexOptions);
+        } catch (RuntimeException | Error failure) {
+            IOUtils.closeQuietly(textReader);
+            throw failure;
+        }
+        return build(
+                Collections.singletonList(new Source(sourceFile, textReader)),
+                textField,
+                indexer,
+                definitionFingerprint);
+    }
+
+    public IndexFileMeta build(
+            List<Source> sources,
+            DataField textField,
+            Options indexOptions,
+            String definitionFingerprint)
+            throws IOException {
+        GlobalIndexer indexer;
+        try {
+            indexer = GlobalIndexer.create(INDEX_TYPE, textField, indexOptions);
+        } catch (RuntimeException | Error failure) {
+            closeSources(sources);
+            throw failure;
+        }
+        return build(sources, textField, indexer, definitionFingerprint);
+    }
+
+    IndexFileMeta build(
+            DataFileMeta sourceFile,
+            PkFullTextDataFileReader textReader,
+            DataField textField,
+            GlobalIndexer indexer,
+            String definitionFingerprint)
+            throws IOException {
+        return build(
+                Collections.singletonList(new Source(sourceFile, textReader)),
+                textField,
+                indexer,
+                definitionFingerprint);
+    }
+
+    IndexFileMeta build(
+            List<Source> sources,
+            DataField textField,
+            GlobalIndexer indexer,
+            String definitionFingerprint)
+            throws IOException {
+        checkArgument(!sources.isEmpty(), "A full-text archive must reference source files.");
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(definitionFingerprint),
+                "Full-text definition fingerprint must not be empty.");
+        long totalRowCount = 0;
+        List<PrimaryKeyIndexSourceFile> sourceFiles = new ArrayList<>(sources.size());
+        for (Source source : sources) {
+            checkArgument(
+                    source.sourceFile.rowCount() > 0, "Full-text source file must contain rows.");
+            totalRowCount = Math.addExact(totalRowCount, source.sourceFile.rowCount());
+            sourceFiles.add(
+                    new PrimaryKeyIndexSourceFile(
+                            source.sourceFile.fileName(), source.sourceFile.rowCount()));
+        }
+
+        ArchiveFileWriter fileWriter = new ArchiveFileWriter();
+        GlobalIndexWriter writer = null;
+        boolean success = false;
+        try {
+            writer = indexer.createWriter(fileWriter);
+            checkArgument(
+                    writer instanceof GlobalIndexSingleColumnWriter,
+                    "Full-text indexer must create a single-column writer.");
+            GlobalIndexSingleColumnWriter singleColumnWriter =
+                    (GlobalIndexSingleColumnWriter) writer;
+            long sourceOffset = 0;
+            for (Source source : sources) {
+                checkArgument(
+                        source.textReader.rowCount() == source.sourceFile.rowCount(),
+                        "Text row count %s does not match source file %s row count %s.",
+                        source.textReader.rowCount(),
+                        source.sourceFile.fileName(),
+                        source.sourceFile.rowCount());
+                for (long rowPosition = 0;
+                        rowPosition < source.sourceFile.rowCount();
+                        rowPosition++) {
+                    singleColumnWriter.write(
+                            source.textReader.readNextText(), sourceOffset + rowPosition);
+                }
+                sourceOffset += source.sourceFile.rowCount();
+            }
+            List<ResultEntry> results = writer.finish();
+            checkArgument(
+                    results.size() == 1,
+                    "Full-text build must produce exactly one archive, but produced %s.",
+                    results.size());
+            checkArgument(
+                    fileWriter.createdFiles.size() == 1,
+                    "Full-text build must allocate exactly one archive, but allocated %s.",
+                    fileWriter.createdFiles.size());
+            ResultEntry result = results.get(0);
+            checkArgument(
+                    result.rowCount() == totalRowCount,
+                    "Full-text archive row count %s does not match source row count %s.",
+                    result.rowCount(),
+                    totalRowCount);
+            Path archivePath = fileWriter.path(result.fileName());
+            byte[] archiveMetadata = result.meta() == null ? new byte[0] : result.meta();
+            IndexFileMeta archive =
+                    new IndexFileMeta(
+                            INDEX_TYPE,
+                            result.fileName(),
+                            fileIO.getFileSize(archivePath),
+                            result.rowCount(),
+                            new GlobalIndexMeta(
+                                    0,
+                                    totalRowCount - 1,
+                                    textField.id(),
+                                    null,
+                                    archiveMetadata,
+                                    new PrimaryKeyIndexSourceMeta(
+                                                    sourceFiles, definitionFingerprint)
+                                            .serialize()),
+                            pathFactory.isExternalPath() ? archivePath.toString() : null);
+            success = true;
+            return archive;
+        } finally {
+            for (Source source : sources) {
+                IOUtils.closeQuietly(source.textReader);
+            }
+            if (writer instanceof AutoCloseable) {
+                IOUtils.closeQuietly((AutoCloseable) writer);
+            }
+            if (!success) {
+                fileWriter.deleteCreatedFiles();
+            }
+        }
+    }
+
+    private static void closeSources(List<Source> sources) {
+        for (Source source : sources) {
+            IOUtils.closeQuietly(source.textReader);
+        }
+    }
+
+    /** One data-file source whose row positions are appended to an archive. */
+    public static class Source {
+
+        private final DataFileMeta sourceFile;
+        private final PkFullTextDataFileReader textReader;
+
+        public Source(DataFileMeta sourceFile, PkFullTextDataFileReader textReader) {
+            this.sourceFile = sourceFile;
+            this.textReader = textReader;
+        }
+
+        void close() {
+            IOUtils.closeQuietly(textReader);
+        }
+    }
+
+    private class ArchiveFileWriter implements GlobalIndexFileWriter {
+
+        private final Map<String, Path> createdFiles = new HashMap<>();
+
+        @Override
+        public String newFileName(String prefix) {
+            Path path = pathFactory.newPath();
+            createdFiles.put(path.getName(), path);
+            return path.getName();
+        }
+
+        @Override
+        public PositionOutputStream newOutputStream(String fileName) throws IOException {
+            return fileIO.newOutputStream(path(fileName), false);
+        }
+
+        private Path path(String fileName) {
+            Path path = createdFiles.get(fileName);
+            checkArgument(path != null, "Full-text archive %s was not allocated.", fileName);
+            return path;
+        }
+
+        private void deleteCreatedFiles() {
+            for (Path path : createdFiles.values()) {
+                fileIO.deleteQuietly(path);
+            }
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearch.java
+++ b/paimon-core/src/main/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearch.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.globalindex.GlobalIndexReader;
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.predicate.FullTextSearch;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.PrimaryKeyFullTextSearchSplit;
+import org.apache.paimon.table.source.PrimaryKeySearchPosition;
+import org.apache.paimon.table.source.PrimaryKeySearchRanker;
+import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Searches source-backed full-text payloads and fuses their local ranks. */
+public class PrimaryKeyFullTextBucketSearch {
+
+    private final ReaderFactory readerFactory;
+
+    public PrimaryKeyFullTextBucketSearch(ReaderFactory readerFactory) {
+        this.readerFactory = readerFactory;
+    }
+
+    public List<PrimaryKeySearchPosition> search(
+            PrimaryKeyFullTextSearchSplit split,
+            Map<String, DeletionVector> deletionVectors,
+            String column,
+            String query,
+            int limit) {
+        List<List<PrimaryKeySearchPosition>> localRankings =
+                searchRankings(split, deletionVectors, column, query, limit);
+        if (localRankings.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return PrimaryKeySearchRanker.rrf(localRankings, limit);
+    }
+
+    public List<List<PrimaryKeySearchPosition>> searchRankings(
+            PrimaryKeyFullTextSearchSplit split,
+            Map<String, DeletionVector> deletionVectors,
+            String column,
+            String query,
+            int limit) {
+        checkArgument(limit > 0, "Full-text search limit must be positive: %s.", limit);
+        DataSplit dataSplit = split.dataSplit();
+        Map<String, DataFileMeta> files = new HashMap<>();
+        for (DataFileMeta file : dataSplit.dataFiles()) {
+            checkArgument(
+                    files.put(file.fileName(), file) == null,
+                    "Duplicate full-text source file %s.",
+                    file.fileName());
+        }
+
+        List<PayloadRequest> requests = new ArrayList<>();
+        for (IndexFileMeta payload : split.payloadFiles()) {
+            List<SourceRange> sourceRanges = new ArrayList<>();
+            boolean needsInclude = false;
+            long totalRowCount = 0;
+            for (PrimaryKeyIndexSourceFile source :
+                    PrimaryKeyIndexSourceMeta.fromIndexFile(payload).sourceFiles()) {
+                DataFileMeta file = files.get(source.fileName());
+                if (file != null) {
+                    checkArgument(
+                            source.rowCount() == file.rowCount(),
+                            "Full-text payload %s source row count does not match data file %s.",
+                            payload.fileName(),
+                            source.fileName());
+                }
+                DeletionVector deletionVector = deletionVectors.get(source.fileName());
+                needsInclude |=
+                        file == null || (deletionVector != null && !deletionVector.isEmpty());
+                sourceRanges.add(
+                        new SourceRange(
+                                source.fileName(), totalRowCount, source.rowCount(), file != null));
+                totalRowCount = Math.addExact(totalRowCount, source.rowCount());
+            }
+            RoaringNavigableMap64 include =
+                    needsInclude ? liveRows(sourceRanges, deletionVectors) : null;
+            if (include != null && include.isEmpty()) {
+                continue;
+            }
+            GlobalIndexReader reader = readerFactory.create(payload);
+            CompletableFuture<Optional<ScoredGlobalIndexResult>> future;
+            try {
+                FullTextSearch predicate = new FullTextSearch(column, query, limit);
+                if (include != null) {
+                    predicate.withIncludeRowIds(include);
+                }
+                future =
+                        reader.visitFullTextSearch(predicate)
+                                .whenComplete((ignored, error) -> IOUtils.closeQuietly(reader));
+            } catch (RuntimeException | Error t) {
+                IOUtils.closeQuietly(reader);
+                throw t;
+            }
+            requests.add(new PayloadRequest(sourceRanges, totalRowCount, include, future));
+        }
+
+        CompletableFuture.allOf(
+                        requests.stream()
+                                .map(request -> request.future)
+                                .toArray(CompletableFuture[]::new))
+                .join();
+        List<List<PrimaryKeySearchPosition>> localRankings = new ArrayList<>(requests.size());
+        for (PayloadRequest request : requests) {
+            Optional<ScoredGlobalIndexResult> result = request.future.join();
+            if (!result.isPresent()) {
+                continue;
+            }
+            ScoredGlobalIndexResult scored = result.get();
+            List<PrimaryKeySearchPosition> ranking = new ArrayList<>();
+            for (long rowId : scored.results()) {
+                checkArgument(
+                        rowId >= 0 && rowId < request.totalRowCount,
+                        "Full-text index returned archive row position %s outside row count %s.",
+                        rowId,
+                        request.totalRowCount);
+                if (request.include != null && !request.include.contains(rowId)) {
+                    continue;
+                }
+                SourceRange source = request.source(rowId);
+                checkArgument(
+                        source != null && source.active,
+                        "Full-text index returned row position %s from an inactive source.",
+                        rowId);
+                ranking.add(
+                        new PrimaryKeySearchPosition(
+                                dataSplit.partition(),
+                                dataSplit.bucket(),
+                                source.fileName,
+                                rowId - source.offset,
+                                scored.scoreGetter().score(rowId)));
+            }
+            ranking.sort(
+                    (left, right) -> {
+                        int scoreOrder = Float.compare(right.score(), left.score());
+                        if (scoreOrder != 0) {
+                            return scoreOrder;
+                        }
+                        int fileOrder = left.dataFileName().compareTo(right.dataFileName());
+                        return fileOrder != 0
+                                ? fileOrder
+                                : Long.compare(left.rowPosition(), right.rowPosition());
+                    });
+            localRankings.add(ranking);
+        }
+        return Collections.unmodifiableList(localRankings);
+    }
+
+    @Nullable
+    private static RoaringNavigableMap64 liveRows(
+            long rowCount, @Nullable DeletionVector deletionVector) {
+        if (deletionVector == null || deletionVector.isEmpty()) {
+            return null;
+        }
+        RoaringNavigableMap64 live = new RoaringNavigableMap64();
+        if (rowCount > 0) {
+            live.addRange(new Range(0, rowCount - 1));
+        }
+        RoaringNavigableMap64 deleted = new RoaringNavigableMap64();
+        deletionVector.forEachDeletedPosition(
+                position -> {
+                    checkArgument(
+                            position >= 0 && position < rowCount,
+                            "Deletion vector contains invalid row position %s.",
+                            position);
+                    deleted.add(position);
+                });
+        live.andNot(deleted);
+        return live;
+    }
+
+    private static RoaringNavigableMap64 liveRows(
+            List<SourceRange> sourceRanges, Map<String, DeletionVector> deletionVectors) {
+        RoaringNavigableMap64 include = new RoaringNavigableMap64();
+        for (SourceRange source : sourceRanges) {
+            if (!source.active) {
+                continue;
+            }
+            RoaringNavigableMap64 local =
+                    liveRows(source.rowCount, deletionVectors.get(source.fileName));
+            if (local == null) {
+                if (source.rowCount > 0) {
+                    include.addRange(new Range(source.offset, source.offset + source.rowCount - 1));
+                }
+            } else {
+                for (long rowId : local) {
+                    include.add(source.offset + rowId);
+                }
+            }
+        }
+        return include;
+    }
+
+    /** Creates one independently closeable reader for an immutable payload archive. */
+    @FunctionalInterface
+    public interface ReaderFactory {
+        GlobalIndexReader create(IndexFileMeta payload);
+    }
+
+    private static class PayloadRequest {
+
+        private final List<SourceRange> sourceRanges;
+        private final long totalRowCount;
+        @Nullable private final RoaringNavigableMap64 include;
+        private final CompletableFuture<Optional<ScoredGlobalIndexResult>> future;
+
+        private PayloadRequest(
+                List<SourceRange> sourceRanges,
+                long totalRowCount,
+                @Nullable RoaringNavigableMap64 include,
+                CompletableFuture<Optional<ScoredGlobalIndexResult>> future) {
+            this.sourceRanges = sourceRanges;
+            this.totalRowCount = totalRowCount;
+            this.include = include;
+            this.future = future;
+        }
+
+        @Nullable
+        private SourceRange source(long rowId) {
+            for (SourceRange source : sourceRanges) {
+                if (rowId >= source.offset && rowId < source.offset + source.rowCount) {
+                    return source;
+                }
+            }
+            return null;
+        }
+    }
+
+    private static class SourceRange {
+
+        private final String fileName;
+        private final long offset;
+        private final long rowCount;
+        private final boolean active;
+
+        private SourceRange(String fileName, long offset, long rowCount, boolean active) {
+            this.fileName = fileName;
+            this.offset = offset;
+            this.rowCount = rowCount;
+            this.active = active;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/operation/PrimaryKeyIndexedSplitRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/PrimaryKeyIndexedSplitRead.java
@@ -26,7 +26,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.PrimaryKeyVectorPositionReader;
+import org.apache.paimon.table.source.PrimaryKeyIndexPositionReader;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
@@ -116,6 +116,6 @@ public class PrimaryKeyIndexedSplitRead implements SplitRead<InternalRow> {
         IntFunction<Float> scoreGetter =
                 scoreByPosition == null ? position -> Float.NaN : scoreByPosition::get;
         FileRecordReader<InternalRow> reader = rawRead.createFileReader(dataSplit, rowPositions);
-        return new PrimaryKeyVectorPositionReader(reader, rowPositions, scoreGetter);
+        return new PrimaryKeyIndexPositionReader(reader, rowPositions, scoreGetter);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -997,7 +997,8 @@ public class SchemaManager implements Serializable {
         CoreOptions options = new CoreOptions(schema.options());
         if (options.primaryKeyVectorIndexColumns().contains(fieldName)
                 || options.primaryKeyBTreeIndexColumns().contains(fieldName)
-                || options.primaryKeyBitmapIndexColumns().contains(fieldName)) {
+                || options.primaryKeyBitmapIndexColumns().contains(fieldName)
+                || options.primaryKeyFullTextIndexColumns().contains(fieldName)) {
             throw new UnsupportedOperationException(
                     String.format(
                             "Cannot %s primary-key index column: [%s]", operation, fieldName));

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaValidation.java
@@ -357,6 +357,7 @@ public class SchemaValidation {
         validatePrimaryKeyIndexColumns(options);
         validatePrimaryKeySortedIndexes(schema, options);
         validatePrimaryKeyVectorIndex(schema, options);
+        validatePrimaryKeyFullTextIndex(schema, options);
 
         validateMergeFunctionFactory(schema);
 
@@ -956,22 +957,78 @@ public class SchemaValidation {
                 options.primaryKeyVectorDistanceMetric(indexColumn));
     }
 
+    private static void validatePrimaryKeyFullTextIndex(TableSchema schema, CoreOptions options) {
+        if (!options.primaryKeyFullTextIndexEnabled()) {
+            return;
+        }
+
+        List<String> indexColumns = options.primaryKeyFullTextIndexColumns();
+        checkArgument(
+                indexColumns.size() == 1,
+                "%s must contain exactly one column in the first release, but is %s.",
+                CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(),
+                indexColumns);
+        String indexColumn = indexColumns.get(0);
+        checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(indexColumn),
+                "%s must contain a non-empty column.",
+                CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
+        checkArgument(
+                !schema.primaryKeys().isEmpty(),
+                "Primary-key full-text index requires a primary-key table.");
+        checkArgument(
+                options.mergeEngine() == MergeEngine.FIRST_ROW || options.deletionVectorsEnabled(),
+                "Primary-key full-text index requires deletion-vectors.enabled = true.");
+        checkArgument(
+                !options.deletionVectorsMergeOnRead(),
+                "Primary-key full-text index requires deletion-vectors.merge-on-read = false.");
+        checkArgument(
+                options.bucket() > 0 || options.bucket() == BucketMode.POSTPONE_BUCKET,
+                "Primary-key full-text index requires fixed or postpone bucket mode "
+                        + "(bucket > 0 or bucket = -2), but bucket is %s.",
+                options.bucket());
+        checkArgument(
+                !options.pkClusteringOverride(),
+                "Primary-key full-text index does not support pk-clustering-override.");
+        checkArgument(
+                schema.nameToFieldMap().containsKey(indexColumn),
+                "%s entry '%s' must reference an existing column.",
+                CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(),
+                indexColumn);
+        DataTypeRoot typeRoot = schema.nameToFieldMap().get(indexColumn).type().getTypeRoot();
+        checkArgument(
+                typeRoot == DataTypeRoot.CHAR || typeRoot == DataTypeRoot.VARCHAR,
+                "%s entry '%s' must reference a CHAR/VARCHAR/STRING column.",
+                CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(),
+                indexColumn);
+    }
+
     private static void validatePrimaryKeyIndexColumns(CoreOptions options) {
         List<String> vectorColumns = options.primaryKeyVectorIndexColumns();
         List<String> btreeColumns = options.primaryKeyBTreeIndexColumns();
         List<String> bitmapColumns = options.primaryKeyBitmapIndexColumns();
+        List<String> fullTextColumns = options.primaryKeyFullTextIndexColumns();
         validateNoDuplicatePrimaryKeyIndexColumns(
                 vectorColumns, CoreOptions.PK_VECTOR_INDEX_COLUMNS.key());
         validateNoDuplicatePrimaryKeyIndexColumns(
                 btreeColumns, CoreOptions.PK_BTREE_INDEX_COLUMNS.key());
         validateNoDuplicatePrimaryKeyIndexColumns(
                 bitmapColumns, CoreOptions.PK_BITMAP_INDEX_COLUMNS.key());
+        validateNoDuplicatePrimaryKeyIndexColumns(
+                fullTextColumns, CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
 
         Set<String> indexedColumns = new HashSet<>();
         validateUniquePrimaryKeyIndexColumns(indexedColumns, vectorColumns);
         validateUniquePrimaryKeyIndexColumns(indexedColumns, btreeColumns);
         validateUniquePrimaryKeyIndexColumns(indexedColumns, bitmapColumns);
-        for (String column : indexedColumns) {
+        validateUniquePrimaryKeyIndexColumns(indexedColumns, fullTextColumns);
+
+        Set<String> compactedIndexColumns = new HashSet<>();
+        compactedIndexColumns.addAll(vectorColumns);
+        compactedIndexColumns.addAll(btreeColumns);
+        compactedIndexColumns.addAll(bitmapColumns);
+        compactedIndexColumns.addAll(fullTextColumns);
+        for (String column : compactedIndexColumns) {
             String fanoutKey = CoreOptions.primaryKeyIndexCompactionLevelFanoutKey(column);
             checkArgument(
                     options.primaryKeyIndexCompactionLevelFanout(column) > 1,

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextScanImpl.java
@@ -94,7 +94,7 @@ public class FullTextScanImpl implements FullTextScan {
                         return false;
                     }
                     GlobalIndexMeta globalIndex = entry.indexFile().globalIndexMeta();
-                    if (globalIndex == null) {
+                    if (globalIndex == null || globalIndex.sourceMeta() != null) {
                         return false;
                     }
                     return !matchedTextColumnIds(globalIndex, textColumnIds).isEmpty()

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/FullTextSearchBuilderImpl.java
@@ -18,13 +18,20 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.index.pk.PrimaryKeyIndexDefinition;
+import org.apache.paimon.index.pk.PrimaryKeyIndexDefinitions;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
@@ -40,6 +47,7 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
     private String fieldName;
     private String query;
     private PartitionPredicate partitionFilter;
+    @Nullable private Snapshot pinnedSnapshot;
 
     public FullTextSearchBuilderImpl(InnerTable table) {
         this.table = (FileStoreTable) table;
@@ -66,20 +74,63 @@ public class FullTextSearchBuilderImpl implements FullTextSearchBuilder {
 
     @Override
     public FullTextScan newFullTextScan() {
-        return new FullTextScanImpl(table, partitionFilter, textColumns());
+        DataField textColumn = textColumn();
+        Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);
+        return definition.isPresent()
+                ? new PrimaryKeyFullTextScan(
+                        table, definition.get(), partitionFilter, pinnedSnapshot)
+                : new FullTextScanImpl(
+                        table, partitionFilter, Collections.singletonList(textColumn));
     }
 
     @Override
     public FullTextRead newFullTextRead() {
         checkArgument(limit > 0, "Limit must be positive, set via withLimit()");
-        return new FullTextReadImpl(table, partitionFilter, limit, textColumns(), query);
+        DataField textColumn = textColumn();
+        Optional<PrimaryKeyIndexDefinition> definition = primaryKeyFullTextDefinition(textColumn);
+        return definition.isPresent()
+                ? new PrimaryKeyFullTextRead(table, definition.get(), textColumn, query, limit)
+                : new FullTextReadImpl(
+                        table,
+                        partitionFilter,
+                        limit,
+                        Collections.singletonList(textColumn),
+                        query);
     }
 
-    private List<DataField> textColumns() {
+    private DataField textColumn() {
         checkNotNull(query, "Query must be set via withQuery()");
         checkNotNull(fieldName, "Field name must be set via withQuery()");
         DataField textColumn = table.rowType().getField(fieldName);
         checkNotNull(textColumn, "Text column '%s' does not exist.", fieldName);
-        return Collections.singletonList(textColumn);
+        return textColumn;
+    }
+
+    private Optional<PrimaryKeyIndexDefinition> primaryKeyFullTextDefinition(DataField textColumn) {
+        if (table.coreOptions().dataEvolutionEnabled()) {
+            return Optional.empty();
+        }
+        List<String> configuredColumns = table.coreOptions().primaryKeyFullTextIndexColumns();
+        if (configuredColumns.isEmpty()) {
+            return Optional.empty();
+        }
+        for (PrimaryKeyIndexDefinition definition :
+                PrimaryKeyIndexDefinitions.create(table.schema()).definitions()) {
+            if (definition.family() == PrimaryKeyIndexDefinition.Family.FULL_TEXT
+                    && definition.fieldId() == textColumn.id()) {
+                return Optional.of(definition);
+            }
+        }
+        throw new IllegalArgumentException(
+                String.format(
+                        "Text column '%s' is not configured by '%s' (%s).",
+                        textColumn.name(),
+                        CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(),
+                        configuredColumns));
+    }
+
+    FullTextSearchBuilderImpl withSnapshot(Snapshot snapshot) {
+        this.pinnedSnapshot = snapshot;
+        return this;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/HybridSearchBuilderImpl.java
@@ -18,21 +18,31 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.HybridSearchRanker;
+import org.apache.paimon.globalindex.IndexedSplit;
 import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.HybridSearchRoute;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
+import org.apache.paimon.table.source.snapshot.TimeTravelUtil;
 import org.apache.paimon.utils.Pair;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Implementation for {@link HybridSearchBuilder}. */
 public class HybridSearchBuilderImpl implements HybridSearchBuilder {
@@ -120,12 +130,27 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
     public List<Route> routeBuilders() {
         validateSearch();
 
+        Snapshot snapshot = null;
+        if (table instanceof FileStoreTable) {
+            FileStoreTable fileStoreTable = (FileStoreTable) table;
+            if (!TimeTravelUtil.tryTravelToSnapshot(fileStoreTable).isPresent()) {
+                snapshot = fileStoreTable.latestSnapshot().orElse(null);
+            }
+        }
         List<Route> routeBuilders = new ArrayList<>(routes.size());
         for (HybridSearchRoute route : routes) {
             if (route.isVector()) {
-                routeBuilders.add(new Route(route, newVectorSearchBuilder(route)));
+                VectorSearchBuilder builder = newVectorSearchBuilder(route);
+                if (snapshot != null && builder instanceof VectorSearchBuilderImpl) {
+                    ((VectorSearchBuilderImpl) builder).withSnapshot(snapshot);
+                }
+                routeBuilders.add(new Route(route, builder));
             } else {
-                routeBuilders.add(new Route(route, newFullTextSearchBuilder(route)));
+                FullTextSearchBuilder builder = newFullTextSearchBuilder(route);
+                if (snapshot != null && builder instanceof FullTextSearchBuilderImpl) {
+                    ((FullTextSearchBuilderImpl) builder).withSnapshot(snapshot);
+                }
+                routeBuilders.add(new Route(route, builder));
             }
         }
         return routeBuilders;
@@ -154,6 +179,23 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
     public ScoredGlobalIndexResult rank(List<RouteResult> routeResults) {
         validateSearch();
 
+        boolean hasPhysical = false;
+        boolean hasGlobal = false;
+        for (RouteResult routeResult : routeResults) {
+            if (routeResult.result() instanceof PrimaryKeyScoredResult) {
+                hasPhysical = true;
+            } else {
+                hasGlobal = true;
+            }
+        }
+        if (hasPhysical && hasGlobal) {
+            throw new UnsupportedOperationException(
+                    "Hybrid search cannot combine physical primary-key positions and global row-id address spaces.");
+        }
+        if (hasPhysical) {
+            return rankPhysical(routeResults);
+        }
+
         List<HybridSearchRanker.WeightedResult> weightedResults =
                 new ArrayList<>(routeResults.size());
         for (RouteResult routeResult : routeResults) {
@@ -166,9 +208,138 @@ public class HybridSearchBuilderImpl implements HybridSearchBuilder {
         return HybridSearchRanker.rank(ranker, weightedResults, limit);
     }
 
+    private PrimaryKeyScoredResult rankPhysical(List<RouteResult> routeResults) {
+        Long snapshotId = null;
+        List<PrimaryKeySearchRanker.Ranking> rankings = new ArrayList<>(routeResults.size());
+        List<PrimaryKeyScoredResult> physicalResults = new ArrayList<>(routeResults.size());
+        for (RouteResult routeResult : routeResults) {
+            PrimaryKeyScoredResult result = (PrimaryKeyScoredResult) routeResult.result();
+            if (snapshotId == null) {
+                snapshotId = result.snapshotId();
+            } else {
+                checkArgument(
+                        snapshotId == result.snapshotId(),
+                        "Primary-key hybrid routes must use the same snapshot, but found %s and %s.",
+                        snapshotId,
+                        result.snapshotId());
+            }
+            physicalResults.add(result);
+            if (!result.positions().isEmpty()) {
+                rankings.add(
+                        new PrimaryKeySearchRanker.Ranking(
+                                result.positions(), routeResult.route().weight()));
+            }
+        }
+
+        List<PrimaryKeySearchPosition> positions;
+        if (HybridSearchRanker.WEIGHTED_SCORE_RANKER.equals(ranker)) {
+            positions = PrimaryKeySearchRanker.weightedScore(rankings, limit);
+        } else if (HybridSearchRanker.MRR_RANKER.equals(ranker)) {
+            positions = PrimaryKeySearchRanker.weightedMrr(rankings, limit);
+        } else {
+            positions = PrimaryKeySearchRanker.weightedRrf(rankings, limit);
+        }
+        return new PrimaryKeyScoredResult(
+                snapshotId, physicalSources(physicalResults, positions), positions);
+    }
+
+    private static List<DataSplit> physicalSources(
+            List<PrimaryKeyScoredResult> results, List<PrimaryKeySearchPosition> positions) {
+        Map<PhysicalFileKey, DataSplit> available = new LinkedHashMap<>();
+        for (PrimaryKeyScoredResult result : results) {
+            for (IndexedSplit indexedSplit : result.splits()) {
+                DataSplit source = indexedSplit.dataSplit();
+                checkArgument(
+                        source.dataFiles().size() == 1,
+                        "Primary-key scored source split must contain exactly one data file.");
+                PhysicalFileKey key =
+                        new PhysicalFileKey(
+                                source.partition(),
+                                source.bucket(),
+                                source.dataFiles().get(0).fileName());
+                DataSplit previous = available.putIfAbsent(key, source);
+                if (previous != null) {
+                    checkArgument(
+                            previous.snapshotId() == source.snapshotId()
+                                    && previous.bucketPath().equals(source.bucketPath())
+                                    && Objects.equals(
+                                            previous.totalBuckets(), source.totalBuckets())
+                                    && previous.dataFiles().get(0).fileSize()
+                                            == source.dataFiles().get(0).fileSize()
+                                    && previous.dataFiles().get(0).rowCount()
+                                            == source.dataFiles().get(0).rowCount()
+                                    && Objects.equals(deletionFile(previous), deletionFile(source)),
+                            "Primary-key hybrid routes contain inconsistent metadata for data file %s.",
+                            key.dataFileName);
+                }
+            }
+        }
+
+        Map<PhysicalFileKey, DataSplit> selected = new LinkedHashMap<>();
+        for (PrimaryKeySearchPosition position : positions) {
+            PhysicalFileKey key = PhysicalFileKey.from(position);
+            DataSplit source = available.get(key);
+            checkArgument(
+                    source != null,
+                    "Primary-key hybrid result references unknown data file %s.",
+                    position.dataFileName());
+            selected.putIfAbsent(key, source);
+        }
+        return Collections.unmodifiableList(new ArrayList<>(selected.values()));
+    }
+
+    private static DeletionFile deletionFile(DataSplit split) {
+        if (!split.deletionFiles().isPresent()) {
+            return null;
+        }
+        checkArgument(
+                split.deletionFiles().get().size() == 1,
+                "Primary-key scored source split must contain exactly one deletion-file entry.");
+        return split.deletionFiles().get().get(0);
+    }
+
+    private static class PhysicalFileKey {
+
+        private final BinaryRow partition;
+        private final int bucket;
+        private final String dataFileName;
+
+        private PhysicalFileKey(BinaryRow partition, int bucket, String dataFileName) {
+            this.partition = partition.copy();
+            this.bucket = bucket;
+            this.dataFileName = dataFileName;
+        }
+
+        private static PhysicalFileKey from(PrimaryKeySearchPosition position) {
+            return new PhysicalFileKey(
+                    position.partition(), position.bucket(), position.dataFileName());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof PhysicalFileKey)) {
+                return false;
+            }
+            PhysicalFileKey that = (PhysicalFileKey) o;
+            return bucket == that.bucket
+                    && partition.equals(that.partition)
+                    && dataFileName.equals(that.dataFileName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(partition, bucket, dataFileName);
+        }
+    }
+
     @Override
     public RouteResult toRouteResult(Route route, GlobalIndexResult result) {
-        if (result instanceof ScoredGlobalIndexResult) {
+        if (result instanceof PrimaryKeyVectorResult) {
+            return new RouteResult(route.route(), ((PrimaryKeyVectorResult) result).scoredResult());
+        } else if (result instanceof ScoredGlobalIndexResult) {
             return new RouteResult(route.route(), (ScoredGlobalIndexResult) result);
         } else if (result.results().isEmpty()) {
             return new RouteResult(route.route(), ScoredGlobalIndexResult.createEmpty());

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextRead.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextRead.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
+import org.apache.paimon.KeyValueFileStore;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.globalindex.GlobalIndexIOMeta;
+import org.apache.paimon.globalindex.GlobalIndexReadThreadPool;
+import org.apache.paimon.globalindex.GlobalIndexReader;
+import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexDefinition;
+import org.apache.paimon.index.pkfulltext.PkFullTextDataFileReader;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexBuilder;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
+import org.apache.paimon.index.pkfulltext.PrimaryKeyFullTextBucketSearch;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.table.DelegatedFileStoreTable;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.DataField;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.paimon.CoreOptions.GLOBAL_INDEX_THREAD_NUM;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** Reads primary-key full-text payloads and optional temporary fallback indexes. */
+public class PrimaryKeyFullTextRead implements FullTextRead {
+
+    private final GlobalIndexSearchMode searchMode;
+    private final int limit;
+    private final BucketRankingSearch indexedSearch;
+    private final BucketRankingSearch rawSearch;
+
+    public PrimaryKeyFullTextRead(
+            FileStoreTable table,
+            PrimaryKeyIndexDefinition definition,
+            DataField textField,
+            String query,
+            int limit) {
+        checkArgument(limit > 0, "Full-text search limit must be positive: %s.", limit);
+        checkArgument(
+                definition.family() == PrimaryKeyIndexDefinition.Family.FULL_TEXT,
+                "Primary-key full-text read requires a full-text definition.");
+        checkArgument(
+                definition.fieldId() == textField.id(),
+                "Full-text definition does not match field %s.",
+                textField.name());
+        ProductionSearch production =
+                new ProductionSearch(table, definition, textField, query, limit);
+        this.searchMode = table.coreOptions().globalIndexSearchMode();
+        this.limit = limit;
+        this.indexedSearch = production::searchIndexed;
+        this.rawSearch = production::searchRaw;
+    }
+
+    PrimaryKeyFullTextRead(
+            GlobalIndexSearchMode searchMode,
+            int limit,
+            BucketRankingSearch indexedSearch,
+            BucketRankingSearch rawSearch) {
+        checkArgument(limit > 0, "Full-text search limit must be positive: %s.", limit);
+        this.searchMode = searchMode;
+        this.limit = limit;
+        this.indexedSearch = indexedSearch;
+        this.rawSearch = rawSearch;
+    }
+
+    @Override
+    public PrimaryKeyScoredResult read(FullTextScan.Plan plan) {
+        checkArgument(
+                plan instanceof PrimaryKeyFullTextScan.Plan,
+                "Primary-key full-text read requires a PrimaryKeyFullTextScan plan.");
+        PrimaryKeyFullTextScan.Plan primaryKeyPlan = (PrimaryKeyFullTextScan.Plan) plan;
+        return read(primaryKeyPlan.snapshotId(), primaryKeyPlan.splits());
+    }
+
+    @Override
+    public PrimaryKeyScoredResult read(List<FullTextSearchSplit> splits) {
+        if (splits.isEmpty()) {
+            return new PrimaryKeyScoredResult(0, Collections.emptyList(), Collections.emptyList());
+        }
+        checkArgument(
+                splits.get(0) instanceof PrimaryKeyFullTextSearchSplit,
+                "Primary-key full-text read requires primary-key full-text splits.");
+        long snapshotId = ((PrimaryKeyFullTextSearchSplit) splits.get(0)).dataSplit().snapshotId();
+        return read(snapshotId, splits);
+    }
+
+    private PrimaryKeyScoredResult read(long snapshotId, List<FullTextSearchSplit> splits) {
+        List<DataSplit> sourceSplits = new ArrayList<>(splits.size());
+        List<List<PrimaryKeySearchPosition>> rankings = new ArrayList<>();
+        for (FullTextSearchSplit searchSplit : splits) {
+            checkArgument(
+                    searchSplit instanceof PrimaryKeyFullTextSearchSplit,
+                    "Primary-key full-text read received an incompatible split.");
+            PrimaryKeyFullTextSearchSplit split = (PrimaryKeyFullTextSearchSplit) searchSplit;
+            checkArgument(
+                    split.dataSplit().snapshotId() == snapshotId,
+                    "Full-text bucket split snapshot does not match its plan.");
+            sourceSplits.add(split.dataSplit());
+            rankings.addAll(indexedSearch.search(split));
+            if (searchMode != GlobalIndexSearchMode.FAST && !split.uncoveredDataFiles().isEmpty()) {
+                rankings.addAll(rawSearch.search(split));
+            }
+        }
+        List<PrimaryKeySearchPosition> positions =
+                rankings.isEmpty()
+                        ? Collections.emptyList()
+                        : PrimaryKeySearchRanker.rrf(rankings, limit);
+        return new PrimaryKeyScoredResult(snapshotId, sourceSplits, positions);
+    }
+
+    @FunctionalInterface
+    interface BucketRankingSearch {
+        List<List<PrimaryKeySearchPosition>> search(PrimaryKeyFullTextSearchSplit split);
+    }
+
+    private static KeyValueFileStore keyValueStore(FileStoreTable table) {
+        FileStoreTable unwrapped = table;
+        while (unwrapped instanceof DelegatedFileStoreTable) {
+            unwrapped = ((DelegatedFileStoreTable) unwrapped).wrapped();
+        }
+        checkArgument(
+                unwrapped.store() instanceof KeyValueFileStore,
+                "Primary-key full-text search requires a key-value file store.");
+        return (KeyValueFileStore) unwrapped.store();
+    }
+
+    private static class ProductionSearch {
+
+        private final FileStoreTable table;
+        private final PrimaryKeyIndexDefinition definition;
+        private final DataField textField;
+        private final String query;
+        private final int limit;
+        private final FileIO fileIO;
+        private final IndexFileHandler indexFileHandler;
+        private final KeyValueFileReaderFactory.Builder readerFactoryBuilder;
+        private final ExecutorService executor;
+        private final GlobalIndexer indexer;
+        private final GlobalIndexFileReader archiveReader;
+
+        private ProductionSearch(
+                FileStoreTable table,
+                PrimaryKeyIndexDefinition definition,
+                DataField textField,
+                String query,
+                int limit) {
+            this.table = table;
+            this.definition = definition;
+            this.textField = textField;
+            this.query = checkNotNull(query, "Full-text query must not be null.");
+            this.limit = limit;
+            this.fileIO = table.fileIO();
+            this.indexFileHandler = table.store().newIndexFileHandler();
+            this.readerFactoryBuilder = keyValueStore(table).newReaderFactoryBuilder();
+            this.executor =
+                    GlobalIndexReadThreadPool.getExecutorService(
+                            table.coreOptions().toConfiguration().get(GLOBAL_INDEX_THREAD_NUM));
+            this.indexer =
+                    GlobalIndexer.create(
+                            PkFullTextIndexFile.INDEX_TYPE, textField, definition.options());
+            this.archiveReader = meta -> fileIO.newInputStream(meta.filePath());
+        }
+
+        private List<List<PrimaryKeySearchPosition>> searchIndexed(
+                PrimaryKeyFullTextSearchSplit split) {
+            if (split.payloadFiles().isEmpty()) {
+                return Collections.emptyList();
+            }
+            return bucketSearch(split)
+                    .searchRankings(
+                            split,
+                            deletionVectors(split.dataSplit()),
+                            textField.name(),
+                            query,
+                            limit);
+        }
+
+        private List<List<PrimaryKeySearchPosition>> searchRaw(
+                PrimaryKeyFullTextSearchSplit split) {
+            DataSplit rawDataSplit = uncoveredSplit(split);
+            if (rawDataSplit.dataFiles().isEmpty()) {
+                return Collections.emptyList();
+            }
+            PkFullTextIndexFile indexFile =
+                    indexFileHandler.pkFullTextIndex(
+                            rawDataSplit.partition(), rawDataSplit.bucket());
+            PkFullTextIndexBuilder builder =
+                    new PkFullTextIndexBuilder(
+                            indexFile,
+                            new PkFullTextDataFileReader.Factory(
+                                    readerFactoryBuilder,
+                                    rawDataSplit.partition(),
+                                    rawDataSplit.bucket(),
+                                    textField),
+                            textField,
+                            definition.options(),
+                            definition.definitionFingerprint());
+            List<CompletableFuture<IndexFileMeta>> builds = new ArrayList<>();
+            for (DataFileMeta dataFile : rawDataSplit.dataFiles()) {
+                builds.add(
+                        CompletableFuture.supplyAsync(
+                                () -> {
+                                    try {
+                                        return builder.build(dataFile);
+                                    } catch (IOException e) {
+                                        throw new UncheckedIOException(e);
+                                    }
+                                },
+                                executor));
+            }
+
+            List<IndexFileMeta> temporaryPayloads = new ArrayList<>();
+            try {
+                CompletableFuture.allOf(builds.toArray(new CompletableFuture[0])).join();
+                for (CompletableFuture<IndexFileMeta> build : builds) {
+                    temporaryPayloads.add(build.join());
+                }
+                PrimaryKeyFullTextSearchSplit temporarySplit =
+                        new PrimaryKeyFullTextSearchSplit(
+                                rawDataSplit, temporaryPayloads, Collections.emptyList());
+                return bucketSearch(temporarySplit)
+                        .searchRankings(
+                                temporarySplit,
+                                deletionVectors(rawDataSplit),
+                                textField.name(),
+                                query,
+                                limit);
+            } finally {
+                for (CompletableFuture<IndexFileMeta> build : builds) {
+                    if (build.isDone()
+                            && !build.isCompletedExceptionally()
+                            && !build.isCancelled()) {
+                        IndexFileMeta payload = build.getNow(null);
+                        if (payload != null) {
+                            indexFile.delete(payload);
+                        }
+                    }
+                }
+            }
+        }
+
+        private PrimaryKeyFullTextBucketSearch bucketSearch(PrimaryKeyFullTextSearchSplit split) {
+            PkFullTextIndexFile indexFile =
+                    indexFileHandler.pkFullTextIndex(
+                            split.dataSplit().partition(), split.dataSplit().bucket());
+            return new PrimaryKeyFullTextBucketSearch(
+                    payload -> {
+                        GlobalIndexMeta meta = checkNotNull(payload.globalIndexMeta());
+                        GlobalIndexIOMeta ioMeta =
+                                new GlobalIndexIOMeta(
+                                        indexFile.path(payload),
+                                        payload.fileSize(),
+                                        meta.indexMeta());
+                        GlobalIndexReader reader =
+                                indexer.createReader(
+                                        archiveReader, Collections.singletonList(ioMeta), executor);
+                        return reader;
+                    });
+        }
+
+        private Map<String, DeletionVector> deletionVectors(DataSplit split) {
+            try {
+                DeletionVector.Factory factory =
+                        DeletionVector.factory(
+                                fileIO, split.dataFiles(), split.deletionFiles().orElse(null));
+                Map<String, DeletionVector> result = new HashMap<>();
+                for (DataFileMeta file : split.dataFiles()) {
+                    Optional<DeletionVector> deletionVector = factory.create(file.fileName());
+                    if (deletionVector.isPresent()) {
+                        result.put(file.fileName(), deletionVector.get());
+                    }
+                }
+                return result;
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read full-text deletion vectors.", e);
+            }
+        }
+
+        private static DataSplit uncoveredSplit(PrimaryKeyFullTextSearchSplit split) {
+            DataSplit source = split.dataSplit();
+            Set<String> uncovered = new HashSet<>(split.uncoveredDataFiles());
+            List<DataFileMeta> dataFiles = new ArrayList<>();
+            List<DeletionFile> deletionFiles = new ArrayList<>();
+            List<DeletionFile> sourceDeletions = source.deletionFiles().orElse(null);
+            for (int i = 0; i < source.dataFiles().size(); i++) {
+                DataFileMeta dataFile = source.dataFiles().get(i);
+                if (uncovered.remove(dataFile.fileName())) {
+                    dataFiles.add(dataFile);
+                    deletionFiles.add(sourceDeletions == null ? null : sourceDeletions.get(i));
+                }
+            }
+            checkArgument(
+                    uncovered.isEmpty(),
+                    "Full-text split references unknown uncovered files %s.",
+                    uncovered);
+            DataSplit.Builder builder =
+                    DataSplit.builder()
+                            .withSnapshot(source.snapshotId())
+                            .withPartition(source.partition())
+                            .withBucket(source.bucket())
+                            .withBucketPath(source.bucketPath())
+                            .withTotalBuckets(source.totalBuckets())
+                            .withDataFiles(dataFiles)
+                            .isStreaming(false)
+                            .rawConvertible(false);
+            if (sourceDeletions != null) {
+                builder.withDataDeletionFiles(deletionFiles);
+            }
+            return builder.build();
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextScan.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexDefinition;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourcePolicy;
+import org.apache.paimon.index.pkfulltext.PkFullTextBucketIndexState;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.utils.Pair;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Plans compaction-visible full-text inputs from one captured primary-key snapshot. */
+public class PrimaryKeyFullTextScan implements FullTextScan {
+
+    private final FileStoreTable table;
+    private final PrimaryKeyIndexDefinition definition;
+    @Nullable private final PartitionPredicate partitionFilter;
+    @Nullable private final Snapshot pinnedSnapshot;
+
+    public PrimaryKeyFullTextScan(
+            FileStoreTable table,
+            PrimaryKeyIndexDefinition definition,
+            @Nullable PartitionPredicate partitionFilter) {
+        this(table, definition, partitionFilter, null);
+    }
+
+    PrimaryKeyFullTextScan(
+            FileStoreTable table,
+            PrimaryKeyIndexDefinition definition,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Snapshot pinnedSnapshot) {
+        checkArgument(
+                definition.family() == PrimaryKeyIndexDefinition.Family.FULL_TEXT,
+                "Primary-key full-text scan requires a full-text index definition.");
+        this.table = table;
+        this.definition = definition;
+        this.partitionFilter = partitionFilter;
+        this.pinnedSnapshot = pinnedSnapshot;
+    }
+
+    @Override
+    public Plan scan() {
+        FileStoreTable scanTable = scanTable();
+        SnapshotReader snapshotReader = scanTable.newSnapshotReader().keepStats();
+        DataTableScan dataScan = scanTable.newScan(ignored -> snapshotReader);
+        checkArgument(
+                dataScan instanceof PrimaryKeyBatchScan,
+                "Primary-key full-text search requires a primary-key batch scan.");
+        PrimaryKeyBatchScan batchScan = (PrimaryKeyBatchScan) dataScan;
+        if (partitionFilter != null) {
+            batchScan.withPartitionFilter(partitionFilter);
+        }
+        TableScan.Plan tablePlan = batchScan.planWithoutAuth();
+        if (!(tablePlan instanceof SnapshotReader.Plan)) {
+            checkArgument(
+                    tablePlan.splits().isEmpty(),
+                    "Primary-key full-text search requires a snapshot plan.");
+            return new Plan(0, Collections.emptyList());
+        }
+        SnapshotReader.Plan snapshotPlan = (SnapshotReader.Plan) tablePlan;
+        if (snapshotPlan.snapshotId() == null) {
+            return new Plan(0, Collections.emptyList());
+        }
+        Snapshot snapshot =
+                pinnedSnapshot == null
+                        ? snapshotReader.snapshotManager().snapshot(snapshotPlan.snapshotId())
+                        : pinnedSnapshot;
+        checkArgument(snapshot != null, "Primary-key full-text snapshot does not exist.");
+        checkArgument(
+                snapshot.id() == snapshotPlan.snapshotId(),
+                "Primary-key full-text plan snapshot %s does not match pinned snapshot %s.",
+                snapshotPlan.snapshotId(),
+                snapshot.id());
+
+        IndexFileHandler indexFileHandler = snapshotReader.indexFileHandler();
+        checkArgument(
+                indexFileHandler != null, "Primary-key full-text index handler is unavailable.");
+        List<IndexManifestEntry> payloadEntries =
+                indexFileHandler.scan(
+                        snapshot,
+                        entry ->
+                                matchesDefinition(entry)
+                                        && (partitionFilter == null
+                                                || partitionFilter.test(entry.partition())));
+        return plan(
+                snapshot.id(),
+                snapshotPlan.splits(),
+                payloadEntries,
+                definition.fieldId(),
+                definition.definitionFingerprint());
+    }
+
+    private FileStoreTable scanTable() {
+        if (pinnedSnapshot == null) {
+            return table;
+        }
+        return (FileStoreTable)
+                table.copy(
+                        Collections.singletonMap(
+                                CoreOptions.SCAN_SNAPSHOT_ID.key(),
+                                String.valueOf(pinnedSnapshot.id())));
+    }
+
+    private boolean matchesDefinition(IndexManifestEntry entry) {
+        IndexFileMeta payload = entry.indexFile();
+        GlobalIndexMeta globalMeta = payload.globalIndexMeta();
+        if (!PkFullTextIndexFile.INDEX_TYPE.equals(payload.indexType())
+                || globalMeta == null
+                || globalMeta.sourceMeta() == null
+                || globalMeta.indexFieldId() != definition.fieldId()) {
+            return false;
+        }
+        return PrimaryKeyIndexSourceMeta.deserialize(globalMeta.sourceMeta())
+                .definitionFingerprint()
+                .filter(definition.definitionFingerprint()::equals)
+                .isPresent();
+    }
+
+    static Plan plan(
+            long snapshotId,
+            List<? extends Split> dataSplits,
+            List<IndexManifestEntry> payloadEntries,
+            int textFieldId,
+            String definitionFingerprint) {
+        Map<Pair<BinaryRow, Integer>, List<IndexFileMeta>> payloads = new LinkedHashMap<>();
+        for (IndexManifestEntry entry : payloadEntries) {
+            checkArgument(
+                    entry.kind() == FileKind.ADD,
+                    "Primary-key full-text index file %s is not active.",
+                    entry.indexFile().fileName());
+            Pair<BinaryRow, Integer> key = Pair.of(entry.partition(), entry.bucket());
+            payloads.computeIfAbsent(key, ignored -> new ArrayList<>()).add(entry.indexFile());
+        }
+
+        Map<Pair<BinaryRow, Integer>, BucketAccumulator> buckets = new LinkedHashMap<>();
+        for (Split split : dataSplits) {
+            DataSplit dataSplit = unwrapDataSplit(split);
+            checkArgument(
+                    dataSplit.snapshotId() == snapshotId,
+                    "Data split snapshot %s does not match full-text scan snapshot %s.",
+                    dataSplit.snapshotId(),
+                    snapshotId);
+            checkArgument(
+                    !dataSplit.isStreaming(),
+                    "Primary-key full-text search requires a batch split.");
+            if (dataSplit.bucket() < 0) {
+                continue;
+            }
+            Pair<BinaryRow, Integer> key = Pair.of(dataSplit.partition(), dataSplit.bucket());
+            BucketAccumulator accumulator = buckets.get(key);
+            if (accumulator == null) {
+                accumulator = new BucketAccumulator(dataSplit);
+                buckets.put(key, accumulator);
+            }
+            accumulator.add(dataSplit);
+        }
+
+        List<PrimaryKeyFullTextSearchSplit> result = new ArrayList<>();
+        for (Map.Entry<Pair<BinaryRow, Integer>, BucketAccumulator> entry : buckets.entrySet()) {
+            BucketAccumulator bucket = entry.getValue();
+            if (bucket.isEmpty()) {
+                continue;
+            }
+            PkFullTextBucketIndexState state =
+                    PkFullTextBucketIndexState.fromActivePayloads(
+                            textFieldId,
+                            definitionFingerprint,
+                            payloads.getOrDefault(entry.getKey(), Collections.emptyList()));
+            Set<String> activeSources = bucket.dataFileNames();
+            Map<String, IndexFileMeta> currentPayloads = new LinkedHashMap<>();
+            Set<String> covered = new HashSet<>();
+            for (Map.Entry<String, IndexFileMeta> payload :
+                    state.payloadBySourceFile().entrySet()) {
+                if (activeSources.contains(payload.getKey())) {
+                    currentPayloads.put(payload.getValue().fileName(), payload.getValue());
+                    covered.add(payload.getKey());
+                }
+            }
+            List<String> uncovered = new ArrayList<>();
+            for (DataFileMeta dataFile : bucket.dataFiles()) {
+                if (!covered.contains(dataFile.fileName())) {
+                    uncovered.add(dataFile.fileName());
+                }
+            }
+            result.add(
+                    new PrimaryKeyFullTextSearchSplit(
+                            bucket.build(), new ArrayList<>(currentPayloads.values()), uncovered));
+        }
+        return new Plan(snapshotId, result);
+    }
+
+    private static DataSplit unwrapDataSplit(Split split) {
+        if (split instanceof IndexedSplit) {
+            return ((IndexedSplit) split).dataSplit();
+        }
+        checkArgument(
+                split instanceof DataSplit,
+                "Unsupported primary-key full-text source split: %s.",
+                split.getClass().getName());
+        return (DataSplit) split;
+    }
+
+    /** Immutable snapshot full-text plan. */
+    public static class Plan implements FullTextScan.Plan {
+
+        private final long snapshotId;
+        private final List<FullTextSearchSplit> splits;
+
+        private Plan(long snapshotId, List<PrimaryKeyFullTextSearchSplit> splits) {
+            this.snapshotId = snapshotId;
+            this.splits = Collections.unmodifiableList(new ArrayList<FullTextSearchSplit>(splits));
+        }
+
+        public long snapshotId() {
+            return snapshotId;
+        }
+
+        @Override
+        public List<FullTextSearchSplit> splits() {
+            return splits;
+        }
+    }
+
+    private static class BucketAccumulator {
+
+        private final long snapshotId;
+        private final BinaryRow partition;
+        private final int bucket;
+        private final String bucketPath;
+        @Nullable private final Integer totalBuckets;
+        private final List<DataFileMeta> dataFiles = new ArrayList<>();
+        private final List<DeletionFile> deletionFiles = new ArrayList<>();
+        private final Set<String> dataFileNames = new HashSet<>();
+        private boolean hasDeletionMetadata;
+
+        private BucketAccumulator(DataSplit split) {
+            this.snapshotId = split.snapshotId();
+            this.partition = split.partition();
+            this.bucket = split.bucket();
+            this.bucketPath = split.bucketPath();
+            this.totalBuckets = split.totalBuckets();
+        }
+
+        private void add(DataSplit split) {
+            checkArgument(
+                    snapshotId == split.snapshotId()
+                            && partition.equals(split.partition())
+                            && bucket == split.bucket()
+                            && bucketPath.equals(split.bucketPath()),
+                    "Cannot combine data splits from different snapshot buckets.");
+            checkArgument(
+                    totalBuckets == null
+                            ? split.totalBuckets() == null
+                            : totalBuckets.equals(split.totalBuckets()),
+                    "Bucket split total-bucket metadata is inconsistent.");
+            List<DeletionFile> splitDeletions = split.deletionFiles().orElse(null);
+            checkArgument(
+                    splitDeletions == null || splitDeletions.size() == split.dataFiles().size(),
+                    "Deletion files must align with data files in a full-text bucket split.");
+            hasDeletionMetadata |= splitDeletions != null;
+            for (int i = 0; i < split.dataFiles().size(); i++) {
+                DataFileMeta file = split.dataFiles().get(i);
+                if (!PrimaryKeyIndexSourcePolicy.shouldRead(file)) {
+                    continue;
+                }
+                checkArgument(
+                        dataFileNames.add(file.fileName()),
+                        "Data file %s appears more than once in full-text bucket planning.",
+                        file.fileName());
+                dataFiles.add(file);
+                deletionFiles.add(splitDeletions == null ? null : splitDeletions.get(i));
+            }
+        }
+
+        private boolean isEmpty() {
+            return dataFiles.isEmpty();
+        }
+
+        private List<DataFileMeta> dataFiles() {
+            return dataFiles;
+        }
+
+        private Set<String> dataFileNames() {
+            return dataFileNames;
+        }
+
+        private DataSplit build() {
+            DataSplit.Builder builder =
+                    DataSplit.builder()
+                            .withSnapshot(snapshotId)
+                            .withPartition(partition)
+                            .withBucket(bucket)
+                            .withBucketPath(bucketPath)
+                            .withTotalBuckets(totalBuckets)
+                            .withDataFiles(dataFiles)
+                            .isStreaming(false)
+                            .rawConvertible(false);
+            if (hasDeletionMetadata) {
+                builder.withDataDeletionFiles(deletionFiles);
+            }
+            return builder.build();
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextSearchSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyFullTextSearchSplit.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexFileMetaSerializer;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataInputViewStreamWrapper;
+import org.apache.paimon.io.DataOutputViewStreamWrapper;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Compaction-visible data files and full-text payloads for one snapshot bucket. */
+public class PrimaryKeyFullTextSearchSplit extends FullTextSearchSplit {
+
+    private static final long serialVersionUID = 1L;
+    private static final int VERSION = 1;
+
+    private DataSplit dataSplit;
+    private transient List<IndexFileMeta> payloadFiles;
+    private List<String> uncoveredDataFiles;
+
+    public PrimaryKeyFullTextSearchSplit(
+            DataSplit dataSplit,
+            List<IndexFileMeta> payloadFiles,
+            List<String> uncoveredDataFiles) {
+        checkArgument(
+                !dataSplit.isStreaming(), "Primary-key full-text search requires a batch split.");
+        Set<String> sourceFiles = new HashSet<>();
+        for (DataFileMeta dataFile : dataSplit.dataFiles()) {
+            checkArgument(
+                    sourceFiles.add(dataFile.fileName()),
+                    "Data file %s appears more than once in a full-text bucket split.",
+                    dataFile.fileName());
+        }
+
+        Set<String> covered = new HashSet<>();
+        for (IndexFileMeta payload : payloadFiles) {
+            boolean coversActiveSource = false;
+            for (PrimaryKeyIndexSourceFile source :
+                    PrimaryKeyIndexSourceMeta.fromIndexFile(payload).sourceFiles()) {
+                if (!sourceFiles.contains(source.fileName())) {
+                    continue;
+                }
+                coversActiveSource = true;
+                checkArgument(
+                        covered.add(source.fileName()),
+                        "Data file %s is covered by more than one full-text payload.",
+                        source.fileName());
+            }
+            checkArgument(
+                    coversActiveSource,
+                    "Full-text payload %s does not cover an active data file in its bucket split.",
+                    payload.fileName());
+        }
+
+        Set<String> uncovered = new HashSet<>();
+        for (String source : uncoveredDataFiles) {
+            checkArgument(
+                    sourceFiles.contains(source),
+                    "Uncovered full-text data file %s is outside its bucket split.",
+                    source);
+            checkArgument(
+                    uncovered.add(source),
+                    "Uncovered full-text data file %s appears more than once.",
+                    source);
+            checkArgument(
+                    !covered.contains(source),
+                    "Data file %s cannot be both indexed and uncovered.",
+                    source);
+        }
+        checkArgument(
+                covered.size() + uncovered.size() == sourceFiles.size(),
+                "Every full-text source file must be indexed or explicitly uncovered.");
+
+        this.dataSplit = dataSplit;
+        this.payloadFiles = Collections.unmodifiableList(new ArrayList<>(payloadFiles));
+        this.uncoveredDataFiles = Collections.unmodifiableList(new ArrayList<>(uncoveredDataFiles));
+    }
+
+    public DataSplit dataSplit() {
+        return dataSplit;
+    }
+
+    public List<IndexFileMeta> payloadFiles() {
+        return payloadFiles;
+    }
+
+    public List<String> uncoveredDataFiles() {
+        return uncoveredDataFiles;
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        out.writeInt(VERSION);
+        out.writeInt(payloadFiles.size());
+        IndexFileMetaSerializer serializer = new IndexFileMetaSerializer();
+        for (IndexFileMeta payloadFile : payloadFiles) {
+            serializer.serialize(payloadFile, new DataOutputViewStreamWrapper(out));
+        }
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        int version = in.readInt();
+        if (version != VERSION) {
+            throw new IOException("Unsupported PrimaryKeyFullTextSearchSplit version: " + version);
+        }
+        int payloadFileCount = in.readInt();
+        if (payloadFileCount < 0) {
+            throw new IOException("Negative primary-key full-text payload file count.");
+        }
+        List<IndexFileMeta> payloads = new ArrayList<>(payloadFileCount);
+        IndexFileMetaSerializer serializer = new IndexFileMetaSerializer();
+        for (int i = 0; i < payloadFileCount; i++) {
+            payloads.add(serializer.deserialize(new DataInputViewStreamWrapper(in)));
+        }
+        this.payloadFiles = Collections.unmodifiableList(payloads);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PrimaryKeyFullTextSearchSplit that = (PrimaryKeyFullTextSearchSplit) o;
+        return Objects.equals(dataSplit, that.dataSplit)
+                && Objects.equals(payloadFiles, that.payloadFiles)
+                && Objects.equals(uncoveredDataFiles, that.uncoveredDataFiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataSplit, payloadFiles, uncoveredDataFiles);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyIndexPositionReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyIndexPositionReader.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.FileRecordIterator;
+import org.apache.paimon.reader.FileRecordReader;
+import org.apache.paimon.reader.ScoreRecordIterator;
+import org.apache.paimon.reader.ScoreRecordReader;
+import org.apache.paimon.utils.RoaringBitmap32;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.function.IntFunction;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Reads selected primary-key physical file positions and exposes their search scores. */
+public class PrimaryKeyIndexPositionReader implements ScoreRecordReader<InternalRow> {
+
+    private final FileRecordReader<InternalRow> reader;
+    private final RoaringBitmap32 rowPositions;
+    private final IntFunction<Float> scoreGetter;
+    private final int lastPosition;
+    private boolean exhausted;
+
+    public PrimaryKeyIndexPositionReader(
+            FileRecordReader<InternalRow> reader,
+            RoaringBitmap32 rowPositions,
+            IntFunction<Float> scoreGetter) {
+        checkArgument(!rowPositions.isEmpty(), "Selected row positions must not be empty.");
+        this.reader = reader;
+        this.rowPositions = rowPositions.clone();
+        this.scoreGetter = scoreGetter;
+        this.lastPosition = rowPositions.last();
+    }
+
+    @Nullable
+    @Override
+    public ScoreRecordIterator<InternalRow> readBatch() throws IOException {
+        if (exhausted) {
+            return null;
+        }
+        FileRecordIterator<InternalRow> batch = reader.readBatch();
+        if (batch == null) {
+            return null;
+        }
+        FileRecordIterator<InternalRow> selected = batch.selection(rowPositions);
+        return new ScoreRecordIterator<InternalRow>() {
+
+            private long returnedPosition = -1;
+            private float returnedScore = Float.NaN;
+
+            @Override
+            public float returnedScore() {
+                return returnedScore;
+            }
+
+            @Override
+            public long returnedRowId() {
+                return returnedPosition;
+            }
+
+            @Nullable
+            @Override
+            public InternalRow next() throws IOException {
+                InternalRow row = selected.next();
+                if (row != null) {
+                    returnedPosition = selected.returnedPosition();
+                    returnedScore = scoreGetter.apply((int) returnedPosition);
+                    if (returnedPosition >= lastPosition) {
+                        exhausted = true;
+                    }
+                }
+                return row;
+            }
+
+            @Override
+            public void releaseBatch() {
+                selected.releaseBatch();
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyScoredResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyScoredResult.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.globalindex.ScoreGetter;
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Snapshot-scoped scored search result addressed by physical primary-key row positions. */
+public class PrimaryKeyScoredResult implements GlobalIndexSplitResult, ScoredGlobalIndexResult {
+
+    private final long snapshotId;
+    private final List<PrimaryKeySearchPosition> positions;
+    private final List<IndexedSplit> splits;
+
+    public PrimaryKeyScoredResult(
+            long snapshotId,
+            List<DataSplit> sourceSplits,
+            List<PrimaryKeySearchPosition> positions) {
+        this.snapshotId = snapshotId;
+        this.positions = Collections.unmodifiableList(new ArrayList<>(positions));
+        this.splits =
+                Collections.unmodifiableList(
+                        materializeSplits(snapshotId, sourceSplits, positions));
+    }
+
+    @Override
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    public List<PrimaryKeySearchPosition> positions() {
+        return positions;
+    }
+
+    @Override
+    public List<IndexedSplit> splits() {
+        return splits;
+    }
+
+    @Override
+    public RoaringNavigableMap64 results() {
+        throw new UnsupportedOperationException(
+                "Primary-key scored results use physical file positions, not global row ids.");
+    }
+
+    @Override
+    public ScoreGetter scoreGetter() {
+        throw new UnsupportedOperationException(
+                "Primary-key scored results attach scores to physical file positions, not global row ids.");
+    }
+
+    private static List<IndexedSplit> materializeSplits(
+            long snapshotId,
+            List<DataSplit> sourceSplits,
+            List<PrimaryKeySearchPosition> positions) {
+        Map<FileKey, SourceFile> sources = sourceFiles(snapshotId, sourceSplits);
+        TreeMap<PrimaryKeySearchPosition, PrimaryKeySearchPosition> orderedPositions =
+                new TreeMap<>();
+        for (PrimaryKeySearchPosition position : positions) {
+            checkArgument(
+                    orderedPositions.put(position, position) == null,
+                    "Primary-key search result contains duplicate physical position %s.",
+                    position);
+        }
+
+        Map<FileKey, TreeMap<Integer, Float>> selectedByFile = new LinkedHashMap<>();
+        for (PrimaryKeySearchPosition position : orderedPositions.values()) {
+            FileKey key = FileKey.from(position);
+            SourceFile sourceFile = sources.get(key);
+            checkArgument(
+                    sourceFile != null,
+                    "Primary-key search position references unknown data file %s in bucket %s.",
+                    position.dataFileName(),
+                    position.bucket());
+            checkArgument(
+                    position.rowPosition() < sourceFile.dataFile.rowCount()
+                            && position.rowPosition() <= Integer.MAX_VALUE,
+                    "Primary-key search row position %s is outside data file %s.",
+                    position.rowPosition(),
+                    position.dataFileName());
+            selectedByFile
+                    .computeIfAbsent(key, ignored -> new TreeMap<>())
+                    .put((int) position.rowPosition(), position.score());
+        }
+
+        List<IndexedSplit> result = new ArrayList<>(selectedByFile.size());
+        for (Map.Entry<FileKey, TreeMap<Integer, Float>> entry : selectedByFile.entrySet()) {
+            SourceFile sourceFile = sources.get(entry.getKey());
+            DataSplit source = sourceFile.split;
+            DataSplit.Builder builder =
+                    DataSplit.builder()
+                            .withSnapshot(source.snapshotId())
+                            .withPartition(source.partition())
+                            .withBucket(source.bucket())
+                            .withBucketPath(source.bucketPath())
+                            .withTotalBuckets(source.totalBuckets())
+                            .withDataFiles(Collections.singletonList(sourceFile.dataFile))
+                            .isStreaming(false)
+                            .rawConvertible(false);
+            if (source.deletionFiles().isPresent()) {
+                builder.withDataDeletionFiles(
+                        Collections.singletonList(
+                                source.deletionFiles().get().get(sourceFile.fileIndex)));
+            }
+            result.add(
+                    new IndexedSplit(
+                            builder.build(), ranges(entry.getValue()), scores(entry.getValue())));
+        }
+        return result;
+    }
+
+    private static Map<FileKey, SourceFile> sourceFiles(
+            long snapshotId, List<DataSplit> sourceSplits) {
+        Map<FileKey, SourceFile> result = new HashMap<>();
+        for (DataSplit source : sourceSplits) {
+            checkArgument(
+                    source.snapshotId() == snapshotId,
+                    "Primary-key source split snapshot %s does not match result snapshot %s.",
+                    source.snapshotId(),
+                    snapshotId);
+            for (int i = 0; i < source.dataFiles().size(); i++) {
+                DataFileMeta dataFile = source.dataFiles().get(i);
+                FileKey key = new FileKey(source.partition(), source.bucket(), dataFile.fileName());
+                checkArgument(
+                        result.put(key, new SourceFile(source, dataFile, i)) == null,
+                        "Data file %s appears more than once in primary-key search sources.",
+                        dataFile.fileName());
+            }
+        }
+        return result;
+    }
+
+    private static List<Range> ranges(TreeMap<Integer, Float> selected) {
+        List<Range> result = new ArrayList<>();
+        long from = -1;
+        long to = -1;
+        for (int position : selected.keySet()) {
+            if (from < 0) {
+                from = position;
+            } else if (position != to + 1) {
+                result.add(new Range(from, to));
+                from = position;
+            }
+            to = position;
+        }
+        if (from >= 0) {
+            result.add(new Range(from, to));
+        }
+        return result;
+    }
+
+    private static float[] scores(TreeMap<Integer, Float> selected) {
+        float[] result = new float[selected.size()];
+        int index = 0;
+        for (float score : selected.values()) {
+            result[index++] = score;
+        }
+        return result;
+    }
+
+    private static class SourceFile {
+
+        private final DataSplit split;
+        private final DataFileMeta dataFile;
+        private final int fileIndex;
+
+        private SourceFile(DataSplit split, DataFileMeta dataFile, int fileIndex) {
+            this.split = split;
+            this.dataFile = dataFile;
+            this.fileIndex = fileIndex;
+        }
+    }
+
+    private static class FileKey {
+
+        private final BinaryRow partition;
+        private final int bucket;
+        private final String dataFileName;
+
+        private FileKey(BinaryRow partition, int bucket, String dataFileName) {
+            this.partition = partition.copy();
+            this.bucket = bucket;
+            this.dataFileName = dataFileName;
+        }
+
+        private static FileKey from(PrimaryKeySearchPosition position) {
+            return new FileKey(position.partition(), position.bucket(), position.dataFileName());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof FileKey)) {
+                return false;
+            }
+            FileKey fileKey = (FileKey) o;
+            return bucket == fileKey.bucket
+                    && partition.equals(fileKey.partition)
+                    && dataFileName.equals(fileKey.dataFileName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(partition, bucket, dataFileName);
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySearchPosition.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySearchPosition.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.BinaryRow;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** A scored physical row position in a primary-key table snapshot. */
+public final class PrimaryKeySearchPosition
+        implements Comparable<PrimaryKeySearchPosition>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final BinaryRow partition;
+    private final int bucket;
+    private final String dataFileName;
+    private final long rowPosition;
+    private final float score;
+
+    public PrimaryKeySearchPosition(
+            BinaryRow partition, int bucket, String dataFileName, long rowPosition, float score) {
+        checkArgument(rowPosition >= 0, "Row position must not be negative: %s.", rowPosition);
+        checkArgument(
+                !Float.isNaN(score) && !Float.isInfinite(score),
+                "Search score must be finite: %s.",
+                score);
+        this.partition = Objects.requireNonNull(partition, "partition").copy();
+        this.bucket = bucket;
+        this.dataFileName = Objects.requireNonNull(dataFileName, "dataFileName");
+        this.rowPosition = rowPosition;
+        this.score = score;
+    }
+
+    public BinaryRow partition() {
+        return partition;
+    }
+
+    public int bucket() {
+        return bucket;
+    }
+
+    public String dataFileName() {
+        return dataFileName;
+    }
+
+    public long rowPosition() {
+        return rowPosition;
+    }
+
+    public float score() {
+        return score;
+    }
+
+    public PrimaryKeySearchPosition withScore(float newScore) {
+        return new PrimaryKeySearchPosition(partition, bucket, dataFileName, rowPosition, newScore);
+    }
+
+    @Override
+    public int compareTo(PrimaryKeySearchPosition other) {
+        int comparison = compareBytes(partition.toBytes(), other.partition.toBytes());
+        if (comparison != 0) {
+            return comparison;
+        }
+        comparison = Integer.compare(bucket, other.bucket);
+        if (comparison != 0) {
+            return comparison;
+        }
+        comparison = dataFileName.compareTo(other.dataFileName);
+        return comparison != 0 ? comparison : Long.compare(rowPosition, other.rowPosition);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PrimaryKeySearchPosition)) {
+            return false;
+        }
+        PrimaryKeySearchPosition that = (PrimaryKeySearchPosition) o;
+        return bucket == that.bucket
+                && rowPosition == that.rowPosition
+                && partition.equals(that.partition)
+                && dataFileName.equals(that.dataFileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partition, bucket, dataFileName, rowPosition);
+    }
+
+    @Override
+    public String toString() {
+        return "PrimaryKeySearchPosition{"
+                + "partition="
+                + partition
+                + ", bucket="
+                + bucket
+                + ", dataFileName='"
+                + dataFileName
+                + '\''
+                + ", rowPosition="
+                + rowPosition
+                + ", score="
+                + score
+                + '}';
+    }
+
+    private static int compareBytes(byte[] left, byte[] right) {
+        int count = Math.min(left.length, right.length);
+        for (int i = 0; i < count; i++) {
+            int comparison = Integer.compare(left[i] & 0xFF, right[i] & 0xFF);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return Integer.compare(left.length, right.length);
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySearchRanker.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySearchRanker.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+
+/** Deterministic reciprocal-rank fusion for physical primary-key search positions. */
+public final class PrimaryKeySearchRanker {
+
+    public static final int DEFAULT_RRF_K = 60;
+
+    private static final Comparator<PrimaryKeySearchPosition> LOCAL_BEST_FIRST =
+            (left, right) -> {
+                int score = Float.compare(right.score(), left.score());
+                return score != 0 ? score : left.compareTo(right);
+            };
+
+    private PrimaryKeySearchRanker() {}
+
+    public static List<PrimaryKeySearchPosition> rrf(
+            List<List<PrimaryKeySearchPosition>> rankings, int limit) {
+        List<Ranking> weighted = new ArrayList<>(rankings.size());
+        for (List<PrimaryKeySearchPosition> ranking : rankings) {
+            weighted.add(new Ranking(ranking, 1D));
+        }
+        return weightedRrf(weighted, limit);
+    }
+
+    public static List<PrimaryKeySearchPosition> weightedRrf(List<Ranking> rankings, int limit) {
+        checkArgument(limit > 0, "RRF result limit must be positive: %s.", limit);
+        Map<PrimaryKeySearchPosition, Double> fusedScores = new HashMap<>();
+        for (Ranking ranking : rankings) {
+            addRanking(fusedScores, ranking);
+        }
+
+        return topK(fusedScores, limit);
+    }
+
+    /** Fuses heterogeneous route scores after independently normalizing each route to [0, 1]. */
+    public static List<PrimaryKeySearchPosition> weightedScore(List<Ranking> rankings, int limit) {
+        checkArgument(limit > 0, "Weighted-score result limit must be positive: %s.", limit);
+        Map<PrimaryKeySearchPosition, Double> fusedScores = new HashMap<>();
+        for (Ranking ranking : rankings) {
+            Set<PrimaryKeySearchPosition> unique = new HashSet<>();
+            float min = Float.POSITIVE_INFINITY;
+            float max = Float.NEGATIVE_INFINITY;
+            for (PrimaryKeySearchPosition position : ranking.positions) {
+                checkArgument(
+                        unique.add(position),
+                        "One weighted-score ranking contains duplicate physical position %s.",
+                        position);
+                min = Math.min(min, position.score());
+                max = Math.max(max, position.score());
+            }
+            float range = max - min;
+            for (PrimaryKeySearchPosition position : ranking.positions) {
+                double normalized = range > 0F ? (position.score() - min) / range : 1D;
+                fusedScores.merge(position, ranking.weight * normalized, Double::sum);
+            }
+        }
+        return topK(fusedScores, limit);
+    }
+
+    /** Fuses routes using weighted reciprocal rank without the RRF smoothing constant. */
+    public static List<PrimaryKeySearchPosition> weightedMrr(List<Ranking> rankings, int limit) {
+        checkArgument(limit > 0, "MRR result limit must be positive: %s.", limit);
+        Map<PrimaryKeySearchPosition, Double> fusedScores = new HashMap<>();
+        for (Ranking ranking : rankings) {
+            List<PrimaryKeySearchPosition> sorted = new ArrayList<>(ranking.positions);
+            sorted.sort(LOCAL_BEST_FIRST);
+            Set<PrimaryKeySearchPosition> unique = new HashSet<>();
+            for (int i = 0; i < sorted.size(); i++) {
+                PrimaryKeySearchPosition position = sorted.get(i);
+                checkArgument(
+                        unique.add(position),
+                        "One MRR ranking contains duplicate physical position %s.",
+                        position);
+                fusedScores.merge(position, ranking.weight / (i + 1D), Double::sum);
+            }
+        }
+        return topK(fusedScores, limit);
+    }
+
+    private static List<PrimaryKeySearchPosition> topK(
+            Map<PrimaryKeySearchPosition, Double> fusedScores, int limit) {
+
+        Comparator<PrimaryKeySearchPosition> bestFirst =
+                (left, right) -> {
+                    int score = Float.compare(right.score(), left.score());
+                    return score != 0 ? score : left.compareTo(right);
+                };
+        PriorityQueue<PrimaryKeySearchPosition> topK =
+                new PriorityQueue<>(limit, bestFirst.reversed());
+        for (Map.Entry<PrimaryKeySearchPosition, Double> entry : fusedScores.entrySet()) {
+            PrimaryKeySearchPosition position =
+                    entry.getKey().withScore(entry.getValue().floatValue());
+            if (topK.size() < limit) {
+                topK.add(position);
+            } else if (bestFirst.compare(position, topK.peek()) < 0) {
+                topK.poll();
+                topK.add(position);
+            }
+        }
+        List<PrimaryKeySearchPosition> result = new ArrayList<>(topK);
+        result.sort(bestFirst);
+        return Collections.unmodifiableList(result);
+    }
+
+    private static void addRanking(
+            Map<PrimaryKeySearchPosition, Double> fusedScores, Ranking ranking) {
+        List<PrimaryKeySearchPosition> sorted = new ArrayList<>(ranking.positions);
+        sorted.sort(LOCAL_BEST_FIRST);
+        Set<PrimaryKeySearchPosition> unique = new HashSet<>();
+        int rank = 0;
+        float previousScore = Float.NaN;
+        for (int i = 0; i < sorted.size(); i++) {
+            PrimaryKeySearchPosition position = sorted.get(i);
+            checkArgument(
+                    unique.add(position),
+                    "One RRF ranking contains duplicate physical position %s.",
+                    position);
+            if (i == 0 || Float.compare(position.score(), previousScore) != 0) {
+                rank = i + 1;
+                previousScore = position.score();
+            }
+            double contribution = ranking.weight / (DEFAULT_RRF_K + rank);
+            fusedScores.merge(position, contribution, Double::sum);
+        }
+    }
+
+    /** One locally scored ranking and its optional route weight. */
+    public static class Ranking implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final List<PrimaryKeySearchPosition> positions;
+        private final double weight;
+
+        public Ranking(List<PrimaryKeySearchPosition> positions, double weight) {
+            checkArgument(
+                    weight > 0D && !Double.isNaN(weight) && !Double.isInfinite(weight),
+                    "Search route weight must be finite and positive: %s.",
+                    weight);
+            this.positions = Collections.unmodifiableList(new ArrayList<>(positions));
+            this.weight = weight;
+        }
+
+        public List<PrimaryKeySearchPosition> positions() {
+            return positions;
+        }
+
+        public double weight() {
+            return weight;
+        }
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorPositionReader.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorPositionReader.java
@@ -19,88 +19,18 @@
 package org.apache.paimon.table.source;
 
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.reader.FileRecordIterator;
 import org.apache.paimon.reader.FileRecordReader;
-import org.apache.paimon.reader.ScoreRecordIterator;
-import org.apache.paimon.reader.ScoreRecordReader;
 import org.apache.paimon.utils.RoaringBitmap32;
 
-import javax.annotation.Nullable;
-
-import java.io.IOException;
 import java.util.function.IntFunction;
 
-import static org.apache.paimon.utils.Preconditions.checkArgument;
-
-/** Reads selected physical file positions and exposes their vector-search scores. */
-public class PrimaryKeyVectorPositionReader implements ScoreRecordReader<InternalRow> {
-
-    private final FileRecordReader<InternalRow> reader;
-    private final RoaringBitmap32 rowPositions;
-    private final IntFunction<Float> scoreGetter;
-    private final int lastPosition;
-    private boolean exhausted;
+/** Compatibility adapter for the generic primary-key index position reader. */
+public class PrimaryKeyVectorPositionReader extends PrimaryKeyIndexPositionReader {
 
     public PrimaryKeyVectorPositionReader(
             FileRecordReader<InternalRow> reader,
             RoaringBitmap32 rowPositions,
             IntFunction<Float> scoreGetter) {
-        checkArgument(!rowPositions.isEmpty(), "Selected row positions must not be empty.");
-        this.reader = reader;
-        this.rowPositions = rowPositions.clone();
-        this.scoreGetter = scoreGetter;
-        this.lastPosition = rowPositions.last();
-    }
-
-    @Nullable
-    @Override
-    public ScoreRecordIterator<InternalRow> readBatch() throws IOException {
-        if (exhausted) {
-            return null;
-        }
-        FileRecordIterator<InternalRow> batch = reader.readBatch();
-        if (batch == null) {
-            return null;
-        }
-        FileRecordIterator<InternalRow> selected = batch.selection(rowPositions);
-        return new ScoreRecordIterator<InternalRow>() {
-
-            private long returnedPosition = -1;
-            private float returnedScore = Float.NaN;
-
-            @Override
-            public float returnedScore() {
-                return returnedScore;
-            }
-
-            @Override
-            public long returnedRowId() {
-                return returnedPosition;
-            }
-
-            @Nullable
-            @Override
-            public InternalRow next() throws IOException {
-                InternalRow row = selected.next();
-                if (row != null) {
-                    returnedPosition = selected.returnedPosition();
-                    returnedScore = scoreGetter.apply((int) returnedPosition);
-                    if (returnedPosition >= lastPosition) {
-                        exhausted = true;
-                    }
-                }
-                return row;
-            }
-
-            @Override
-            public void releaseBatch() {
-                selected.releaseBatch();
-            }
-        };
-    }
-
-    @Override
-    public void close() throws IOException {
-        reader.close();
+        super(reader, rowPositions, scoreGetter);
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorResult.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorResult.java
@@ -18,172 +18,65 @@
 
 package org.apache.paimon.table.source;
 
-import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.globalindex.IndexedSplit;
-import org.apache.paimon.io.DataFileMeta;
-import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.TreeMap;
 
 import static org.apache.paimon.globalindex.VectorSearchMetric.normalize;
-import static org.apache.paimon.utils.Preconditions.checkArgument;
 
-/** Snapshot-scoped vector result addressed by physical primary-key table row positions. */
+/** Compatibility result adapting primary-key vector candidates to generic physical positions. */
 public class PrimaryKeyVectorResult implements GlobalIndexSplitResult {
 
-    private final PrimaryKeyVectorScan.Plan plan;
-    private final List<PrimaryKeyVectorRead.Candidate> candidates;
-    private final String metric;
+    private final PrimaryKeyScoredResult delegate;
 
     PrimaryKeyVectorResult(
             PrimaryKeyVectorScan.Plan plan,
             List<PrimaryKeyVectorRead.Candidate> candidates,
             String metric) {
-        this.plan = plan;
-        this.candidates = Collections.unmodifiableList(new ArrayList<>(candidates));
-        this.metric = normalize(metric);
+        String normalizedMetric = normalize(metric);
+        List<DataSplit> sourceSplits = new ArrayList<>(plan.splits().size());
+        for (VectorSearchSplit split : plan.splits()) {
+            sourceSplits.add(((BucketVectorSearchSplit) split).dataSplit());
+        }
+        List<PrimaryKeySearchPosition> positions = new ArrayList<>(candidates.size());
+        for (PrimaryKeyVectorRead.Candidate candidate : candidates) {
+            positions.add(
+                    new PrimaryKeySearchPosition(
+                            candidate.partition(),
+                            candidate.bucket(),
+                            candidate.dataFileName(),
+                            candidate.rowPosition(),
+                            score(normalizedMetric, candidate.distance())));
+        }
+        this.delegate = new PrimaryKeyScoredResult(plan.snapshotId(), sourceSplits, positions);
     }
 
     @Override
     public long snapshotId() {
-        return plan.snapshotId();
+        return delegate.snapshotId();
+    }
+
+    public List<PrimaryKeySearchPosition> positions() {
+        return delegate.positions();
+    }
+
+    PrimaryKeyScoredResult scoredResult() {
+        return delegate;
     }
 
     @Override
     public List<IndexedSplit> splits() {
-        Map<FileKey, BucketVectorSearchSplit> sourceSplits = sourceSplits();
-        Map<FileKey, TreeMap<Integer, Float>> selectedByFile = new LinkedHashMap<>();
-        for (PrimaryKeyVectorRead.Candidate candidate : candidates) {
-            FileKey key =
-                    new FileKey(
-                            candidate.partition(), candidate.bucket(), candidate.dataFileName());
-            BucketVectorSearchSplit bucketSplit = sourceSplits.get(key);
-            checkArgument(
-                    bucketSplit != null,
-                    "Primary-key vector candidate references unknown data file %s in bucket %s.",
-                    candidate.dataFileName(),
-                    candidate.bucket());
-            DataFileMeta dataFile = dataFile(bucketSplit.dataSplit(), candidate.dataFileName());
-            checkArgument(
-                    candidate.rowPosition() >= 0
-                            && candidate.rowPosition() < dataFile.rowCount()
-                            && candidate.rowPosition() <= Integer.MAX_VALUE,
-                    "Primary-key vector row position %s is outside data file %s.",
-                    candidate.rowPosition(),
-                    candidate.dataFileName());
-            TreeMap<Integer, Float> selected =
-                    selectedByFile.computeIfAbsent(key, ignored -> new TreeMap<>());
-            checkArgument(
-                    selected.put((int) candidate.rowPosition(), score(candidate.distance()))
-                            == null,
-                    "Primary-key vector candidate contains duplicate row position %s for data file %s.",
-                    candidate.rowPosition(),
-                    candidate.dataFileName());
-        }
-
-        List<IndexedSplit> result = new ArrayList<>(selectedByFile.size());
-        for (Map.Entry<FileKey, TreeMap<Integer, Float>> entry : selectedByFile.entrySet()) {
-            BucketVectorSearchSplit bucketSplit = sourceSplits.get(entry.getKey());
-            DataSplit source = bucketSplit.dataSplit();
-            int fileIndex = fileIndex(source, entry.getKey().dataFileName);
-            DataSplit.Builder builder =
-                    DataSplit.builder()
-                            .withSnapshot(source.snapshotId())
-                            .withPartition(source.partition())
-                            .withBucket(source.bucket())
-                            .withBucketPath(source.bucketPath())
-                            .withTotalBuckets(source.totalBuckets())
-                            .withDataFiles(
-                                    Collections.singletonList(source.dataFiles().get(fileIndex)))
-                            .isStreaming(false)
-                            .rawConvertible(false);
-            if (source.deletionFiles().isPresent()) {
-                builder.withDataDeletionFiles(
-                        Collections.singletonList(source.deletionFiles().get().get(fileIndex)));
-            }
-            result.add(
-                    new IndexedSplit(
-                            builder.build(), ranges(entry.getValue()), scores(entry.getValue())));
-        }
-        return Collections.unmodifiableList(result);
+        return delegate.splits();
     }
 
     @Override
     public RoaringNavigableMap64 results() {
-        throw new UnsupportedOperationException(
-                "Primary-key vector results use physical file positions, not global row ids.");
+        return delegate.results();
     }
 
-    private Map<FileKey, BucketVectorSearchSplit> sourceSplits() {
-        Map<FileKey, BucketVectorSearchSplit> result = new HashMap<>();
-        for (VectorSearchSplit searchSplit : plan.splits()) {
-            BucketVectorSearchSplit bucketSplit = (BucketVectorSearchSplit) searchSplit;
-            for (DataFileMeta dataFile : bucketSplit.dataSplit().dataFiles()) {
-                FileKey key =
-                        new FileKey(
-                                bucketSplit.dataSplit().partition(),
-                                bucketSplit.dataSplit().bucket(),
-                                dataFile.fileName());
-                checkArgument(
-                        result.put(key, bucketSplit) == null,
-                        "Data file %s appears more than once in primary-key vector plan.",
-                        dataFile.fileName());
-            }
-        }
-        return result;
-    }
-
-    private static List<Range> ranges(TreeMap<Integer, Float> selected) {
-        List<Range> result = new ArrayList<>();
-        long from = -1;
-        long to = -1;
-        for (int position : selected.keySet()) {
-            if (from < 0) {
-                from = position;
-            } else if (position != to + 1) {
-                result.add(new Range(from, to));
-                from = position;
-            }
-            to = position;
-        }
-        if (from >= 0) {
-            result.add(new Range(from, to));
-        }
-        return result;
-    }
-
-    private static float[] scores(TreeMap<Integer, Float> selected) {
-        float[] result = new float[selected.size()];
-        int index = 0;
-        for (float score : selected.values()) {
-            result[index++] = score;
-        }
-        return result;
-    }
-
-    private static DataFileMeta dataFile(DataSplit split, String dataFileName) {
-        return split.dataFiles().get(fileIndex(split, dataFileName));
-    }
-
-    private static int fileIndex(DataSplit split, String dataFileName) {
-        for (int i = 0; i < split.dataFiles().size(); i++) {
-            if (dataFileName.equals(split.dataFiles().get(i).fileName())) {
-                return i;
-            }
-        }
-        throw new IllegalArgumentException(
-                "Data file " + dataFileName + " does not exist in vector bucket split.");
-    }
-
-    private float score(float distance) {
+    private static float score(String metric, float distance) {
         if ("l2".equals(metric)) {
             return 1F / (1F + distance);
         } else if ("cosine".equals(metric)) {
@@ -192,37 +85,5 @@ public class PrimaryKeyVectorResult implements GlobalIndexSplitResult {
             return -distance;
         }
         throw new IllegalArgumentException("Unsupported primary-key vector metric: " + metric);
-    }
-
-    private static class FileKey {
-
-        private final BinaryRow partition;
-        private final int bucket;
-        private final String dataFileName;
-
-        private FileKey(BinaryRow partition, int bucket, String dataFileName) {
-            this.partition = partition.copy();
-            this.bucket = bucket;
-            this.dataFileName = dataFileName;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            FileKey fileKey = (FileKey) o;
-            return bucket == fileKey.bucket
-                    && partition.equals(fileKey.partition)
-                    && dataFileName.equals(fileKey.dataFileName);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(partition, bucket, dataFileName);
-        }
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeyVectorScan.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.globalindex.IndexedSplit;
@@ -53,13 +54,14 @@ public class PrimaryKeyVectorScan implements VectorScan {
     private final String indexType;
     @Nullable private final PartitionPredicate partitionFilter;
     @Nullable private final Predicate filter;
+    @Nullable private final Snapshot pinnedSnapshot;
 
     public PrimaryKeyVectorScan(
             FileStoreTable table,
             int vectorFieldId,
             String indexType,
             @Nullable PartitionPredicate partitionFilter) {
-        this(table, vectorFieldId, indexType, partitionFilter, null);
+        this(table, vectorFieldId, indexType, partitionFilter, null, null);
     }
 
     public PrimaryKeyVectorScan(
@@ -68,11 +70,22 @@ public class PrimaryKeyVectorScan implements VectorScan {
             String indexType,
             @Nullable PartitionPredicate partitionFilter,
             @Nullable Predicate filter) {
+        this(table, vectorFieldId, indexType, partitionFilter, filter, null);
+    }
+
+    PrimaryKeyVectorScan(
+            FileStoreTable table,
+            int vectorFieldId,
+            String indexType,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Predicate filter,
+            @Nullable Snapshot pinnedSnapshot) {
         this.table = table;
         this.vectorFieldId = vectorFieldId;
         this.indexType = indexType;
         this.partitionFilter = partitionFilter;
         this.filter = filter;
+        this.pinnedSnapshot = pinnedSnapshot;
     }
 
     @Override
@@ -85,8 +98,9 @@ public class PrimaryKeyVectorScan implements VectorScan {
                         || (table.coreOptions().deletionVectorsEnabled()
                                 && !table.coreOptions().deletionVectorsMergeOnRead()),
                 "Primary-key vector pre-filter requires deletion vectors without merge-on-read.");
-        SnapshotReader snapshotReader = table.newSnapshotReader().keepStats();
-        DataTableScan dataScan = table.newScan(ignored -> snapshotReader);
+        FileStoreTable scanTable = scanTable();
+        SnapshotReader snapshotReader = scanTable.newSnapshotReader().keepStats();
+        DataTableScan dataScan = scanTable.newScan(ignored -> snapshotReader);
         checkArgument(
                 dataScan instanceof PrimaryKeyBatchScan,
                 "Primary-key vector search requires a primary-key batch scan.");
@@ -108,8 +122,16 @@ public class PrimaryKeyVectorScan implements VectorScan {
         if (snapshotPlan.snapshotId() == null) {
             return new Plan(0, Collections.emptyList());
         }
-        Snapshot snapshot = snapshotReader.snapshotManager().snapshot(snapshotPlan.snapshotId());
+        Snapshot snapshot =
+                pinnedSnapshot == null
+                        ? snapshotReader.snapshotManager().snapshot(snapshotPlan.snapshotId())
+                        : pinnedSnapshot;
         checkArgument(snapshot != null, "Primary-key vector snapshot does not exist.");
+        checkArgument(
+                snapshot.id() == snapshotPlan.snapshotId(),
+                "Primary-key vector plan snapshot %s does not match pinned snapshot %s.",
+                snapshotPlan.snapshotId(),
+                snapshot.id());
 
         IndexFileHandler indexFileHandler = snapshotReader.indexFileHandler();
         checkArgument(indexFileHandler != null, "Primary-key vector index handler is unavailable.");
@@ -125,6 +147,17 @@ public class PrimaryKeyVectorScan implements VectorScan {
                                         && (partitionFilter == null
                                                 || partitionFilter.test(entry.partition())));
         return plan(snapshot.id(), snapshotPlan.splits(), vectorIndexEntries);
+    }
+
+    private FileStoreTable scanTable() {
+        if (pinnedSnapshot == null) {
+            return table;
+        }
+        return (FileStoreTable)
+                table.copy(
+                        Collections.singletonMap(
+                                CoreOptions.SCAN_SNAPSHOT_ID.key(),
+                                String.valueOf(pinnedSnapshot.id())));
     }
 
     static Plan plan(

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorSearchBuilderImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.table.source;
 
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
@@ -25,6 +26,8 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Pair;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,6 +51,7 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
     protected DataField vectorColumn;
     protected float[] vector;
     protected Map<String, String> options = new HashMap<>();
+    @Nullable private Snapshot pinnedSnapshot;
 
     public VectorSearchBuilderImpl(InnerTable table) {
         this.table = (FileStoreTable) table;
@@ -130,7 +134,8 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
                     vectorColumn.id(),
                     table.coreOptions().primaryKeyVectorIndexType(vectorColumn.name()),
                     partitionFilter,
-                    filter);
+                    filter,
+                    pinnedSnapshot);
         }
         return new DataEvolutionVectorScan(table, partitionFilter, filter, vectorColumn, options);
     }
@@ -148,5 +153,10 @@ public class VectorSearchBuilderImpl implements VectorSearchBuilder {
     protected boolean isPrimaryKeyVectorSearch() {
         return vectorColumn != null
                 && table.coreOptions().primaryKeyVectorIndexColumns().contains(vectorColumn.name());
+    }
+
+    VectorSearchBuilderImpl withSnapshot(Snapshot snapshot) {
+        this.pinnedSnapshot = snapshot;
+        return this;
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pk/BucketedPrimaryKeyIndexMaintainerTest.java
@@ -18,19 +18,28 @@
 
 package org.apache.paimon.index.pk;
 
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileHandler;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.index.pkfulltext.BucketedFullTextIndexMaintainer;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
 import org.apache.paimon.index.pksorted.BucketedSortedIndexMaintainer;
 import org.apache.paimon.index.pksorted.PkSortedIndexFile;
 import org.apache.paimon.index.pkvector.BucketedVectorIndexMaintainer;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
 import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +48,9 @@ import org.junit.jupiter.api.io.TempDir;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -51,6 +62,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_SELF;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -82,6 +94,111 @@ class BucketedPrimaryKeyIndexMaintainerTest {
 
         verify(vector).withExecutor(executor);
         verify(vector).close();
+    }
+
+    @Test
+    void testDelegatesFullTextLifecycleAndMergesCommit() throws Exception {
+        IndexFileMeta payload =
+                new IndexFileMeta("full-text", "payload", 1, 1, (GlobalIndexMeta) null, null);
+        BucketedFullTextIndexMaintainer fullText = mock(BucketedFullTextIndexMaintainer.class);
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                mock(BucketedFullTextIndexMaintainer.FullTextIndexCommit.class);
+        BucketedFullTextIndexMaintainer.FullTextIndexIncrement increment =
+                mock(BucketedFullTextIndexMaintainer.FullTextIndexIncrement.class);
+        when(fullText.prepareCommit(any(), any(), eq(true))).thenReturn(commit);
+        when(commit.appendIncrement()).thenReturn(Optional.empty());
+        when(commit.compactIncrement()).thenReturn(Optional.of(increment));
+        when(increment.newIndexFiles()).thenReturn(Collections.singletonList(payload));
+        when(increment.deletedIndexFiles()).thenReturn(Collections.emptyList());
+        when(fullText.buildNotCompleted()).thenReturn(true);
+        BucketedPrimaryKeyIndexMaintainer maintainer =
+                BucketedPrimaryKeyIndexMaintainer.ofFullText(fullText);
+        CompactIncrement compactIncrement = CompactIncrement.emptyIncrement();
+
+        maintainer.prepareCommit(DataIncrement.emptyIncrement(), compactIncrement, true);
+
+        assertThat(compactIncrement.newIndexFiles()).containsExactly(payload);
+        assertThat(maintainer.buildNotCompleted()).isTrue();
+        maintainer.withExecutor(buildExecutor);
+        maintainer.close();
+        verify(fullText).withExecutor(buildExecutor);
+        verify(fullText).close();
+    }
+
+    @Test
+    void testFactoryCreatesConfiguredFullTextMaintainer() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content");
+        options.put("fields.content.pk-index.compaction.level-fanout", "2");
+        options.put("fields.content.pk-index.compaction.stale-ratio-threshold", "1.0");
+        TableSchema schema =
+                new TableSchema(
+                        0,
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT().notNull()),
+                                new DataField(1, "content", DataTypes.STRING())),
+                        0,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        options,
+                        "");
+        IndexFileHandler handler = mock(IndexFileHandler.class);
+        when(handler.pkFullTextIndex(any(), eq(0))).thenReturn(mock(PkFullTextIndexFile.class));
+        KeyValueFileReaderFactory.Builder readerBuilder =
+                mock(KeyValueFileReaderFactory.Builder.class, RETURNS_SELF);
+        DataFileMeta first = dataFile("data-1", 1);
+        DataFileMeta second = dataFile("data-2", 1);
+        String fingerprint =
+                PrimaryKeyIndexDefinitions.create(schema)
+                        .definitions()
+                        .get(0)
+                        .definitionFingerprint();
+
+        BucketedPrimaryKeyIndexMaintainer.Factory factory =
+                BucketedPrimaryKeyIndexMaintainer.Factory.create(handler, readerBuilder, schema);
+        BucketedPrimaryKeyIndexMaintainer maintainer =
+                factory.create(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        Arrays.asList(first, second),
+                        Arrays.asList(
+                                fullTextPayload("payload-1", first, fingerprint),
+                                fullTextPayload("payload-2", second, fingerprint)),
+                        buildExecutor);
+
+        assertThat(factory.indexFileHandler()).isSameAs(handler);
+        assertThat(maintainer.buildNotCompleted()).isFalse();
+        assertThat(maintainer.hasPendingMaintenance()).isTrue();
+    }
+
+    @Test
+    void testLaterDefinitionFailureAbortsPreparedFullTextCommit() throws Exception {
+        DataFileMeta source = dataFile("data-1", 3);
+        BucketedFullTextIndexMaintainer fullText = mock(BucketedFullTextIndexMaintainer.class);
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit fullTextCommit =
+                mock(BucketedFullTextIndexMaintainer.FullTextIndexCommit.class);
+        when(fullText.prepareCommit(any(), any(), eq(true))).thenReturn(fullTextCommit);
+        when(fullTextCommit.appendIncrement()).thenReturn(Optional.empty());
+        when(fullTextCommit.compactIncrement()).thenReturn(Optional.empty());
+        BucketedSortedIndexMaintainer failing =
+                sortedMaintainer(
+                        8,
+                        "bitmap",
+                        source,
+                        dataFile -> {
+                            throw new IllegalStateException("expected sorted failure");
+                        });
+        BucketedPrimaryKeyIndexMaintainer maintainer =
+                BucketedPrimaryKeyIndexMaintainer.of(
+                        null, fullText, Collections.singletonList(failing));
+
+        assertThatThrownBy(
+                        () ->
+                                maintainer.prepareCommit(
+                                        DataIncrement.emptyIncrement(), compactAfter(source), true))
+                .hasMessage("expected sorted failure");
+
+        verify(fullTextCommit).abort(any());
     }
 
     @Test
@@ -366,6 +483,27 @@ class BucketedPrimaryKeyIndexMaintainerTest {
                         null,
                         new byte[] {1},
                         new PrimaryKeyIndexSourceMeta(sources).serialize()),
+                null);
+    }
+
+    private static IndexFileMeta fullTextPayload(
+            String fileName, DataFileMeta sourceFile, String fingerprint) {
+        PrimaryKeyIndexSourceMeta sourceMeta =
+                new PrimaryKeyIndexSourceMeta(
+                        new PrimaryKeyIndexSourceFile(sourceFile.fileName(), sourceFile.rowCount()),
+                        fingerprint);
+        return new IndexFileMeta(
+                "full-text",
+                fileName,
+                1,
+                sourceFile.rowCount(),
+                new GlobalIndexMeta(
+                        0,
+                        sourceFile.rowCount() - 1,
+                        1,
+                        null,
+                        new byte[] {1},
+                        sourceMeta.serialize()),
                 null);
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexDefinitionsTest.java
@@ -86,6 +86,75 @@ class PrimaryKeyIndexDefinitionsTest {
     }
 
     @Test
+    void testCreatesFullTextDefinitionWithoutIndexType() {
+        Map<String, String> options = new HashMap<>();
+        options.put("pk-full-text.index.columns", "name");
+
+        List<PrimaryKeyIndexDefinition> definitions =
+                PrimaryKeyIndexDefinitions.create(schema(options)).definitions();
+
+        assertThat(definitions).hasSize(1);
+        assertThat(definitions.get(0).column()).isEqualTo("name");
+        assertThat(definitions.get(0).indexType()).isEqualTo("full-text");
+        assertThat(definitions.get(0).family().name()).isEqualTo("FULL_TEXT");
+    }
+
+    @Test
+    void testResolvesFullTextIndexOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("pk-full-text.index.columns", "name");
+        options.put(
+                "fields.name.pk-full-text.index.options",
+                "{\"full-text.tokenizer\":\"jieba\",\"ngram.min-gram\":\"2\"}");
+
+        PrimaryKeyIndexDefinition definition =
+                PrimaryKeyIndexDefinitions.create(schema(options)).definitions().get(0);
+
+        assertThat(definition.options().get("full-text.tokenizer")).isEqualTo("jieba");
+        assertThat(definition.options().get("full-text.ngram.min-gram")).isEqualTo("2");
+        assertThat(definition.options().toMap())
+                .doesNotContainKey("pk-full-text.index.columns")
+                .doesNotContainKey("fields.name.pk-full-text.index.options");
+    }
+
+    @Test
+    void testFullTextDefinitionFingerprintIsStableAndOptionSensitive() {
+        Map<String, String> left = new HashMap<>();
+        left.put("pk-full-text.index.columns", "name");
+        left.put(
+                "fields.name.pk-full-text.index.options",
+                "{\"full-text.tokenizer\":\"ngram\",\"ngram.min-gram\":\"2\"}");
+        Map<String, String> reordered = new HashMap<>();
+        reordered.put("pk-full-text.index.columns", "name");
+        reordered.put(
+                "fields.name.pk-full-text.index.options",
+                "{\"ngram.min-gram\":\"2\",\"full-text.tokenizer\":\"ngram\"}");
+        Map<String, String> changed = new HashMap<>(left);
+        changed.put(
+                "fields.name.pk-full-text.index.options",
+                "{\"full-text.tokenizer\":\"ngram\",\"ngram.min-gram\":\"3\"}");
+
+        String fingerprint =
+                PrimaryKeyIndexDefinitions.create(schema(left))
+                        .definitions()
+                        .get(0)
+                        .definitionFingerprint();
+        String reorderedFingerprint =
+                PrimaryKeyIndexDefinitions.create(schema(reordered))
+                        .definitions()
+                        .get(0)
+                        .definitionFingerprint();
+        String changedFingerprint =
+                PrimaryKeyIndexDefinitions.create(schema(changed))
+                        .definitions()
+                        .get(0)
+                        .definitionFingerprint();
+
+        assertThat(fingerprint).hasSize(64).isEqualTo(reorderedFingerprint);
+        assertThat(changedFingerprint).isNotEqualTo(fingerprint);
+    }
+
+    @Test
     void testLegacyVectorCompactionOptionsAreIgnored() {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.PK_VECTOR_INDEX_COLUMNS.key(), "embedding");

--- a/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexSourceMetaTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pk/PrimaryKeyIndexSourceMetaTest.java
@@ -60,6 +60,19 @@ class PrimaryKeyIndexSourceMetaTest {
     }
 
     @Test
+    void testDefinitionFingerprintRoundTrip() {
+        PrimaryKeyIndexSourceMeta metadata =
+                new PrimaryKeyIndexSourceMeta(
+                        new PrimaryKeyIndexSourceFile("data-1", 5), "full-text-definition");
+
+        PrimaryKeyIndexSourceMeta restored =
+                PrimaryKeyIndexSourceMeta.deserialize(metadata.serialize());
+
+        assertThat(restored.sourceFile()).isEqualTo(metadata.sourceFile());
+        assertThat(restored.definitionFingerprint()).contains("full-text-definition");
+    }
+
+    @Test
     void testRejectsInvalidSourceFile() {
         assertThatThrownBy(() -> new PrimaryKeyIndexSourceFile("data-1", -1))
                 .hasMessageContaining("row count must not be negative");
@@ -68,13 +81,13 @@ class PrimaryKeyIndexSourceMetaTest {
     @Test
     void testRejectsUnsupportedVersion() throws Exception {
         DataOutputSerializer output = new DataOutputSerializer(64);
-        output.writeInt(2);
+        output.writeInt(3);
         output.writeInt(1);
         output.writeUTF("data-1");
         output.writeLong(1);
 
         assertThatThrownBy(() -> PrimaryKeyIndexSourceMeta.deserialize(output.getCopyOfBuffer()))
-                .hasMessageContaining("Unsupported index source version: 2");
+                .hasMessageContaining("Unsupported index source version: 3");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/BucketedFullTextIndexMaintainerTest.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.CompactIncrement;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.DataIncrement;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests file-aligned maintenance of primary-key full-text archives. */
+class BucketedFullTextIndexMaintainerTest {
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @AfterEach
+    void shutdownExecutor() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    void testReplacesArchiveWithCompactSourceWithoutMergingArchives() throws Exception {
+        DataFileMeta oldData = dataFile("old-data");
+        DataFileMeta newData = dataFile("new-data");
+        IndexFileMeta oldPayload = payload("old-payload", oldData, "fingerprint");
+        IndexFileMeta newPayload = payload("new-payload", newData, "fingerprint");
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(newData)).thenReturn(newPayload);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        mock(PkFullTextIndexFile.class),
+                        builder,
+                        Collections.singletonList(oldData),
+                        Collections.singletonList(oldPayload),
+                        executor);
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(),
+                        new CompactIncrement(
+                                Collections.singletonList(oldData),
+                                Collections.singletonList(newData),
+                                Collections.emptyList()),
+                        true);
+
+        assertThat(commit.compactIncrement()).isPresent();
+        assertThat(commit.compactIncrement().get().newIndexFiles()).containsExactly(newPayload);
+        assertThat(commit.compactIncrement().get().deletedIndexFiles()).containsExactly(oldPayload);
+        assertThat(maintainer.state().payloadBySourceFile()).containsOnlyKeys("new-data");
+        verify(builder).build(newData);
+    }
+
+    @Test
+    void testMergesArchivesAtConfiguredFanout() throws Exception {
+        DataFileMeta first = dataFile("data-1");
+        DataFileMeta second = dataFile("data-2");
+        IndexFileMeta firstPayload = payload("payload-1", first, "fingerprint");
+        IndexFileMeta secondPayload = payload("payload-2", second, "fingerprint");
+        IndexFileMeta merged = payload("merged", Arrays.asList(first, second), "fingerprint");
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(Arrays.asList(first, second))).thenReturn(merged);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        mock(PkFullTextIndexFile.class),
+                        builder,
+                        2,
+                        0.5,
+                        Arrays.asList(first, second),
+                        Arrays.asList(firstPayload, secondPayload),
+                        executor);
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(), CompactIncrement.emptyIncrement(), true);
+
+        assertThat(commit.appendIncrement()).isPresent();
+        assertThat(commit.appendIncrement().get().newIndexFiles()).containsExactly(merged);
+        assertThat(commit.appendIncrement().get().deletedIndexFiles())
+                .containsExactly(firstPayload, secondPayload);
+        assertThat(maintainer.state().payloadBySourceFile()).containsOnlyKeys("data-1", "data-2");
+        assertThat(maintainer.payloads()).containsExactly(merged);
+        verify(builder).build(Arrays.asList(first, second));
+    }
+
+    @Test
+    void testRebuildsArchiveAtConfiguredStaleRatio() throws Exception {
+        DataFileMeta active = dataFile("active");
+        DataFileMeta removed = dataFile("removed");
+        IndexFileMeta oldPayload =
+                payload("old-payload", Arrays.asList(active, removed), "fingerprint");
+        IndexFileMeta rebuilt = payload("rebuilt", active, "fingerprint");
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(active)).thenReturn(rebuilt);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        mock(PkFullTextIndexFile.class),
+                        builder,
+                        5,
+                        0.5,
+                        Collections.singletonList(active),
+                        Collections.singletonList(oldPayload),
+                        executor);
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(), CompactIncrement.emptyIncrement(), true);
+
+        assertThat(commit.appendIncrement()).isPresent();
+        assertThat(commit.appendIncrement().get().newIndexFiles()).containsExactly(rebuilt);
+        assertThat(commit.appendIncrement().get().deletedIndexFiles()).containsExactly(oldPayload);
+        assertThat(maintainer.payloads()).containsExactly(rebuilt);
+        verify(builder).build(active);
+    }
+
+    @Test
+    void testRebuildsOldFingerprintAndRetriesAfterFailure() throws Exception {
+        DataFileMeta data = dataFile("data");
+        IndexFileMeta oldPayload = payload("old-payload", data, "old-fingerprint");
+        IndexFileMeta newPayload = payload("new-payload", data, "new-fingerprint");
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(data))
+                .thenThrow(new IOException("first failure"))
+                .thenReturn(newPayload);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "new-fingerprint",
+                        mock(PkFullTextIndexFile.class),
+                        builder,
+                        Collections.singletonList(data),
+                        Collections.singletonList(oldPayload),
+                        executor);
+
+        assertThatThrownBy(
+                        () ->
+                                maintainer.prepareCommit(
+                                        DataIncrement.emptyIncrement(),
+                                        CompactIncrement.emptyIncrement(),
+                                        true))
+                .hasMessageContaining("first failure");
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(), CompactIncrement.emptyIncrement(), true);
+
+        assertThat(commit.appendIncrement()).isPresent();
+        assertThat(commit.appendIncrement().get().newIndexFiles()).containsExactly(newPayload);
+        assertThat(commit.appendIncrement().get().deletedIndexFiles()).containsExactly(oldPayload);
+    }
+
+    @Test
+    void testNonBlockingBuildPublishesOnALaterAppendIncrement() throws Exception {
+        DataFileMeta data = dataFile("data");
+        IndexFileMeta payload = payload("payload", data, "fingerprint");
+        CountDownLatch buildStarted = new CountDownLatch(1);
+        CountDownLatch allowBuild = new CountDownLatch(1);
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(data))
+                .thenAnswer(
+                        ignored -> {
+                            buildStarted.countDown();
+                            assertThat(allowBuild.await(30, TimeUnit.SECONDS)).isTrue();
+                            return payload;
+                        });
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        mock(PkFullTextIndexFile.class),
+                        builder,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        executor);
+        try {
+            BucketedFullTextIndexMaintainer.FullTextIndexCommit first =
+                    maintainer.prepareCommit(
+                            DataIncrement.emptyIncrement(),
+                            new CompactIncrement(
+                                    Collections.emptyList(),
+                                    Collections.singletonList(data),
+                                    Collections.emptyList()),
+                            false);
+            assertThat(first.compactIncrement()).isEmpty();
+            assertThat(buildStarted.await(30, TimeUnit.SECONDS)).isTrue();
+            assertThat(maintainer.buildNotCompleted()).isTrue();
+            allowBuild.countDown();
+
+            BucketedFullTextIndexMaintainer.FullTextIndexCommit second =
+                    maintainer.prepareCommit(
+                            DataIncrement.emptyIncrement(),
+                            CompactIncrement.emptyIncrement(),
+                            true);
+            assertThat(second.appendIncrement()).isPresent();
+            assertThat(second.appendIncrement().get().newIndexFiles()).containsExactly(payload);
+        } finally {
+            allowBuild.countDown();
+        }
+    }
+
+    @Test
+    void testCoordinatorAbortRestoresStateAndDeletesGeneratedArchive() throws Exception {
+        DataFileMeta data = dataFile("data");
+        IndexFileMeta payload = payload("payload", data, "fingerprint");
+        PkFullTextIndexFile indexFile = mock(PkFullTextIndexFile.class);
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(data)).thenReturn(payload);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        indexFile,
+                        builder,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        executor);
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(),
+                        new CompactIncrement(
+                                Collections.emptyList(),
+                                Collections.singletonList(data),
+                                Collections.emptyList()),
+                        true);
+        assertThat(maintainer.payloads()).containsExactly(payload);
+
+        commit.abort(new IllegalStateException("later definition failed"));
+
+        assertThat(maintainer.payloads()).isEmpty();
+        verify(indexFile).delete(payload);
+    }
+
+    @Test
+    void testAbortDoesNotDeleteRejectedArchiveTwice() throws Exception {
+        DataFileMeta data = dataFile("data");
+        IndexFileMeta rejected = payload("rejected", dataFile("other"), "fingerprint");
+        IndexFileMeta accepted = payload("accepted", data, "fingerprint");
+        PkFullTextIndexFile indexFile = mock(PkFullTextIndexFile.class);
+        PkFullTextIndexBuilder builder = mock(PkFullTextIndexBuilder.class);
+        when(builder.build(data)).thenReturn(rejected, accepted);
+        BucketedFullTextIndexMaintainer maintainer =
+                new BucketedFullTextIndexMaintainer(
+                        7,
+                        "fingerprint",
+                        indexFile,
+                        builder,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        executor);
+
+        BucketedFullTextIndexMaintainer.FullTextIndexCommit commit =
+                maintainer.prepareCommit(
+                        DataIncrement.emptyIncrement(),
+                        new CompactIncrement(
+                                Collections.emptyList(),
+                                Collections.singletonList(data),
+                                Collections.emptyList()),
+                        true);
+
+        verify(indexFile).delete(rejected);
+        commit.abort(new IllegalStateException("later definition failed"));
+
+        verify(indexFile, times(1)).delete(rejected);
+        verify(indexFile).delete(accepted);
+    }
+
+    private static DataFileMeta dataFile(String fileName) {
+        return DataFileMeta.forAppend(
+                        fileName,
+                        100,
+                        1,
+                        SimpleStats.EMPTY_STATS,
+                        0,
+                        1,
+                        1,
+                        Collections.emptyList(),
+                        null,
+                        FileSource.COMPACT,
+                        null,
+                        null,
+                        null,
+                        null)
+                .upgrade(1);
+    }
+
+    private static IndexFileMeta payload(
+            String payloadName, DataFileMeta source, String fingerprint) {
+        return payload(payloadName, Collections.singletonList(source), fingerprint);
+    }
+
+    private static IndexFileMeta payload(
+            String payloadName, List<DataFileMeta> sources, String fingerprint) {
+        List<PrimaryKeyIndexSourceFile> sourceFiles = new ArrayList<>();
+        long rowCount = 0;
+        for (DataFileMeta source : sources) {
+            sourceFiles.add(new PrimaryKeyIndexSourceFile(source.fileName(), source.rowCount()));
+            rowCount += source.rowCount();
+        }
+        PrimaryKeyIndexSourceMeta sourceMeta =
+                new PrimaryKeyIndexSourceMeta(sourceFiles, fingerprint);
+        return new IndexFileMeta(
+                "full-text",
+                payloadName,
+                100,
+                rowCount,
+                new GlobalIndexMeta(0, rowCount - 1, 7, null, null, sourceMeta.serialize()),
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexStateTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextBucketIndexStateTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests restored file-aligned primary-key full-text state. */
+class PkFullTextBucketIndexStateTest {
+
+    @Test
+    void testClassifiesCurrentAndRetiresOldFingerprintsAndOtherFields() {
+        IndexFileMeta current = payload("current", "data", 7, "new");
+        IndexFileMeta old = payload("old", "old-data", 7, "old");
+        IndexFileMeta otherField = payload("other", "other-data", 8, "new");
+
+        PkFullTextBucketIndexState state =
+                PkFullTextBucketIndexState.fromActivePayloads(
+                        7, "new", Arrays.asList(current, old, otherField));
+
+        assertThat(state.currentPayloads()).containsExactly(current);
+        assertThat(state.stalePayloads()).containsExactly(old, otherField);
+        assertThat(state.payloadBySourceFile()).containsEntry("data", current);
+    }
+
+    @Test
+    void testRejectsDuplicateCurrentCoverage() {
+        assertThatThrownBy(
+                        () ->
+                                PkFullTextBucketIndexState.fromActivePayloads(
+                                        7,
+                                        "new",
+                                        Arrays.asList(
+                                                payload("first", "data", 7, "new"),
+                                                payload("second", "data", 7, "new"))))
+                .hasMessageContaining("data")
+                .hasMessageContaining("covered by both full-text archives");
+    }
+
+    @Test
+    void testMapsEverySourceOfMultiSourceArchive() {
+        PrimaryKeyIndexSourceMeta sourceMeta =
+                new PrimaryKeyIndexSourceMeta(
+                        Arrays.asList(
+                                new PrimaryKeyIndexSourceFile("data-1", 1),
+                                new PrimaryKeyIndexSourceFile("data-2", 1)),
+                        "new");
+        IndexFileMeta payload = payload("multi", 7, 2, sourceMeta);
+
+        PkFullTextBucketIndexState state =
+                PkFullTextBucketIndexState.fromActivePayloads(
+                        7, "new", Collections.singletonList(payload));
+
+        assertThat(state.currentPayloads()).containsExactly(payload);
+        assertThat(state.payloadBySourceFile())
+                .containsEntry("data-1", payload)
+                .containsEntry("data-2", payload);
+    }
+
+    private static IndexFileMeta payload(
+            String payloadName, String sourceName, int fieldId, String fingerprint) {
+        return payload(
+                payloadName,
+                fieldId,
+                1,
+                new PrimaryKeyIndexSourceMeta(
+                        new PrimaryKeyIndexSourceFile(sourceName, 1), fingerprint));
+    }
+
+    private static IndexFileMeta payload(
+            String payloadName, int fieldId, long rowCount, PrimaryKeyIndexSourceMeta sourceMeta) {
+        return new IndexFileMeta(
+                "full-text",
+                payloadName,
+                100,
+                rowCount,
+                new GlobalIndexMeta(0, rowCount - 1, fieldId, null, null, sourceMeta.serialize()),
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextDataFileReaderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextDataFileReaderTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.KeyValue;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.format.FlushingFileFormat;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.io.KeyValueFileReaderFactory;
+import org.apache.paimon.io.KeyValueFileWriterFactory;
+import org.apache.paimon.io.RollingFileWriter;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.KeyValueFieldsExtractor;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowKind;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.FileStorePathFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.paimon.options.MemorySize.VALUE_128_MB;
+import static org.apache.paimon.utils.FileStorePathFactoryTest.createNonPartFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests reading physical text positions from compact data files. */
+class PkFullTextDataFileReaderTest {
+
+    @TempDir java.nio.file.Path tempDir;
+
+    @Test
+    void testReadsProjectedTextAndPreservesNullPositions() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        Path tablePath = new Path(tempDir.toUri());
+        DataField keyField = new DataField(0, "id", DataTypes.INT());
+        DataField textField = new DataField(1, "content", DataTypes.STRING());
+        DataField payloadField = new DataField(2, "payload", DataTypes.INT());
+        RowType keyType = RowType.of(keyField);
+        RowType valueType = RowType.of(textField, payloadField);
+        List<DataField> fields = Arrays.asList(keyField, textField, payloadField);
+        TableSchema schema =
+                new TableSchema(
+                        0,
+                        fields,
+                        2,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        Collections.emptyMap(),
+                        "");
+        SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
+        assertThat(schemaManager.commit(schema)).isTrue();
+        FileStorePathFactory pathFactory = createNonPartFactory(tablePath);
+        FlushingFileFormat format = new FlushingFileFormat("avro");
+        CoreOptions options = new CoreOptions(new Options());
+
+        KeyValueFileWriterFactory writerFactory =
+                KeyValueFileWriterFactory.builder(
+                                fileIO,
+                                schema.id(),
+                                keyType,
+                                valueType,
+                                format,
+                                ignored -> pathFactory,
+                                VALUE_128_MB.getBytes())
+                        .build(BinaryRow.EMPTY_ROW, 0, options);
+        RollingFileWriter<KeyValue, DataFileMeta> writer =
+                writerFactory.createRollingMergeTreeFileWriter(1, FileSource.COMPACT);
+        try {
+            writer.write(keyValue(1, "first", 10));
+            writer.write(keyValue(2, null, 20));
+            writer.write(keyValue(3, "third", 30));
+        } finally {
+            writer.close();
+        }
+        DataFileMeta dataFile = writer.result().get(0);
+
+        KeyValueFileReaderFactory.Builder readerFactoryBuilder =
+                KeyValueFileReaderFactory.builder(
+                        fileIO,
+                        schemaManager,
+                        schema,
+                        keyType,
+                        valueType,
+                        ignored -> format,
+                        pathFactory,
+                        fieldsExtractor(keyType, valueType),
+                        options);
+        PkFullTextDataFileReader reader =
+                new PkFullTextDataFileReader.Factory(
+                                readerFactoryBuilder, BinaryRow.EMPTY_ROW, 0, textField)
+                        .create(dataFile);
+        try {
+            assertThat(reader.rowCount()).isEqualTo(3);
+            assertThat(reader.readNextText()).hasToString("first");
+            assertThat(reader.readNextText()).isNull();
+            assertThat(reader.readNextText()).hasToString("third");
+            assertThatThrownBy(reader::readNextText).hasMessageContaining("Read past data file");
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static KeyValue keyValue(int key, String text, int payload) {
+        return new KeyValue()
+                .replace(
+                        GenericRow.of(key),
+                        RowKind.INSERT,
+                        GenericRow.of(
+                                text == null ? null : BinaryString.fromString(text), payload));
+    }
+
+    private static KeyValueFieldsExtractor fieldsExtractor(RowType keyType, RowType valueType) {
+        return new KeyValueFieldsExtractor() {
+            @Override
+            public List<DataField> keyFields(TableSchema schema) {
+                return keyType.getFields();
+            }
+
+            @Override
+            public List<DataField> valueFields(TableSchema schema) {
+                return valueType.getFields();
+            }
+        };
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFileTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PkFullTextIndexFileTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.globalindex.GlobalIndexIOMeta;
+import org.apache.paimon.globalindex.GlobalIndexReader;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.GlobalIndexWriter;
+import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
+import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.IndexPathFactory;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests building one file-aligned primary-key full-text archive. */
+class PkFullTextIndexFileTest {
+
+    @TempDir java.nio.file.Path tempPath;
+
+    @Test
+    void testWritesEveryPhysicalOrdinalAndV2SourceMetadata() throws Exception {
+        LocalFileIO fileIO = LocalFileIO.create();
+        PkFullTextDataFileReader reader = mock(PkFullTextDataFileReader.class);
+        when(reader.rowCount()).thenReturn(3L);
+        when(reader.readNextText())
+                .thenReturn(
+                        BinaryString.fromString("first"), null, BinaryString.fromString("third"));
+        RecordingIndexer indexer = new RecordingIndexer();
+
+        IndexFileMeta archive =
+                new PkFullTextIndexFile(fileIO, pathFactory())
+                        .build(
+                                dataFile("data-1", 3),
+                                reader,
+                                new DataField(7, "content", DataTypes.STRING()),
+                                indexer,
+                                "definition-fingerprint");
+
+        assertThat(indexer.rowIds).containsExactly(0L, 1L, 2L);
+        assertThat(indexer.values)
+                .containsExactly(
+                        BinaryString.fromString("first"), null, BinaryString.fromString("third"));
+        assertThat(archive.indexType()).isEqualTo("full-text");
+        assertThat(archive.rowCount()).isEqualTo(3);
+        assertThat(archive.globalIndexMeta().rowRangeStart()).isZero();
+        assertThat(archive.globalIndexMeta().rowRangeEnd()).isEqualTo(2);
+        assertThat(archive.globalIndexMeta().indexFieldId()).isEqualTo(7);
+        PrimaryKeyIndexSourceMeta sourceMeta = PrimaryKeyIndexSourceMeta.fromIndexFile(archive);
+        assertThat(sourceMeta.sourceFile().fileName()).isEqualTo("data-1");
+        assertThat(sourceMeta.sourceFile().rowCount()).isEqualTo(3);
+        assertThat(sourceMeta.definitionFingerprint()).contains("definition-fingerprint");
+    }
+
+    @Test
+    void testBuildsMultiSourceArchiveWithContinuousRowIds() throws Exception {
+        PkFullTextDataFileReader first = mock(PkFullTextDataFileReader.class);
+        when(first.rowCount()).thenReturn(2L);
+        when(first.readNextText())
+                .thenReturn(BinaryString.fromString("first"), BinaryString.fromString("second"));
+        PkFullTextDataFileReader second = mock(PkFullTextDataFileReader.class);
+        when(second.rowCount()).thenReturn(1L);
+        when(second.readNextText()).thenReturn(BinaryString.fromString("third"));
+        RecordingIndexer indexer = new RecordingIndexer();
+
+        IndexFileMeta archive =
+                new PkFullTextIndexFile(LocalFileIO.create(), pathFactory())
+                        .build(
+                                Arrays.asList(
+                                        new PkFullTextIndexFile.Source(
+                                                dataFile("data-1", 2), first),
+                                        new PkFullTextIndexFile.Source(
+                                                dataFile("data-2", 1), second)),
+                                new DataField(7, "content", DataTypes.STRING()),
+                                indexer,
+                                "definition-fingerprint");
+
+        assertThat(indexer.rowIds).containsExactly(0L, 1L, 2L);
+        assertThat(indexer.values)
+                .containsExactly(
+                        BinaryString.fromString("first"),
+                        BinaryString.fromString("second"),
+                        BinaryString.fromString("third"));
+        assertThat(archive.rowCount()).isEqualTo(3);
+        assertThat(archive.globalIndexMeta().rowRangeEnd()).isEqualTo(2);
+        PrimaryKeyIndexSourceMeta sourceMeta = PrimaryKeyIndexSourceMeta.fromIndexFile(archive);
+        assertThat(sourceMeta.sourceFiles())
+                .extracting(source -> source.fileName() + ":" + source.rowCount())
+                .containsExactly("data-1:2", "data-2:1");
+    }
+
+    @Test
+    void testBuilderOpensTheFileReaderAndDelegatesEffectiveOptions() throws Exception {
+        DataFileMeta source = dataFile("data-1", 3);
+        DataField textField = new DataField(7, "content", DataTypes.STRING());
+        Options options = new Options();
+        PkFullTextIndexFile indexFile = mock(PkFullTextIndexFile.class);
+        PkFullTextDataFileReader.Factory readerFactory =
+                mock(PkFullTextDataFileReader.Factory.class);
+        PkFullTextDataFileReader reader = mock(PkFullTextDataFileReader.class);
+        IndexFileMeta expected = mock(IndexFileMeta.class);
+        when(readerFactory.create(source)).thenReturn(reader);
+        when(indexFile.build(source, reader, textField, options, "fingerprint"))
+                .thenReturn(expected);
+
+        IndexFileMeta actual =
+                new PkFullTextIndexBuilder(
+                                indexFile, readerFactory, textField, options, "fingerprint")
+                        .build(source);
+
+        assertThat(actual).isSameAs(expected);
+        verify(readerFactory).create(source);
+        verify(indexFile).build(source, reader, textField, options, "fingerprint");
+    }
+
+    @Test
+    void testBuilderDelegatesOrderedSources() throws Exception {
+        DataFileMeta first = dataFile("data-1", 2);
+        DataFileMeta second = dataFile("data-2", 1);
+        DataField textField = new DataField(7, "content", DataTypes.STRING());
+        Options options = new Options();
+        PkFullTextIndexFile indexFile = mock(PkFullTextIndexFile.class);
+        PkFullTextDataFileReader.Factory readerFactory =
+                mock(PkFullTextDataFileReader.Factory.class);
+        when(readerFactory.create(first)).thenReturn(mock(PkFullTextDataFileReader.class));
+        when(readerFactory.create(second)).thenReturn(mock(PkFullTextDataFileReader.class));
+        IndexFileMeta expected = mock(IndexFileMeta.class);
+        when(indexFile.build(anyList(), same(textField), same(options), eq("fingerprint")))
+                .thenReturn(expected);
+
+        IndexFileMeta actual =
+                new PkFullTextIndexBuilder(
+                                indexFile, readerFactory, textField, options, "fingerprint")
+                        .build(Arrays.asList(first, second));
+
+        assertThat(actual).isSameAs(expected);
+        verify(readerFactory).create(first);
+        verify(readerFactory).create(second);
+        verify(indexFile).build(anyList(), same(textField), same(options), eq("fingerprint"));
+    }
+
+    @Test
+    void testClosesReaderWhenIndexerCreationFails() throws Exception {
+        PkFullTextDataFileReader reader = mock(PkFullTextDataFileReader.class);
+
+        assertThatThrownBy(
+                        () ->
+                                new PkFullTextIndexFile(LocalFileIO.create(), pathFactory())
+                                        .build(
+                                                dataFile("data-1", 1),
+                                                reader,
+                                                new DataField(7, "content", DataTypes.STRING()),
+                                                new Options(),
+                                                "fingerprint"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(reader).close();
+    }
+
+    private static DataFileMeta dataFile(String fileName, long rowCount) {
+        return DataFileMeta.forAppend(
+                fileName,
+                100,
+                rowCount,
+                SimpleStats.EMPTY_STATS,
+                0,
+                1,
+                1,
+                Collections.emptyList(),
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private IndexPathFactory pathFactory() {
+        Path directory = new Path(tempPath.toUri());
+        return new IndexPathFactory() {
+            @Override
+            public Path toPath(String fileName) {
+                return new Path(directory, fileName);
+            }
+
+            @Override
+            public Path newPath() {
+                return new Path(directory, UUID.randomUUID().toString());
+            }
+
+            @Override
+            public boolean isExternalPath() {
+                return false;
+            }
+        };
+    }
+
+    private static class RecordingIndexer implements GlobalIndexer {
+
+        private final List<Object> values = new ArrayList<>();
+        private final List<Long> rowIds = new ArrayList<>();
+
+        @Override
+        public GlobalIndexWriter createWriter(GlobalIndexFileWriter fileWriter) {
+            return new GlobalIndexSingleColumnWriter() {
+                @Override
+                public void write(Object key, long relativeRowId) {
+                    values.add(key);
+                    rowIds.add(relativeRowId);
+                }
+
+                @Override
+                public List<ResultEntry> finish() {
+                    try {
+                        String fileName = fileWriter.newFileName("full-text");
+                        try (PositionOutputStream out = fileWriter.newOutputStream(fileName)) {
+                            out.write(1);
+                        }
+                        return Collections.singletonList(
+                                new ResultEntry(fileName, rowIds.size(), new byte[] {2}));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public GlobalIndexReader createReader(
+                GlobalIndexFileReader fileReader,
+                List<GlobalIndexIOMeta> files,
+                ExecutorService executor) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearchTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/index/pkfulltext/PrimaryKeyFullTextBucketSearchTest.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.index.pkfulltext;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.deletionvectors.BitmapDeletionVector;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.globalindex.GlobalIndexReader;
+import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FullTextSearch;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.PrimaryKeyFullTextSearchSplit;
+import org.apache.paimon.table.source.PrimaryKeySearchPosition;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+/** Tests payload-local full-text search and cross-payload RRF. */
+class PrimaryKeyFullTextBucketSearchTest {
+
+    @Test
+    void testFiltersDeletedRowsAndFusesPayloadRanks() {
+        PrimaryKeyFullTextSearchSplit split = split();
+        BitmapDeletionVector deletionVector = new BitmapDeletionVector();
+        deletionVector.delete(0);
+        Map<String, DeletionVector> deletionVectors = Collections.singletonMap("a", deletionVector);
+        Map<String, AtomicInteger> closes = new HashMap<>();
+
+        PrimaryKeyFullTextBucketSearch search =
+                new PrimaryKeyFullTextBucketSearch(
+                        payload -> {
+                            String source =
+                                    PrimaryKeyIndexSourceMeta.fromIndexFile(payload)
+                                            .sourceFile()
+                                            .fileName();
+                            closes.put(source, new AtomicInteger());
+                            if (source.equals("a")) {
+                                return reader(scores(0, 10F, 1, 9F, 2, 8F), closes.get(source));
+                            }
+                            return reader(scores(0, 4F), closes.get(source));
+                        });
+
+        List<PrimaryKeySearchPosition> result =
+                search.search(split, deletionVectors, "content", "hello", 3);
+
+        assertThat(result)
+                .extracting(
+                        PrimaryKeySearchPosition::dataFileName,
+                        PrimaryKeySearchPosition::rowPosition)
+                .containsExactly(tuple("a", 1L), tuple("b", 0L), tuple("a", 2L));
+        assertThat(result.get(0).score()).isEqualTo(1F / 61F);
+        assertThat(result.get(1).score()).isEqualTo(1F / 61F);
+        assertThat(result.get(2).score()).isEqualTo(1F / 62F);
+        assertThat(closes.get("a")).hasValue(1);
+        assertThat(closes.get("b")).hasValue(1);
+    }
+
+    @Test
+    void testOrdersEachPayloadByScoreBeforeRankFusion() {
+        AtomicInteger closes = new AtomicInteger();
+        PrimaryKeyFullTextBucketSearch search =
+                new PrimaryKeyFullTextBucketSearch(
+                        payload -> reader(scores(0, 1F, 2, 10F), closes));
+        PrimaryKeyFullTextSearchSplit split =
+                new PrimaryKeyFullTextSearchSplit(
+                        dataSplit(Collections.singletonList(dataFile("a"))),
+                        Collections.singletonList(payload("a", "index-a")),
+                        Collections.emptyList());
+
+        List<List<PrimaryKeySearchPosition>> rankings =
+                search.searchRankings(split, Collections.emptyMap(), "content", "hello", 2);
+
+        assertThat(rankings).hasSize(1);
+        assertThat(rankings.get(0))
+                .extracting(PrimaryKeySearchPosition::rowPosition, PrimaryKeySearchPosition::score)
+                .containsExactly(tuple(2L, 10F), tuple(0L, 1F));
+        assertThat(closes).hasValue(1);
+    }
+
+    @Test
+    void testMapsMultiSourceRowsAndShiftsDeletionVectors() {
+        BitmapDeletionVector deletionVector = new BitmapDeletionVector();
+        deletionVector.delete(1);
+        AtomicInteger closes = new AtomicInteger();
+        PrimaryKeyFullTextBucketSearch search =
+                new PrimaryKeyFullTextBucketSearch(
+                        ignored -> reader(scores(0, 10F, 3, 9F, 4, 8F, 5, 7F), closes));
+        PrimaryKeyFullTextSearchSplit split =
+                new PrimaryKeyFullTextSearchSplit(
+                        dataSplit(Arrays.asList(dataFile("a"), dataFile("b"))),
+                        Collections.singletonList(payload(Arrays.asList("a", "b"), "index-ab")),
+                        Collections.emptyList());
+
+        List<List<PrimaryKeySearchPosition>> rankings =
+                search.searchRankings(
+                        split,
+                        Collections.singletonMap("b", deletionVector),
+                        "content",
+                        "hello",
+                        4);
+
+        assertThat(rankings).hasSize(1);
+        assertThat(rankings.get(0))
+                .extracting(
+                        PrimaryKeySearchPosition::dataFileName,
+                        PrimaryKeySearchPosition::rowPosition,
+                        PrimaryKeySearchPosition::score)
+                .containsExactly(tuple("a", 0L, 10F), tuple("b", 0L, 9F), tuple("b", 2L, 7F));
+        assertThat(closes).hasValue(1);
+    }
+
+    @Test
+    void testClosesReaderAfterFailedSearch() {
+        AtomicInteger closes = new AtomicInteger();
+        PrimaryKeyFullTextBucketSearch search =
+                new PrimaryKeyFullTextBucketSearch(
+                        payload ->
+                                new FullTextOnlyReader() {
+                                    @Override
+                                    public CompletableFuture<Optional<ScoredGlobalIndexResult>>
+                                            visitFullTextSearch(FullTextSearch fullTextSearch) {
+                                        CompletableFuture<Optional<ScoredGlobalIndexResult>>
+                                                failed = new CompletableFuture<>();
+                                        failed.completeExceptionally(new IOException("broken"));
+                                        return failed;
+                                    }
+
+                                    @Override
+                                    public void close() {
+                                        closes.incrementAndGet();
+                                    }
+                                });
+
+        assertThatThrownBy(
+                        () ->
+                                search.search(
+                                        new PrimaryKeyFullTextSearchSplit(
+                                                dataSplit(Collections.singletonList(dataFile("a"))),
+                                                Collections.singletonList(payload("a", "index-a")),
+                                                Collections.emptyList()),
+                                        Collections.emptyMap(),
+                                        "content",
+                                        "hello",
+                                        1))
+                .isInstanceOf(CompletionException.class)
+                .hasRootCauseMessage("broken");
+        assertThat(closes).hasValue(1);
+    }
+
+    private static GlobalIndexReader reader(Map<Long, Float> scores, AtomicInteger closeCounter) {
+        return new FullTextOnlyReader() {
+            @Override
+            public CompletableFuture<Optional<ScoredGlobalIndexResult>> visitFullTextSearch(
+                    FullTextSearch fullTextSearch) {
+                RoaringNavigableMap64 rows = new RoaringNavigableMap64();
+                RoaringNavigableMap64 include = fullTextSearch.includeRowIds();
+                for (Long row : scores.keySet()) {
+                    if (include == null || include.contains(row)) {
+                        rows.add(row);
+                    }
+                }
+                return CompletableFuture.completedFuture(
+                        Optional.of(ScoredGlobalIndexResult.create(rows, scores::get)));
+            }
+
+            @Override
+            public void close() {
+                closeCounter.incrementAndGet();
+            }
+        };
+    }
+
+    private abstract static class FullTextOnlyReader implements GlobalIndexReader {
+
+        private CompletableFuture<Optional<GlobalIndexResult>> emptyResult() {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitIsNotNull(FieldRef fieldRef) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitIsNull(FieldRef fieldRef) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitStartsWith(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitEndsWith(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitContains(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitLike(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitLessThan(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitGreaterOrEqual(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitNotEqual(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitLessOrEqual(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitEqual(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitGreaterThan(
+                FieldRef fieldRef, Object literal) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitIn(
+                FieldRef fieldRef, List<Object> literals) {
+            return emptyResult();
+        }
+
+        @Override
+        public CompletableFuture<Optional<GlobalIndexResult>> visitNotIn(
+                FieldRef fieldRef, List<Object> literals) {
+            return emptyResult();
+        }
+    }
+
+    private static Map<Long, Float> scores(Object... pairs) {
+        Map<Long, Float> scores = new LinkedHashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            scores.put(((Number) pairs[i]).longValue(), ((Number) pairs[i + 1]).floatValue());
+        }
+        return scores;
+    }
+
+    private static PrimaryKeyFullTextSearchSplit split() {
+        List<DataFileMeta> dataFiles = Arrays.asList(dataFile("a"), dataFile("b"));
+        return new PrimaryKeyFullTextSearchSplit(
+                dataSplit(dataFiles),
+                Arrays.asList(payload("a", "index-a"), payload("b", "index-b")),
+                Collections.emptyList());
+    }
+
+    private static DataSplit dataSplit(List<DataFileMeta> dataFiles) {
+        return DataSplit.builder()
+                .withSnapshot(11)
+                .withPartition(BinaryRow.EMPTY_ROW)
+                .withBucket(0)
+                .withBucketPath("bucket-0")
+                .withTotalBuckets(1)
+                .withDataFiles(dataFiles)
+                .build();
+    }
+
+    private static DataFileMeta dataFile(String name) {
+        return DataFileMeta.create(
+                name,
+                100,
+                3,
+                BinaryRow.EMPTY_ROW,
+                BinaryRow.EMPTY_ROW,
+                SimpleStats.EMPTY_STATS,
+                SimpleStats.EMPTY_STATS,
+                0,
+                0,
+                0,
+                1,
+                Collections.emptyList(),
+                0L,
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private static IndexFileMeta payload(String source, String name) {
+        return payload(Collections.singletonList(source), name);
+    }
+
+    private static IndexFileMeta payload(List<String> sources, String name) {
+        List<PrimaryKeyIndexSourceFile> sourceFiles = new java.util.ArrayList<>();
+        for (String source : sources) {
+            sourceFiles.add(new PrimaryKeyIndexSourceFile(source, 3));
+        }
+        byte[] sourceMeta = new PrimaryKeyIndexSourceMeta(sourceFiles, "fingerprint").serialize();
+        long rowCount = 3L * sourceFiles.size();
+        return new IndexFileMeta(
+                "full-text",
+                name,
+                100,
+                rowCount,
+                new GlobalIndexMeta(0, rowCount - 1, 7, null, null, sourceMeta),
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexWriteTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexWriteTest.java
@@ -129,6 +129,29 @@ class PrimaryKeyIndexWriteTest {
     }
 
     @Test
+    void testCreatesCoordinatorForFullTextDefinition() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "10");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "comment");
+        TestFileStore store = createStore(options);
+        KeyValueFileStoreWrite write = (KeyValueFileStoreWrite) store.newWrite();
+        write.withIOManager(ioManager);
+        TestKeyValueGenerator generator = new TestKeyValueGenerator();
+        KeyValue record = generator.next();
+
+        AbstractFileStoreWrite.WriterContainer<KeyValue> container =
+                write.createWriterContainer(generator.getPartition(record), 1);
+
+        assertThat(container.primaryKeyIndexMaintainer).isNotNull();
+        assertThat(readField(container.primaryKeyIndexMaintainer, "fullTextMaintainer"))
+                .isNotNull();
+        assertThat((List<?>) readField(container.primaryKeyIndexMaintainer, "sortedMaintainers"))
+                .isEmpty();
+        write.close();
+    }
+
+    @Test
     void testPostponeBucketDefersCoordinatorUntilFixedBucketCompaction() throws Exception {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.BUCKET.key(), String.valueOf(BucketMode.POSTPONE_BUCKET));

--- a/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexedSplitReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/PrimaryKeyIndexedSplitReadTest.java
@@ -27,7 +27,7 @@ import org.apache.paimon.reader.FileRecordReader;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.stats.SimpleStats;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.PrimaryKeyVectorPositionReader;
+import org.apache.paimon.table.source.PrimaryKeyIndexPositionReader;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringBitmap32;
 
@@ -63,7 +63,7 @@ class PrimaryKeyIndexedSplitReadTest {
         RecordReader<InternalRow> reader =
                 new PrimaryKeyIndexedSplitRead(rawRead).createReader(split);
 
-        assertThat(reader).isInstanceOf(PrimaryKeyVectorPositionReader.class);
+        assertThat(reader).isInstanceOf(PrimaryKeyIndexPositionReader.class);
         ArgumentCaptor<RoaringBitmap32> positions = ArgumentCaptor.forClass(RoaringBitmap32.class);
         verify(rawRead).createFileReader(eq(dataSplit), positions.capture());
         assertThat(positions.getValue()).isEqualTo(RoaringBitmap32.bitmapOf(1, 3));

--- a/paimon-core/src/test/java/org/apache/paimon/schema/PrimaryKeyFullTextIndexValidationTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/PrimaryKeyFullTextIndexValidationTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.schema;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.paimon.schema.SchemaValidation.validateTableSchema;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for primary-key full-text index option validation. */
+class PrimaryKeyFullTextIndexValidationTest {
+
+    @Test
+    void testValidConfiguration() {
+        assertThatCode(() -> validateTableSchema(schema(enabledOptions())))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectsMultipleColumnsForFirstRelease() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content,other_content");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key())
+                .hasMessageContaining("exactly one column");
+    }
+
+    @Test
+    void testRejectsDuplicateColumns() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content,content");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key())
+                .hasMessageContaining("duplicate");
+    }
+
+    @Test
+    void testRejectsEmptyColumn() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), " ");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key())
+                .hasMessageContaining("non-empty column");
+    }
+
+    @Test
+    void testRejectsUnknownColumn() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "unknown");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("entry 'unknown'")
+                .hasMessageContaining("existing column");
+    }
+
+    @Test
+    void testRejectsNonCharacterColumn() {
+        TableSchema intContentSchema =
+                new TableSchema(
+                        0,
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT().notNull()),
+                                new DataField(1, "content", DataTypes.INT())),
+                        0,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        enabledOptions(),
+                        "");
+
+        assertThatThrownBy(() -> validateTableSchema(intContentSchema))
+                .hasMessageContaining("entry 'content'")
+                .hasMessageContaining("CHAR/VARCHAR/STRING");
+    }
+
+    @Test
+    void testRequiresDeletionVectors() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "false");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("requires deletion-vectors.enabled = true");
+    }
+
+    @Test
+    void testSupportsFirstRowWithoutDeletionVectors() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.MERGE_ENGINE.key(), "first-row");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "false");
+
+        assertThatCode(() -> validateTableSchema(schema(options))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectsDeletionVectorMergeOnRead() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.DELETION_VECTORS_MERGE_ON_READ.key(), "true");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("requires deletion-vectors.merge-on-read = false");
+    }
+
+    @Test
+    void testRejectsDynamicBucket() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.BUCKET.key(), "-1");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("requires fixed or postpone bucket mode");
+    }
+
+    @Test
+    void testSupportsPostponeBucket() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.BUCKET.key(), "-2");
+
+        assertThatCode(() -> validateTableSchema(schema(options))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectsPkClusteringOverride() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_CLUSTERING_OVERRIDE.key(), "true");
+        options.put(CoreOptions.CLUSTERING_COLUMNS.key(), "content");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("does not support pk-clustering-override");
+    }
+
+    @Test
+    void testRejectsColumnConfiguredForAnotherPrimaryKeyIndexFamily() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.PK_BTREE_INDEX_COLUMNS.key(), "content");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("content")
+                .hasMessageContaining("at most one primary-key index");
+    }
+
+    @Test
+    void testRejectsInvalidLsmCompactionOptions() {
+        Map<String, String> options = enabledOptions();
+        options.put("fields.content.pk-index.compaction.level-fanout", "1");
+
+        assertThatThrownBy(() -> validateTableSchema(schema(options)))
+                .hasMessageContaining("fields.content.pk-index.compaction.level-fanout")
+                .hasMessageContaining("greater than 1");
+    }
+
+    @Test
+    void testRequiresPrimaryKeyTable() {
+        Map<String, String> options = enabledOptions();
+        options.put(CoreOptions.BUCKET_KEY.key(), "id");
+
+        TableSchema appendTable =
+                new TableSchema(
+                        0,
+                        fields(),
+                        0,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        options,
+                        "");
+
+        assertThatThrownBy(() -> validateTableSchema(appendTable))
+                .hasMessageContaining("Primary-key full-text index requires a primary-key table");
+    }
+
+    private static Map<String, String> enabledOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content");
+        return options;
+    }
+
+    private static java.util.List<DataField> fields() {
+        return Arrays.asList(
+                new DataField(0, "id", DataTypes.INT().notNull()),
+                new DataField(1, "content", DataTypes.STRING()),
+                new DataField(2, "other_content", DataTypes.STRING()));
+    }
+
+    private static TableSchema schema(Map<String, String> options) {
+        return new TableSchema(
+                0,
+                fields(),
+                0,
+                Collections.emptyList(),
+                Collections.singletonList("id"),
+                options,
+                "");
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -227,6 +227,42 @@ public class SchemaManagerTest {
     }
 
     @Test
+    public void testRejectDestructivePrimaryKeyFullTextIndexColumnChanges() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "1");
+        options.put(CoreOptions.DELETION_VECTORS_ENABLED.key(), "true");
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content");
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT().notNull()),
+                                new DataField(1, "content", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        options,
+                        "");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), path);
+        manager.createTable(schema);
+
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.renameColumn(
+                                                new String[] {"content"}, "renamed_content")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot rename primary-key index column: [content]");
+        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.dropColumn("content")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot drop primary-key index column: [content]");
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.updateColumnType("content", DataTypes.INT())))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Cannot update type of primary-key index column: [content]");
+    }
+
+    @Test
     public void testRejectDropPrimaryKeyBitmapIndexColumn() throws Exception {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.BUCKET.key(), "1");

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/FullTextSearchBuilderTest.java
@@ -34,6 +34,8 @@ import org.apache.paimon.globalindex.btree.BTreeGlobalIndexerFactory;
 import org.apache.paimon.globalindex.testfulltext.TestFullTextGlobalIndexerFactory;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
 import org.apache.paimon.io.CompactIncrement;
 import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.options.Options;
@@ -744,6 +746,25 @@ public class FullTextSearchBuilderTest extends TableTestBase {
     }
 
     @Test
+    public void testOrdinaryFullTextScanSkipsSourceBackedPrimaryKeyArchive() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+
+        String[] documents = {"Apache Paimon", "vector search"};
+        writeDocuments(table, documents);
+        buildAndCommitSourceBackedIndex(table, documents);
+
+        FullTextScan.Plan plan =
+                table.newFullTextSearchBuilder()
+                        .withQuery(TEXT_FIELD_NAME, matchQuery("Paimon"))
+                        .withLimit(2)
+                        .newFullTextScan()
+                        .scan();
+
+        assertThat(plan.splits()).isEmpty();
+    }
+
+    @Test
     public void testFullTextSearchSplitSerialization() throws Exception {
         createTableDefault();
         FileStoreTable table = getTableDefault();
@@ -898,6 +919,66 @@ public class FullTextSearchBuilderTest extends TableTestBase {
                         0,
                         null,
                         dataIncrement,
+                        CompactIncrement.emptyIncrement());
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(Collections.singletonList(message));
+        }
+    }
+
+    private void buildAndCommitSourceBackedIndex(FileStoreTable table, String[] documents)
+            throws Exception {
+        Options options = table.coreOptions().toConfiguration();
+        DataField textField = table.rowType().getField(TEXT_FIELD_NAME);
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter)
+                        GlobalIndexBuilderUtils.createIndexWriter(
+                                table,
+                                TestFullTextGlobalIndexerFactory.IDENTIFIER,
+                                textField,
+                                options);
+        for (int i = 0; i < documents.length; i++) {
+            writer.write(documents[i], i);
+        }
+
+        List<IndexFileMeta> indexFiles =
+                GlobalIndexBuilderUtils.toIndexFileMetas(
+                        table.fileIO(),
+                        table.store().pathFactory().globalIndexFileFactory(),
+                        table.coreOptions(),
+                        new Range(0, documents.length - 1),
+                        Collections.singletonList(textField),
+                        TestFullTextGlobalIndexerFactory.IDENTIFIER,
+                        writer.finish());
+        byte[] sourceMeta =
+                new PrimaryKeyIndexSourceMeta(
+                                new PrimaryKeyIndexSourceFile("data-file", documents.length),
+                                "fingerprint")
+                        .serialize();
+        List<IndexFileMeta> sourceBackedFiles = new ArrayList<>();
+        for (IndexFileMeta indexFile : indexFiles) {
+            GlobalIndexMeta meta = indexFile.globalIndexMeta();
+            sourceBackedFiles.add(
+                    new IndexFileMeta(
+                            indexFile.indexType(),
+                            indexFile.fileName(),
+                            indexFile.fileSize(),
+                            indexFile.rowCount(),
+                            new GlobalIndexMeta(
+                                    meta.rowRangeStart(),
+                                    meta.rowRangeEnd(),
+                                    meta.indexFieldId(),
+                                    meta.extraFieldIds(),
+                                    meta.indexMeta(),
+                                    sourceMeta),
+                            indexFile.externalPath()));
+        }
+
+        CommitMessage message =
+                new CommitMessageImpl(
+                        BinaryRow.EMPTY_ROW,
+                        0,
+                        null,
+                        DataIncrement.indexIncrement(sourceBackedFiles),
                         CompactIncrement.emptyIncrement());
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(Collections.singletonList(message));

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextReadTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextReadTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.CoreOptions.GlobalIndexSearchMode;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+/** Tests PK full-text search modes and physical scored results. */
+class PrimaryKeyFullTextReadTest {
+
+    @Test
+    void testFastSkipsRawFallbackAndPropagatesScores() {
+        AtomicInteger rawCalls = new AtomicInteger();
+        PrimaryKeyFullTextRead read =
+                new PrimaryKeyFullTextRead(
+                        GlobalIndexSearchMode.FAST,
+                        10,
+                        split ->
+                                Collections.singletonList(
+                                        Collections.singletonList(position("indexed", 1, 9F))),
+                        split -> {
+                            rawCalls.incrementAndGet();
+                            return Collections.singletonList(
+                                    Collections.singletonList(position("raw", 0, 8F)));
+                        });
+
+        PrimaryKeyScoredResult result = read.read(Collections.singletonList(split()));
+
+        assertThat(rawCalls).hasValue(0);
+        assertThat(result.snapshotId()).isEqualTo(11);
+        assertThat(result.positions())
+                .extracting(
+                        PrimaryKeySearchPosition::dataFileName,
+                        PrimaryKeySearchPosition::rowPosition)
+                .containsExactly(tuple("indexed", 1L));
+        assertThat(result.positions().get(0).score()).isEqualTo(1F / 61F);
+        IndexedSplit indexedSplit = result.splits().get(0);
+        assertThat(indexedSplit.scores()).containsExactly(1F / 61F);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = GlobalIndexSearchMode.class,
+            names = {"FULL", "DETAIL"})
+    void testCompleteModesSearchAndCleanRawFallback(GlobalIndexSearchMode mode) {
+        AtomicInteger rawCalls = new AtomicInteger();
+        AtomicInteger cleanups = new AtomicInteger();
+        PrimaryKeyFullTextRead read =
+                new PrimaryKeyFullTextRead(
+                        mode,
+                        10,
+                        split ->
+                                Collections.singletonList(
+                                        Collections.singletonList(position("indexed", 1, 9F))),
+                        split -> {
+                            rawCalls.incrementAndGet();
+                            try (Cleanup ignored = new Cleanup(cleanups)) {
+                                return Collections.singletonList(
+                                        Collections.singletonList(position("raw", 0, 8F)));
+                            }
+                        });
+
+        PrimaryKeyScoredResult result = read.read(Collections.singletonList(split()));
+
+        assertThat(rawCalls).hasValue(1);
+        assertThat(cleanups).hasValue(1);
+        assertThat(result.positions())
+                .extracting(
+                        PrimaryKeySearchPosition::dataFileName,
+                        PrimaryKeySearchPosition::rowPosition)
+                .containsExactly(tuple("indexed", 1L), tuple("raw", 0L));
+        assertThat(result.positions())
+                .allSatisfy(position -> assertThat(position.score()).isEqualTo(1F / 61F));
+    }
+
+    private static PrimaryKeySearchPosition position(
+            String dataFile, long rowPosition, float score) {
+        return new PrimaryKeySearchPosition(BinaryRow.EMPTY_ROW, 0, dataFile, rowPosition, score);
+    }
+
+    private static PrimaryKeyFullTextSearchSplit split() {
+        List<DataFileMeta> dataFiles = Arrays.asList(dataFile("indexed"), dataFile("raw"));
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withSnapshot(11)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withTotalBuckets(1)
+                        .withDataFiles(dataFiles)
+                        .build();
+        return new PrimaryKeyFullTextSearchSplit(
+                dataSplit,
+                Collections.singletonList(payload("indexed")),
+                Collections.singletonList("raw"));
+    }
+
+    private static DataFileMeta dataFile(String name) {
+        return DataFileMeta.create(
+                name,
+                100,
+                2,
+                BinaryRow.EMPTY_ROW,
+                BinaryRow.EMPTY_ROW,
+                SimpleStats.EMPTY_STATS,
+                SimpleStats.EMPTY_STATS,
+                0,
+                0,
+                0,
+                1,
+                Collections.emptyList(),
+                0L,
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private static IndexFileMeta payload(String source) {
+        byte[] sourceMeta =
+                new PrimaryKeyIndexSourceMeta(
+                                new PrimaryKeyIndexSourceFile(source, 2), "fingerprint")
+                        .serialize();
+        return new IndexFileMeta(
+                "full-text",
+                "index-" + source,
+                100,
+                2,
+                new GlobalIndexMeta(0, 1, 7, null, null, sourceMeta),
+                null);
+    }
+
+    private static class Cleanup implements AutoCloseable {
+
+        private final AtomicInteger cleanups;
+
+        private Cleanup(AtomicInteger cleanups) {
+            this.cleanups = cleanups;
+        }
+
+        @Override
+        public void close() {
+            cleanups.incrementAndGet();
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextScanTest.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileHandler;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexDefinition;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileKind;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.manifest.IndexManifestEntry;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.snapshot.SnapshotReader;
+import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests snapshot-consistent planning for primary-key full-text search. */
+class PrimaryKeyFullTextScanTest {
+
+    private static final int FIELD_ID = 7;
+    private static final String FINGERPRINT = "current-definition";
+
+    @Test
+    void testSeparatesCurrentCoverageAndExcludesIneligibleFiles() {
+        DataFileMeta indexed = dataFile("indexed", 1, FileSource.COMPACT);
+        DataFileMeta uncovered = dataFile("uncovered", 2, FileSource.COMPACT);
+        DataFileMeta levelZero = dataFile("level-zero", 0, FileSource.COMPACT);
+        DataFileMeta appended = dataFile("appended", 1, FileSource.APPEND);
+        DeletionFile indexedDv = new DeletionFile("indexed.dv", 0, 10, 1L);
+        DeletionFile uncoveredDv = new DeletionFile("uncovered.dv", 10, 10, 1L);
+        DataSplit source =
+                dataSplit(
+                        Arrays.asList(indexed, uncovered, levelZero, appended),
+                        Arrays.asList(indexedDv, uncoveredDv, null, null));
+
+        List<IndexManifestEntry> payloads =
+                Arrays.asList(
+                        payloadEntry("indexed", FIELD_ID, FINGERPRINT, "current"),
+                        payloadEntry("uncovered", FIELD_ID, "old-definition", "stale"),
+                        payloadEntry("uncovered", 8, FINGERPRINT, "other-field"));
+
+        PrimaryKeyFullTextScan.Plan plan =
+                PrimaryKeyFullTextScan.plan(
+                        11, Collections.singletonList(source), payloads, FIELD_ID, FINGERPRINT);
+
+        assertThat(plan.snapshotId()).isEqualTo(11);
+        assertThat(plan.splits()).hasSize(1);
+        PrimaryKeyFullTextSearchSplit split = (PrimaryKeyFullTextSearchSplit) plan.splits().get(0);
+        assertThat(split.dataSplit().dataFiles()).containsExactly(indexed, uncovered);
+        assertThat(split.dataSplit().deletionFiles()).isPresent();
+        assertThat(split.dataSplit().deletionFiles().get()).containsExactly(indexedDv, uncoveredDv);
+        assertThat(split.payloadFiles())
+                .extracting(IndexFileMeta::fileName)
+                .containsExactly("current");
+        assertThat(split.uncoveredDataFiles()).containsExactly("uncovered");
+    }
+
+    @Test
+    void testPlansMultiSourceArchiveOnce() {
+        DataFileMeta first = dataFile("data-1", 1, FileSource.COMPACT);
+        DataFileMeta second = dataFile("data-2", 1, FileSource.COMPACT);
+        IndexManifestEntry payload =
+                payloadEntry(
+                        Arrays.asList("data-1", "data-2"), FIELD_ID, FINGERPRINT, "multi-source");
+
+        PrimaryKeyFullTextScan.Plan plan =
+                PrimaryKeyFullTextScan.plan(
+                        11,
+                        Collections.singletonList(dataSplit(Arrays.asList(first, second), null)),
+                        Collections.singletonList(payload),
+                        FIELD_ID,
+                        FINGERPRINT);
+
+        PrimaryKeyFullTextSearchSplit split = (PrimaryKeyFullTextSearchSplit) plan.splits().get(0);
+        assertThat(split.payloadFiles()).containsExactly(payload.indexFile());
+        assertThat(split.uncoveredDataFiles()).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testCapturesOneSnapshotAndPrunesPartitions() {
+        FileStoreTable table = mock(FileStoreTable.class);
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.id()).thenReturn(11L);
+        Options tableOptions = new Options();
+        tableOptions.set(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS, "content");
+        when(table.coreOptions()).thenReturn(new CoreOptions(tableOptions));
+        when(table.copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "11")))
+                .thenReturn(table);
+
+        SnapshotReader reader = mock(SnapshotReader.class, RETURNS_SELF);
+        SnapshotReader.Plan snapshotPlan = mock(SnapshotReader.Plan.class, CALLS_REAL_METHODS);
+        when(snapshotPlan.snapshotId()).thenReturn(11L);
+        when(snapshotPlan.splits())
+                .thenReturn(
+                        Collections.singletonList(
+                                dataSplit(
+                                        Collections.singletonList(
+                                                dataFile("indexed", 1, FileSource.COMPACT)),
+                                        null)));
+        when(reader.read()).thenReturn(snapshotPlan);
+        when(table.newSnapshotReader()).thenReturn(reader);
+
+        PartitionPredicate partitionFilter = mock(PartitionPredicate.class);
+        when(partitionFilter.test(BinaryRow.EMPTY_ROW)).thenReturn(true);
+        PrimaryKeyIndexDefinition definition = definition();
+        List<IndexManifestEntry> entries =
+                Arrays.asList(
+                        payloadEntry(
+                                "indexed", FIELD_ID, definition.definitionFingerprint(), "current"),
+                        payloadEntry("indexed", FIELD_ID, "old-definition", "stale"));
+        IndexFileHandler indexFileHandler = mock(IndexFileHandler.class);
+        when(indexFileHandler.scan(eq(snapshot), any(Filter.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Filter<IndexManifestEntry> filter = invocation.getArgument(1);
+                            List<IndexManifestEntry> filtered = new ArrayList<>();
+                            for (IndexManifestEntry entry : entries) {
+                                if (filter.test(entry)) {
+                                    filtered.add(entry);
+                                }
+                            }
+                            return filtered;
+                        });
+        when(reader.indexFileHandler()).thenReturn(indexFileHandler);
+        configureBatchScan(table, reader, snapshot);
+
+        PrimaryKeyFullTextScan.Plan plan =
+                new PrimaryKeyFullTextScan(table, definition, partitionFilter, snapshot).scan();
+
+        assertThat(plan.snapshotId()).isEqualTo(11);
+        PrimaryKeyFullTextSearchSplit split = (PrimaryKeyFullTextSearchSplit) plan.splits().get(0);
+        assertThat(split.payloadFiles())
+                .extracting(IndexFileMeta::fileName)
+                .containsExactly("current");
+        assertThat(split.uncoveredDataFiles()).isEmpty();
+        verify(table).copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "11"));
+        verify(reader).withPartitionFilter(partitionFilter);
+        verify(reader).indexFileHandler();
+    }
+
+    @Test
+    void testSplitSerialization() throws Exception {
+        PrimaryKeyFullTextSearchSplit split =
+                new PrimaryKeyFullTextSearchSplit(
+                        dataSplit(
+                                Arrays.asList(
+                                        dataFile("indexed", 1, FileSource.COMPACT),
+                                        dataFile("raw", 1, FileSource.COMPACT)),
+                                Arrays.asList(new DeletionFile("indexed.dv", 0, 10, 1L), null)),
+                        Collections.singletonList(
+                                payloadEntry("indexed", FIELD_ID, FINGERPRINT, "current")
+                                        .indexFile()),
+                        Collections.singletonList("raw"));
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(split);
+        }
+        PrimaryKeyFullTextSearchSplit restored;
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            restored = (PrimaryKeyFullTextSearchSplit) input.readObject();
+        }
+
+        assertThat(restored).isEqualTo(split);
+    }
+
+    private static PrimaryKeyIndexDefinition definition() {
+        return new PrimaryKeyIndexDefinition(
+                "content",
+                FIELD_ID,
+                "full-text",
+                new Options(),
+                PrimaryKeyIndexDefinition.Family.FULL_TEXT,
+                2,
+                0.5);
+    }
+
+    private static DataSplit dataSplit(
+            List<DataFileMeta> dataFiles, List<DeletionFile> deletionFiles) {
+        DataSplit.Builder builder =
+                DataSplit.builder()
+                        .withSnapshot(11)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withTotalBuckets(1)
+                        .withDataFiles(dataFiles);
+        if (deletionFiles != null) {
+            builder.withDataDeletionFiles(deletionFiles);
+        }
+        return builder.build();
+    }
+
+    private static IndexManifestEntry payloadEntry(
+            String sourceFile, int fieldId, String definitionFingerprint, String payloadFile) {
+        return payloadEntry(
+                Collections.singletonList(sourceFile), fieldId, definitionFingerprint, payloadFile);
+    }
+
+    private static IndexManifestEntry payloadEntry(
+            List<String> sourceFiles,
+            int fieldId,
+            String definitionFingerprint,
+            String payloadFile) {
+        List<PrimaryKeyIndexSourceFile> sources = new ArrayList<>();
+        for (String sourceFile : sourceFiles) {
+            sources.add(new PrimaryKeyIndexSourceFile(sourceFile, 2));
+        }
+        byte[] sourceMeta =
+                new PrimaryKeyIndexSourceMeta(sources, definitionFingerprint).serialize();
+        long rowCount = 2L * sources.size();
+        return new IndexManifestEntry(
+                FileKind.ADD,
+                BinaryRow.EMPTY_ROW,
+                0,
+                new IndexFileMeta(
+                        "full-text",
+                        payloadFile,
+                        100,
+                        rowCount,
+                        new GlobalIndexMeta(0, rowCount - 1, fieldId, null, null, sourceMeta),
+                        null));
+    }
+
+    private static void configureBatchScan(
+            FileStoreTable table, SnapshotReader snapshotReader, Snapshot snapshot) {
+        TableSchema schema = mock(TableSchema.class);
+        when(schema.primaryKeys()).thenReturn(Collections.singletonList("id"));
+        when(table.schema()).thenReturn(schema);
+        when(table.schemaManager()).thenReturn(mock(SchemaManager.class));
+        SnapshotManager snapshotManager = mock(SnapshotManager.class);
+        when(snapshotManager.latestSnapshot()).thenReturn(snapshot);
+        when(snapshotManager.snapshot(snapshot.id())).thenReturn(snapshot);
+        when(snapshotReader.snapshotManager()).thenReturn(snapshotManager);
+        when(table.newScan(any(FileStoreTable.SnapshotReaderFactory.class)))
+                .thenAnswer(
+                        invocation -> {
+                            FileStoreTable.SnapshotReaderFactory factory =
+                                    invocation.getArgument(0);
+                            return new PrimaryKeyBatchScan(
+                                    table, factory.create(table), mock(TableQueryAuth.class), null);
+                        });
+    }
+
+    private static DataFileMeta dataFile(String fileName, int level, FileSource fileSource) {
+        return DataFileMeta.create(
+                fileName,
+                100,
+                2,
+                BinaryRow.EMPTY_ROW,
+                BinaryRow.EMPTY_ROW,
+                SimpleStats.EMPTY_STATS,
+                SimpleStats.EMPTY_STATS,
+                0,
+                0,
+                0,
+                level,
+                Collections.emptyList(),
+                0L,
+                null,
+                fileSource,
+                null,
+                null,
+                null,
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextSearchTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyFullTextSearchTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests Java API dispatch for configured primary-key full-text indexes. */
+class PrimaryKeyFullTextSearchTest {
+
+    @Test
+    void testDispatchesConfiguredFieldToPrimaryKeyScan() {
+        FileStoreTable table = table(false);
+
+        FullTextScan scan =
+                new FullTextSearchBuilderImpl(table)
+                        .withQuery("content", "hello")
+                        .withLimit(10)
+                        .newFullTextScan();
+
+        assertThat(scan).isInstanceOf(PrimaryKeyFullTextScan.class);
+    }
+
+    @Test
+    void testRejectsMismatchedPrimaryKeyFullTextField() {
+        FileStoreTable table = table(false);
+
+        assertThatThrownBy(
+                        () ->
+                                new FullTextSearchBuilderImpl(table)
+                                        .withQuery("other", "hello")
+                                        .withLimit(10)
+                                        .newFullTextScan())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("other")
+                .hasMessageContaining(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key());
+    }
+
+    @Test
+    void testDataEvolutionRetainsGlobalFullTextPath() {
+        FileStoreTable table = table(true);
+
+        FullTextScan scan =
+                new FullTextSearchBuilderImpl(table)
+                        .withQuery("content", "hello")
+                        .withLimit(10)
+                        .newFullTextScan();
+
+        assertThat(scan).isInstanceOf(FullTextScanImpl.class);
+    }
+
+    private static FileStoreTable table(boolean dataEvolution) {
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.BUCKET.key(), "2");
+        options.put(CoreOptions.PK_FULL_TEXT_INDEX_COLUMNS.key(), "content");
+        options.put(CoreOptions.DATA_EVOLUTION_ENABLED.key(), Boolean.toString(dataEvolution));
+        TableSchema schema =
+                new TableSchema(
+                        1,
+                        Arrays.asList(
+                                new DataField(0, "id", DataTypes.INT().notNull()),
+                                new DataField(1, "content", DataTypes.STRING()),
+                                new DataField(2, "other", DataTypes.STRING())),
+                        2,
+                        Collections.emptyList(),
+                        Collections.singletonList("id"),
+                        options,
+                        null);
+        FileStoreTable table = mock(FileStoreTable.class);
+        when(table.schema()).thenReturn(schema);
+        when(table.rowType()).thenReturn(schema.logicalRowType());
+        when(table.coreOptions()).thenReturn(new CoreOptions(options));
+        return table;
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyHybridSearchTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyHybridSearchTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.predicate.HybridSearchRoute;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for snapshot-scoped hybrid search on primary-key physical positions. */
+class PrimaryKeyHybridSearchTest {
+
+    @Test
+    void testRrfFusesPhysicalRoutesAndDeduplicatesSourceFiles() {
+        PrimaryKeySearchPosition a = position("a", 0, 10F);
+        PrimaryKeySearchPosition b = position("b", 0, 9F);
+        PrimaryKeySearchPosition c = position("c", 0, 8F);
+        PrimaryKeyScoredResult vectorResult =
+                result(7, new String[] {"a", "b"}, new PrimaryKeySearchPosition[] {a, b});
+        PrimaryKeyScoredResult textResult =
+                result(
+                        7,
+                        new String[] {"b", "c"},
+                        new PrimaryKeySearchPosition[] {b.withScore(100F), c});
+        HybridSearchRoute vectorRoute = new HybridSearchRoute("vector", new float[] {1F}, 2, 1F);
+        HybridSearchRoute textRoute = HybridSearchRoute.fullText("text", "query", 2, 2F, null);
+        HybridSearchBuilderImpl builder =
+                (HybridSearchBuilderImpl)
+                        new HybridSearchBuilderImpl(null)
+                                .addRoute(vectorRoute)
+                                .addRoute(textRoute)
+                                .withLimit(3)
+                                .withRrfRanker();
+
+        ScoredGlobalIndexResult ranked =
+                builder.rank(
+                        Arrays.asList(
+                                new HybridSearchBuilder.RouteResult(vectorRoute, vectorResult),
+                                new HybridSearchBuilder.RouteResult(textRoute, textResult)));
+
+        assertThat(ranked).isInstanceOf(PrimaryKeyScoredResult.class);
+        PrimaryKeyScoredResult physical = (PrimaryKeyScoredResult) ranked;
+        assertThat(physical.snapshotId()).isEqualTo(7);
+        assertThat(physical.positions())
+                .extracting(PrimaryKeySearchPosition::dataFileName)
+                .containsExactly("b", "c", "a");
+        assertThat(physical.splits()).hasSize(3);
+        assertThat(physical.positions().get(0).score())
+                .isCloseTo(
+                        (float) (1D / 62D + 2D / 61D),
+                        org.assertj.core.data.Offset.offset(0.000001F));
+    }
+
+    @Test
+    void testRejectsPhysicalRoutesFromDifferentSnapshots() {
+        PrimaryKeyScoredResult first =
+                result(
+                        7,
+                        new String[] {"a"},
+                        new PrimaryKeySearchPosition[] {position("a", 0, 1F)});
+        PrimaryKeyScoredResult second =
+                result(
+                        8,
+                        new String[] {"a"},
+                        new PrimaryKeySearchPosition[] {position("a", 0, 1F)});
+        HybridSearchRoute firstRoute = new HybridSearchRoute("first", new float[] {1F}, 1, 1F);
+        HybridSearchRoute secondRoute = new HybridSearchRoute("second", new float[] {1F}, 1, 1F);
+        HybridSearchBuilderImpl builder =
+                (HybridSearchBuilderImpl)
+                        new HybridSearchBuilderImpl(null)
+                                .addRoute(firstRoute)
+                                .addRoute(secondRoute)
+                                .withLimit(1);
+
+        assertThatThrownBy(
+                        () ->
+                                builder.rank(
+                                        Arrays.asList(
+                                                new HybridSearchBuilder.RouteResult(
+                                                        firstRoute, first),
+                                                new HybridSearchBuilder.RouteResult(
+                                                        secondRoute, second))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("same snapshot");
+    }
+
+    @Test
+    void testRejectsMixedPhysicalAndGlobalAddressSpaces() {
+        PrimaryKeyScoredResult physical =
+                result(
+                        7,
+                        new String[] {"a"},
+                        new PrimaryKeySearchPosition[] {position("a", 0, 1F)});
+        RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
+        rowIds.add(1L);
+        ScoredGlobalIndexResult global = ScoredGlobalIndexResult.create(rowIds, ignored -> 1F);
+        HybridSearchRoute physicalRoute =
+                new HybridSearchRoute("physical", new float[] {1F}, 1, 1F);
+        HybridSearchRoute globalRoute = new HybridSearchRoute("global", new float[] {1F}, 1, 1F);
+        HybridSearchBuilderImpl builder =
+                (HybridSearchBuilderImpl)
+                        new HybridSearchBuilderImpl(null)
+                                .addRoute(physicalRoute)
+                                .addRoute(globalRoute)
+                                .withLimit(1);
+
+        assertThatThrownBy(
+                        () ->
+                                builder.rank(
+                                        Arrays.asList(
+                                                new HybridSearchBuilder.RouteResult(
+                                                        physicalRoute, physical),
+                                                new HybridSearchBuilder.RouteResult(
+                                                        globalRoute, global))))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("address spaces");
+    }
+
+    private static PrimaryKeyScoredResult result(
+            long snapshotId, String[] files, PrimaryKeySearchPosition[] positions) {
+        DataSplit source =
+                DataSplit.builder()
+                        .withSnapshot(snapshotId)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withTotalBuckets(1)
+                        .withDataFiles(
+                                Arrays.stream(files)
+                                        .map(PrimaryKeyHybridSearchTest::dataFile)
+                                        .collect(java.util.stream.Collectors.toList()))
+                        .build();
+        return new PrimaryKeyScoredResult(
+                snapshotId, Collections.singletonList(source), Arrays.asList(positions));
+    }
+
+    private static PrimaryKeySearchPosition position(String file, long row, float score) {
+        return new PrimaryKeySearchPosition(BinaryRow.EMPTY_ROW, 0, file, row, score);
+    }
+
+    private static DataFileMeta dataFile(String fileName) {
+        return DataFileMeta.forAppend(
+                fileName,
+                100,
+                5,
+                SimpleStats.EMPTY_STATS,
+                0,
+                1,
+                1,
+                Collections.emptyList(),
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyScoredResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyScoredResultTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.utils.Range;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for snapshot-scoped scored physical primary-key results. */
+class PrimaryKeyScoredResultTest {
+
+    @Test
+    void testMaterializesDeterministicFileSplitsAndAlignedScores() {
+        DataFileMeta fileB = dataFile("file-b");
+        DataFileMeta fileA = dataFile("file-a");
+        DeletionFile deletionB = new DeletionFile("dv-b", 10, 20, 1L);
+        DeletionFile deletionA = new DeletionFile("dv-a", 10, 20, 1L);
+        DataSplit source =
+                DataSplit.builder()
+                        .withSnapshot(7)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(2)
+                        .withBucketPath("bucket-2")
+                        .withTotalBuckets(3)
+                        .withDataFiles(Arrays.asList(fileB, fileA))
+                        .withDataDeletionFiles(Arrays.asList(deletionB, deletionA))
+                        .build();
+        List<PrimaryKeySearchPosition> positions =
+                Arrays.asList(
+                        new PrimaryKeySearchPosition(BinaryRow.EMPTY_ROW, 2, "file-b", 4, 0.25F),
+                        new PrimaryKeySearchPosition(BinaryRow.EMPTY_ROW, 2, "file-a", 3, 0.5F),
+                        new PrimaryKeySearchPosition(BinaryRow.EMPTY_ROW, 2, "file-a", 1, 0.75F));
+
+        PrimaryKeyScoredResult result =
+                new PrimaryKeyScoredResult(7, Collections.singletonList(source), positions);
+
+        assertThat(result.snapshotId()).isEqualTo(7);
+        assertThat(result.positions()).containsExactlyElementsOf(positions);
+        assertThat(result.splits()).hasSize(2);
+        IndexedSplit first = result.splits().get(0);
+        assertThat(first.dataSplit().dataFiles()).containsExactly(fileA);
+        assertThat(first.dataSplit().deletionFiles().get()).containsExactly(deletionA);
+        assertThat(first.rowRanges()).containsExactly(new Range(1, 1), new Range(3, 3));
+        assertThat(first.scores()).containsExactly(0.75F, 0.5F);
+        IndexedSplit second = result.splits().get(1);
+        assertThat(second.dataSplit().dataFiles()).containsExactly(fileB);
+        assertThat(second.dataSplit().deletionFiles().get()).containsExactly(deletionB);
+        assertThat(second.rowRanges()).containsExactly(new Range(4, 4));
+        assertThat(second.scores()).containsExactly(0.25F);
+    }
+
+    private static DataFileMeta dataFile(String fileName) {
+        return DataFileMeta.forAppend(
+                fileName,
+                100,
+                5,
+                SimpleStats.EMPTY_STATS,
+                0,
+                1,
+                1,
+                Collections.emptyList(),
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySearchRankerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySearchRankerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table.source;
+
+import org.apache.paimon.data.BinaryRow;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for deterministic reciprocal-rank fusion of physical search positions. */
+class PrimaryKeySearchRankerTest {
+
+    @Test
+    void testFusesDuplicatePositionsAndAssignsTheSameRankToLocalTies() {
+        PrimaryKeySearchPosition a = position("a", 0, 10F);
+        PrimaryKeySearchPosition b = position("b", 0, 10F);
+        PrimaryKeySearchPosition c = position("c", 0, 5F);
+        List<PrimaryKeySearchPosition> fused =
+                PrimaryKeySearchRanker.rrf(
+                        Arrays.asList(
+                                Arrays.asList(c, b, a),
+                                Arrays.asList(a.withScore(1F), c.withScore(8F))),
+                        3);
+
+        assertThat(fused)
+                .extracting(PrimaryKeySearchPosition::dataFileName)
+                .containsExactly("a", "c", "b");
+        assertThat(fused.get(0).score())
+                .isCloseTo((float) (1D / 61D + 1D / 62D), within(0.000001F));
+        assertThat(fused.get(1).score())
+                .isCloseTo((float) (1D / 63D + 1D / 61D), within(0.000001F));
+        assertThat(fused.get(2).score()).isCloseTo((float) (1D / 61D), within(0.000001F));
+    }
+
+    @Test
+    void testUsesRouteWeightsAndDeterministicPhysicalTieBreaking() {
+        PrimaryKeySearchPosition a = position("a", 0, 1F);
+        PrimaryKeySearchPosition b = position("b", 0, 1F);
+        List<PrimaryKeySearchPosition> fused =
+                PrimaryKeySearchRanker.weightedRrf(
+                        Arrays.asList(
+                                new PrimaryKeySearchRanker.Ranking(
+                                        Collections.singletonList(a), 2D),
+                                new PrimaryKeySearchRanker.Ranking(
+                                        Collections.singletonList(b), 2D)),
+                        1);
+
+        assertThat(fused).hasSize(1);
+        assertThat(fused.get(0).dataFileName()).isEqualTo("a");
+        assertThat(fused.get(0).score()).isCloseTo((float) (2D / 61D), within(0.000001F));
+    }
+
+    @Test
+    void testWeightedScoreNormalizesEachPhysicalRoute() {
+        PrimaryKeySearchPosition a = position("a", 0, 0F);
+        PrimaryKeySearchPosition b = position("b", 0, 10F);
+        PrimaryKeySearchPosition c = position("c", 0, 0F);
+
+        List<PrimaryKeySearchPosition> fused =
+                PrimaryKeySearchRanker.weightedScore(
+                        Arrays.asList(
+                                new PrimaryKeySearchRanker.Ranking(Arrays.asList(a, b), 1D),
+                                new PrimaryKeySearchRanker.Ranking(
+                                        Arrays.asList(a.withScore(100F), c), 2D)),
+                        3);
+
+        assertThat(fused)
+                .extracting(PrimaryKeySearchPosition::dataFileName)
+                .containsExactly("a", "b", "c");
+        assertThat(fused).extracting(PrimaryKeySearchPosition::score).containsExactly(2F, 1F, 0F);
+    }
+
+    private static PrimaryKeySearchPosition position(
+            String dataFileName, long rowPosition, float score) {
+        return new PrimaryKeySearchPosition(
+                BinaryRow.EMPTY_ROW, 0, dataFileName, rowPosition, score);
+    }
+
+    private static org.assertj.core.data.Offset<Float> within(float value) {
+        return org.assertj.core.data.Offset.offset(value);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyVectorResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyVectorResultTest.java
@@ -52,9 +52,13 @@ class PrimaryKeyVectorResultTest {
                         new PrimaryKeyVectorRead.Candidate(
                                 BinaryRow.EMPTY_ROW, 0, "data-1", 2, 4F));
 
-        List<IndexedSplit> splits = new PrimaryKeyVectorResult(plan, candidates, "l2").splits();
+        PrimaryKeyVectorResult result = new PrimaryKeyVectorResult(plan, candidates, "l2");
+        List<IndexedSplit> splits = result.splits();
 
         assertThat(splits).hasSize(1);
+        assertThat(result.positions())
+                .extracting(PrimaryKeySearchPosition::score)
+                .containsExactly(1F / (1F + 0.1F), 1F / (1F + 1F), 1F / (1F + 4F));
         IndexedSplit split = splits.get(0);
         assertThat(split.dataSplit().snapshotId()).isEqualTo(11);
         assertThat(split.dataSplit().dataFiles()).containsExactly(dataFile);

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyVectorScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeyVectorScanTest.java
@@ -106,6 +106,8 @@ class PrimaryKeyVectorScanTest {
         when(snapshot.id()).thenReturn(11L);
         when(table.coreOptions()).thenReturn(coreOptions);
         when(table.latestSnapshot()).thenReturn(Optional.of(snapshot));
+        when(table.copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "11")))
+                .thenReturn(table);
 
         SnapshotReader snapshotReader = mock(SnapshotReader.class, RETURNS_SELF);
         SnapshotReader.Plan snapshotPlan = mock(SnapshotReader.Plan.class, CALLS_REAL_METHODS);
@@ -136,7 +138,8 @@ class PrimaryKeyVectorScanTest {
         when(snapshotReader.indexFileHandler()).thenReturn(indexFileHandler);
         configureBatchScan(table, snapshotReader, snapshot);
 
-        PrimaryKeyVectorScan.Plan plan = new PrimaryKeyVectorScan(table, 7, "ivf-pq", null).scan();
+        PrimaryKeyVectorScan.Plan plan =
+                new PrimaryKeyVectorScan(table, 7, "ivf-pq", null, null, snapshot).scan();
 
         assertThat(plan.snapshotId()).isEqualTo(11);
         assertThat(plan.splits()).hasSize(1);
@@ -144,6 +147,7 @@ class PrimaryKeyVectorScanTest {
         assertThat(bucketSplit.payloadFiles())
                 .extracting(IndexFileMeta::fileName)
                 .containsExactly("ann-match");
+        verify(table).copy(Collections.singletonMap(CoreOptions.SCAN_SNAPSHOT_ID.key(), "11"));
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/FullTextSearchProcedure.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/procedure/FullTextSearchProcedure.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.format.json.JsonFormatWriter;
+import org.apache.paimon.format.json.JsonOptions;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.globalindex.GlobalIndexResult;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.reader.ScoreRecordIterator;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InternalRowUtils;
+import org.apache.paimon.utils.StringUtils;
+
+import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.procedure.ProcedureContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Procedure for local full-text search with optional JSON projection and search scores. */
+public class FullTextSearchProcedure extends ProcedureBase {
+
+    public static final String IDENTIFIER = "full_text_search";
+    public static final String SEARCH_SCORE = "__paimon_search_score";
+
+    private static final int MAX_TOP_K = 10_000;
+
+    private static final DataField SEARCH_SCORE_FIELD =
+            new DataField(Integer.MAX_VALUE, SEARCH_SCORE, DataTypes.FLOAT());
+
+    @ProcedureHint(
+            argument = {
+                @ArgumentHint(name = "table", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "column", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "query", type = @DataTypeHint("STRING")),
+                @ArgumentHint(name = "top_k", type = @DataTypeHint("INT")),
+                @ArgumentHint(
+                        name = "projection",
+                        type = @DataTypeHint("STRING"),
+                        isOptional = true),
+                @ArgumentHint(name = "options", type = @DataTypeHint("STRING"), isOptional = true)
+            })
+    public String[] call(
+            ProcedureContext procedureContext,
+            String tableId,
+            String column,
+            String query,
+            Integer topK,
+            String projection,
+            String options)
+            throws Exception {
+        validateSearch(column, query, topK);
+
+        Table table = table(tableId);
+        Map<String, String> optionsMap = optionalConfigMap(options);
+        String queryAuthOption = CoreOptions.QUERY_AUTH_ENABLED.key();
+        if (optionsMap.containsKey(queryAuthOption)) {
+            throw new IllegalArgumentException(
+                    String.format("Option '%s' is not allowed", queryAuthOption));
+        }
+        if (!optionsMap.isEmpty()) {
+            table = table.copy(optionsMap);
+        }
+
+        Projection parsedProjection = Projection.parse(projection, table.rowType());
+        GlobalIndexResult result =
+                table.newFullTextSearchBuilder()
+                        .withQuery(column, query)
+                        .withLimit(topK)
+                        .executeLocal();
+
+        ReadBuilder readBuilder = table.newReadBuilder();
+        if (parsedProjection.dataProjection != null) {
+            readBuilder.withProjection(parsedProjection.dataProjection);
+        }
+        TableScan.Plan plan = readBuilder.newScan().withGlobalIndexResult(result).plan();
+        return readRows(readBuilder, plan, parsedProjection);
+    }
+
+    private static void validateSearch(String column, String query, Integer topK) {
+        if (StringUtils.isNullOrWhitespaceOnly(column)) {
+            throw new IllegalArgumentException("column must not be blank");
+        }
+        if (StringUtils.isNullOrWhitespaceOnly(query)) {
+            throw new IllegalArgumentException("query must not be blank");
+        }
+        if (topK == null || topK <= 0) {
+            throw new IllegalArgumentException("top_k must be positive");
+        }
+        if (topK > MAX_TOP_K) {
+            throw new IllegalArgumentException("top_k must not exceed " + MAX_TOP_K);
+        }
+    }
+
+    private static String[] readRows(
+            ReadBuilder readBuilder, TableScan.Plan plan, Projection projection)
+            throws IOException {
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream(1024);
+        JsonOptions jsonOptions = new JsonOptions(new Options());
+        List<Float> scores = new ArrayList<>();
+        try (JsonFormatWriter jsonWriter =
+                        new JsonFormatWriter(
+                                new ByteArrayPositionOutputStream(byteOut),
+                                projection.outputType,
+                                jsonOptions,
+                                "none");
+                RecordReader<InternalRow> reader = readBuilder.newRead().createReader(plan)) {
+            RecordReader.RecordIterator<InternalRow> batch;
+            while ((batch = reader.readBatch()) != null) {
+                try {
+                    if (!(batch instanceof ScoreRecordIterator)) {
+                        throw new IllegalStateException(
+                                "Full-text search reader did not expose search scores.");
+                    }
+                    ScoreRecordIterator<InternalRow> scoredBatch =
+                            (ScoreRecordIterator<InternalRow>) batch;
+                    InternalRow row;
+                    while ((row = scoredBatch.next()) != null) {
+                        float score = scoredBatch.returnedScore();
+                        if (Float.isNaN(score)) {
+                            throw new IllegalStateException(
+                                    "Full-text search reader returned a missing score.");
+                        }
+                        jsonWriter.addElement(projection.output(row, score));
+                        scores.add(score);
+                    }
+                } finally {
+                    batch.releaseBatch();
+                }
+            }
+        }
+
+        String[] lines =
+                StringUtils.split(byteOut.toString("UTF-8"), jsonOptions.getLineDelimiter());
+        List<ScoredJson> rows = new ArrayList<>(lines.length);
+        int scoreIndex = 0;
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                if (scoreIndex >= scores.size()) {
+                    throw new IllegalStateException(
+                            "Full-text JSON rows and scores are misaligned.");
+                }
+                rows.add(new ScoredJson(trimmed, scores.get(scoreIndex++)));
+            }
+        }
+        if (scoreIndex != scores.size()) {
+            throw new IllegalStateException("Full-text JSON rows and scores are misaligned.");
+        }
+        Collections.sort(
+                rows,
+                (left, right) -> {
+                    int scoreOrder = Float.compare(right.score, left.score);
+                    return scoreOrder != 0 ? scoreOrder : left.json.compareTo(right.json);
+                });
+        return rows.stream().map(row -> row.json).toArray(String[]::new);
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    private static class Projection {
+
+        private final RowType readType;
+        private final RowType outputType;
+        private final int[] dataProjection;
+        private final int[] outputToRead;
+
+        private Projection(
+                RowType readType, RowType outputType, int[] dataProjection, int[] outputToRead) {
+            this.readType = readType;
+            this.outputType = outputType;
+            this.dataProjection = dataProjection;
+            this.outputToRead = outputToRead;
+        }
+
+        private static Projection parse(String projection, RowType tableType) {
+            if (StringUtils.isNullOrWhitespaceOnly(projection)) {
+                return new Projection(tableType, tableType, null, null);
+            }
+
+            String[] names = projection.split(",", -1);
+            List<Integer> dataIndices = new ArrayList<>();
+            List<DataField> outputFields = new ArrayList<>();
+            int[] outputToRead = new int[names.length];
+            Set<String> seen = new HashSet<>();
+            for (int i = 0; i < names.length; i++) {
+                String name = names[i].trim();
+                if (name.isEmpty()) {
+                    throw new IllegalArgumentException("Projection column must not be blank");
+                }
+                if (!seen.add(name)) {
+                    throw new IllegalArgumentException("Duplicate projection column: " + name);
+                }
+                if (SEARCH_SCORE.equals(name)) {
+                    outputFields.add(SEARCH_SCORE_FIELD);
+                    outputToRead[i] = -1;
+                    continue;
+                }
+
+                int tableIndex = tableType.getFieldIndex(name);
+                if (tableIndex < 0) {
+                    throw new IllegalArgumentException("Unknown projection column: " + name);
+                }
+                outputFields.add(tableType.getFields().get(tableIndex));
+                outputToRead[i] = dataIndices.size();
+                dataIndices.add(tableIndex);
+            }
+
+            int[] dataProjection = dataIndices.stream().mapToInt(Integer::intValue).toArray();
+            return new Projection(
+                    tableType.project(dataProjection),
+                    new RowType(outputFields),
+                    dataProjection,
+                    outputToRead);
+        }
+
+        private InternalRow output(InternalRow row, float score) {
+            if (outputToRead == null) {
+                return row;
+            }
+            GenericRow output = new GenericRow(outputToRead.length);
+            for (int i = 0; i < outputToRead.length; i++) {
+                int readIndex = outputToRead[i];
+                output.setField(
+                        i,
+                        readIndex < 0
+                                ? score
+                                : InternalRowUtils.get(
+                                        row, readIndex, readType.getTypeAt(readIndex)));
+            }
+            return output;
+        }
+    }
+
+    private static class ScoredJson {
+
+        private final String json;
+        private final float score;
+
+        private ScoredJson(String json, float score) {
+            this.json = json;
+            this.score = score;
+        }
+    }
+
+    /** A {@link PositionOutputStream} wrapping a {@link ByteArrayOutputStream}. */
+    private static class ByteArrayPositionOutputStream extends PositionOutputStream {
+
+        private final ByteArrayOutputStream out;
+
+        private ByteArrayPositionOutputStream(ByteArrayOutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public long getPos() {
+            return out.size();
+        }
+
+        @Override
+        public void write(int b) {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            out.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
+++ b/paimon-flink/paimon-flink-common/src/main/resources/META-INF/services/org.apache.paimon.factories.Factory
@@ -109,4 +109,5 @@ org.apache.paimon.flink.procedure.DataEvolutionMergeIntoProcedure
 org.apache.paimon.flink.procedure.ReassignRowIdProcedure
 org.apache.paimon.flink.procedure.CreateGlobalIndexProcedure
 org.apache.paimon.flink.procedure.VectorSearchProcedure
+org.apache.paimon.flink.procedure.FullTextSearchProcedure
 org.apache.paimon.flink.procedure.DropGlobalIndexProcedure

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/FullTextSearchProcedureITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/FullTextSearchProcedureITCase.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.flink.CatalogITCaseBase;
+import org.apache.paimon.index.pkfulltext.PkFullTextIndexFile;
+
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** IT cases for {@link FullTextSearchProcedure}. */
+public class FullTextSearchProcedureITCase extends CatalogITCaseBase {
+
+    @Test
+    public void testPrimaryKeyFullTextSearchWithScoreProjection() throws Exception {
+        createPrimaryKeyFullTextTable("T");
+        sql("INSERT INTO T VALUES (0, 'lake format')");
+        sql(
+                "INSERT INTO T VALUES "
+                        + "(1, 'paimon full text search'), "
+                        + "(2, 'apache paimon storage')");
+
+        tEnv.getConfig().set(TableConfigOptions.TABLE_DML_SYNC, true);
+        sql("CALL sys.compact(`table` => 'default.T')");
+
+        assertThat(
+                        paimonTable("T").store().newIndexFileHandler().scanEntries().stream()
+                                .filter(
+                                        entry ->
+                                                PkFullTextIndexFile.INDEX_TYPE.equals(
+                                                        entry.indexFile().indexType())))
+                .isNotEmpty();
+
+        List<String> rows =
+                sql(
+                                "CALL sys.full_text_search("
+                                        + "`table` => 'default.T', "
+                                        + "`column` => 'content', "
+                                        + "query => '{\"match\":{\"column\":\"content\",\"terms\":\"paimon storage\"}}', "
+                                        + "top_k => 10, "
+                                        + "projection => 'id,__paimon_search_score')")
+                        .stream()
+                        .map(row -> row.getField(0).toString())
+                        .collect(Collectors.toList());
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0)).contains("\"id\":\"2\"");
+        assertThat(rows.get(1)).contains("\"id\":\"1\"");
+        assertThat(rows).allMatch(row -> row.contains("\"__paimon_search_score\":\""));
+    }
+
+    @Test
+    public void testValidatesQueryLimitAndProjection() {
+        createPrimaryKeyFullTextTable("VALIDATION_T");
+
+        assertThatThrownBy(
+                        () ->
+                                search(
+                                        "VALIDATION_T",
+                                        "{\"match\":{\"column\":\"content\",\"terms\":\"paimon\"}}",
+                                        0,
+                                        "id"))
+                .hasStackTraceContaining("top_k must be positive");
+        assertThatThrownBy(() -> search("VALIDATION_T", "   ", 1, "id"))
+                .hasStackTraceContaining("query must not be blank");
+        assertThatThrownBy(
+                        () ->
+                                search(
+                                        "VALIDATION_T",
+                                        "{\"match\":{\"column\":\"content\",\"terms\":\"paimon\"}}",
+                                        1,
+                                        "missing"))
+                .hasStackTraceContaining("Unknown projection column");
+        assertThatThrownBy(
+                        () ->
+                                search(
+                                        "VALIDATION_T",
+                                        "{\"match\":{\"column\":\"content\",\"terms\":\"paimon\"}}",
+                                        10_001,
+                                        "id"))
+                .hasStackTraceContaining("top_k must not exceed 10000");
+    }
+
+    @Test
+    public void testRejectsQueryAuthorizationOverride() {
+        createPrimaryKeyFullTextTable("AUTH_T");
+
+        assertThatThrownBy(
+                        () ->
+                                sql(
+                                        "CALL sys.full_text_search("
+                                                + "`table` => 'default.AUTH_T', "
+                                                + "`column` => 'content', "
+                                                + "query => '{\"match\":{\"column\":\"content\",\"terms\":\"paimon\"}}', "
+                                                + "top_k => 1, "
+                                                + "projection => 'id', "
+                                                + "options => 'query-auth.enabled=false')"))
+                .hasStackTraceContaining("Option 'query-auth.enabled' is not allowed");
+    }
+
+    private List<Row> search(String table, String query, int topK, String projection) {
+        return sql(
+                "CALL sys.full_text_search("
+                        + "`table` => 'default.%s', "
+                        + "`column` => 'content', "
+                        + "query => '%s', "
+                        + "top_k => %d, "
+                        + "projection => '%s')",
+                table, query, topK, projection);
+    }
+
+    private void createPrimaryKeyFullTextTable(String tableName) {
+        sql(
+                "CREATE TABLE %s ("
+                        + "id INT, "
+                        + "content STRING, "
+                        + "PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ("
+                        + "'bucket' = '1', "
+                        + "'file.format' = 'json', "
+                        + "'file.compression' = 'none', "
+                        + "'deletion-vectors.enabled' = 'true', "
+                        + "'pk-full-text.index.columns' = 'content'"
+                        + ")",
+                tableName);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/TestPrimaryKeyFullTextGlobalIndexerFactory.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/procedure/TestPrimaryKeyFullTextGlobalIndexerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.procedure;
+
+import org.apache.paimon.globalindex.testfulltext.TestFullTextGlobalIndexerFactory;
+
+/** Test-only non-native backend for the fixed primary-key full-text SPI identifier. */
+public class TestPrimaryKeyFullTextGlobalIndexerFactory extends TestFullTextGlobalIndexerFactory {
+
+    @Override
+    public String identifier() {
+        return "full-text";
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
+++ b/paimon-flink/paimon-flink-common/src/test/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
@@ -1,0 +1,1 @@
+org.apache.paimon.flink.procedure.TestPrimaryKeyFullTextGlobalIndexerFactory

--- a/paimon-full-text/README.md
+++ b/paimon-full-text/README.md
@@ -4,7 +4,10 @@ Full-text search global index for Apache Paimon, backed by the native `paimon-fu
 
 ## Overview
 
-This module provides full-text search capabilities for Paimon's Data Evolution (append) tables through the Global Index framework. It contains only the Paimon integration layer. Native full-text access, JNI, FFI, index archive handling, and query parsing are provided by the separate `paimon-full-text-index` dependency.
+This module provides full-text search for both Data Evolution (append) tables through the Global
+Index framework and compaction-visible primary-key tables through file-aligned index archives. It
+contains only the Paimon integration layer. Native full-text access, JNI, FFI, index archive
+handling, and query parsing are provided by the separate `paimon-full-text-index` dependency.
 
 ### Architecture
 
@@ -93,7 +96,55 @@ All integers are **big-endian**.
 
 ## Usage
 
-### Build Index
+### Primary-Key Tables
+
+Primary-key full-text indexing uses the fixed `full-text` SPI automatically. Configure the text
+column directly on the table; no separate implementation selector is needed.
+
+```sql
+CREATE TABLE articles (
+    id BIGINT,
+    content STRING,
+    PRIMARY KEY (id) NOT ENFORCED
+) WITH (
+    'bucket' = '16',
+    'deletion-vectors.enabled' = 'true',
+    'pk-full-text.index.columns' = 'content',
+    'fields.content.pk-full-text.index.options' = '{"tokenizer":"jieba"}'
+);
+```
+
+Paimon creates native archives from level-1-or-higher compact-output data files and incrementally
+consolidates them with the shared primary-key index LSM policy. One archive can cover multiple
+ordered source files; its row IDs concatenate their physical row positions. The shared
+`fields.<column>.pk-index.compaction.level-fanout` and
+`fields.<column>.pk-index.compaction.stale-ratio-threshold` options control size-tier and stale-source
+rebuilds. No full-text implementation selector or full-text-specific compaction option is needed.
+
+Level-0 files are outside full-text search until compaction publishes the data file and archive
+atomically. This compaction-visible rule also applies to `global-index.search-mode=full` and
+`detail`; those modes build temporary indexes only for eligible compact files whose persistent
+archive is missing.
+
+Within each archive segment the native engine produces a scored ranking. Paimon shifts and filters
+each source file's live positions with its deletion vector, maps results back to physical files,
+fuses segment-local rankings with RRF, and exposes the synthetic score as
+`__paimon_search_score` in Spark and the Flink `full_text_search` procedure.
+
+```sql
+CALL sys.full_text_search(
+    `table` => 'default.articles',
+    `column` => 'content',
+    query => '{"match":{"query":"paimon lake"}}',
+    top_k => 10,
+    projection => 'id,content,__paimon_search_score'
+);
+```
+
+See [Primary-Key Full-Text Index](../docs/docs/primary-key-table/full-text-index.md) for
+requirements, Spark and Java examples, search modes, Hybrid search, and first-release limitations.
+
+### Build a Global Index
 
 ```sql
 CALL sys.create_global_index(

--- a/paimon-full-text/src/test/java/org/apache/paimon/fulltext/index/NativePrimaryKeyFullTextIndexTest.java
+++ b/paimon-full-text/src/test/java/org/apache/paimon/fulltext/index/NativePrimaryKeyFullTextIndexTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fulltext.index;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.deletionvectors.BitmapDeletionVector;
+import org.apache.paimon.deletionvectors.DeletionVector;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.PositionOutputStream;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.globalindex.GlobalIndexIOMeta;
+import org.apache.paimon.globalindex.GlobalIndexSingleColumnWriter;
+import org.apache.paimon.globalindex.GlobalIndexer;
+import org.apache.paimon.globalindex.ResultEntry;
+import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
+import org.apache.paimon.globalindex.io.GlobalIndexFileWriter;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceFile;
+import org.apache.paimon.index.pk.PrimaryKeyIndexSourceMeta;
+import org.apache.paimon.index.pkfulltext.PrimaryKeyFullTextBucketSearch;
+import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.manifest.FileSource;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.stats.SimpleStats;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.PrimaryKeyFullTextSearchSplit;
+import org.apache.paimon.table.source.PrimaryKeySearchPosition;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.JsonSerdeUtil;
+
+import org.apache.paimon.shade.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/** Native SPI tests for file-aligned primary-key full-text archives. */
+class NativePrimaryKeyFullTextIndexTest {
+
+    private static final DataField TEXT_FIELD = new DataField(7, "content", DataTypes.STRING());
+
+    @TempDir java.nio.file.Path tempDir;
+
+    private FileIO fileIO;
+    private Path indexPath;
+
+    @BeforeEach
+    void before() {
+        assumeTrue(isNativeAvailable(), "Native full-text library not available, skipping tests");
+        fileIO = LocalFileIO.create();
+        indexPath = new Path(tempDir.toUri());
+    }
+
+    @AfterEach
+    void after() throws IOException {
+        if (fileIO != null) {
+            fileIO.delete(indexPath, true);
+        }
+    }
+
+    @Test
+    void testPreservesNullOrdinalFiltersDeletedRowsAndOrdersByNativeScore() throws Exception {
+        Options options = new Options();
+        IndexFileMeta archive =
+                buildArchive(
+                        Arrays.asList(
+                                BinaryString.fromString("paimon vector"),
+                                null,
+                                BinaryString.fromString("paimon lake"),
+                                BinaryString.fromString("paimon storage")),
+                        options,
+                        "native-definition");
+
+        assertThat(archive.indexType()).isEqualTo("full-text");
+        assertThat(archive.rowCount()).isEqualTo(4);
+        assertThat(archive.globalIndexMeta().rowRangeStart()).isZero();
+        assertThat(archive.globalIndexMeta().rowRangeEnd()).isEqualTo(3);
+        assertThat(archive.globalIndexMeta().indexFieldId()).isEqualTo(TEXT_FIELD.id());
+        PrimaryKeyIndexSourceMeta sourceMeta = PrimaryKeyIndexSourceMeta.fromIndexFile(archive);
+        assertThat(sourceMeta.sourceFile().fileName()).isEqualTo("data-1");
+        assertThat(sourceMeta.sourceFile().rowCount()).isEqualTo(4);
+        assertThat(sourceMeta.definitionFingerprint()).contains("native-definition");
+
+        DataFileMeta dataFile = dataFile(4);
+        PrimaryKeyFullTextSearchSplit split =
+                new PrimaryKeyFullTextSearchSplit(
+                        DataSplit.builder()
+                                .withSnapshot(1)
+                                .withPartition(BinaryRow.EMPTY_ROW)
+                                .withBucket(0)
+                                .withBucketPath(indexPath.toString())
+                                .withTotalBuckets(1)
+                                .withDataFiles(Collections.singletonList(dataFile))
+                                .build(),
+                        Collections.singletonList(archive),
+                        Collections.emptyList());
+        BitmapDeletionVector deletionVector = new BitmapDeletionVector();
+        deletionVector.delete(2);
+        Map<String, DeletionVector> deletionVectors =
+                Collections.singletonMap(dataFile.fileName(), deletionVector);
+        GlobalIndexer indexer = GlobalIndexer.create("full-text", TEXT_FIELD, options);
+        PrimaryKeyFullTextBucketSearch search =
+                new PrimaryKeyFullTextBucketSearch(
+                        payload ->
+                                indexer.createReader(
+                                        fileReader(),
+                                        Collections.singletonList(toIOMeta(payload)),
+                                        newDirectExecutorService()));
+
+        List<List<PrimaryKeySearchPosition>> rankings =
+                search.searchRankings(
+                        split, deletionVectors, "content", boostQuery("paimon", "vector", 0.1F), 2);
+
+        assertThat(rankings).hasSize(1);
+        assertThat(rankings.get(0))
+                .extracting(
+                        PrimaryKeySearchPosition::rowPosition,
+                        PrimaryKeySearchPosition::dataFileName)
+                .containsExactly(tuple(3L, "data-1"), tuple(0L, "data-1"));
+        assertThat(rankings.get(0).get(0).score()).isGreaterThan(rankings.get(0).get(1).score());
+    }
+
+    @Test
+    void testPersistsTokenizerOptionsInPkArchiveMetadata() throws Exception {
+        Options options = new Options();
+        options.set("full-text.tokenizer", "ngram");
+        options.set("full-text.ngram.min-gram", "2");
+        options.set("full-text.ngram.max-gram", "2");
+
+        IndexFileMeta archive =
+                buildArchive(
+                        Collections.singletonList(BinaryString.fromString("中文全文检索")),
+                        options,
+                        "ngram-definition");
+
+        assertThat(serializedOptions(archive.globalIndexMeta().indexMeta()))
+                .containsEntry("tokenizer", "ngram")
+                .containsEntry("ngram.min-gram", "2")
+                .containsEntry("ngram.max-gram", "2");
+    }
+
+    private IndexFileMeta buildArchive(
+            List<BinaryString> texts, Options options, String definitionFingerprint)
+            throws Exception {
+        GlobalIndexer indexer = GlobalIndexer.create("full-text", TEXT_FIELD, options);
+        GlobalIndexSingleColumnWriter writer =
+                (GlobalIndexSingleColumnWriter) indexer.createWriter(fileWriter());
+        for (int i = 0; i < texts.size(); i++) {
+            writer.write(texts.get(i), i);
+        }
+        List<ResultEntry> results = writer.finish();
+        assertThat(results).hasSize(1);
+        ResultEntry result = results.get(0);
+        Path path = new Path(indexPath, result.fileName());
+        return new IndexFileMeta(
+                "full-text",
+                result.fileName(),
+                fileIO.getFileSize(path),
+                result.rowCount(),
+                new GlobalIndexMeta(
+                        0,
+                        texts.size() - 1,
+                        TEXT_FIELD.id(),
+                        null,
+                        result.meta(),
+                        new PrimaryKeyIndexSourceMeta(
+                                        new PrimaryKeyIndexSourceFile("data-1", texts.size()),
+                                        definitionFingerprint)
+                                .serialize()),
+                null);
+    }
+
+    private GlobalIndexFileWriter fileWriter() {
+        return new GlobalIndexFileWriter() {
+            @Override
+            public String newFileName(String prefix) {
+                return prefix + "-" + UUID.randomUUID();
+            }
+
+            @Override
+            public PositionOutputStream newOutputStream(String fileName) throws IOException {
+                return fileIO.newOutputStream(new Path(indexPath, fileName), false);
+            }
+        };
+    }
+
+    private GlobalIndexFileReader fileReader() {
+        return meta -> fileIO.newInputStream(meta.filePath());
+    }
+
+    private GlobalIndexIOMeta toIOMeta(IndexFileMeta archive) {
+        return new GlobalIndexIOMeta(
+                new Path(indexPath, archive.fileName()),
+                archive.fileSize(),
+                archive.globalIndexMeta().indexMeta());
+    }
+
+    private static DataFileMeta dataFile(long rowCount) {
+        return DataFileMeta.forAppend(
+                "data-1",
+                100,
+                rowCount,
+                SimpleStats.EMPTY_STATS,
+                0,
+                1,
+                1,
+                Collections.emptyList(),
+                null,
+                FileSource.COMPACT,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    private static Map<String, String> serializedOptions(byte[] metadata) {
+        return JsonSerdeUtil.fromJson(
+                new String(metadata, StandardCharsets.UTF_8),
+                new TypeReference<Map<String, String>>() {});
+    }
+
+    private static String boostQuery(String positive, String negative, float negativeBoost) {
+        return "{\"boost\":{\"positive\":"
+                + matchQuery(positive)
+                + ",\"negative\":"
+                + matchQuery(negative)
+                + ",\"negative_boost\":"
+                + negativeBoost
+                + "}}";
+    }
+
+    private static String matchQuery(String terms) {
+        return "{\"match\":{\"query\":\"" + terms + "\"}}";
+    }
+
+    private static boolean isNativeAvailable() {
+        String path = System.getenv("PAIMON_FTINDEX_JNI_LIB_PATH");
+        return path != null && !path.isEmpty() && new File(path).isFile();
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/sql/TestPrimaryKeyFullTextGlobalIndexerFactory.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/sql/TestPrimaryKeyFullTextGlobalIndexerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.sql;
+
+import org.apache.paimon.globalindex.testfulltext.TestFullTextGlobalIndexerFactory;
+
+/** Test-only non-native backend for the fixed primary-key full-text SPI identifier. */
+public class TestPrimaryKeyFullTextGlobalIndexerFactory extends TestFullTextGlobalIndexerFactory {
+
+    @Override
+    public String identifier() {
+        return "full-text";
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
+++ b/paimon-spark/paimon-spark-ut/src/test/resources/META-INF/services/org.apache.paimon.globalindex.GlobalIndexerFactory
@@ -1,0 +1,1 @@
+org.apache.paimon.spark.sql.TestPrimaryKeyFullTextGlobalIndexerFactory

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FullTextSearchTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/FullTextSearchTest.scala
@@ -68,6 +68,52 @@ class FullTextSearchTest extends PaimonSparkTestBase {
 
   // ========== Index Read/Search Tests ==========
 
+  test("primary-key full-text search uses physical splits and exposes scores") {
+    withTable("T") {
+      spark.sql("""
+                  |CREATE TABLE T (id INT, content STRING)
+                  |TBLPROPERTIES (
+                  |  'primary-key' = 'id',
+                  |  'bucket' = '1',
+                  |  'deletion-vectors.enabled' = 'true',
+                  |  'pk-full-text.index.columns' = 'content')
+                  |""".stripMargin)
+
+      spark.sql("INSERT INTO T VALUES (0, 'lake format')")
+      spark.sql("""
+                  |INSERT INTO T VALUES
+                  |  (1, 'paimon full text search'),
+                  |  (2, 'apache paimon storage')
+                  |""".stripMargin)
+      spark.sql("CALL sys.compact(table => 'T')")
+
+      val compactedFiles = spark.sql("SELECT level FROM `T$files`").collect()
+      assert(compactedFiles.exists(_.getInt(0) > 0))
+      val payloads = loadTable("T")
+        .store()
+        .newIndexFileHandler()
+        .scanEntries()
+        .asScala
+        .filter(_.indexFile().indexType() == "full-text")
+      assert(payloads.nonEmpty)
+
+      val rows = spark
+        .sql("""
+               |SELECT id, __paimon_search_score
+               |FROM full_text_search(
+               |  'T',
+               |  'content',
+               |  '{"match":{"column":"content","terms":"paimon"}}',
+               |  10)
+               |ORDER BY id
+               |""".stripMargin)
+        .collect()
+
+      assert(rows.map(_.getInt(0)).toSeq == Seq(1, 2))
+      assert(rows.forall(row => !row.isNullAt(1) && row.getFloat(1) > 0.0f))
+    }
+  }
+
   test("full-text search - basic search") {
     withTable("T") {
       spark.sql("""

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/HybridSearchTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/HybridSearchTest.scala
@@ -24,6 +24,64 @@ import org.apache.paimon.spark.PaimonSparkTestBase
 /** Tests for hybrid search. */
 class HybridSearchTest extends PaimonSparkTestBase {
 
+  test("primary-key hybrid search fuses vector and full-text physical positions") {
+    withTable("T") {
+      spark.sql(
+        s"""
+           |CREATE TABLE T (id INT, content STRING, vec ARRAY<FLOAT>)
+           |TBLPROPERTIES (
+           |  'primary-key' = 'id',
+           |  'bucket' = '1',
+           |  'deletion-vectors.enabled' = 'true',
+           |  'pk-full-text.index.columns' = 'content',
+           |  'vector-field' = 'vec',
+           |  'field.vec.vector-dim' = '2',
+           |  'pk-vector.index.columns' = 'vec',
+           |  'fields.vec.pk-vector.index.type' = '${TestVectorGlobalIndexerFactory.IDENTIFIER}',
+           |  'fields.vec.pk-vector.distance.metric' = 'l2',
+           |  'test.vector.dimension' = '2',
+           |  'test.vector.metric' = 'l2')
+           |""".stripMargin)
+
+      spark.sql("""
+                  |INSERT INTO T VALUES
+                  |  (0, 'lake format', array(1.0f, 0.0f)),
+                  |  (1, 'paimon hybrid search', array(0.9f, 0.1f)),
+                  |  (2, 'paimon full text', array(0.0f, 1.0f))
+                  |""".stripMargin)
+      spark.sql("CALL sys.compact(table => 'T')")
+
+      val rows = spark
+        .sql("""
+               |SELECT id, __paimon_search_score
+               |FROM hybrid_search(
+               |  'T',
+               |  array(
+               |    named_struct(
+               |      'field', 'vec',
+               |      'query_vector', array(1.0f, 0.0f),
+               |      'limit', 2,
+               |      'weight', 1.0f,
+               |      'options', map())),
+               |  array(
+               |    named_struct(
+               |      'column', 'content',
+               |      'query', '{"match":{"column":"content","terms":"paimon"}}',
+               |      'limit', 2,
+               |      'weight', 1.0f,
+               |      'options', map())),
+               |  3,
+               |  'rrf')
+               |ORDER BY __paimon_search_score DESC, id
+               |""".stripMargin)
+        .collect()
+
+      assert(rows.length == 3)
+      assert(rows.head.getInt(0) == 1)
+      assert(rows.forall(row => !row.isNullAt(1) && row.getFloat(1) > 0.0f))
+    }
+  }
+
   test("hybrid search ranks results from multiple vector columns") {
     withTable("T") {
       spark.sql("""


### PR DESCRIPTION
## Summary

Add compaction-visible full-text indexing and search for primary-key tables. The index follows the primary-key table lifecycle, filters physical rows with deletion vectors, and incrementally consolidates immutable archives with the shared primary-key index LSM policy.

## Changes

- Add primary-key full-text configuration, schema validation, deterministic analyzer fingerprints, and source metadata for ordered multi-file archives.
- Build bucket-local native full-text archives from level-1-or-higher compact output and maintain them asynchronously with shared fanout and stale-ratio compaction options.
- Support multi-source archive row-ID mapping, deletion-vector offsets, atomic publish/rollback, stale-source reclamation, and compatibility with existing single-source archives.
- Add snapshot-scoped full-text scan/read/search over physical data-file positions, deterministic RRF ranking, temporary-index fallback for uncovered eligible files, and hybrid vector/full-text fusion.
- Expose primary-key full-text search through Spark SQL and the Flink `full_text_search` procedure, with documentation for configuration, visibility, maintenance, and limitations.

## Testing

- [x] JDK 8: 21 focused `paimon-core` test classes (144 tests)
- [x] Spark 3 / JDK 8: `FullTextSearchTest` and `HybridSearchTest` (13 tests)
- [x] Spark 4 / JDK 17: `FullTextSearchTest` and `HybridSearchTest` (13 tests)
- [x] Flink 1 / JDK 8: `FullTextSearchProcedureITCase`
- [x] Flink 2 / JDK 11: `FullTextSearchProcedureITCase`
- [x] JDK 8: clean `paimon-core` and `paimon-full-text` compile with Checkstyle, Spotless, and Maven Enforcer
- [x] Native primary-key full-text contract test invoked; it runs when `PAIMON_FTINDEX_JNI_LIB_PATH` is available

## Notes

- Primary-key full-text uses the fixed `full-text` implementation; no `index.type` option is introduced.
- Level-0 foreground files remain outside full-text coverage until compaction.
- The first release supports one character full-text column per primary-key table.
- Python API changes are intentionally out of scope.
