### PR TITLE
[python] Add zero-copy coalesced BLOB range views

### DIFF
--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -52,9 +52,10 @@ def pread(stream, length: int, offset: int) -> bytes:
 # merged read at SPAN so threads stay busy and memory stays bounded.
 _COALESCE_GAP = 1 << 20
 _COALESCE_SPAN = 8 << 20
+_COALESCE_VIEW_MAX_READ_AMPLIFICATION = 2.0
 
 
-def _coalesce_ranges(items, max_gap, max_span):
+def _coalesce_ranges(items, max_gap, max_span, max_read_amplification=0):
     """Group ``(idx, path, offset, length)`` (length >= 0) into merged spans:
     ``[(path, span_offset, span_length, [(idx, offset, length), ...])]``."""
     from collections import defaultdict
@@ -64,16 +65,26 @@ def _coalesce_ranges(items, max_gap, max_span):
     spans = []
     for path, group in by_path.items():
         group.sort(key=lambda x: x[2])
-        cur, start, end = [], None, None
+        cur, start, end, useful = [], None, None, 0
         for idx, _, off, length in group:
             stop = off + length
-            if cur and off - end <= max_gap and stop - start <= max_span:
+            next_useful = useful + length
+            next_start = start if cur else off
+            next_end = max(end, stop) if cur else stop
+            next_span = next_end - next_start
+            within_read_amplification = (
+                max_read_amplification <= 0
+                or next_span <= next_useful * max_read_amplification
+            )
+            if (cur and off - end <= max_gap and stop - start <= max_span
+                    and within_read_amplification):
                 cur.append((idx, off, length))
-                end = max(end, stop)
+                end = next_end
+                useful = next_useful
             else:
                 if cur:
                     spans.append((path, start, end - start, cur))
-                cur, start, end = [(idx, off, length)], off, stop
+                cur, start, end, useful = [(idx, off, length)], off, stop, length
         if cur:
             spans.append((path, start, end - start, cur))
     return spans
@@ -185,33 +196,61 @@ class FileIO(ABC):
         A failed read propagates and aborts the whole batch (unlike a per-row
         ``file.open()`` loop that fails one row at a time).
         """
+        return self._read_ranges_coalesced(
+            ranges, parallelism, max_gap, max_span,
+            max_read_amplification=0, return_views=False)
+
+    def read_ranges_coalesced_views(self, ranges, parallelism,
+                                    max_gap=_COALESCE_GAP, max_span=_COALESCE_SPAN,
+                                    max_read_amplification=(
+                                        _COALESCE_VIEW_MAX_READ_AMPLIFICATION)):
+        """Read coalesced ranges as zero-copy ``memoryview`` slices.
+
+        Member ranges from the same merged span share the span's backing buffer
+        instead of allocating one ``bytes`` object per member. Callers must
+        accept the Python buffer protocol. Use :meth:`read_ranges_coalesced`
+        when concrete ``bytes`` results are required. Sparse spans are split by
+        ``max_read_amplification`` so views do not retain excessive gap bytes;
+        set it to a non-positive value to disable this bound.
+        """
+        return self._read_ranges_coalesced(
+            ranges, parallelism, max_gap, max_span, max_read_amplification,
+            return_views=True)
+
+    def _read_ranges_coalesced(self, ranges, parallelism, max_gap, max_span,
+                               max_read_amplification, return_views):
         from concurrent.futures import ThreadPoolExecutor
         # Threads write disjoint results[idx]; safe under the GIL (no list resize).
-        results: List[Optional[bytes]] = [None] * len(ranges)
+        results = [None] * len(ranges)
         coalescible, singletons = [], []
-        for i, r in enumerate(ranges):
+        for index, value in enumerate(ranges):
             # None path/offset/length => null blob, leave result None.
-            if r is None or r[0] is None or r[1] is None or r[2] is None:
+            if (value is None or value[0] is None
+                    or value[1] is None or value[2] is None):
                 continue
-            path, offset, length = r
+            path, offset, length = value
             if length < 0:  # unknown length => read to EOF, never coalesced
-                singletons.append((i, path, offset, length))
+                singletons.append((index, path, offset, length))
             else:
-                coalescible.append((i, path, offset, length))
+                coalescible.append((index, path, offset, length))
 
-        spans = _coalesce_ranges(coalescible, max_gap, max_span)
+        spans = _coalesce_ranges(
+            coalescible, max_gap, max_span, max_read_amplification)
 
         def _run(task):
             kind, payload = task
             if kind == "span":
                 path, span_off, span_len, members = payload
                 buf = self.read_file_range(path, span_off, span_len)
+                if return_views:
+                    buf = memoryview(buf)
                 for idx, off, length in members:
                     s = off - span_off
                     results[idx] = buf[s:s + length]
             else:
                 idx, path, off, length = payload
-                results[idx] = self.read_file_range(path, off, length)
+                result = self.read_file_range(path, off, length)
+                results[idx] = memoryview(result) if return_views else result
 
         tasks = [("span", s) for s in spans] + [("one", g) for g in singletons]
         if not tasks:

--- a/paimon-python/pypaimon/common/file_io.py
+++ b/paimon-python/pypaimon/common/file_io.py
@@ -52,10 +52,10 @@ def pread(stream, length: int, offset: int) -> bytes:
 # merged read at SPAN so threads stay busy and memory stays bounded.
 _COALESCE_GAP = 1 << 20
 _COALESCE_SPAN = 8 << 20
-_COALESCE_VIEW_MAX_READ_AMPLIFICATION = 2.0
+_COALESCE_VIEW_MAX_RETAINED_AMPLIFICATION = 2.0
 
 
-def _coalesce_ranges(items, max_gap, max_span, max_read_amplification=0):
+def _coalesce_ranges(items, max_gap, max_span):
     """Group ``(idx, path, offset, length)`` (length >= 0) into merged spans:
     ``[(path, span_offset, span_length, [(idx, offset, length), ...])]``."""
     from collections import defaultdict
@@ -65,26 +65,16 @@ def _coalesce_ranges(items, max_gap, max_span, max_read_amplification=0):
     spans = []
     for path, group in by_path.items():
         group.sort(key=lambda x: x[2])
-        cur, start, end, useful = [], None, None, 0
+        cur, start, end = [], None, None
         for idx, _, off, length in group:
             stop = off + length
-            next_useful = useful + length
-            next_start = start if cur else off
-            next_end = max(end, stop) if cur else stop
-            next_span = next_end - next_start
-            within_read_amplification = (
-                max_read_amplification <= 0
-                or next_span <= next_useful * max_read_amplification
-            )
-            if (cur and off - end <= max_gap and stop - start <= max_span
-                    and within_read_amplification):
+            if cur and off - end <= max_gap and stop - start <= max_span:
                 cur.append((idx, off, length))
-                end = next_end
-                useful = next_useful
+                end = max(end, stop)
             else:
                 if cur:
                     spans.append((path, start, end - start, cur))
-                cur, start, end, useful = [(idx, off, length)], off, stop, length
+                cur, start, end = [(idx, off, length)], off, stop
         if cur:
             spans.append((path, start, end - start, cur))
     return spans
@@ -198,27 +188,28 @@ class FileIO(ABC):
         """
         return self._read_ranges_coalesced(
             ranges, parallelism, max_gap, max_span,
-            max_read_amplification=0, return_views=False)
+            max_retained_amplification=0, return_views=False)
 
     def read_ranges_coalesced_views(self, ranges, parallelism,
                                     max_gap=_COALESCE_GAP, max_span=_COALESCE_SPAN,
-                                    max_read_amplification=(
-                                        _COALESCE_VIEW_MAX_READ_AMPLIFICATION)):
+                                    max_retained_amplification=(
+                                        _COALESCE_VIEW_MAX_RETAINED_AMPLIFICATION)):
         """Read coalesced ranges as zero-copy ``memoryview`` slices.
 
         Member ranges from the same merged span share the span's backing buffer
         instead of allocating one ``bytes`` object per member. Callers must
         accept the Python buffer protocol. Use :meth:`read_ranges_coalesced`
-        when concrete ``bytes`` results are required. Sparse spans are split by
-        ``max_read_amplification`` so views do not retain excessive gap bytes;
-        set it to a non-positive value to disable this bound.
+        when concrete ``bytes`` results are required. Each view keeps its backing
+        buffer alive. Sparse spans use independent views so they do not retain
+        excessive gap bytes; set ``max_retained_amplification`` to a non-positive
+        value to always share the merged buffer.
         """
         return self._read_ranges_coalesced(
-            ranges, parallelism, max_gap, max_span, max_read_amplification,
+            ranges, parallelism, max_gap, max_span, max_retained_amplification,
             return_views=True)
 
     def _read_ranges_coalesced(self, ranges, parallelism, max_gap, max_span,
-                               max_read_amplification, return_views):
+                               max_retained_amplification, return_views):
         from concurrent.futures import ThreadPoolExecutor
         # Threads write disjoint results[idx]; safe under the GIL (no list resize).
         results = [None] * len(ranges)
@@ -234,8 +225,7 @@ class FileIO(ABC):
             else:
                 coalescible.append((index, path, offset, length))
 
-        spans = _coalesce_ranges(
-            coalescible, max_gap, max_span, max_read_amplification)
+        spans = _coalesce_ranges(coalescible, max_gap, max_span)
 
         def _run(task):
             kind, payload = task
@@ -244,9 +234,17 @@ class FileIO(ABC):
                 buf = self.read_file_range(path, span_off, span_len)
                 if return_views:
                     buf = memoryview(buf)
+                    useful = sum(length for _, _, length in members)
+                    share_buffer = (
+                        max_retained_amplification <= 0
+                        or span_len <= useful * max_retained_amplification
+                    )
                 for idx, off, length in members:
                     s = off - span_off
-                    results[idx] = buf[s:s + length]
+                    value = buf[s:s + length]
+                    if return_views and not share_buffer:
+                        value = memoryview(bytes(value))
+                    results[idx] = value
             else:
                 idx, path, off, length = payload
                 result = self.read_file_range(path, off, length)

--- a/paimon-python/pypaimon/daft/daft_blob_read.py
+++ b/paimon-python/pypaimon/daft/daft_blob_read.py
@@ -77,6 +77,8 @@ def read_blob(column, catalog_options: Dict[str, str], table: str, *, max_concur
 
     @daft.func.batch(return_dtype=DataType.binary())
     def _read_blobs(files):
+        import pyarrow as pa
+
         pos_field, size_field = _file_range_fields()
         # Vectorized field extraction: per-File attr access (to_pylist +
         # f.path/.position/.size) is GIL-bound and serializes the pool. daft
@@ -93,7 +95,8 @@ def read_blob(column, catalog_options: Dict[str, str], table: str, *, max_concur
                       for f in files.to_pylist()]
 
         fio = _get_file_io(_cache_key(catalog_options), table)
-        # Coalesce same-file adjacent reads to cut per-request round trips.
-        return fio.read_ranges_coalesced(ranges, max_concurrency)
+        # Build Arrow from shared views without intermediate BLOB copies.
+        views = fio.read_ranges_coalesced_views(ranges, max_concurrency)
+        return pa.array(views, type=pa.binary())
 
     return _read_blobs(column)

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -2580,17 +2580,6 @@ class CoalesceRangesTest(unittest.TestCase):
         # max_span forces a split even when contiguous
         self.assertEqual(len(_coalesce_ranges(
             [(0, "a", 0, 10), (1, "a", 10, 10)], max_gap=100, max_span=15)), 2)
-        # A read-amplification bound prevents sparse ranges from sharing a span.
-        self.assertEqual(len(_coalesce_ranges(
-            [(0, "a", 0, 10), (1, "a", 100, 10)],
-            max_gap=100,
-            max_span=1 << 30,
-            max_read_amplification=2.0)), 2)
-        self.assertEqual(len(_coalesce_ranges(
-            [(0, "a", 0, 10), (1, "a", 100, 10)],
-            max_gap=100,
-            max_span=1 << 30,
-            max_read_amplification=0)), 1)
 
     def test_read_ranges_coalesced(self):
         from pypaimon.common.file_io import FileIO
@@ -2622,7 +2611,8 @@ class CoalesceRangesTest(unittest.TestCase):
             file_io = FileIO.get(f"file://{tmp_dir}", {})
             ranges = [(path, 0, 10), (path, 10, 10), None,
                       (path, 500, 20), (path, 100, -1)]
-            got = file_io.read_ranges_coalesced_views(ranges, parallelism=4)
+            got = file_io.read_ranges_coalesced_views(
+                ranges, parallelism=4, max_gap=100)
 
             self.assertIsInstance(got[0], memoryview)
             self.assertIsInstance(got[1], memoryview)
@@ -2633,6 +2623,50 @@ class CoalesceRangesTest(unittest.TestCase):
             self.assertEqual(bytes(got[3]), data[500:520])
             self.assertIsNot(got[0].obj, got[3].obj)
             self.assertEqual(bytes(got[4]), data[100:])
+
+            array = pa.array(got, type=pa.binary())
+            self.assertEqual(array.to_pylist(), [
+                data[0:10], data[10:20], None, data[500:520], data[100:],
+            ])
+
+    def test_sparse_views_preserve_coalesced_read(self):
+        from pypaimon.common.file_io import FileIO
+        data = bytes(range(256)) * 4
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "f.bin")
+            with open(path, 'wb') as output:
+                output.write(data)
+            file_io = FileIO.get(f"file://{tmp_dir}", {})
+            reads = []
+            original_read = file_io.read_file_range
+
+            def read_file_range(file_path, offset, length):
+                reads.append((file_path, offset, length))
+                return original_read(file_path, offset, length)
+
+            file_io.read_file_range = read_file_range
+            got = file_io.read_ranges_coalesced_views(
+                [(path, 0, 10), (path, 1000, 10)],
+                parallelism=4,
+                max_gap=1000,
+                max_span=1 << 20,
+            )
+
+            self.assertEqual(reads, [(path, 0, 1010)])
+            self.assertEqual(bytes(got[0]), data[0:10])
+            self.assertEqual(bytes(got[1]), data[1000:1010])
+            self.assertIsNot(got[0].obj, got[1].obj)
+
+            reads.clear()
+            shared = file_io.read_ranges_coalesced_views(
+                [(path, 0, 10), (path, 1000, 10)],
+                parallelism=4,
+                max_gap=1000,
+                max_span=1 << 20,
+                max_retained_amplification=0,
+            )
+            self.assertEqual(reads, [(path, 0, 1010)])
+            self.assertIs(shared[0].obj, shared[1].obj)
 
 
 class ReadFileRangeTest(unittest.TestCase):

--- a/paimon-python/pypaimon/tests/blob_test.py
+++ b/paimon-python/pypaimon/tests/blob_test.py
@@ -2580,6 +2580,17 @@ class CoalesceRangesTest(unittest.TestCase):
         # max_span forces a split even when contiguous
         self.assertEqual(len(_coalesce_ranges(
             [(0, "a", 0, 10), (1, "a", 10, 10)], max_gap=100, max_span=15)), 2)
+        # A read-amplification bound prevents sparse ranges from sharing a span.
+        self.assertEqual(len(_coalesce_ranges(
+            [(0, "a", 0, 10), (1, "a", 100, 10)],
+            max_gap=100,
+            max_span=1 << 30,
+            max_read_amplification=2.0)), 2)
+        self.assertEqual(len(_coalesce_ranges(
+            [(0, "a", 0, 10), (1, "a", 100, 10)],
+            max_gap=100,
+            max_span=1 << 30,
+            max_read_amplification=0)), 1)
 
     def test_read_ranges_coalesced(self):
         from pypaimon.common.file_io import FileIO
@@ -2592,12 +2603,36 @@ class CoalesceRangesTest(unittest.TestCase):
             ranges = [(path, 0, 10), (path, 10, 10), None, (path, 500, 20),
                       (path, 100, -1), (path, None, None)]
             got = fio.read_ranges_coalesced(ranges, parallelism=4)
+            self.assertIsInstance(got[0], bytes)
+            self.assertIsInstance(got[1], bytes)
             self.assertEqual(got[0], data[0:10])
             self.assertEqual(got[1], data[10:20])   # contiguous with got[0], merged
             self.assertIsNone(got[2])
             self.assertEqual(got[3], data[500:520])
             self.assertEqual(got[4], data[100:])     # length -1 => read to EOF
             self.assertIsNone(got[5])                # None offset/length => skipped
+
+    def test_read_ranges_coalesced_views(self):
+        from pypaimon.common.file_io import FileIO
+        data = bytes(range(256)) * 4
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "f.bin")
+            with open(path, 'wb') as output:
+                output.write(data)
+            file_io = FileIO.get(f"file://{tmp_dir}", {})
+            ranges = [(path, 0, 10), (path, 10, 10), None,
+                      (path, 500, 20), (path, 100, -1)]
+            got = file_io.read_ranges_coalesced_views(ranges, parallelism=4)
+
+            self.assertIsInstance(got[0], memoryview)
+            self.assertIsInstance(got[1], memoryview)
+            self.assertEqual(bytes(got[0]), data[0:10])
+            self.assertEqual(bytes(got[1]), data[10:20])
+            self.assertIs(got[0].obj, got[1].obj)
+            self.assertIsNone(got[2])
+            self.assertEqual(bytes(got[3]), data[500:520])
+            self.assertIsNot(got[0].obj, got[3].obj)
+            self.assertEqual(bytes(got[4]), data[100:])
 
 
 class ReadFileRangeTest(unittest.TestCase):


### PR DESCRIPTION
### Purpose

Add bounded shared views for coalesced BLOB reads without changing the existing `bytes` API. Daft uses the views directly, and process-local training loaders can reuse them.

### Tests

Added shared/sparse view and Arrow conversion coverage. Passed BLOB and Daft BLOB tests; targeted view tests also pass on Python 3.6.
