### PR TITLE
[test-util] Drop dead cache_docker_images.sh ref in DockerImageVersions

### DIFF
--- a/paimon-test-utils/src/main/java/org/apache/paimon/testutils/junit/DockerImageVersions.java
+++ b/paimon-test-utils/src/main/java/org/apache/paimon/testutils/junit/DockerImageVersions.java
@@ -20,11 +20,7 @@ package org.apache.paimon.testutils.junit;
 
 /**
  * Utility class for defining the image names and versions of Docker containers used during the Java
- * tests. The names/versions are centralised here in order to make testing version updates easier,
- * as well as to provide a central file to use as a key when caching testing Docker files.
- *
- * <p>In order for an image to be cached it must be added to {@code
- * cache_docker_images.sh#DOCKER_IMAGE_CACHE_PATTERN}.
+ * tests. The names/versions are centralised here in order to make testing version updates easier.
  */
 public class DockerImageVersions {
 


### PR DESCRIPTION

### Purpose


- Remove the class-Javadoc `<p>` paragraph and the "central file ... when caching testing Docker files" clause, both referencing `cache_docker_images.sh#DOCKER_IMAGE_CACHE_PATTERN`.
- That script does not exist in Paimon — a dead reference inherited from Flink (repo-wide grep finds only this file's self-reference).
- Leaves the valid version-centralisation purpose, matching the sibling `paimon-flink/paimon-flink-cdc` `DockerImageVersions` clean `/** Docker image versions. */` javadoc.

### Tests

- No behavior change (Javadoc-only) — no test added. `mvn spotless:check -pl paimon-test-utils` and `mvn -pl paimon-test-utils clean install` passed under JDK 11.


