### PR TITLE
[vfs] Fix misleading Javadoc on VFSTableRootIdentifier

### DIFF
--- a/paimon-vfs/paimon-vfs-common/src/main/java/org/apache/paimon/vfs/VFSTableRootIdentifier.java
+++ b/paimon-vfs/paimon-vfs-common/src/main/java/org/apache/paimon/vfs/VFSTableRootIdentifier.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
-/** Identifier for objects under a table. */
+/** Identifier for the root of a table. */
 public class VFSTableRootIdentifier extends VFSTableIdentifier {
 
     public VFSTableRootIdentifier(String databaseName, String tableName) {


### PR DESCRIPTION
### Purpose

- `VFSTableRootIdentifier`'s class Javadoc was a verbatim copy of sibling `VFSTableObjectIdentifier` ("Identifier for objects under a table."), misstating the class's meaning.
- It actually identifies the table root: `filePath()` returns `tableInfo.tablePath()`, and `VFSOperations.getVFSIdentifier` builds it when the relative path is null.
- Corrected to "Identifier for the root of a table.", matching the sibling doc style (catalog / database / table / objects-under-a-table).

### Tests

- Doc-only wording fix, no behavior change — no test added. `mvn spotless:check checkstyle:check -pl paimon-vfs/paimon-vfs-common` passed; module compiles clean.


