### PR TITLE
[spark] Fix Scala 2.13 dependency resolution for Spark 4 modules

### DIFF
--- a/paimon-spark/paimon-spark-4.0/pom.xml
+++ b/paimon-spark/paimon-spark-4.0/pom.xml
@@ -38,6 +38,10 @@ under the License.
              2.x; otherwise `log4j-slf4j2-impl` + `slf4j-api:1.7.32` mix produces
              `NoClassDefFoundError: org/slf4j/spi/LoggingEventBuilder` at test startup. -->
         <slf4j.version>2.0.16</slf4j.version>
+        <!-- Spark 4 only supports Scala 2.13. Pin it locally so this _2.13 module resolves its
+             dependencies to _2.13 even when the spark4 profile is inactive (see issue #6682);
+             otherwise it inherits scala.binary.version=2.12 from paimon-parent. -->
+        <scala.binary.version>2.13</scala.binary.version>
     </properties>
 
     <dependencies>

--- a/paimon-spark/paimon-spark-4.1/pom.xml
+++ b/paimon-spark/paimon-spark-4.1/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
     <properties>
         <spark.version>4.1.2</spark.version>
+        <!-- Spark 4 only supports Scala 2.13. Pin it locally so this _2.13 module resolves its
+             dependencies to _2.13 even when the spark4 profile is inactive (see issue #6682);
+             otherwise it inherits scala.binary.version=2.12 from paimon-parent. -->
+        <scala.binary.version>2.13</scala.binary.version>
     </properties>
 
     <dependencies>

--- a/paimon-spark/paimon-spark4-common/pom.xml
+++ b/paimon-spark/paimon-spark4-common/pom.xml
@@ -35,6 +35,10 @@ under the License.
 
     <properties>
         <spark.version>${paimon-spark-common.spark.version}</spark.version>
+        <!-- Spark 4 only supports Scala 2.13. Pin it locally so this _2.13 module resolves its
+             dependencies to _2.13 even when the spark4 profile is inactive (see issue #6682);
+             otherwise it inherits scala.binary.version=2.12 from paimon-parent. -->
+        <scala.binary.version>2.13</scala.binary.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### Purpose

close #6682

- The Spark 4 modules (`paimon-spark4-common`, `paimon-spark-4.0`, `paimon-spark-4.1`) hardcode `_2.13` in their `artifactId` but resolve dependencies via `${scala.binary.version}`, which defaults to `2.12` and is only set to `2.13` by the `spark4` profile.
- With the profile inactive (external consumers of the published POMs, or a direct module build), they resolve `_2.12` artifacts that either do not exist or mix Scala 2.12 and 2.13 on the classpath.
- Spark 4 is Scala-2.13-only, so pin `scala.binary.version=2.13` in each module. This completes the partial fix in stale PR #6683 (`paimon-spark-4.0` only).

### Tests

- No unit test: a Maven coordinate-resolution fix with no runtime behavior to assert (cf. POM fixes #8560, #8555).
- `help:effective-pom` with `spark4` **inactive**: every `paimon-spark*`/`spark-*` coordinate now resolves to `_2.13` (was `_2.12`). No-op when the profile is active; Spark `*ITCase` covered by CI.


