### PR TITLE
[common] Optimize BlobRef data materialization

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
@@ -35,6 +35,9 @@ import java.util.Objects;
 @Public
 public class BlobRef implements Blob {
 
+    /** The maximum safe size of a byte array. Some VMs reserve header words in an array. */
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
     private final UriReader uriReader;
     private final BlobDescriptor descriptor;
 
@@ -45,17 +48,22 @@ public class BlobRef implements Blob {
 
     @Override
     public byte[] toData() {
-        try (SeekableInputStream inputStream = newInputStream()) {
+        try {
             long length = descriptor.length();
-            if (length >= 0) {
-                if (length > Integer.MAX_VALUE) {
-                    throw new IOException("Blob is too large to materialize as byte[]: " + length);
-                }
-                byte[] data = new byte[(int) length];
-                IOUtils.readFully(inputStream, data);
-                return data;
+            if (length > MAX_ARRAY_SIZE) {
+                throw new IOException(
+                        String.format(
+                                "Blob is too large to materialize as byte[]: %d, maximum is %d",
+                                length, MAX_ARRAY_SIZE));
             }
-            return IOUtils.readFully(inputStream, false);
+            try (SeekableInputStream inputStream = newInputStream()) {
+                if (length >= 0) {
+                    byte[] data = new byte[(int) length];
+                    IOUtils.readFully(inputStream, data);
+                    return data;
+                }
+                return IOUtils.readFully(inputStream, false);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/BlobRef.java
@@ -45,8 +45,17 @@ public class BlobRef implements Blob {
 
     @Override
     public byte[] toData() {
-        try {
-            return IOUtils.readFully(newInputStream(), true);
+        try (SeekableInputStream inputStream = newInputStream()) {
+            long length = descriptor.length();
+            if (length >= 0) {
+                if (length > Integer.MAX_VALUE) {
+                    throw new IOException("Blob is too large to materialize as byte[]: " + length);
+                }
+                byte[] data = new byte[(int) length];
+                IOUtils.readFully(inputStream, data);
+                return data;
+            }
+            return IOUtils.readFully(inputStream, false);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -18,7 +18,9 @@
 
 package org.apache.paimon.data;
 
+import org.apache.paimon.fs.ByteArraySeekableStream;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.UriReader;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,5 +81,45 @@ public class BlobTest {
         String uri = "http://example.com/file.txt";
         Blob blob = Blob.fromHttp(uri);
         assertThat(blob).isInstanceOf(BlobRef.class);
+    }
+
+    @Test
+    public void testBlobRefReadsKnownLengthDirectly() {
+        byte[] data = new byte[8194];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        TrackingSeekableInputStream inputStream = new TrackingSeekableInputStream(data);
+        UriReader uriReader = uri -> inputStream;
+        Blob blob = Blob.fromDescriptor(uriReader, new BlobDescriptor("test", 2, data.length - 2));
+
+        assertThat(blob.toData()).isEqualTo(Arrays.copyOfRange(data, 2, data.length));
+        assertThat(inputStream.readCalls).isEqualTo(1);
+        assertThat(inputStream.maxRequestedBytes).isEqualTo(data.length - 2);
+        assertThat(inputStream.closed).isTrue();
+    }
+
+    private static class TrackingSeekableInputStream extends ByteArraySeekableStream {
+
+        private int readCalls;
+        private int maxRequestedBytes;
+        private boolean closed;
+
+        private TrackingSeekableInputStream(byte[] data) {
+            super(data);
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length) throws IOException {
+            readCalls++;
+            maxRequestedBytes = Math.max(maxRequestedBytes, length);
+            return super.read(bytes, offset, length);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -31,8 +31,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link Blob}. */
 public class BlobTest {
@@ -97,6 +99,24 @@ public class BlobTest {
         assertThat(inputStream.readCalls).isEqualTo(1);
         assertThat(inputStream.maxRequestedBytes).isEqualTo(data.length - 2);
         assertThat(inputStream.closed).isTrue();
+    }
+
+    @Test
+    public void testBlobRefRejectsTooLargeLengthBeforeOpeningStream() {
+        AtomicBoolean streamOpened = new AtomicBoolean();
+        UriReader uriReader =
+                uri -> {
+                    streamOpened.set(true);
+                    return new ByteArraySeekableStream(new byte[0]);
+                };
+        long length = (long) Integer.MAX_VALUE - 7;
+        Blob blob = Blob.fromDescriptor(uriReader, new BlobDescriptor("test", 0, length));
+
+        assertThatThrownBy(blob::toData)
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(IOException.class)
+                .hasMessageContaining("Blob is too large to materialize as byte[]");
+        assertThat(streamOpened).isFalse();
     }
 
     private static class TrackingSeekableInputStream extends ByteArraySeekableStream {


### PR DESCRIPTION
## What changed

- Materialize known-length `BlobRef` values into an exactly sized byte array.
- Keep the existing streaming fallback for descriptors without a known length.
- Reject values larger than the maximum Java byte-array size.
- Ensure the input stream is closed after materialization.
- Add coverage for direct known-length reads and stream closure.

## Why

`BlobRef.toData()` previously used a dynamically growing buffer even though `BlobDescriptor` already exposes the remaining data length. That caused avoidable intermediate allocations, copies, and chunked reads when materializing large blobs.

## Impact

Known-length blob references now materialize with a single exact allocation and direct read. Unknown-length descriptors retain the existing behavior.

## Performance

Test dataset: a 6 GB BlobView table with 1,000 rows, each containing a 6,400 KiB blob.

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Elapsed time | 174.918 s | 75.282 s | 56.96% lower |

- Speedup: **2.32×**
- Throughput improvement: **approximately 132.35%**
- Time saved per round: **99.636 seconds**

## Validation

- `mvn -pl paimon-common -Dtest=BlobTest test`
- 6 tests passed, 0 failures
