### PR TITLE
[lumina] Normalize distance metric to native name in index metadata

### DIFF
--- a/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
+++ b/paimon-lumina/src/main/java/org/apache/paimon/lumina/index/LuminaVectorIndexOptions.java
@@ -125,6 +125,9 @@ public class LuminaVectorIndexOptions {
         this.indexType = options.get(INDEX_TYPE);
         validateEncodingMetricCombination(options.get(ENCODING_TYPE), this.metric);
         this.luminaOptions = buildLuminaOptions(options);
+        // Persist the canonical native metric name so LuminaIndexMeta.metric() can read it
+        // back, regardless of whether the user configured "L2" (enum) or "l2" (native).
+        this.luminaOptions.put(toLuminaKey(DISTANCE_METRIC), metric.getLuminaName());
     }
 
     /**

--- a/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorOptionsTest.java
+++ b/paimon-lumina/src/test/java/org/apache/paimon/lumina/index/LuminaVectorOptionsTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /** Tests for Lumina vector options. */
 public class LuminaVectorOptionsTest {
@@ -115,6 +116,36 @@ public class LuminaVectorOptionsTest {
         assertThat(meta.dim()).isEqualTo(256);
         assertThat(meta.distanceMetric()).isEqualTo("inner_product");
         assertThat(meta.metric()).isEqualTo(LuminaVectorMetric.INNER_PRODUCT);
+    }
+
+    @Test
+    public void enumFormMetricIsNormalizedToNativeNameInMeta() {
+        // A user may configure the metric using the enum-form name (e.g. "L2"), which
+        // parseMetric() accepts. The meta must persist the native name ("l2") so that the read
+        // path LuminaIndexMeta.metric() -> fromLuminaName() can resolve it without throwing.
+        Map<String, String> enumFormL2 = new HashMap<>();
+        enumFormL2.put("lumina.distance.metric", "L2");
+        enumFormL2.put("lumina.index.dimension", "128");
+
+        Map<String, String> l2Meta =
+                new LuminaVectorIndexOptions(Options.fromMap(enumFormL2)).toLuminaOptions();
+        assertThat(l2Meta).containsEntry("distance.metric", "l2");
+        assertThatCode(() -> new LuminaIndexMeta(l2Meta).metric()).doesNotThrowAnyException();
+        assertThat(new LuminaIndexMeta(l2Meta).metric()).isEqualTo(LuminaVectorMetric.L2);
+
+        // Same normalization for another enum-form metric.
+        Map<String, String> enumFormIp = new HashMap<>();
+        enumFormIp.put("lumina.distance.metric", "INNER_PRODUCT");
+        enumFormIp.put("lumina.index.dimension", "128");
+        assertThat(new LuminaVectorIndexOptions(Options.fromMap(enumFormIp)).toLuminaOptions())
+                .containsEntry("distance.metric", "inner_product");
+
+        // No regression: a native-form name stays as-is.
+        Map<String, String> nativeFormL2 = new HashMap<>();
+        nativeFormL2.put("lumina.distance.metric", "l2");
+        nativeFormL2.put("lumina.index.dimension", "128");
+        assertThat(new LuminaVectorIndexOptions(Options.fromMap(nativeFormL2)).toLuminaOptions())
+                .containsEntry("distance.metric", "l2");
     }
 
     /** Builds the native lumina meta map (what gets serialized into the index file) for a field. */


### PR DESCRIPTION

### Purpose

fix #8675

- An index built with `lumina.distance.metric=L2` (enum form) persisted the raw string into the index meta, so `LuminaIndexMeta.metric()` threw `IllegalArgumentException` on every search.
- `parseMetric()` accepts enum-form names (`L2`, `COSINE`, `INNER_PRODUCT`), but the read path `LuminaVectorMetric.fromLuminaName()` matches native lowercase only.
- Persist the canonical native name via `metric.getLuminaName()` after `buildLuminaOptions()`, mirroring `LuminaVectorGlobalIndexer.metric()` which already normalizes.

### Tests

- Added `LuminaVectorOptionsTest#enumFormMetricIsNormalizedToNativeNameInMeta` covering enum-form `L2`/`INNER_PRODUCT` normalization to native names, readability via `LuminaIndexMeta.metric()`, and native-form no-regression.
- `mvn -pl paimon-lumina -am -DfailIfNoTests=false -Dtest=LuminaVectorOptionsTest clean install` (JDK 11) — 6 tests passed; checkstyle + spotless + rat passed.
- Native-lib test classes (x86_64-only) not run on this arm64 machine — covered by CI (fork Actions).
