### PR TITLE
[format] Optimize Vectorized readBytes with direct array access for heap buffers

### DIFF
--- a/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedPlainValuesReader.java
+++ b/paimon-format/src/main/java/org/apache/paimon/format/parquet/reader/VectorizedPlainValuesReader.java
@@ -200,10 +200,18 @@ public class VectorizedPlainValuesReader extends ValuesReader implements Vectori
         int requiredBytes = total * 4;
         ByteBuffer buffer = getBuffer(requiredBytes);
 
-        for (int i = 0; i < total; i += 1) {
-            c.setByte(rowId + i, buffer.get());
-            // skip the next 3 bytes
-            buffer.position(buffer.position() + 3);
+        if (buffer.hasArray()) {
+            byte[] array = buffer.array();
+            int offset = buffer.arrayOffset() + buffer.position();
+            for (int i = 0; i < total; i++) {
+                c.setByte(rowId + i, array[offset + i * 4]);
+            }
+        } else {
+            for (int i = 0; i < total; i += 1) {
+                c.setByte(rowId + i, buffer.get());
+                // skip the next 3 bytes
+                buffer.position(buffer.position() + 3);
+            }
         }
     }
 


### PR DESCRIPTION
### Purpose
- ReadBytes decodes Tinyint, stored as 4 byte little endian, and reads through the ByteBuffer with buffer.get() + a manual position(+3) skip on every value, which is expensive due to bounds check and a position modify per element.
 - This adds a fast path for heap backed buffers that reads straight from the backing byte[] via array[offset + i*4] with no cursor overhead of ByteBuffer
 - The original loop is retained as a fallback for direct buffer.
 - Decode output is byte identical, there is no API or format change.

### Tests
 - Existing UT