### PR TITLE
[core] Handle query auth wrappers in split consumers

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/reader/ScoreRecordReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/reader/ScoreRecordReader.java
@@ -18,9 +18,12 @@
 
 package org.apache.paimon.reader;
 
+import org.apache.paimon.utils.Filter;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 /** A {@link RecordReader} whose records expose vector-search scores and row identifiers. */
 public interface ScoreRecordReader<T> extends RecordReader<T> {
@@ -28,4 +31,40 @@ public interface ScoreRecordReader<T> extends RecordReader<T> {
     @Nullable
     @Override
     ScoreRecordIterator<T> readBatch() throws IOException;
+
+    @Override
+    default <R> ScoreRecordReader<R> transform(Function<T, R> function) {
+        ScoreRecordReader<T> thisReader = this;
+        return new ScoreRecordReader<R>() {
+            @Nullable
+            @Override
+            public ScoreRecordIterator<R> readBatch() throws IOException {
+                ScoreRecordIterator<T> iterator = thisReader.readBatch();
+                return iterator == null ? null : iterator.transform(function);
+            }
+
+            @Override
+            public void close() throws IOException {
+                thisReader.close();
+            }
+        };
+    }
+
+    @Override
+    default ScoreRecordReader<T> filter(Filter<T> filter) {
+        ScoreRecordReader<T> thisReader = this;
+        return new ScoreRecordReader<T>() {
+            @Nullable
+            @Override
+            public ScoreRecordIterator<T> readBatch() throws IOException {
+                ScoreRecordIterator<T> iterator = thisReader.readBatch();
+                return iterator == null ? null : iterator.filter(filter);
+            }
+
+            @Override
+            public void close() throws IOException {
+                thisReader.close();
+            }
+        };
+    }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/reader/ScoreRecordReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/reader/ScoreRecordReaderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.reader;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ScoreRecordReader}. */
+public class ScoreRecordReaderTest {
+
+    @Test
+    public void testFilterAndTransformPreserveScoreMetadata() throws IOException {
+        ScoreRecordReader<Integer> reader =
+                new ScoreRecordReader<Integer>() {
+                    private boolean emitted;
+
+                    @Nullable
+                    @Override
+                    public ScoreRecordIterator<Integer> readBatch() {
+                        if (emitted) {
+                            return null;
+                        }
+                        emitted = true;
+                        return new TestingScoreRecordIterator();
+                    }
+
+                    @Override
+                    public void close() {}
+                };
+
+        ScoreRecordReader<String> transformed =
+                reader.filter(value -> value == 1).transform(String::valueOf);
+        ScoreRecordIterator<String> iterator = transformed.readBatch();
+
+        assertThat(iterator).isNotNull();
+        assertThat(iterator.next()).isEqualTo("1");
+        assertThat(iterator.returnedRowId()).isEqualTo(11L);
+        assertThat(iterator.returnedScore()).isEqualTo(0.75f);
+        assertThat(iterator.next()).isNull();
+        assertThat(transformed.readBatch()).isNull();
+    }
+
+    private static class TestingScoreRecordIterator implements ScoreRecordIterator<Integer> {
+
+        private final int[] values = {0, 1};
+        private final long[] rowIds = {10L, 11L};
+        private final float[] scores = {0.25f, 0.75f};
+        private int index = -1;
+
+        @Nullable
+        @Override
+        public Integer next() {
+            index++;
+            return index < values.length ? values[index] : null;
+        }
+
+        @Override
+        public float returnedScore() {
+            return scores[index];
+        }
+
+        @Override
+        public long returnedRowId() {
+            return rowIds[index];
+        }
+
+        @Override
+        public void releaseBatch() {}
+    }
+}

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
@@ -24,12 +24,12 @@ import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.JoinedRow;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.Options;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
-import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
@@ -42,12 +42,12 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.paimon.CoreOptions.QUERY_AUTH_ENABLED;
 import static org.apache.paimon.CoreOptions.SCAN_MODE;
 import static org.apache.paimon.CoreOptions.StartupMode.LATEST;
 import static org.apache.paimon.io.SplitsParallelReadUtil.parallelExecute;
@@ -81,11 +81,12 @@ public class IndexBootstrap implements Serializable {
                         .mapToInt(Integer::intValue)
                         .toArray();
 
-        // force using the latest scan mode
+        // Force using the latest scan mode and bypass query auth for this internal index read.
+        Options bootstrapOptions = new Options();
+        bootstrapOptions.set(SCAN_MODE, LATEST);
+        bootstrapOptions.set(QUERY_AUTH_ENABLED, false);
         ReadBuilder readBuilder =
-                table.copy(Collections.singletonMap(SCAN_MODE.key(), LATEST.toString()))
-                        .newReadBuilder()
-                        .withProjection(keyProjection);
+                table.copy(bootstrapOptions.toMap()).newReadBuilder().withProjection(keyProjection);
 
         DataTableScan tableScan = (DataTableScan) readBuilder.newScan();
         List<Split> splits =
@@ -142,7 +143,7 @@ public class IndexBootstrap implements Serializable {
 
     @VisibleForTesting
     static DataSplit unwrapDataSplit(Split split) {
-        return (DataSplit) QueryAuthSplit.unwrap(split);
+        return (DataSplit) split;
     }
 
     public static RowType bootstrapType(TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
@@ -121,7 +121,7 @@ public class IndexBootstrap implements Serializable {
                 options.pageSize(),
                 options.crossPartitionUpsertBootstrapParallelism(),
                 split -> {
-                    DataSplit dataSplit = unwrapDataSplit(split);
+                    DataSplit dataSplit = (DataSplit) split;
                     int bucket = dataSplit.bucket();
                     return partBucketConverter.toGenericRow(
                             new JoinedRow(dataSplit.partition(), GenericRow.of(bucket)));
@@ -131,7 +131,7 @@ public class IndexBootstrap implements Serializable {
 
     @VisibleForTesting
     static boolean filterSplit(Split split, long indexTtl, long currentTime) {
-        List<DataFileMeta> files = unwrapDataSplit(split).dataFiles();
+        List<DataFileMeta> files = ((DataSplit) split).dataFiles();
         for (DataFileMeta file : files) {
             long fileTime = file.creationTimeEpochMillis();
             if (currentTime <= fileTime + indexTtl) {
@@ -139,11 +139,6 @@ public class IndexBootstrap implements Serializable {
             }
         }
         return false;
-    }
-
-    @VisibleForTesting
-    static DataSplit unwrapDataSplit(Split split) {
-        return (DataSplit) split;
     }
 
     public static RowType bootstrapType(TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
+++ b/paimon-core/src/main/java/org/apache/paimon/crosspartition/IndexBootstrap.java
@@ -29,6 +29,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
@@ -119,7 +120,7 @@ public class IndexBootstrap implements Serializable {
                 options.pageSize(),
                 options.crossPartitionUpsertBootstrapParallelism(),
                 split -> {
-                    DataSplit dataSplit = ((DataSplit) split);
+                    DataSplit dataSplit = unwrapDataSplit(split);
                     int bucket = dataSplit.bucket();
                     return partBucketConverter.toGenericRow(
                             new JoinedRow(dataSplit.partition(), GenericRow.of(bucket)));
@@ -129,7 +130,7 @@ public class IndexBootstrap implements Serializable {
 
     @VisibleForTesting
     static boolean filterSplit(Split split, long indexTtl, long currentTime) {
-        List<DataFileMeta> files = ((DataSplit) split).dataFiles();
+        List<DataFileMeta> files = unwrapDataSplit(split).dataFiles();
         for (DataFileMeta file : files) {
             long fileTime = file.creationTimeEpochMillis();
             if (currentTime <= fileTime + indexTtl) {
@@ -137,6 +138,11 @@ public class IndexBootstrap implements Serializable {
             }
         }
         return false;
+    }
+
+    @VisibleForTesting
+    static DataSplit unwrapDataSplit(Split split) {
+        return (DataSplit) QueryAuthSplit.unwrap(split);
     }
 
     public static RowType bootstrapType(TableSchema schema) {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/DataEvolutionBatchScan.java
@@ -37,6 +37,7 @@ import org.apache.paimon.table.source.AppendBatchTableScan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Filter;
@@ -332,12 +333,17 @@ public class DataEvolutionBatchScan implements DataTableScan {
     public static Plan wrapToIndexSplits(
             List<Split> splits, RowRangeIndex rowRangeIndex, ScoreGetter scoreGetter) {
         List<Split> indexedSplits = new ArrayList<>();
-        Function<Split, List<IndexedSplit>> process =
-                split ->
-                        Collections.singletonList(
-                                split instanceof IndexedSplit
-                                        ? (IndexedSplit) split
-                                        : wrap((DataSplit) split, rowRangeIndex, scoreGetter));
+        Function<Split, List<Split>> process =
+                split -> {
+                    Split wrappedSplit = QueryAuthSplit.unwrap(split);
+                    if (wrappedSplit instanceof IndexedSplit) {
+                        return Collections.singletonList(split);
+                    }
+                    IndexedSplit indexedSplit =
+                            wrap((DataSplit) wrappedSplit, rowRangeIndex, scoreGetter);
+                    return Collections.singletonList(
+                            QueryAuthSplit.retainAuth(split, indexedSplit));
+                };
         randomlyExecuteSequentialReturn(process, splits, null).forEachRemaining(indexedSplits::add);
         return () -> indexedSplits;
     }

--- a/paimon-core/src/main/java/org/apache/paimon/operation/ListUnexistingFiles.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/ListUnexistingFiles.java
@@ -40,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static org.apache.paimon.CoreOptions.QUERY_AUTH_ENABLED;
+
 /** List what data files recorded in manifests are missing from the filesystem. */
 public class ListUnexistingFiles {
 
@@ -48,11 +50,14 @@ public class ListUnexistingFiles {
     private final ThreadPoolExecutor executor;
 
     public ListUnexistingFiles(FileStoreTable table) {
-        this.table = table;
-        this.pathFactory = table.store().pathFactory();
+        this.table =
+                table.coreOptions().queryAuthEnabled()
+                        ? table.copy(Collections.singletonMap(QUERY_AUTH_ENABLED.key(), "false"))
+                        : table;
+        this.pathFactory = this.table.store().pathFactory();
         this.executor =
                 FileOperationThreadPool.getExecutorService(
-                        table.coreOptions().fileOperationThreadNum());
+                        this.table.coreOptions().fileOperationThreadNum());
     }
 
     public Map<Integer, Map<String, DataFileMeta>> list(BinaryRow partition) throws Exception {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
@@ -31,6 +31,7 @@ import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.ChainSplit;
@@ -303,6 +304,17 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
             // after query authorization instead.
             if (!options.queryAuthEnabled()) {
                 super.withLimit(limit);
+            }
+            return this;
+        }
+
+        @Override
+        public ChainTableBatchScan withTopN(TopN topN) {
+            // Query authorization is applied only after the physical chain inputs have been
+            // assembled. Pushing TopN into those raw inputs could prune authorized rows when
+            // unauthorized rows rank higher. The engine applies the logical TopN after auth.
+            if (!options.queryAuthEnabled()) {
+                super.withTopN(topN);
             }
             return this;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
@@ -62,7 +62,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
-import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /**
  * Chain table which mainly read from the snapshot branch. However, if the snapshot branch does not
@@ -435,18 +434,12 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                             deltaScan.withPartitionFilter(selectedDeltaPartitions);
                         }
 
-                        List<DataSplit> deltaSubSplits =
-                                deltaScan.plan().splits().stream()
-                                        .map(s -> (DataSplit) s)
-                                        .collect(Collectors.toList());
-                        List<DataSplit> snapshotSubSplits = new ArrayList<>();
+                        List<Split> deltaSubSplits = deltaScan.plan().splits();
+                        List<Split> snapshotSubSplits = Collections.emptyList();
                         if (partitionPairs.getValue() != null) {
                             snapshotScan.withPartitionFilter(
                                     Collections.singletonList(partitionPairs.getValue()));
-                            snapshotSubSplits =
-                                    snapshotScan.plan().splits().stream()
-                                            .map(s -> (DataSplit) s)
-                                            .collect(Collectors.toList());
+                            snapshotSubSplits = snapshotScan.plan().splits();
                         }
                         splits.addAll(
                                 ChainTableUtils.buildChainSplits(
@@ -520,15 +513,6 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                     newChainPartitionListingScan(true, getMainPartitionPredicate())
                             .listPartitions());
             return snapshotPartitions;
-        }
-
-        private static Split retainQueryAuth(List<Split> sourceSplits, Split replacement) {
-            for (Split sourceSplit : sourceSplits) {
-                if (sourceSplit instanceof QueryAuthSplit) {
-                    return QueryAuthSplit.retainAuth(sourceSplit, replacement);
-                }
-            }
-            return replacement;
         }
 
         private DataTableScan newFilteredScan(boolean snapshot) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
@@ -36,6 +37,7 @@ import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.RowType;
@@ -60,6 +62,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.paimon.utils.Preconditions.checkArgument;
+import static org.apache.paimon.utils.Preconditions.checkNotNull;
 
 /**
  * Chain table which mainly read from the snapshot branch. However, if the snapshot branch does not
@@ -494,25 +497,40 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
             }
 
             for (Split split : mainScan.plan().splits()) {
-                DataSplit dataSplit = (DataSplit) split;
+                DataSplit dataSplit = unwrapDataSplit(split);
                 HashMap<String, String> fileBucketPathMapping = new HashMap<>();
                 HashMap<String, String> fileBranchMapping = new HashMap<>();
                 for (DataFileMeta file : dataSplit.dataFiles()) {
-                    fileBucketPathMapping.put(file.fileName(), ((DataSplit) split).bucketPath());
+                    fileBucketPathMapping.put(file.fileName(), dataSplit.bucketPath());
                     fileBranchMapping.put(file.fileName(), options.scanFallbackSnapshotBranch());
                 }
                 splits.add(
-                        new ChainSplit(
-                                dataSplit.partition(),
-                                dataSplit.dataFiles(),
-                                fileBranchMapping,
-                                fileBucketPathMapping));
+                        QueryAuthSplit.retainAuth(
+                                split,
+                                new ChainSplit(
+                                        dataSplit.partition(),
+                                        dataSplit.dataFiles(),
+                                        fileBranchMapping,
+                                        fileBucketPathMapping)));
             }
 
             snapshotPartitions.addAll(
                     newChainPartitionListingScan(true, getMainPartitionPredicate())
                             .listPartitions());
             return snapshotPartitions;
+        }
+
+        private static DataSplit unwrapDataSplit(Split split) {
+            return (DataSplit) QueryAuthSplit.unwrap(split);
+        }
+
+        private static Split retainQueryAuth(List<Split> sourceSplits, Split replacement) {
+            for (Split sourceSplit : sourceSplits) {
+                if (sourceSplit instanceof QueryAuthSplit) {
+                    return QueryAuthSplit.retainAuth(sourceSplit, replacement);
+                }
+            }
+            return replacement;
         }
 
         private DataTableScan newFilteredScan(boolean snapshot) {
@@ -582,7 +600,8 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
 
         @Override
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
-            if (split instanceof ChainSplit || split instanceof DataSplit) {
+            Split wrappedSplit = QueryAuthSplit.unwrap(split);
+            if (wrappedSplit instanceof ChainSplit || wrappedSplit instanceof DataSplit) {
                 return fallbackRead.createReader(split);
             }
             throw new IllegalArgumentException(

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
@@ -222,7 +222,8 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
             this(tableSchema, chainGroupReadTable, FileStoreTable::newScan);
         }
 
-        private ChainTableBatchScan(
+        @VisibleForTesting
+        ChainTableBatchScan(
                 TableSchema tableSchema,
                 ChainGroupReadTable chainGroupReadTable,
                 Function<FileStoreTable, DataTableScan> scanCreator) {
@@ -362,6 +363,7 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                 for (List<BinaryRow> deltaPartitionsInGroup : groupedDeltaPartitions.values()) {
 
                     // Sort delta by chain dimension ascending.
+                    // chainPartitionForCompare avoids copying BinaryRow in the comparator hot path.
                     deltaPartitionsInGroup.sort(
                             (a, b) ->
                                     chainPartitionComparator.compare(
@@ -497,7 +499,7 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
             }
 
             for (Split split : mainScan.plan().splits()) {
-                DataSplit dataSplit = unwrapDataSplit(split);
+                DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
                 HashMap<String, String> fileBucketPathMapping = new HashMap<>();
                 HashMap<String, String> fileBranchMapping = new HashMap<>();
                 for (DataFileMeta file : dataSplit.dataFiles()) {
@@ -518,10 +520,6 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                     newChainPartitionListingScan(true, getMainPartitionPredicate())
                             .listPartitions());
             return snapshotPartitions;
-        }
-
-        private static DataSplit unwrapDataSplit(Split split) {
-            return (DataSplit) QueryAuthSplit.unwrap(split);
         }
 
         private static Split retainQueryAuth(List<Split> sourceSplits, Split replacement) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainGroupReadTable.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.annotation.VisibleForTesting;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
@@ -39,6 +40,7 @@ import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableQueryAuth;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ChainPartitionProjector;
@@ -46,6 +48,8 @@ import org.apache.paimon.utils.ChainTableUtils;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.RowDataToObjectArrayConverter;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,6 +123,13 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
 
     private DataTableScan newDeltaScan(Function<FileStoreTable, DataTableScan> scanCreator) {
         return scanCreator.apply(other());
+    }
+
+    static FileStoreTable withoutQueryAuth(FileStoreTable table) {
+        if (!table.coreOptions().queryAuthEnabled()) {
+            return table;
+        }
+        return table.copy(Collections.singletonMap(CoreOptions.QUERY_AUTH_ENABLED.key(), "false"));
     }
 
     @Override
@@ -212,6 +223,8 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
         private final ChainGroupReadTable chainGroupReadTable;
         private final RecordComparator chainPartitionComparator;
         private final ChainPartitionProjector partitionProjector;
+        private final TableQueryAuth queryAuth;
+        @Nullable private RowType readType;
         private Predicate dataPredicate;
         private Filter<Integer> bucketFilter;
         protected boolean preloadTargetSnapshot = true;
@@ -230,9 +243,10 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                     chainGroupReadTable.wrapped,
                     chainGroupReadTable.other(),
                     tableSchema,
-                    scanCreator);
+                    physicalScanCreator(scanCreator));
             this.options = CoreOptions.fromMap(tableSchema.options());
             this.chainGroupReadTable = chainGroupReadTable;
+            this.queryAuth = chainGroupReadTable.catalogEnvironment().tableQueryAuth(this.options);
             this.partitionConverter =
                     new RowDataToObjectArrayConverter(tableSchema.logicalPartitionType());
             this.partitionComparator =
@@ -251,6 +265,19 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                             partitionProjector.chainPartitionType().getFieldTypes());
         }
 
+        private static Function<FileStoreTable, DataTableScan> physicalScanCreator(
+                Function<FileStoreTable, DataTableScan> scanCreator) {
+            return table -> scanCreator.apply(ChainGroupReadTable.withoutQueryAuth(table));
+        }
+
+        @Override
+        public ChainTableBatchScan withReadType(@Nullable RowType readType) {
+            this.readType = readType;
+            mainScan.withReadType(readType);
+            fallbackScan.withReadType(readType);
+            return this;
+        }
+
         @Override
         public ChainTableBatchScan withFilter(Predicate predicate) {
             super.withFilter(predicate);
@@ -264,6 +291,18 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                                 tableSchema.partitionKeys());
                 dataPredicate =
                         pair.getRight().isEmpty() ? null : PredicateBuilder.and(pair.getRight());
+            }
+            return this;
+        }
+
+        @Override
+        public ChainTableBatchScan withLimit(int limit) {
+            // Query authorization is applied only after the physical chain inputs have been
+            // assembled. Pushing a limit into those raw inputs could exhaust the limit with rows
+            // which are later removed by authorization. ReadBuilderImpl applies the logical limit
+            // after query authorization instead.
+            if (!options.queryAuthEnabled()) {
+                super.withLimit(limit);
             }
             return this;
         }
@@ -335,6 +374,8 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
          */
         @Override
         public Plan plan() {
+            TableQueryAuthResult queryAuthResult =
+                    queryAuth.auth(readType == null ? null : readType.getFieldNames());
             List<Split> splits = new ArrayList<>();
             PredicateBuilder builder = new PredicateBuilder(tableSchema.logicalPartitionType());
             Set<BinaryRow> snapshotPartitions = preloadTargetSnapshotSplits(splits);
@@ -451,7 +492,8 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                     }
                 }
             }
-            return new DataFilePlan<>(splits);
+            Plan plan = new DataFilePlan<>(splits);
+            return queryAuthResult == null ? plan : queryAuthResult.convertPlan(plan);
         }
 
         @Override
@@ -500,13 +542,11 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
                     fileBranchMapping.put(file.fileName(), options.scanFallbackSnapshotBranch());
                 }
                 splits.add(
-                        QueryAuthSplit.retainAuth(
-                                split,
-                                new ChainSplit(
-                                        dataSplit.partition(),
-                                        dataSplit.dataFiles(),
-                                        fileBranchMapping,
-                                        fileBucketPathMapping)));
+                        new ChainSplit(
+                                dataSplit.partition(),
+                                dataSplit.dataFiles(),
+                                fileBranchMapping,
+                                fileBucketPathMapping));
             }
 
             snapshotPartitions.addAll(
@@ -525,6 +565,9 @@ public class ChainGroupReadTable extends FallbackReadFileStoreTable {
             }
             if (bucketFilter != null) {
                 scan.withBucketFilter(bucketFilter);
+            }
+            if (readType != null) {
+                scan.withReadType(readType);
             }
             return scan;
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainTableFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainTableFileStoreTable.java
@@ -28,6 +28,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.ChainSplit;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.TableRead;
@@ -209,7 +210,8 @@ public class ChainTableFileStoreTable extends FallbackReadFileStoreTable {
                 // FallbackSplit (including FallbackDataSplit): use inherited fallback read logic
                 return fallbackRead.createReader(split);
             }
-            if (split instanceof ChainSplit || split instanceof DataSplit) {
+            Split wrappedSplit = QueryAuthSplit.unwrap(split);
+            if (wrappedSplit instanceof ChainSplit || wrappedSplit instanceof DataSplit) {
                 return chainGroupRead.createReader(split);
             }
             // Other split types: use inherited fallback read logic

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.Snapshot;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.RecordComparator;
 import org.apache.paimon.data.BinaryRow;
@@ -37,8 +38,10 @@ import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamDataTableScan;
+import org.apache.paimon.table.source.TableQueryAuth;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.table.source.snapshot.StartingContext;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.ChainPartitionProjector;
 import org.apache.paimon.utils.ChainTableUtils;
 import org.apache.paimon.utils.Filter;
@@ -90,6 +93,11 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     /** Projector for splitting full partition into group and chain parts. */
     private final ChainPartitionProjector partitionProjector;
 
+    /** Query authorization for the logical chain table, applied after physical split assembly. */
+    private final TableQueryAuth queryAuth;
+
+    @Nullable private RowType readType;
+
     /** Comparator for chain partition keys only. */
     private final RecordComparator chainPartitionComparator;
 
@@ -132,7 +140,14 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         this.batchScan =
                 new ChainGroupReadTable.ChainTableBatchScan(
                         chainGroupReadTable.schema(), chainGroupReadTable);
-        this.deltaStreamScan = (DataTableStreamScan) chainGroupReadTable.other().newStreamScan();
+        this.deltaStreamScan =
+                (DataTableStreamScan)
+                        ChainGroupReadTable.withoutQueryAuth(chainGroupReadTable.other())
+                                .newStreamScan();
+        this.queryAuth =
+                chainGroupReadTable
+                        .catalogEnvironment()
+                        .tableQueryAuth(chainGroupReadTable.coreOptions());
 
         ChainTableUtils.validateChainTableForIncrementalRead(chainGroupReadTable);
 
@@ -161,6 +176,13 @@ public class ChainTableStreamScan implements StreamDataTableScan {
 
     @Override
     public TableScan.Plan plan() {
+        TableQueryAuthResult queryAuthResult =
+                queryAuth.auth(readType == null ? null : readType.getFieldNames());
+        TableScan.Plan plan = planWithoutQueryAuth();
+        return queryAuthResult == null ? plan : queryAuthResult.convertPlan(plan);
+    }
+
+    private TableScan.Plan planWithoutQueryAuth() {
         if (!startingDone) {
             return planStarting();
         }
@@ -336,9 +358,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         for (Map.Entry<BinaryRow, List<Split>> entry : snapshotSplitsByPartition.entrySet()) {
             for (Split split : entry.getValue()) {
                 DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
-                allSplits.add(
-                        QueryAuthSplit.retainAuth(
-                                split, ChainSplit.from(dataSplit, snapshotBranch)));
+                allSplits.add(ChainSplit.from(dataSplit, snapshotBranch));
             }
         }
 
@@ -356,9 +376,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
                             > 0) {
                 for (Split split : entry.getValue()) {
                     DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
-                    allSplits.add(
-                            QueryAuthSplit.retainAuth(
-                                    split, ChainSplit.from(dataSplit, deltaBranch)));
+                    allSplits.add(ChainSplit.from(dataSplit, deltaBranch));
                 }
             }
         }
@@ -532,6 +550,14 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     }
 
     @Override
+    public InnerTableScan withReadType(@Nullable RowType readType) {
+        this.readType = readType;
+        batchScan.withReadType(readType);
+        deltaStreamScan.withReadType(readType);
+        return this;
+    }
+
+    @Override
     public InnerTableScan withPartitionFilter(Map<String, String> partitionSpec) {
         throw new UnsupportedOperationException(
                 "Partition filter is not supported in chain table streaming read.");
@@ -587,6 +613,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), String.valueOf(snapshotId));
         options.put(CoreOptions.SCAN_MODE.key(), CoreOptions.StartupMode.FROM_SNAPSHOT.toString());
+        options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "false");
         return options;
     }
 
@@ -603,6 +630,9 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         }
         if (bucketFilter != null) {
             scan.withBucketFilter(bucketFilter);
+        }
+        if (readType != null) {
+            scan.withReadType(readType);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
@@ -335,7 +335,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
 
         for (Map.Entry<BinaryRow, List<Split>> entry : snapshotSplitsByPartition.entrySet()) {
             for (Split split : entry.getValue()) {
-                DataSplit dataSplit = unwrapDataSplit(split);
+                DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
                 allSplits.add(
                         QueryAuthSplit.retainAuth(
                                 split, ChainSplit.from(dataSplit, snapshotBranch)));
@@ -355,7 +355,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
                                     partitionProjector.extractChainPartition(latestPartition))
                             > 0) {
                 for (Split split : entry.getValue()) {
-                    DataSplit dataSplit = unwrapDataSplit(split);
+                    DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
                     allSplits.add(
                             QueryAuthSplit.retainAuth(
                                     split, ChainSplit.from(dataSplit, deltaBranch)));
@@ -487,14 +487,10 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     private static Map<BinaryRow, List<Split>> groupByPartition(DataTableScan scan) {
         Map<BinaryRow, List<Split>> grouped = new LinkedHashMap<>();
         for (Split split : scan.plan().splits()) {
-            DataSplit dataSplit = unwrapDataSplit(split);
+            DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
             grouped.computeIfAbsent(dataSplit.partition(), k -> new ArrayList<>()).add(split);
         }
         return grouped;
-    }
-
-    private static DataSplit unwrapDataSplit(Split split) {
-        return (DataSplit) QueryAuthSplit.unwrap(split);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
@@ -328,8 +328,8 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     private List<Split> buildLightweightStartingSplits(
             String snapshotBranch,
             String deltaBranch,
-            Map<BinaryRow, List<DataSplit>> snapshotSplitsByPartition,
-            Map<BinaryRow, List<DataSplit>> deltaSplitsByPartition,
+            Map<BinaryRow, List<Split>> snapshotSplitsByPartition,
+            Map<BinaryRow, List<Split>> deltaSplitsByPartition,
             Map<Object, BinaryRow> latestChainPartitionPerGroup) {
         List<Split> allSplits = new ArrayList<>();
 
@@ -375,15 +375,15 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     private List<Split> buildMergedStartingSplits(
             String snapshotBranch,
             String deltaBranch,
-            Map<BinaryRow, List<DataSplit>> snapshotSplitsByPartition,
-            Map<BinaryRow, List<DataSplit>> deltaSplitsByPartition,
+            Map<BinaryRow, List<Split>> snapshotSplitsByPartition,
+            Map<BinaryRow, List<Split>> deltaSplitsByPartition,
             Map<Object, BinaryRow> latestChainPartitionPerGroup) {
         List<Split> allSplits = new ArrayList<>();
 
         // Pre-group delta splits and find the latest delta partition per group.
-        Map<Object, List<DataSplit>> deltaSplitsByGroup = new HashMap<>();
+        Map<Object, List<Split>> deltaSplitsByGroup = new HashMap<>();
         Map<Object, BinaryRow> latestDeltaPartitionPerGroup = new HashMap<>();
-        for (Map.Entry<BinaryRow, List<DataSplit>> e : deltaSplitsByPartition.entrySet()) {
+        for (Map.Entry<BinaryRow, List<Split>> e : deltaSplitsByPartition.entrySet()) {
             BinaryRow deltaPartition = e.getKey();
             Object groupKey = toGroupKey(deltaPartition);
             deltaSplitsByGroup
@@ -404,7 +404,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         for (Map.Entry<Object, BinaryRow> entry : latestChainPartitionPerGroup.entrySet()) {
             Object groupKey = entry.getKey();
             BinaryRow snapshotPartition = entry.getValue();
-            List<DataSplit> snapshotSplits =
+            List<Split> snapshotSplits =
                     snapshotSplitsByPartition.getOrDefault(
                             snapshotPartition, Collections.emptyList());
 
@@ -418,15 +418,16 @@ public class ChainTableStreamScan implements StreamDataTableScan {
                                                     snapshotPartition))
                                     > 0;
 
-            List<DataSplit> selectedDeltaSplits = new ArrayList<>();
+            List<Split> selectedDeltaSplits = new ArrayList<>();
             if (hasDeltaAfterSnapshot) {
-                for (DataSplit dataSplit : deltaSplitsByGroup.get(groupKey)) {
+                for (Split split : deltaSplitsByGroup.get(groupKey)) {
+                    DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
                     BinaryRow deltaPartition = dataSplit.partition();
                     if (chainPartitionComparator.compare(
                                     partitionProjector.extractChainPartition(deltaPartition),
                                     partitionProjector.extractChainPartition(snapshotPartition))
                             > 0) {
-                        selectedDeltaSplits.add(dataSplit);
+                        selectedDeltaSplits.add(split);
                     }
                 }
             }
@@ -444,7 +445,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
 
         // Delta-only groups: there is no snapshot anchor, so merge all delta partitions in the
         // group into the latest delta partition.
-        for (Map.Entry<Object, List<DataSplit>> entry : deltaSplitsByGroup.entrySet()) {
+        for (Map.Entry<Object, List<Split>> entry : deltaSplitsByGroup.entrySet()) {
             Object groupKey = entry.getKey();
             if (!latestChainPartitionPerGroup.containsKey(groupKey)) {
                 BinaryRow logicalPartition = latestDeltaPartitionPerGroup.get(groupKey);

--- a/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/ChainTableStreamScan.java
@@ -33,6 +33,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.DataTableStreamScan;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamDataTableScan;
@@ -238,7 +239,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         }
 
         // 1. Read delta branch data at the pinned snapshot, grouped by partition.
-        Map<BinaryRow, List<DataSplit>> deltaSplitsByPartition;
+        Map<BinaryRow, List<Split>> deltaSplitsByPartition;
         if (deltaLatestId != null) {
             FileStoreTable pinnedDelta = deltaTable.copy(pinnedOptions(deltaLatestId));
             DataTableScan pinnedDeltaScan = pinnedDelta.newScan();
@@ -273,7 +274,7 @@ public class ChainTableStreamScan implements StreamDataTableScan {
         // 3. Scan file splits for latest snapshot partitions only, at the pinned snapshot.
         //    Reuse the pinnedSnapshot from step 2 to avoid redundant copy operations.
         List<BinaryRow> latestPartitions = new ArrayList<>(latestChainPartitionPerGroup.values());
-        Map<BinaryRow, List<DataSplit>> snapshotSplitsByPartition;
+        Map<BinaryRow, List<Split>> snapshotSplitsByPartition;
         if (!latestPartitions.isEmpty() && pinnedSnapshot != null) {
             DataTableScan snapshotScan = pinnedSnapshot.newScan();
             snapshotScan.withPartitionFilter(latestPartitions);
@@ -332,13 +333,16 @@ public class ChainTableStreamScan implements StreamDataTableScan {
             Map<Object, BinaryRow> latestChainPartitionPerGroup) {
         List<Split> allSplits = new ArrayList<>();
 
-        for (Map.Entry<BinaryRow, List<DataSplit>> entry : snapshotSplitsByPartition.entrySet()) {
-            for (DataSplit ds : entry.getValue()) {
-                allSplits.add(ChainSplit.from(ds, snapshotBranch));
+        for (Map.Entry<BinaryRow, List<Split>> entry : snapshotSplitsByPartition.entrySet()) {
+            for (Split split : entry.getValue()) {
+                DataSplit dataSplit = unwrapDataSplit(split);
+                allSplits.add(
+                        QueryAuthSplit.retainAuth(
+                                split, ChainSplit.from(dataSplit, snapshotBranch)));
             }
         }
 
-        for (Map.Entry<BinaryRow, List<DataSplit>> entry : deltaSplitsByPartition.entrySet()) {
+        for (Map.Entry<BinaryRow, List<Split>> entry : deltaSplitsByPartition.entrySet()) {
             BinaryRow partition = entry.getKey();
             Object groupKey = toGroupKey(partition);
             BinaryRow latestPartition = latestChainPartitionPerGroup.get(groupKey);
@@ -350,8 +354,11 @@ public class ChainTableStreamScan implements StreamDataTableScan {
                                     partitionProjector.extractChainPartition(partition),
                                     partitionProjector.extractChainPartition(latestPartition))
                             > 0) {
-                for (DataSplit ds : entry.getValue()) {
-                    allSplits.add(ChainSplit.from(ds, deltaBranch));
+                for (Split split : entry.getValue()) {
+                    DataSplit dataSplit = unwrapDataSplit(split);
+                    allSplits.add(
+                            QueryAuthSplit.retainAuth(
+                                    split, ChainSplit.from(dataSplit, deltaBranch)));
                 }
             }
         }
@@ -477,13 +484,17 @@ public class ChainTableStreamScan implements StreamDataTableScan {
     }
 
     /** Plans a scan and groups the resulting splits by partition. */
-    private static Map<BinaryRow, List<DataSplit>> groupByPartition(DataTableScan scan) {
-        Map<BinaryRow, List<DataSplit>> grouped = new LinkedHashMap<>();
-        for (Split s : scan.plan().splits()) {
-            DataSplit ds = (DataSplit) s;
-            grouped.computeIfAbsent(ds.partition(), k -> new ArrayList<>()).add(ds);
+    private static Map<BinaryRow, List<Split>> groupByPartition(DataTableScan scan) {
+        Map<BinaryRow, List<Split>> grouped = new LinkedHashMap<>();
+        for (Split split : scan.plan().splits()) {
+            DataSplit dataSplit = unwrapDataSplit(split);
+            grouped.computeIfAbsent(dataSplit.partition(), k -> new ArrayList<>()).add(split);
         }
         return grouped;
+    }
+
+    private static DataSplit unwrapDataSplit(Split split) {
+        return (DataSplit) QueryAuthSplit.unwrap(split);
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/FallbackReadFileStoreTable.java
@@ -564,8 +564,7 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
             Set<BinaryRow> completePartitions =
                     new HashSet<>(newPartitionListingScan(true).listPartitions());
             for (Split split : mainScan.plan().splits()) {
-                DataSplit dataSplit = (DataSplit) split;
-                splits.add(toFallbackSplit(dataSplit, false));
+                splits.add(toFallbackSplit(split, false));
             }
 
             List<BinaryRow> remainingPartitions =
@@ -691,9 +690,10 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
             if (split instanceof FallbackSplit) {
                 FallbackSplit fallbackSplit = (FallbackSplit) split;
+                Split wrappedSplit = fallbackSplit.wrapped();
                 if (fallbackSplit.isFallback()) {
                     try {
-                        return fallbackRead.createReader(fallbackSplit.wrapped());
+                        return fallbackRead.createReader(wrappedSplit);
                     } catch (Exception e) {
                         if (fallbackReadFailFast) {
                             if (e instanceof IOException) {
@@ -703,16 +703,15 @@ public class FallbackReadFileStoreTable extends DelegatedFileStoreTable {
                                 throw (RuntimeException) e;
                             }
                             throw new IOException(
-                                    "Failed to read fallback branch split: "
-                                            + fallbackSplit.wrapped(),
-                                    e);
+                                    "Failed to read fallback branch split: " + wrappedSplit, e);
                         }
                         LOG.error(
                                 "Reading from supplemental branch has problems: {}",
-                                fallbackSplit.wrapped(),
+                                wrappedSplit,
                                 e);
                     }
                 }
+                return mainRead.createReader(wrappedSplit);
             }
             return mainRead.createReader(split);
         }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
@@ -54,6 +54,11 @@ public class QueryAuthSplit implements Split {
         return split instanceof QueryAuthSplit ? ((QueryAuthSplit) split).split() : split;
     }
 
+    /** Unwraps one query authorization layer and returns the wrapped data split. */
+    public static DataSplit unwrapDataSplit(Split split) {
+        return (DataSplit) unwrap(split);
+    }
+
     /** Retains the source split's query authorization result on a replacement split. */
     public static Split retainAuth(Split source, Split replacement) {
         if (source instanceof QueryAuthSplit) {

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
@@ -54,6 +54,14 @@ public class QueryAuthSplit implements Split {
         return split instanceof QueryAuthSplit ? ((QueryAuthSplit) split).split() : split;
     }
 
+    /** Retains the source split's query authorization result on a replacement split. */
+    public static Split retainAuth(Split source, Split replacement) {
+        if (source instanceof QueryAuthSplit) {
+            return new QueryAuthSplit(replacement, ((QueryAuthSplit) source).authResult());
+        }
+        return replacement;
+    }
+
     @Nullable
     public TableQueryAuthResult authResult() {
         return authResult;

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
@@ -23,6 +23,7 @@ import org.apache.paimon.io.DataInputView;
 import org.apache.paimon.io.DataInputViewStreamWrapper;
 import org.apache.paimon.io.DataOutputView;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
+import org.apache.paimon.table.FallbackReadFileStoreTable.FallbackSplit;
 
 import javax.annotation.Nullable;
 
@@ -49,12 +50,19 @@ public class QueryAuthSplit implements Split {
         return split;
     }
 
-    /** Unwraps one query authorization layer to expose the wrapped split. */
+    /** Unwraps one fallback layer followed by one query authorization layer. */
     public static Split unwrap(Split split) {
+        if (split instanceof FallbackSplit) {
+            Split wrapped = ((FallbackSplit) split).wrapped();
+            // FallbackDataSplit is already a DataSplit and deliberately wraps itself.
+            if (wrapped != split) {
+                split = wrapped;
+            }
+        }
         return split instanceof QueryAuthSplit ? ((QueryAuthSplit) split).split() : split;
     }
 
-    /** Unwraps one query authorization layer and returns the wrapped data split. */
+    /** Unwraps one fallback and query authorization layer and returns the data split. */
     public static DataSplit unwrapDataSplit(Split split) {
         return (DataSplit) unwrap(split);
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/QueryAuthSplit.java
@@ -49,6 +49,11 @@ public class QueryAuthSplit implements Split {
         return split;
     }
 
+    /** Unwraps one query authorization layer to expose the wrapped split. */
+    public static Split unwrap(Split split) {
+        return split instanceof QueryAuthSplit ? ((QueryAuthSplit) split).split() : split;
+    }
+
     @Nullable
     public TableQueryAuthResult authResult() {
         return authResult;

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/BinlogTable.java
@@ -28,6 +28,7 @@ import org.apache.paimon.table.SpecialFields;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.DataField;
@@ -118,7 +119,7 @@ public class BinlogTable extends AuditLogTable {
 
         @Override
         public RecordReader<InternalRow> createReader(Split split) throws IOException {
-            DataSplit dataSplit = (DataSplit) split;
+            DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
             // When sequence number is enabled, the underlying data layout is:
             // [_SEQUENCE_NUMBER, pk, pt, col1, ...]
             // We need to offset the field index to skip the sequence number field.

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/CompactBucketsTable.java
@@ -108,10 +108,15 @@ public class CompactBucketsTable implements DataTable, ReadonlyTable {
 
     // if need to specify the database of a table, use this method
     public CompactBucketsTable(FileStoreTable wrapped, boolean isContinuous, String databaseName) {
-        this.wrapped = wrapped;
+        this.wrapped =
+                wrapped.coreOptions().queryAuthEnabled()
+                        ? wrapped.copy(
+                                Collections.singletonMap(
+                                        CoreOptions.QUERY_AUTH_ENABLED.key(), "false"))
+                        : wrapped;
         this.isContinuous = isContinuous;
         this.databaseName = databaseName;
-        this.baseSchemaId = wrapped.schema().id();
+        this.baseSchemaId = this.wrapped.schema().id();
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileKeyRangesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileKeyRangesTable.java
@@ -40,6 +40,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadOnceTableScan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
@@ -274,13 +275,14 @@ public class FileKeyRangesTable implements ReadonlyTable {
                     };
 
             List<Iterator<InternalRow>> iteratorList = new ArrayList<>();
-            for (Split dataSplit : splits) {
+            for (Split plannedSplit : splits) {
+                DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(plannedSplit);
                 iteratorList.add(
                         Iterators.transform(
-                                ((DataSplit) dataSplit).dataFiles().iterator(),
+                                dataSplit.dataFiles().iterator(),
                                 file ->
                                         toRow(
-                                                (DataSplit) dataSplit,
+                                                dataSplit,
                                                 partitionCastExecutor,
                                                 keyConverters,
                                                 file)));

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FileMonitorTable.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyList;
+import static org.apache.paimon.CoreOptions.QUERY_AUTH_ENABLED;
 import static org.apache.paimon.CoreOptions.SCAN_BOUNDED_WATERMARK;
 import static org.apache.paimon.CoreOptions.STREAM_SCAN_MODE;
 import static org.apache.paimon.CoreOptions.StreamScanMode.FILE_MONITOR;
@@ -98,6 +99,7 @@ public class FileMonitorTable implements DataTable, ReadonlyTable {
         Map<String, String> dynamicOptions = new HashMap<>();
         dynamicOptions.put(STREAM_SCAN_MODE.key(), FILE_MONITOR.getValue());
         dynamicOptions.put(SCAN_BOUNDED_WATERMARK.key(), null);
+        dynamicOptions.put(QUERY_AUTH_ENABLED.key(), "false");
         this.wrapped = wrapped.copy(dynamicOptions);
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/FilesTable.java
@@ -47,6 +47,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableRead;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadOnceTableScan;
 import org.apache.paimon.table.source.SingletonSplit;
 import org.apache.paimon.table.source.Split;
@@ -375,13 +376,14 @@ public class FilesTable implements ReadonlyTable {
                                     });
                         }
                     };
-            for (Split dataSplit : splits) {
+            for (Split plannedSplit : splits) {
+                DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(plannedSplit);
                 iteratorList.add(
                         Iterators.transform(
-                                ((DataSplit) dataSplit).dataFiles().iterator(),
+                                dataSplit.dataFiles().iterator(),
                                 file ->
                                         toRow(
-                                                (DataSplit) dataSplit,
+                                                dataSplit,
                                                 partitionCastExecutor,
                                                 keyConverters,
                                                 file,

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ChainTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ChainTableUtils.java
@@ -377,15 +377,15 @@ public class ChainTableUtils {
     /**
      * Builds per-bucket {@link ChainSplit}s from the given snapshot and delta splits. Files that
      * originate from the snapshot splits are tagged with {@code snapshotBranch}; all other files
-     * are tagged with {@code deltaBranch}. If an input split carries query authorization, the
-     * corresponding output split retains it.
+     * are tagged with {@code deltaBranch}. Query authorization belongs to the logical chain-table
+     * plan and must be applied by the caller after all physical splits have been assembled.
      *
      * @param logicalPartition the logical partition for the resulting ChainSplits
      * @param snapshotSplits splits from the snapshot branch
      * @param deltaSplits splits from the delta branch
      * @param snapshotBranch name of the snapshot branch
      * @param deltaBranch name of the delta branch
-     * @return one split per bucket, optionally wrapped with query authorization
+     * @return one raw chain split per bucket
      */
     public static List<Split> buildChainSplits(
             BinaryRow logicalPartition,
@@ -432,7 +432,7 @@ public class ChainTableUtils {
                                     .collect(Collectors.toList()),
                             fileBranchMapping,
                             fileBucketPathMapping);
-            result.add(retainQueryAuth(entry.getValue(), chainSplit));
+            result.add(chainSplit);
         }
         return result;
     }
@@ -448,15 +448,6 @@ public class ChainTableUtils {
         }
         bucketSplits.computeIfAbsent(ds.bucket(), k -> new ArrayList<>()).add(split);
         return totalBuckets;
-    }
-
-    private static Split retainQueryAuth(List<Split> sourceSplits, Split replacement) {
-        for (Split sourceSplit : sourceSplits) {
-            if (sourceSplit instanceof QueryAuthSplit) {
-                return QueryAuthSplit.retainAuth(sourceSplit, replacement);
-            }
-        }
-        return replacement;
     }
 
     /**

--- a/paimon-core/src/main/java/org/apache/paimon/utils/ChainTableUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/utils/ChainTableUtils.java
@@ -31,6 +31,8 @@ import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.ChainSplit;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.RowType;
 
 import java.time.LocalDateTime;
@@ -375,40 +377,43 @@ public class ChainTableUtils {
     /**
      * Builds per-bucket {@link ChainSplit}s from the given snapshot and delta splits. Files that
      * originate from the snapshot splits are tagged with {@code snapshotBranch}; all other files
-     * are tagged with {@code deltaBranch}.
+     * are tagged with {@code deltaBranch}. If an input split carries query authorization, the
+     * corresponding output split retains it.
      *
      * @param logicalPartition the logical partition for the resulting ChainSplits
      * @param snapshotSplits splits from the snapshot branch
      * @param deltaSplits splits from the delta branch
      * @param snapshotBranch name of the snapshot branch
      * @param deltaBranch name of the delta branch
-     * @return one ChainSplit per bucket
+     * @return one split per bucket, optionally wrapped with query authorization
      */
-    public static List<ChainSplit> buildChainSplits(
+    public static List<Split> buildChainSplits(
             BinaryRow logicalPartition,
-            List<DataSplit> snapshotSplits,
-            List<DataSplit> deltaSplits,
+            List<Split> snapshotSplits,
+            List<Split> deltaSplits,
             String snapshotBranch,
             String deltaBranch) {
         Set<String> snapshotFileNames =
                 snapshotSplits.stream()
+                        .map(QueryAuthSplit::unwrapDataSplit)
                         .flatMap(s -> s.dataFiles().stream().map(DataFileMeta::fileName))
                         .collect(Collectors.toSet());
 
-        Map<Integer, List<DataSplit>> bucketSplits = new LinkedHashMap<>();
+        Map<Integer, List<Split>> bucketSplits = new LinkedHashMap<>();
         Integer bucketInAll = null;
-        for (DataSplit ds : snapshotSplits) {
-            bucketInAll = addToBucketMap(ds, bucketSplits, bucketInAll);
+        for (Split split : snapshotSplits) {
+            bucketInAll = addToBucketMap(split, bucketSplits, bucketInAll);
         }
-        for (DataSplit ds : deltaSplits) {
-            bucketInAll = addToBucketMap(ds, bucketSplits, bucketInAll);
+        for (Split split : deltaSplits) {
+            bucketInAll = addToBucketMap(split, bucketSplits, bucketInAll);
         }
 
-        List<ChainSplit> result = new ArrayList<>();
-        for (Map.Entry<Integer, List<DataSplit>> entry : bucketSplits.entrySet()) {
+        List<Split> result = new ArrayList<>();
+        for (Map.Entry<Integer, List<Split>> entry : bucketSplits.entrySet()) {
             Map<String, String> fileBranchMapping = new HashMap<>();
             Map<String, String> fileBucketPathMapping = new HashMap<>();
-            for (DataSplit ds : entry.getValue()) {
+            for (Split split : entry.getValue()) {
+                DataSplit ds = QueryAuthSplit.unwrapDataSplit(split);
                 for (DataFileMeta file : ds.dataFiles()) {
                     fileBucketPathMapping.put(file.fileName(), ds.bucketPath());
                     String branch =
@@ -418,28 +423,40 @@ public class ChainTableUtils {
                     fileBranchMapping.put(file.fileName(), branch);
                 }
             }
-            result.add(
+            ChainSplit chainSplit =
                     new ChainSplit(
                             logicalPartition,
                             entry.getValue().stream()
+                                    .map(QueryAuthSplit::unwrapDataSplit)
                                     .flatMap(ds -> ds.dataFiles().stream())
                                     .collect(Collectors.toList()),
                             fileBranchMapping,
-                            fileBucketPathMapping));
+                            fileBucketPathMapping);
+            result.add(retainQueryAuth(entry.getValue(), chainSplit));
         }
         return result;
     }
 
     private static Integer addToBucketMap(
-            DataSplit ds, Map<Integer, List<DataSplit>> bucketSplits, Integer bucketInAll) {
+            Split split, Map<Integer, List<Split>> bucketSplits, Integer bucketInAll) {
+        DataSplit ds = QueryAuthSplit.unwrapDataSplit(split);
         Integer totalBuckets = ds.totalBuckets();
         checkNotNull(totalBuckets, "totalBuckets should not be null");
         if (bucketInAll != null) {
             checkArgument(
                     totalBuckets.equals(bucketInAll), "Inconsistent bucket num " + ds.bucket());
         }
-        bucketSplits.computeIfAbsent(ds.bucket(), k -> new ArrayList<>()).add(ds);
+        bucketSplits.computeIfAbsent(ds.bucket(), k -> new ArrayList<>()).add(split);
         return totalBuckets;
+    }
+
+    private static Split retainQueryAuth(List<Split> sourceSplits, Split replacement) {
+        for (Split sourceSplit : sourceSplits) {
+            if (sourceSplit instanceof QueryAuthSplit) {
+                return QueryAuthSplit.retainAuth(sourceSplit, replacement);
+            }
+        }
+        return replacement;
     }
 
     /**

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -27,17 +27,30 @@ import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.manifest.FileSource;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FieldTransform;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.DelegatedFileStoreTable;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
+import org.apache.paimon.table.FallbackReadFileStoreTable.FallbackSplit;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.source.DataSplit;
-import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.Filter;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Pair;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -45,11 +58,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.apache.paimon.crosspartition.IndexBootstrap.BUCKET_FIELD;
 import static org.apache.paimon.crosspartition.IndexBootstrap.filterSplit;
-import static org.apache.paimon.crosspartition.IndexBootstrap.unwrapDataSplit;
 import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -100,7 +113,11 @@ public class IndexBootstrapTest extends TableTestBase {
     }
 
     private Table createTable() throws Exception {
-        Identifier identifier = identifier("T");
+        return createTable("T");
+    }
+
+    private Table createTable(String tableName) throws Exception {
+        Identifier identifier = identifier(tableName);
         Options options = new Options();
         options.set(CoreOptions.BUCKET, -1);
         Schema schema =
@@ -133,15 +150,164 @@ public class IndexBootstrapTest extends TableTestBase {
     }
 
     @Test
-    public void testQueryAuthSplit() {
+    public void testFallbackDataSplit() {
         DataSplit dataSplit = newSplit(newFile(100), newFile(200));
-        QueryAuthSplit authSplit =
-                new QueryAuthSplit(
-                        dataSplit, new TableQueryAuthResult(Collections.emptyList(), null));
+        FallbackSplit fallbackSplit = FallbackReadFileStoreTable.toFallbackSplit(dataSplit, true);
 
-        assertThat(unwrapDataSplit(authSplit)).isSameAs(dataSplit);
-        assertThat(filterSplit(authSplit, 50, 230)).isTrue();
-        assertThat(filterSplit(authSplit, 50, 300)).isFalse();
+        assertThat(fallbackSplit).isInstanceOf(DataSplit.class);
+        assertThat(filterSplit(fallbackSplit, 50, 230)).isTrue();
+        assertThat(filterSplit(fallbackSplit, 50, 300)).isFalse();
+        assertThat(fallbackSplit.isFallback()).isTrue();
+    }
+
+    @Test
+    public void testBootstrapIgnoresQueryAuth() throws Exception {
+        FileStoreTable table = (FileStoreTable) createTable();
+        write(
+                table,
+                row(1, 1, 1, 2),
+                row(1, 2, 2, 3),
+                row(1, 3, 3, 4),
+                row(2, 4, 4, 5),
+                row(2, 5, 5, 6),
+                row(3, 6, 6, 7),
+                row(3, 7, 7, 8));
+
+        TableQueryAuthResult authResult = queryAuthResult(table);
+        IndexBootstrap indexBootstrap =
+                new IndexBootstrap(new QueryAuthFileStoreTable(table, authResult));
+
+        List<GenericRow> result = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = indexBootstrap.bootstrap(1, 0)) {
+            reader.forEachRemaining(
+                    row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2))));
+        }
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(
+                        GenericRow.of(1, 1, 2),
+                        GenericRow.of(2, 1, 3),
+                        GenericRow.of(3, 1, 4),
+                        GenericRow.of(4, 2, 5),
+                        GenericRow.of(5, 2, 6),
+                        GenericRow.of(6, 3, 7),
+                        GenericRow.of(7, 3, 8));
+    }
+
+    @Test
+    public void testBootstrapIgnoresQueryAuthWithFallback() throws Exception {
+        FileStoreTable mainTable = (FileStoreTable) createTable("MAIN");
+        FileStoreTable fallbackTable = (FileStoreTable) createTable("FALLBACK");
+        write(mainTable, row(1, 10, 10, 2));
+        write(fallbackTable, row(2, 20, 20, 3));
+
+        TableQueryAuthResult authResult = queryAuthResult(mainTable);
+        FallbackReadFileStoreTable table =
+                new FallbackReadFileStoreTable(
+                        new QueryAuthFileStoreTable(mainTable, authResult),
+                        new QueryAuthFileStoreTable(fallbackTable, authResult),
+                        true);
+
+        List<GenericRow> result = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = new IndexBootstrap(table).bootstrap(1, 0)) {
+            reader.forEachRemaining(
+                    row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2))));
+        }
+
+        assertThat(result)
+                .containsExactlyInAnyOrder(GenericRow.of(10, 1, 2), GenericRow.of(20, 2, 3));
+    }
+
+    private TableQueryAuthResult queryAuthResult(FileStoreTable table) {
+        Predicate filter = new PredicateBuilder(table.rowType()).equal(0, 1);
+        return new TableQueryAuthResult(
+                Collections.singletonList(JsonSerdeUtil.toFlatJson(filter)),
+                Collections.singletonMap(
+                        "pk",
+                        JsonSerdeUtil.toFlatJson(
+                                new FieldTransform(new FieldRef(0, "pt", DataTypes.INT())))));
+    }
+
+    private static class QueryAuthFileStoreTable extends DelegatedFileStoreTable {
+
+        private final TableQueryAuthResult authResult;
+        private final boolean queryAuthEnabled;
+
+        private QueryAuthFileStoreTable(FileStoreTable wrapped, TableQueryAuthResult authResult) {
+            this(wrapped, authResult, true);
+        }
+
+        private QueryAuthFileStoreTable(
+                FileStoreTable wrapped, TableQueryAuthResult authResult, boolean queryAuthEnabled) {
+            super(wrapped);
+            this.authResult = authResult;
+            this.queryAuthEnabled = queryAuthEnabled;
+        }
+
+        @Override
+        public DataTableScan newScan() {
+            DataTableScan delegate = wrapped.newScan();
+            if (!queryAuthEnabled) {
+                return delegate;
+            }
+            DataTableScan scan =
+                    Mockito.mock(DataTableScan.class, AdditionalAnswers.delegatesTo(delegate));
+            Mockito.doAnswer(
+                            invocation -> {
+                                Filter<Integer> filter = invocation.getArgument(0);
+                                delegate.withBucketFilter(filter);
+                                return scan;
+                            })
+                    .when(scan)
+                    .withBucketFilter(Mockito.any());
+            Mockito.doAnswer(
+                            invocation -> {
+                                Filter<Integer> filter = invocation.getArgument(0);
+                                delegate.withLevelFilter(filter);
+                                return scan;
+                            })
+                    .when(scan)
+                    .withLevelFilter(Mockito.any());
+            Mockito.doAnswer(ignored -> authResult.convertPlan(delegate.plan())).when(scan).plan();
+            return scan;
+        }
+
+        @Override
+        public FileStoreTable copy(Map<String, String> dynamicOptions) {
+            return new QueryAuthFileStoreTable(
+                    wrapped.copy(dynamicOptions), authResult, queryAuthEnabled(dynamicOptions));
+        }
+
+        @Override
+        public FileStoreTable copy(TableSchema newTableSchema) {
+            return new QueryAuthFileStoreTable(
+                    wrapped.copy(newTableSchema), authResult, queryAuthEnabled);
+        }
+
+        @Override
+        public FileStoreTable copyWithoutTimeTravel(Map<String, String> dynamicOptions) {
+            return new QueryAuthFileStoreTable(
+                    wrapped.copyWithoutTimeTravel(dynamicOptions),
+                    authResult,
+                    queryAuthEnabled(dynamicOptions));
+        }
+
+        @Override
+        public FileStoreTable copyWithLatestSchema() {
+            return new QueryAuthFileStoreTable(
+                    wrapped.copyWithLatestSchema(), authResult, queryAuthEnabled);
+        }
+
+        @Override
+        public FileStoreTable switchToBranch(String branchName) {
+            return new QueryAuthFileStoreTable(
+                    wrapped.switchToBranch(branchName), authResult, queryAuthEnabled);
+        }
+
+        private boolean queryAuthEnabled(Map<String, String> dynamicOptions) {
+            String value = dynamicOptions.get(CoreOptions.QUERY_AUTH_ENABLED.key());
+            return value == null ? queryAuthEnabled : Boolean.parseBoolean(value);
+        }
     }
 
     private DataSplit newSplit(DataFileMeta... files) {

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -44,14 +44,17 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.CommonTestUtils;
 import org.apache.paimon.utils.Filter;
 import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Pair;
+import org.apache.paimon.utils.TraceableFileIO;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -106,10 +109,7 @@ public class IndexBootstrapTest extends TableTestBase {
                         GenericRow.of(2, 1, 3), GenericRow.of(4, 2, 5), GenericRow.of(6, 3, 7));
         result.clear();
 
-        // In ParallelExecution, latch.countDown first, then close the reader, it may not be closed
-        // here, (this is good, beneficial for query speed) but TableTestBase.after will check leak
-        // streams. So sleep here to avoid unstable.
-        Thread.sleep(1000);
+        waitForParallelReadersClosed();
     }
 
     private Table createTable() throws Exception {
@@ -182,6 +182,7 @@ public class IndexBootstrapTest extends TableTestBase {
             reader.forEachRemaining(
                     row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2))));
         }
+        waitForParallelReadersClosed();
 
         assertThat(result)
                 .containsExactlyInAnyOrder(
@@ -213,6 +214,7 @@ public class IndexBootstrapTest extends TableTestBase {
             reader.forEachRemaining(
                     row -> result.add(GenericRow.of(row.getInt(0), row.getInt(1), row.getInt(2))));
         }
+        waitForParallelReadersClosed();
 
         assertThat(result)
                 .containsExactlyInAnyOrder(GenericRow.of(10, 1, 2), GenericRow.of(20, 2, 3));
@@ -226,6 +228,16 @@ public class IndexBootstrapTest extends TableTestBase {
                         "pk",
                         JsonSerdeUtil.toFlatJson(
                                 new FieldTransform(new FieldRef(0, "pt", DataTypes.INT())))));
+    }
+
+    private void waitForParallelReadersClosed() throws Exception {
+        CommonTestUtils.waitUtil(
+                () ->
+                        TraceableFileIO.openInputStreams(
+                                        path -> path.toString().contains(tempPath.toString()))
+                                .isEmpty(),
+                Duration.ofSeconds(10),
+                Duration.ofMillis(10));
     }
 
     private static class QueryAuthFileStoreTable extends DelegatedFileStoreTable {

--- a/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/crosspartition/IndexBootstrapTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.crosspartition;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
@@ -31,6 +32,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.TableTestBase;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Pair;
@@ -47,6 +49,7 @@ import java.util.function.Consumer;
 
 import static org.apache.paimon.crosspartition.IndexBootstrap.BUCKET_FIELD;
 import static org.apache.paimon.crosspartition.IndexBootstrap.filterSplit;
+import static org.apache.paimon.crosspartition.IndexBootstrap.unwrapDataSplit;
 import static org.apache.paimon.data.BinaryRow.EMPTY_ROW;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -127,6 +130,18 @@ public class IndexBootstrapTest extends TableTestBase {
         assertThat(filterSplit(newSplit(newFile(100), newFile(200)), 50, 230)).isTrue();
         assertThat(filterSplit(newSplit(newFile(100), newFile(200)), 50, 300)).isFalse();
         assertThat(filterSplit(newSplit(newFile(100), newFile(200)), 200, 230)).isTrue();
+    }
+
+    @Test
+    public void testQueryAuthSplit() {
+        DataSplit dataSplit = newSplit(newFile(100), newFile(200));
+        QueryAuthSplit authSplit =
+                new QueryAuthSplit(
+                        dataSplit, new TableQueryAuthResult(Collections.emptyList(), null));
+
+        assertThat(unwrapDataSplit(authSplit)).isSameAs(dataSplit);
+        assertThat(filterSplit(authSplit, 50, 230)).isTrue();
+        assertThat(filterSplit(authSplit, 50, 300)).isFalse();
     }
 
     private DataSplit newSplit(DataFileMeta... files) {

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/DataEvolutionBatchScanTest.java
@@ -18,13 +18,16 @@
 
 package org.apache.paimon.globalindex;
 
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.table.source.AppendBatchTableScan;
+import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.snapshot.SnapshotReader;
 import org.apache.paimon.types.DataField;
@@ -110,6 +113,41 @@ public class DataEvolutionBatchScanTest {
 
         assertThat(returned).isSameAs(scan);
         verify(batchScan).withShard(0, 2);
+    }
+
+    @Test
+    public void testPlanRetainsQueryAuthWhenWrappingIndexedSplit() {
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withSnapshot(1L)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(Collections.singletonList(newAppendFile(10L, 10L, "file")))
+                        .build();
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask"));
+        QueryAuthSplit queryAuthSplit = new QueryAuthSplit(dataSplit, authResult);
+        RowRangeIndex rowRangeIndex =
+                RowRangeIndex.create(Collections.singletonList(new Range(12L, 15L)));
+
+        AppendBatchTableScan batchScan = mock(AppendBatchTableScan.class);
+        when(batchScan.withRowRangeIndex(rowRangeIndex)).thenReturn(batchScan);
+        when(batchScan.plan())
+                .thenReturn(new DataFilePlan<>(Collections.singletonList(queryAuthSplit)));
+
+        List<Split> splits =
+                new DataEvolutionBatchScan(null, batchScan)
+                        .withRowRangeIndex(rowRangeIndex)
+                        .plan()
+                        .splits();
+
+        assertThat(splits).hasSize(1);
+        QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
+        assertThat(result.authResult()).isSameAs(authResult);
+        IndexedSplit indexedSplit = (IndexedSplit) result.split();
+        assertThat(indexedSplit.dataSplit()).isSameAs(dataSplit);
+        assertThat(indexedSplit.rowRanges()).containsExactly(new Range(12L, 15L));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/operation/ListUnexistingFilesTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/ListUnexistingFilesTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.operation;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.FileSystemCatalog;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.BinaryRowWriter;
 import org.apache.paimon.data.GenericRow;
@@ -32,14 +33,19 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.TableCommitImpl;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,6 +96,37 @@ public class ListUnexistingFilesTest {
             Map<Integer, Map<String, DataFileMeta>> result = operation.list(binaryRow.apply(i));
             assertThat(result.values().stream().mapToInt(Map::size).sum()).isEqualTo(numDeletes[i]);
         }
+    }
+
+    @Test
+    public void testListFilesDisablesQueryAuth() throws Exception {
+        int[] numDeletes = new int[1];
+        FileStoreTable table =
+                prepareRandomlyDeletedTable(
+                        tempDir.toString(), "mydb", "auth_t", -1, 1, numDeletes, false);
+        List<Split> rawSplits = table.newScan().plan().splits();
+        table = table.copy(Collections.singletonMap(CoreOptions.QUERY_AUTH_ENABLED.key(), "true"));
+
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap());
+        DataTableScan authScan = Mockito.mock(DataTableScan.class);
+        Mockito.when(authScan.withLevelFilter(Mockito.any())).thenReturn(authScan);
+        Mockito.when(authScan.withPartitionFilter(Mockito.<List<BinaryRow>>any()))
+                .thenReturn(authScan);
+        Mockito.when(authScan.plan()).thenReturn(authResult.convertPlan(() -> rawSplits));
+
+        FileStoreTable authTable =
+                Mockito.mock(FileStoreTable.class, AdditionalAnswers.delegatesTo(table));
+        Mockito.when(authTable.newScan()).thenReturn(authScan);
+
+        BinaryRow partition = new BinaryRow(1);
+        BinaryRowWriter writer = new BinaryRowWriter(partition);
+        writer.writeInt(0, 0);
+        writer.complete();
+
+        Map<Integer, Map<String, DataFileMeta>> result =
+                new ListUnexistingFiles(authTable).list(partition);
+        assertThat(result.values().stream().mapToInt(Map::size).sum()).isEqualTo(numDeletes[0]);
     }
 
     public static FileStoreTable prepareRandomlyDeletedTable(

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -88,10 +88,13 @@ import org.apache.paimon.table.sink.CommitMessageImpl;
 import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.InnerTableScan;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.system.CompactBucketsTable;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -2818,6 +2821,48 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
 
         // no exception
         table.newReadBuilder().withProjection(new int[] {1}).newScan().plan();
+    }
+
+    @Test
+    void testCompactBucketsTableBypassesQueryAuth() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_compact_buckets_table");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        singletonList(new DataField(0, "id", DataTypes.INT())),
+                        emptyList(),
+                        emptyList(),
+                        singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        batchWrite(table, singletonList(1));
+        setRowFilter(
+                identifier,
+                singletonList(
+                        LeafPredicate.of(
+                                new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                                GreaterThan.INSTANCE,
+                                singletonList(0))));
+
+        assertThat(table.newScan().plan().splits())
+                .isNotEmpty()
+                .allSatisfy(split -> assertThat(split).isInstanceOf(QueryAuthSplit.class));
+
+        CompactBucketsTable bucketsTable = new CompactBucketsTable(table, false);
+        List<Split> splits = bucketsTable.newScan().plan().splits();
+        assertThat(splits)
+                .isNotEmpty()
+                .allSatisfy(split -> assertThat(split).isInstanceOf(DataSplit.class));
+        for (Split split : splits) {
+            try (RecordReader<InternalRow> reader = bucketsTable.newRead().createReader(split)) {
+                List<InternalRow> rows = new ArrayList<>();
+                reader.forEachRemaining(rows::add);
+                assertThat(rows).hasSize(1);
+            }
+        }
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/rest/RESTCatalogTest.java
@@ -93,8 +93,10 @@ import org.apache.paimon.table.source.InnerTableScan;
 import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.table.system.CompactBucketsTable;
+import org.apache.paimon.table.system.FileMonitorTable;
 import org.apache.paimon.table.system.SystemTableLoader;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
@@ -2858,6 +2860,46 @@ public abstract class RESTCatalogTest extends CatalogTestBase {
                 .allSatisfy(split -> assertThat(split).isInstanceOf(DataSplit.class));
         for (Split split : splits) {
             try (RecordReader<InternalRow> reader = bucketsTable.newRead().createReader(split)) {
+                List<InternalRow> rows = new ArrayList<>();
+                reader.forEachRemaining(rows::add);
+                assertThat(rows).hasSize(1);
+            }
+        }
+    }
+
+    @Test
+    void testFileMonitorTableBypassesQueryAuth() throws Exception {
+        Identifier identifier = Identifier.create("test_table_db", "auth_file_monitor_table");
+        catalog.createDatabase(identifier.getDatabaseName(), true);
+        catalog.createTable(
+                identifier,
+                new Schema(
+                        singletonList(new DataField(0, "id", DataTypes.INT())),
+                        emptyList(),
+                        emptyList(),
+                        singletonMap(QUERY_AUTH_ENABLED.key(), "true"),
+                        ""),
+                true);
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier);
+        batchWrite(table, singletonList(1));
+        setRowFilter(
+                identifier,
+                singletonList(
+                        LeafPredicate.of(
+                                new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                                GreaterThan.INSTANCE,
+                                singletonList(0))));
+
+        FileMonitorTable monitorTable = new FileMonitorTable(table);
+        ReadBuilder readBuilder = monitorTable.newReadBuilder();
+        StreamTableScan scan = readBuilder.newStreamScan();
+        List<Split> splits = scan.plan().splits();
+        assertThat(splits)
+                .isNotEmpty()
+                .allSatisfy(split -> assertThat(split).isNotInstanceOf(QueryAuthSplit.class));
+        for (Split split : splits) {
+            try (RecordReader<InternalRow> reader = readBuilder.newRead().createReader(split)) {
                 List<InternalRow> rows = new ArrayList<>();
                 reader.forEachRemaining(rows::add);
                 assertThat(rows).hasSize(1);

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.TableQueryAuthResult;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.io.DataFileTestDataGenerator;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.source.ChainSplit;
+import org.apache.paimon.table.source.DataFilePlan;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.DataTableScan;
+import org.apache.paimon.table.source.DataTableStreamScan;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.types.DataField;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.utils.SnapshotManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for query authorization handling in chain table scans. */
+public class ChainGroupReadTableTest {
+
+    @Test
+    public void testBatchScanRetainsQueryAuth() throws Exception {
+        TableSchema schema = tableSchema();
+        PrimaryKeyFileStoreTable snapshotTable = table(schema, "snapshot");
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta");
+        ChainGroupReadTable chainTable = new ChainGroupReadTable(snapshotTable, deltaTable);
+
+        BinaryRow partition = BinaryRow.singleColumn(1);
+        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition));
+        DataTableScan snapshotScan = mock(DataTableScan.class);
+        when(snapshotScan.plan())
+                .thenReturn(new DataFilePlan<>(Collections.singletonList(sourceSplit)));
+        when(snapshotScan.listPartitions()).thenReturn(Collections.singletonList(partition));
+
+        DataTableScan deltaScan = mock(DataTableScan.class);
+        when(deltaScan.listPartitions()).thenReturn(Collections.emptyList());
+
+        ChainGroupReadTable.ChainTableBatchScan scan =
+                new ChainGroupReadTable.ChainTableBatchScan(
+                        schema,
+                        chainTable,
+                        table -> table == snapshotTable ? snapshotScan : deltaScan);
+        List<Split> splits = scan.plan().splits();
+
+        assertThat(splits).hasSize(1);
+        QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
+        assertThat(result.authResult()).isSameAs(sourceSplit.authResult());
+        assertThat(result.split()).isInstanceOf(ChainSplit.class);
+
+        InnerTableRead snapshotRead = mock(InnerTableRead.class);
+        InnerTableRead deltaRead = mock(InnerTableRead.class);
+        RecordReader<InternalRow> reader = mock(RecordReader.class);
+        when(snapshotTable.newRead()).thenReturn(snapshotRead);
+        when(deltaTable.newRead()).thenReturn(deltaRead);
+        when(deltaRead.createReader(result)).thenReturn(reader);
+
+        assertThat(chainTable.newRead().createReader(result)).isSameAs(reader);
+        verify(deltaRead).createReader(result);
+    }
+
+    @Test
+    public void testStreamStartingPlanRetainsQueryAuth() {
+        TableSchema schema = tableSchema();
+        PrimaryKeyFileStoreTable snapshotTable = table(schema, "snapshot");
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta");
+
+        DataTableScan unusedScan = mock(DataTableScan.class);
+        when(snapshotTable.newScan()).thenReturn(unusedScan);
+        when(deltaTable.newScan()).thenReturn(unusedScan);
+
+        DataTableStreamScan deltaStreamScan = mock(DataTableStreamScan.class);
+        when(deltaTable.newStreamScan()).thenReturn(deltaStreamScan);
+
+        SnapshotManager snapshotManager = mock(SnapshotManager.class);
+        when(snapshotManager.latestSnapshotId()).thenReturn(null);
+        when(snapshotTable.snapshotManager()).thenReturn(snapshotManager);
+
+        SnapshotManager deltaSnapshotManager = mock(SnapshotManager.class);
+        when(deltaSnapshotManager.latestSnapshotId()).thenReturn(1L);
+        when(deltaTable.snapshotManager()).thenReturn(deltaSnapshotManager);
+
+        BinaryRow partition = BinaryRow.singleColumn(1);
+        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition));
+        DataTableScan pinnedDeltaScan = mock(DataTableScan.class);
+        when(pinnedDeltaScan.plan())
+                .thenReturn(new DataFilePlan<>(Collections.singletonList(sourceSplit)));
+        PrimaryKeyFileStoreTable pinnedDeltaTable = table(schema, "delta");
+        when(pinnedDeltaTable.newScan()).thenReturn(pinnedDeltaScan);
+        when(deltaTable.copy(anyMap())).thenReturn(pinnedDeltaTable);
+
+        ChainTableStreamScan scan =
+                new ChainTableStreamScan(new ChainGroupReadTable(snapshotTable, deltaTable));
+        List<Split> splits = scan.plan().splits();
+
+        assertThat(splits).hasSize(1);
+        QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
+        assertThat(result.authResult()).isSameAs(sourceSplit.authResult());
+        assertThat(result.split()).isInstanceOf(ChainSplit.class);
+        verify(deltaStreamScan).restore(2L);
+    }
+
+    private static PrimaryKeyFileStoreTable table(TableSchema schema, String branch) {
+        PrimaryKeyFileStoreTable table = mock(PrimaryKeyFileStoreTable.class);
+        when(table.schema()).thenReturn(schema);
+        Map<String, String> options = new HashMap<>(schema.options());
+        options.put(CoreOptions.BRANCH.key(), branch);
+        when(table.coreOptions()).thenReturn(CoreOptions.fromMap(options));
+        return table;
+    }
+
+    private static TableSchema tableSchema() {
+        List<DataField> fields =
+                Arrays.asList(
+                        new DataField(0, "pt", DataTypes.INT()),
+                        new DataField(1, "k", DataTypes.INT()),
+                        new DataField(2, "v", DataTypes.INT()));
+        Map<String, String> options = new HashMap<>();
+        options.put(CoreOptions.SCAN_FALLBACK_SNAPSHOT_BRANCH.key(), "snapshot");
+        options.put(CoreOptions.SCAN_FALLBACK_DELTA_BRANCH.key(), "delta");
+        return new TableSchema(
+                0,
+                fields,
+                2,
+                Collections.singletonList("pt"),
+                Arrays.asList("pt", "k"),
+                options,
+                "");
+    }
+
+    private static DataSplit dataSplit(BinaryRow partition) {
+        return DataSplit.builder()
+                .withSnapshot(1L)
+                .withPartition(partition)
+                .withBucket(0)
+                .withBucketPath("pt=1/bucket-0")
+                .withTotalBuckets(1)
+                .withDataFiles(
+                        Collections.singletonList(
+                                DataFileTestDataGenerator.builder().build().next().meta))
+                .build();
+    }
+
+    private static QueryAuthSplit queryAuthSplit(DataSplit split) {
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(null, Collections.singletonMap("v", "mask"));
+        return new QueryAuthSplit(split, authResult);
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
@@ -24,6 +24,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileTestDataGenerator;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.predicate.TopN;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.ChainSplit;
@@ -176,6 +177,36 @@ public class ChainGroupReadTableTest {
         verify(deltaScan, never()).withLimit(anyInt());
         verifyQueryAuthDisabled(snapshotTable);
         verifyQueryAuthDisabled(deltaTable);
+    }
+
+    @Test
+    public void testBatchScanDoesNotPushTopNBeforeQueryAuth() {
+        TableSchema schema = tableSchema();
+        TableQueryAuthResult logicalAuth = maskingAuth("logical");
+        CatalogEnvironment catalogEnvironment = catalogEnvironment(logicalAuth);
+        PrimaryKeyFileStoreTable snapshotTable =
+                table(schema, "snapshot", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawSnapshotTable =
+                table(schema, "snapshot", false, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawDeltaTable = table(schema, "delta", false, catalogEnvironment);
+        when(snapshotTable.copy(anyMap())).thenReturn(rawSnapshotTable);
+        when(deltaTable.copy(anyMap())).thenReturn(rawDeltaTable);
+
+        DataTableScan snapshotScan = mock(DataTableScan.class);
+        DataTableScan deltaScan = mock(DataTableScan.class);
+        ChainGroupReadTable chainTable = new ChainGroupReadTable(snapshotTable, deltaTable);
+        ChainGroupReadTable.ChainTableBatchScan scan =
+                new ChainGroupReadTable.ChainTableBatchScan(
+                        schema,
+                        chainTable,
+                        table -> table == rawSnapshotTable ? snapshotScan : deltaScan);
+
+        TopN topN = mock(TopN.class);
+        scan.withTopN(topN);
+
+        verify(snapshotScan, never()).withTopN(topN);
+        verify(deltaScan, never()).withTopN(topN);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
@@ -96,7 +96,16 @@ public class ChainGroupReadTableTest {
 
     @Test
     public void testStreamStartingPlanRetainsQueryAuth() {
-        TableSchema schema = tableSchema();
+        testStreamStartingPlanRetainsQueryAuth(false);
+    }
+
+    @Test
+    public void testStreamMergedStartingPlanRetainsQueryAuth() {
+        testStreamStartingPlanRetainsQueryAuth(true);
+    }
+
+    private void testStreamStartingPlanRetainsQueryAuth(boolean mergeSnapshot) {
+        TableSchema schema = tableSchema(mergeSnapshot);
         PrimaryKeyFileStoreTable snapshotTable = table(schema, "snapshot");
         PrimaryKeyFileStoreTable deltaTable = table(schema, "delta");
 
@@ -145,6 +154,10 @@ public class ChainGroupReadTableTest {
     }
 
     private static TableSchema tableSchema() {
+        return tableSchema(false);
+    }
+
+    private static TableSchema tableSchema(boolean mergeSnapshot) {
         List<DataField> fields =
                 Arrays.asList(
                         new DataField(0, "pt", DataTypes.INT()),
@@ -153,6 +166,9 @@ public class ChainGroupReadTableTest {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.SCAN_FALLBACK_SNAPSHOT_BRANCH.key(), "snapshot");
         options.put(CoreOptions.SCAN_FALLBACK_DELTA_BRANCH.key(), "delta");
+        options.put(
+                CoreOptions.CHAIN_TABLE_STREAMING_MERGE_SNAPSHOT.key(),
+                String.valueOf(mergeSnapshot));
         return new TableSchema(
                 0,
                 fields,

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChainGroupReadTableTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.io.DataFileTestDataGenerator;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.ChainSplit;
@@ -35,6 +36,8 @@ import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.Test;
@@ -46,8 +49,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,14 +63,22 @@ import static org.mockito.Mockito.when;
 public class ChainGroupReadTableTest {
 
     @Test
-    public void testBatchScanRetainsQueryAuth() throws Exception {
+    public void testBatchScanUsesLogicalQueryAuth() throws Exception {
         TableSchema schema = tableSchema();
-        PrimaryKeyFileStoreTable snapshotTable = table(schema, "snapshot");
-        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta");
+        TableQueryAuthResult logicalAuth = maskingAuth("logical");
+        CatalogEnvironment catalogEnvironment = catalogEnvironment(logicalAuth);
+        PrimaryKeyFileStoreTable snapshotTable =
+                table(schema, "snapshot", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawSnapshotTable =
+                table(schema, "snapshot", false, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawDeltaTable = table(schema, "delta", false, catalogEnvironment);
+        when(snapshotTable.copy(anyMap())).thenReturn(rawSnapshotTable);
+        when(deltaTable.copy(anyMap())).thenReturn(rawDeltaTable);
         ChainGroupReadTable chainTable = new ChainGroupReadTable(snapshotTable, deltaTable);
 
         BinaryRow partition = BinaryRow.singleColumn(1);
-        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition));
+        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition), maskingAuth("physical"));
         DataTableScan snapshotScan = mock(DataTableScan.class);
         when(snapshotScan.plan())
                 .thenReturn(new DataFilePlan<>(Collections.singletonList(sourceSplit)));
@@ -75,13 +91,16 @@ public class ChainGroupReadTableTest {
                 new ChainGroupReadTable.ChainTableBatchScan(
                         schema,
                         chainTable,
-                        table -> table == snapshotTable ? snapshotScan : deltaScan);
+                        table -> table == rawSnapshotTable ? snapshotScan : deltaScan);
         List<Split> splits = scan.plan().splits();
 
         assertThat(splits).hasSize(1);
         QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
-        assertThat(result.authResult()).isSameAs(sourceSplit.authResult());
+        assertThat(result.authResult()).isSameAs(logicalAuth);
+        assertThat(result.authResult()).isNotSameAs(sourceSplit.authResult());
         assertThat(result.split()).isInstanceOf(ChainSplit.class);
+        verifyQueryAuthDisabled(snapshotTable);
+        verifyQueryAuthDisabled(deltaTable);
 
         InnerTableRead snapshotRead = mock(InnerTableRead.class);
         InnerTableRead deltaRead = mock(InnerTableRead.class);
@@ -92,6 +111,71 @@ public class ChainGroupReadTableTest {
 
         assertThat(chainTable.newRead().createReader(result)).isSameAs(reader);
         verify(deltaRead).createReader(result);
+    }
+
+    @Test
+    public void testBatchScanKeepsHistoricalAnchorOutsideAuthorizedPartition() {
+        TableSchema schema = tableSchema();
+        RowType rowType = schema.logicalRowType();
+        TableQueryAuthResult logicalAuth =
+                new TableQueryAuthResult(
+                        Collections.singletonList(
+                                JsonSerdeUtil.toFlatJson(
+                                        new PredicateBuilder(rowType).equal(0, 20260720))),
+                        null);
+        CatalogEnvironment catalogEnvironment = catalogEnvironment(logicalAuth);
+        PrimaryKeyFileStoreTable snapshotTable =
+                table(schema, "snapshot", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawSnapshotTable =
+                table(schema, "snapshot", false, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawDeltaTable = table(schema, "delta", false, catalogEnvironment);
+        when(snapshotTable.copy(anyMap())).thenReturn(rawSnapshotTable);
+        when(deltaTable.copy(anyMap())).thenReturn(rawDeltaTable);
+
+        BinaryRow historicalPartition = BinaryRow.singleColumn(20260719);
+        BinaryRow authorizedPartition = BinaryRow.singleColumn(20260720);
+        DataTableScan snapshotScan = mock(DataTableScan.class);
+        when(snapshotScan.listPartitions())
+                .thenReturn(Collections.singletonList(historicalPartition));
+        when(snapshotScan.plan())
+                .thenReturn(
+                        new DataFilePlan<>(
+                                Collections.singletonList(
+                                        queryAuthSplit(
+                                                dataSplit(historicalPartition),
+                                                maskingAuth("snapshot")))));
+        DataTableScan deltaScan = mock(DataTableScan.class);
+        when(deltaScan.listPartitions()).thenReturn(Collections.singletonList(authorizedPartition));
+        when(deltaScan.plan())
+                .thenReturn(
+                        new DataFilePlan<>(
+                                Collections.singletonList(
+                                        queryAuthSplit(
+                                                dataSplit(authorizedPartition),
+                                                maskingAuth("delta")))));
+
+        ChainGroupReadTable chainTable = new ChainGroupReadTable(snapshotTable, deltaTable);
+        ChainGroupReadTable.ChainTableBatchScan scan =
+                new ChainGroupReadTable.ChainTableBatchScan(
+                        schema,
+                        chainTable,
+                        table -> table == rawSnapshotTable ? snapshotScan : deltaScan);
+        scan.skipPreloadTargetSnapshot();
+        scan.withLimit(1);
+
+        List<Split> splits = scan.plan().splits();
+
+        assertThat(splits).hasSize(1);
+        QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
+        assertThat(result.authResult()).isSameAs(logicalAuth);
+        ChainSplit chainSplit = (ChainSplit) result.split();
+        assertThat(chainSplit.logicalPartition()).isEqualTo(authorizedPartition);
+        assertThat(chainSplit.dataFiles()).hasSize(2);
+        verify(snapshotScan, never()).withLimit(anyInt());
+        verify(deltaScan, never()).withLimit(anyInt());
+        verifyQueryAuthDisabled(snapshotTable);
+        verifyQueryAuthDisabled(deltaTable);
     }
 
     @Test
@@ -106,15 +190,21 @@ public class ChainGroupReadTableTest {
 
     private void testStreamStartingPlanRetainsQueryAuth(boolean mergeSnapshot) {
         TableSchema schema = tableSchema(mergeSnapshot);
-        PrimaryKeyFileStoreTable snapshotTable = table(schema, "snapshot");
-        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta");
+        TableQueryAuthResult logicalAuth = maskingAuth("logical");
+        CatalogEnvironment catalogEnvironment = catalogEnvironment(logicalAuth);
+        PrimaryKeyFileStoreTable snapshotTable =
+                table(schema, "snapshot", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable deltaTable = table(schema, "delta", true, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawSnapshotTable =
+                table(schema, "snapshot", false, catalogEnvironment);
+        PrimaryKeyFileStoreTable rawDeltaTable = table(schema, "delta", false, catalogEnvironment);
 
         DataTableScan unusedScan = mock(DataTableScan.class);
-        when(snapshotTable.newScan()).thenReturn(unusedScan);
-        when(deltaTable.newScan()).thenReturn(unusedScan);
+        when(rawSnapshotTable.newScan()).thenReturn(unusedScan);
+        when(rawDeltaTable.newScan()).thenReturn(unusedScan);
 
         DataTableStreamScan deltaStreamScan = mock(DataTableStreamScan.class);
-        when(deltaTable.newStreamScan()).thenReturn(deltaStreamScan);
+        when(rawDeltaTable.newStreamScan()).thenReturn(deltaStreamScan);
 
         SnapshotManager snapshotManager = mock(SnapshotManager.class);
         when(snapshotManager.latestSnapshotId()).thenReturn(null);
@@ -125,13 +215,22 @@ public class ChainGroupReadTableTest {
         when(deltaTable.snapshotManager()).thenReturn(deltaSnapshotManager);
 
         BinaryRow partition = BinaryRow.singleColumn(1);
-        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition));
+        QueryAuthSplit sourceSplit = queryAuthSplit(dataSplit(partition), maskingAuth("physical"));
         DataTableScan pinnedDeltaScan = mock(DataTableScan.class);
         when(pinnedDeltaScan.plan())
                 .thenReturn(new DataFilePlan<>(Collections.singletonList(sourceSplit)));
-        PrimaryKeyFileStoreTable pinnedDeltaTable = table(schema, "delta");
+        PrimaryKeyFileStoreTable pinnedDeltaTable =
+                table(schema, "delta", false, catalogEnvironment);
         when(pinnedDeltaTable.newScan()).thenReturn(pinnedDeltaScan);
-        when(deltaTable.copy(anyMap())).thenReturn(pinnedDeltaTable);
+        when(snapshotTable.copy(anyMap())).thenReturn(rawSnapshotTable);
+        when(deltaTable.copy(anyMap()))
+                .thenAnswer(
+                        invocation -> {
+                            Map<String, String> options = invocation.getArgument(0);
+                            return options.containsKey(CoreOptions.SCAN_SNAPSHOT_ID.key())
+                                    ? pinnedDeltaTable
+                                    : rawDeltaTable;
+                        });
 
         ChainTableStreamScan scan =
                 new ChainTableStreamScan(new ChainGroupReadTable(snapshotTable, deltaTable));
@@ -139,18 +238,46 @@ public class ChainGroupReadTableTest {
 
         assertThat(splits).hasSize(1);
         QueryAuthSplit result = (QueryAuthSplit) splits.get(0);
-        assertThat(result.authResult()).isSameAs(sourceSplit.authResult());
+        assertThat(result.authResult()).isSameAs(logicalAuth);
+        assertThat(result.authResult()).isNotSameAs(sourceSplit.authResult());
         assertThat(result.split()).isInstanceOf(ChainSplit.class);
         verify(deltaStreamScan).restore(2L);
+        verifyQueryAuthDisabled(snapshotTable);
+        verifyQueryAuthDisabled(deltaTable);
     }
 
-    private static PrimaryKeyFileStoreTable table(TableSchema schema, String branch) {
+    private static PrimaryKeyFileStoreTable table(
+            TableSchema schema,
+            String branch,
+            boolean queryAuthEnabled,
+            CatalogEnvironment catalogEnvironment) {
         PrimaryKeyFileStoreTable table = mock(PrimaryKeyFileStoreTable.class);
         when(table.schema()).thenReturn(schema);
         Map<String, String> options = new HashMap<>(schema.options());
         options.put(CoreOptions.BRANCH.key(), branch);
+        options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), String.valueOf(queryAuthEnabled));
         when(table.coreOptions()).thenReturn(CoreOptions.fromMap(options));
+        when(table.catalogEnvironment()).thenReturn(catalogEnvironment);
         return table;
+    }
+
+    private static CatalogEnvironment catalogEnvironment(TableQueryAuthResult authResult) {
+        CatalogEnvironment catalogEnvironment = mock(CatalogEnvironment.class);
+        when(catalogEnvironment.tableQueryAuth(any(CoreOptions.class)))
+                .thenReturn(select -> authResult);
+        return catalogEnvironment;
+    }
+
+    private static void verifyQueryAuthDisabled(PrimaryKeyFileStoreTable table) {
+        verify(table, atLeastOnce())
+                .copy(
+                        argThat(
+                                (Map<String, String> options) ->
+                                        "false"
+                                                .equals(
+                                                        options.get(
+                                                                CoreOptions.QUERY_AUTH_ENABLED
+                                                                        .key()))));
     }
 
     private static TableSchema tableSchema() {
@@ -166,6 +293,9 @@ public class ChainGroupReadTableTest {
         Map<String, String> options = new HashMap<>();
         options.put(CoreOptions.SCAN_FALLBACK_SNAPSHOT_BRANCH.key(), "snapshot");
         options.put(CoreOptions.SCAN_FALLBACK_DELTA_BRANCH.key(), "delta");
+        options.put(CoreOptions.QUERY_AUTH_ENABLED.key(), "true");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_PATTERN.key(), "$pt");
+        options.put(CoreOptions.PARTITION_TIMESTAMP_FORMATTER.key(), "yyyyMMdd");
         options.put(
                 CoreOptions.CHAIN_TABLE_STREAMING_MERGE_SNAPSHOT.key(),
                 String.valueOf(mergeSnapshot));
@@ -192,9 +322,11 @@ public class ChainGroupReadTableTest {
                 .build();
     }
 
-    private static QueryAuthSplit queryAuthSplit(DataSplit split) {
-        TableQueryAuthResult authResult =
-                new TableQueryAuthResult(null, Collections.singletonMap("v", "mask"));
+    private static QueryAuthSplit queryAuthSplit(DataSplit split, TableQueryAuthResult authResult) {
         return new QueryAuthSplit(split, authResult);
+    }
+
+    private static TableQueryAuthResult maskingAuth(String value) {
+        return new TableQueryAuthResult(null, Collections.singletonMap("v", value));
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/ChainTableFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/ChainTableFileStoreTableTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.table;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.TableQueryAuthResult;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.table.FallbackReadFileStoreTable.FallbackSplitImpl;
+import org.apache.paimon.table.source.ChainSplit;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.Split;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for split routing in {@link ChainTableFileStoreTable}. */
+public class ChainTableFileStoreTableTest {
+
+    @Test
+    public void testQueryAuthChainSplitRoutedToChainGroupRead() throws Exception {
+        assertQueryAuthSplitRoutedToChainGroupRead(mock(ChainSplit.class));
+    }
+
+    @Test
+    public void testQueryAuthDataSplitRoutedToChainGroupRead() throws Exception {
+        assertQueryAuthSplitRoutedToChainGroupRead(mock(DataSplit.class));
+    }
+
+    @Test
+    public void testFallbackSplitStillUsesFallbackRead() throws Exception {
+        ReadFixture fixture = new ReadFixture();
+        QueryAuthSplit wrappedSplit = queryAuthSplit(mock(DataSplit.class));
+        FallbackSplitImpl fallbackSplit = new FallbackSplitImpl(wrappedSplit, false);
+        RecordReader<InternalRow> reader = mock(RecordReader.class);
+        when(fixture.wrappedRead.createReader(wrappedSplit)).thenReturn(reader);
+
+        assertThat(fixture.table.newRead().createReader(fallbackSplit)).isSameAs(reader);
+
+        verify(fixture.wrappedRead).createReader(wrappedSplit);
+    }
+
+    private void assertQueryAuthSplitRoutedToChainGroupRead(Split wrappedSplit) throws IOException {
+        ReadFixture fixture = new ReadFixture();
+        QueryAuthSplit split = queryAuthSplit(wrappedSplit);
+        RecordReader<InternalRow> reader = mock(RecordReader.class);
+        when(fixture.chainGroupRead.createReader(split)).thenReturn(reader);
+
+        assertThat(fixture.table.newRead().createReader(split)).isSameAs(reader);
+
+        verify(fixture.chainGroupRead).createReader(split);
+        verify(fixture.wrappedRead, never()).createReader(any(Split.class));
+    }
+
+    private static QueryAuthSplit queryAuthSplit(Split split) {
+        return new QueryAuthSplit(
+                split, new TableQueryAuthResult(null, Collections.singletonMap("v", "mask")));
+    }
+
+    private static class ReadFixture {
+
+        private final FileStoreTable wrapped = mock(FileStoreTable.class);
+        private final ChainGroupReadTable chainGroup = mock(ChainGroupReadTable.class);
+        private final InnerTableRead wrappedRead = mock(InnerTableRead.class);
+        private final InnerTableRead chainGroupRead = mock(InnerTableRead.class);
+        private final ChainTableFileStoreTable table;
+
+        private ReadFixture() {
+            when(wrapped.coreOptions()).thenReturn(CoreOptions.fromMap(Collections.emptyMap()));
+            when(wrapped.newRead()).thenReturn(wrappedRead);
+            when(chainGroup.newRead()).thenReturn(chainGroupRead);
+            table = new ChainTableFileStoreTable(wrapped, chainGroup);
+        }
+    }
+}

--- a/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/FallbackReadFileStoreTableTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
@@ -29,6 +30,8 @@ import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.PartitionPredicate;
+import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.predicate.FieldTransform;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.reader.RecordReader;
@@ -40,11 +43,14 @@ import org.apache.paimon.table.sink.StreamTableCommit;
 import org.apache.paimon.table.sink.StreamTableWrite;
 import org.apache.paimon.table.source.DataTableScan;
 import org.apache.paimon.table.source.InnerTableRead;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.InstantiationUtil;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.TraceableFileIO;
 
@@ -53,6 +59,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.AdditionalAnswers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -208,6 +215,60 @@ public class FallbackReadFileStoreTableTest {
         assertThat(fs2.isFallback())
                 .as("Partition that only exists in fallback branch should be read from fallback")
                 .isTrue();
+    }
+
+    @Test
+    public void testPlanAndReadWithQueryAuthSplit() throws Exception {
+        FileStoreTable mainTable = createTable();
+        writeDataIntoTable(mainTable, 0, rowData(1, 10));
+
+        mainTable.createBranch("bc");
+        FileStoreTable branchTable = createTableFromBranch(mainTable, "bc");
+        writeDataIntoTable(branchTable, 0, rowData(2, 20));
+
+        FallbackReadFileStoreTable table =
+                new FallbackReadFileStoreTable(mainTable, branchTable, true);
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(
+                        null,
+                        Collections.singletonMap(
+                                "a",
+                                JsonSerdeUtil.toFlatJson(
+                                        new FieldTransform(
+                                                new FieldRef(0, "pt", DataTypes.INT())))));
+        DataTableScan scan =
+                table.newFallbackScan(
+                        fileStoreTable -> queryAuthScan(fileStoreTable.newScan(), authResult));
+
+        List<Split> splits = scan.plan().splits();
+        assertThat(splits).hasSize(2);
+        assertThat(splits)
+                .allSatisfy(
+                        split -> {
+                            assertThat(split)
+                                    .isInstanceOf(FallbackReadFileStoreTable.FallbackSplit.class);
+                            Split wrapped =
+                                    ((FallbackReadFileStoreTable.FallbackSplit) split).wrapped();
+                            assertThat(wrapped).isInstanceOf(QueryAuthSplit.class);
+                        });
+
+        List<Pair<Integer, Integer>> result = new ArrayList<>();
+        for (Split split : splits) {
+            Split deserialized =
+                    InstantiationUtil.deserializeObject(
+                            InstantiationUtil.serializeObject(split), getClass().getClassLoader());
+            RecordReader<InternalRow> reader = table.newRead().createReader(deserialized);
+            reader.forEachRemaining(r -> result.add(Pair.of(r.getInt(0), r.getInt(1))));
+            reader.close();
+        }
+        assertThat(result).containsExactlyInAnyOrder(Pair.of(1, 1), Pair.of(2, 2));
+    }
+
+    private DataTableScan queryAuthScan(DataTableScan delegate, TableQueryAuthResult authResult) {
+        DataTableScan scan =
+                Mockito.mock(DataTableScan.class, AdditionalAnswers.delegatesTo(delegate));
+        Mockito.doAnswer(ignored -> authResult.convertPlan(delegate.plan())).when(scan).plan();
+        return scan;
     }
 
     @ParameterizedTest

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/QueryAuthSplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/QueryAuthSplitTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileTestDataGenerator;
 import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataOutputViewStreamWrapper;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.utils.InstantiationUtil;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,14 @@ public class QueryAuthSplitTest {
         assertThat(QueryAuthSplit.unwrapDataSplit(dataSplit)).isSameAs(dataSplit);
         assertThat(QueryAuthSplit.unwrapDataSplit(new QueryAuthSplit(dataSplit, authResult())))
                 .isSameAs(dataSplit);
+
+        Split fallbackDataSplit = FallbackReadFileStoreTable.toFallbackSplit(dataSplit, false);
+        assertThat(QueryAuthSplit.unwrapDataSplit(fallbackDataSplit)).isSameAs(fallbackDataSplit);
+
+        Split fallbackQueryAuthSplit =
+                new FallbackReadFileStoreTable.FallbackSplitImpl(
+                        new QueryAuthSplit(dataSplit, authResult()), false);
+        assertThat(QueryAuthSplit.unwrapDataSplit(fallbackQueryAuthSplit)).isSameAs(dataSplit);
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/QueryAuthSplitTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/QueryAuthSplitTest.java
@@ -38,6 +38,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class QueryAuthSplitTest {
 
     @Test
+    public void testUnwrapDataSplit() {
+        DataSplit dataSplit = dataSplit();
+
+        assertThat(QueryAuthSplit.unwrapDataSplit(dataSplit)).isSameAs(dataSplit);
+        assertThat(QueryAuthSplit.unwrapDataSplit(new QueryAuthSplit(dataSplit, authResult())))
+                .isSameAs(dataSplit);
+    }
+
+    @Test
     public void testSerializeAndDeserialize() throws Exception {
         QueryAuthSplit split = new QueryAuthSplit(dataSplit(), authResult());
 

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/BinlogTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/BinlogTableTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.system;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
@@ -27,6 +28,8 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
@@ -35,12 +38,18 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowKind;
+import org.apache.paimon.utils.JsonSerdeUtil;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
@@ -48,6 +57,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link BinlogTable}. */
 public class BinlogTableTest extends TableTestBase {
+
+    private FileStoreTable dataTable;
 
     @Test
     public void testReadBinlogFromLatest() throws Exception {
@@ -58,6 +69,29 @@ public class BinlogTableTest extends TableTestBase {
         List<InternalRow> result = read(binlogTable);
         List<InternalRow> expectRow = getExpectedResult();
         assertThat(result).containsExactlyInAnyOrderElementsOf(expectRow);
+    }
+
+    @Test
+    public void testReadQueryAuthSplits() throws Exception {
+        BinlogTable binlogTable = createBinlogTable("binlog_table_with_auth", false);
+        PredicateBuilder builder = new PredicateBuilder(dataTable.rowType());
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(
+                        Collections.singletonList(JsonSerdeUtil.toFlatJson(builder.equal(1, 2))),
+                        null);
+
+        ReadBuilder readBuilder = binlogTable.newReadBuilder();
+        TableRead read = readBuilder.newRead();
+        List<String> result = new ArrayList<>();
+        for (Split split : readBuilder.newScan().plan().splits()) {
+            try (RecordReader<InternalRow> reader =
+                    read.createReader(new QueryAuthSplit(split, authResult))) {
+                reader.forEachRemaining(
+                        row -> result.add(row.getString(0) + "-" + row.getArray(2).getInt(0)));
+            }
+        }
+
+        assertThat(result).containsExactly(RowKind.UPDATE_AFTER.shortString() + "-2");
     }
 
     @Test
@@ -121,10 +155,9 @@ public class BinlogTableTest extends TableTestBase {
         TableSchema tableSchema =
                 SchemaUtils.forceCommit(
                         new SchemaManager(fileIO, tablePath), schemaBuilder.build());
-        FileStoreTable table =
-                FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+        dataTable = FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
 
-        writeTestData(table);
+        writeTestData(dataTable);
 
         Identifier binlogTableId =
                 identifier(tableName + SYSTEM_TABLE_SPLITTER + BinlogTable.BINLOG);

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FileKeyRangesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FileKeyRangesTableTest.java
@@ -19,26 +19,34 @@
 package org.apache.paimon.table.system;
 
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.predicate.In;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.TableTestBase;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.apache.paimon.catalog.Identifier.SYSTEM_TABLE_SPLITTER;
 import static org.apache.paimon.io.DataFileTestUtils.row;
@@ -94,6 +102,26 @@ public class FileKeyRangesTableTest extends TableTestBase {
                             assertThat(row.getString(8)).isNotNull();
                             assertThat(row.getString(9)).isNotNull();
                         });
+    }
+
+    @Test
+    public void testReadQueryAuthSplits() throws Exception {
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap());
+        List<Split> splits =
+                table.newScan().plan().splits().stream()
+                        .map(split -> new QueryAuthSplit(split, authResult))
+                        .collect(Collectors.toList());
+        FilesTable.FilesSplit filesSplit = Mockito.mock(FilesTable.FilesSplit.class);
+        Mockito.when(filesSplit.splits(Mockito.any(FileStoreTable.class))).thenReturn(splits);
+
+        List<String> paths = new ArrayList<>();
+        try (RecordReader<InternalRow> reader =
+                fileKeyRangesTable.newRead().createReader(filesSplit)) {
+            reader.forEachRemaining(row -> paths.add(row.getString(2).toString()));
+        }
+
+        assertThat(paths).hasSameSizeAs(read(fileKeyRangesTable));
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/FilesTableTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.table.system;
 
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -34,6 +35,7 @@ import org.apache.paimon.predicate.In;
 import org.apache.paimon.predicate.LeafPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
@@ -47,13 +49,16 @@ import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
 import org.apache.paimon.table.sink.CommitMessage;
 import org.apache.paimon.table.sink.CommitMessageImpl;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.utils.SnapshotManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -125,6 +130,25 @@ public class FilesTableTest extends TableTestBase {
                 .containsExactlyInAnyOrder("{1, 10}-1-0");
         assertThat(readPartBucketLevel(builder.equal(5, 5)))
                 .containsExactlyInAnyOrder("{2, 20}-0-5");
+    }
+
+    @Test
+    public void testReadQueryAuthSplits() throws Exception {
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(Collections.emptyList(), Collections.emptyMap());
+        List<Split> splits =
+                table.newScan().plan().splits().stream()
+                        .map(split -> new QueryAuthSplit(split, authResult))
+                        .collect(Collectors.toList());
+        FilesTable.FilesSplit filesSplit = Mockito.mock(FilesTable.FilesSplit.class);
+        Mockito.when(filesSplit.splits(Mockito.any(FileStoreTable.class))).thenReturn(splits);
+
+        List<String> paths = new ArrayList<>();
+        try (RecordReader<InternalRow> reader = filesTable.newRead().createReader(filesSplit)) {
+            reader.forEachRemaining(row -> paths.add(row.getString(2).toString()));
+        }
+
+        assertThat(paths).hasSameSizeAs(read(filesTable));
     }
 
     private List<String> readPartBucketLevel(Predicate predicate) throws IOException {

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/pipeline/cdc/source/enumerator/CDCSourceEnumerator.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/pipeline/cdc/source/enumerator/CDCSourceEnumerator.java
@@ -30,6 +30,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamDataTableScan;
@@ -315,8 +316,13 @@ public class CDCSourceEnumerator
             FileStoreTable table,
             Identifier identifier,
             @Nullable Long lastSchemaId) {
-        Preconditions.checkState(split instanceof DataSplit);
-        long snapshotId = ((DataSplit) split).snapshotId();
+        Split unwrappedSplit = QueryAuthSplit.unwrap(split);
+        Preconditions.checkState(
+                unwrappedSplit instanceof DataSplit,
+                "CDC source expects DataSplit, but got %s.",
+                unwrappedSplit == null ? "null" : unwrappedSplit.getClass().getName());
+        DataSplit dataSplit = (DataSplit) unwrappedSplit;
+        long snapshotId = dataSplit.snapshotId();
         long schemaId = table.snapshot(snapshotId).schemaId();
         return new TableAwareFileStoreSourceSplit(
                 splitId, split, 0, identifier, lastSchemaId, schemaId);

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/pipeline/cdc/source/reader/CDCSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/pipeline/cdc/source/reader/CDCSourceSplitReader.java
@@ -30,6 +30,7 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReader.RecordIterator;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.utils.Pool;
 
@@ -213,9 +214,10 @@ public class CDCSourceSplitReader
         }
 
         // update metric when split changes
-        if (nextSplit.split() instanceof DataSplit) {
+        Split split = QueryAuthSplit.unwrap(nextSplit.split());
+        if (split instanceof DataSplit) {
             long eventTime =
-                    ((DataSplit) nextSplit.split())
+                    ((DataSplit) split)
                             .earliestFileCreationEpochMillis()
                             .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
             metrics.recordSnapshotUpdate(eventTime);

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/pipeline/cdc/source/enumerator/CDCSourceEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/pipeline/cdc/source/enumerator/CDCSourceEnumeratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.pipeline.cdc.source.enumerator;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
@@ -30,9 +31,12 @@ import org.apache.paimon.flink.source.FileSplitEnumeratorTestBase;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.table.FallbackReadFileStoreTable;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.IncrementalSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamDataTableScan;
 import org.apache.paimon.table.source.TableScan;
@@ -61,6 +65,7 @@ import static org.apache.paimon.flink.pipeline.cdc.CDCOptions.toCDCOption;
 import static org.apache.paimon.io.DataFileTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link CDCSourceEnumerator}. */
 public class CDCSourceEnumeratorTest
@@ -319,6 +324,83 @@ public class CDCSourceEnumeratorTest
         assertThat(assignments).containsKey(0);
         assertThat(toDataSplits(assignments.get(0).getAssignedSplits()))
                 .containsExactly(splits.get(0), splits.get(1));
+    }
+
+    @Test
+    public void testQueryAuthSplitKeepsWrapperAndRejectsNonDataSplit() throws Exception {
+        Options options = new Options();
+        options.setString("warehouse", warehouseFolder.toAbsolutePath().toString());
+        Configuration cdcConfig = new Configuration();
+        cdcConfig.set(toCDCOption(CDCOptions.DATABASE), DATABASE);
+        CDCSourceEnumerator enumerator =
+                new CDCSourceEnumerator(
+                        getSplitEnumeratorContext(1),
+                        new org.apache.flink.configuration.Configuration(),
+                        1L,
+                        CatalogContext.create(options),
+                        cdcConfig,
+                        null);
+
+        Identifier identifier = Identifier.create(DATABASE, TABLE + 0);
+        FileStoreTable wrappedTable = (FileStoreTable) catalog.getTable(identifier);
+        FileStoreTable table =
+                new FallbackReadFileStoreTable(wrappedTable, wrappedTable, true) {
+                    @Override
+                    public Snapshot snapshot(long snapshotId) {
+                        return new Snapshot(
+                                0,
+                                snapshotId,
+                                7L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                "user",
+                                0L,
+                                Snapshot.CommitKind.APPEND,
+                                0L,
+                                0L,
+                                0L,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null);
+                    }
+                };
+        DataSplit dataSplit = createDataSplit(5L, 0, Collections.emptyList());
+        QueryAuthSplit queryAuthSplit = new QueryAuthSplit(dataSplit, null);
+
+        TableAwareFileStoreSourceSplit result =
+                enumerator.toTableAwareSplit("split-1", queryAuthSplit, table, identifier, null);
+
+        assertThat(result.split()).isSameAs(queryAuthSplit);
+        assertThat(result.getSchemaId()).isEqualTo(7L);
+
+        IncrementalSplit incrementalSplit =
+                new IncrementalSplit(
+                        5L,
+                        row(0),
+                        0,
+                        1,
+                        Collections.emptyList(),
+                        null,
+                        Collections.emptyList(),
+                        null,
+                        true);
+        assertThatThrownBy(
+                        () ->
+                                enumerator.toTableAwareSplit(
+                                        "split-2", incrementalSplit, table, identifier, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "CDC source expects DataSplit, but got "
+                                + IncrementalSplit.class.getName()
+                                + ".");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/pipeline/cdc/source/reader/CDCSourceSplitReaderTest.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/pipeline/cdc/source/reader/CDCSourceSplitReaderTest.java
@@ -23,6 +23,7 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -39,6 +40,7 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.utils.InstantiationUtil;
@@ -133,6 +135,42 @@ public class CDCSourceSplitReaderTest {
     }
 
     @Test
+    public void testQueryAuthSplitUpdatesFetchLagMetric() throws Exception {
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tablePath);
+        FileStoreSourceReaderMetrics metrics =
+                new FileStoreSourceReaderMetrics(new DummyMetricGroup());
+        CDCSourceSplitReader reader =
+                createReader(
+                        new TestingTableRead(
+                                new SingleBatchRecordReader(new TrackingRecordIterator())),
+                        Collections.emptyList(),
+                        metrics);
+
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, kvs());
+        TableAwareFileStoreSourceSplit split = newSourceSplit("id1", row(1), 0, files);
+        assignSplit(
+                reader,
+                new TableAwareFileStoreSourceSplit(
+                        split.splitId(),
+                        new QueryAuthSplit(split.split(), new TableQueryAuthResult(null, null)),
+                        split.recordsToSkip(),
+                        split.getIdentifier(),
+                        split.getLastSchemaId(),
+                        split.getSchemaId(),
+                        split.schemaChangeEventsToSkip()));
+
+        RecordsWithSplitIds<RecordIterator<Event>> records = reader.fetch();
+        assertThat(metrics.getLatestFileCreationTime())
+                .isEqualTo(
+                        files.stream()
+                                .mapToLong(DataFileMeta::creationTimeEpochMillis)
+                                .min()
+                                .orElse(FileStoreSourceReaderMetrics.UNDEFINED));
+        records.recycle();
+        reader.close();
+    }
+
+    @Test
     public void testSplitReaderWakeupAble() throws Exception {
         TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tablePath);
         CDCSourceSplitReader reader = createReader(rw.createReadWithKey());
@@ -167,10 +205,17 @@ public class CDCSourceSplitReaderTest {
 
     private CDCSourceSplitReader createReader(
             TableRead tableRead, List<SchemaChangeEvent> schemaChangeEvents) {
-        return new TestCDCSourceSplitReader(
-                new FileStoreSourceReaderMetrics(new DummyMetricGroup()),
+        return createReader(
                 tableRead,
-                schemaChangeEvents);
+                schemaChangeEvents,
+                new FileStoreSourceReaderMetrics(new DummyMetricGroup()));
+    }
+
+    private CDCSourceSplitReader createReader(
+            TableRead tableRead,
+            List<SchemaChangeEvent> schemaChangeEvents,
+            FileStoreSourceReaderMetrics metrics) {
+        return new TestCDCSourceSplitReader(metrics, tableRead, schemaChangeEvents);
     }
 
     private void innerTestOnce(int skip) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -213,7 +213,8 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 table instanceof FallbackReadFileStoreTable
                         && ((FallbackReadFileStoreTable) table).other()
                                 instanceof ChainGroupReadTable;
-        if (!isChainTable
+        if (!table.coreOptions().queryAuthEnabled()
+                && !isChainTable
                 && options.get(LOOKUP_CACHE_MODE) == LookupCacheMode.AUTO
                 && new HashSet<>(table.primaryKeys()).equals(new HashSet<>(joinKeys))) {
             if (isRemoteServiceAvailable(table)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/FileStoreLookupFunction.java
@@ -124,6 +124,11 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
             int[] joinKeyIndex,
             @Nullable Predicate predicate,
             @Nullable ShuffleStrategy strategy) {
+        if (table.coreOptions().queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Lookup join does not support query authorization.");
+        }
+
         if (!TableScanUtils.supportCompactDiffStreamingReading(table)) {
             TableScanUtils.streamingReadingValidate(table);
         }
@@ -213,8 +218,7 @@ public class FileStoreLookupFunction implements Serializable, Closeable {
                 table instanceof FallbackReadFileStoreTable
                         && ((FallbackReadFileStoreTable) table).other()
                                 instanceof ChainGroupReadTable;
-        if (!table.coreOptions().queryAuthEnabled()
-                && !isChainTable
+        if (!isChainTable
                 && options.get(LOOKUP_CACHE_MODE) == LookupCacheMode.AUTO
                 && new HashSet<>(table.primaryKeys()).equals(new HashSet<>(joinKeys))) {
             if (isRemoteServiceAvailable(table)) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/lookup/PrimaryKeyPartialLookupTable.java
@@ -83,6 +83,10 @@ public class PrimaryKeyPartialLookupTable implements LookupTable {
         }
 
         CoreOptions coreOptions = CoreOptions.fromMap(table.options());
+        if (coreOptions.queryAuthEnabled()) {
+            throw new UnsupportedOperationException(
+                    "Primary key partial lookup does not support query authorization.");
+        }
 
         if (!coreOptions.needLookup()
                 && coreOptions.mergeEngine() != CoreOptions.MergeEngine.DEDUPLICATE) {

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumerator.java
@@ -30,7 +30,9 @@ import org.apache.paimon.table.source.ChainSplit;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
 import org.apache.paimon.table.source.IncrementalSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
 
@@ -328,13 +330,14 @@ public class ContinuousFileSplitEnumerator
     }
 
     protected int assignSuggestedTask(FileStoreSourceSplit split) {
+        Split unwrappedSplit = QueryAuthSplit.unwrap(split.split());
         int task;
-        if (split.split() instanceof DataSplit) {
-            task = assignSuggestedTask((DataSplit) split.split());
-        } else if (split.split() instanceof ChainSplit) {
-            task = assignSuggestedTask((ChainSplit) split.split());
+        if (unwrappedSplit instanceof DataSplit) {
+            task = assignSuggestedTask((DataSplit) unwrappedSplit);
+        } else if (unwrappedSplit instanceof ChainSplit) {
+            task = assignSuggestedTask((ChainSplit) unwrappedSplit);
         } else {
-            task = assignSuggestedTask((IncrementalSplit) split.split());
+            task = assignSuggestedTask((IncrementalSplit) unwrappedSplit);
         }
 
         // Split assigners keep splits in a map keyed by task, but only ever hand out splits for

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/FileStoreSourceSplitReader.java
@@ -25,6 +25,7 @@ import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReader.RecordIterator;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.BlobType;
@@ -219,9 +220,10 @@ public class FileStoreSourceSplitReader
         }
 
         // update metric when split changes
-        if (nextSplit.split() instanceof DataSplit) {
+        Split split = QueryAuthSplit.unwrap(nextSplit.split());
+        if (split instanceof DataSplit) {
             long eventTime =
-                    ((DataSplit) nextSplit.split())
+                    ((DataSplit) split)
                             .earliestFileCreationEpochMillis()
                             .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
             metrics.recordSnapshotUpdate(eventTime);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumerator.java
@@ -23,8 +23,8 @@ import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.flink.source.PendingSplitsCheckpoint;
 import org.apache.paimon.flink.source.assigners.AlignedSplitAssigner;
 import org.apache.paimon.flink.source.assigners.SplitAssigner;
-import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.SnapshotNotExistPlan;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
@@ -123,7 +123,7 @@ public class AlignedContinuousFileSplitEnumerator extends ContinuousFileSplitEnu
         Map<Long, List<FileStoreSourceSplit>> splitsBySnapshot = new TreeMap<>();
 
         for (FileStoreSourceSplit split : splits) {
-            long snapshotId = ((DataSplit) split.split()).snapshotId();
+            long snapshotId = QueryAuthSplit.unwrapDataSplit(split.split()).snapshotId();
             splitsBySnapshot.computeIfAbsent(snapshotId, snapshot -> new ArrayList<>()).add(split);
         }
 

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/AlignedSplitAssigner.java
@@ -21,6 +21,7 @@ package org.apache.paimon.flink.source.assigners;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.flink.source.align.PlaceholderSplit;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.utils.Preconditions;
 
 import javax.annotation.Nullable;
@@ -66,9 +67,10 @@ public class AlignedSplitAssigner implements SplitAssigner {
 
     @Override
     public void addSplit(int subtask, FileStoreSourceSplit splits) {
-        long snapshotId = ((DataSplit) splits.split()).snapshotId();
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(splits.split());
+        long snapshotId = dataSplit.snapshotId();
         PendingSnapshot last = pendingSplitAssignment.peekLast();
-        boolean isPlaceholder = splits.split() instanceof PlaceholderSplit;
+        boolean isPlaceholder = dataSplit instanceof PlaceholderSplit;
         if (last == null || last.snapshotId != snapshotId) {
             last = new PendingSnapshot(snapshotId, isPlaceholder, new HashMap<>());
             last.add(subtask, splits);
@@ -85,8 +87,9 @@ public class AlignedSplitAssigner implements SplitAssigner {
             return;
         }
 
-        long snapshotId = ((DataSplit) splits.get(0).split()).snapshotId();
-        boolean isPlaceholder = splits.get(0).split() instanceof PlaceholderSplit;
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(splits.get(0).split());
+        long snapshotId = dataSplit.snapshotId();
+        boolean isPlaceholder = dataSplit instanceof PlaceholderSplit;
         PendingSnapshot head = pendingSplitAssignment.peek();
         if (head == null || snapshotId != head.snapshotId) {
             head = new PendingSnapshot(snapshotId, isPlaceholder, new HashMap<>());
@@ -154,7 +157,7 @@ public class AlignedSplitAssigner implements SplitAssigner {
 
         public void add(int subtask, FileStoreSourceSplit split) {
             Preconditions.checkArgument(
-                    ((DataSplit) split.split()).snapshotId() == snapshotId,
+                    QueryAuthSplit.unwrapDataSplit(split.split()).snapshotId() == snapshotId,
                     "SnapshotId not equal. This is a bug, please file an issue.");
             subtaskSplits.computeIfAbsent(subtask, id -> new ArrayList<>()).add(split);
         }
@@ -166,7 +169,8 @@ public class AlignedSplitAssigner implements SplitAssigner {
             splits.forEach(
                     split ->
                             Preconditions.checkArgument(
-                                    ((DataSplit) split.split()).snapshotId() == snapshotId,
+                                    QueryAuthSplit.unwrapDataSplit(split.split()).snapshotId()
+                                            == snapshotId,
                                     "SnapshotId not equal"));
             subtaskSplits.put(subtask, splits);
         }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssigner.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.table.connector.source.DynamicFilteringData;
@@ -115,7 +116,7 @@ public class DynamicPartitionPruningAssigner implements SplitAssigner {
     }
 
     private boolean filter(FileStoreSourceSplit sourceSplit) {
-        DataSplit dataSplit = (DataSplit) sourceSplit.split();
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(sourceSplit.split());
         BinaryRow partition = dataSplit.partition();
         FlinkRowData projected = new FlinkRowData(partitionRowProjection.apply(partition));
         return dynamicFilteringData.contains(projected);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/assigners/PreAssignSplitAssigner.java
@@ -23,6 +23,7 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.FlinkRowData;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.utils.BinPacking;
 import org.apache.paimon.utils.SerializableFunction;
 
@@ -293,7 +294,7 @@ public class PreAssignSplitAssigner implements SplitAssigner {
             Projection partitionRowProjection,
             DynamicFilteringData dynamicFilteringData,
             FileStoreSourceSplit sourceSplit) {
-        DataSplit dataSplit = (DataSplit) sourceSplit.split();
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(sourceSplit.split());
         BinaryRow partition = dataSplit.partition();
         FlinkRowData projected = new FlinkRowData(partitionRowProjection.apply(partition));
         return dynamicFilteringData.contains(projected);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorSource.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/MonitorSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.flink.source.operator;
 
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.flink.NestedProjectedRowData;
 import org.apache.paimon.flink.source.AbstractNonCoordinatedSource;
 import org.apache.paimon.flink.source.AbstractNonCoordinatedSourceReader;
@@ -30,6 +31,7 @@ import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.ChannelComputer;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.EndOfScanException;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.StreamTableScan;
@@ -314,9 +316,11 @@ public class MonitorSource extends AbstractNonCoordinatedSource<Split> {
                     }
                     return ChannelComputer.select(key.f1, numPartitions);
                 },
-                split -> {
-                    DataSplit dataSplit = (DataSplit) split;
-                    return Tuple2.of(dataSplit.partition(), dataSplit.bucket());
-                });
+                MonitorSource::splitKey);
+    }
+
+    static Tuple2<BinaryRow, Integer> splitKey(Split split) {
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
+        return Tuple2.of(dataSplit.partition(), dataSplit.bucket());
     }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/source/operator/ReadOperator.java
@@ -25,6 +25,7 @@ import org.apache.paimon.flink.NestedProjectedRowData;
 import org.apache.paimon.flink.source.RecordLimiter;
 import org.apache.paimon.flink.source.metrics.FileStoreSourceReaderMetrics;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.utils.CloseableIterator;
@@ -114,8 +115,9 @@ public class ReadOperator extends AbstractStreamOperator<RowData>
 
         Split split = record.getValue();
         // update metric when reading a new split
+        DataSplit dataSplit = QueryAuthSplit.unwrapDataSplit(split);
         long eventTime =
-                ((DataSplit) split)
+                dataSplit
                         .earliestFileCreationEpochMillis()
                         .orElse(FileStoreSourceReaderMetrics.UNDEFINED);
         sourceReaderMetrics.recordSnapshotUpdate(eventTime);

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/utils/TableScanUtils.java
@@ -23,6 +23,8 @@ import org.apache.paimon.flink.source.FileStoreSourceSplit;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
+import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 
 import java.util.HashMap;
@@ -67,8 +69,9 @@ public class TableScanUtils {
 
     /** Get snapshot id from {@link FileStoreSourceSplit}. */
     public static Optional<Long> getSnapshotId(FileStoreSourceSplit split) {
-        if (split.split() instanceof DataSplit) {
-            return Optional.of(((DataSplit) split.split()).snapshotId());
+        Split unwrappedSplit = QueryAuthSplit.unwrap(split.split());
+        if (unwrappedSplit instanceof DataSplit) {
+            return Optional.of(((DataSplit) unwrappedSplit).snapshotId());
         }
         return Optional.empty();
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -19,6 +19,9 @@
 package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.FileSystemCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -29,10 +32,13 @@ import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.QueryExecutor
 import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.RemoteQueryExecutor;
 import org.apache.paimon.lookup.rocksdb.RocksDBOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.predicate.Predicate;
+import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.service.ServiceManager;
+import org.apache.paimon.table.CatalogEnvironment;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.sink.CommitMessage;
@@ -42,6 +48,7 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
+import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.TraceableFileIO;
 
 import org.apache.flink.table.data.RowData;
@@ -137,6 +144,23 @@ public class FileStoreLookupFunctionTest {
             boolean refreshAsync,
             Integer fullLoadThreshold)
             throws Exception {
+        return createFileStoreTable(
+                isPartition,
+                dynamicPartition,
+                refreshAsync,
+                fullLoadThreshold,
+                false,
+                CatalogEnvironment.empty());
+    }
+
+    private FileStoreTable createFileStoreTable(
+            boolean isPartition,
+            boolean dynamicPartition,
+            boolean refreshAsync,
+            Integer fullLoadThreshold,
+            boolean queryAuthEnabled,
+            CatalogEnvironment catalogEnvironment)
+            throws Exception {
         SchemaManager schemaManager = new SchemaManager(fileIO, tablePath);
         Options conf = new Options();
         conf.set(FlinkConnectorOptions.LOOKUP_REFRESH_ASYNC, refreshAsync);
@@ -151,11 +175,11 @@ public class FileStoreLookupFunctionTest {
         if (fullLoadThreshold != null) {
             conf.set(FlinkConnectorOptions.LOOKUP_REFRESH_FULL_LOAD_THRESHOLD, fullLoadThreshold);
         }
+        if (queryAuthEnabled) {
+            conf.set(CoreOptions.QUERY_AUTH_ENABLED, true);
+        }
 
-        RowType rowType =
-                RowType.of(
-                        new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
-                        new String[] {"pt", "k", "v"});
+        RowType rowType = tableRowType();
         Schema schema =
                 new Schema(
                         rowType.getFields(),
@@ -164,8 +188,7 @@ public class FileStoreLookupFunctionTest {
                         conf.toMap(),
                         "");
         TableSchema tableSchema = schemaManager.createTable(schema);
-        return FileStoreTableFactory.create(
-                fileIO, new org.apache.paimon.fs.Path(tempDir.toString()), tableSchema);
+        return FileStoreTableFactory.create(fileIO, tablePath, tableSchema, catalogEnvironment);
     }
 
     @AfterEach
@@ -217,6 +240,77 @@ public class FileStoreLookupFunctionTest {
         QueryExecutor queryExecutor =
                 ((PrimaryKeyPartialLookupTable) lookupFunction.lookupTable()).queryExecutor();
         assertThat(queryExecutor).isInstanceOf(RemoteQueryExecutor.class);
+    }
+
+    @Test
+    public void testQueryAuthUsesFullCacheAndAppliesRowFilter() throws Exception {
+        Predicate authFilter = new PredicateBuilder(tableRowType()).equal(2, 20L);
+        TableQueryAuthResult authResult =
+                new TableQueryAuthResult(
+                        Collections.singletonList(JsonSerdeUtil.toFlatJson(authFilter)), null);
+        Identifier identifier = Identifier.create("default", "table");
+        CatalogEnvironment catalogEnvironment =
+                new CatalogEnvironment(
+                        identifier,
+                        null,
+                        () ->
+                                new FileSystemCatalog(fileIO, tablePath) {
+                                    @Override
+                                    public TableQueryAuthResult authTableQuery(
+                                            Identifier ignored, List<String> select) {
+                                        return authResult;
+                                    }
+                                },
+                        null,
+                        null,
+                        null,
+                        false,
+                        false);
+        table = createFileStoreTable(false, false, false, null, true, catalogEnvironment);
+
+        StreamTableWrite writer = table.newStreamWriteBuilder().newWrite();
+        writer.write(GenericRow.of(1, 1, 10L));
+        writer.write(GenericRow.of(2, 2, 20L));
+        commit(writer.prepareCommit(true, 1));
+        writer.close();
+
+        ServiceManager serviceManager = new ServiceManager(fileIO, tablePath);
+        serviceManager.resetService(
+                PRIMARY_KEY_LOOKUP, new InetSocketAddress[] {new InetSocketAddress(1)});
+        lookupFunction = createLookupFunction(table, true);
+        lookupFunction.open(tempDir.toString());
+
+        assertThat(lookupFunction.lookupTable()).isInstanceOf(FullCacheLookupTable.class);
+        assertThat(lookupFunction.lookup(new FlinkRowData(GenericRow.of(1, 1)))).isEmpty();
+        assertThat(lookupFunction.lookup(new FlinkRowData(GenericRow.of(2, 2)))).hasSize(1);
+    }
+
+    @Test
+    public void testPartialLookupRejectsQueryAuth() throws Exception {
+        table = createFileStoreTable(false, false, false, null, true, CatalogEnvironment.empty());
+
+        assertThatThrownBy(
+                        () ->
+                                PrimaryKeyPartialLookupTable.createLocalTable(
+                                        table,
+                                        new int[] {0, 1},
+                                        tempDir.resolve("local").toFile(),
+                                        Arrays.asList("pt", "k"),
+                                        Collections.emptySet()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("does not support query authorization");
+        assertThatThrownBy(
+                        () ->
+                                PrimaryKeyPartialLookupTable.createRemoteTable(
+                                        table, new int[] {0, 1}, Arrays.asList("pt", "k")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("does not support query authorization");
+    }
+
+    private RowType tableRowType() {
+        return RowType.of(
+                new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.BIGINT()},
+                new String[] {"pt", "k", "v"});
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/lookup/FileStoreLookupFunctionTest.java
@@ -19,9 +19,6 @@
 package org.apache.paimon.flink.lookup;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.catalog.FileSystemCatalog;
-import org.apache.paimon.catalog.Identifier;
-import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -32,8 +29,6 @@ import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.QueryExecutor
 import org.apache.paimon.flink.lookup.PrimaryKeyPartialLookupTable.RemoteQueryExecutor;
 import org.apache.paimon.lookup.rocksdb.RocksDBOptions;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.predicate.Predicate;
-import org.apache.paimon.predicate.PredicateBuilder;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.schema.TableSchema;
@@ -48,7 +43,6 @@ import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.TraceableFileIO;
 
 import org.apache.flink.table.data.RowData;
@@ -243,46 +237,12 @@ public class FileStoreLookupFunctionTest {
     }
 
     @Test
-    public void testQueryAuthUsesFullCacheAndAppliesRowFilter() throws Exception {
-        Predicate authFilter = new PredicateBuilder(tableRowType()).equal(2, 20L);
-        TableQueryAuthResult authResult =
-                new TableQueryAuthResult(
-                        Collections.singletonList(JsonSerdeUtil.toFlatJson(authFilter)), null);
-        Identifier identifier = Identifier.create("default", "table");
-        CatalogEnvironment catalogEnvironment =
-                new CatalogEnvironment(
-                        identifier,
-                        null,
-                        () ->
-                                new FileSystemCatalog(fileIO, tablePath) {
-                                    @Override
-                                    public TableQueryAuthResult authTableQuery(
-                                            Identifier ignored, List<String> select) {
-                                        return authResult;
-                                    }
-                                },
-                        null,
-                        null,
-                        null,
-                        false,
-                        false);
-        table = createFileStoreTable(false, false, false, null, true, catalogEnvironment);
+    public void testLookupRejectsQueryAuth() throws Exception {
+        table = createFileStoreTable(false, false, false, null, true, CatalogEnvironment.empty());
 
-        StreamTableWrite writer = table.newStreamWriteBuilder().newWrite();
-        writer.write(GenericRow.of(1, 1, 10L));
-        writer.write(GenericRow.of(2, 2, 20L));
-        commit(writer.prepareCommit(true, 1));
-        writer.close();
-
-        ServiceManager serviceManager = new ServiceManager(fileIO, tablePath);
-        serviceManager.resetService(
-                PRIMARY_KEY_LOOKUP, new InetSocketAddress[] {new InetSocketAddress(1)});
-        lookupFunction = createLookupFunction(table, true);
-        lookupFunction.open(tempDir.toString());
-
-        assertThat(lookupFunction.lookupTable()).isInstanceOf(FullCacheLookupTable.class);
-        assertThat(lookupFunction.lookup(new FlinkRowData(GenericRow.of(1, 1)))).isEmpty();
-        assertThat(lookupFunction.lookup(new FlinkRowData(GenericRow.of(2, 2)))).hasSize(1);
+        assertThatThrownBy(() -> createLookupFunction(table, true))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Lookup join does not support query authorization");
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/ContinuousFileSplitEnumeratorTest.java
@@ -18,11 +18,13 @@
 
 package org.apache.paimon.flink.source;
 
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.source.DataFilePlan;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.IncrementalSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.table.source.TableScan;
 
@@ -902,6 +904,21 @@ public class ContinuousFileSplitEnumeratorTest
                         true);
 
         assertThat(enumerator.assignSuggestedTask(split)).isEqualTo(4 % parallelism);
+    }
+
+    @Test
+    public void testQueryAuthSplitAssignedByWrappedDataSplit() {
+        int parallelism = 3;
+        ContinuousFileSplitEnumerator enumerator = buildEnumerator(parallelism);
+        DataSplit dataSplit = createDataSplit(1L, 4, Collections.emptyList());
+        QueryAuthSplit queryAuthSplit =
+                new QueryAuthSplit(
+                        dataSplit,
+                        new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask")));
+        FileStoreSourceSplit sourceSplit = new FileStoreSourceSplit("split", queryAuthSplit);
+
+        assertThat(enumerator.assignSuggestedTask(sourceSplit)).isEqualTo(4 % parallelism);
+        assertThat(sourceSplit.split()).isSameAs(queryAuthSplit);
     }
 
     private ContinuousFileSplitEnumerator buildEnumerator(int parallelism) {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitReaderTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/FileStoreSourceSplitReaderTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.source;
 
 import org.apache.paimon.KeyValue;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
@@ -31,6 +32,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.utils.RecordWriter;
@@ -109,6 +111,38 @@ public class FileStoreSourceSplitReaderTest {
     }
 
     @Test
+    public void testQueryAuthSplitUpdatesFetchLagMetric() throws Exception {
+        TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
+        FileStoreSourceReaderMetrics metrics =
+                new FileStoreSourceReaderMetrics(new DummyMetricGroup());
+        FileStoreSourceSplitReader reader =
+                createReader(
+                        new TestingTableRead(
+                                new SingleBatchRecordReader(new TrackingRecordIterator())),
+                        null,
+                        metrics);
+
+        List<DataFileMeta> files = rw.writeFiles(row(1), 0, kvs());
+        FileStoreSourceSplit split = newSourceSplit("id1", row(1), 0, files);
+        assignSplit(
+                reader,
+                new FileStoreSourceSplit(
+                        split.splitId(),
+                        new QueryAuthSplit(split.split(), new TableQueryAuthResult(null, null)),
+                        split.recordsToSkip()));
+
+        RecordsWithSplitIds<RecordIterator<RowData>> records = reader.fetch();
+        assertThat(metrics.getLatestFileCreationTime())
+                .isEqualTo(
+                        files.stream()
+                                .mapToLong(DataFileMeta::creationTimeEpochMillis)
+                                .min()
+                                .orElse(FileStoreSourceReaderMetrics.UNDEFINED));
+        records.recycle();
+        reader.close();
+    }
+
+    @Test
     public void testSplitReaderWakeupAble() throws Exception {
         TestChangelogDataReadWrite rw = new TestChangelogDataReadWrite(tempDir.toString());
         FileStoreSourceSplitReader reader = createReader(rw.createReadWithKey(), null);
@@ -138,12 +172,14 @@ public class FileStoreSourceSplitReaderTest {
     }
 
     private FileStoreSourceSplitReader createReader(TableRead tableRead, @Nullable Long limit) {
+        return createReader(
+                tableRead, limit, new FileStoreSourceReaderMetrics(new DummyMetricGroup()));
+    }
+
+    private FileStoreSourceSplitReader createReader(
+            TableRead tableRead, @Nullable Long limit, FileStoreSourceReaderMetrics metrics) {
         return new FileStoreSourceSplitReader(
-                tableRead,
-                limit == null ? null : new RecordLimiter(limit),
-                new FileStoreSourceReaderMetrics(new DummyMetricGroup()),
-                null,
-                false);
+                tableRead, limit == null ? null : new RecordLimiter(limit), metrics, null, false);
     }
 
     private void innerTestOnce(int skip) throws Exception {

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumeratorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/align/AlignedContinuousFileSplitEnumeratorTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.flink.source.align;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.TableQueryAuthResult;
 import org.apache.paimon.consumer.ConsumerManager;
 import org.apache.paimon.flink.source.FileSplitEnumeratorTestBase;
 import org.apache.paimon.flink.source.FileStoreSourceSplit;
@@ -34,6 +35,7 @@ import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.StreamTableScan;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
@@ -137,6 +139,35 @@ public class AlignedContinuousFileSplitEnumeratorTest
         assertThat(assignments).containsOnlyKeys(0, 1);
         assertThat(assignments.get(0).getAssignedSplits()).containsExactly(expectedSplits.get(1));
         assertThat(assignments.get(1).getAssignedSplits()).containsExactly(expectedSplits.get(2));
+    }
+
+    @Test
+    public void testQueryAuthSplitsAssignedBySnapshot() {
+        final TestingSplitEnumeratorContext<FileStoreSourceSplit> context =
+                getSplitEnumeratorContext(1);
+        FileStoreSourceSplit first =
+                queryAuthSplit(createSnapshotSplit(1, 0, Collections.emptyList()));
+        FileStoreSourceSplit second =
+                queryAuthSplit(createSnapshotSplit(1, 0, Collections.emptyList()));
+
+        final AlignedContinuousFileSplitEnumerator enumerator =
+                new Builder()
+                        .setSplitEnumeratorContext(context)
+                        .setInitialSplits(Arrays.asList(first, second))
+                        .build();
+
+        enumerator.handleSplitRequest(0, "test-host");
+        List<FileStoreSourceSplit> assignedSplits =
+                context.getSplitAssignments().get(0).getAssignedSplits();
+        assertThat(assignedSplits).containsExactly(first, second);
+        assertThat(assignedSplits)
+                .allSatisfy(split -> assertThat(split.split()).isInstanceOf(QueryAuthSplit.class));
+
+        context.getSplitAssignments().clear();
+        enumerator.addSplitsBack(assignedSplits, 0);
+        enumerator.handleSplitRequest(0, "test-host");
+        assertThat(context.getSplitAssignments().get(0).getAssignedSplits())
+                .containsExactly(first, second);
     }
 
     @Test
@@ -255,6 +286,15 @@ public class AlignedContinuousFileSplitEnumeratorTest
                     -1,
                     10);
         }
+    }
+
+    private static FileStoreSourceSplit queryAuthSplit(FileStoreSourceSplit sourceSplit) {
+        return new FileStoreSourceSplit(
+                sourceSplit.splitId(),
+                new QueryAuthSplit(
+                        sourceSplit.split(),
+                        new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask"))),
+                sourceSplit.recordsToSkip());
     }
 
     @Override

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssignerTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/assigners/DynamicPartitionPruningAssignerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.source.assigners;
+
+import org.apache.paimon.catalog.TableQueryAuthResult;
+import org.apache.paimon.codegen.Projection;
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
+
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.table.connector.source.DynamicFilteringData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.IntType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.paimon.io.DataFileTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for dynamic partition pruning assigners. */
+public class DynamicPartitionPruningAssignerTest {
+
+    private static final Projection IDENTITY_PROJECTION = input -> (BinaryRow) input;
+
+    @Test
+    public void testPreAssignQueryAuthSplits() {
+        FileStoreSourceSplit selected = queryAuthSplit("selected", 1);
+        FileStoreSourceSplit filtered = queryAuthSplit("filtered", 2);
+
+        PreAssignSplitAssigner assigner =
+                new PreAssignSplitAssigner(
+                        10,
+                        1,
+                        Arrays.asList(selected, filtered),
+                        IDENTITY_PROJECTION,
+                        new TestDynamicFilteringData(1),
+                        split -> 1L);
+
+        assertThat(assigner.getNext(0, null)).containsExactly(selected);
+        assertThat(selected.split()).isInstanceOf(QueryAuthSplit.class);
+    }
+
+    @Test
+    public void testPreemptiveQueryAuthSplits() {
+        FileStoreSourceSplit filtered = queryAuthSplit("filtered", 2);
+        FileStoreSourceSplit selected = queryAuthSplit("selected", 1);
+        DynamicPartitionPruningAssigner assigner =
+                new DynamicPartitionPruningAssigner(
+                        new FIFOSplitAssigner(Arrays.asList(filtered, selected)),
+                        IDENTITY_PROJECTION,
+                        new TestDynamicFilteringData(1));
+
+        assertThat(assigner.remainingSplits()).containsExactly(selected);
+        assertThat(assigner.getNext(0, null)).containsExactly(selected);
+        assertThat(selected.split()).isInstanceOf(QueryAuthSplit.class);
+    }
+
+    private static FileStoreSourceSplit queryAuthSplit(String id, int partition) {
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withSnapshot(1L)
+                        .withPartition(row(partition))
+                        .withBucket(0)
+                        .withDataFiles(Collections.emptyList())
+                        .isStreaming(false)
+                        .withBucketPath("")
+                        .build();
+        return new FileStoreSourceSplit(
+                id,
+                new QueryAuthSplit(
+                        dataSplit,
+                        new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask"))));
+    }
+
+    private static class TestDynamicFilteringData extends DynamicFilteringData {
+
+        private final int selectedPartition;
+
+        private TestDynamicFilteringData(int selectedPartition) {
+            super(
+                    new GenericTypeInfo<>(RowData.class),
+                    org.apache.flink.table.types.logical.RowType.of(new IntType()),
+                    Collections.emptyList(),
+                    true);
+            this.selectedPartition = selectedPartition;
+        }
+
+        @Override
+        public boolean contains(RowData row) {
+            return row.getInt(0) == selectedPartition;
+        }
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/source/operator/OperatorSourceTest.java
@@ -22,13 +22,20 @@ import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.utils.TestingMetricUtils;
+import org.apache.paimon.metrics.MetricRegistry;
+import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.table.Table;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataTypes;
@@ -62,6 +69,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -216,6 +224,66 @@ public class OperatorSourceTest {
                 .containsExactlyInAnyOrder(
                         new StreamRecord<>(GenericRowData.of(1, 1, 1)),
                         new StreamRecord<>(GenericRowData.of(2, 2, 2)));
+    }
+
+    @Test
+    public void testQueryAuthSplitInDedicatedSourcePath() throws Exception {
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withSnapshot(1L)
+                        .withPartition(BinaryRow.EMPTY_ROW)
+                        .withBucket(0)
+                        .withBucketPath("bucket-0")
+                        .withDataFiles(Collections.emptyList())
+                        .build();
+        QueryAuthSplit queryAuthSplit = new QueryAuthSplit(dataSplit, null);
+        assertThat(MonitorSource.splitKey(queryAuthSplit))
+                .isEqualTo(MonitorSource.splitKey(dataSplit));
+
+        AtomicReference<Split> readerSplit = new AtomicReference<>();
+        TableRead capturingRead =
+                new TableRead() {
+                    @Override
+                    public TableRead withMetricRegistry(MetricRegistry registry) {
+                        return this;
+                    }
+
+                    @Override
+                    public TableRead executeFilter() {
+                        return this;
+                    }
+
+                    @Override
+                    public TableRead withIOManager(IOManager ioManager) {
+                        return this;
+                    }
+
+                    @Override
+                    public RecordReader<InternalRow> createReader(Split split) {
+                        readerSplit.set(split);
+                        return new RecordReader<InternalRow>() {
+                            @Override
+                            public RecordIterator<InternalRow> readBatch() {
+                                return null;
+                            }
+
+                            @Override
+                            public void close() {}
+                        };
+                    }
+                };
+
+        ReadOperator readOperator = new ReadOperator(() -> capturingRead, null, null);
+        OneInputStreamOperatorTestHarness<Split, RowData> harness =
+                new OneInputStreamOperatorTestHarness<>(readOperator);
+        harness.setup(
+                InternalSerializers.create(
+                        RowType.of(new IntType(), new IntType(), new IntType())));
+        harness.open();
+        harness.processElement(new StreamRecord<>(queryAuthSplit));
+
+        assertThat(readerSplit.get()).isSameAs(queryAuthSplit);
+        assertThat(harness.getOutput()).isEmpty();
     }
 
     @Test

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/utils/TableScanUtilsTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/utils/TableScanUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.utils;
+
+import org.apache.paimon.catalog.TableQueryAuthResult;
+import org.apache.paimon.flink.source.FileStoreSourceSplit;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.QueryAuthSplit;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.apache.paimon.io.DataFileTestUtils.row;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link TableScanUtils}. */
+public class TableScanUtilsTest {
+
+    @Test
+    public void testGetSnapshotIdFromQueryAuthSplit() {
+        DataSplit dataSplit =
+                DataSplit.builder()
+                        .withSnapshot(5L)
+                        .withPartition(row(1))
+                        .withBucket(0)
+                        .withDataFiles(Collections.emptyList())
+                        .isStreaming(true)
+                        .withBucketPath("")
+                        .build();
+        QueryAuthSplit queryAuthSplit =
+                new QueryAuthSplit(
+                        dataSplit,
+                        new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask")));
+        FileStoreSourceSplit sourceSplit = new FileStoreSourceSplit("split", queryAuthSplit);
+
+        assertThat(TableScanUtils.getSnapshotId(sourceSplit)).contains(5L);
+        assertThat(sourceSplit.split()).isSameAs(queryAuthSplit);
+    }
+}

--- a/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-3.3/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -21,8 +21,9 @@ package org.apache.paimon.spark
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate.{FullTextSearch, HybridSearch, Predicate, TopN, VectorSearch}
 import org.apache.paimon.spark.read.VariantExtractionInfo
+import org.apache.paimon.spark.util.SplitUtils
 import org.apache.paimon.table.{BucketMode, FileStoreTable, InnerTable}
-import org.apache.paimon.table.source.{DataSplit, Split}
+import org.apache.paimon.table.source.Split
 
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.read.SupportsReportPartitioning
@@ -82,12 +83,12 @@ case class PaimonScan(
 
   /** Extract the bucket number from the splits only if all splits have the same totalBuckets number. */
   private def extractBucketNumber(): Option[Int] = {
-    val splits = inputSplits
-    if (splits.exists(!_.isInstanceOf[DataSplit])) {
+    val dataSplits = inputSplits.map(SplitUtils.dataSplit)
+    if (dataSplits.exists(_.isEmpty)) {
       None
     } else {
       val deduplicated =
-        splits.map(s => Option(s.asInstanceOf[DataSplit].totalBuckets())).toSeq.distinct
+        dataSplits.map(s => Option(s.get.totalBuckets())).toSeq.distinct
 
       deduplicated match {
         case Seq(Some(num)) => Some(num)
@@ -108,16 +109,17 @@ case class PaimonScan(
   }
 
   override def getInputPartitions(splits: Array[Split]): Seq[PaimonInputPartition] = {
-    if (!shouldDoBucketedScan || splits.exists(!_.isInstanceOf[DataSplit])) {
+    val splitsWithMetadata = splits.map(split => (split, SplitUtils.dataSplit(split)))
+    if (!shouldDoBucketedScan || splitsWithMetadata.exists(_._2.isEmpty)) {
       return super.getInputPartitions(splits)
     }
 
-    splits
-      .map(_.asInstanceOf[DataSplit])
-      .groupBy(_.bucket())
+    splitsWithMetadata
+      .map { case (split, dataSplit) => (split, dataSplit.get) }
+      .groupBy(_._2.bucket())
       .map {
         case (bucket, groupedSplits) =>
-          PaimonBucketedInputPartition(groupedSplits, bucket)
+          PaimonBucketedInputPartition(groupedSplits.map(_._1), bucket)
       }
       .toSeq
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonRecordReaderIterator.scala
@@ -23,7 +23,7 @@ import org.apache.paimon.fs.Path
 import org.apache.paimon.reader.{FileRecordIterator, RecordReader, ScoreRecordIterator, ScoreRecordReader}
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.spark.schema.PaimonMetadataColumn.{PARTITION_AND_BUCKET_META_COLUMNS, PATH_AND_INDEX_META_COLUMNS, VECTOR_SEARCH_META_COLUMN_NAMES}
-import org.apache.paimon.table.source.{DataSplit, Split}
+import org.apache.paimon.table.source.{DataSplit, QueryAuthSplit, Split}
 import org.apache.paimon.utils.{CloseableIterator, Preconditions}
 
 import org.apache.spark.sql.PaimonUtils
@@ -37,12 +37,15 @@ case class PaimonRecordReaderIterator(
     split: Split)
   extends CloseableIterator[PaimonInternalRow] {
 
+  private val metadataSplit = QueryAuthSplit.unwrap(split)
+
   if (
-    metadataColumns.exists(c => PARTITION_AND_BUCKET_META_COLUMNS.contains(c.name)) && !split
+    metadataColumns.exists(
+      c => PARTITION_AND_BUCKET_META_COLUMNS.contains(c.name)) && !metadataSplit
       .isInstanceOf[DataSplit]
   ) {
     throw new RuntimeException(
-      "There need be DataSplit when path and index metadata columns are required")
+      "A DataSplit is required when partition or bucket metadata columns are requested")
   }
 
   private val needMetadata = metadataColumns.nonEmpty
@@ -169,9 +172,9 @@ case class PaimonRecordReaderIterator(
           case PaimonMetadataColumn.FILE_PATH_COLUMN =>
             metadataRow.setField(index, BinaryString.fromString(lastFilePath.toString))
           case PaimonMetadataColumn.PARTITION_COLUMN =>
-            metadataRow.setField(index, split.asInstanceOf[DataSplit].partition())
+            metadataRow.setField(index, metadataSplit.asInstanceOf[DataSplit].partition())
           case PaimonMetadataColumn.BUCKET_COLUMN =>
-            metadataRow.setField(index, split.asInstanceOf[DataSplit].bucket())
+            metadataRow.setField(index, metadataSplit.asInstanceOf[DataSplit].bucket())
         }
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/PaimonScan.scala
@@ -23,8 +23,9 @@ import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.predicate.{FullTextSearch, HybridSearch, Predicate, TopN, VectorSearch}
 import org.apache.paimon.spark.commands.BucketExpression.quote
 import org.apache.paimon.spark.read.VariantExtractionInfo
+import org.apache.paimon.spark.util.SplitUtils
 import org.apache.paimon.table.{BucketMode, FileStoreTable, InnerTable}
-import org.apache.paimon.table.source.{DataSplit, Split}
+import org.apache.paimon.table.source.Split
 
 import org.apache.spark.sql.PaimonUtils.fieldReference
 import org.apache.spark.sql.connector.expressions._
@@ -93,12 +94,12 @@ case class PaimonScan(
 
   /** Extract the bucket number from the splits only if all splits have the same totalBuckets number. */
   private def extractBucketNumber(): Option[Int] = {
-    val splits = inputSplits
-    if (splits.exists(!_.isInstanceOf[DataSplit])) {
+    val dataSplits = inputSplits.map(SplitUtils.dataSplit)
+    if (dataSplits.exists(_.isEmpty)) {
       None
     } else {
       val deduplicated =
-        splits.map(s => Option(s.asInstanceOf[DataSplit].totalBuckets())).toSeq.distinct
+        dataSplits.map(s => Option(s.get.totalBuckets())).toSeq.distinct
 
       deduplicated match {
         case Seq(Some(num)) => Some(num)
@@ -136,14 +137,14 @@ case class PaimonScan(
 
     val allSplitsKeepOrdering = inputPartitions.toSeq
       .map(_.asInstanceOf[PaimonBucketedInputPartition])
-      .map(_.splits.asInstanceOf[Seq[DataSplit]])
+      .map(_.splits.map(SplitUtils.dataSplit))
       .forall {
         splits =>
           // Only support report ordering if all matches:
           // - one `Split` per InputPartition (TODO: Re-construct splits using minKey/maxKey)
           // - `Split` is not rawConvertible so that the merge read can happen
           // - `Split` only contains one data file so it always sorted even without merge read
-          splits.size < 2 && splits.forall {
+          splits.forall(_.isDefined) && splits.size < 2 && splits.flatten.forall {
             split => !split.rawConvertible() || split.dataFiles().size() < 2
           }
       }
@@ -164,16 +165,17 @@ case class PaimonScan(
   }
 
   override protected def getInputPartitions(splits: Array[Split]): Seq[PaimonInputPartition] = {
-    if (!shouldDoBucketedScan || splits.exists(!_.isInstanceOf[DataSplit])) {
+    val splitsWithMetadata = splits.map(split => (split, SplitUtils.dataSplit(split)))
+    if (!shouldDoBucketedScan || splitsWithMetadata.exists(_._2.isEmpty)) {
       return super.getInputPartitions(splits)
     }
 
-    splits
-      .map(_.asInstanceOf[DataSplit])
-      .groupBy(_.bucket())
+    splitsWithMetadata
+      .map { case (split, dataSplit) => (split, dataSplit.get) }
+      .groupBy(_._2.bucket())
       .map {
         case (bucket, groupedSplits) =>
-          PaimonBucketedInputPartition(groupedSplits, bucket)
+          PaimonBucketedInputPartition(groupedSplits.map(_._1), bucket)
       }
       .toSeq
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -32,7 +32,7 @@ import org.apache.paimon.spark.data.SparkInternalRow
 import org.apache.paimon.spark.read.VectorSearchResultUtils
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
 import org.apache.paimon.table.{InnerTable, SpecialFields, Table}
-import org.apache.paimon.table.source.{BatchVectorSearchBuilder, DataSplit, InnerTableScan, PrimaryKeyScoredResult, PrimaryKeySearchPosition, PrimaryKeyVectorResult, ReadBuilder, VectorScan}
+import org.apache.paimon.table.source.{BatchVectorSearchBuilder, DataSplit, InnerTableScan, PrimaryKeyScoredResult, PrimaryKeySearchPosition, PrimaryKeyVectorResult, QueryAuthSplit, ReadBuilder, VectorScan}
 import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.RoaringNavigableMap64
 
@@ -567,7 +567,7 @@ case class LateralVectorSearchExec(
 
     scan.plan().splits().asScala.iterator.flatMap {
       split =>
-        val indexedSplit = split.asInstanceOf[IndexedSplit]
+        val indexedSplit = QueryAuthSplit.unwrap(split).asInstanceOf[IndexedSplit]
         val dataSplit = indexedSplit.dataSplit()
         val file = LateralVectorSearchPhysicalFile.from(dataSplit)
         val reader =

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -355,7 +355,7 @@ case class LateralVectorSearchExec(
       .withLimit(limit)
       .withOptions(options.asJava)
     pushSearchFilters(Seq(readBuilder, physicalReadBuilder), vectorSearchBuilder)
-    pushQueryAuthFilter(coreOptions, vectorSearchBuilder)
+    pushQueryAuthFilter(coreOptions, (readFieldNames :+ columnName).distinct, vectorSearchBuilder)
 
     val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
     val batchSize =
@@ -410,6 +410,7 @@ case class LateralVectorSearchExec(
 
   private def pushQueryAuthFilter(
       coreOptions: CoreOptions,
+      authFieldNames: Seq[String],
       vectorSearchBuilder: BatchVectorSearchBuilder): Unit = {
     if (!coreOptions.queryAuthEnabled()) {
       return
@@ -418,7 +419,10 @@ case class LateralVectorSearchExec(
     // Vector search applies its limit before physical readers enforce QueryAuthSplit. Push the row
     // filter into candidate selection so unauthorized rows cannot consume the limit.
     val table = innerTable.asInstanceOf[FileStoreTable]
-    val authResult = table.catalogEnvironment().tableQueryAuth(coreOptions).auth(null)
+    val authResult = table
+      .catalogEnvironment()
+      .tableQueryAuth(coreOptions)
+      .auth(authFieldNames.asJava)
     Option(authResult)
       .flatMap(result => Option(result.extractPredicate()))
       .flatMap(predicate => Option(TableQueryAuthResult.remapPredicate(predicate, table.rowType())))

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -19,6 +19,7 @@
 package org.apache.paimon.spark.execution
 
 import org.apache.paimon.CoreOptions
+import org.apache.paimon.catalog.TableQueryAuthResult
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.globalindex.{GlobalIndexResult, IndexedSplit, ScoredGlobalIndexResult}
 import org.apache.paimon.partition.PartitionPredicate
@@ -31,7 +32,7 @@ import org.apache.paimon.spark.catalyst.plans.logical.{CopyIntoLocationCommand, 
 import org.apache.paimon.spark.data.SparkInternalRow
 import org.apache.paimon.spark.read.VectorSearchResultUtils
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.{InnerTable, SpecialFields, Table}
+import org.apache.paimon.table.{FileStoreTable, InnerTable, SpecialFields, Table}
 import org.apache.paimon.table.source.{BatchVectorSearchBuilder, DataSplit, InnerTableScan, PrimaryKeyScoredResult, PrimaryKeySearchPosition, PrimaryKeyVectorResult, QueryAuthSplit, ReadBuilder, VectorScan}
 import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.RoaringNavigableMap64
@@ -354,6 +355,7 @@ case class LateralVectorSearchExec(
       .withLimit(limit)
       .withOptions(options.asJava)
     pushSearchFilters(Seq(readBuilder, physicalReadBuilder), vectorSearchBuilder)
+    pushQueryAuthFilter(coreOptions, vectorSearchBuilder)
 
     val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
     val batchSize =
@@ -404,6 +406,23 @@ case class LateralVectorSearchExec(
         vectorSearchBuilder.withFilter(dataFilter)
       }
     }
+  }
+
+  private def pushQueryAuthFilter(
+      coreOptions: CoreOptions,
+      vectorSearchBuilder: BatchVectorSearchBuilder): Unit = {
+    if (!coreOptions.queryAuthEnabled()) {
+      return
+    }
+
+    // Vector search applies its limit before physical readers enforce QueryAuthSplit. Push the row
+    // filter into candidate selection so unauthorized rows cannot consume the limit.
+    val table = innerTable.asInstanceOf[FileStoreTable]
+    val authResult = table.catalogEnvironment().tableQueryAuth(coreOptions).auth(null)
+    Option(authResult)
+      .flatMap(result => Option(result.extractPredicate()))
+      .flatMap(predicate => Option(TableQueryAuthResult.remapPredicate(predicate, table.rowType())))
+      .foreach(vectorSearchBuilder.withFilter)
   }
 
   private def convertSearchFilters(): Seq[Predicate] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -315,6 +315,7 @@ case class LateralVectorSearchExec(
   private def createSearchContext(
       rightProjection: UnsafeProjection,
       readerTracker: LateralVectorSearchReaderTracker): LateralVectorSearchContext = {
+    val coreOptions = new CoreOptions(innerTable.options())
     val rowType = innerTable.rowType()
     val readFieldNames = vectorSearchOutput
       .filterNot(
@@ -356,7 +357,7 @@ case class LateralVectorSearchExec(
 
     val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
     val batchSize =
-      Math.max(1, new CoreOptions(innerTable.options()).vectorSearchLateralJoinBatchSize())
+      Math.max(1, coreOptions.vectorSearchLateralJoinBatchSize())
 
     LateralVectorSearchContext(
       readBuilder,
@@ -367,7 +368,8 @@ case class LateralVectorSearchExec(
       sparkRow,
       rowIdOrdinal = resultRowType.getFieldIndex(SpecialFields.ROW_ID.name()),
       metaColumnsOnly =
-        VectorSearchResultUtils.isVectorSearchMetaOnly(vectorSearchOutput.map(_.name)),
+        VectorSearchResultUtils.isVectorSearchMetaOnly(vectorSearchOutput.map(_.name)) &&
+          !coreOptions.queryAuthEnabled(),
       projectionInputOrdinals = vectorSearchOutput.map {
         attr =>
           if (attr.name == PaimonMetadataColumn.SEARCH_SCORE_COLUMN) {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BinPackingSplits.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/read/BinPackingSplits.scala
@@ -25,7 +25,7 @@ import org.apache.paimon.spark.PaimonInputPartition
 import org.apache.paimon.spark.util.SplitUtils
 import org.apache.paimon.table.FallbackReadFileStoreTable.FallbackSplit
 import org.apache.paimon.table.format.FormatDataSplit
-import org.apache.paimon.table.source.{DataSplit, DeletionFile, Split}
+import org.apache.paimon.table.source.{DataSplit, DeletionFile, QueryAuthSplit, Split}
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.PaimonSparkSession
@@ -78,18 +78,22 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
   def pack(splits: Array[Split]): Seq[PaimonInputPartition] = {
     val (toReshuffle, reserved) = splits.partition {
       case _: FallbackSplit => false
-      case split: DataSplit => split.rawConvertible() || coreOptions.dataEvolutionEnabled()
-      // FormatDataSplit is already packed with multiple files by target size in the core scan,
-      // so each split maps directly to one input partition here.
-      case _: FormatDataSplit => false
-      case _ => false
+      case split =>
+        SplitUtils.unwrapQueryAuth(split) match {
+          case dataSplit: DataSplit =>
+            dataSplit.rawConvertible() || coreOptions.dataEvolutionEnabled()
+          // FormatDataSplit is already packed with multiple files by target size in the core scan,
+          // so each split maps directly to one input partition here.
+          case _: FormatDataSplit => false
+          case _ => false
+        }
     }
     if (toReshuffle.nonEmpty) {
       val startTS = System.currentTimeMillis()
       val reshuffled = if (coreOptions.dataEvolutionEnabled()) {
-        packDataEvolutionSplit(toReshuffle.collect { case ds: DataSplit => ds })
+        packDataEvolutionSplit(toReshuffle)
       } else {
-        packDataSplit(toReshuffle.collect { case ds: DataSplit => ds })
+        packDataSplit(toReshuffle)
       }
       val all = reserved.map(PaimonInputPartition.apply) ++ reshuffled
       val duration = System.currentTimeMillis() - startTS
@@ -102,22 +106,23 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
     }
   }
 
-  private def packDataSplit(splits: Array[DataSplit]): Array[PaimonInputPartition] = {
-    val maxSplitBytes = computeMaxSplitBytes(splits)
+  private def packDataSplit(splits: Array[Split]): Array[PaimonInputPartition] = {
+    val maxSplitBytes = computeMaxSplitBytes(splits.map(SplitUtils.dataSplit(_).get))
 
     var currentSize = 0L
-    val currentSplits = new ArrayBuffer[DataSplit]
+    val currentSplits = new ArrayBuffer[Split]
     val partitions = new ArrayBuffer[PaimonInputPartition]
 
-    var currentSplit: Option[DataSplit] = None
+    var currentSplit: Option[(Split, DataSplit)] = None
     val currentDataFiles = new ArrayBuffer[DataFileMeta]
     val currentDeletionFiles = new ArrayBuffer[DeletionFile]
 
     def closeDataSplit(): Unit = {
       if (currentSplit.nonEmpty && currentDataFiles.nonEmpty) {
-        val newSplit =
-          copyDataSplit(currentSplit.get, currentDataFiles.toSeq, currentDeletionFiles.toSeq)
-        currentSplits += newSplit
+        val (sourceSplit, dataSplit) = currentSplit.get
+        val replacement =
+          copyDataSplit(dataSplit, currentDataFiles.toSeq, currentDeletionFiles.toSeq)
+        currentSplits += QueryAuthSplit.retainAuth(sourceSplit, replacement)
       }
       currentDataFiles.clear()
       currentDeletionFiles.clear()
@@ -134,13 +139,20 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
 
     splits.foreach {
       split =>
-        if (!currentSplit.exists(withSamePartitionAndBucket(_, split))) {
+        val dataSplit = SplitUtils.dataSplit(split).get
+        if (
+          !currentSplit.exists {
+            case (source, currentDataSplit) =>
+              withSamePartitionAndBucket(currentDataSplit, dataSplit) &&
+              withSameQueryAuth(source, split)
+          }
+        ) {
           // close and open another data split
           closeDataSplit()
-          currentSplit = Some(split)
+          currentSplit = Some((split, dataSplit))
         }
 
-        val ddFiles = dataFileAndDeletionFiles(split)
+        val ddFiles = dataFileAndDeletionFiles(dataSplit)
         ddFiles.foreach {
           case (dataFile, deletionFile) =>
             val size =
@@ -161,11 +173,11 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
     partitions.toArray
   }
 
-  private def packDataEvolutionSplit(splits: Array[DataSplit]): Array[PaimonInputPartition] = {
-    val maxSplitBytes = computeMaxSplitBytes(splits)
+  private def packDataEvolutionSplit(splits: Array[Split]): Array[PaimonInputPartition] = {
+    val maxSplitBytes = computeMaxSplitBytes(splits.map(SplitUtils.dataSplit(_).get))
 
     var currentSize = 0L
-    val currentSplits = new ArrayBuffer[DataSplit]
+    val currentSplits = new ArrayBuffer[Split]
     val partitions = new ArrayBuffer[PaimonInputPartition]
 
     def closeInputPartition(): Unit = {
@@ -178,7 +190,7 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
 
     splits.foreach {
       split =>
-        val ddFiles = dataFileAndDeletionFiles(split)
+        val ddFiles = dataFileAndDeletionFiles(SplitUtils.dataSplit(split).get)
         val size = ddFiles.map {
           case (dataFile, deletionFile) =>
             (dataFile.fileSize() * readRowSizeRatio).toLong + openCostInBytes + Option(deletionFile)
@@ -217,6 +229,16 @@ case class BinPackingSplits(coreOptions: CoreOptions, readRowSizeRatio: Double =
 
   private def withSamePartitionAndBucket(split1: DataSplit, split2: DataSplit): Boolean = {
     split1.partition().equals(split2.partition()) && split1.bucket() == split2.bucket()
+  }
+
+  private def withSameQueryAuth(split1: Split, split2: Split): Boolean = {
+    (split1, split2) match {
+      case (auth1: QueryAuthSplit, auth2: QueryAuthSplit) =>
+        Option(auth1.authResult()).map(r => (r.filter(), r.columnMasking())) ==
+          Option(auth2.authResult()).map(r => (r.filter(), r.columnMasking()))
+      case (_: QueryAuthSplit, _) | (_, _: QueryAuthSplit) => false
+      case _ => true
+    }
   }
 
   private def dataFileAndDeletionFiles(split: DataSplit): Array[(DataFileMeta, DeletionFile)] = {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonReadLimits.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/PaimonReadLimits.scala
@@ -110,7 +110,7 @@ case class PaimonReadLimitGuard(limits: Array[ReadLimit], lastTriggerMillis: Lon
   private def getBytesAndRows(indexedDataSplit: IndexedDataSplit): (Long, Long) = {
     var rows = 0L
     var bytes = 0L
-    indexedDataSplit.entry.dataFiles().asScala.foreach {
+    indexedDataSplit.dataSplit.dataFiles().asScala.foreach {
       file =>
         rows += file.rowCount()
         bytes += file.fileSize()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/sources/StreamHelper.scala
@@ -22,7 +22,7 @@ import org.apache.paimon.CoreOptions
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.spark.SparkTypeUtils
 import org.apache.paimon.table.DataTable
-import org.apache.paimon.table.source.{DataSplit, StreamDataTableScan}
+import org.apache.paimon.table.source.{DataSplit, QueryAuthSplit, Split, StreamDataTableScan}
 import org.apache.paimon.table.source.TableScan.Plan
 import org.apache.paimon.table.source.snapshot.StartingContext
 import org.apache.paimon.utils.{InternalRowPartitionComputer, TypeUtils}
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.StructType
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-case class IndexedDataSplit(snapshotId: Long, index: Long, entry: DataSplit)
+case class IndexedDataSplit(snapshotId: Long, index: Long, entry: Split, dataSplit: DataSplit)
 
 private[spark] trait StreamHelper {
 
@@ -122,16 +122,20 @@ private[spark] trait StreamHelper {
 
   /** Sort the [[DataSplit]] list and index them. */
   private def convertPlanToIndexedSplits(plan: Plan): Array[IndexedDataSplit] = {
-    val dataSplits =
-      plan.splits().asScala.collect { case dataSplit: DataSplit => dataSplit }.toArray
-    val snapshotId = dataSplits.head.snapshotId()
+    val dataSplits = plan
+      .splits()
+      .asScala
+      .map(split => (split, QueryAuthSplit.unwrap(split)))
+      .collect { case (entry, dataSplit: DataSplit) => (entry, dataSplit) }
+      .toArray
+    val snapshotId = dataSplits.head._2.snapshotId()
 
     dataSplits
-      .sortWith((ds1, ds2) => compareByPartitionAndBucket(ds1, ds2) < 0)
+      .sortWith((ds1, ds2) => compareByPartitionAndBucket(ds1._2, ds2._2) < 0)
       .zipWithIndex
       .map {
-        case (split, idx) =>
-          IndexedDataSplit(snapshotId, idx, split)
+        case ((entry, dataSplit), idx) =>
+          IndexedDataSplit(snapshotId, idx, entry, dataSplit)
       }
   }
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SplitUtils.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/util/SplitUtils.scala
@@ -19,7 +19,7 @@
 package org.apache.paimon.spark.util
 
 import org.apache.paimon.table.format.FormatDataSplit
-import org.apache.paimon.table.source.{DataSplit, Split}
+import org.apache.paimon.table.source.{DataSplit, QueryAuthSplit, Split}
 
 import java.util.{Collections => JCollections}
 
@@ -27,8 +27,22 @@ import scala.collection.JavaConverters._
 
 object SplitUtils {
 
-  def splitSize(split: Split): Long = {
+  private[spark] def unwrapQueryAuth(split: Split): Split = {
     split match {
+      case _: QueryAuthSplit => QueryAuthSplit.unwrap(split)
+      case _ => split
+    }
+  }
+
+  private[spark] def dataSplit(split: Split): Option[DataSplit] = {
+    unwrapQueryAuth(split) match {
+      case ds: DataSplit => Some(ds)
+      case _ => None
+    }
+  }
+
+  def splitSize(split: Split): Long = {
+    unwrapQueryAuth(split) match {
       case ds: DataSplit =>
         ds.dataFiles().asScala.map(_.fileSize).sum
       case fs: FormatDataSplit =>
@@ -40,7 +54,7 @@ object SplitUtils {
   def fileCount(split: Split): Long = dataFileCount(split) + deleteFileCount(split)
 
   def dataFileCount(split: Split): Long = {
-    split match {
+    unwrapQueryAuth(split) match {
       case ds: DataSplit => ds.dataFiles().size()
       case fs: FormatDataSplit => fs.fileCount()
       case _ => 0
@@ -48,7 +62,7 @@ object SplitUtils {
   }
 
   def deleteFileCount(split: Split): Long = {
-    split match {
+    unwrapQueryAuth(split) match {
       case ds: DataSplit =>
         ds.deletionFiles()
           .orElse(JCollections.emptyList())

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -846,6 +846,48 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testLateralPrimaryKeyVectorSearchMetadataOnlyWithRowFilter() {
+        spark.sql(
+                "CREATE TABLE t_auth_vector_metadata ("
+                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>) "
+                        + "TBLPROPERTIES ("
+                        + "'primary-key'='id', "
+                        + "'bucket'='1', "
+                        + "'deletion-vectors.enabled'='true', "
+                        + "'vector-field'='embedding', "
+                        + "'field.embedding.vector-dim'='2', "
+                        + "'pk-vector.index.columns'='embedding', "
+                        + "'fields.embedding.pk-vector.index.type'='test-vector-ann', "
+                        + "'fields.embedding.pk-vector.distance.metric'='l2', "
+                        + "'test.vector.dimension'='2', "
+                        + "'test.vector.metric'='l2', "
+                        + "'query-auth.enabled'='true')");
+        spark.sql(
+                "INSERT INTO t_auth_vector_metadata VALUES "
+                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f)), "
+                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f))");
+
+        Predicate idEq1Predicate =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(1));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_auth_vector_metadata"),
+                Collections.singletonList(idEq1Predicate));
+
+        List<Row> rows =
+                spark.sql(
+                                "SELECT q.id AS query_id, r._row_id AS row_id "
+                                        + "FROM t_auth_vector_metadata AS q, "
+                                        + "LATERAL (SELECT _row_id FROM vector_search("
+                                        + "'t_auth_vector_metadata', 'embedding', "
+                                        + "q.query_embedding, 1)) AS r")
+                        .collectAsList();
+        assertThat(rows).isEmpty();
+    }
+
+    @Test
     public void testLateralPrimaryKeyVectorSearchWithAllowedRowFilter() {
         spark.sql(
                 "CREATE TABLE t_auth_vector_allowed ("

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -842,7 +842,7 @@ public class SparkCatalogWithRestTest {
                                         + "LATERAL (SELECT id FROM vector_search("
                                         + "'t_auth_vector', 'embedding', q.query_embedding, 1)) AS r")
                         .collectAsList();
-        assertThat(rows).isEmpty();
+        assertThat(rows.toString()).isEqualTo("[[1,1]]");
     }
 
     @Test
@@ -884,7 +884,7 @@ public class SparkCatalogWithRestTest {
                                         + "'t_auth_vector_metadata', 'embedding', "
                                         + "q.query_embedding, 1)) AS r")
                         .collectAsList();
-        assertThat(rows).isEmpty();
+        assertThat(rows.toString()).isEqualTo("[[1,0]]");
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -56,6 +56,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
+import org.apache.spark.sql.streaming.StreamingQuery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -761,6 +762,46 @@ public class SparkCatalogWithRestTest {
         assertThat(rows.get(0).getInt(0)).isEqualTo(2);
         assertThat(rows.get(0).getStruct(1).getString(0)).isEqualTo("p2");
         assertThat(rows.get(0).getInt(2)).isBetween(0, 1);
+    }
+
+    @Test
+    public void testStreamingRowFilter() throws Exception {
+        spark.sql(
+                "CREATE TABLE t_stream_auth (id INT, name STRING) TBLPROPERTIES "
+                        + "('query-auth.enabled'='true')");
+        spark.sql("INSERT INTO t_stream_auth VALUES (1, 'blocked'), (2, 'allowed')");
+
+        Predicate idEq2Predicate =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(2));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_stream_auth"),
+                Collections.singletonList(idEq2Predicate));
+
+        StreamingQuery query =
+                spark.readStream()
+                        .format("paimon")
+                        .table("t_stream_auth")
+                        .writeStream()
+                        .format("memory")
+                        .option(
+                                "checkpointLocation",
+                                tempFile.resolve("stream-auth-checkpoint").toString())
+                        .queryName("stream_auth_result")
+                        .outputMode("append")
+                        .start();
+        try {
+            query.processAllAvailable();
+            assertThat(
+                            spark.sql("SELECT * FROM stream_auth_result ORDER BY id")
+                                    .collectAsList()
+                                    .toString())
+                    .isEqualTo("[[2,allowed]]");
+        } finally {
+            query.stop();
+        }
     }
 
     @Test

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -846,6 +846,48 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testLateralPrimaryKeyVectorSearchWithAllowedRowFilter() {
+        spark.sql(
+                "CREATE TABLE t_auth_vector_allowed ("
+                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>) "
+                        + "TBLPROPERTIES ("
+                        + "'primary-key'='id', "
+                        + "'bucket'='1', "
+                        + "'deletion-vectors.enabled'='true', "
+                        + "'vector-field'='embedding', "
+                        + "'field.embedding.vector-dim'='2', "
+                        + "'pk-vector.index.columns'='embedding', "
+                        + "'fields.embedding.pk-vector.index.type'='test-vector-ann', "
+                        + "'fields.embedding.pk-vector.distance.metric'='l2', "
+                        + "'test.vector.dimension'='2', "
+                        + "'test.vector.metric'='l2', "
+                        + "'query-auth.enabled'='true')");
+        spark.sql(
+                "INSERT INTO t_auth_vector_allowed VALUES "
+                        + "(1, array(1.0f, 0.0f), array(0.0f, 0.0f)), "
+                        + "(2, array(5.0f, 0.0f), array(0.0f, 0.0f))");
+
+        Predicate idEq1Predicate =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(1));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_auth_vector_allowed"),
+                Collections.singletonList(idEq1Predicate));
+
+        List<Row> rows =
+                spark.sql(
+                                "SELECT q.id AS query_id, r.id AS result_id "
+                                        + "FROM t_auth_vector_allowed AS q, "
+                                        + "LATERAL (SELECT id FROM vector_search("
+                                        + "'t_auth_vector_allowed', 'embedding', "
+                                        + "q.query_embedding, 1)) AS r")
+                        .collectAsList();
+        assertThat(rows.toString()).isEqualTo("[[1,1]]");
+    }
+
+    @Test
     public void testRowFilterDeletionVectorsTable() {
         // Deletion-vectors table: deleted rows excluded via the deletion vector, then filtered.
         spark.sql(

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -805,6 +805,47 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testLateralPrimaryKeyVectorSearchWithRowFilter() {
+        spark.sql(
+                "CREATE TABLE t_auth_vector ("
+                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>) "
+                        + "TBLPROPERTIES ("
+                        + "'primary-key'='id', "
+                        + "'bucket'='1', "
+                        + "'deletion-vectors.enabled'='true', "
+                        + "'vector-field'='embedding', "
+                        + "'field.embedding.vector-dim'='2', "
+                        + "'pk-vector.index.columns'='embedding', "
+                        + "'fields.embedding.pk-vector.index.type'='test-vector-ann', "
+                        + "'fields.embedding.pk-vector.distance.metric'='l2', "
+                        + "'test.vector.dimension'='2', "
+                        + "'test.vector.metric'='l2', "
+                        + "'query-auth.enabled'='true')");
+        spark.sql(
+                "INSERT INTO t_auth_vector VALUES "
+                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f)), "
+                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f))");
+
+        Predicate idEq1Predicate =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(1));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_auth_vector"),
+                Collections.singletonList(idEq1Predicate));
+
+        List<Row> rows =
+                spark.sql(
+                                "SELECT q.id AS query_id, r.id AS result_id "
+                                        + "FROM t_auth_vector AS q, "
+                                        + "LATERAL (SELECT id FROM vector_search("
+                                        + "'t_auth_vector', 'embedding', q.query_embedding, 1)) AS r")
+                        .collectAsList();
+        assertThat(rows).isEmpty();
+    }
+
+    @Test
     public void testRowFilterDeletionVectorsTable() {
         // Deletion-vectors table: deleted rows excluded via the deletion vector, then filtered.
         spark.sql(

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -805,10 +805,10 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
-    public void testLateralPrimaryKeyVectorSearchWithRowFilter() {
+    public void testLateralPrimaryKeyVectorSearchWithRowAndColumnAuth() {
         spark.sql(
                 "CREATE TABLE t_auth_vector ("
-                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>) "
+                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>, secret STRING) "
                         + "TBLPROPERTIES ("
                         + "'primary-key'='id', "
                         + "'bucket'='1', "
@@ -823,17 +823,18 @@ public class SparkCatalogWithRestTest {
                         + "'query-auth.enabled'='true')");
         spark.sql(
                 "INSERT INTO t_auth_vector VALUES "
-                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f)), "
-                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f))");
+                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f), 's1'), "
+                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f), 's2')");
 
         Predicate idEq1Predicate =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
                         Equal.INSTANCE,
                         Collections.singletonList(1));
-        restCatalogServer.setRowFilterAuth(
-                Identifier.create("db2", "t_auth_vector"),
-                Collections.singletonList(idEq1Predicate));
+        Identifier identifier = Identifier.create("db2", "t_auth_vector");
+        restCatalogServer.setRowFilterAuth(identifier, Collections.singletonList(idEq1Predicate));
+        restCatalogServer.addTableColumnAuth(
+                identifier, Arrays.asList("id", "embedding", "query_embedding"));
 
         List<Row> rows =
                 spark.sql(
@@ -849,7 +850,7 @@ public class SparkCatalogWithRestTest {
     public void testLateralPrimaryKeyVectorSearchMetadataOnlyWithRowFilter() {
         spark.sql(
                 "CREATE TABLE t_auth_vector_metadata ("
-                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>) "
+                        + "id INT, embedding ARRAY<FLOAT>, query_embedding ARRAY<FLOAT>, secret STRING) "
                         + "TBLPROPERTIES ("
                         + "'primary-key'='id', "
                         + "'bucket'='1', "
@@ -864,17 +865,18 @@ public class SparkCatalogWithRestTest {
                         + "'query-auth.enabled'='true')");
         spark.sql(
                 "INSERT INTO t_auth_vector_metadata VALUES "
-                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f)), "
-                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f))");
+                        + "(1, array(5.0f, 0.0f), array(0.0f, 0.0f), 's1'), "
+                        + "(2, array(1.0f, 0.0f), array(0.0f, 0.0f), 's2')");
 
         Predicate idEq1Predicate =
                 LeafPredicate.of(
                         new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
                         Equal.INSTANCE,
                         Collections.singletonList(1));
-        restCatalogServer.setRowFilterAuth(
-                Identifier.create("db2", "t_auth_vector_metadata"),
-                Collections.singletonList(idEq1Predicate));
+        Identifier identifier = Identifier.create("db2", "t_auth_vector_metadata");
+        restCatalogServer.setRowFilterAuth(identifier, Collections.singletonList(idEq1Predicate));
+        restCatalogServer.addTableColumnAuth(
+                identifier, Arrays.asList("id", "embedding", "query_embedding"));
 
         List<Row> rows =
                 spark.sql(

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkCatalogWithRestTest.java
@@ -734,6 +734,36 @@ public class SparkCatalogWithRestTest {
     }
 
     @Test
+    public void testRowFilterWithPartitionAndBucketMetadata() {
+        spark.sql(
+                "CREATE TABLE t_auth_metadata (id INT, name STRING, pt STRING) "
+                        + "PARTITIONED BY (pt) TBLPROPERTIES "
+                        + "('bucket'='2', 'bucket-key'='id', 'query-auth.enabled'='true')");
+        spark.sql(
+                "INSERT INTO t_auth_metadata VALUES "
+                        + "(1, 'blocked', 'p1'), (2, 'allowed', 'p2')");
+
+        Predicate idEq2Predicate =
+                LeafPredicate.of(
+                        new FieldTransform(new FieldRef(0, "id", DataTypes.INT())),
+                        Equal.INSTANCE,
+                        Collections.singletonList(2));
+        restCatalogServer.setRowFilterAuth(
+                Identifier.create("db2", "t_auth_metadata"),
+                Collections.singletonList(idEq2Predicate));
+
+        List<Row> rows =
+                spark.sql(
+                                "SELECT id, __paimon_partition, __paimon_bucket "
+                                        + "FROM t_auth_metadata ORDER BY id")
+                        .collectAsList();
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getInt(0)).isEqualTo(2);
+        assertThat(rows.get(0).getStruct(1).getString(0)).isEqualTo("p2");
+        assertThat(rows.get(0).getInt(2)).isBetween(0, 1);
+    }
+
+    @Test
     public void testRowFilterDeletionVectorsTable() {
         // Deletion-vectors table: deleted rows excluded via the deletion vector, then filtered.
         spark.sql(

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/BinPackingSplitsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/BinPackingSplitsTest.scala
@@ -19,15 +19,17 @@
 package org.apache.paimon.spark
 
 import org.apache.paimon.CoreOptions
+import org.apache.paimon.catalog.TableQueryAuthResult
 import org.apache.paimon.data.BinaryRow
 import org.apache.paimon.io.DataFileMeta
 import org.apache.paimon.manifest.FileSource
 import org.apache.paimon.spark.read.BinPackingSplits
-import org.apache.paimon.table.source.{DataSplit, DeletionFile, Split}
+import org.apache.paimon.spark.util.SplitUtils
+import org.apache.paimon.table.source.{DataSplit, DeletionFile, QueryAuthSplit, Split}
 
 import org.junit.jupiter.api.Assertions
 
-import java.util.{HashMap => JHashMap}
+import java.util.{Collections => JCollections, HashMap => JHashMap}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -66,6 +68,31 @@ class BinPackingSplitsTest extends PaimonSparkTestBase {
     val binPacking = BinPackingSplits(CoreOptions.fromMap(new JHashMap()))
     val reshuffled = binPacking.pack(dataSplits)
     Assertions.assertEquals(1, reshuffled.length)
+  }
+
+  test("Paimon: reshuffle query auth splits and retain auth") {
+    withSparkSQLConf("spark.sql.files.minPartitionNum" -> "1") {
+      val authResult =
+        new TableQueryAuthResult(JCollections.emptyList(), JCollections.emptyMap())
+      val splits = (0 until 5).map {
+        index =>
+          val dataSplit = newDataSplit(s"auth-$index", Seq(10L), rawConvertible = true)
+          new QueryAuthSplit(dataSplit, authResult): Split
+      }.toArray
+      val binPacking = BinPackingSplits(
+        CoreOptions.fromMap(
+          Map("source.split.open-file-cost" -> "0 B", "source.split.target-size" -> "1 MB").asJava))
+
+      val reshuffled = binPacking.pack(splits)
+
+      Assertions.assertEquals(1, reshuffled.length)
+      Assertions.assertEquals(1, reshuffled.head.splits.length)
+      val packed = reshuffled.head.splits.head
+      Assertions.assertTrue(packed.isInstanceOf[QueryAuthSplit])
+      Assertions.assertSame(authResult, packed.asInstanceOf[QueryAuthSplit].authResult())
+      Assertions.assertEquals(5, SplitUtils.dataFileCount(packed))
+      Assertions.assertEquals(50L, SplitUtils.splitSize(packed))
+    }
   }
 
   test("Paimon: pack data evolution splits by split granularity") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonRecordReaderIteratorTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/PaimonRecordReaderIteratorTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark
+
+import org.apache.paimon.catalog.TableQueryAuthResult
+import org.apache.paimon.data.{BinaryRow, InternalRow => PaimonInternalRow}
+import org.apache.paimon.reader.RecordReader
+import org.apache.paimon.spark.schema.PaimonMetadataColumn
+import org.apache.paimon.table.FallbackReadFileStoreTable
+import org.apache.paimon.table.source.{DataSplit, QueryAuthSplit}
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+
+import java.util.Collections
+
+/** Tests for [[PaimonRecordReaderIterator]]. */
+class PaimonRecordReaderIteratorTest extends PaimonSparkTestBase {
+
+  test("Paimon: fallback query auth split exposes metadata") {
+    val dataSplit = DataSplit
+      .builder()
+      .withSnapshot(1L)
+      .withPartition(BinaryRow.singleColumn(1))
+      .withBucket(2)
+      .withDataFiles(Collections.emptyList())
+      .isStreaming(false)
+      .withBucketPath("")
+      .build()
+    val queryAuthSplit = new QueryAuthSplit(
+      dataSplit,
+      new TableQueryAuthResult(null, Collections.singletonMap("f0", "mask")))
+    val fallbackSplit =
+      new FallbackReadFileStoreTable.FallbackSplitImpl(queryAuthSplit, false)
+    val emptyReader = new RecordReader[PaimonInternalRow] {
+      override def readBatch(): RecordReader.RecordIterator[PaimonInternalRow] = null
+
+      override def close(): Unit = {}
+    }
+
+    assertDoesNotThrow(
+      () =>
+        PaimonRecordReaderIterator(emptyReader, Seq(PaimonMetadataColumn.BUCKET), fallbackSplit))
+  }
+}


### PR DESCRIPTION
### Purpose

Fix failures and incorrect reader routing when query authorization wraps planned splits in `QueryAuthSplit` while specialized split consumers assume they receive raw `DataSplit` instances.

The affected paths include:

- fallback branch scans, where fallback metadata and query-auth wrappers can be nested;
- cross-partition index bootstrap, which must build the index from unfiltered and unmasked primary keys;
- chain table batch and streaming scans, which replace `DataSplit` with `ChainSplit`;
- data evolution scans, which replace `DataSplit` with `IndexedSplit`; and
- the top-level chain table reader, which must route query-auth-wrapped chain and delta splits to the chain-aware reader.

### Changes

- Add one-layer `QueryAuthSplit.unwrap`, `unwrapDataSplit`, and `retainAuth` helpers.
- Make fallback planning accept generic `Split` values. Reader dispatch removes only the fallback wrapper and preserves the query-auth wrapper for row filtering and column masking.
- Make `IndexBootstrap` explicitly disable query auth on its internal latest-snapshot read. This ensures the index is built from the original primary keys instead of query-filtered or column-masked values.
- Preserve query authorization when chain table batch and streaming scans transform `DataSplit` into `ChainSplit`, including lightweight and `chain-table.streaming.merge-snapshot` starting plans.
- Route `QueryAuthSplit(ChainSplit)` and `QueryAuthSplit(DataSplit)` through the chain-aware reader while passing the original wrapper to retain authorization context.
- Preserve query authorization when data evolution scans transform `DataSplit` into `IndexedSplit`.
- Add regression coverage for fallback planning/serialization/reading, index bootstrap, chain table batch and streaming scans, chain reader routing, data evolution, and split helper serialization.

### Tests

```shell
mvn -pl paimon-core -am -Pfast-build \
  -DfailIfNoTests=false \
  -DwildcardSuites=none \
  -Dtest=ChainTableFileStoreTableTest,ChainGroupReadTableTest,FallbackReadFileStoreTableTest,DataEvolutionBatchScanTest,IndexBootstrapTest,QueryAuthSplitTest \
  test
```

Result: 35 tests passed.

Final validation:

```shell
mvn -pl paimon-core -DskipTests validate
```

Checkstyle, Spotless, and Maven Enforcer passed.
