### PR TITLE
[service] Log full stack trace on KvQueryServer shutdown failure

### DIFF
--- a/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/KvQueryServer.java
+++ b/paimon-service/paimon-service-runtime/src/main/java/org/apache/paimon/service/server/KvQueryServer.java
@@ -91,7 +91,7 @@ public class KvQueryServer extends NetworkServer<KvRequest, KvResponse> implemen
             shutdownServer().get(10L, TimeUnit.SECONDS);
             LOG.info("{} was shutdown successfully.", getServerName());
         } catch (Exception e) {
-            LOG.warn("{} shutdown failed: {}", getServerName(), e);
+            LOG.warn("{} shutdown failed.", getServerName(), e);
         }
     }
 }


### PR DESCRIPTION
### Purpose

- `KvQueryServer.shutdown()` logged failures as `LOG.warn("{} shutdown failed: {}", getServerName(), e)`. The second `{}` consumes `e`, so SLF4J renders it via `toString()` and drops the stack trace, making shutdown failures hard to diagnose.
- Dropping that placeholder passes `e` as the trailing throwable, so SLF4J logs the full stack trace.
- Matches the sibling `KvQueryClient.shutdown()`, which already logs the throwable with its stack trace.

### Tests

- Logging-only change, no behavior change — no test added. `mvn -pl paimon-service/paimon-service-runtime clean install` (JDK 11) passed checkstyle + spotless + rat with 12 unit tests green (KvQueryTableTest, NetworkClientTest, NetworkServerTest, ClientHandlerTest).
