### PR TITLE
[vortex] Reject unsupported element types nested in ARRAY

### DIFF
--- a/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexFileFormat.java
+++ b/paimon-vortex/paimon-vortex-format/src/main/java/org/apache/paimon/format/vortex/VortexFileFormat.java
@@ -183,7 +183,7 @@ public class VortexFileFormat extends FileFormat {
 
         @Override
         public Void visit(ArrayType arrayType) {
-            return null;
+            return arrayType.getElementType().accept(this);
         }
 
         @Override

--- a/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexFileFormatTest.java
+++ b/paimon-vortex/paimon-vortex-format/src/test/java/org/apache/paimon/format/vortex/VortexFileFormatTest.java
@@ -101,6 +101,25 @@ public class VortexFileFormatTest {
     }
 
     @Test
+    public void testValidateDataFields_UnsupportedTypeNestedInArray() {
+        VortexFileFormat format =
+                new VortexFileFormat(
+                        new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType =
+                RowType.of(DataTypes.ARRAY(DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())));
+        assertThrows(UnsupportedOperationException.class, () -> format.validateDataFields(rowType));
+    }
+
+    @Test
+    public void testValidateDataFields_SupportedTypeNestedInArray() {
+        VortexFileFormat format =
+                new VortexFileFormat(
+                        new FileFormatFactory.FormatContext(new Options(), 1024, 1024));
+        RowType rowType = RowType.of(DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())));
+        assertDoesNotThrow(() -> format.validateDataFields(rowType));
+    }
+
+    @Test
     public void testValidateDataFields_SupportedTypes() {
         VortexFileFormat format =
                 new VortexFileFormat(


### PR DESCRIPTION

### Purpose

fix #8688

- `VortexRowTypeVisitor.visit(ArrayType)` returned without checking the element type, so unsupported types (`MAP`/`MULTISET`/`VARIANT`/`BLOB`) nested inside an `ARRAY` passed `validateDataFields` even though they are rejected at the top level and inside `ROW`.
- Recurse into the element type via `arrayType.getElementType().accept(this)`, matching `visit(RowType)`. `ARRAY` of supported types stays valid.

### Tests

- Added `VortexFileFormatTest#testValidateDataFields_UnsupportedTypeNestedInArray` (`ARRAY<MAP<STRING,INT>>` is rejected) and `#testValidateDataFields_SupportedTypeNestedInArray` (`ARRAY<ARRAY<INT>>` is accepted).
- `mvn -pl paimon-vortex/paimon-vortex-format test` — 11 tests passed (JDK 11). Native round-trip tests (`*ReadWriteTest`, converter semantic tests) are covered by CI (fork Actions).

