### PR TITLE
[iceberg] Fix REST committer factory Javadoc and log message typo

### DIFF
--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRESTMetadataCommitterFactory.java
@@ -20,7 +20,7 @@ package org.apache.paimon.iceberg;
 
 import org.apache.paimon.table.FileStoreTable;
 
-/** doc. */
+/** Factory to create {@link IcebergRestMetadataCommitter}. */
 public class IcebergRESTMetadataCommitterFactory implements IcebergMetadataCommitterFactory {
     @Override
     public String identifier() {

--- a/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
+++ b/paimon-iceberg/src/main/java/org/apache/paimon/iceberg/IcebergRestMetadataCommitter.java
@@ -324,7 +324,7 @@ public class IcebergRestMetadataCommitter implements IcebergMetadataCommitter {
             return createTable(new Schema(), null, newMetadata);
         } else {
             LOG.info(
-                    "Partition fieldId > 0. In order to avoid partition evlolution, dummy schema will be created first");
+                    "Partition fieldId > 0. In order to avoid partition evolution, dummy schema will be created first");
 
             int size =
                     spec.fields().stream().mapToInt(PartitionField::sourceId).max().orElseThrow();


### PR DESCRIPTION
### Purpose

- Replace the `/** doc. */` placeholder Javadoc on `IcebergRESTMetadataCommitterFactory` with `/** Factory to create {@link IcebergRestMetadataCommitter}. */`, matching the `IcebergMetadataCommitterFactory` interface and sibling `IcebergHiveMetadataCommitterFactory`; REST was the only placeholder.
- Fix the spelling typo `evlolution` -> `evolution` in an `IcebergRestMetadataCommitter` `LOG.info` message.

### Tests

- No behavior change (Javadoc + log-string edits); no test added.
- `mvn -pl paimon-iceberg clean install` passed on JDK 11 — checkstyle, spotless, rat, and all tests green (26 unit + 4 ITCase).
