### PR TITLE
[spark] Fix remove_unexisting_files on empty table

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/procedure/SparkRemoveUnexistingFiles.scala
@@ -27,6 +27,7 @@ import org.apache.paimon.table.FileStoreTable
 import org.apache.paimon.table.sink.{CommitMessage, CommitMessageImpl, CommitMessageSerializer}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{PaimonSparkSession, SparkSession}
 import org.apache.spark.sql.catalyst.SQLConfHelper
 
@@ -43,8 +44,12 @@ case class SparkRemoveUnexistingFiles(
   extends SQLConfHelper
   with Logging {
 
-  private def buildRDD() = {
+  private def buildRDD(): RDD[String] = {
     val binaryPartitions = table.newScan().listPartitions()
+    if (binaryPartitions.isEmpty) {
+      return spark.sparkContext.emptyRDD[String]
+    }
+
     val realParallelism = Math.min(binaryPartitions.size(), parallelism)
 
     val numPartitionFields = table.schema().partitionKeys().size()

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
@@ -26,6 +26,7 @@ import java.util.UUID
 class RemoveUnexistingFilesProcedureTest extends PaimonSparkTestBase {
 
   test("Paimon procedure: remove unexisting files on empty table") {
+    spark.sql("CREATE DATABASE IF NOT EXISTS mydb")
     spark.sql("CREATE TABLE mydb.t_empty (id INT) USING paimon")
 
     checkAnswer(
@@ -61,6 +62,7 @@ class RemoveUnexistingFilesProcedureTest extends PaimonSparkTestBase {
 
     val actual = new Array[Int](numPartitions)
     val pattern = "pt=(\\d+?)/".r
+    spark.sql("CREATE DATABASE IF NOT EXISTS mydb")
     spark.sql(s"USE mydb")
     spark
       .sql(s"CALL sys.remove_unexisting_files(table => '$tableName', dry_run => true)")

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
@@ -27,13 +27,17 @@ class RemoveUnexistingFilesProcedureTest extends PaimonSparkTestBase {
 
   test("Paimon procedure: remove unexisting files on empty table") {
     spark.sql("CREATE DATABASE IF NOT EXISTS mydb")
-    spark.sql("CREATE TABLE mydb.t_empty (id INT) USING paimon")
+    try {
+      spark.sql("CREATE TABLE mydb.t_empty (id INT) USING paimon")
 
-    checkAnswer(
-      spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty', dry_run => true)"),
-      Nil)
+      checkAnswer(
+        spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty', dry_run => true)"),
+        Nil)
 
-    checkAnswer(spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty')"), Nil)
+      checkAnswer(spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty')"), Nil)
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS mydb.t_empty")
+    }
   }
 
   test("Paimon procedure: remove unexisting files, bucket = -1") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/procedure/RemoveUnexistingFilesProcedureTest.scala
@@ -25,6 +25,16 @@ import java.util.UUID
 
 class RemoveUnexistingFilesProcedureTest extends PaimonSparkTestBase {
 
+  test("Paimon procedure: remove unexisting files on empty table") {
+    spark.sql("CREATE TABLE mydb.t_empty (id INT) USING paimon")
+
+    checkAnswer(
+      spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty', dry_run => true)"),
+      Nil)
+
+    checkAnswer(spark.sql("CALL sys.remove_unexisting_files(table => 'mydb.t_empty')"), Nil)
+  }
+
   test("Paimon procedure: remove unexisting files, bucket = -1") {
     testImpl(-1)
   }


### PR DESCRIPTION
### Purpose
Fix `sys.remove_unexisting_files` on newly created empty tables in Spark.

Previously, `SparkRemoveUnexistingFiles` called `parallelize` with `realParallelism = 0` when `table.newScan().listPartitions()` returned an empty list, which caused Spark to fail with `IllegalArgumentException: Positive number of partitions required`. This change short-circuits the empty-table case and returns an empty result instead of launching a Spark job.


### Tests
Added `RemoveUnexistingFilesProcedureTest: Paimon procedure: remove unexisting files on empty table`
