### PR TITLE
[core] Support scalar TopN global index pushdown

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -90,16 +90,26 @@ public class GlobalIndexEvaluator implements Closeable {
         int fieldId = rowType.getField(fieldRef.name()).id();
         Collection<GlobalIndexReader> readers =
                 indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
+        if (readers.isEmpty()) {
+            return Optional.empty();
+        }
+        long readerMaxResultSize = scalarSearch.maxResultSize() / readers.size();
+        long readerMaxScannedRowIds = scalarSearch.maxScannedRowIds() / readers.size();
+        if (readerMaxResultSize < scalarSearch.topN().limit()
+                || readerMaxScannedRowIds < scalarSearch.topN().limit()) {
+            return Optional.empty();
+        }
+        ScalarSearch readerSearch =
+                scalarSearch
+                        .withMaxResultSize(readerMaxResultSize)
+                        .withMaxScannedRowIds(readerMaxScannedRowIds);
         List<CompletableFuture<Optional<GlobalIndexResult>>> futures = new ArrayList<>();
         for (GlobalIndexReader reader : readers) {
             try {
-                futures.add(reader.visitScalarSearch(scalarSearch));
+                futures.add(reader.visitScalarSearch(readerSearch));
             } catch (UnsupportedOperationException ignored) {
                 return Optional.empty();
             }
-        }
-        if (futures.isEmpty()) {
-            return Optional.empty();
         }
 
         try {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -99,6 +99,8 @@ public class GlobalIndexEvaluator implements Closeable {
         }
         long readerMaxResultSize = scalarSearch.maxResultSize() / readers.size();
         long readerMaxScannedRowIds = scalarSearch.maxScannedRowIds() / readers.size();
+        int readerMaxIndexFiles = scalarSearch.maxIndexFiles() / readers.size();
+        long readerMaxIndexBytes = scalarSearch.maxIndexBytes() / readers.size();
         if (readerMaxResultSize < scalarSearch.topN().limit()
                 || readerMaxScannedRowIds < scalarSearch.topN().limit()) {
             return Optional.empty();
@@ -106,9 +108,10 @@ public class GlobalIndexEvaluator implements Closeable {
         ScalarSearch readerSearch =
                 scalarSearch
                         .withMaxResultSize(readerMaxResultSize)
-                        .withMaxScannedRowIds(readerMaxScannedRowIds);
+                        .withMaxScannedRowIds(readerMaxScannedRowIds)
+                        .withMaxIndexFiles(readerMaxIndexFiles)
+                        .withMaxIndexBytes(readerMaxIndexBytes);
         RoaringNavigableMap64 result = new RoaringNavigableMap64();
-        boolean exact = true;
         long resultSize = 0;
         try {
             for (GlobalIndexReader reader : readers) {
@@ -130,9 +133,8 @@ public class GlobalIndexEvaluator implements Closeable {
                     return Optional.empty();
                 }
                 result.or(current.get().results());
-                exact &= current.get().isExact();
             }
-            return Optional.of(GlobalIndexResult.create(result, exact));
+            return Optional.of(GlobalIndexResult.create(result));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted during scalar index evaluation", e);

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -29,6 +29,7 @@ import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.LeafTernaryFunction;
 import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
 
@@ -73,6 +74,48 @@ public class GlobalIndexEvaluator implements Closeable {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted during index evaluation", e);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            if (e.getCause() instanceof Error) {
+                throw (Error) e.getCause();
+            }
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    public Optional<GlobalIndexResult> evaluateScalarSearch(ScalarSearch scalarSearch) {
+        FieldRef fieldRef = scalarSearch.topN().orders().get(0).field();
+        int fieldId = rowType.getField(fieldRef.name()).id();
+        Collection<GlobalIndexReader> readers =
+                indexReadersCache.computeIfAbsent(fieldId, readersFunction::apply);
+        List<CompletableFuture<Optional<GlobalIndexResult>>> futures = new ArrayList<>();
+        for (GlobalIndexReader reader : readers) {
+            try {
+                futures.add(reader.visitScalarSearch(scalarSearch));
+            } catch (UnsupportedOperationException ignored) {
+                // Try another index implementation for the same field.
+            }
+        }
+        if (futures.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+            Optional<GlobalIndexResult> result = Optional.empty();
+            for (CompletableFuture<Optional<GlobalIndexResult>> future : futures) {
+                Optional<GlobalIndexResult> current = future.join();
+                if (!current.isPresent()) {
+                    continue;
+                }
+                result = result.isPresent() ? Optional.of(result.get().or(current.get())) : current;
+            }
+            return result;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during scalar index evaluation", e);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -32,6 +32,7 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import javax.annotation.Nullable;
 
@@ -86,6 +87,9 @@ public class GlobalIndexEvaluator implements Closeable {
     }
 
     public Optional<GlobalIndexResult> evaluateScalarSearch(ScalarSearch scalarSearch) {
+        if (scalarSearch.topN().orders().size() != 1) {
+            return Optional.empty();
+        }
         FieldRef fieldRef = scalarSearch.topN().orders().get(0).field();
         int fieldId = rowType.getField(fieldRef.name()).id();
         Collection<GlobalIndexReader> readers =
@@ -103,21 +107,17 @@ public class GlobalIndexEvaluator implements Closeable {
                 scalarSearch
                         .withMaxResultSize(readerMaxResultSize)
                         .withMaxScannedRowIds(readerMaxScannedRowIds);
-        List<CompletableFuture<Optional<GlobalIndexResult>>> futures = new ArrayList<>();
-        for (GlobalIndexReader reader : readers) {
-            try {
-                futures.add(reader.visitScalarSearch(readerSearch));
-            } catch (UnsupportedOperationException ignored) {
-                return Optional.empty();
-            }
-        }
-
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        boolean exact = true;
+        long resultSize = 0;
         try {
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-            Optional<GlobalIndexResult> result = Optional.empty();
-            long resultSize = 0;
-            for (CompletableFuture<Optional<GlobalIndexResult>> future : futures) {
-                Optional<GlobalIndexResult> current = future.join();
+            for (GlobalIndexReader reader : readers) {
+                Optional<GlobalIndexResult> current;
+                try {
+                    current = reader.visitScalarSearch(readerSearch).get();
+                } catch (UnsupportedOperationException ignored) {
+                    return Optional.empty();
+                }
                 if (!current.isPresent()) {
                     return Optional.empty();
                 }
@@ -129,13 +129,17 @@ public class GlobalIndexEvaluator implements Closeable {
                 if (resultSize > scalarSearch.maxResultSize()) {
                     return Optional.empty();
                 }
-                result = result.isPresent() ? Optional.of(result.get().or(current.get())) : current;
+                result.or(current.get().results());
+                exact &= current.get().isExact();
             }
-            return result;
+            return Optional.of(GlobalIndexResult.create(result, exact));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted during scalar index evaluation", e);
         } catch (ExecutionException e) {
+            if (e.getCause() instanceof UnsupportedOperationException) {
+                return Optional.empty();
+            }
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();
             }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexEvaluator.java
@@ -95,7 +95,7 @@ public class GlobalIndexEvaluator implements Closeable {
             try {
                 futures.add(reader.visitScalarSearch(scalarSearch));
             } catch (UnsupportedOperationException ignored) {
-                // Try another index implementation for the same field.
+                return Optional.empty();
             }
         }
         if (futures.isEmpty()) {
@@ -105,10 +105,19 @@ public class GlobalIndexEvaluator implements Closeable {
         try {
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
             Optional<GlobalIndexResult> result = Optional.empty();
+            long resultSize = 0;
             for (CompletableFuture<Optional<GlobalIndexResult>> future : futures) {
                 Optional<GlobalIndexResult> current = future.join();
                 if (!current.isPresent()) {
-                    continue;
+                    return Optional.empty();
+                }
+                long currentSize = current.get().results().getLongCardinality();
+                if (Long.MAX_VALUE - resultSize < currentSize) {
+                    return Optional.empty();
+                }
+                resultSize += currentSize;
+                if (resultSize > scalarSearch.maxResultSize()) {
+                    return Optional.empty();
                 }
                 result = result.isPresent() ? Optional.of(result.get().or(current.get())) : current;
             }
@@ -147,16 +156,23 @@ public class GlobalIndexEvaluator implements Closeable {
         List<CompletableFuture<Optional<GlobalIndexResult>>> readerFutures =
                 new ArrayList<>(readers.size());
         for (GlobalIndexReader reader : readers) {
-            readerFutures.add(predicate.function().visit(reader, fieldRef, predicate.literals()));
+            try {
+                readerFutures.add(
+                        predicate.function().visit(reader, fieldRef, predicate.literals()));
+            } catch (UnsupportedOperationException ignored) {
+                readerFutures.add(CompletableFuture.completedFuture(Optional.empty()));
+            }
         }
 
         return CompletableFuture.allOf(readerFutures.toArray(new CompletableFuture[0]))
                 .thenApply(
                         v -> {
                             Optional<GlobalIndexResult> compoundResult = Optional.empty();
+                            boolean exact = true;
                             for (CompletableFuture<Optional<GlobalIndexResult>> f : readerFutures) {
                                 Optional<GlobalIndexResult> childResult = f.join();
                                 if (!childResult.isPresent()) {
+                                    exact = false;
                                     continue;
                                 }
                                 if (compoundResult.isPresent()) {
@@ -167,10 +183,23 @@ public class GlobalIndexEvaluator implements Closeable {
                                     compoundResult = childResult;
                                 }
                                 if (compoundResult.get().results().isEmpty()) {
-                                    return compoundResult;
+                                    return Optional.of(
+                                            compoundResult
+                                                    .get()
+                                                    .withExact(
+                                                            exact
+                                                                    && compoundResult
+                                                                            .get()
+                                                                            .isExact()));
                                 }
                             }
-                            return compoundResult;
+                            if (!compoundResult.isPresent()) {
+                                return compoundResult;
+                            }
+                            return Optional.of(
+                                    compoundResult
+                                            .get()
+                                            .withExact(exact && compoundResult.get().isExact()));
                         });
     }
 
@@ -208,6 +237,7 @@ public class GlobalIndexEvaluator implements Closeable {
             return Optional.of(compoundResult);
         } else {
             Optional<GlobalIndexResult> compoundResult = Optional.empty();
+            boolean exact = true;
             for (Optional<GlobalIndexResult> childResult : results) {
                 if (childResult.isPresent()) {
                     if (compoundResult.isPresent()) {
@@ -215,12 +245,21 @@ public class GlobalIndexEvaluator implements Closeable {
                     } else {
                         compoundResult = childResult;
                     }
+                } else {
+                    exact = false;
                 }
                 if (compoundResult.isPresent() && compoundResult.get().results().isEmpty()) {
-                    return compoundResult;
+                    return Optional.of(
+                            compoundResult
+                                    .get()
+                                    .withExact(exact && compoundResult.get().isExact()));
                 }
             }
-            return compoundResult;
+            if (!compoundResult.isPresent()) {
+                return compoundResult;
+            }
+            return Optional.of(
+                    compoundResult.get().withExact(exact && compoundResult.get().isExact()));
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
@@ -63,6 +63,7 @@ public interface GlobalIndexReader
         throw new UnsupportedOperationException();
     }
 
+    /** Returns a bounded candidate superset for scalar TopN, not an exact predicate result. */
     default CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
             ScalarSearch scalarSearch) {
         throw new UnsupportedOperationException();

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.predicate.BatchVectorSearch;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.predicate.FunctionVisitor;
 import org.apache.paimon.predicate.LeafPredicate;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.VectorSearch;
 
 import java.io.Closeable;
@@ -59,6 +60,11 @@ public interface GlobalIndexReader
 
     default CompletableFuture<Optional<ScoredGlobalIndexResult>> visitFullTextSearch(
             FullTextSearch fullTextSearch) {
+        throw new UnsupportedOperationException();
+    }
+
+    default CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+            ScalarSearch scalarSearch) {
         throw new UnsupportedOperationException();
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResult.java
@@ -31,7 +31,7 @@ public interface GlobalIndexResult {
 
     /** Whether the bitmap is the exact predicate result instead of a pruning candidate set. */
     default boolean isExact() {
-        return true;
+        return false;
     }
 
     default GlobalIndexResult withExact(boolean exact) {
@@ -65,11 +65,16 @@ public interface GlobalIndexResult {
 
     /** Returns an empty {@link GlobalIndexResult}. */
     static GlobalIndexResult createEmpty() {
-        return create(new RoaringNavigableMap64());
+        return createExact(new RoaringNavigableMap64());
     }
 
-    /** Returns a new {@link GlobalIndexResult} from bitmap. */
+    /** Returns a new inexact pruning candidate result from bitmap. */
     static GlobalIndexResult create(RoaringNavigableMap64 bitmap) {
+        return create(bitmap, false);
+    }
+
+    /** Returns a new exact predicate result from bitmap. */
+    static GlobalIndexResult createExact(RoaringNavigableMap64 bitmap) {
         return create(bitmap, true);
     }
 
@@ -92,7 +97,7 @@ public interface GlobalIndexResult {
     static GlobalIndexResult fromRange(Range range) {
         RoaringNavigableMap64 result64 = new RoaringNavigableMap64();
         result64.addRange(range);
-        return create(result64);
+        return createExact(result64);
     }
 
     static GlobalIndexResult fromRanges(List<Range> ranges) {
@@ -100,6 +105,6 @@ public interface GlobalIndexResult {
         for (Range range : ranges) {
             result64.addRange(range);
         }
-        return create(result64);
+        return createExact(result64);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResult.java
@@ -29,6 +29,15 @@ public interface GlobalIndexResult {
     /** Returns the bitmap representing row ids. */
     RoaringNavigableMap64 results();
 
+    /** Whether the bitmap is the exact predicate result instead of a pruning candidate set. */
+    default boolean isExact() {
+        return true;
+    }
+
+    default GlobalIndexResult withExact(boolean exact) {
+        return exact == isExact() ? this : create(results(), exact);
+    }
+
     default GlobalIndexResult offset(long startOffset) {
         if (startOffset == 0) {
             return this;
@@ -39,15 +48,19 @@ public interface GlobalIndexResult {
         for (long rowId : roaringNavigableMap64) {
             roaringNavigableMap64Offset.add(rowId + startOffset);
         }
-        return create(roaringNavigableMap64Offset);
+        return create(roaringNavigableMap64Offset, isExact());
     }
 
     default GlobalIndexResult and(GlobalIndexResult other) {
-        return create(RoaringNavigableMap64.and(this.results(), other.results()));
+        return create(
+                RoaringNavigableMap64.and(this.results(), other.results()),
+                this.isExact() && other.isExact());
     }
 
     default GlobalIndexResult or(GlobalIndexResult other) {
-        return create(RoaringNavigableMap64.or(this.results(), other.results()));
+        return create(
+                RoaringNavigableMap64.or(this.results(), other.results()),
+                this.isExact() && other.isExact());
     }
 
     /** Returns an empty {@link GlobalIndexResult}. */
@@ -57,7 +70,22 @@ public interface GlobalIndexResult {
 
     /** Returns a new {@link GlobalIndexResult} from bitmap. */
     static GlobalIndexResult create(RoaringNavigableMap64 bitmap) {
-        return () -> bitmap;
+        return create(bitmap, true);
+    }
+
+    /** Returns a new {@link GlobalIndexResult} from bitmap with exactness metadata. */
+    static GlobalIndexResult create(RoaringNavigableMap64 bitmap, boolean exact) {
+        return new GlobalIndexResult() {
+            @Override
+            public RoaringNavigableMap64 results() {
+                return bitmap;
+            }
+
+            @Override
+            public boolean isExact() {
+                return exact;
+            }
+        };
     }
 
     /** Returns a new {@link GlobalIndexResult} from {@link Range}. */

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResultSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexResultSerializer.java
@@ -35,7 +35,8 @@ import static org.apache.paimon.utils.Preconditions.checkArgument;
 /** GlobalIndexResultSerializer to serialize and deserialize GlobalIndexResult. */
 public class GlobalIndexResultSerializer implements Serializer<GlobalIndexResult> {
 
-    private static final int VERSION = 1;
+    private static final int LEGACY_VERSION = 1;
+    private static final int VERSION = 2;
 
     @Override
     public Serializer<GlobalIndexResult> duplicate() {
@@ -60,6 +61,7 @@ public class GlobalIndexResultSerializer implements Serializer<GlobalIndexResult
     public void serialize(GlobalIndexResult globalIndexResult, DataOutputView dataOutput)
             throws IOException {
         dataOutput.writeInt(VERSION);
+        dataOutput.writeBoolean(globalIndexResult.isExact());
 
         RoaringNavigableMap64 roaringNavigableMap64 = globalIndexResult.results();
         byte[] bytes = roaringNavigableMap64.serialize();
@@ -82,9 +84,10 @@ public class GlobalIndexResultSerializer implements Serializer<GlobalIndexResult
     @Override
     public GlobalIndexResult deserialize(DataInputView dataInput) throws IOException {
         int version = dataInput.readInt();
-        if (version != VERSION) {
+        if (version != LEGACY_VERSION && version != VERSION) {
             throw new IllegalStateException("Invalid version: " + version);
         }
+        boolean exact = version == VERSION && dataInput.readBoolean();
 
         int size = dataInput.readInt();
         byte[] bytes = new byte[size];
@@ -95,7 +98,7 @@ public class GlobalIndexResultSerializer implements Serializer<GlobalIndexResult
         int scoreSize = dataInput.readInt();
 
         if (scoreSize == 0) {
-            return GlobalIndexResult.create(roaringNavigableMap64);
+            return GlobalIndexResult.create(roaringNavigableMap64, exact);
         }
         checkArgument(
                 scoreSize == roaringNavigableMap64.getIntCardinality(),
@@ -115,7 +118,7 @@ public class GlobalIndexResultSerializer implements Serializer<GlobalIndexResult
             scoreMap.put(rowId, scores[i++]);
         }
 
-        return ScoredGlobalIndexResult.create(roaringNavigableMap64, scoreMap::get);
+        return ScoredGlobalIndexResult.create(roaringNavigableMap64, scoreMap::get, exact);
     }
 
     public byte[] serialize(GlobalIndexResult globalIndexResult) throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/OffsetGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/OffsetGlobalIndexReader.java
@@ -21,6 +21,7 @@ package org.apache.paimon.globalindex;
 import org.apache.paimon.predicate.BatchVectorSearch;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.FullTextSearch;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.VectorSearch;
 
 import java.io.IOException;
@@ -145,6 +146,13 @@ public class OffsetGlobalIndexReader implements GlobalIndexReader {
             FullTextSearch fullTextSearch) {
         return wrapped.visitFullTextSearch(fullTextSearch.offsetRange(this.offset, this.to))
                 .thenApply(opt -> opt.map(r -> r.offset(offset)));
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+            ScalarSearch scalarSearch) {
+        return wrapped.visitScalarSearch(scalarSearch.offsetRange(this.offset, this.to))
+                .thenApply(this::applyOffset);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/ScoredGlobalIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/ScoredGlobalIndexResult.java
@@ -119,7 +119,7 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
         return create(new RoaringNavigableMap64(), rowId -> 0, true);
     }
 
-    /** Returns a new {@link ScoredGlobalIndexResult} from bitmap. */
+    /** Returns a new exact ranked-search result from bitmap. */
     static ScoredGlobalIndexResult create(RoaringNavigableMap64 bitmap, ScoreGetter scoreGetter) {
         return create(bitmap, scoreGetter, true);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/ScoredGlobalIndexResult.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/ScoredGlobalIndexResult.java
@@ -28,6 +28,11 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
 
     ScoreGetter scoreGetter();
 
+    @Override
+    default ScoredGlobalIndexResult withExact(boolean exact) {
+        return exact == isExact() ? this : create(results(), scoreGetter(), exact);
+    }
+
     default GlobalIndexResult and(GlobalIndexResult other) {
         throw new UnsupportedOperationException("Please realize this by specified global index");
     }
@@ -44,7 +49,10 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
             roaringNavigableMap64Offset.add(rowId + offset);
         }
 
-        return create(roaringNavigableMap64Offset, rowId -> thisScoreGetter.score(rowId - offset));
+        return create(
+                roaringNavigableMap64Offset,
+                rowId -> thisScoreGetter.score(rowId - offset),
+                isExact());
     }
 
     @Override
@@ -59,23 +67,15 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
         RoaringNavigableMap64 otherRowIds = other.results();
         ScoreGetter otherScoreGetter = ((ScoredGlobalIndexResult) other).scoreGetter();
 
-        final RoaringNavigableMap64 resultOr = RoaringNavigableMap64.or(thisRowIds, otherRowIds);
-        return new ScoredGlobalIndexResult() {
-            @Override
-            public ScoreGetter scoreGetter() {
-                return rowId -> {
+        return create(
+                RoaringNavigableMap64.or(thisRowIds, otherRowIds),
+                rowId -> {
                     if (thisRowIds.contains(rowId)) {
                         return thisScoreGetter.score(rowId);
                     }
                     return otherScoreGetter.score(rowId);
-                };
-            }
-
-            @Override
-            public RoaringNavigableMap64 results() {
-                return resultOr;
-            }
-        };
+                },
+                isExact() && other.isExact());
     }
 
     default ScoredGlobalIndexResult topK(int k) {
@@ -111,16 +111,22 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
             topKRowIds.add(entry[0]);
         }
 
-        return ScoredGlobalIndexResult.create(topKRowIds, scoreGetter);
+        return ScoredGlobalIndexResult.create(topKRowIds, scoreGetter, isExact());
     }
 
     /** Returns an empty {@link ScoredGlobalIndexResult}. */
     static ScoredGlobalIndexResult createEmpty() {
-        return create(new RoaringNavigableMap64(), rowId -> 0);
+        return create(new RoaringNavigableMap64(), rowId -> 0, true);
     }
 
     /** Returns a new {@link ScoredGlobalIndexResult} from bitmap. */
     static ScoredGlobalIndexResult create(RoaringNavigableMap64 bitmap, ScoreGetter scoreGetter) {
+        return create(bitmap, scoreGetter, true);
+    }
+
+    /** Returns a new {@link ScoredGlobalIndexResult} with exactness metadata. */
+    static ScoredGlobalIndexResult create(
+            RoaringNavigableMap64 bitmap, ScoreGetter scoreGetter, boolean exact) {
         return new ScoredGlobalIndexResult() {
             @Override
             public ScoreGetter scoreGetter() {
@@ -130,6 +136,11 @@ public interface ScoredGlobalIndexResult extends GlobalIndexResult {
             @Override
             public RoaringNavigableMap64 results() {
                 return bitmap;
+            }
+
+            @Override
+            public boolean isExact() {
+                return exact;
             }
         };
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
@@ -294,9 +294,21 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         return Optional.of(GlobalIndexResult.create(bitmap));
     }
 
-    protected CompletableFuture<Optional<GlobalIndexResult>> visitAllFiles(
-            Function<R, Optional<GlobalIndexResult>> visitor) {
-        return visitSelectedFiles(Optional.of(fileSelector.allFiles()), visitor);
+    protected CompletableFuture<Optional<GlobalIndexResult>> visitAllReaders(
+            Function<List<R>, Optional<GlobalIndexResult>> visitor) {
+        List<GlobalIndexIOMeta> files = fileSelector.allFiles();
+        if (files.isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.createEmpty()));
+        }
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    List<R> readers = new ArrayList<>(files.size());
+                    for (GlobalIndexIOMeta file : files) {
+                        readers.add(getOrCreateReader(file));
+                    }
+                    return visitor.apply(readers);
+                },
+                executor);
     }
 
     protected abstract R openReader(GlobalIndexIOMeta meta);
@@ -396,20 +408,25 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
                 .thenApply(v -> unionResults(futures));
     }
 
-    private R getOrCreateReader(GlobalIndexIOMeta meta) {
+    protected R getOrCreateReader(GlobalIndexIOMeta meta) {
         return readerCache.computeIfAbsent(meta.filePath(), ignored -> openReader(meta));
     }
 
     private Optional<GlobalIndexResult> unionResults(
             List<CompletableFuture<Optional<GlobalIndexResult>>> futures) {
         Optional<GlobalIndexResult> result = Optional.empty();
+        boolean exact = true;
         for (CompletableFuture<Optional<GlobalIndexResult>> future : futures) {
             Optional<GlobalIndexResult> current = future.join();
             if (!current.isPresent()) {
+                exact = false;
                 continue;
             }
             result = result.isPresent() ? Optional.of(result.get().or(current.get())) : current;
         }
-        return result;
+        if (!result.isPresent()) {
+            return result;
+        }
+        return Optional.of(result.get().withExact(exact && result.get().isExact()));
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
@@ -294,6 +294,11 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         return Optional.of(GlobalIndexResult.create(bitmap));
     }
 
+    protected CompletableFuture<Optional<GlobalIndexResult>> visitAllFiles(
+            Function<R, Optional<GlobalIndexResult>> visitor) {
+        return visitSelectedFiles(Optional.of(fileSelector.allFiles()), visitor);
+    }
+
     protected abstract R openReader(GlobalIndexIOMeta meta);
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
@@ -295,10 +295,15 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
     }
 
     protected CompletableFuture<Optional<GlobalIndexResult>> visitAllReaders(
+            int maxIndexFiles,
+            long maxIndexBytes,
             Function<List<R>, Optional<GlobalIndexResult>> visitor) {
         List<GlobalIndexIOMeta> files = fileSelector.allFiles();
         if (files.isEmpty()) {
             return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.createEmpty()));
+        }
+        if (files.size() > maxIndexFiles || !withinSizeLimit(files, maxIndexBytes)) {
+            return CompletableFuture.completedFuture(Optional.empty());
         }
         return CompletableFuture.supplyAsync(
                 () -> {
@@ -342,7 +347,7 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         return fallbackScanMaxSize > 0 && literal != null;
     }
 
-    private static boolean fallbackScanEnabled(List<GlobalIndexIOMeta> files, long maxSize) {
+    private static boolean withinSizeLimit(List<GlobalIndexIOMeta> files, long maxSize) {
         if (maxSize <= 0) {
             return false;
         }
@@ -380,7 +385,7 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         if (selected.isEmpty()) {
             return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.createEmpty()));
         }
-        if (!fallbackScanEnabled(selected, fallbackScanMaxSize)) {
+        if (!withinSizeLimit(selected, fallbackScanMaxSize)) {
             return unsupported();
         }
         return visitSelectedFiles(selectedOpt, visitor);

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
@@ -279,7 +279,7 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
     protected Optional<GlobalIndexResult> visitNotBetween(R reader, Object from, Object to) {
         RoaringNavigableMap64 result = lessThan(reader, from);
         result.or(greaterThan(reader, to));
-        return Optional.of(GlobalIndexResult.create(result));
+        return Optional.of(GlobalIndexResult.createExact(result));
     }
 
     protected RoaringNavigableMap64 like(R reader, Function<Object, Boolean> keyPredicate) {
@@ -291,7 +291,7 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
     protected abstract RoaringNavigableMap64 greaterThan(R reader, Object literal);
 
     protected Optional<GlobalIndexResult> createResult(RoaringNavigableMap64 bitmap) {
-        return Optional.of(GlobalIndexResult.create(bitmap));
+        return Optional.of(GlobalIndexResult.createExact(bitmap));
     }
 
     protected CompletableFuture<Optional<GlobalIndexResult>> visitAllReaders(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileMetaSelector.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileMetaSelector.java
@@ -276,6 +276,10 @@ public class SortedFileMetaSelector implements FunctionVisitor<Optional<List<Glo
                 .collect(Collectors.toList());
     }
 
+    public List<GlobalIndexIOMeta> allFiles() {
+        return files.stream().map(Pair::getLeft).collect(Collectors.toList());
+    }
+
     public static byte[] prefixUpperBound(byte[] prefix) {
         for (int i = prefix.length - 1; i >= 0; i--) {
             int unsignedByte = prefix[i] & 0xFF;

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.globalindex;
 
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.VectorSearch;
 import org.apache.paimon.utils.IOUtils;
 
@@ -154,6 +155,12 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                             }
                             return result;
                         });
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+            ScalarSearch scalarSearch) {
+        return unionAsync(reader -> reader.visitScalarSearch(scalarSearch));
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -166,8 +166,16 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
         if (readers.isEmpty()) {
             return CompletableFuture.completedFuture(Optional.empty());
         }
+        int concurrency = Math.min(readers.size(), scalarSearch.maxConcurrentReaders());
+        if (concurrency == 0) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
         long childMaxResultSize = scalarSearch.maxResultSize() / readers.size();
         long childMaxScannedRowIds = scalarSearch.maxScannedRowIds() / readers.size();
+        int childMaxIndexFiles = scalarSearch.maxIndexFiles() / readers.size();
+        long childMaxIndexBytes = scalarSearch.maxIndexBytes() / readers.size();
+        int childMaxConcurrentReaders =
+                Math.max(1, scalarSearch.maxConcurrentReaders() / concurrency);
         if (childMaxResultSize < scalarSearch.topN().limit()
                 || childMaxScannedRowIds < scalarSearch.topN().limit()) {
             return CompletableFuture.completedFuture(Optional.empty());
@@ -175,11 +183,32 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
         ScalarSearch childSearch =
                 scalarSearch
                         .withMaxResultSize(childMaxResultSize)
-                        .withMaxScannedRowIds(childMaxScannedRowIds);
-        ScalarUnionAccumulator accumulator = new ScalarUnionAccumulator();
+                        .withMaxScannedRowIds(childMaxScannedRowIds)
+                        .withMaxIndexFiles(childMaxIndexFiles)
+                        .withMaxIndexBytes(childMaxIndexBytes)
+                        .withMaxConcurrentReaders(childMaxConcurrentReaders);
+        List<CompletableFuture<ScalarUnionAccumulator>> futures = new ArrayList<>(concurrency);
+        for (int lane = 0; lane < concurrency; lane++) {
+            futures.add(
+                    visitScalarLane(childSearch, scalarSearch.maxResultSize(), lane, concurrency));
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(
+                        ignored -> {
+                            ScalarUnionAccumulator accumulator = new ScalarUnionAccumulator();
+                            for (CompletableFuture<ScalarUnionAccumulator> future : futures) {
+                                accumulator.merge(future.join(), scalarSearch.maxResultSize());
+                            }
+                            return accumulator.result();
+                        });
+    }
+
+    private CompletableFuture<ScalarUnionAccumulator> visitScalarLane(
+            ScalarSearch childSearch, long maxResultSize, int start, int stride) {
         CompletableFuture<ScalarUnionAccumulator> future =
-                CompletableFuture.completedFuture(accumulator);
-        for (GlobalIndexReader reader : readers) {
+                CompletableFuture.completedFuture(new ScalarUnionAccumulator());
+        for (int i = start; i < readers.size(); i += stride) {
+            GlobalIndexReader reader = readers.get(i);
             future =
                     future.thenCompose(
                             current -> {
@@ -190,9 +219,7 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                                     return reader.visitScalarSearch(childSearch)
                                             .thenApply(
                                                     child -> {
-                                                        current.add(
-                                                                child,
-                                                                scalarSearch.maxResultSize());
+                                                        current.add(child, maxResultSize);
                                                         return current;
                                                     });
                                 } catch (UnsupportedOperationException ignored) {
@@ -201,7 +228,7 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                                 }
                             });
         }
-        return future.thenApply(ScalarUnionAccumulator::result);
+        return future;
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(
@@ -238,7 +265,6 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
 
     private static class ScalarUnionAccumulator {
         private final RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
-        private boolean exact = true;
         private boolean hasResult;
         private boolean failed;
         private long resultSize;
@@ -259,15 +285,31 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                 return;
             }
             rowIds.or(result.get().results());
-            exact &= result.get().isExact();
             hasResult = true;
+        }
+
+        private void merge(ScalarUnionAccumulator other, long maxResultSize) {
+            if (failed) {
+                return;
+            }
+            if (other.failed || Long.MAX_VALUE - resultSize < other.resultSize) {
+                failed = true;
+                return;
+            }
+            resultSize += other.resultSize;
+            if (resultSize > maxResultSize) {
+                failed = true;
+                return;
+            }
+            rowIds.or(other.rowIds);
+            hasResult |= other.hasResult;
         }
 
         private Optional<GlobalIndexResult> result() {
             if (failed || !hasResult) {
                 return Optional.empty();
             }
-            return Optional.of(GlobalIndexResult.create(rowIds, exact));
+            return Optional.of(GlobalIndexResult.create(rowIds));
         }
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -162,8 +162,21 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
             ScalarSearch scalarSearch) {
         // Scalar results from child readers cover different row ranges. Returning a partial union
         // could drop the actual TopN rows, so every child must support and complete the search.
+        if (readers.isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        long childMaxResultSize = scalarSearch.maxResultSize() / readers.size();
+        long childMaxScannedRowIds = scalarSearch.maxScannedRowIds() / readers.size();
+        if (childMaxResultSize < scalarSearch.topN().limit()
+                || childMaxScannedRowIds < scalarSearch.topN().limit()) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+        ScalarSearch childSearch =
+                scalarSearch
+                        .withMaxResultSize(childMaxResultSize)
+                        .withMaxScannedRowIds(childMaxScannedRowIds);
         return unionAsync(
-                reader -> reader.visitScalarSearch(scalarSearch),
+                reader -> reader.visitScalarSearch(childSearch),
                 true,
                 scalarSearch.maxResultSize());
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -160,24 +160,57 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
     @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
             ScalarSearch scalarSearch) {
-        return unionAsync(reader -> reader.visitScalarSearch(scalarSearch));
+        // Scalar results from child readers cover different row ranges. Returning a partial union
+        // could drop the actual TopN rows, so every child must support and complete the search.
+        return unionAsync(
+                reader -> reader.visitScalarSearch(scalarSearch),
+                true,
+                scalarSearch.maxResultSize());
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(
             Function<GlobalIndexReader, CompletableFuture<Optional<GlobalIndexResult>>> visitor) {
+        return unionAsync(visitor, false, Long.MAX_VALUE);
+    }
+
+    private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(
+            Function<GlobalIndexReader, CompletableFuture<Optional<GlobalIndexResult>>> visitor,
+            boolean requireAllReaders,
+            long maxResultSize) {
         List<CompletableFuture<Optional<GlobalIndexResult>>> futures =
                 new ArrayList<>(readers.size());
         for (GlobalIndexReader reader : readers) {
-            futures.add(visitor.apply(reader));
+            try {
+                futures.add(visitor.apply(reader));
+            } catch (UnsupportedOperationException e) {
+                if (requireAllReaders) {
+                    return CompletableFuture.completedFuture(Optional.empty());
+                }
+                throw e;
+            }
         }
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                 .thenApply(
                         v -> {
                             Optional<GlobalIndexResult> result = Optional.empty();
+                            boolean exact = true;
+                            long resultSize = 0;
                             for (CompletableFuture<Optional<GlobalIndexResult>> f : futures) {
                                 Optional<GlobalIndexResult> current = f.join();
                                 if (!current.isPresent()) {
+                                    if (requireAllReaders) {
+                                        return Optional.empty();
+                                    }
+                                    exact = false;
                                     continue;
+                                }
+                                long currentSize = current.get().results().getLongCardinality();
+                                if (Long.MAX_VALUE - resultSize < currentSize) {
+                                    return Optional.empty();
+                                }
+                                resultSize += currentSize;
+                                if (resultSize > maxResultSize) {
+                                    return Optional.empty();
                                 }
                                 if (!result.isPresent()) {
                                     result = current;
@@ -185,7 +218,11 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                                     result = Optional.of(result.get().or(current.get()));
                                 }
                             }
-                            return result;
+                            if (!result.isPresent()) {
+                                return result;
+                            }
+                            return Optional.of(
+                                    result.get().withExact(exact && result.get().isExact()));
                         });
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -22,6 +22,7 @@ import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.VectorSearch;
 import org.apache.paimon.utils.IOUtils;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -175,55 +176,51 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                 scalarSearch
                         .withMaxResultSize(childMaxResultSize)
                         .withMaxScannedRowIds(childMaxScannedRowIds);
-        return unionAsync(
-                reader -> reader.visitScalarSearch(childSearch),
-                true,
-                scalarSearch.maxResultSize());
+        ScalarUnionAccumulator accumulator = new ScalarUnionAccumulator();
+        CompletableFuture<ScalarUnionAccumulator> future =
+                CompletableFuture.completedFuture(accumulator);
+        for (GlobalIndexReader reader : readers) {
+            future =
+                    future.thenCompose(
+                            current -> {
+                                if (current.failed) {
+                                    return CompletableFuture.completedFuture(current);
+                                }
+                                try {
+                                    return reader.visitScalarSearch(childSearch)
+                                            .thenApply(
+                                                    child -> {
+                                                        current.add(
+                                                                child,
+                                                                scalarSearch.maxResultSize());
+                                                        return current;
+                                                    });
+                                } catch (UnsupportedOperationException ignored) {
+                                    current.failed = true;
+                                    return CompletableFuture.completedFuture(current);
+                                }
+                            });
+        }
+        return future.thenApply(ScalarUnionAccumulator::result);
     }
 
     private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(
             Function<GlobalIndexReader, CompletableFuture<Optional<GlobalIndexResult>>> visitor) {
-        return unionAsync(visitor, false, Long.MAX_VALUE);
-    }
-
-    private CompletableFuture<Optional<GlobalIndexResult>> unionAsync(
-            Function<GlobalIndexReader, CompletableFuture<Optional<GlobalIndexResult>>> visitor,
-            boolean requireAllReaders,
-            long maxResultSize) {
         List<CompletableFuture<Optional<GlobalIndexResult>>> futures =
                 new ArrayList<>(readers.size());
         for (GlobalIndexReader reader : readers) {
-            try {
-                futures.add(visitor.apply(reader));
-            } catch (UnsupportedOperationException e) {
-                if (requireAllReaders) {
-                    return CompletableFuture.completedFuture(Optional.empty());
-                }
-                throw e;
-            }
+            futures.add(visitor.apply(reader));
         }
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
                 .thenApply(
                         v -> {
                             Optional<GlobalIndexResult> result = Optional.empty();
                             boolean exact = true;
-                            long resultSize = 0;
                             for (CompletableFuture<Optional<GlobalIndexResult>> f : futures) {
                                 Optional<GlobalIndexResult> current = f.join();
                                 if (!current.isPresent()) {
-                                    if (requireAllReaders) {
-                                        return Optional.empty();
-                                    }
                                     exact = false;
                                     continue;
-                                }
-                                long currentSize = current.get().results().getLongCardinality();
-                                if (Long.MAX_VALUE - resultSize < currentSize) {
-                                    return Optional.empty();
-                                }
-                                resultSize += currentSize;
-                                if (resultSize > maxResultSize) {
-                                    return Optional.empty();
                                 }
                                 if (!result.isPresent()) {
                                     result = current;
@@ -237,6 +234,41 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
                             return Optional.of(
                                     result.get().withExact(exact && result.get().isExact()));
                         });
+    }
+
+    private static class ScalarUnionAccumulator {
+        private final RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
+        private boolean exact = true;
+        private boolean hasResult;
+        private boolean failed;
+        private long resultSize;
+
+        private void add(Optional<GlobalIndexResult> result, long maxResultSize) {
+            if (!result.isPresent()) {
+                failed = true;
+                return;
+            }
+            long currentSize = result.get().results().getLongCardinality();
+            if (Long.MAX_VALUE - resultSize < currentSize) {
+                failed = true;
+                return;
+            }
+            resultSize += currentSize;
+            if (resultSize > maxResultSize) {
+                failed = true;
+                return;
+            }
+            rowIds.or(result.get().results());
+            exact &= result.get().isExact();
+            hasResult = true;
+        }
+
+        private Optional<GlobalIndexResult> result() {
+            if (failed || !hasResult) {
+                return Optional.empty();
+            }
+            return Optional.of(GlobalIndexResult.create(rowIds, exact));
+        }
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/bitmap/BitmapIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/bitmap/BitmapIndexReader.java
@@ -172,7 +172,7 @@ class BitmapIndexReader implements BitmapGlobalIndexFormat.SeekableReader, Close
     }
 
     private static Optional<GlobalIndexResult> createResult(RoaringNavigableMap64 bitmap) {
-        return Optional.of(GlobalIndexResult.create(bitmap));
+        return Optional.of(GlobalIndexResult.createExact(bitmap));
     }
 
     private RoaringNavigableMap64 isNull() {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -70,20 +70,64 @@ public class BTreeIndexReader implements Closeable {
     /** A key and its local row ids stored in one btree entry. */
     public static class KeyRowIds {
         private final Object key;
-        private final long[] rowIds;
+        private final MemorySlice serializedRowIds;
+        private final int rowIdCount;
 
-        public KeyRowIds(Object key, long[] rowIds) {
+        private KeyRowIds(Object key, MemorySlice serializedRowIds) {
             this.key = key;
-            this.rowIds = rowIds;
+            this.serializedRowIds = serializedRowIds;
+            this.rowIdCount = readRowIdCount(serializedRowIds.toInput());
         }
 
         public Object key() {
             return key;
         }
 
+        public int rowIdCount() {
+            return rowIdCount;
+        }
+
+        public RowIdIterator rowIdIterator() {
+            return new RowIdIterator(serializedRowIds);
+        }
+
         public long[] rowIds() {
+            long[] rowIds = new long[rowIdCount];
+            RowIdIterator iterator = rowIdIterator();
+            for (int i = 0; i < rowIds.length; i++) {
+                rowIds[i] = iterator.nextLong();
+            }
             return rowIds;
         }
+    }
+
+    /** Streaming iterator over the encoded row ids of one key. */
+    public static class RowIdIterator {
+        private final MemorySliceInput input;
+        private int remaining;
+
+        private RowIdIterator(MemorySlice serializedRowIds) {
+            this.input = serializedRowIds.toInput();
+            this.remaining = readRowIdCount(input);
+        }
+
+        public boolean hasNext() {
+            return remaining > 0;
+        }
+
+        public long nextLong() {
+            if (!hasNext()) {
+                throw new NoSuchElementException("No more row ids in btree entry.");
+            }
+            remaining--;
+            return input.readVarLenLong();
+        }
+    }
+
+    private static int readRowIdCount(MemorySliceInput input) {
+        int count = input.readVarLenInt();
+        Preconditions.checkState(count > 0, "Invalid row id length: 0");
+        return count;
     }
 
     /**
@@ -111,7 +155,7 @@ public class BTreeIndexReader implements Closeable {
                 if (dataIter != null && dataIter.hasNext()) {
                     Map.Entry<MemorySlice, MemorySlice> entry = dataIter.next();
                     Object key = keySerializer.deserialize(entry.getKey());
-                    next = new KeyRowIds(key, deserializeRowIds(entry.getValue()));
+                    next = new KeyRowIds(key, entry.getValue());
                     return true;
                 }
 
@@ -156,8 +200,7 @@ public class BTreeIndexReader implements Closeable {
                 throw new NoSuchElementException("No more entries in btree index file.");
             }
             Map.Entry<MemorySlice, MemorySlice> entry = dataIter.previous();
-            return new KeyRowIds(
-                    keySerializer.deserialize(entry.getKey()), deserializeRowIds(entry.getValue()));
+            return new KeyRowIds(keySerializer.deserialize(entry.getKey()), entry.getValue());
         }
     }
 
@@ -381,7 +424,7 @@ public class BTreeIndexReader implements Closeable {
     public Optional<GlobalIndexResult> visitScalarSearch(ScalarSearch scalarSearch) {
         try {
             return Optional.of(GlobalIndexResult.create(scalarSearch(scalarSearch)));
-        } catch (ScalarSearchResultTooLargeException ignored) {
+        } catch (ScalarSearchBudgetExceededException ignored) {
             return Optional.empty();
         } catch (IOException e) {
             throw new RuntimeException("fail to read btree index file.", e);
@@ -389,12 +432,13 @@ public class BTreeIndexReader implements Closeable {
     }
 
     private RoaringNavigableMap64 scalarSearch(ScalarSearch scalarSearch)
-            throws IOException, ScalarSearchResultTooLargeException {
+            throws IOException, ScalarSearchBudgetExceededException {
         SortValue order = scalarSearch.topN().orders().get(0);
         int limit = scalarSearch.topN().limit();
         RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
         ScalarSearchResultAccumulator result =
-                new ScalarSearchResultAccumulator(scalarSearch.maxResultSize());
+                new ScalarSearchResultAccumulator(
+                        scalarSearch.maxResultSize(), scalarSearch.maxScannedRowIds());
         if (limit == 0) {
             return result.rowIds();
         }
@@ -420,7 +464,7 @@ public class BTreeIndexReader implements Closeable {
             SortValue.SortDirection direction,
             long targetCardinality,
             @Nullable RoaringNavigableMap64 includeRowIds)
-            throws IOException, ScalarSearchResultTooLargeException {
+            throws IOException, ScalarSearchBudgetExceededException {
         if (targetCardinality <= 0 || minKey == null) {
             return;
         }
@@ -428,7 +472,7 @@ public class BTreeIndexReader implements Closeable {
         if (direction == SortValue.SortDirection.ASCENDING) {
             EntryIterator iterator = entryIterator();
             while (iterator.hasNext()) {
-                if (!addMatchingRows(result, iterator.next().rowIds(), includeRowIds)) {
+                if (!addMatchingRows(result, iterator.next(), includeRowIds)) {
                     continue;
                 }
                 if (result.cardinality() >= targetCardinality) {
@@ -440,7 +484,7 @@ public class BTreeIndexReader implements Closeable {
 
         ReverseEntryIterator iterator = reverseEntryIterator();
         while (iterator.hasNext()) {
-            if (!addMatchingRows(result, iterator.next().rowIds(), includeRowIds)) {
+            if (!addMatchingRows(result, iterator.next(), includeRowIds)) {
                 continue;
             }
             if (result.cardinality() >= targetCardinality) {
@@ -451,11 +495,15 @@ public class BTreeIndexReader implements Closeable {
 
     private void addMatchingNullRows(
             ScalarSearchResultAccumulator result, @Nullable RoaringNavigableMap64 includeRowIds)
-            throws ScalarSearchResultTooLargeException {
-        for (long rowId : nullBitmap.get()) {
+            throws ScalarSearchBudgetExceededException {
+        RoaringNavigableMap64 nullRowIds = nullBitmap.get();
+        if (!result.reserveScannedRowIds(nullRowIds.getLongCardinality())) {
+            throw new ScalarSearchBudgetExceededException();
+        }
+        for (long rowId : nullRowIds) {
             if (includeRowIds == null || includeRowIds.contains(rowId)) {
                 if (!result.add(rowId)) {
-                    throw new ScalarSearchResultTooLargeException();
+                    throw new ScalarSearchBudgetExceededException();
                 }
             }
         }
@@ -463,15 +511,20 @@ public class BTreeIndexReader implements Closeable {
 
     private boolean addMatchingRows(
             ScalarSearchResultAccumulator result,
-            long[] rowIds,
+            KeyRowIds keyRowIds,
             @Nullable RoaringNavigableMap64 includeRowIds)
-            throws ScalarSearchResultTooLargeException {
+            throws ScalarSearchBudgetExceededException {
+        if (!result.reserveScannedRowIds(keyRowIds.rowIdCount())) {
+            throw new ScalarSearchBudgetExceededException();
+        }
         boolean matched = false;
-        for (long rowId : rowIds) {
+        RowIdIterator iterator = keyRowIds.rowIdIterator();
+        while (iterator.hasNext()) {
+            long rowId = iterator.nextLong();
             if (includeRowIds == null || includeRowIds.contains(rowId)) {
                 matched = true;
                 if (!result.add(rowId)) {
-                    throw new ScalarSearchResultTooLargeException();
+                    throw new ScalarSearchBudgetExceededException();
                 }
             }
         }
@@ -481,11 +534,14 @@ public class BTreeIndexReader implements Closeable {
     static class ScalarSearchResultAccumulator {
         private final RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
         private final long maxResultSize;
+        private final long maxScannedRowIds;
         private long cardinality;
-        private boolean exceededMaxResultSize;
+        private long scannedRowIds;
+        private boolean exceededBudget;
 
-        ScalarSearchResultAccumulator(long maxResultSize) {
+        ScalarSearchResultAccumulator(long maxResultSize, long maxScannedRowIds) {
             this.maxResultSize = maxResultSize;
+            this.maxScannedRowIds = maxScannedRowIds;
         }
 
         boolean add(long rowId) {
@@ -493,7 +549,7 @@ public class BTreeIndexReader implements Closeable {
                 return true;
             }
             if (cardinality >= maxResultSize) {
-                exceededMaxResultSize = true;
+                exceededBudget = true;
                 return false;
             }
             rowIds.add(rowId);
@@ -501,12 +557,21 @@ public class BTreeIndexReader implements Closeable {
             return true;
         }
 
+        boolean reserveScannedRowIds(long count) {
+            if (count > maxScannedRowIds - scannedRowIds) {
+                exceededBudget = true;
+                return false;
+            }
+            scannedRowIds += count;
+            return true;
+        }
+
         long cardinality() {
             return cardinality;
         }
 
-        boolean exceededMaxResultSize() {
-            return exceededMaxResultSize;
+        boolean exceededBudget() {
+            return exceededBudget;
         }
 
         RoaringNavigableMap64 rowIds() {
@@ -532,7 +597,7 @@ public class BTreeIndexReader implements Closeable {
         T get() throws IOException;
     }
 
-    private static class ScalarSearchResultTooLargeException extends Exception {
+    private static class ScalarSearchBudgetExceededException extends Exception {
         private static final long serialVersionUID = 1L;
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -317,10 +317,6 @@ public class BTreeIndexReader implements Closeable {
         return new EntryIterator(maxReadBlockSize);
     }
 
-    public ReverseEntryIterator reverseEntryIterator() {
-        return reverseEntryIterator(Long.MAX_VALUE);
-    }
-
     ReverseEntryIterator reverseEntryIterator(long maxReadBlockSize) {
         return new ReverseEntryIterator(maxReadBlockSize);
     }
@@ -330,10 +326,6 @@ public class BTreeIndexReader implements Closeable {
         for (long rowId : nullBitmap.get()) {
             consumer.accept(rowId);
         }
-    }
-
-    RoaringNavigableMap64 nullRowIds() {
-        return nullBitmap.get();
     }
 
     Optional<RoaringNavigableMap64> nullRowIds(long maxReadBlockSize) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -30,6 +30,8 @@ import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;
+import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.sst.BlockCache;
 import org.apache.paimon.sst.BlockHandle;
 import org.apache.paimon.sst.BlockIterator;
@@ -127,6 +129,35 @@ public class BTreeIndexReader implements Closeable {
             KeyRowIds current = next;
             next = null;
             return current;
+        }
+    }
+
+    /** Reverse iterator over all non-null key entries. */
+    public class ReverseEntryIterator {
+        private final SstFileReader.SstFileIterator fileIter;
+        private BlockIterator dataIter;
+
+        private ReverseEntryIterator() {
+            this.fileIter = reader.createReverseIterator();
+        }
+
+        public boolean hasNext() throws IOException {
+            while (dataIter == null || !dataIter.hasPrevious()) {
+                dataIter = fileIter.readBatchReverse();
+                if (dataIter == null) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public KeyRowIds next() throws IOException {
+            if (!hasNext()) {
+                throw new NoSuchElementException("No more entries in btree index file.");
+            }
+            Map.Entry<MemorySlice, MemorySlice> entry = dataIter.previous();
+            return new KeyRowIds(
+                    keySerializer.deserialize(entry.getKey()), deserializeRowIds(entry.getValue()));
         }
     }
 
@@ -235,6 +266,10 @@ public class BTreeIndexReader implements Closeable {
         return new EntryIterator();
     }
 
+    public ReverseEntryIterator reverseEntryIterator() {
+        return new ReverseEntryIterator();
+    }
+
     /** Visits all local row ids belonging to null keys. */
     public void scanNullRowIds(LongConsumer consumer) {
         for (long rowId : nullBitmap.get()) {
@@ -337,6 +372,94 @@ public class BTreeIndexReader implements Closeable {
 
     public Optional<GlobalIndexResult> visitBetween(Object from, Object to) {
         return createResult(() -> rangeQuery(from, to, true, true));
+    }
+
+    public Optional<GlobalIndexResult> visitScalarSearch(ScalarSearch scalarSearch) {
+        return createResult(() -> scalarSearch(scalarSearch));
+    }
+
+    private RoaringNavigableMap64 scalarSearch(ScalarSearch scalarSearch) throws IOException {
+        SortValue order = scalarSearch.topN().orders().get(0);
+        int limit = scalarSearch.topN().limit();
+        RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+
+        if (order.nullOrdering() == SortValue.NullOrdering.NULLS_FIRST) {
+            result.or(matchingNullRows(includeRowIds));
+            if (result.getLongCardinality() >= limit) {
+                return result;
+            }
+            result.or(
+                    matchingNonNullRows(
+                            order.direction(), limit - result.getLongCardinality(), includeRowIds));
+            return result;
+        }
+
+        result.or(matchingNonNullRows(order.direction(), limit, includeRowIds));
+        if (result.getLongCardinality() < limit) {
+            result.or(matchingNullRows(includeRowIds));
+        }
+        return result;
+    }
+
+    private RoaringNavigableMap64 matchingNonNullRows(
+            SortValue.SortDirection direction,
+            long limit,
+            @Nullable RoaringNavigableMap64 includeRowIds)
+            throws IOException {
+        if (limit <= 0 || minKey == null) {
+            return new RoaringNavigableMap64();
+        }
+
+        if (direction == SortValue.SortDirection.ASCENDING) {
+            RoaringNavigableMap64 result = new RoaringNavigableMap64();
+            EntryIterator iterator = entryIterator();
+            while (iterator.hasNext()) {
+                RoaringNavigableMap64 group = matchingRows(iterator.next().rowIds(), includeRowIds);
+                if (group.isEmpty()) {
+                    continue;
+                }
+                result.or(group);
+                if (result.getLongCardinality() >= limit) {
+                    break;
+                }
+            }
+            return result;
+        }
+
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        ReverseEntryIterator iterator = reverseEntryIterator();
+        while (iterator.hasNext()) {
+            RoaringNavigableMap64 group = matchingRows(iterator.next().rowIds(), includeRowIds);
+            if (group.isEmpty()) {
+                continue;
+            }
+            result.or(group);
+            if (result.getLongCardinality() >= limit) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    private RoaringNavigableMap64 matchingNullRows(@Nullable RoaringNavigableMap64 includeRowIds) {
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        result.or(nullBitmap.get());
+        if (includeRowIds != null) {
+            result.and(includeRowIds);
+        }
+        return result;
+    }
+
+    private RoaringNavigableMap64 matchingRows(
+            long[] rowIds, @Nullable RoaringNavigableMap64 includeRowIds) {
+        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        for (long rowId : rowIds) {
+            if (includeRowIds == null || includeRowIds.contains(rowId)) {
+                result.add(rowId);
+            }
+        }
+        return result;
     }
 
     private Optional<GlobalIndexResult> createResult(IOSupplier<RoaringNavigableMap64> supplier) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -277,6 +277,10 @@ public class BTreeIndexReader implements Closeable {
         }
     }
 
+    RoaringNavigableMap64 nullRowIds() {
+        return nullBitmap.get();
+    }
+
     public Optional<GlobalIndexResult> visitIsNotNull() {
         return createResult(this::allNonNullRows);
     }
@@ -306,15 +310,15 @@ public class BTreeIndexReader implements Closeable {
     }
 
     public Optional<GlobalIndexResult> visitEndsWith(Object literal) {
-        return createResult(this::allNonNullRows);
+        return createResult(this::allNonNullRows, false);
     }
 
     public Optional<GlobalIndexResult> visitContains(Object literal) {
-        return createResult(this::allNonNullRows);
+        return createResult(this::allNonNullRows, false);
     }
 
     public Optional<GlobalIndexResult> visitLike(Object literal) {
-        return createResult(this::allNonNullRows);
+        return createResult(this::allNonNullRows, false);
     }
 
     public Optional<GlobalIndexResult> visitLessThan(Object literal) {
@@ -375,96 +379,149 @@ public class BTreeIndexReader implements Closeable {
     }
 
     public Optional<GlobalIndexResult> visitScalarSearch(ScalarSearch scalarSearch) {
-        return createResult(() -> scalarSearch(scalarSearch));
+        try {
+            return Optional.of(GlobalIndexResult.create(scalarSearch(scalarSearch)));
+        } catch (ScalarSearchResultTooLargeException ignored) {
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new RuntimeException("fail to read btree index file.", e);
+        }
     }
 
-    private RoaringNavigableMap64 scalarSearch(ScalarSearch scalarSearch) throws IOException {
+    private RoaringNavigableMap64 scalarSearch(ScalarSearch scalarSearch)
+            throws IOException, ScalarSearchResultTooLargeException {
         SortValue order = scalarSearch.topN().orders().get(0);
         int limit = scalarSearch.topN().limit();
         RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
-        RoaringNavigableMap64 result = new RoaringNavigableMap64();
+        ScalarSearchResultAccumulator result =
+                new ScalarSearchResultAccumulator(scalarSearch.maxResultSize());
+        if (limit == 0) {
+            return result.rowIds();
+        }
 
         if (order.nullOrdering() == SortValue.NullOrdering.NULLS_FIRST) {
-            result.or(matchingNullRows(includeRowIds));
-            if (result.getLongCardinality() >= limit) {
-                return result;
+            addMatchingNullRows(result, includeRowIds);
+            if (result.cardinality() >= limit) {
+                return result.rowIds();
             }
-            result.or(
-                    matchingNonNullRows(
-                            order.direction(), limit - result.getLongCardinality(), includeRowIds));
-            return result;
+            addMatchingNonNullRows(result, order.direction(), limit, includeRowIds);
+            return result.rowIds();
         }
 
-        result.or(matchingNonNullRows(order.direction(), limit, includeRowIds));
-        if (result.getLongCardinality() < limit) {
-            result.or(matchingNullRows(includeRowIds));
+        addMatchingNonNullRows(result, order.direction(), limit, includeRowIds);
+        if (result.cardinality() < limit) {
+            addMatchingNullRows(result, includeRowIds);
         }
-        return result;
+        return result.rowIds();
     }
 
-    private RoaringNavigableMap64 matchingNonNullRows(
+    private void addMatchingNonNullRows(
+            ScalarSearchResultAccumulator result,
             SortValue.SortDirection direction,
-            long limit,
+            long targetCardinality,
             @Nullable RoaringNavigableMap64 includeRowIds)
-            throws IOException {
-        if (limit <= 0 || minKey == null) {
-            return new RoaringNavigableMap64();
+            throws IOException, ScalarSearchResultTooLargeException {
+        if (targetCardinality <= 0 || minKey == null) {
+            return;
         }
 
         if (direction == SortValue.SortDirection.ASCENDING) {
-            RoaringNavigableMap64 result = new RoaringNavigableMap64();
             EntryIterator iterator = entryIterator();
             while (iterator.hasNext()) {
-                RoaringNavigableMap64 group = matchingRows(iterator.next().rowIds(), includeRowIds);
-                if (group.isEmpty()) {
+                if (!addMatchingRows(result, iterator.next().rowIds(), includeRowIds)) {
                     continue;
                 }
-                result.or(group);
-                if (result.getLongCardinality() >= limit) {
+                if (result.cardinality() >= targetCardinality) {
                     break;
                 }
             }
-            return result;
+            return;
         }
 
-        RoaringNavigableMap64 result = new RoaringNavigableMap64();
         ReverseEntryIterator iterator = reverseEntryIterator();
         while (iterator.hasNext()) {
-            RoaringNavigableMap64 group = matchingRows(iterator.next().rowIds(), includeRowIds);
-            if (group.isEmpty()) {
+            if (!addMatchingRows(result, iterator.next().rowIds(), includeRowIds)) {
                 continue;
             }
-            result.or(group);
-            if (result.getLongCardinality() >= limit) {
+            if (result.cardinality() >= targetCardinality) {
                 break;
             }
         }
-        return result;
     }
 
-    private RoaringNavigableMap64 matchingNullRows(@Nullable RoaringNavigableMap64 includeRowIds) {
-        RoaringNavigableMap64 result = new RoaringNavigableMap64();
-        result.or(nullBitmap.get());
-        if (includeRowIds != null) {
-            result.and(includeRowIds);
-        }
-        return result;
-    }
-
-    private RoaringNavigableMap64 matchingRows(
-            long[] rowIds, @Nullable RoaringNavigableMap64 includeRowIds) {
-        RoaringNavigableMap64 result = new RoaringNavigableMap64();
-        for (long rowId : rowIds) {
+    private void addMatchingNullRows(
+            ScalarSearchResultAccumulator result, @Nullable RoaringNavigableMap64 includeRowIds)
+            throws ScalarSearchResultTooLargeException {
+        for (long rowId : nullBitmap.get()) {
             if (includeRowIds == null || includeRowIds.contains(rowId)) {
-                result.add(rowId);
+                if (!result.add(rowId)) {
+                    throw new ScalarSearchResultTooLargeException();
+                }
             }
         }
-        return result;
+    }
+
+    private boolean addMatchingRows(
+            ScalarSearchResultAccumulator result,
+            long[] rowIds,
+            @Nullable RoaringNavigableMap64 includeRowIds)
+            throws ScalarSearchResultTooLargeException {
+        boolean matched = false;
+        for (long rowId : rowIds) {
+            if (includeRowIds == null || includeRowIds.contains(rowId)) {
+                matched = true;
+                if (!result.add(rowId)) {
+                    throw new ScalarSearchResultTooLargeException();
+                }
+            }
+        }
+        return matched;
+    }
+
+    static class ScalarSearchResultAccumulator {
+        private final RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
+        private final long maxResultSize;
+        private long cardinality;
+        private boolean exceededMaxResultSize;
+
+        ScalarSearchResultAccumulator(long maxResultSize) {
+            this.maxResultSize = maxResultSize;
+        }
+
+        boolean add(long rowId) {
+            if (rowIds.contains(rowId)) {
+                return true;
+            }
+            if (cardinality >= maxResultSize) {
+                exceededMaxResultSize = true;
+                return false;
+            }
+            rowIds.add(rowId);
+            cardinality++;
+            return true;
+        }
+
+        long cardinality() {
+            return cardinality;
+        }
+
+        boolean exceededMaxResultSize() {
+            return exceededMaxResultSize;
+        }
+
+        RoaringNavigableMap64 rowIds() {
+            return rowIds;
+        }
     }
 
     private Optional<GlobalIndexResult> createResult(IOSupplier<RoaringNavigableMap64> supplier) {
+        return createResult(supplier, true);
+    }
+
+    private Optional<GlobalIndexResult> createResult(
+            IOSupplier<RoaringNavigableMap64> supplier, boolean exact) {
         try {
-            return Optional.of(GlobalIndexResult.create(supplier.get()));
+            return Optional.of(GlobalIndexResult.create(supplier.get(), exact));
         } catch (IOException e) {
             throw new RuntimeException("fail to read btree index file.", e);
         }
@@ -473,6 +530,10 @@ public class BTreeIndexReader implements Closeable {
     @FunctionalInterface
     private interface IOSupplier<T> {
         T get() throws IOException;
+    }
+
+    private static class ScalarSearchResultTooLargeException extends Exception {
+        private static final long serialVersionUID = 1L;
     }
 
     private RoaringNavigableMap64 allNonNullRows() throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -30,8 +30,6 @@ import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.memory.MemorySliceInput;
-import org.apache.paimon.predicate.ScalarSearch;
-import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.sst.BlockCache;
 import org.apache.paimon.sst.BlockHandle;
 import org.apache.paimon.sst.BlockIterator;
@@ -64,6 +62,7 @@ public class BTreeIndexReader implements Closeable {
     private final KeySerializer keySerializer;
     private final Comparator<Object> comparator;
     private final LazyField<RoaringNavigableMap64> nullBitmap;
+    @Nullable private final BlockHandle nullBitmapHandle;
     private final Object minKey;
     private final Object maxKey;
 
@@ -137,11 +136,13 @@ public class BTreeIndexReader implements Closeable {
      */
     public class EntryIterator {
         private final SstFileReader.SstFileIterator fileIter;
+        private final long maxReadBlockSize;
         private BlockIterator dataIter;
         private KeyRowIds next;
 
-        private EntryIterator() {
+        private EntryIterator(long maxReadBlockSize) {
             this.fileIter = reader.createIterator();
+            this.maxReadBlockSize = maxReadBlockSize;
             this.dataIter = null;
             this.next = null;
         }
@@ -159,7 +160,7 @@ public class BTreeIndexReader implements Closeable {
                     return true;
                 }
 
-                dataIter = fileIter.readBatch();
+                dataIter = fileIter.readBatch(maxReadBlockSize);
                 if (dataIter == null) {
                     return false;
                 }
@@ -179,15 +180,17 @@ public class BTreeIndexReader implements Closeable {
     /** Reverse iterator over all non-null key entries. */
     public class ReverseEntryIterator {
         private final SstFileReader.SstFileIterator fileIter;
+        private final long maxReadBlockSize;
         private BlockIterator dataIter;
 
-        private ReverseEntryIterator() {
+        private ReverseEntryIterator(long maxReadBlockSize) {
             this.fileIter = reader.createReverseIterator();
+            this.maxReadBlockSize = maxReadBlockSize;
         }
 
         public boolean hasNext() throws IOException {
             while (dataIter == null || !dataIter.hasPrevious()) {
-                dataIter = fileIter.readBatchReverse();
+                dataIter = fileIter.readBatchReverse(maxReadBlockSize);
                 if (dataIter == null) {
                     return false;
                 }
@@ -233,6 +236,7 @@ public class BTreeIndexReader implements Closeable {
         // prepare nullBitmap and SstFileReader
         this.nullBitmap =
                 new LazyField<>(() -> readNullBitmap(blockCache, footer.getNullBitmapHandle()));
+        this.nullBitmapHandle = footer.getNullBitmapHandle();
         FileBasedBloomFilter bloomFilter =
                 FileBasedBloomFilter.create(
                         input, filePath, cacheManager, footer.getBloomFilterHandle());
@@ -306,11 +310,19 @@ public class BTreeIndexReader implements Closeable {
 
     /** Returns a sequential iterator over all non-null key entries in this index file. */
     public EntryIterator entryIterator() {
-        return new EntryIterator();
+        return entryIterator(Long.MAX_VALUE);
+    }
+
+    EntryIterator entryIterator(long maxReadBlockSize) {
+        return new EntryIterator(maxReadBlockSize);
     }
 
     public ReverseEntryIterator reverseEntryIterator() {
-        return new ReverseEntryIterator();
+        return reverseEntryIterator(Long.MAX_VALUE);
+    }
+
+    ReverseEntryIterator reverseEntryIterator(long maxReadBlockSize) {
+        return new ReverseEntryIterator(maxReadBlockSize);
     }
 
     /** Visits all local row ids belonging to null keys. */
@@ -322,6 +334,13 @@ public class BTreeIndexReader implements Closeable {
 
     RoaringNavigableMap64 nullRowIds() {
         return nullBitmap.get();
+    }
+
+    Optional<RoaringNavigableMap64> nullRowIds(long maxReadBlockSize) {
+        if (nullBitmapHandle != null && nullBitmapHandle.size() + 4L > maxReadBlockSize) {
+            return Optional.empty();
+        }
+        return Optional.of(nullBitmap.get());
     }
 
     public Optional<GlobalIndexResult> visitIsNotNull() {
@@ -421,116 +440,6 @@ public class BTreeIndexReader implements Closeable {
         return createResult(() -> rangeQuery(from, to, true, true));
     }
 
-    public Optional<GlobalIndexResult> visitScalarSearch(ScalarSearch scalarSearch) {
-        try {
-            return Optional.of(GlobalIndexResult.create(scalarSearch(scalarSearch)));
-        } catch (ScalarSearchBudgetExceededException ignored) {
-            return Optional.empty();
-        } catch (IOException e) {
-            throw new RuntimeException("fail to read btree index file.", e);
-        }
-    }
-
-    private RoaringNavigableMap64 scalarSearch(ScalarSearch scalarSearch)
-            throws IOException, ScalarSearchBudgetExceededException {
-        SortValue order = scalarSearch.topN().orders().get(0);
-        int limit = scalarSearch.topN().limit();
-        RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
-        ScalarSearchResultAccumulator result =
-                new ScalarSearchResultAccumulator(
-                        scalarSearch.maxResultSize(), scalarSearch.maxScannedRowIds());
-        if (limit == 0) {
-            return result.rowIds();
-        }
-
-        if (order.nullOrdering() == SortValue.NullOrdering.NULLS_FIRST) {
-            addMatchingNullRows(result, includeRowIds);
-            if (result.cardinality() >= limit) {
-                return result.rowIds();
-            }
-            addMatchingNonNullRows(result, order.direction(), limit, includeRowIds);
-            return result.rowIds();
-        }
-
-        addMatchingNonNullRows(result, order.direction(), limit, includeRowIds);
-        if (result.cardinality() < limit) {
-            addMatchingNullRows(result, includeRowIds);
-        }
-        return result.rowIds();
-    }
-
-    private void addMatchingNonNullRows(
-            ScalarSearchResultAccumulator result,
-            SortValue.SortDirection direction,
-            long targetCardinality,
-            @Nullable RoaringNavigableMap64 includeRowIds)
-            throws IOException, ScalarSearchBudgetExceededException {
-        if (targetCardinality <= 0 || minKey == null) {
-            return;
-        }
-
-        if (direction == SortValue.SortDirection.ASCENDING) {
-            EntryIterator iterator = entryIterator();
-            while (iterator.hasNext()) {
-                if (!addMatchingRows(result, iterator.next(), includeRowIds)) {
-                    continue;
-                }
-                if (result.cardinality() >= targetCardinality) {
-                    break;
-                }
-            }
-            return;
-        }
-
-        ReverseEntryIterator iterator = reverseEntryIterator();
-        while (iterator.hasNext()) {
-            if (!addMatchingRows(result, iterator.next(), includeRowIds)) {
-                continue;
-            }
-            if (result.cardinality() >= targetCardinality) {
-                break;
-            }
-        }
-    }
-
-    private void addMatchingNullRows(
-            ScalarSearchResultAccumulator result, @Nullable RoaringNavigableMap64 includeRowIds)
-            throws ScalarSearchBudgetExceededException {
-        RoaringNavigableMap64 nullRowIds = nullBitmap.get();
-        if (!result.reserveScannedRowIds(nullRowIds.getLongCardinality())) {
-            throw new ScalarSearchBudgetExceededException();
-        }
-        for (long rowId : nullRowIds) {
-            if (includeRowIds == null || includeRowIds.contains(rowId)) {
-                if (!result.add(rowId)) {
-                    throw new ScalarSearchBudgetExceededException();
-                }
-            }
-        }
-    }
-
-    private boolean addMatchingRows(
-            ScalarSearchResultAccumulator result,
-            KeyRowIds keyRowIds,
-            @Nullable RoaringNavigableMap64 includeRowIds)
-            throws ScalarSearchBudgetExceededException {
-        if (!result.reserveScannedRowIds(keyRowIds.rowIdCount())) {
-            throw new ScalarSearchBudgetExceededException();
-        }
-        boolean matched = false;
-        RowIdIterator iterator = keyRowIds.rowIdIterator();
-        while (iterator.hasNext()) {
-            long rowId = iterator.nextLong();
-            if (includeRowIds == null || includeRowIds.contains(rowId)) {
-                matched = true;
-                if (!result.add(rowId)) {
-                    throw new ScalarSearchBudgetExceededException();
-                }
-            }
-        }
-        return matched;
-    }
-
     static class ScalarSearchResultAccumulator {
         private final RoaringNavigableMap64 rowIds = new RoaringNavigableMap64();
         private final long maxResultSize;
@@ -595,10 +504,6 @@ public class BTreeIndexReader implements Closeable {
     @FunctionalInterface
     private interface IOSupplier<T> {
         T get() throws IOException;
-    }
-
-    private static class ScalarSearchBudgetExceededException extends Exception {
-        private static final long serialVersionUID = 1L;
     }
 
     private RoaringNavigableMap64 allNonNullRows() throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -148,10 +148,16 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
     @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
             ScalarSearch scalarSearch) {
+        if (scalarSearch.topN().orders().size() != 1) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
         if (scalarSearch.includeRowIds() != null && scalarSearch.includeRowIds().isEmpty()) {
             return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.createEmpty()));
         }
-        return visitAllReaders(readers -> scalarSearch(readers, scalarSearch));
+        return visitAllReaders(
+                scalarSearch.maxIndexFiles(),
+                scalarSearch.maxIndexBytes(),
+                readers -> scalarSearch(readers, scalarSearch));
     }
 
     @Override
@@ -184,7 +190,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 new BTreeIndexReader.ScalarSearchResultAccumulator(
                         scalarSearch.maxResultSize(), scalarSearch.maxScannedRowIds());
         if (limit == 0) {
-            return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
+            return Optional.of(GlobalIndexResult.createEmpty());
         }
 
         SortValue order = scalarSearch.topN().orders().get(0);
@@ -193,7 +199,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 return Optional.empty();
             }
             if (result.cardinality() >= limit) {
-                return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
+                return Optional.of(GlobalIndexResult.create(result.rowIds()));
             }
         }
 
@@ -205,7 +211,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 && !addNullRows(readers, scalarSearch, result)) {
             return Optional.empty();
         }
-        return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
+        return Optional.of(GlobalIndexResult.create(result.rowIds()));
     }
 
     private boolean addNullRows(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -26,11 +26,15 @@ import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -41,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIndexReader> {
 
     private final KeySerializer keySerializer;
+    private final Comparator<Object> comparator;
     private final CacheManager cacheManager;
     private final GlobalIndexFileReader fileReader;
 
@@ -55,6 +60,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
         this.cacheManager = cacheManager;
         this.fileReader = fileReader;
         this.keySerializer = keySerializer;
+        this.comparator = keySerializer.createComparator();
     }
 
     @Override
@@ -139,9 +145,12 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
     }
 
     @Override
-    public java.util.concurrent.CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
             ScalarSearch scalarSearch) {
-        return visitAllFiles(reader -> reader.visitScalarSearch(scalarSearch));
+        if (scalarSearch.includeRowIds() != null && scalarSearch.includeRowIds().isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.createEmpty()));
+        }
+        return visitAllReaders(readers -> scalarSearch(readers, scalarSearch));
     }
 
     @Override
@@ -165,5 +174,151 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
 
     private RoaringNavigableMap64 bitmap(Optional<GlobalIndexResult> result) {
         return result.get().results();
+    }
+
+    private Optional<GlobalIndexResult> scalarSearch(
+            List<BTreeIndexReader> readers, ScalarSearch scalarSearch) {
+        int limit = scalarSearch.topN().limit();
+        BTreeIndexReader.ScalarSearchResultAccumulator result =
+                new BTreeIndexReader.ScalarSearchResultAccumulator(scalarSearch.maxResultSize());
+        if (limit == 0) {
+            return Optional.of(GlobalIndexResult.create(result.rowIds()));
+        }
+
+        SortValue order = scalarSearch.topN().orders().get(0);
+        if (order.nullOrdering() == SortValue.NullOrdering.NULLS_FIRST) {
+            if (!addNullRows(readers, scalarSearch, result)) {
+                return Optional.empty();
+            }
+            if (result.cardinality() >= limit) {
+                return Optional.of(GlobalIndexResult.create(result.rowIds()));
+            }
+        }
+
+        if (!addNonNullRows(readers, scalarSearch, order, result)) {
+            return Optional.empty();
+        }
+        if (order.nullOrdering() == SortValue.NullOrdering.NULLS_LAST
+                && result.cardinality() < limit
+                && !addNullRows(readers, scalarSearch, result)) {
+            return Optional.empty();
+        }
+        return Optional.of(GlobalIndexResult.create(result.rowIds()));
+    }
+
+    private boolean addNullRows(
+            List<BTreeIndexReader> readers,
+            ScalarSearch scalarSearch,
+            BTreeIndexReader.ScalarSearchResultAccumulator result) {
+        RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
+        for (BTreeIndexReader reader : readers) {
+            for (long rowId : reader.nullRowIds()) {
+                if (includeRowIds == null || includeRowIds.contains(rowId)) {
+                    if (!result.add(rowId)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean addNonNullRows(
+            List<BTreeIndexReader> readers,
+            ScalarSearch scalarSearch,
+            SortValue order,
+            BTreeIndexReader.ScalarSearchResultAccumulator result) {
+        Comparator<EntryCursor> cursorComparator =
+                (left, right) -> comparator.compare(left.current().key(), right.current().key());
+        if (order.direction() == SortValue.SortDirection.DESCENDING) {
+            cursorComparator = cursorComparator.reversed();
+        }
+
+        PriorityQueue<EntryCursor> cursors = new PriorityQueue<>(cursorComparator);
+        try {
+            for (BTreeIndexReader reader : readers) {
+                EntryCursor cursor = new EntryCursor(reader, order.direction());
+                if (cursor.advance()) {
+                    cursors.offer(cursor);
+                }
+            }
+
+            while (!cursors.isEmpty()) {
+                Object currentKey = cursors.peek().current().key();
+                boolean matched = false;
+                while (!cursors.isEmpty()
+                        && comparator.compare(cursors.peek().current().key(), currentKey) == 0) {
+                    EntryCursor cursor = cursors.poll();
+                    matched |= addRows(cursor.current().rowIds(), scalarSearch, result);
+                    if (result.exceededMaxResultSize()) {
+                        return false;
+                    }
+                    if (cursor.advance()) {
+                        cursors.offer(cursor);
+                    }
+                }
+                if (matched && result.cardinality() >= scalarSearch.topN().limit()) {
+                    break;
+                }
+            }
+            return true;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to scan BTree index files for scalar TopN.", e);
+        }
+    }
+
+    private boolean addRows(
+            long[] rowIds,
+            ScalarSearch scalarSearch,
+            BTreeIndexReader.ScalarSearchResultAccumulator result) {
+        boolean matched = false;
+        RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
+        for (long rowId : rowIds) {
+            if (includeRowIds == null || includeRowIds.contains(rowId)) {
+                matched = true;
+                if (!result.add(rowId)) {
+                    return true;
+                }
+            }
+        }
+        return matched;
+    }
+
+    private static class EntryCursor {
+        private final SortValue.SortDirection direction;
+        private final BTreeIndexReader.EntryIterator forwardIterator;
+        private final BTreeIndexReader.ReverseEntryIterator reverseIterator;
+        private BTreeIndexReader.KeyRowIds current;
+
+        private EntryCursor(BTreeIndexReader reader, SortValue.SortDirection direction) {
+            this.direction = direction;
+            this.forwardIterator =
+                    direction == SortValue.SortDirection.ASCENDING ? reader.entryIterator() : null;
+            this.reverseIterator =
+                    direction == SortValue.SortDirection.DESCENDING
+                            ? reader.reverseEntryIterator()
+                            : null;
+        }
+
+        private boolean advance() throws IOException {
+            if (direction == SortValue.SortDirection.ASCENDING) {
+                if (!forwardIterator.hasNext()) {
+                    current = null;
+                    return false;
+                }
+                current = forwardIterator.next();
+                return true;
+            }
+            if (!reverseIterator.hasNext()) {
+                current = null;
+                return false;
+            }
+            current = reverseIterator.next();
+            return true;
+        }
+
+        private BTreeIndexReader.KeyRowIds current() {
+            return current;
+        }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -27,6 +27,7 @@ import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.SortValue;
+import org.apache.paimon.sst.SstFileReader;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.io.IOException;
@@ -183,7 +184,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 new BTreeIndexReader.ScalarSearchResultAccumulator(
                         scalarSearch.maxResultSize(), scalarSearch.maxScannedRowIds());
         if (limit == 0) {
-            return Optional.of(GlobalIndexResult.create(result.rowIds()));
+            return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
         }
 
         SortValue order = scalarSearch.topN().orders().get(0);
@@ -192,7 +193,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 return Optional.empty();
             }
             if (result.cardinality() >= limit) {
-                return Optional.of(GlobalIndexResult.create(result.rowIds()));
+                return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
             }
         }
 
@@ -204,7 +205,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 && !addNullRows(readers, scalarSearch, result)) {
             return Optional.empty();
         }
-        return Optional.of(GlobalIndexResult.create(result.rowIds()));
+        return Optional.of(GlobalIndexResult.createExact(result.rowIds()));
     }
 
     private boolean addNullRows(
@@ -213,7 +214,12 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
             BTreeIndexReader.ScalarSearchResultAccumulator result) {
         RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
         for (BTreeIndexReader reader : readers) {
-            RoaringNavigableMap64 nullRowIds = reader.nullRowIds();
+            Optional<RoaringNavigableMap64> optionalNullRowIds =
+                    reader.nullRowIds(scalarSearch.maxReadBlockSize());
+            if (!optionalNullRowIds.isPresent()) {
+                return false;
+            }
+            RoaringNavigableMap64 nullRowIds = optionalNullRowIds.get();
             if (!result.reserveScannedRowIds(nullRowIds.getLongCardinality())) {
                 return false;
             }
@@ -242,7 +248,8 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
         PriorityQueue<EntryCursor> cursors = new PriorityQueue<>(cursorComparator);
         try {
             for (BTreeIndexReader reader : readers) {
-                EntryCursor cursor = new EntryCursor(reader, order.direction());
+                EntryCursor cursor =
+                        new EntryCursor(reader, order.direction(), scalarSearch.maxReadBlockSize());
                 if (cursor.advance()) {
                     cursors.offer(cursor);
                 }
@@ -267,6 +274,8 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 }
             }
             return true;
+        } catch (SstFileReader.BlockTooLargeException ignored) {
+            return false;
         } catch (IOException e) {
             throw new RuntimeException("Failed to scan BTree index files for scalar TopN.", e);
         }
@@ -300,13 +309,16 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
         private final BTreeIndexReader.ReverseEntryIterator reverseIterator;
         private BTreeIndexReader.KeyRowIds current;
 
-        private EntryCursor(BTreeIndexReader reader, SortValue.SortDirection direction) {
+        private EntryCursor(
+                BTreeIndexReader reader, SortValue.SortDirection direction, long maxReadBlockSize) {
             this.direction = direction;
             this.forwardIterator =
-                    direction == SortValue.SortDirection.ASCENDING ? reader.entryIterator() : null;
+                    direction == SortValue.SortDirection.ASCENDING
+                            ? reader.entryIterator(maxReadBlockSize)
+                            : null;
             this.reverseIterator =
                     direction == SortValue.SortDirection.DESCENDING
-                            ? reader.reverseEntryIterator()
+                            ? reader.reverseEntryIterator(maxReadBlockSize)
                             : null;
         }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -180,7 +180,8 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
             List<BTreeIndexReader> readers, ScalarSearch scalarSearch) {
         int limit = scalarSearch.topN().limit();
         BTreeIndexReader.ScalarSearchResultAccumulator result =
-                new BTreeIndexReader.ScalarSearchResultAccumulator(scalarSearch.maxResultSize());
+                new BTreeIndexReader.ScalarSearchResultAccumulator(
+                        scalarSearch.maxResultSize(), scalarSearch.maxScannedRowIds());
         if (limit == 0) {
             return Optional.of(GlobalIndexResult.create(result.rowIds()));
         }
@@ -212,7 +213,11 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
             BTreeIndexReader.ScalarSearchResultAccumulator result) {
         RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
         for (BTreeIndexReader reader : readers) {
-            for (long rowId : reader.nullRowIds()) {
+            RoaringNavigableMap64 nullRowIds = reader.nullRowIds();
+            if (!result.reserveScannedRowIds(nullRowIds.getLongCardinality())) {
+                return false;
+            }
+            for (long rowId : nullRowIds) {
                 if (includeRowIds == null || includeRowIds.contains(rowId)) {
                     if (!result.add(rowId)) {
                         return false;
@@ -249,8 +254,8 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
                 while (!cursors.isEmpty()
                         && comparator.compare(cursors.peek().current().key(), currentKey) == 0) {
                     EntryCursor cursor = cursors.poll();
-                    matched |= addRows(cursor.current().rowIds(), scalarSearch, result);
-                    if (result.exceededMaxResultSize()) {
+                    matched |= addRows(cursor.current(), scalarSearch, result);
+                    if (result.exceededBudget()) {
                         return false;
                     }
                     if (cursor.advance()) {
@@ -268,12 +273,17 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
     }
 
     private boolean addRows(
-            long[] rowIds,
+            BTreeIndexReader.KeyRowIds keyRowIds,
             ScalarSearch scalarSearch,
             BTreeIndexReader.ScalarSearchResultAccumulator result) {
+        if (!result.reserveScannedRowIds(keyRowIds.rowIdCount())) {
+            return false;
+        }
         boolean matched = false;
         RoaringNavigableMap64 includeRowIds = scalarSearch.includeRowIds();
-        for (long rowId : rowIds) {
+        BTreeIndexReader.RowIdIterator iterator = keyRowIds.rowIdIterator();
+        while (iterator.hasNext()) {
+            long rowId = iterator.nextLong();
             if (includeRowIds == null || includeRowIds.contains(rowId)) {
                 matched = true;
                 if (!result.add(rowId)) {

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -25,6 +25,7 @@ import org.apache.paimon.globalindex.SortedFileGlobalIndexReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.io.IOException;
@@ -135,6 +136,12 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
     protected Optional<GlobalIndexResult> visitBetween(
             BTreeIndexReader reader, Object from, Object to) {
         return reader.visitBetween(from, to);
+    }
+
+    @Override
+    public java.util.concurrent.CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+            ScalarSearch scalarSearch) {
+        return visitAllFiles(reader -> reader.visitScalarSearch(scalarSearch));
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
@@ -36,16 +36,18 @@ public class ScalarSearch implements Serializable {
     @Nullable private final RoaringNavigableMap64 includeRowIds;
     private final long maxResultSize;
     private final long maxScannedRowIds;
+    private final long maxReadBlockSize;
 
     public ScalarSearch(TopN topN) {
-        this(topN, null, Long.MAX_VALUE, Long.MAX_VALUE);
+        this(topN, null, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
     private ScalarSearch(
             TopN topN,
             @Nullable RoaringNavigableMap64 includeRowIds,
             long maxResultSize,
-            long maxScannedRowIds) {
+            long maxScannedRowIds,
+            long maxReadBlockSize) {
         this.topN = checkNotNull(topN);
         checkArgument(topN.limit() >= 0, "Limit must not be negative, got: %s", topN.limit());
         checkArgument(
@@ -57,9 +59,14 @@ public class ScalarSearch implements Serializable {
                 maxScannedRowIds >= 0,
                 "Max scanned row ids must not be negative, got: %s",
                 maxScannedRowIds);
+        checkArgument(
+                maxReadBlockSize >= 0,
+                "Max read block size must not be negative, got: %s",
+                maxReadBlockSize);
         this.includeRowIds = includeRowIds;
         this.maxResultSize = maxResultSize;
         this.maxScannedRowIds = maxScannedRowIds;
+        this.maxReadBlockSize = maxReadBlockSize;
     }
 
     public TopN topN() {
@@ -72,7 +79,8 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withIncludeRowIds(@Nullable RoaringNavigableMap64 includeRowIds) {
-        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
+        return new ScalarSearch(
+                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
     }
 
     public long maxResultSize() {
@@ -80,7 +88,8 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withMaxResultSize(long maxResultSize) {
-        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
+        return new ScalarSearch(
+                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
     }
 
     public long maxScannedRowIds() {
@@ -88,7 +97,17 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withMaxScannedRowIds(long maxScannedRowIds) {
-        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
+        return new ScalarSearch(
+                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
+    }
+
+    public long maxReadBlockSize() {
+        return maxReadBlockSize;
+    }
+
+    public ScalarSearch withMaxReadBlockSize(long maxReadBlockSize) {
+        return new ScalarSearch(
+                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
     }
 
     public ScalarSearch offsetRange(long from, long to) {
@@ -99,16 +118,18 @@ public class ScalarSearch implements Serializable {
                 topN,
                 VectorSearchUtils.offsetRowIds(includeRowIds, from, to),
                 maxResultSize,
-                maxScannedRowIds);
+                maxScannedRowIds,
+                maxReadBlockSize);
     }
 
     @Override
     public String toString() {
         return String.format(
-                "%s, IncludeRows(%s), MaxResultSize(%s), MaxScannedRowIds(%s)",
+                "%s, IncludeRows(%s), MaxResultSize(%s), MaxScannedRowIds(%s), MaxReadBlockSize(%s)",
                 topN,
                 includeRowIds == null ? "ALL" : includeRowIds.getLongCardinality(),
                 maxResultSize,
-                maxScannedRowIds);
+                maxScannedRowIds,
+                maxReadBlockSize);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.predicate;
+
+import org.apache.paimon.utils.RoaringNavigableMap64;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
+
+/** A scalar TopN search optionally restricted to a set of candidate row IDs. */
+public class ScalarSearch implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TopN topN;
+
+    @Nullable private RoaringNavigableMap64 includeRowIds;
+
+    public ScalarSearch(TopN topN) {
+        this.topN = checkNotNull(topN);
+        checkArgument(topN.limit() > 0, "Limit must be positive, got: %s", topN.limit());
+    }
+
+    public TopN topN() {
+        return topN;
+    }
+
+    @Nullable
+    public RoaringNavigableMap64 includeRowIds() {
+        return includeRowIds;
+    }
+
+    public ScalarSearch withIncludeRowIds(@Nullable RoaringNavigableMap64 includeRowIds) {
+        this.includeRowIds = includeRowIds;
+        return this;
+    }
+
+    public ScalarSearch offsetRange(long from, long to) {
+        if (includeRowIds == null) {
+            return this;
+        }
+        return new ScalarSearch(topN)
+                .withIncludeRowIds(VectorSearchUtils.offsetRowIds(includeRowIds, from, to));
+    }
+
+    @Override
+    public String toString() {
+        return topN.toString();
+    }
+}

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
@@ -35,13 +35,17 @@ public class ScalarSearch implements Serializable {
     private final TopN topN;
     @Nullable private final RoaringNavigableMap64 includeRowIds;
     private final long maxResultSize;
+    private final long maxScannedRowIds;
 
     public ScalarSearch(TopN topN) {
-        this(topN, null, Long.MAX_VALUE);
+        this(topN, null, Long.MAX_VALUE, Long.MAX_VALUE);
     }
 
     private ScalarSearch(
-            TopN topN, @Nullable RoaringNavigableMap64 includeRowIds, long maxResultSize) {
+            TopN topN,
+            @Nullable RoaringNavigableMap64 includeRowIds,
+            long maxResultSize,
+            long maxScannedRowIds) {
         this.topN = checkNotNull(topN);
         checkArgument(topN.limit() >= 0, "Limit must not be negative, got: %s", topN.limit());
         checkArgument(
@@ -49,8 +53,13 @@ public class ScalarSearch implements Serializable {
                 "Max result size %s must not be smaller than limit %s.",
                 maxResultSize,
                 topN.limit());
+        checkArgument(
+                maxScannedRowIds >= 0,
+                "Max scanned row ids must not be negative, got: %s",
+                maxScannedRowIds);
         this.includeRowIds = includeRowIds;
         this.maxResultSize = maxResultSize;
+        this.maxScannedRowIds = maxScannedRowIds;
     }
 
     public TopN topN() {
@@ -63,7 +72,7 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withIncludeRowIds(@Nullable RoaringNavigableMap64 includeRowIds) {
-        return new ScalarSearch(topN, includeRowIds, maxResultSize);
+        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
     }
 
     public long maxResultSize() {
@@ -71,7 +80,15 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withMaxResultSize(long maxResultSize) {
-        return new ScalarSearch(topN, includeRowIds, maxResultSize);
+        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
+    }
+
+    public long maxScannedRowIds() {
+        return maxScannedRowIds;
+    }
+
+    public ScalarSearch withMaxScannedRowIds(long maxScannedRowIds) {
+        return new ScalarSearch(topN, includeRowIds, maxResultSize, maxScannedRowIds);
     }
 
     public ScalarSearch offsetRange(long from, long to) {
@@ -79,15 +96,19 @@ public class ScalarSearch implements Serializable {
             return this;
         }
         return new ScalarSearch(
-                topN, VectorSearchUtils.offsetRowIds(includeRowIds, from, to), maxResultSize);
+                topN,
+                VectorSearchUtils.offsetRowIds(includeRowIds, from, to),
+                maxResultSize,
+                maxScannedRowIds);
     }
 
     @Override
     public String toString() {
         return String.format(
-                "%s, IncludeRows(%s), MaxResultSize(%s)",
+                "%s, IncludeRows(%s), MaxResultSize(%s), MaxScannedRowIds(%s)",
                 topN,
                 includeRowIds == null ? "ALL" : includeRowIds.getLongCardinality(),
-                maxResultSize);
+                maxResultSize,
+                maxScannedRowIds);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
@@ -27,7 +27,10 @@ import java.io.Serializable;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
-/** A scalar TopN search optionally restricted to a set of candidate row IDs. */
+/**
+ * A scalar TopN search optionally restricted to candidate row IDs and planner-provided resource
+ * bounds.
+ */
 public class ScalarSearch implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -37,9 +40,20 @@ public class ScalarSearch implements Serializable {
     private final long maxResultSize;
     private final long maxScannedRowIds;
     private final long maxReadBlockSize;
+    private final int maxIndexFiles;
+    private final long maxIndexBytes;
+    private final int maxConcurrentReaders;
 
     public ScalarSearch(TopN topN) {
-        this(topN, null, Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+        this(
+                topN,
+                null,
+                Long.MAX_VALUE,
+                Long.MAX_VALUE,
+                Long.MAX_VALUE,
+                Integer.MAX_VALUE,
+                Long.MAX_VALUE,
+                Integer.MAX_VALUE);
     }
 
     private ScalarSearch(
@@ -47,7 +61,10 @@ public class ScalarSearch implements Serializable {
             @Nullable RoaringNavigableMap64 includeRowIds,
             long maxResultSize,
             long maxScannedRowIds,
-            long maxReadBlockSize) {
+            long maxReadBlockSize,
+            int maxIndexFiles,
+            long maxIndexBytes,
+            int maxConcurrentReaders) {
         this.topN = checkNotNull(topN);
         checkArgument(topN.limit() >= 0, "Limit must not be negative, got: %s", topN.limit());
         checkArgument(
@@ -63,10 +80,21 @@ public class ScalarSearch implements Serializable {
                 maxReadBlockSize >= 0,
                 "Max read block size must not be negative, got: %s",
                 maxReadBlockSize);
+        checkArgument(
+                maxIndexFiles >= 0, "Max index files must not be negative, got: %s", maxIndexFiles);
+        checkArgument(
+                maxIndexBytes >= 0, "Max index bytes must not be negative, got: %s", maxIndexBytes);
+        checkArgument(
+                maxConcurrentReaders >= 0,
+                "Max concurrent readers must not be negative, got: %s",
+                maxConcurrentReaders);
         this.includeRowIds = includeRowIds;
         this.maxResultSize = maxResultSize;
         this.maxScannedRowIds = maxScannedRowIds;
         this.maxReadBlockSize = maxReadBlockSize;
+        this.maxIndexFiles = maxIndexFiles;
+        this.maxIndexBytes = maxIndexBytes;
+        this.maxConcurrentReaders = maxConcurrentReaders;
     }
 
     public TopN topN() {
@@ -80,7 +108,14 @@ public class ScalarSearch implements Serializable {
 
     public ScalarSearch withIncludeRowIds(@Nullable RoaringNavigableMap64 includeRowIds) {
         return new ScalarSearch(
-                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 
     public long maxResultSize() {
@@ -89,7 +124,14 @@ public class ScalarSearch implements Serializable {
 
     public ScalarSearch withMaxResultSize(long maxResultSize) {
         return new ScalarSearch(
-                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 
     public long maxScannedRowIds() {
@@ -98,7 +140,14 @@ public class ScalarSearch implements Serializable {
 
     public ScalarSearch withMaxScannedRowIds(long maxScannedRowIds) {
         return new ScalarSearch(
-                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 
     public long maxReadBlockSize() {
@@ -107,7 +156,62 @@ public class ScalarSearch implements Serializable {
 
     public ScalarSearch withMaxReadBlockSize(long maxReadBlockSize) {
         return new ScalarSearch(
-                topN, includeRowIds, maxResultSize, maxScannedRowIds, maxReadBlockSize);
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
+    }
+
+    public int maxIndexFiles() {
+        return maxIndexFiles;
+    }
+
+    public ScalarSearch withMaxIndexFiles(int maxIndexFiles) {
+        return new ScalarSearch(
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
+    }
+
+    public long maxIndexBytes() {
+        return maxIndexBytes;
+    }
+
+    public ScalarSearch withMaxIndexBytes(long maxIndexBytes) {
+        return new ScalarSearch(
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
+    }
+
+    public int maxConcurrentReaders() {
+        return maxConcurrentReaders;
+    }
+
+    public ScalarSearch withMaxConcurrentReaders(int maxConcurrentReaders) {
+        return new ScalarSearch(
+                topN,
+                includeRowIds,
+                maxResultSize,
+                maxScannedRowIds,
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 
     public ScalarSearch offsetRange(long from, long to) {
@@ -119,17 +223,25 @@ public class ScalarSearch implements Serializable {
                 VectorSearchUtils.offsetRowIds(includeRowIds, from, to),
                 maxResultSize,
                 maxScannedRowIds,
-                maxReadBlockSize);
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 
     @Override
     public String toString() {
         return String.format(
-                "%s, IncludeRows(%s), MaxResultSize(%s), MaxScannedRowIds(%s), MaxReadBlockSize(%s)",
+                "%s, IncludeRows(%s), MaxResultSize(%s), MaxScannedRowIds(%s), "
+                        + "MaxReadBlockSize(%s), MaxIndexFiles(%s), MaxIndexBytes(%s), "
+                        + "MaxConcurrentReaders(%s)",
                 topN,
                 includeRowIds == null ? "ALL" : includeRowIds.getLongCardinality(),
                 maxResultSize,
                 maxScannedRowIds,
-                maxReadBlockSize);
+                maxReadBlockSize,
+                maxIndexFiles,
+                maxIndexBytes,
+                maxConcurrentReaders);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/predicate/ScalarSearch.java
@@ -33,12 +33,24 @@ public class ScalarSearch implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final TopN topN;
-
-    @Nullable private RoaringNavigableMap64 includeRowIds;
+    @Nullable private final RoaringNavigableMap64 includeRowIds;
+    private final long maxResultSize;
 
     public ScalarSearch(TopN topN) {
+        this(topN, null, Long.MAX_VALUE);
+    }
+
+    private ScalarSearch(
+            TopN topN, @Nullable RoaringNavigableMap64 includeRowIds, long maxResultSize) {
         this.topN = checkNotNull(topN);
-        checkArgument(topN.limit() > 0, "Limit must be positive, got: %s", topN.limit());
+        checkArgument(topN.limit() >= 0, "Limit must not be negative, got: %s", topN.limit());
+        checkArgument(
+                maxResultSize >= topN.limit(),
+                "Max result size %s must not be smaller than limit %s.",
+                maxResultSize,
+                topN.limit());
+        this.includeRowIds = includeRowIds;
+        this.maxResultSize = maxResultSize;
     }
 
     public TopN topN() {
@@ -51,20 +63,31 @@ public class ScalarSearch implements Serializable {
     }
 
     public ScalarSearch withIncludeRowIds(@Nullable RoaringNavigableMap64 includeRowIds) {
-        this.includeRowIds = includeRowIds;
-        return this;
+        return new ScalarSearch(topN, includeRowIds, maxResultSize);
+    }
+
+    public long maxResultSize() {
+        return maxResultSize;
+    }
+
+    public ScalarSearch withMaxResultSize(long maxResultSize) {
+        return new ScalarSearch(topN, includeRowIds, maxResultSize);
     }
 
     public ScalarSearch offsetRange(long from, long to) {
         if (includeRowIds == null) {
             return this;
         }
-        return new ScalarSearch(topN)
-                .withIncludeRowIds(VectorSearchUtils.offsetRowIds(includeRowIds, from, to));
+        return new ScalarSearch(
+                topN, VectorSearchUtils.offsetRowIds(includeRowIds, from, to), maxResultSize);
     }
 
     @Override
     public String toString() {
-        return topN.toString();
+        return String.format(
+                "%s, IncludeRows(%s), MaxResultSize(%s)",
+                topN,
+                includeRowIds == null ? "ALL" : includeRowIds.getLongCardinality(),
+                maxResultSize);
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockCache.java
@@ -63,6 +63,10 @@ public class BlockCache implements Closeable {
         return buffer;
     }
 
+    byte[] read(long offset, int length) throws IOException {
+        return readFrom(offset, length);
+    }
+
     public MemorySegment getBlock(
             long position, int length, Function<byte[], byte[]> decompressFunc, boolean isIndex) {
         CacheKey cacheKey = CacheKey.forPosition(filePath, position, length, isIndex);

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
@@ -31,6 +31,7 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
     private final BlockReader reader;
     private final MemorySliceInput input;
     private BlockEntry polled;
+    private int reversePosition = -1;
 
     public BlockIterator(BlockReader reader) {
         this.reader = reader;
@@ -86,6 +87,23 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
         }
 
         return false;
+    }
+
+    public void seekToLast() {
+        polled = null;
+        reversePosition = reader.recordCount() - 1;
+    }
+
+    public boolean hasPrevious() {
+        return reversePosition >= 0;
+    }
+
+    public BlockEntry previous() {
+        if (!hasPrevious()) {
+            throw new NoSuchElementException();
+        }
+        input.setPosition(reader.seekTo(reversePosition--));
+        return readEntry();
     }
 
     private BlockEntry readEntry() {

--- a/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/BlockIterator.java
@@ -32,6 +32,7 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
     private final MemorySliceInput input;
     private BlockEntry polled;
     private int reversePosition = -1;
+    private boolean reverseMode;
 
     public BlockIterator(BlockReader reader) {
         this.reader = reader;
@@ -40,7 +41,7 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
 
     @Override
     public boolean hasNext() {
-        return polled != null || input.isReadable();
+        return !reverseMode && (polled != null || input.isReadable());
     }
 
     @Override
@@ -64,6 +65,9 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
     }
 
     public boolean seekTo(MemorySlice targetKey) {
+        reverseMode = false;
+        reversePosition = -1;
+        polled = null;
         int left = 0;
         int right = reader.recordCount() - 1;
 
@@ -91,11 +95,12 @@ public class BlockIterator implements Iterator<Map.Entry<MemorySlice, MemorySlic
 
     public void seekToLast() {
         polled = null;
+        reverseMode = true;
         reversePosition = reader.recordCount() - 1;
     }
 
     public boolean hasPrevious() {
-        return reversePosition >= 0;
+        return reverseMode && reversePosition >= 0;
     }
 
     public BlockEntry previous() {

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
@@ -92,6 +92,12 @@ public class SstFileReader implements Closeable {
         return new SstFileIterator(indexBlock.iterator());
     }
 
+    public SstFileIterator createReverseIterator() {
+        BlockIterator iterator = indexBlock.iterator();
+        iterator.seekToLast();
+        return new SstFileIterator(iterator);
+    }
+
     private BlockIterator getNextBlock(BlockIterator indexBlockIterator) {
         // index block handle, point to the key, value position.
         MemorySlice blockHandle = indexBlockIterator.next().getValue();
@@ -212,6 +218,19 @@ public class SstFileReader implements Closeable {
             }
 
             return getNextBlock(indexIterator);
+        }
+
+        public BlockIterator readBatchReverse() throws IOException {
+            if (!indexIterator.hasPrevious()) {
+                return null;
+            }
+
+            MemorySlice blockHandle = indexIterator.previous().getValue();
+            BlockReader dataBlock =
+                    readBlock(BlockHandle.readBlockHandle(blockHandle.toInput()), false);
+            BlockIterator iterator = dataBlock.iterator();
+            iterator.seekToLast();
+            return iterator;
         }
     }
 }

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.sst;
 
 import org.apache.paimon.compression.BlockCompressionFactory;
+import org.apache.paimon.compression.BlockCompressionType;
 import org.apache.paimon.compression.BlockDecompressor;
 import org.apache.paimon.memory.MemorySegment;
 import org.apache.paimon.memory.MemorySlice;
@@ -35,6 +36,7 @@ import java.util.Comparator;
 
 import static org.apache.paimon.sst.SstFileUtils.crc32c;
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.VarLengthIntUtils.MAX_VAR_INT_SIZE;
 
 /**
  * An SST File Reader which serves point queries and range queries. Users can call {@code
@@ -106,22 +108,60 @@ public class SstFileReader implements Closeable {
         return dataBlock.iterator();
     }
 
+    private BlockIterator getNextBlock(
+            BlockIterator indexBlockIterator, long maxUncompressedBlockSize) throws IOException {
+        MemorySlice blockHandle = indexBlockIterator.next().getValue();
+        BlockReader dataBlock =
+                readBlock(
+                        BlockHandle.readBlockHandle(blockHandle.toInput()),
+                        false,
+                        maxUncompressedBlockSize);
+        return dataBlock.iterator();
+    }
+
     /**
      * @param blockHandle The block handle.
      * @param index Whether read the block as an index.
      * @return The reader of the target block.
      */
     private BlockReader readBlock(BlockHandle blockHandle, boolean index) {
-        // read block trailer
+        BlockTrailer blockTrailer = readBlockTrailer(blockHandle);
+        return readBlock(blockHandle, index, blockTrailer);
+    }
+
+    private BlockReader readBlock(
+            BlockHandle blockHandle, boolean index, long maxUncompressedBlockSize)
+            throws IOException {
+        BlockTrailer blockTrailer = readBlockTrailer(blockHandle);
+        long uncompressedBlockSize = uncompressedBlockSize(blockHandle, blockTrailer);
+        if (uncompressedBlockSize > maxUncompressedBlockSize) {
+            throw new BlockTooLargeException(uncompressedBlockSize, maxUncompressedBlockSize);
+        }
+        return readBlock(blockHandle, index, blockTrailer);
+    }
+
+    private BlockTrailer readBlockTrailer(BlockHandle blockHandle) {
         MemorySegment trailerData =
                 blockCache.getBlock(
                         blockHandle.offset() + blockHandle.size(),
                         BlockTrailer.ENCODED_LENGTH,
                         b -> b,
                         true);
-        BlockTrailer blockTrailer =
-                BlockTrailer.readBlockTrailer(MemorySlice.wrap(trailerData).toInput());
+        return BlockTrailer.readBlockTrailer(MemorySlice.wrap(trailerData).toInput());
+    }
 
+    private long uncompressedBlockSize(BlockHandle blockHandle, BlockTrailer blockTrailer)
+            throws IOException {
+        if (blockTrailer.getCompressionType() == BlockCompressionType.NONE) {
+            return blockHandle.size();
+        }
+        int prefixLength = Math.min(MAX_VAR_INT_SIZE, blockHandle.size());
+        byte[] prefix = blockCache.read(blockHandle.offset(), prefixLength);
+        return MemorySlice.wrap(prefix).toInput().readVarLenInt();
+    }
+
+    private BlockReader readBlock(
+            BlockHandle blockHandle, boolean index, BlockTrailer blockTrailer) {
         MemorySegment unCompressedBlock =
                 blockCache.getBlock(
                         blockHandle.offset(),
@@ -129,6 +169,18 @@ public class SstFileReader implements Closeable {
                         bytes -> decompressBlock(bytes, blockTrailer),
                         index);
         return BlockReader.create(MemorySlice.wrap(unCompressedBlock), comparator);
+    }
+
+    /** Raised before loading a data block whose uncompressed size exceeds the caller's limit. */
+    public static class BlockTooLargeException extends IOException {
+        private static final long serialVersionUID = 1L;
+
+        private BlockTooLargeException(long blockSize, long maxBlockSize) {
+            super(
+                    String.format(
+                            "Uncompressed SST block size %s exceeds limit %s.",
+                            blockSize, maxBlockSize));
+        }
     }
 
     private byte[] decompressBlock(byte[] compressedBytes, BlockTrailer blockTrailer) {
@@ -220,6 +272,20 @@ public class SstFileReader implements Closeable {
             return getNextBlock(indexIterator);
         }
 
+        public BlockIterator readBatch(long maxUncompressedBlockSize) throws IOException {
+            if (seekedDataBlock != null) {
+                BlockIterator result = seekedDataBlock;
+                seekedDataBlock = null;
+                return result;
+            }
+
+            if (!indexIterator.hasNext()) {
+                return null;
+            }
+
+            return getNextBlock(indexIterator, maxUncompressedBlockSize);
+        }
+
         public BlockIterator readBatchReverse() throws IOException {
             if (!indexIterator.hasPrevious()) {
                 return null;
@@ -228,6 +294,22 @@ public class SstFileReader implements Closeable {
             MemorySlice blockHandle = indexIterator.previous().getValue();
             BlockReader dataBlock =
                     readBlock(BlockHandle.readBlockHandle(blockHandle.toInput()), false);
+            BlockIterator iterator = dataBlock.iterator();
+            iterator.seekToLast();
+            return iterator;
+        }
+
+        public BlockIterator readBatchReverse(long maxUncompressedBlockSize) throws IOException {
+            if (!indexIterator.hasPrevious()) {
+                return null;
+            }
+
+            MemorySlice blockHandle = indexIterator.previous().getValue();
+            BlockReader dataBlock =
+                    readBlock(
+                            BlockHandle.readBlockHandle(blockHandle.toInput()),
+                            false,
+                            maxUncompressedBlockSize);
             BlockIterator iterator = dataBlock.iterator();
             iterator.seekToLast();
             return iterator;

--- a/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/sst/SstFileReader.java
@@ -155,6 +155,8 @@ public class SstFileReader implements Closeable {
         if (blockTrailer.getCompressionType() == BlockCompressionType.NONE) {
             return blockHandle.size();
         }
+        // Read only the length prefix so an oversized compressed block is rejected before the
+        // full block is loaded, decompressed, or inserted into the cache.
         int prefixLength = Math.min(MAX_VAR_INT_SIZE, blockHandle.size());
         byte[] prefix = blockCache.read(blockHandle.offset(), prefixLength);
         return MemorySlice.wrap(prefix).toInput().readVarLenInt();
@@ -284,19 +286,6 @@ public class SstFileReader implements Closeable {
             }
 
             return getNextBlock(indexIterator, maxUncompressedBlockSize);
-        }
-
-        public BlockIterator readBatchReverse() throws IOException {
-            if (!indexIterator.hasPrevious()) {
-                return null;
-            }
-
-            MemorySlice blockHandle = indexIterator.previous().getValue();
-            BlockReader dataBlock =
-                    readBlock(BlockHandle.readBlockHandle(blockHandle.toInput()), false);
-            BlockIterator iterator = dataBlock.iterator();
-            iterator.seekToLast();
-            return iterator;
         }
 
         public BlockIterator readBatchReverse(long maxUncompressedBlockSize) throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -23,6 +23,8 @@ import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
@@ -44,6 +46,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -655,6 +659,31 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testScalarSearchUsesOrderFieldAndUnionsReaders() {
+        RowType rowType = rowType();
+        AtomicInteger requestedField = new AtomicInteger(-1);
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            requestedField.set(fieldId);
+                            return Arrays.asList(
+                                    scalarReaderReturning(resultOf(1, 2)),
+                                    scalarReaderReturning(resultOf(3, 4)));
+                        });
+        ScalarSearch search =
+                new ScalarSearch(
+                        new TopN(new FieldRef(1, "b", DataTypes.INT()), DESCENDING, NULLS_LAST, 2));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluateScalarSearch(search);
+
+        assertThat(requestedField.get()).isEqualTo(1);
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L, 4L);
+        evaluator.close();
+    }
+
+    @Test
     void testUnionReaderClosesRemainingReadersAfterFailure() {
         AtomicBoolean secondClosed = new AtomicBoolean();
         GlobalIndexReader failingReader =
@@ -781,5 +810,15 @@ class GlobalIndexEvaluatorTest {
 
         @Override
         public void close() throws IOException {}
+    }
+
+    private static GlobalIndexReader scalarReaderReturning(GlobalIndexResult expectedResult) {
+        return new StubGlobalIndexReader(null) {
+            @Override
+            public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+                    ScalarSearch scalarSearch) {
+                return CompletableFuture.completedFuture(Optional.of(expectedResult));
+            }
+        };
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -689,6 +689,7 @@ class GlobalIndexEvaluatorTest {
         assertThat(requestedField.get()).isEqualTo(1);
         assertThat(result).isPresent();
         assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L, 4L);
+        assertThat(result.get().isExact()).isFalse();
         evaluator.close();
     }
 
@@ -801,7 +802,10 @@ class GlobalIndexEvaluatorTest {
                                         2))
                         .withMaxResultSize(8)
                         .withMaxScannedRowIds(20)
-                        .withMaxReadBlockSize(1024);
+                        .withMaxReadBlockSize(1024)
+                        .withMaxIndexFiles(6)
+                        .withMaxIndexBytes(1200)
+                        .withMaxConcurrentReaders(4);
 
         assertThat(evaluator.evaluateScalarSearch(search)).isPresent();
         assertThat(received[0].maxResultSize()).isEqualTo(4);
@@ -810,6 +814,12 @@ class GlobalIndexEvaluatorTest {
         assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
         assertThat(received[0].maxReadBlockSize()).isEqualTo(1024);
         assertThat(received[1].maxReadBlockSize()).isEqualTo(1024);
+        assertThat(received[0].maxIndexFiles()).isEqualTo(3);
+        assertThat(received[1].maxIndexFiles()).isEqualTo(3);
+        assertThat(received[0].maxIndexBytes()).isEqualTo(600);
+        assertThat(received[1].maxIndexBytes()).isEqualTo(600);
+        assertThat(received[0].maxConcurrentReaders()).isEqualTo(4);
+        assertThat(received[1].maxConcurrentReaders()).isEqualTo(4);
         evaluator.close();
     }
 
@@ -830,7 +840,10 @@ class GlobalIndexEvaluatorTest {
                                         2))
                         .withMaxResultSize(8)
                         .withMaxScannedRowIds(20)
-                        .withMaxReadBlockSize(1024);
+                        .withMaxReadBlockSize(1024)
+                        .withMaxIndexFiles(6)
+                        .withMaxIndexBytes(1200)
+                        .withMaxConcurrentReaders(4);
 
         assertThat(reader.visitScalarSearch(search).join()).isPresent();
         assertThat(received[0].maxResultSize()).isEqualTo(4);
@@ -839,17 +852,27 @@ class GlobalIndexEvaluatorTest {
         assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
         assertThat(received[0].maxReadBlockSize()).isEqualTo(1024);
         assertThat(received[1].maxReadBlockSize()).isEqualTo(1024);
+        assertThat(received[0].maxIndexFiles()).isEqualTo(3);
+        assertThat(received[1].maxIndexFiles()).isEqualTo(3);
+        assertThat(received[0].maxIndexBytes()).isEqualTo(600);
+        assertThat(received[1].maxIndexBytes()).isEqualTo(600);
+        assertThat(received[0].maxConcurrentReaders()).isEqualTo(2);
+        assertThat(received[1].maxConcurrentReaders()).isEqualTo(2);
     }
 
     @Test
-    void testUnionScalarSearchStartsReadersSequentially() {
+    void testUnionScalarSearchBoundsConcurrency() {
         CompletableFuture<Optional<GlobalIndexResult>> first = new CompletableFuture<>();
+        CompletableFuture<Optional<GlobalIndexResult>> second = new CompletableFuture<>();
+        AtomicBoolean firstStarted = new AtomicBoolean();
         AtomicBoolean secondStarted = new AtomicBoolean();
+        AtomicBoolean thirdStarted = new AtomicBoolean();
         GlobalIndexReader firstReader =
                 new StubGlobalIndexReader(null) {
                     @Override
                     public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
                             ScalarSearch scalarSearch) {
+                        firstStarted.set(true);
                         return first;
                     }
                 };
@@ -859,11 +882,20 @@ class GlobalIndexEvaluatorTest {
                     public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
                             ScalarSearch scalarSearch) {
                         secondStarted.set(true);
-                        return CompletableFuture.completedFuture(Optional.of(resultOf(2)));
+                        return second;
+                    }
+                };
+        GlobalIndexReader thirdReader =
+                new StubGlobalIndexReader(null) {
+                    @Override
+                    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+                            ScalarSearch scalarSearch) {
+                        thirdStarted.set(true);
+                        return CompletableFuture.completedFuture(Optional.of(resultOf(3)));
                     }
                 };
         UnionGlobalIndexReader reader =
-                new UnionGlobalIndexReader(Arrays.asList(firstReader, secondReader));
+                new UnionGlobalIndexReader(Arrays.asList(firstReader, secondReader, thirdReader));
         ScalarSearch search =
                 new ScalarSearch(
                                 new TopN(
@@ -871,14 +903,18 @@ class GlobalIndexEvaluatorTest {
                                         DESCENDING,
                                         NULLS_LAST,
                                         1))
-                        .withMaxResultSize(2);
+                        .withMaxResultSize(3)
+                        .withMaxConcurrentReaders(2);
 
         CompletableFuture<Optional<GlobalIndexResult>> result = reader.visitScalarSearch(search);
-        assertThat(secondStarted).isFalse();
+        assertThat(firstStarted).isTrue();
+        assertThat(secondStarted).isTrue();
+        assertThat(thirdStarted).isFalse();
 
         first.complete(Optional.of(resultOf(1)));
+        assertThat(thirdStarted).isTrue();
+        second.complete(Optional.of(resultOf(2)));
         assertThat(result.join()).isPresent();
-        assertThat(secondStarted).isTrue();
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -725,6 +725,60 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testScalarSearchDistributesBudgetsAcrossReaders() {
+        RowType rowType = rowType();
+        ScalarSearch[] received = new ScalarSearch[2];
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Arrays.asList(
+                                        scalarReaderRecording(received, 0, resultOf(1, 2)),
+                                        scalarReaderRecording(received, 1, resultOf(3, 4))));
+        ScalarSearch search =
+                new ScalarSearch(
+                                new TopN(
+                                        new FieldRef(1, "b", DataTypes.INT()),
+                                        DESCENDING,
+                                        NULLS_LAST,
+                                        2))
+                        .withMaxResultSize(8)
+                        .withMaxScannedRowIds(20);
+
+        assertThat(evaluator.evaluateScalarSearch(search)).isPresent();
+        assertThat(received[0].maxResultSize()).isEqualTo(4);
+        assertThat(received[1].maxResultSize()).isEqualTo(4);
+        assertThat(received[0].maxScannedRowIds()).isEqualTo(10);
+        assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
+        evaluator.close();
+    }
+
+    @Test
+    void testUnionScalarSearchDistributesBudgetsAcrossReaders() {
+        ScalarSearch[] received = new ScalarSearch[2];
+        UnionGlobalIndexReader reader =
+                new UnionGlobalIndexReader(
+                        Arrays.asList(
+                                scalarReaderRecording(received, 0, resultOf(1, 2)),
+                                scalarReaderRecording(received, 1, resultOf(3, 4))));
+        ScalarSearch search =
+                new ScalarSearch(
+                                new TopN(
+                                        new FieldRef(1, "b", DataTypes.INT()),
+                                        DESCENDING,
+                                        NULLS_LAST,
+                                        2))
+                        .withMaxResultSize(8)
+                        .withMaxScannedRowIds(20);
+
+        assertThat(reader.visitScalarSearch(search).join()).isPresent();
+        assertThat(received[0].maxResultSize()).isEqualTo(4);
+        assertThat(received[1].maxResultSize()).isEqualTo(4);
+        assertThat(received[0].maxScannedRowIds()).isEqualTo(10);
+        assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
+    }
+
+    @Test
     void testPartialAndResultIsInexact() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =
@@ -878,6 +932,18 @@ class GlobalIndexEvaluatorTest {
             @Override
             public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
                     ScalarSearch scalarSearch) {
+                return CompletableFuture.completedFuture(Optional.of(expectedResult));
+            }
+        };
+    }
+
+    private static GlobalIndexReader scalarReaderRecording(
+            ScalarSearch[] received, int index, GlobalIndexResult expectedResult) {
+        return new StubGlobalIndexReader(null) {
+            @Override
+            public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+                    ScalarSearch scalarSearch) {
+                received[index] = scalarSearch;
                 return CompletableFuture.completedFuture(Optional.of(expectedResult));
             }
         };

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -845,7 +845,9 @@ class GlobalIndexEvaluatorTest {
                         .withMaxIndexBytes(1200)
                         .withMaxConcurrentReaders(4);
 
-        assertThat(reader.visitScalarSearch(search).join()).isPresent();
+        Optional<GlobalIndexResult> result = reader.visitScalarSearch(search).join();
+        assertThat(result).isPresent();
+        assertThat(result.get().isExact()).isFalse();
         assertThat(received[0].maxResultSize()).isEqualTo(4);
         assertThat(received[1].maxResultSize()).isEqualTo(4);
         assertThat(received[0].maxScannedRowIds()).isEqualTo(10);

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -72,6 +73,14 @@ class GlobalIndexEvaluatorTest {
     }
 
     private static GlobalIndexResult resultOf(long... rowIds) {
+        RoaringNavigableMap64 bm = new RoaringNavigableMap64();
+        for (long id : rowIds) {
+            bm.add(id);
+        }
+        return GlobalIndexResult.createExact(bm);
+    }
+
+    private static GlobalIndexResult candidateResultOf(long... rowIds) {
         RoaringNavigableMap64 bm = new RoaringNavigableMap64();
         for (long id : rowIds) {
             bm.add(id);
@@ -684,6 +693,54 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testScalarSearchRejectsMultipleOrders() {
+        RowType rowType = rowType();
+        AtomicInteger requestedField = new AtomicInteger(-1);
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> {
+                            requestedField.set(fieldId);
+                            return Collections.singletonList(scalarReaderReturning(resultOf(1, 2)));
+                        });
+        ScalarSearch search =
+                new ScalarSearch(
+                        new TopN(
+                                Arrays.asList(
+                                        new SortValue(
+                                                new FieldRef(0, "a", DataTypes.INT()),
+                                                DESCENDING,
+                                                NULLS_LAST),
+                                        new SortValue(
+                                                new FieldRef(1, "b", DataTypes.INT()),
+                                                DESCENDING,
+                                                NULLS_LAST)),
+                                2));
+
+        assertThat(evaluator.evaluateScalarSearch(search)).isEmpty();
+        assertThat(requestedField.get()).isEqualTo(-1);
+        evaluator.close();
+    }
+
+    @Test
+    void testCustomReaderResultDefaultsToInexact() {
+        RowType rowType = rowType();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        readerReturning(candidateResultOf(0, 1))));
+
+        Optional<GlobalIndexResult> result =
+                evaluator.evaluate(new PredicateBuilder(rowType).equal(0, 42));
+
+        assertThat(result).isPresent();
+        assertThat(result.get().isExact()).isFalse();
+        evaluator.close();
+    }
+
+    @Test
     void testScalarSearchRequiresEveryReader() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =
@@ -743,13 +800,16 @@ class GlobalIndexEvaluatorTest {
                                         NULLS_LAST,
                                         2))
                         .withMaxResultSize(8)
-                        .withMaxScannedRowIds(20);
+                        .withMaxScannedRowIds(20)
+                        .withMaxReadBlockSize(1024);
 
         assertThat(evaluator.evaluateScalarSearch(search)).isPresent();
         assertThat(received[0].maxResultSize()).isEqualTo(4);
         assertThat(received[1].maxResultSize()).isEqualTo(4);
         assertThat(received[0].maxScannedRowIds()).isEqualTo(10);
         assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
+        assertThat(received[0].maxReadBlockSize()).isEqualTo(1024);
+        assertThat(received[1].maxReadBlockSize()).isEqualTo(1024);
         evaluator.close();
     }
 
@@ -769,13 +829,56 @@ class GlobalIndexEvaluatorTest {
                                         NULLS_LAST,
                                         2))
                         .withMaxResultSize(8)
-                        .withMaxScannedRowIds(20);
+                        .withMaxScannedRowIds(20)
+                        .withMaxReadBlockSize(1024);
 
         assertThat(reader.visitScalarSearch(search).join()).isPresent();
         assertThat(received[0].maxResultSize()).isEqualTo(4);
         assertThat(received[1].maxResultSize()).isEqualTo(4);
         assertThat(received[0].maxScannedRowIds()).isEqualTo(10);
         assertThat(received[1].maxScannedRowIds()).isEqualTo(10);
+        assertThat(received[0].maxReadBlockSize()).isEqualTo(1024);
+        assertThat(received[1].maxReadBlockSize()).isEqualTo(1024);
+    }
+
+    @Test
+    void testUnionScalarSearchStartsReadersSequentially() {
+        CompletableFuture<Optional<GlobalIndexResult>> first = new CompletableFuture<>();
+        AtomicBoolean secondStarted = new AtomicBoolean();
+        GlobalIndexReader firstReader =
+                new StubGlobalIndexReader(null) {
+                    @Override
+                    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+                            ScalarSearch scalarSearch) {
+                        return first;
+                    }
+                };
+        GlobalIndexReader secondReader =
+                new StubGlobalIndexReader(null) {
+                    @Override
+                    public CompletableFuture<Optional<GlobalIndexResult>> visitScalarSearch(
+                            ScalarSearch scalarSearch) {
+                        secondStarted.set(true);
+                        return CompletableFuture.completedFuture(Optional.of(resultOf(2)));
+                    }
+                };
+        UnionGlobalIndexReader reader =
+                new UnionGlobalIndexReader(Arrays.asList(firstReader, secondReader));
+        ScalarSearch search =
+                new ScalarSearch(
+                                new TopN(
+                                        new FieldRef(1, "b", DataTypes.INT()),
+                                        DESCENDING,
+                                        NULLS_LAST,
+                                        1))
+                        .withMaxResultSize(2);
+
+        CompletableFuture<Optional<GlobalIndexResult>> result = reader.visitScalarSearch(search);
+        assertThat(secondStarted).isFalse();
+
+        first.complete(Optional.of(resultOf(1)));
+        assertThat(result.join()).isPresent();
+        assertThat(secondStarted).isTrue();
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -684,6 +684,67 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testScalarSearchRequiresEveryReader() {
+        RowType rowType = rowType();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Arrays.asList(
+                                        scalarReaderReturning(resultOf(1, 2)),
+                                        new StubGlobalIndexReader(null)));
+        ScalarSearch search =
+                new ScalarSearch(
+                        new TopN(new FieldRef(1, "b", DataTypes.INT()), DESCENDING, NULLS_LAST, 2));
+
+        assertThat(evaluator.evaluateScalarSearch(search)).isEmpty();
+        evaluator.close();
+    }
+
+    @Test
+    void testScalarSearchHonorsResultBudget() {
+        RowType rowType = rowType();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Arrays.asList(
+                                        scalarReaderReturning(resultOf(1, 2)),
+                                        scalarReaderReturning(resultOf(3, 4))));
+        ScalarSearch search =
+                new ScalarSearch(
+                                new TopN(
+                                        new FieldRef(1, "b", DataTypes.INT()),
+                                        DESCENDING,
+                                        NULLS_LAST,
+                                        2))
+                        .withMaxResultSize(3);
+
+        assertThat(evaluator.evaluateScalarSearch(search)).isEmpty();
+        evaluator.close();
+    }
+
+    @Test
+    void testPartialAndResultIsInexact() {
+        RowType rowType = rowType();
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId ->
+                                Collections.singletonList(
+                                        new StubGlobalIndexReader(resultOf(1, 2, 3))));
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        Predicate predicate = PredicateBuilder.and(builder.equal(0, 42), builder.greaterThan(0, 0));
+
+        Optional<GlobalIndexResult> result = evaluator.evaluate(predicate);
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 1L, 2L, 3L);
+        assertThat(result.get().isExact()).isFalse();
+        evaluator.close();
+    }
+
+    @Test
     void testUnionReaderClosesRemainingReadersAfterFailure() {
         AtomicBoolean secondClosed = new AtomicBoolean();
         GlobalIndexReader failingReader =

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexSerDeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexSerDeUtilsTest.java
@@ -43,6 +43,18 @@ public class GlobalIndexSerDeUtilsTest {
 
         assertThat(deserialized).isNotInstanceOf(ScoredGlobalIndexResult.class);
         assertThat(deserialized.results()).isEqualTo(bitmap);
+        assertThat(deserialized.isExact()).isFalse();
+    }
+
+    @Test
+    public void testSerializeAndDeserializeExactGlobalIndexResult() throws IOException {
+        RoaringNavigableMap64 bitmap = RoaringNavigableMap64.bitmapOf(1, 5, 10);
+        GlobalIndexResult original = GlobalIndexResult.createExact(bitmap);
+
+        GlobalIndexResult deserialized = deserialize(serialize(original));
+
+        assertThat(deserialized.results()).isEqualTo(bitmap);
+        assertThat(deserialized.isExact()).isTrue();
     }
 
     @Test
@@ -54,6 +66,7 @@ public class GlobalIndexSerDeUtilsTest {
 
         assertThat(deserialized).isNotInstanceOf(ScoredGlobalIndexResult.class);
         assertThat(deserialized.results().isEmpty()).isTrue();
+        assertThat(deserialized.isExact()).isTrue();
     }
 
     @Test
@@ -72,6 +85,7 @@ public class GlobalIndexSerDeUtilsTest {
 
         assertThat(deserialized).isInstanceOf(ScoredGlobalIndexResult.class);
         assertThat(deserialized.results()).isEqualTo(bitmap);
+        assertThat(deserialized.isExact()).isTrue();
 
         ScoredGlobalIndexResult topkResult = (ScoredGlobalIndexResult) deserialized;
         ScoreGetter scoreGetter = topkResult.scoreGetter();
@@ -104,6 +118,22 @@ public class GlobalIndexSerDeUtilsTest {
         assertThat(scoreGetter.score(Integer.MAX_VALUE + 1L)).isEqualTo(0.5f);
         assertThat(scoreGetter.score(Integer.MAX_VALUE + 100L)).isEqualTo(0.3f);
         assertThat(scoreGetter.score(Long.MAX_VALUE - 1)).isEqualTo(0.1f);
+    }
+
+    @Test
+    public void testDeserializeLegacyResultAsInexact() throws IOException {
+        RoaringNavigableMap64 bitmap = RoaringNavigableMap64.bitmapOf(1, 5, 10);
+        byte[] bitmapBytes = bitmap.serialize();
+        DataOutputSerializer output = new DataOutputSerializer(1024);
+        output.writeInt(1);
+        output.writeInt(bitmapBytes.length);
+        output.write(bitmapBytes);
+        output.writeInt(0);
+
+        GlobalIndexResult deserialized = deserialize(output.getCopyOfBuffer());
+
+        assertThat(deserialized.results()).isEqualTo(bitmap);
+        assertThat(deserialized.isExact()).isFalse();
     }
 
     private byte[] serialize(GlobalIndexResult result) throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -81,6 +81,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_FIRST;
 import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
 import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
 import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
@@ -363,6 +364,83 @@ public abstract class AbstractIndexReaderTest {
                                                     >= 0)
                             .map(Pair::getValue)
                             .collect(Collectors.toList()));
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchWithNullsFirst() throws Exception {
+        data.get(dataNum - 1).setLeft(null);
+        data.get(dataNum - 2).setLeft(null);
+
+        Comparator<Object> nullsFirstComparator = Comparator.nullsFirst(comparator);
+        List<Pair<Object, Long>> sorted = new ArrayList<>(data);
+        sorted.sort((left, right) -> nullsFirstComparator.compare(left.getKey(), right.getKey()));
+
+        int limit = 5;
+        Object boundary = sorted.get(limit - 1).getKey();
+        List<Long> expected =
+                sorted.stream()
+                        .filter(pair -> nullsFirstComparator.compare(pair.getKey(), boundary) <= 0)
+                        .map(Pair::getValue)
+                        .collect(Collectors.toList());
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            GlobalIndexResult result =
+                    reader.visitScalarSearch(
+                                    new ScalarSearch(new TopN(ref, ASCENDING, NULLS_FIRST, limit)))
+                            .join()
+                            .get();
+            assertResult(result, expected);
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchWithEmptyCandidateRows() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        RoaringNavigableMap64 candidates = new RoaringNavigableMap64();
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            GlobalIndexResult result =
+                    reader.visitScalarSearch(
+                                    new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, 1))
+                                            .withIncludeRowIds(candidates))
+                            .join()
+                            .get();
+            assertThat(result.results()).isEmpty();
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchWithZeroLimit() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            GlobalIndexResult result =
+                    reader.visitScalarSearch(
+                                    new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, 0)))
+                            .join()
+                            .get();
+            assertThat(result.results()).isEmpty();
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchFallsBackWhenBoundaryTiesExceedBudget() throws Exception {
+        Object repeatedKey = data.get(0).getKey();
+        for (Pair<Object, Long> pair : data) {
+            pair.setLeft(repeatedKey);
+        }
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            assertThat(
+                            reader.visitScalarSearch(
+                                            new ScalarSearch(
+                                                            new TopN(ref, ASCENDING, NULLS_LAST, 1))
+                                                    .withMaxResultSize(5))
+                                    .join())
+                    .isEmpty();
         }
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -475,6 +475,17 @@ public abstract class AbstractIndexReaderTest {
     }
 
     @TestTemplate
+    public void testScalarSearchFallsBackBeforeReadingOversizedDataBlock() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        ScalarSearch search =
+                new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, 1)).withMaxReadBlockSize(1);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            assertThat(reader.visitScalarSearch(search).join()).isEmpty();
+        }
+    }
+
+    @TestTemplate
     public void testScalarSearchFallsBackBeforeScanningHugeNullGroup() throws Exception {
         for (Pair<Object, Long> pair : data) {
             pair.setLeft(null);

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -347,6 +347,7 @@ public abstract class AbstractIndexReaderTest {
                                                     <= 0)
                             .map(Pair::getValue)
                             .collect(Collectors.toList()));
+            assertThat(ascending.isExact()).isFalse();
 
             Object descendingBoundary = selected.get(selected.size() - limit).getKey();
             GlobalIndexResult descending =
@@ -364,6 +365,7 @@ public abstract class AbstractIndexReaderTest {
                                                     >= 0)
                             .map(Pair::getValue)
                             .collect(Collectors.toList()));
+            assertThat(descending.isExact()).isFalse();
         }
     }
 
@@ -392,6 +394,7 @@ public abstract class AbstractIndexReaderTest {
                             .join()
                             .get();
             assertResult(result, expected);
+            assertThat(result.isExact()).isFalse();
         }
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -444,6 +444,50 @@ public abstract class AbstractIndexReaderTest {
         }
     }
 
+    @TestTemplate
+    public void testScalarSearchFallsBackWhenSparseCandidatesExceedScanBudget() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        RoaringNavigableMap64 candidates = new RoaringNavigableMap64();
+        candidates.add(data.get(dataNum - 1).getValue());
+        ScalarSearch search =
+                new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, 1))
+                        .withIncludeRowIds(candidates)
+                        .withMaxScannedRowIds(5);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            assertThat(reader.visitScalarSearch(search).join()).isEmpty();
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchFallsBackBeforeDecodingHugeKeyGroup() throws Exception {
+        Object repeatedKey = data.get(0).getKey();
+        for (Pair<Object, Long> pair : data) {
+            pair.setLeft(repeatedKey);
+        }
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        ScalarSearch search =
+                new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, 1)).withMaxScannedRowIds(5);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            assertThat(reader.visitScalarSearch(search).join()).isEmpty();
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchFallsBackBeforeScanningHugeNullGroup() throws Exception {
+        for (Pair<Object, Long> pair : data) {
+            pair.setLeft(null);
+        }
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        ScalarSearch search =
+                new ScalarSearch(new TopN(ref, ASCENDING, NULLS_FIRST, 1)).withMaxScannedRowIds(5);
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            assertThat(reader.visitScalarSearch(search).join()).isEmpty();
+        }
+    }
+
     protected abstract GlobalIndexReader prepareDataAndCreateReader() throws Exception;
 
     protected GlobalIndexIOMeta writeData(List<Pair<Object, Long>> data) throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -37,6 +37,8 @@ import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.testutils.junit.parameterized.Parameters;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BooleanType;
@@ -58,6 +60,7 @@ import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.DecimalUtils;
 import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +81,9 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Common test class for BTreeIndexReader. */
@@ -304,6 +310,59 @@ public abstract class AbstractIndexReaderTest {
                             .join()
                             .get();
             Assertions.assertTrue(none.results().isEmpty());
+        }
+    }
+
+    @TestTemplate
+    public void testScalarSearchWithCandidateRows() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        RoaringNavigableMap64 candidates = new RoaringNavigableMap64();
+        for (Pair<Object, Long> pair : data) {
+            if (pair.getValue() % 3 == 0) {
+                candidates.add(pair.getValue());
+            }
+        }
+
+        List<Pair<Object, Long>> selected =
+                data.stream()
+                        .filter(pair -> candidates.contains(pair.getValue()))
+                        .collect(Collectors.toList());
+        int limit = 17;
+
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            Object ascendingBoundary = selected.get(limit - 1).getKey();
+            GlobalIndexResult ascending =
+                    reader.visitScalarSearch(
+                                    new ScalarSearch(new TopN(ref, ASCENDING, NULLS_LAST, limit))
+                                            .withIncludeRowIds(candidates))
+                            .join()
+                            .get();
+            assertResult(
+                    ascending,
+                    selected.stream()
+                            .filter(
+                                    pair ->
+                                            comparator.compare(pair.getKey(), ascendingBoundary)
+                                                    <= 0)
+                            .map(Pair::getValue)
+                            .collect(Collectors.toList()));
+
+            Object descendingBoundary = selected.get(selected.size() - limit).getKey();
+            GlobalIndexResult descending =
+                    reader.visitScalarSearch(
+                                    new ScalarSearch(new TopN(ref, DESCENDING, NULLS_LAST, limit))
+                                            .withIncludeRowIds(candidates))
+                            .join()
+                            .get();
+            assertResult(
+                    descending,
+                    selected.stream()
+                            .filter(
+                                    pair ->
+                                            comparator.compare(pair.getKey(), descendingBoundary)
+                                                    >= 0)
+                            .map(Pair::getValue)
+                            .collect(Collectors.toList()));
         }
     }
 

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
@@ -27,6 +27,8 @@ import org.apache.paimon.globalindex.ResultEntry;
 import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.testutils.junit.parameterized.ParameterizedTestExtension;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.utils.Pair;
@@ -52,6 +54,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
 import static org.apache.paimon.shade.guava30.com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,6 +95,26 @@ public class LazyFilteredBTreeIndexReaderTest extends AbstractIndexReaderTest {
             }
         }
         return -1;
+    }
+
+    @TestTemplate
+    public void testScalarSearchFallsBackForIndexFileBudgets() throws Exception {
+        List<GlobalIndexIOMeta> written = writeData();
+        long totalSize = 0;
+        for (GlobalIndexIOMeta meta : written) {
+            totalSize += meta.fileSize();
+        }
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        TopN topN = new TopN(ref, ASCENDING, NULLS_LAST, 1);
+
+        try (GlobalIndexReader reader =
+                globalIndexer.createReader(fileReader, written, newDirectExecutorService())) {
+            ScalarSearch fileLimited = new ScalarSearch(topN).withMaxIndexFiles(written.size() - 1);
+            assertThat(reader.visitScalarSearch(fileLimited).join()).isEmpty();
+
+            ScalarSearch byteLimited = new ScalarSearch(topN).withMaxIndexBytes(totalSize - 1);
+            assertThat(reader.visitScalarSearch(byteLimited).join()).isEmpty();
+        }
     }
 
     @TestTemplate

--- a/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
@@ -87,6 +87,7 @@ public class BlockIteratorTest {
 
         // 3. test reverse iteration
         iterator.seekToLast();
+        Assertions.assertFalse(iterator.hasNext());
         int expected = ROW_NUM - 1;
         while (iterator.hasPrevious()) {
             Map.Entry<MemorySlice, MemorySlice> reverseEntry = iterator.previous();
@@ -97,6 +98,12 @@ public class BlockIteratorTest {
             expected--;
         }
         Assertions.assertEquals(-1, expected);
+
+        keyOut.reset();
+        keyOut.writeInt(0);
+        iterator.seekTo(keyOut.toSlice());
+        Assertions.assertFalse(iterator.hasPrevious());
+        Assertions.assertTrue(iterator.hasNext());
     }
 
     private MemorySlice writeBlock(boolean aligned) throws IOException {

--- a/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/sst/BlockIteratorTest.java
@@ -84,6 +84,19 @@ public class BlockIteratorTest {
         keyOut.writeInt(ROW_NUM * 2 + 2);
         iterator.seekTo(keyOut.toSlice());
         Assertions.assertFalse(iterator.hasNext());
+
+        // 3. test reverse iteration
+        iterator.seekToLast();
+        int expected = ROW_NUM - 1;
+        while (iterator.hasPrevious()) {
+            Map.Entry<MemorySlice, MemorySlice> reverseEntry = iterator.previous();
+            Assertions.assertEquals(expected * 2, reverseEntry.getKey().readInt(0));
+            Assertions.assertArrayEquals(
+                    constructValue(valueOut, aligned, expected),
+                    reverseEntry.getValue().copyBytes());
+            expected--;
+        }
+        Assertions.assertEquals(-1, expected);
     }
 
     private MemorySlice writeBlock(boolean aligned) throws IOException {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -31,6 +31,7 @@ import org.apache.paimon.predicate.Or;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.predicate.RowIdPredicateVisitor;
+import org.apache.paimon.predicate.ScalarSearch;
 import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.AppendBatchTableScan;
@@ -41,6 +42,7 @@ import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import org.slf4j.Logger;
@@ -68,6 +70,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private final AppendBatchTableScan batchScan;
 
     private Predicate filter;
+    private TopN topN;
+    private RoaringNavigableMap64 topNRowIdFilter;
     private RowRangeIndex pushedRowRangeIndex;
     private GlobalIndexResult globalIndexResult;
 
@@ -148,7 +152,13 @@ public class DataEvolutionBatchScan implements DataTableScan {
 
     @Override
     public InnerTableScan withTopN(TopN topN) {
-        batchScan.withTopN(topN);
+        this.topN = topN;
+        return this;
+    }
+
+    @Override
+    public InnerTableScan withTopNRowIdFilter(RoaringNavigableMap64 rowIds) {
+        this.topNRowIdFilter = rowIds;
         return this;
     }
 
@@ -265,9 +275,13 @@ public class DataEvolutionBatchScan implements DataTableScan {
                     scoreGetter = ((ScoredGlobalIndexResult) result).scoreGetter();
                 }
             }
+            if (rowRangeIndex == null && topNRowIdFilter != null) {
+                rowRangeIndex = RowRangeIndex.create(topNRowIdFilter.toRangeList());
+            }
         }
 
         if (rowRangeIndex == null) {
+            batchScan.withTopN(topN);
             return batchScan.plan();
         }
 
@@ -279,26 +293,62 @@ public class DataEvolutionBatchScan implements DataTableScan {
         if (this.globalIndexResult != null) {
             return Optional.of(globalIndexResult);
         }
-        if (filter == null) {
+        if (filter == null && topN == null) {
             return Optional.empty();
         }
         CoreOptions options = table.coreOptions();
         if (!options.globalIndexEnabled()) {
             return Optional.empty();
         }
-        Predicate globalIndexFilter = rowIdSafeResidualFilter(filter);
-        if (globalIndexFilter == null) {
+        Predicate globalIndexFilter = filter == null ? null : rowIdSafeResidualFilter(filter);
+        if (filter != null && globalIndexFilter == null) {
             return Optional.empty();
         }
         PartitionPredicate partitionFilter =
                 batchScan.snapshotReader().manifestsReader().partitionFilter();
         Optional<GlobalIndexScanner> optionalScanner =
-                GlobalIndexScanner.create(table, partitionFilter, globalIndexFilter);
+                GlobalIndexScanner.create(table, partitionFilter, globalIndexFilter, topN);
         if (!optionalScanner.isPresent()) {
             return Optional.empty();
         }
 
         try (GlobalIndexScanner scanner = optionalScanner.get()) {
+            if (topN != null) {
+                RoaringNavigableMap64 includeRowIds = null;
+                if (topNRowIdFilter != null) {
+                    includeRowIds = new RoaringNavigableMap64();
+                    includeRowIds.or(topNRowIdFilter);
+                }
+                if (globalIndexFilter != null) {
+                    Optional<GlobalIndexResult> filterResult = scanner.scan(globalIndexFilter);
+                    if (!filterResult.isPresent()
+                            || intersectsUnindexedRows(
+                                    includeRowIds,
+                                    scanner.unindexedRowsForCorrectness(globalIndexFilter))) {
+                        return Optional.empty();
+                    }
+                    if (includeRowIds == null) {
+                        includeRowIds = filterResult.get().results();
+                    } else {
+                        includeRowIds.and(filterResult.get().results());
+                    }
+                }
+
+                String orderFieldName = topN.orders().get(0).field().name();
+                int orderFieldId = table.rowType().getField(orderFieldName).id();
+                if (intersectsUnindexedRows(
+                        includeRowIds, scanner.unindexedRowsForCorrectness(orderFieldId))) {
+                    return Optional.empty();
+                }
+
+                Optional<GlobalIndexResult> result =
+                        scanner.scan(new ScalarSearch(topN).withIncludeRowIds(includeRowIds));
+                if (result.isPresent()) {
+                    LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
+                }
+                return result;
+            }
+
             Optional<GlobalIndexResult> result = scanner.scan(globalIndexFilter);
             if (result.isPresent()) {
                 LOG.info("Scan table '{}' with global index.", table.name());
@@ -308,6 +358,20 @@ public class DataEvolutionBatchScan implements DataTableScan {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private boolean intersectsUnindexedRows(
+            @Nullable RoaringNavigableMap64 includeRowIds, GlobalIndexResult unindexedRows) {
+        if (unindexedRows.results().isEmpty()) {
+            return false;
+        }
+        if (includeRowIds == null) {
+            return true;
+        }
+        RoaringNavigableMap64 intersection = new RoaringNavigableMap64();
+        intersection.or(unindexedRows.results());
+        intersection.and(includeRowIds);
+        return !intersection.isEmpty();
     }
 
     @VisibleForTesting

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -69,6 +69,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionBatchScan.class);
     private static final int MAX_SCALAR_TOPN_LIMIT = 100;
     private static final long MAX_SCALAR_TOPN_RESULT_SIZE = 10_000L;
+    private static final long MAX_SCALAR_TOPN_SCANNED_ROW_IDS = 100_000L;
 
     private final FileStoreTable table;
     private final AppendBatchTableScan batchScan;
@@ -376,7 +377,8 @@ public class DataEvolutionBatchScan implements DataTableScan {
                         scanner.scan(
                                 new ScalarSearch(topN)
                                         .withIncludeRowIds(includeRowIds)
-                                        .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE));
+                                        .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE)
+                                        .withMaxScannedRowIds(MAX_SCALAR_TOPN_SCANNED_ROW_IDS));
                 if (result.isPresent()) {
                     LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
                 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -38,6 +38,7 @@ import org.apache.paimon.table.source.AppendBatchTableScan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
@@ -60,11 +61,14 @@ import java.util.function.Function;
 
 import static org.apache.paimon.table.SpecialFields.ROW_ID;
 import static org.apache.paimon.utils.ManifestReadThreadPool.randomlyExecuteSequentialReturn;
+import static org.apache.paimon.utils.Preconditions.checkState;
 
 /** Scan for data evolution table. */
 public class DataEvolutionBatchScan implements DataTableScan {
 
     private static final Logger LOG = LoggerFactory.getLogger(DataEvolutionBatchScan.class);
+    private static final int MAX_SCALAR_TOPN_LIMIT = 100;
+    private static final long MAX_SCALAR_TOPN_RESULT_SIZE = 10_000L;
 
     private final FileStoreTable table;
     private final AppendBatchTableScan batchScan;
@@ -72,6 +76,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private Predicate filter;
     private TopN topN;
     private RoaringNavigableMap64 topNRowIdFilter;
+    private boolean pushedLimit;
     private RowRangeIndex pushedRowRangeIndex;
     private GlobalIndexResult globalIndexResult;
 
@@ -176,6 +181,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
 
     @Override
     public InnerTableScan withLimit(int limit) {
+        this.pushedLimit = true;
         batchScan.withLimit(limit);
         return this;
     }
@@ -263,6 +269,14 @@ public class DataEvolutionBatchScan implements DataTableScan {
 
     @Override
     public Plan plan() {
+        checkState(
+                topNRowIdFilter == null || topN != null,
+                "TopN row ID filter requires a TopN definition.");
+        checkState(topN == null || topN.limit() >= 0, "TopN limit must not be negative.");
+        if (topN != null && topN.limit() == 0) {
+            return () -> Collections.emptyList();
+        }
+
         RowRangeIndex rowRangeIndex = this.pushedRowRangeIndex;
         ScoreGetter scoreGetter = null;
 
@@ -278,6 +292,10 @@ public class DataEvolutionBatchScan implements DataTableScan {
             if (rowRangeIndex == null && topNRowIdFilter != null) {
                 rowRangeIndex = RowRangeIndex.create(topNRowIdFilter.toRangeList());
             }
+        }
+
+        if (rowRangeIndex != null && rowRangeIndex.ranges().isEmpty()) {
+            return () -> Collections.emptyList();
         }
 
         if (rowRangeIndex == null) {
@@ -296,8 +314,16 @@ public class DataEvolutionBatchScan implements DataTableScan {
         if (filter == null && topN == null) {
             return Optional.empty();
         }
+        if (topN != null
+                && topNRowIdFilter != null
+                && topNRowIdFilter.getLongCardinality() <= topN.limit()) {
+            return Optional.of(GlobalIndexResult.create(copy(topNRowIdFilter)));
+        }
         CoreOptions options = table.coreOptions();
         if (!options.globalIndexEnabled()) {
+            return Optional.empty();
+        }
+        if (topN != null && !canUseScalarTopN(options)) {
             return Optional.empty();
         }
         Predicate globalIndexFilter = filter == null ? null : rowIdSafeResidualFilter(filter);
@@ -322,6 +348,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
                 if (globalIndexFilter != null) {
                     Optional<GlobalIndexResult> filterResult = scanner.scan(globalIndexFilter);
                     if (!filterResult.isPresent()
+                            || !filterResult.get().isExact()
                             || intersectsUnindexedRows(
                                     includeRowIds,
                                     scanner.unindexedRowsForCorrectness(globalIndexFilter))) {
@@ -334,6 +361,10 @@ public class DataEvolutionBatchScan implements DataTableScan {
                     }
                 }
 
+                if (includeRowIds != null && includeRowIds.getLongCardinality() <= topN.limit()) {
+                    return Optional.of(GlobalIndexResult.create(includeRowIds));
+                }
+
                 String orderFieldName = topN.orders().get(0).field().name();
                 int orderFieldId = table.rowType().getField(orderFieldName).id();
                 if (intersectsUnindexedRows(
@@ -342,7 +373,10 @@ public class DataEvolutionBatchScan implements DataTableScan {
                 }
 
                 Optional<GlobalIndexResult> result =
-                        scanner.scan(new ScalarSearch(topN).withIncludeRowIds(includeRowIds));
+                        scanner.scan(
+                                new ScalarSearch(topN)
+                                        .withIncludeRowIds(includeRowIds)
+                                        .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE));
                 if (result.isPresent()) {
                     LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
                 }
@@ -358,6 +392,20 @@ public class DataEvolutionBatchScan implements DataTableScan {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private boolean canUseScalarTopN(CoreOptions options) {
+        return topN.orders().size() == 1
+                && topN.limit() <= MAX_SCALAR_TOPN_LIMIT
+                && !pushedLimit
+                && !options.queryAuthEnabled()
+                && !options.deletionVectorsEnabled();
+    }
+
+    private RoaringNavigableMap64 copy(RoaringNavigableMap64 rowIds) {
+        RoaringNavigableMap64 copy = new RoaringNavigableMap64();
+        copy.or(rowIds);
+        return copy;
     }
 
     private boolean intersectsUnindexedRows(
@@ -378,14 +426,24 @@ public class DataEvolutionBatchScan implements DataTableScan {
     public static Plan wrapToIndexSplits(
             List<Split> splits, RowRangeIndex rowRangeIndex, ScoreGetter scoreGetter) {
         List<Split> indexedSplits = new ArrayList<>();
-        Function<Split, List<IndexedSplit>> process =
-                split ->
-                        Collections.singletonList(
-                                split instanceof IndexedSplit
-                                        ? (IndexedSplit) split
-                                        : wrap((DataSplit) split, rowRangeIndex, scoreGetter));
+        Function<Split, List<Split>> process =
+                split -> Collections.singletonList(wrapSplit(split, rowRangeIndex, scoreGetter));
         randomlyExecuteSequentialReturn(process, splits, null).forEachRemaining(indexedSplits::add);
         return () -> indexedSplits;
+    }
+
+    private static Split wrapSplit(
+            Split split, RowRangeIndex rowRangeIndex, ScoreGetter scoreGetter) {
+        if (split instanceof QueryAuthSplit) {
+            QueryAuthSplit authSplit = (QueryAuthSplit) split;
+            return new QueryAuthSplit(
+                    wrapSplit(authSplit.split(), rowRangeIndex, scoreGetter),
+                    authSplit.authResult());
+        }
+        if (split instanceof IndexedSplit) {
+            return split;
+        }
+        return wrap((DataSplit) split, rowRangeIndex, scoreGetter);
     }
 
     private static IndexedSplit wrap(

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -70,6 +70,7 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private static final int MAX_SCALAR_TOPN_LIMIT = 100;
     private static final long MAX_SCALAR_TOPN_RESULT_SIZE = 10_000L;
     private static final long MAX_SCALAR_TOPN_SCANNED_ROW_IDS = 100_000L;
+    private static final long MAX_SCALAR_TOPN_READ_BLOCK_SIZE = 1024L * 1024L;
 
     private final FileStoreTable table;
     private final AppendBatchTableScan batchScan;
@@ -318,82 +319,119 @@ public class DataEvolutionBatchScan implements DataTableScan {
         if (topN != null
                 && topNRowIdFilter != null
                 && topNRowIdFilter.getLongCardinality() <= topN.limit()) {
-            return Optional.of(GlobalIndexResult.create(copy(topNRowIdFilter)));
+            return Optional.of(GlobalIndexResult.create(copy(topNRowIdFilter), filter == null));
         }
         CoreOptions options = table.coreOptions();
         if (!options.globalIndexEnabled()) {
             return Optional.empty();
         }
-        if (topN != null && !canUseScalarTopN(options)) {
-            return Optional.empty();
-        }
         Predicate globalIndexFilter = filter == null ? null : rowIdSafeResidualFilter(filter);
-        if (filter != null && globalIndexFilter == null) {
+        boolean scalarTopNEnabled =
+                topN != null
+                        && canUseScalarTopN(options)
+                        && (filter == null || globalIndexFilter != null);
+        TopN indexTopN = scalarTopNEnabled ? topN : null;
+        if (globalIndexFilter == null && indexTopN == null) {
             return Optional.empty();
         }
         PartitionPredicate partitionFilter =
                 batchScan.snapshotReader().manifestsReader().partitionFilter();
         Optional<GlobalIndexScanner> optionalScanner =
-                GlobalIndexScanner.create(table, partitionFilter, globalIndexFilter, topN);
+                GlobalIndexScanner.create(table, partitionFilter, globalIndexFilter, indexTopN);
         if (!optionalScanner.isPresent()) {
             return Optional.empty();
         }
 
         try (GlobalIndexScanner scanner = optionalScanner.get()) {
-            if (topN != null) {
-                RoaringNavigableMap64 includeRowIds = null;
-                if (topNRowIdFilter != null) {
-                    includeRowIds = new RoaringNavigableMap64();
-                    includeRowIds.or(topNRowIdFilter);
+            Optional<GlobalIndexResult> filterResult = Optional.empty();
+            Optional<GlobalIndexResult> predicateCandidates = Optional.empty();
+            if (globalIndexFilter != null) {
+                filterResult = scanner.scan(globalIndexFilter);
+                if (filterResult.isPresent()) {
+                    GlobalIndexResult unindexedRows = scanner.unindexedRows(globalIndexFilter);
+                    predicateCandidates =
+                            Optional.of(
+                                    filterResult
+                                            .get()
+                                            .or(unindexedRows)
+                                            .withExact(
+                                                    filterResult.get().isExact()
+                                                            && unindexedRows.results().isEmpty()));
                 }
-                if (globalIndexFilter != null) {
-                    Optional<GlobalIndexResult> filterResult = scanner.scan(globalIndexFilter);
-                    if (!filterResult.isPresent()
-                            || !filterResult.get().isExact()
-                            || intersectsUnindexedRows(
-                                    includeRowIds,
-                                    scanner.unindexedRowsForCorrectness(globalIndexFilter))) {
-                        return Optional.empty();
-                    }
-                    if (includeRowIds == null) {
-                        includeRowIds = filterResult.get().results();
-                    } else {
-                        includeRowIds.and(filterResult.get().results());
-                    }
-                }
+            }
 
-                if (includeRowIds != null && includeRowIds.getLongCardinality() <= topN.limit()) {
-                    return Optional.of(GlobalIndexResult.create(includeRowIds));
+            if (topN == null) {
+                if (predicateCandidates.isPresent()) {
+                    LOG.info("Scan table '{}' with global index.", table.name());
                 }
+                return predicateCandidates;
+            }
 
-                String orderFieldName = topN.orders().get(0).field().name();
-                int orderFieldId = table.rowType().getField(orderFieldName).id();
-                if (intersectsUnindexedRows(
-                        includeRowIds, scanner.unindexedRowsForCorrectness(orderFieldId))) {
-                    return Optional.empty();
-                }
+            Optional<GlobalIndexResult> fallbackResult =
+                    intersectTopNRowIdFilter(predicateCandidates);
+            if (!scalarTopNEnabled) {
+                return fallbackResult;
+            }
 
-                Optional<GlobalIndexResult> result =
-                        scanner.scan(
-                                new ScalarSearch(topN)
-                                        .withIncludeRowIds(includeRowIds)
-                                        .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE)
-                                        .withMaxScannedRowIds(MAX_SCALAR_TOPN_SCANNED_ROW_IDS));
-                if (result.isPresent()) {
-                    LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
+            RoaringNavigableMap64 includeRowIds = null;
+            if (topNRowIdFilter != null) {
+                includeRowIds = copy(topNRowIdFilter);
+            }
+            if (globalIndexFilter != null) {
+                if (!filterResult.isPresent()
+                        || !filterResult.get().isExact()
+                        || intersectsUnindexedRows(
+                                includeRowIds,
+                                scanner.unindexedRowsForCorrectness(globalIndexFilter))) {
+                    return fallbackResult;
                 }
+                if (includeRowIds == null) {
+                    includeRowIds = filterResult.get().results();
+                } else {
+                    includeRowIds.and(filterResult.get().results());
+                }
+            }
+
+            if (includeRowIds != null && includeRowIds.getLongCardinality() <= topN.limit()) {
+                return Optional.of(GlobalIndexResult.createExact(includeRowIds));
+            }
+
+            String orderFieldName = topN.orders().get(0).field().name();
+            int orderFieldId = table.rowType().getField(orderFieldName).id();
+            if (intersectsUnindexedRows(
+                    includeRowIds, scanner.unindexedRowsForCorrectness(orderFieldId))) {
+                return fallbackResult;
+            }
+
+            Optional<GlobalIndexResult> result =
+                    scanner.scan(
+                            new ScalarSearch(topN)
+                                    .withIncludeRowIds(includeRowIds)
+                                    .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE)
+                                    .withMaxScannedRowIds(MAX_SCALAR_TOPN_SCANNED_ROW_IDS)
+                                    .withMaxReadBlockSize(MAX_SCALAR_TOPN_READ_BLOCK_SIZE));
+            if (result.isPresent()) {
+                LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
                 return result;
             }
-
-            Optional<GlobalIndexResult> result = scanner.scan(globalIndexFilter);
-            if (result.isPresent()) {
-                LOG.info("Scan table '{}' with global index.", table.name());
-                return Optional.of(result.get().or(scanner.unindexedRows(globalIndexFilter)));
-            }
-            return Optional.empty();
+            return fallbackResult;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private Optional<GlobalIndexResult> intersectTopNRowIdFilter(
+            Optional<GlobalIndexResult> candidates) {
+        if (topNRowIdFilter == null) {
+            return candidates;
+        }
+        RoaringNavigableMap64 intersection = copy(topNRowIdFilter);
+        boolean exact = filter == null;
+        if (candidates.isPresent()) {
+            intersection.and(candidates.get().results());
+            exact = candidates.get().isExact();
+        }
+        return Optional.of(GlobalIndexResult.create(intersection, exact));
     }
 
     private boolean canUseScalarTopN(CoreOptions options) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -71,6 +71,9 @@ public class DataEvolutionBatchScan implements DataTableScan {
     private static final long MAX_SCALAR_TOPN_RESULT_SIZE = 10_000L;
     private static final long MAX_SCALAR_TOPN_SCANNED_ROW_IDS = 100_000L;
     private static final long MAX_SCALAR_TOPN_READ_BLOCK_SIZE = 1024L * 1024L;
+    private static final int MAX_SCALAR_TOPN_INDEX_FILES = 128;
+    private static final long MAX_SCALAR_TOPN_INDEX_BYTES = 1024L * 1024L * 1024L;
+    private static final int MAX_SCALAR_TOPN_CONCURRENT_READERS = 8;
 
     private final FileStoreTable table;
     private final AppendBatchTableScan batchScan;
@@ -409,7 +412,10 @@ public class DataEvolutionBatchScan implements DataTableScan {
                                     .withIncludeRowIds(includeRowIds)
                                     .withMaxResultSize(MAX_SCALAR_TOPN_RESULT_SIZE)
                                     .withMaxScannedRowIds(MAX_SCALAR_TOPN_SCANNED_ROW_IDS)
-                                    .withMaxReadBlockSize(MAX_SCALAR_TOPN_READ_BLOCK_SIZE));
+                                    .withMaxReadBlockSize(MAX_SCALAR_TOPN_READ_BLOCK_SIZE)
+                                    .withMaxIndexFiles(MAX_SCALAR_TOPN_INDEX_FILES)
+                                    .withMaxIndexBytes(MAX_SCALAR_TOPN_INDEX_BYTES)
+                                    .withMaxConcurrentReaders(MAX_SCALAR_TOPN_CONCURRENT_READERS));
             if (result.isPresent()) {
                 LOG.info("Scan table '{}' with scalar global index TopN.", table.name());
                 return result;

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
@@ -110,6 +110,15 @@ public class GlobalIndexCoverage {
         return Range.sortAndMergeOverlap(unindexedRanges, true);
     }
 
+    public List<Range> unindexedRangesForCorrectness(Collection<Integer> fieldIds) {
+        if (snapshot == null || snapshot.nextRowId() == null || snapshot.nextRowId() <= 0) {
+            return Collections.emptyList();
+        }
+
+        List<Range> indexedRanges = Range.sortAndMergeOverlap(indexedRanges(fieldIds), true);
+        return new Range(0, snapshot.nextRowId() - 1).exclude(indexedRanges);
+    }
+
     private void addCoverage(int fieldId, Range range) {
         coverageByField.computeIfAbsent(fieldId, k -> new ArrayList<>()).add(range);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
@@ -52,6 +52,8 @@ public class GlobalIndexCoverage {
     @Nullable private final Snapshot snapshot;
     @Nullable private final PartitionPredicate partitionFilter;
     private final Map<Integer, List<Range>> coverageByField;
+    @Nullable private List<Range> dataRangesByDataFiles;
+    private boolean dataRangesComplete;
 
     public GlobalIndexCoverage(
             FileStoreTable table,
@@ -62,6 +64,7 @@ public class GlobalIndexCoverage {
         this.snapshot = snapshot;
         this.partitionFilter = partitionFilter;
         this.coverageByField = new HashMap<>();
+        this.dataRangesComplete = true;
         for (IndexFileMeta indexFile : indexFiles) {
             GlobalIndexMeta meta = checkNotNull(indexFile.globalIndexMeta());
             if (meta.sourceMeta() != null) {
@@ -116,7 +119,16 @@ public class GlobalIndexCoverage {
         }
 
         List<Range> indexedRanges = Range.sortAndMergeOverlap(indexedRanges(fieldIds), true);
-        return new Range(0, snapshot.nextRowId() - 1).exclude(indexedRanges);
+        List<Range> dataRanges = dataRangesByDataFiles();
+        if (!dataRangesComplete) {
+            return new Range(0, snapshot.nextRowId() - 1).exclude(indexedRanges);
+        }
+
+        List<Range> unindexedRanges = new ArrayList<>();
+        for (Range dataRange : Range.sortAndMergeOverlap(dataRanges, true)) {
+            unindexedRanges.addAll(dataRange.exclude(indexedRanges));
+        }
+        return Range.sortAndMergeOverlap(unindexedRanges, true);
     }
 
     private void addCoverage(int fieldId, Range range) {
@@ -137,6 +149,9 @@ public class GlobalIndexCoverage {
     }
 
     private List<Range> dataRangesByDataFiles() {
+        if (dataRangesByDataFiles != null) {
+            return dataRangesByDataFiles;
+        }
         SnapshotReader snapshotReader =
                 table.newSnapshotReader()
                         .withPartitionFilter(partitionFilter)
@@ -150,9 +165,12 @@ public class GlobalIndexCoverage {
             for (DataFileMeta file : ((DataSplit) split).dataFiles()) {
                 if (file.firstRowId() != null) {
                     dataRanges.add(file.nonNullRowIdRange());
+                } else {
+                    dataRangesComplete = false;
                 }
             }
         }
-        return dataRanges;
+        dataRangesByDataFiles = dataRanges;
+        return dataRangesByDataFiles;
     }
 }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexCoverage.java
@@ -119,9 +119,13 @@ public class GlobalIndexCoverage {
         }
 
         List<Range> indexedRanges = Range.sortAndMergeOverlap(indexedRanges(fieldIds), true);
+        List<Range> snapshotGaps = new Range(0, snapshot.nextRowId() - 1).exclude(indexedRanges);
+        if (snapshotGaps.isEmpty()) {
+            return Collections.emptyList();
+        }
         List<Range> dataRanges = dataRangesByDataFiles();
         if (!dataRangesComplete) {
-            return new Range(0, snapshot.nextRowId() - 1).exclude(indexedRanges);
+            return snapshotGaps;
         }
 
         List<Range> unindexedRanges = new ArrayList<>();

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -308,14 +308,6 @@ public class GlobalIndexScanner implements Closeable {
         return GlobalIndexResult.create(rows);
     }
 
-    public GlobalIndexResult unindexedRows(int fieldId) {
-        RoaringNavigableMap64 rows = new RoaringNavigableMap64();
-        for (Range range : coverage.unindexedRanges(fieldId)) {
-            rows.addRange(range);
-        }
-        return GlobalIndexResult.create(rows);
-    }
-
     public GlobalIndexResult unindexedRowsForCorrectness(Predicate predicate) {
         return unindexedRowsForCorrectness(collectFieldIds(rowType, predicate));
     }

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -251,7 +251,7 @@ public class GlobalIndexScanner implements Closeable {
             return entry -> false;
         }
         Set<Integer> filterFieldIds = new HashSet<>(collectFieldIds(table.rowType(), filter));
-        if (topN != null) {
+        if (topN != null && topN.orders().size() == 1) {
             String fieldName = topN.orders().get(0).field().name();
             filterFieldIds.add(table.rowType().getField(fieldName).id());
         }
@@ -297,6 +297,9 @@ public class GlobalIndexScanner implements Closeable {
     }
 
     public Optional<GlobalIndexResult> scan(ScalarSearch scalarSearch) {
+        if (scalarSearch.topN().orders().size() != 1) {
+            return Optional.empty();
+        }
         return globalIndexEvaluator.evaluateScalarSearch(scalarSearch);
     }
 
@@ -305,7 +308,7 @@ public class GlobalIndexScanner implements Closeable {
         for (Range range : coverage.unindexedRanges(rowType, predicate)) {
             rows.addRange(range);
         }
-        return GlobalIndexResult.create(rows);
+        return GlobalIndexResult.createExact(rows);
     }
 
     public GlobalIndexResult unindexedRowsForCorrectness(Predicate predicate) {
@@ -321,7 +324,7 @@ public class GlobalIndexScanner implements Closeable {
         for (Range range : coverage.unindexedRangesForCorrectness(fieldIds)) {
             rows.addRange(range);
         }
-        return GlobalIndexResult.create(rows);
+        return GlobalIndexResult.createExact(rows);
     }
 
     private Collection<GlobalIndexReader> createReaders(

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -29,6 +29,8 @@ import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.ScalarSearch;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.RowType;
@@ -210,10 +212,19 @@ public class GlobalIndexScanner implements Closeable {
             FileStoreTable table,
             @Nullable PartitionPredicate partitionFilter,
             @Nullable Predicate filter) {
+        return create(table, partitionFilter, filter, null);
+    }
+
+    public static Optional<GlobalIndexScanner> create(
+            FileStoreTable table,
+            @Nullable PartitionPredicate partitionFilter,
+            @Nullable Predicate filter,
+            @Nullable TopN topN) {
         @Nullable Snapshot snapshot = tryTravelOrLatest(table);
         List<IndexFileMeta> indexFiles =
                 table.store().newIndexFileHandler()
-                        .scan(snapshot, indexFileFilter(table, partitionFilter, filter)).stream()
+                        .scan(snapshot, indexFileFilter(table, partitionFilter, filter, topN))
+                        .stream()
                         .map(IndexManifestEntry::indexFile)
                         .collect(Collectors.toList());
         if (indexFiles.isEmpty()) {
@@ -234,11 +245,16 @@ public class GlobalIndexScanner implements Closeable {
     private static Filter<IndexManifestEntry> indexFileFilter(
             FileStoreTable table,
             @Nullable PartitionPredicate partitionFilter,
-            @Nullable Predicate filter) {
-        if (filter == null) {
+            @Nullable Predicate filter,
+            @Nullable TopN topN) {
+        if (filter == null && topN == null) {
             return entry -> false;
         }
-        Set<Integer> filterFieldIds = collectFieldIds(table.rowType(), filter);
+        Set<Integer> filterFieldIds = new HashSet<>(collectFieldIds(table.rowType(), filter));
+        if (topN != null) {
+            String fieldName = topN.orders().get(0).field().name();
+            filterFieldIds.add(table.rowType().getField(fieldName).id());
+        }
         Filter<IndexManifestEntry> indexFileFilter =
                 entry -> {
                     if (partitionFilter != null && !partitionFilter.test(entry.partition())) {
@@ -280,9 +296,37 @@ public class GlobalIndexScanner implements Closeable {
         return globalIndexEvaluator.evaluate(predicate);
     }
 
+    public Optional<GlobalIndexResult> scan(ScalarSearch scalarSearch) {
+        return globalIndexEvaluator.evaluateScalarSearch(scalarSearch);
+    }
+
     public GlobalIndexResult unindexedRows(Predicate predicate) {
         RoaringNavigableMap64 rows = new RoaringNavigableMap64();
         for (Range range : coverage.unindexedRanges(rowType, predicate)) {
+            rows.addRange(range);
+        }
+        return GlobalIndexResult.create(rows);
+    }
+
+    public GlobalIndexResult unindexedRows(int fieldId) {
+        RoaringNavigableMap64 rows = new RoaringNavigableMap64();
+        for (Range range : coverage.unindexedRanges(fieldId)) {
+            rows.addRange(range);
+        }
+        return GlobalIndexResult.create(rows);
+    }
+
+    public GlobalIndexResult unindexedRowsForCorrectness(Predicate predicate) {
+        return unindexedRowsForCorrectness(collectFieldIds(rowType, predicate));
+    }
+
+    public GlobalIndexResult unindexedRowsForCorrectness(int fieldId) {
+        return unindexedRowsForCorrectness(Collections.singleton(fieldId));
+    }
+
+    private GlobalIndexResult unindexedRowsForCorrectness(Collection<Integer> fieldIds) {
+        RoaringNavigableMap64 rows = new RoaringNavigableMap64();
+        for (Range range : coverage.unindexedRangesForCorrectness(fieldIds)) {
             rows.addRange(range);
         }
         return GlobalIndexResult.create(rows);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -206,6 +206,7 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
                 || pushDownLimit != null
                 || snapshotReader.hasNonPartitionFilter()
                 || authHasNonPartitionFilter
+                || options().deletionVectorsEnabled()
                 || !schema.primaryKeys().isEmpty()) {
             return Optional.empty();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/AbstractBatchTableScan.java
@@ -206,7 +206,6 @@ public abstract class AbstractBatchTableScan extends AbstractDataTableScan {
                 || pushDownLimit != null
                 || snapshotReader.hasNonPartitionFilter()
                 || authHasNonPartitionFilter
-                || options().deletionVectorsEnabled()
                 || !schema.primaryKeys().isEmpty()) {
             return Optional.empty();
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/InnerTableScan.java
@@ -27,6 +27,7 @@ import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import javax.annotation.Nullable;
@@ -100,6 +101,10 @@ public interface InnerTableScan extends TableScan {
 
     default InnerTableScan withTopN(TopN topN) {
         return this;
+    }
+
+    default InnerTableScan withTopNRowIdFilter(RoaringNavigableMap64 rowIds) {
+        throw new UnsupportedOperationException("TopN row ID filtering is not supported.");
     }
 
     default InnerTableScan dropStats() {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScan.java
@@ -527,7 +527,8 @@ public final class PrimaryKeySortedIndexScan {
 
             List<Optional<GlobalIndexResult>> localized = new ArrayList<>(sourceCount);
             for (RoaringNavigableMap64 partition : partitions) {
-                localized.add(Optional.of(GlobalIndexResult.create(partition)));
+                localized.add(
+                        Optional.of(GlobalIndexResult.create(partition, result.get().isExact())));
             }
             return localized;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilder.java
@@ -27,6 +27,7 @@ import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import java.io.Serializable;
@@ -140,6 +141,11 @@ public interface ReadBuilder extends Serializable {
      * is a complete filter.
      */
     ReadBuilder withTopN(TopN topN);
+
+    /** Restrict TopN evaluation to the specified row IDs. */
+    default ReadBuilder withTopNRowIdFilter(RoaringNavigableMap64 rowIds) {
+        throw new UnsupportedOperationException("TopN row ID filtering is not supported.");
+    }
 
     /**
      * Specify the shard to be read, and allocate sharded files to read records. Note that this

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -196,6 +196,9 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     @Override
     public TableScan newScan() {
+        checkState(
+                topNRowIdFilter == null || topN != null,
+                "TopN row ID filter requires a TopN definition.");
         InnerTableScan tableScan = configureScan(table.newScan());
         if (limit != null) {
             tableScan.withLimit(limit);

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/ReadBuilderImpl.java
@@ -32,6 +32,7 @@ import org.apache.paimon.table.InnerTable;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import javax.annotation.Nullable;
@@ -59,6 +60,7 @@ public class ReadBuilderImpl implements ReadBuilder {
 
     private Integer limit = null;
     private TopN topN = null;
+    private RoaringNavigableMap64 topNRowIdFilter = null;
 
     private Integer shardIndexOfThisSubtask;
     private Integer shardNumberOfParallelSubtasks;
@@ -146,6 +148,12 @@ public class ReadBuilderImpl implements ReadBuilder {
     }
 
     @Override
+    public ReadBuilder withTopNRowIdFilter(RoaringNavigableMap64 rowIds) {
+        this.topNRowIdFilter = rowIds;
+        return this;
+    }
+
+    @Override
     public ReadBuilder withShard(int indexOfThisSubtask, int numberOfParallelSubtasks) {
         this.shardIndexOfThisSubtask = indexOfThisSubtask;
         this.shardNumberOfParallelSubtasks = numberOfParallelSubtasks;
@@ -194,6 +202,9 @@ public class ReadBuilderImpl implements ReadBuilder {
         }
         if (topN != null) {
             tableScan.withTopN(topN);
+        }
+        if (topNRowIdFilter != null) {
+            tableScan.withTopNRowIdFilter(topNRowIdFilter);
         }
         return tableScan;
     }

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
@@ -18,19 +18,25 @@
 
 package org.apache.paimon.globalindex;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.TopN;
+import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.AppendBatchTableScan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
+import org.apache.paimon.utils.RoaringNavigableMap64;
 import org.apache.paimon.utils.RowRangeIndex;
 
 import org.junit.jupiter.api.Test;
@@ -42,6 +48,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.apache.paimon.table.SpecialFields.ROW_ID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,6 +118,69 @@ public class DataEvolutionBatchScanTest {
 
         assertThat(returned).isSameAs(scan);
         verify(batchScan).withShard(0, 2);
+    }
+
+    @Test
+    public void testTopNFallsBackWhenQueryAuthEnabled() {
+        CoreOptions options = mock(CoreOptions.class);
+        when(options.globalIndexEnabled()).thenReturn(true);
+        when(options.queryAuthEnabled()).thenReturn(true);
+
+        FileStoreTable table = mock(FileStoreTable.class);
+        when(table.coreOptions()).thenReturn(options);
+
+        AppendBatchTableScan batchScan = mock(AppendBatchTableScan.class);
+        TableScan.Plan fallbackPlan = mock(TableScan.Plan.class);
+        when(batchScan.plan()).thenReturn(fallbackPlan);
+
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        DataEvolutionBatchScan scan = new DataEvolutionBatchScan(table, batchScan);
+        scan.withTopN(topN);
+
+        assertThat(scan.plan()).isSameAs(fallbackPlan);
+        verify(batchScan).withTopN(topN);
+    }
+
+    @Test
+    public void testTopNFallsBackWhenLimitIsAlsoPushed() {
+        CoreOptions options = mock(CoreOptions.class);
+        when(options.globalIndexEnabled()).thenReturn(true);
+
+        FileStoreTable table = mock(FileStoreTable.class);
+        when(table.coreOptions()).thenReturn(options);
+
+        AppendBatchTableScan batchScan = mock(AppendBatchTableScan.class);
+        TableScan.Plan fallbackPlan = mock(TableScan.Plan.class);
+        when(batchScan.plan()).thenReturn(fallbackPlan);
+
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        DataEvolutionBatchScan scan = new DataEvolutionBatchScan(table, batchScan);
+        scan.withLimit(1).withTopN(topN);
+
+        assertThat(scan.plan()).isSameAs(fallbackPlan);
+        verify(batchScan).withLimit(1);
+        verify(batchScan).withTopN(topN);
+    }
+
+    @Test
+    public void testSmallExplicitCandidateSetSkipsIndexEvaluationWithFilter() {
+        AppendBatchTableScan batchScan = mock(AppendBatchTableScan.class);
+        mockSnapshotReader(batchScan);
+        when(batchScan.withRowRangeIndex(any(RowRangeIndex.class))).thenReturn(batchScan);
+        when(batchScan.plan()).thenReturn(() -> Collections.emptyList());
+
+        Predicate filter = new PredicateBuilder(rowTypeWithRowId()).greaterThan(0, 5);
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        RoaringNavigableMap64 candidates = new RoaringNavigableMap64();
+        candidates.add(1L);
+
+        DataEvolutionBatchScan scan = new DataEvolutionBatchScan(null, batchScan);
+        scan.withFilter(filter).withTopN(topN).withTopNRowIdFilter(candidates);
+
+        assertThat(scan.plan().splits()).isEmpty();
+        ArgumentCaptor<RowRangeIndex> captor = ArgumentCaptor.forClass(RowRangeIndex.class);
+        verify(batchScan).withRowRangeIndex(captor.capture());
+        assertThat(captor.getValue().ranges()).containsExactly(new Range(1L, 1L));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexCoverageTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexCoverageTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.apache.paimon.Snapshot;
+import org.apache.paimon.index.GlobalIndexMeta;
+import org.apache.paimon.index.IndexFileMeta;
+import org.apache.paimon.table.FileStoreTable;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link GlobalIndexCoverage}. */
+public class GlobalIndexCoverageTest {
+
+    @Test
+    public void testFullCoverageSkipsDataFileScan() {
+        FileStoreTable table = mock(FileStoreTable.class);
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.nextRowId()).thenReturn(10L);
+
+        IndexFileMeta indexFile = mock(IndexFileMeta.class);
+        when(indexFile.globalIndexMeta()).thenReturn(new GlobalIndexMeta(0, 9, 1, null, null));
+
+        GlobalIndexCoverage coverage =
+                new GlobalIndexCoverage(
+                        table, snapshot, null, Collections.singletonList(indexFile));
+
+        assertThat(coverage.unindexedRangesForCorrectness(Collections.singleton(1))).isEmpty();
+        verify(table, never()).newSnapshotReader();
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -42,12 +42,14 @@ import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
+import org.apache.paimon.utils.RowRangeIndex;
 
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +62,7 @@ import java.util.stream.Collectors;
 import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
 import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** Test for BTree indexed batch scan. */
@@ -198,6 +201,102 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
 
         assertThat(indexedRanges(plan)).containsExactly(new Range(100L, 100L));
         assertThat(readF1(readBuilder, plan)).containsExactly("a100");
+    }
+
+    @Test
+    public void testBTreeTopNFallsBackForResidualPredicate() throws Exception {
+        write(3L);
+        createIndex("f0");
+        createIndex("f1");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        Predicate predicate =
+                new PredicateBuilder(table.rowType()).endsWith(1, BinaryString.fromString("0"));
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate).withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).allMatch(split -> split instanceof DataSplit);
+        assertThat(readF1(readBuilder, plan)).contains("a0");
+    }
+
+    @Test
+    public void testBTreeTopNWithZeroLimitReturnsEmptyPlan() throws Exception {
+        write(3L);
+        createIndex("f0");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 0);
+        ReadBuilder readBuilder = table.newReadBuilder().withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).isEmpty();
+        assertThat(readF1(readBuilder, plan)).isEmpty();
+    }
+
+    @Test
+    public void testBTreeTopNWithEmptyCandidatesReturnsEmptyPlan() throws Exception {
+        write(3L);
+        createIndex("f0");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withTopN(topN)
+                        .withTopNRowIdFilter(new RoaringNavigableMap64());
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).isEmpty();
+        assertThat(readF1(readBuilder, plan)).isEmpty();
+    }
+
+    @Test
+    public void testBTreeTopNSkipsScalarPushdownForLargeLimit() throws Exception {
+        write(200L);
+        createIndex("f0");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 101);
+        TableScan.Plan plan = table.newReadBuilder().withTopN(topN).newScan().plan();
+
+        assertThat(plan.splits()).isNotEmpty();
+        assertThat(plan.splits()).allMatch(split -> split instanceof DataSplit);
+    }
+
+    @Test
+    public void testTopNRowIdFilterRequiresTopN() throws Exception {
+        write(3L);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        RoaringNavigableMap64 candidateRows = new RoaringNavigableMap64();
+        candidateRows.add(1L);
+        ReadBuilder readBuilder = table.newReadBuilder().withTopNRowIdFilter(candidateRows);
+
+        assertThatThrownBy(readBuilder::newScan)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("requires a TopN definition");
+    }
+
+    @Test
+    public void testWrapToIndexSplitsPreservesQueryAuthSplit() throws Exception {
+        write(3L);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        List<Split> authSplits =
+                table.newScan().plan().splits().stream()
+                        .map(split -> new QueryAuthSplit(split, null))
+                        .collect(Collectors.toList());
+        TableScan.Plan plan =
+                DataEvolutionBatchScan.wrapToIndexSplits(
+                        authSplits,
+                        RowRangeIndex.create(Collections.singletonList(new Range(1L, 1L))),
+                        null);
+
+        assertThat(plan.splits()).hasSize(1);
+        assertThat(plan.splits().get(0)).isInstanceOf(QueryAuthSplit.class);
+        assertThat(((QueryAuthSplit) plan.splits().get(0)).split())
+                .isInstanceOf(IndexedSplit.class);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -27,6 +27,7 @@ import org.apache.paimon.globalindex.GlobalIndexCoverage;
 import org.apache.paimon.globalindex.GlobalIndexResult;
 import org.apache.paimon.globalindex.GlobalIndexScanner;
 import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.globalindex.btree.BTreeIndexOptions;
 import org.apache.paimon.globalindex.sorted.SortedGlobalIndexBuilder;
 import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
@@ -35,7 +36,9 @@ import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.SortValue;
 import org.apache.paimon.predicate.TopN;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -60,6 +63,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.ASCENDING;
 import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -101,7 +105,7 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
 
         DataEvolutionBatchScan scan = (DataEvolutionBatchScan) table.newScan();
         RoaringNavigableMap64 finalRowIds = rowIds;
-        scan.withGlobalIndexResult(GlobalIndexResult.create(finalRowIds));
+        scan.withGlobalIndexResult(GlobalIndexResult.createExact(finalRowIds));
 
         List<String> readF1 = new ArrayList<>();
         table.newRead()
@@ -204,7 +208,7 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
     }
 
     @Test
-    public void testBTreeTopNFallsBackForResidualPredicate() throws Exception {
+    public void testBTreeTopNKeepsPredicateCandidatesForResidualPredicate() throws Exception {
         write(3L);
         createIndex("f0");
         createIndex("f1");
@@ -216,8 +220,130 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
         ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate).withTopN(topN);
         TableScan.Plan plan = readBuilder.newScan().plan();
 
-        assertThat(plan.splits()).allMatch(split -> split instanceof DataSplit);
+        assertThat(plan.splits()).allMatch(split -> split instanceof IndexedSplit);
+        assertThat(indexedRanges(plan)).containsExactly(new Range(0L, 2L));
         assertThat(readF1(readBuilder, plan)).contains("a0");
+    }
+
+    @Test
+    public void testPredicateIndexSurvivesUnsupportedScalarTopN() throws Exception {
+        write(1000L);
+        createIndex("f1");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        Predicate predicate =
+                new PredicateBuilder(table.rowType()).equal(1, BinaryString.fromString("a900"));
+        TopN topN =
+                new TopN(
+                        Arrays.asList(
+                                new SortValue(
+                                        new FieldRef(0, "f0", DataTypes.INT()),
+                                        DESCENDING,
+                                        NULLS_LAST),
+                                new SortValue(
+                                        new FieldRef(1, "f1", DataTypes.STRING()),
+                                        ASCENDING,
+                                        NULLS_LAST)),
+                        10);
+        ReadBuilder readBuilder = table.newReadBuilder().withFilter(predicate).withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).allMatch(split -> split instanceof IndexedSplit);
+        assertThat(indexedRanges(plan)).containsExactly(new Range(900L, 900L));
+        assertThat(readF1(readBuilder, plan)).containsExactly("a900");
+    }
+
+    @Test
+    public void testBTreeTopNPushdownAcrossIndexRangesWithBoundaryTies() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.STRING());
+        schemaBuilder.column("f2", DataTypes.STRING());
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.option(BTreeIndexOptions.BTREE_INDEX_RECORDS_PER_RANGE.key(), "2");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (int i = 0; i < 8; i++) {
+                int value = i < 4 ? 1 : i - 2;
+                write.write(
+                        GenericRow.of(
+                                value,
+                                BinaryString.fromString("a" + i),
+                                BinaryString.fromString("b" + i)));
+            }
+            commit.commit(write.prepareCommit());
+        }
+        createIndex("f0");
+
+        table = (FileStoreTable) catalog.getTable(identifier());
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), ASCENDING, NULLS_LAST, 3);
+        ReadBuilder readBuilder = table.newReadBuilder().withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).allMatch(split -> split instanceof IndexedSplit);
+        assertThat(indexedRanges(plan).stream().mapToLong(range -> range.to - range.from + 1).sum())
+                .isEqualTo(4L);
+        List<Integer> values = new ArrayList<>();
+        readBuilder
+                .newRead()
+                .executeFilter()
+                .createReader(plan)
+                .forEachRemaining(row -> values.add(row.getInt(0)));
+        assertThat(values).containsExactly(1, 1, 1, 1);
+    }
+
+    @Test
+    public void testBTreeTopNUsesPartitionScopedCoverage() throws Exception {
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.column("pt", DataTypes.STRING());
+        schemaBuilder.column("f0", DataTypes.INT());
+        schemaBuilder.column("f1", DataTypes.STRING());
+        schemaBuilder.option(CoreOptions.ROW_TRACKING_ENABLED.key(), "true");
+        schemaBuilder.option(CoreOptions.DATA_EVOLUTION_ENABLED.key(), "true");
+        schemaBuilder.partitionKeys("pt");
+        catalog.createTable(identifier(), schemaBuilder.build(), true);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite();
+                BatchTableCommit commit = writeBuilder.newCommit()) {
+            for (int i = 0; i < 3; i++) {
+                write.write(
+                        GenericRow.of(
+                                BinaryString.fromString("p0"),
+                                i,
+                                BinaryString.fromString("p0-" + i)));
+                write.write(
+                        GenericRow.of(
+                                BinaryString.fromString("p1"),
+                                i + 10,
+                                BinaryString.fromString("p1-" + i)));
+            }
+            commit.commit(write.prepareCommit());
+        }
+        createIndex("f0");
+
+        table = (FileStoreTable) catalog.getTable(identifier());
+        TopN topN = new TopN(new FieldRef(1, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder()
+                        .withPartitionFilter(Collections.singletonMap("pt", "p0"))
+                        .withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).allMatch(split -> split instanceof IndexedSplit);
+        List<String> values = new ArrayList<>();
+        readBuilder
+                .newRead()
+                .executeFilter()
+                .createReader(plan)
+                .forEachRemaining(row -> values.add(row.getString(2).toString()));
+        assertThat(values).containsExactly("p0-2");
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -32,8 +32,10 @@ import org.apache.paimon.index.GlobalIndexMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -55,6 +57,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -136,6 +140,64 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
                         });
 
         assertThat(readF1).containsExactly("a200", "a300", "a400", "a56789");
+    }
+
+    @Test
+    public void testBTreeGlobalIndexPredicateTopNPushdown() throws Exception {
+        write(1000L);
+        createIndex("f0");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        RoaringNavigableMap64 candidateRows = new RoaringNavigableMap64();
+        candidateRows.add(100L);
+        candidateRows.add(900L);
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withTopN(topN).withTopNRowIdFilter(candidateRows);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).allMatch(split -> split instanceof IndexedSplit);
+        assertThat(indexedRanges(plan)).containsExactly(new Range(900L, 900L));
+        assertThat(readF1(readBuilder, plan)).containsExactly("a900");
+    }
+
+    @Test
+    public void testBTreeTopNFallsBackForUnindexedTail() throws Exception {
+        write(500L);
+        createIndex("f0");
+        appendRows(500, 1000);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        RoaringNavigableMap64 candidateRows = new RoaringNavigableMap64();
+        candidateRows.add(100L);
+        candidateRows.add(900L);
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withTopN(topN).withTopNRowIdFilter(candidateRows);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(indexedRanges(plan))
+                .containsExactlyInAnyOrder(new Range(100L, 100L), new Range(900L, 900L));
+        assertThat(readF1(readBuilder, plan)).containsExactlyInAnyOrder("a100", "a900");
+    }
+
+    @Test
+    public void testCandidateTopNDoesNotApplyWholeTableSplitPruning() throws Exception {
+        write(500L);
+        appendRows(500, 1000);
+        createIndex("f0");
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        RoaringNavigableMap64 candidateRows = new RoaringNavigableMap64();
+        candidateRows.add(100L);
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder =
+                table.newReadBuilder().withTopN(topN).withTopNRowIdFilter(candidateRows);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(indexedRanges(plan)).containsExactly(new Range(100L, 100L));
+        assertThat(readF1(readBuilder, plan)).containsExactly("a100");
     }
 
     @Test
@@ -420,6 +482,14 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
                 .createReader(plan)
                 .forEachRemaining(row -> readF1.add(row.getString(1).toString()));
         return readF1;
+    }
+
+    private List<Range> indexedRanges(TableScan.Plan plan) {
+        return plan.splits().stream()
+                .map(split -> (IndexedSplit) split)
+                .flatMap(split -> split.rowRanges().stream())
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     private List<String> readF1(FileStoreTable table, Predicate predicate) throws Exception {

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -256,6 +256,7 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
     @Test
     public void testBTreeTopNPushdownAcrossIndexRangesWithBoundaryTies() throws Exception {
         Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.options(schemaDefault().options());
         schemaBuilder.column("f0", DataTypes.INT());
         schemaBuilder.column("f1", DataTypes.STRING());
         schemaBuilder.column("f2", DataTypes.STRING());
@@ -300,6 +301,7 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
     @Test
     public void testBTreeTopNUsesPartitionScopedCoverage() throws Exception {
         Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.options(schemaDefault().options());
         schemaBuilder.column("pt", DataTypes.STRING());
         schemaBuilder.column("f0", DataTypes.INT());
         schemaBuilder.column("f1", DataTypes.STRING());

--- a/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/DataEvolutionDeletionVectorTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.deletionvectors.DeletionVector;
 import org.apache.paimon.deletionvectors.append.BaseAppendDeleteFileMaintainer;
 import org.apache.paimon.format.blob.BlobFileFormat;
 import org.apache.paimon.globalindex.IndexedSplit;
+import org.apache.paimon.globalindex.sorted.SortedGlobalIndexBuilder;
 import org.apache.paimon.index.DeletionVectorMeta;
 import org.apache.paimon.index.IndexFileMeta;
 import org.apache.paimon.io.CompactIncrement;
@@ -42,6 +43,8 @@ import org.apache.paimon.io.DataIncrement;
 import org.apache.paimon.manifest.FileKind;
 import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.manifest.ManifestEntry;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
@@ -74,6 +77,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.deletionvectors.DeletionVectorsIndexFile.DELETION_VECTORS_INDEX;
+import static org.apache.paimon.predicate.SortValue.NullOrdering.NULLS_LAST;
+import static org.apache.paimon.predicate.SortValue.SortDirection.DESCENDING;
 import static org.apache.paimon.table.BucketMode.UNAWARE_BUCKET;
 import static org.apache.paimon.types.VectorType.isVectorStoreFile;
 import static org.apache.paimon.utils.DataEvolutionUtils.retrieveAnchorFile;
@@ -246,6 +251,24 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                         "7|name-7|base-7|7",
                         "8|name-8|base-8|8",
                         "9|name-9|base-9|9");
+    }
+
+    @Test
+    public void testTopNFallsBackWhenDeletionVectorsEnabled() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+        writeBaseRows(table);
+        createBTreeIndex(table, "f0");
+        commitDeletionVectors(table, Collections.singletonList(new DvSpec(new Range(10, 14), 14)));
+
+        table = getTableDefault();
+        TopN topN = new TopN(new FieldRef(0, "f0", DataTypes.INT()), DESCENDING, NULLS_LAST, 1);
+        ReadBuilder readBuilder = table.newReadBuilder().withTopN(topN);
+        TableScan.Plan plan = readBuilder.newScan().plan();
+
+        assertThat(plan.splits()).isNotEmpty();
+        assertThat(plan.splits()).allMatch(split -> split instanceof DataSplit);
+        assertThat(readRows(readBuilder, plan)).contains("13|name-13|base-13|13");
     }
 
     @Test
@@ -667,6 +690,25 @@ public class DataEvolutionDeletionVectorTest extends DataEvolutionTestBase {
                 new DataEvolutionCompactionCommitPreparation(table, snapshot)
                         .prepare(commitMessages));
         commit(table, commitMessages);
+    }
+
+    private void createBTreeIndex(FileStoreTable table, String fieldName) throws Exception {
+        SortedGlobalIndexBuilder builder =
+                new SortedGlobalIndexBuilder(table, "btree").withIndexField(fieldName);
+        List<DataSplit> dataSplits =
+                builder.scan()
+                        .map(org.apache.paimon.utils.Pair::getRight)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Expected scan result when building index."));
+        List<CommitMessage> commitMessages = new ArrayList<>();
+        for (DataSplit dataSplit : dataSplits) {
+            commitMessages.addAll(builder.build(dataSplit, ioManager));
+        }
+        try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
+            commit.commit(commitMessages);
+        }
     }
 
     private void commitDeletionVectors(FileStoreTable table, List<DvSpec> deletionVectorSpecs)

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexBatchScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexBatchScanTest.java
@@ -235,7 +235,7 @@ class PrimaryKeySortedIndexBatchScanTest {
         when(reader.visitEqual(any(), eq(42)))
                 .thenReturn(
                         CompletableFuture.completedFuture(
-                                Optional.of(GlobalIndexResult.create(positions))));
+                                Optional.of(GlobalIndexResult.createExact(positions))));
         return reader;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexResultTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexResultTest.java
@@ -222,7 +222,7 @@ class PrimaryKeySortedIndexResultTest {
         when(reader.visitEqual(any(), any()))
                 .thenReturn(
                         CompletableFuture.completedFuture(
-                                Optional.of(GlobalIndexResult.create(positions))));
+                                Optional.of(GlobalIndexResult.createExact(positions))));
         return reader;
     }
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/PrimaryKeySortedIndexScanTest.java
@@ -182,7 +182,7 @@ class PrimaryKeySortedIndexScanTest {
         when(reader.visitEqual(any(), eq(42)))
                 .thenReturn(
                         CompletableFuture.completedFuture(
-                                Optional.of(GlobalIndexResult.create(positions))));
+                                Optional.of(GlobalIndexResult.createExact(positions))));
         AtomicInteger readersCreated = new AtomicInteger();
 
         PrimaryKeySortedIndexScan.EvaluatedPlan evaluated =
@@ -376,7 +376,8 @@ class PrimaryKeySortedIndexScanTest {
 
     private static CompletableFuture<Optional<GlobalIndexResult>> completedResult(
             RoaringNavigableMap64 positions) {
-        return CompletableFuture.completedFuture(Optional.of(GlobalIndexResult.create(positions)));
+        return CompletableFuture.completedFuture(
+                Optional.of(GlobalIndexResult.createExact(positions)));
     }
 
     private static class CountingRoaringNavigableMap64 extends RoaringNavigableMap64 {

--- a/paimon-eslib/src/main/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexReader.java
+++ b/paimon-eslib/src/main/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexReader.java
@@ -1432,7 +1432,7 @@ public class ESIndexGlobalIndexReader implements GlobalIndexReader {
             for (long id : searcher.allRowIds()) {
                 bitmap.add(id);
             }
-            return Optional.of(GlobalIndexResult.create(bitmap));
+            return Optional.of(GlobalIndexResult.create(bitmap, false));
         } catch (IOException e) {
             throw new RuntimeException(
                     "Failed to read conservative ES index rows for field: " + logicalField, e);
@@ -1545,6 +1545,9 @@ public class ESIndexGlobalIndexReader implements GlobalIndexReader {
         Optional<GlobalIndexResult> matching = dispatchFilter(fieldRef, matchingFilter);
         if (matching.isEmpty()) {
             return Optional.empty();
+        }
+        if (!existing.get().isExact() || !matching.get().isExact()) {
+            return conservativeAllRows(fieldRef.name());
         }
 
         RoaringNavigableMap64 result = new RoaringNavigableMap64();

--- a/paimon-eslib/src/main/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexReader.java
+++ b/paimon-eslib/src/main/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexReader.java
@@ -1416,7 +1416,7 @@ public class ESIndexGlobalIndexReader implements GlobalIndexReader {
             // everything. Returning Optional.empty() here would mean "index can't evaluate" and
             // force a
             // raw-scan fallback (wrong semantics + loses the index's selectivity).
-            return Optional.of(GlobalIndexResult.create(bitmap));
+            return Optional.of(GlobalIndexResult.createExact(bitmap));
         } catch (IOException e) {
             throw new RuntimeException("Filter failed on field: " + fieldName, e);
         }
@@ -1553,7 +1553,7 @@ public class ESIndexGlobalIndexReader implements GlobalIndexReader {
         RoaringNavigableMap64 result = new RoaringNavigableMap64();
         result.or(existing.get().results());
         result.andNot(matching.get().results());
-        return Optional.of(GlobalIndexResult.create(result));
+        return Optional.of(GlobalIndexResult.createExact(result));
     }
 
     private IndexFilter exactValueFilter(FieldRef fieldRef, Object literal) {
@@ -1930,7 +1930,7 @@ public class ESIndexGlobalIndexReader implements GlobalIndexReader {
 
     private static CompletableFuture<Optional<GlobalIndexResult>> emptyFilterFuture() {
         return CompletableFuture.completedFuture(
-                Optional.of(GlobalIndexResult.create(new RoaringNavigableMap64())));
+                Optional.of(GlobalIndexResult.createExact(new RoaringNavigableMap64())));
     }
 
     private static boolean isReversedRange(FieldRef fieldRef, Object from, Object to) {

--- a/paimon-eslib/src/test/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexE2ETest.java
+++ b/paimon-eslib/src/test/java/org/apache/paimon/eslib/index/ESIndexGlobalIndexE2ETest.java
@@ -69,6 +69,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -451,6 +452,7 @@ class ESIndexGlobalIndexE2ETest {
                 reader.visitGreaterThan(titleRef, "abc").join();
         assertTrue(unsupportedTitleRange.isPresent());
         assertEquals(20, unsupportedTitleRange.get().results().getIntCardinality());
+        assertFalse(unsupportedTitleRange.get().isExact());
 
         // --- scalar filter: price >= 100 means rows 10..19 (price = i*10) ---
         FieldRef priceRef = new FieldRef(3, "price", DataTypes.INT());
@@ -683,6 +685,16 @@ class ESIndexGlobalIndexE2ETest {
             assertTrue(contains(candidates.get().results(), 0L));
             assertTrue(contains(candidates.get().results(), 1L));
             assertTrue(contains(candidates.get().results(), 3L));
+            assertFalse(candidates.get().isExact());
+
+            Optional<GlobalIndexResult> notEqual =
+                    union.visitNotEqual(new FieldRef(0, "value", DataTypes.BIGINT()), 5L).join();
+            assertTrue(notEqual.isPresent());
+            assertEquals(3, notEqual.get().results().getIntCardinality());
+            assertTrue(contains(notEqual.get().results(), 0L));
+            assertTrue(contains(notEqual.get().results(), 1L));
+            assertTrue(contains(notEqual.get().results(), 2L));
+            assertFalse(notEqual.get().isExact());
         } finally {
             union.close();
         }
@@ -848,6 +860,7 @@ class ESIndexGlobalIndexE2ETest {
                     4,
                     keywordRange.get().results().getIntCardinality(),
                     "unsupported KEYWORD ordering must conservatively retain the whole shard");
+            assertFalse(keywordRange.get().isExact());
         } finally {
             reader.close();
         }
@@ -1574,6 +1587,7 @@ class ESIndexGlobalIndexE2ETest {
                     1,
                     fallback.get().results().getIntCardinality(),
                     "a lossy millisecond index must conservatively retain every row");
+            assertFalse(fallback.get().isExact());
             assertTrue(reader.visitIsNotNull(ts).join().isPresent());
         } finally {
             reader.close();


### PR DESCRIPTION
### Purpose

Push down single-column TopN on data-evolution tables to BTree global indexes. The implementation merges sorted index files in both directions, preserves boundary ties, tracks exact predicate candidates, and safely falls back when coverage or resource bounds are insufficient.

### Tests

- BTree scalar TopN for ASC/DESC, NULLS FIRST/LAST, ties, candidate row IDs, and multiple files/ranges.
- Fallback tests for inexact predicates, incomplete coverage, query auth/deletion vectors, and result/scan/block/file/byte budgets.
- Data-evolution and Lance end-to-end tests.
