### PR TITLE
[core] Optimize latest snapshot retrieval for file store writers.

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/AbstractFileStoreWrite.java
@@ -490,7 +490,7 @@ public abstract class AbstractFileStoreWrite<T> implements FileStoreWrite<T> {
             }
         }
 
-        Snapshot latestSnapshot = snapshotManager.latestSnapshot();
+        Snapshot latestSnapshot = snapshotManager.latestSnapshotFromFileSystem();
         boolean actualIgnorePreviousFiles =
                 ignorePreviousFilesForWriter(
                         partition, bucket, latestSnapshot, ignorePreviousFiles);

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -109,7 +109,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -2151,7 +2150,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         FileStoreTable tableTestWrite = (FileStoreTable) catalog.getTable(identifier);
         List<Integer> data = Lists.newArrayList(12);
         Exception exception =
-                assertThrows(UncheckedIOException.class, () -> batchWrite(tableTestWrite, data));
+                assertThrows(RuntimeException.class, () -> batchWrite(tableTestWrite, data));
         assertEquals(RESTTestFileIO.TOKEN_EXPIRED_MSG, exception.getCause().getMessage());
         RESTToken dataToken =
                 new RESTToken(
@@ -2176,7 +2175,7 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
         restTokenFileIO.isObjectStore();
         resetDataTokenOnRestServer(identifier);
         Exception exception =
-                assertThrows(UncheckedIOException.class, () -> batchWrite(tableTestWrite, data));
+                assertThrows(RuntimeException.class, () -> batchWrite(tableTestWrite, data));
         assertEquals(RESTTestFileIO.TOKEN_UN_EXIST_MSG, exception.getCause().getMessage());
     }
 


### PR DESCRIPTION
Author: tanjie.master <tanjiemaster@gmail.com>  
Date: Thu Jul 16 12:30:23 2026 +0800

### Purpose

This PR optimizes latest snapshot retrieval in `AbstractFileStoreWrite` by using `latestSnapshotFromFileSystem` instead of `latestSnapshot`.

When creating a `FileStoreWriter`, it no longer queries the catalog for the latest snapshot. Instead, it retrieves the latest snapshot directly from the snapshot directory in the file system.

This avoids unnecessary catalog requests when creating writers under high concurrency.

This PR was inspired by [PR #5680](https://github.com/apache/paimon/pull/5680).

### Tests

Existing tests should cover this change.

### API and Format

No API or format changes.

### Documentation

No new features.