### PR TITLE
[python][daft] Add Jindo IO config for OSS catalogs

### DIFF
--- a/paimon-python/pypaimon/daft/daft_io_config.py
+++ b/paimon-python/pypaimon/daft/daft_io_config.py
@@ -22,6 +22,11 @@ from urllib.parse import urlparse
 
 from daft.io import IOConfig, S3Config
 
+try:
+    from daft.io import JindoConfig
+except ImportError:
+    JindoConfig = None
+
 
 def serialize_io_config(io_config: IOConfig) -> bytes:
     """Serialize an IOConfig to the bytes Daft's File struct embeds, via its __reduce__."""
@@ -50,6 +55,7 @@ def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]
     if scheme == "oss":
         parsed = urlparse(warehouse)
         oss_cfg: dict[str, str] = {}
+        jindo_cfg = None
 
         bucket = parsed.netloc
         if bucket:
@@ -77,7 +83,21 @@ def _convert_paimon_catalog_options_to_io_config(catalog_options: dict[str, str]
         if token:
             oss_cfg["security_token"] = token
 
-        return IOConfig(opendal_backends={"oss": oss_cfg}) if oss_cfg else None
+        if JindoConfig is not None and oss_cfg:
+            jindo_cfg = JindoConfig(
+                endpoint=catalog_options.get("fs.oss.endpoint"),
+                region=region,
+                access_key_id=key_id,
+                access_key_secret=key_secret,
+                security_token=token,
+            )
+
+        if not oss_cfg:
+            return None
+        io_config_kwargs = {"opendal_backends": {"oss": oss_cfg}}
+        if jindo_cfg is not None:
+            io_config_kwargs["jindo"] = jindo_cfg
+        return IOConfig(**io_config_kwargs)
 
     # S3-compatible (s3://, s3a://, s3n://)
     any_props_set = False

--- a/paimon-python/pypaimon/tests/daft/daft_io_config_test.py
+++ b/paimon-python/pypaimon/tests/daft/daft_io_config_test.py
@@ -1,0 +1,95 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import pytest
+
+pypaimon = pytest.importorskip("pypaimon")
+daft = pytest.importorskip("daft")
+
+from pypaimon.daft import daft_io_config
+
+
+def _oss_options():
+    return {
+        "warehouse": "oss://test-bucket/warehouse",
+        "fs.oss.endpoint": "oss-cn-hangzhou.aliyuncs.com",
+        "fs.oss.region": "cn-hangzhou",
+        "fs.oss.accessKeyId": "AK",
+        "fs.oss.accessKeySecret": "SK",
+        "fs.oss.securityToken": "TOKEN",
+    }
+
+
+def test_oss_io_config_preserves_opendal_backend():
+    cfg = daft_io_config._convert_paimon_catalog_options_to_io_config(_oss_options())
+
+    oss_cfg = cfg.opendal_backends["oss"]
+    assert oss_cfg["bucket"] == "test-bucket"
+    assert oss_cfg["endpoint"] == "https://oss-cn-hangzhou.aliyuncs.com"
+    assert oss_cfg["region"] == "cn-hangzhou"
+    assert oss_cfg["access_key_id"] == "AK"
+    assert oss_cfg["access_key_secret"] == "SK"
+    assert oss_cfg["security_token"] == "TOKEN"
+
+
+def test_oss_io_config_adds_jindo_when_daft_supports_it(monkeypatch):
+    class _FakeJindoConfig:
+        def __init__(
+            self,
+            endpoint=None,
+            region=None,
+            access_key_id=None,
+            access_key_secret=None,
+            security_token=None,
+        ):
+            self.endpoint = endpoint
+            self.region = region
+            self.access_key_id = access_key_id
+            self.access_key_secret = access_key_secret
+            self.security_token = security_token
+
+    class _FakeIOConfig:
+        def __init__(self, jindo=None, opendal_backends=None, **_):
+            self.jindo = jindo
+            self.opendal_backends = opendal_backends or {}
+
+    monkeypatch.setattr(daft_io_config, "JindoConfig", _FakeJindoConfig)
+    monkeypatch.setattr(daft_io_config, "IOConfig", _FakeIOConfig)
+
+    cfg = daft_io_config._convert_paimon_catalog_options_to_io_config(_oss_options())
+
+    assert cfg.opendal_backends["oss"]["endpoint"] == "https://oss-cn-hangzhou.aliyuncs.com"
+    assert cfg.jindo.endpoint == "oss-cn-hangzhou.aliyuncs.com"
+    assert cfg.jindo.region == "cn-hangzhou"
+    assert cfg.jindo.access_key_id == "AK"
+    assert cfg.jindo.access_key_secret == "SK"
+    assert cfg.jindo.security_token == "TOKEN"
+
+
+def test_oss_io_config_keeps_legacy_daft_io_config_shape(monkeypatch):
+    class _FakeIOConfig:
+        def __init__(self, **kwargs):
+            assert "jindo" not in kwargs
+            self.opendal_backends = kwargs["opendal_backends"]
+
+    monkeypatch.setattr(daft_io_config, "JindoConfig", None)
+    monkeypatch.setattr(daft_io_config, "IOConfig", _FakeIOConfig)
+
+    cfg = daft_io_config._convert_paimon_catalog_options_to_io_config(_oss_options())
+
+    assert cfg.opendal_backends["oss"]["access_key_id"] == "AK"


### PR DESCRIPTION
### Purpose

When PyPaimon reads an OSS-backed table through Daft's native parquet reader, the catalog options are converted to a Daft IOConfig. Today the OSS branch only fills the OpenDAL OSS backend. That works for Daft builds that route oss:// through OpenDAL, but Daft builds with a Jindo backend need the same fs.oss.* credentials in IOConfig.jindo.

This patch keeps the existing OpenDAL OSS config and, when the installed Daft exposes JindoConfig, also fills IOConfig.jindo from the same fs.oss.* catalog options. Older Daft builds without JindoConfig keep the previous IOConfig shape.

### Tests

- python -m pytest paimon-python/pypaimon/tests/daft/daft_io_config_test.py paimon-python/pypaimon/tests/daft/daft_blob_test.py paimon-python/pypaimon/tests/daft/daft_data_test.py -q
- python -m pytest paimon-python/pypaimon/tests/daft --ignore=paimon-python/pypaimon/tests/daft/daft_catalog_rest_test.py -q
- Verified against an OSS-backed DLF REST table with Daft native parquet reader: source format parquet, Jindo config present, row count 1000.
