### PR TITLE
[lance] Reject unsupported MULTISET type in LanceFileFormat schema validation

### DIFF
--- a/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
+++ b/paimon-lance/src/main/java/org/apache/paimon/format/lance/LanceFileFormat.java
@@ -200,7 +200,8 @@ public class LanceFileFormat extends FileFormat {
 
         @Override
         public Void visit(MultisetType multisetType) {
-            return null;
+            throw new UnsupportedOperationException(
+                    "Lance file format does not support type MULTISET");
         }
 
         @Override

--- a/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
+++ b/paimon-lance/src/test/java/org/apache/paimon/format/lance/LanceFileFormatTest.java
@@ -56,6 +56,14 @@ public class LanceFileFormatTest {
     }
 
     @Test
+    public void testValidateDataFields_UnsupportedMultisetType() {
+        LanceFileFormat format =
+                new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.MULTISET(DataTypes.STRING()));
+        assertThrows(UnsupportedOperationException.class, () -> format.validateDataFields(rowType));
+    }
+
+    @Test
     public void testValidateDataFields_SupportedTypes() {
         LanceFileFormat format =
                 new LanceFileFormat(new FileFormatFactory.FormatContext(new Options(), 1024, 1024));


### PR DESCRIPTION

### Purpose

fix #8677

- `LanceFileFormat.LanceRowTypeVisitor.visit(MultisetType)` returned `null`, so a MULTISET column passed `validateDataFields()` but then failed opaquely at write time in `ArrowFieldTypeConversion.visit(MultisetType)` (`UnsupportedOperationException`).
- Make `visit(MultisetType)` throw at validation time, mirroring the sibling `visit(MapType)` which already rejects MAP with a clear message.

### Tests

- Added `LanceFileFormatTest#testValidateDataFields_UnsupportedMultisetType` asserting `validateDataFields` throws `UnsupportedOperationException` for a MULTISET column.
- `mvn -pl paimon-lance -DfailIfNoTests=false clean install` — passed (checkstyle + spotless + rat). `LanceFileFormatTest`: 5 tests passed.


