### PR TITLE
[common] Avoid full-file scan for non-null rows in BTreeIndexReader

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexIOMeta.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexIOMeta.java
@@ -30,10 +30,24 @@ public class GlobalIndexIOMeta {
     private final long fileSize;
     private final byte[] metadata;
 
+    /**
+     * Total number of logical rows covered by this index file, i.e. the size of the dense local row
+     * id universe {@code [0, rowCount)}, or {@code -1} when unknown. For btree indexes the writer
+     * assigns exactly one dense row id per logical row (null rows included), so a reader can derive
+     * the non-null rows as the complement of the null bitmap within {@code [0, rowCount)} instead
+     * of scanning the whole file.
+     */
+    private final long rowCount;
+
     public GlobalIndexIOMeta(Path filePath, long fileSize, byte[] metadata) {
+        this(filePath, fileSize, metadata, -1);
+    }
+
+    public GlobalIndexIOMeta(Path filePath, long fileSize, byte[] metadata, long rowCount) {
         this.filePath = filePath;
         this.fileSize = fileSize;
         this.metadata = metadata;
+        this.rowCount = rowCount;
     }
 
     public Path filePath() {
@@ -46,6 +60,11 @@ public class GlobalIndexIOMeta {
 
     public byte[] metadata() {
         return metadata;
+    }
+
+    /** Row count of this index file, or {@code -1} when unknown. */
+    public long rowCount() {
+        return rowCount;
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/SortedFileGlobalIndexReader.java
@@ -48,6 +48,7 @@ import java.util.function.Supplier;
 public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         implements GlobalIndexReader {
 
+    private final List<GlobalIndexIOMeta> files;
     private final SortedFileMetaSelector fileSelector;
     private final long fallbackScanMaxSize;
     private final Map<Path, R> readerCache;
@@ -58,10 +59,33 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
             KeySerializer keySerializer,
             long fallbackScanMaxSize,
             ExecutorService executor) {
+        this.files = files;
         this.fileSelector = new SortedFileMetaSelector(files, keySerializer);
         this.fallbackScanMaxSize = fallbackScanMaxSize;
         this.readerCache = new ConcurrentHashMap<>();
         this.executor = executor;
+    }
+
+    /** Fans out {@code visitor} over every file of this range and unions the per-file results. */
+    protected CompletableFuture<Optional<GlobalIndexResult>> visitAllFiles(
+            Function<R, Optional<GlobalIndexResult>> visitor) {
+        return visitSelectedFiles(Optional.of(files), visitor);
+    }
+
+    /**
+     * Conservative "all non-null rows" answer shared by the string negations that cannot prune
+     * (ENDS WITH / CONTAINS / unoptimizable LIKE). The default is a budget-gated fallback scan;
+     * subclasses that can derive it cheaply may override.
+     */
+    protected CompletableFuture<Optional<GlobalIndexResult>> visitConservativeString(
+            FieldRef fieldRef,
+            Object literal,
+            Supplier<Optional<List<GlobalIndexIOMeta>>> selector,
+            Function<R, Optional<GlobalIndexResult>> visitor) {
+        if (!canFallbackStringScan(fieldRef, literal)) {
+            return unsupported();
+        }
+        return visitFallbackParallel(selector, visitor);
     }
 
     @Override
@@ -88,10 +112,9 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
     @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitEndsWith(
             FieldRef fieldRef, Object literal) {
-        if (!canFallbackStringScan(fieldRef, literal)) {
-            return unsupported();
-        }
-        return visitFallbackParallel(
+        return visitConservativeString(
+                fieldRef,
+                literal,
                 () -> fileSelector.visitEndsWith(fieldRef, literal),
                 reader -> visitEndsWith(reader, literal));
     }
@@ -99,10 +122,9 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
     @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitContains(
             FieldRef fieldRef, Object literal) {
-        if (!canFallbackStringScan(fieldRef, literal)) {
-            return unsupported();
-        }
-        return visitFallbackParallel(
+        return visitConservativeString(
+                fieldRef,
+                literal,
                 () -> fileSelector.visitContains(fieldRef, literal),
                 reader -> visitContains(reader, literal));
     }
@@ -117,10 +139,9 @@ public abstract class SortedFileGlobalIndexReader<R extends Closeable>
         Optional<Pair<LeafBinaryFunction, Object>> optimized =
                 LikeOptimization.tryOptimize(literal);
         if (!optimized.isPresent()) {
-            if (!canFallbackStringScan(fieldRef, literal)) {
-                return unsupported();
-            }
-            return visitFallbackParallel(
+            return visitConservativeString(
+                    fieldRef,
+                    literal,
                     () -> fileSelector.visitLike(fieldRef, literal),
                     reader -> visitLike(reader, fieldRef, literal));
         }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -37,6 +37,7 @@ import org.apache.paimon.sst.SstFileReader;
 import org.apache.paimon.utils.FileBasedBloomFilter;
 import org.apache.paimon.utils.LazyField;
 import org.apache.paimon.utils.Preconditions;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import javax.annotation.Nullable;
@@ -64,6 +65,7 @@ public class BTreeIndexReader implements Closeable {
     private final LazyField<RoaringNavigableMap64> nullBitmap;
     private final Object minKey;
     private final Object maxKey;
+    private final long rowCount;
 
     /** A key and its local row ids stored in one btree entry. */
     public static class KeyRowIds {
@@ -138,6 +140,7 @@ public class BTreeIndexReader implements Closeable {
             throws IOException {
         this.keySerializer = keySerializer;
         this.comparator = keySerializer.createComparator();
+        this.rowCount = globalIndexIOMeta.rowCount();
         SortedIndexFileMeta indexMeta =
                 SortedIndexFileMeta.deserialize(globalIndexIOMeta.metadata());
         if (indexMeta.getFirstKey() != null) {
@@ -353,11 +356,20 @@ public class BTreeIndexReader implements Closeable {
     }
 
     private RoaringNavigableMap64 allNonNullRows() throws IOException {
-        // Traverse all data to avoid returning null values, which is very advantageous in
-        // situations where there are many null values
-        // TODO do not traverse all data if less null values
         if (minKey == null) {
+            // this btree index file only stores nulls, so there are no non-null rows.
             return new RoaringNavigableMap64();
+        }
+        if (rowCount > 0) {
+            // The non-null rows are exactly the dense local id universe [0, rowCount) minus the
+            // null rows: the writer assigns one dense row id per logical row and records every
+            // null row in nullBitmap. Deriving the complement avoids scanning the whole file,
+            // which is a large win when null values are few. Fall back to a full range scan only
+            // when rowCount is unknown (e.g. metadata that predates plumbing the count here).
+            RoaringNavigableMap64 result = new RoaringNavigableMap64();
+            result.addRange(new Range(0, rowCount - 1));
+            result.andNot(nullBitmap.get());
+            return result;
         }
         return rangeQuery(minKey, maxKey, true, true);
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/BTreeIndexReader.java
@@ -37,7 +37,6 @@ import org.apache.paimon.sst.SstFileReader;
 import org.apache.paimon.utils.FileBasedBloomFilter;
 import org.apache.paimon.utils.LazyField;
 import org.apache.paimon.utils.Preconditions;
-import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import javax.annotation.Nullable;
@@ -65,7 +64,6 @@ public class BTreeIndexReader implements Closeable {
     private final LazyField<RoaringNavigableMap64> nullBitmap;
     private final Object minKey;
     private final Object maxKey;
-    private final long rowCount;
 
     /** A key and its local row ids stored in one btree entry. */
     public static class KeyRowIds {
@@ -140,7 +138,6 @@ public class BTreeIndexReader implements Closeable {
             throws IOException {
         this.keySerializer = keySerializer;
         this.comparator = keySerializer.createComparator();
-        this.rowCount = globalIndexIOMeta.rowCount();
         SortedIndexFileMeta indexMeta =
                 SortedIndexFileMeta.deserialize(globalIndexIOMeta.metadata());
         if (indexMeta.getFirstKey() != null) {
@@ -243,6 +240,11 @@ public class BTreeIndexReader implements Closeable {
         for (long rowId : nullBitmap.get()) {
             consumer.accept(rowId);
         }
+    }
+
+    /** Read-only view of this file's null row-id bitmap; callers must not mutate it. */
+    public RoaringNavigableMap64 nullRows() {
+        return nullBitmap.get();
     }
 
     public Optional<GlobalIndexResult> visitIsNotNull() {
@@ -360,17 +362,8 @@ public class BTreeIndexReader implements Closeable {
             // this btree index file only stores nulls, so there are no non-null rows.
             return new RoaringNavigableMap64();
         }
-        if (rowCount > 0) {
-            // The non-null rows are exactly the dense local id universe [0, rowCount) minus the
-            // null rows: the writer assigns one dense row id per logical row and records every
-            // null row in nullBitmap. Deriving the complement avoids scanning the whole file,
-            // which is a large win when null values are few. Fall back to a full range scan only
-            // when rowCount is unknown (e.g. metadata that predates plumbing the count here).
-            RoaringNavigableMap64 result = new RoaringNavigableMap64();
-            result.addRange(new Range(0, rowCount - 1));
-            result.andNot(nullBitmap.get());
-            return result;
-        }
+        // Fallback used only when the range width is unknown; when it is known the complement is
+        // derived cheaply from the null bitmaps in LazyFilteredBTreeReader.
         return rangeQuery(minKey, maxKey, true, true);
     }
 

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeReader.java
@@ -25,12 +25,17 @@ import org.apache.paimon.globalindex.SortedFileGlobalIndexReader;
 import org.apache.paimon.globalindex.io.GlobalIndexFileReader;
 import org.apache.paimon.io.cache.CacheManager;
 import org.apache.paimon.predicate.FieldRef;
+import org.apache.paimon.types.DataTypeFamily;
+import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * An Index Reader for BTree which dynamically filters file list by input predicate, then visits
@@ -42,6 +47,7 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
     private final KeySerializer keySerializer;
     private final CacheManager cacheManager;
     private final GlobalIndexFileReader fileReader;
+    private final long rangeWidth;
 
     public LazyFilteredBTreeReader(
             List<GlobalIndexIOMeta> files,
@@ -54,6 +60,91 @@ public class LazyFilteredBTreeReader extends SortedFileGlobalIndexReader<BTreeIn
         this.cacheManager = cacheManager;
         this.fileReader = fileReader;
         this.keySerializer = keySerializer;
+        this.rangeWidth = rangeWidth(files);
+    }
+
+    /**
+     * The dense local id universe [0, rangeWidth) shared by all files of this range, i.e. the sum
+     * of the per-file row counts, or -1 when any count is unknown (older metadata) so the negations
+     * fall back to a full-file scan.
+     */
+    private static long rangeWidth(List<GlobalIndexIOMeta> files) {
+        long total = 0;
+        for (GlobalIndexIOMeta file : files) {
+            long count = file.rowCount();
+            if (count < 0) {
+                return -1;
+            }
+            total += count;
+        }
+        return total;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitIsNotNull(FieldRef fieldRef) {
+        if (rangeWidth <= 0) {
+            return super.visitIsNotNull(fieldRef);
+        }
+        return nonNullRowsInRange();
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotEqual(
+            FieldRef fieldRef, Object literal) {
+        if (rangeWidth <= 0) {
+            return super.visitNotEqual(fieldRef, literal);
+        }
+        return nonNullRowsInRange()
+                .thenCombine(
+                        super.visitEqual(fieldRef, literal), LazyFilteredBTreeReader::subtract);
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotIn(
+            FieldRef fieldRef, List<Object> literals) {
+        if (rangeWidth <= 0) {
+            return super.visitNotIn(fieldRef, literals);
+        }
+        return nonNullRowsInRange()
+                .thenCombine(super.visitIn(fieldRef, literals), LazyFilteredBTreeReader::subtract);
+    }
+
+    @Override
+    protected CompletableFuture<Optional<GlobalIndexResult>> visitConservativeString(
+            FieldRef fieldRef,
+            Object literal,
+            Supplier<Optional<List<GlobalIndexIOMeta>>> selector,
+            Function<BTreeIndexReader, Optional<GlobalIndexResult>> visitor) {
+        if (rangeWidth > 0
+                && literal != null
+                && fieldRef.type().is(DataTypeFamily.CHARACTER_STRING)) {
+            return nonNullRowsInRange();
+        }
+        return super.visitConservativeString(fieldRef, literal, selector, visitor);
+    }
+
+    /**
+     * The non-null rows of this range: the dense id universe [0, rangeWidth) minus the union of
+     * every file's null bitmap. All files of a range share this id space, so unioning their null
+     * bitmaps yields the range's null ids exactly. Every bitmap built here is fresh, so this is
+     * safe under concurrent visits on one shared reader.
+     */
+    private CompletableFuture<Optional<GlobalIndexResult>> nonNullRowsInRange() {
+        return visitAllFiles(reader -> Optional.of(GlobalIndexResult.create(reader.nullRows())))
+                .thenApply(
+                        nullUnion -> {
+                            RoaringNavigableMap64 result = new RoaringNavigableMap64();
+                            result.addRange(new Range(0, rangeWidth - 1));
+                            nullUnion.ifPresent(u -> result.andNot(u.results()));
+                            return Optional.of(GlobalIndexResult.create(result));
+                        });
+    }
+
+    private static Optional<GlobalIndexResult> subtract(
+            Optional<GlobalIndexResult> nonNull, Optional<GlobalIndexResult> matched) {
+        RoaringNavigableMap64 result = nonNull.get().results();
+        matched.ifPresent(m -> result.andNot(m.results()));
+        return Optional.of(GlobalIndexResult.create(result));
     }
 
     @Override

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -312,9 +312,9 @@ public abstract class AbstractIndexReaderTest {
         FieldRef ref = new FieldRef(1, "testField", dataType);
         List<Object> originalKeys = data.stream().map(Pair::getKey).collect(Collectors.toList());
 
-        // No nulls, few nulls, half, many nulls and all nulls. allNonNullRows() must return the
-        // exact non-null row ids on both the complement path (single file, rowCount attached) and
-        // the range-scan fallback (multi file, rowCount unknown).
+        // No nulls, few nulls, half, many nulls and all nulls. The non-null row ids must be exact
+        // on both the complement path (row counts attached, single- or multi-file) and the
+        // full-file scan fallback (row counts unknown).
         for (double nullFraction : new double[] {0.0, 0.01, 0.5, 0.99, 1.0}) {
             applyTailNulls(originalKeys, nullFraction);
             try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
@@ -379,9 +379,9 @@ public abstract class AbstractIndexReaderTest {
         ResultEntry resultEntry = results.get(0);
         Path filePath = new Path(new Path(tempPath.toUri()), resultEntry.fileName());
         long fileSize = fileIO.getFileSize(filePath);
-        // Attaching rowCount lets BTreeIndexReader derive the non-null rows from the null bitmap
-        // instead of scanning. It is only valid when the file's local row ids are dense and
-        // 0-based, which holds here because the whole data set is written to a single file.
+        // Attaching rowCount lets the reader derive the non-null rows from the null bitmaps over
+        // the range's [0, sum-of-row-counts) universe instead of scanning. All files of a range
+        // share that dense id space, so the per-file counts sum to the universe size.
         return attachRowCount
                 ? new GlobalIndexIOMeta(
                         filePath, fileSize, resultEntry.meta(), resultEntry.rowCount())

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/AbstractIndexReaderTest.java
@@ -307,9 +307,68 @@ public abstract class AbstractIndexReaderTest {
         }
     }
 
+    @TestTemplate
+    public void testIsNotNullAcrossNullDensities() throws Exception {
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        List<Object> originalKeys = data.stream().map(Pair::getKey).collect(Collectors.toList());
+
+        // No nulls, few nulls, half, many nulls and all nulls. allNonNullRows() must return the
+        // exact non-null row ids on both the complement path (single file, rowCount attached) and
+        // the range-scan fallback (multi file, rowCount unknown).
+        for (double nullFraction : new double[] {0.0, 0.01, 0.5, 0.99, 1.0}) {
+            applyTailNulls(originalKeys, nullFraction);
+            try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+                GlobalIndexResult result = reader.visitIsNotNull(ref).join().get();
+                assertResult(result, filter(Objects::nonNull));
+            }
+        }
+    }
+
+    @TestTemplate
+    public void testNotEqualAndNotInWithNulls() throws Exception {
+        // Null the tail so the surviving non-null keys stay a sorted prefix; both visitors build
+        // on allNonNullRows() and must exclude the null rows (NULL <> x and NULL NOT IN (..) are
+        // never true).
+        int nullCount = (int) (dataNum * 0.3);
+        for (int i = dataNum - nullCount; i < dataNum; i++) {
+            data.get(i).setLeft(null);
+        }
+
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        try (GlobalIndexReader reader = prepareDataAndCreateReader()) {
+            Object literal = data.get(0).getKey(); // the lowest key, guaranteed non-null
+
+            GlobalIndexResult notEqual = reader.visitNotEqual(ref, literal).join().get();
+            assertResult(
+                    notEqual, filter(obj -> obj != null && comparator.compare(obj, literal) != 0));
+
+            List<Object> literals = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                literals.add(data.get(i).getKey());
+            }
+            TreeSet<Object> set = new TreeSet<>(comparator);
+            set.addAll(literals);
+            GlobalIndexResult notIn = reader.visitNotIn(ref, literals).join().get();
+            assertResult(notIn, filter(obj -> obj != null && !set.contains(obj)));
+        }
+    }
+
+    /** Restores the original keys, then sets the highest-key tail to null by the given fraction. */
+    private void applyTailNulls(List<Object> originalKeys, double nullFraction) {
+        int firstNull = dataNum - (int) (dataNum * nullFraction);
+        for (int i = 0; i < dataNum; i++) {
+            data.get(i).setLeft(i < firstNull ? originalKeys.get(i) : null);
+        }
+    }
+
     protected abstract GlobalIndexReader prepareDataAndCreateReader() throws Exception;
 
     protected GlobalIndexIOMeta writeData(List<Pair<Object, Long>> data) throws IOException {
+        return writeData(data, false);
+    }
+
+    protected GlobalIndexIOMeta writeData(List<Pair<Object, Long>> data, boolean attachRowCount)
+            throws IOException {
         GlobalIndexSingleColumnWriter indexWriter = globalIndexer.createWriter(fileWriter);
         for (Pair<Object, Long> pair : data) {
             indexWriter.write(pair.getKey(), pair.getValue());
@@ -318,11 +377,15 @@ public abstract class AbstractIndexReaderTest {
         Assertions.assertEquals(1, results.size());
 
         ResultEntry resultEntry = results.get(0);
-        String fileName = resultEntry.fileName();
-        return new GlobalIndexIOMeta(
-                new Path(new Path(tempPath.toUri()), fileName),
-                fileIO.getFileSize(new Path(new Path(tempPath.toUri()), fileName)),
-                resultEntry.meta());
+        Path filePath = new Path(new Path(tempPath.toUri()), resultEntry.fileName());
+        long fileSize = fileIO.getFileSize(filePath);
+        // Attaching rowCount lets BTreeIndexReader derive the non-null rows from the null bitmap
+        // instead of scanning. It is only valid when the file's local row ids are dense and
+        // 0-based, which holds here because the whole data set is written to a single file.
+        return attachRowCount
+                ? new GlobalIndexIOMeta(
+                        filePath, fileSize, resultEntry.meta(), resultEntry.rowCount())
+                : new GlobalIndexIOMeta(filePath, fileSize, resultEntry.meta());
     }
 
     protected List<Long> filter(Predicate<Object> filter) {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexReaderTest.java
@@ -39,7 +39,10 @@ public class BTreeIndexReaderTest extends AbstractIndexReaderTest {
 
     @Override
     protected GlobalIndexReader prepareDataAndCreateReader() throws Exception {
-        GlobalIndexIOMeta written = writeData(data);
+        // Attach rowCount so allNonNullRows() takes the complement path (a single file has dense
+        // 0-based local row ids). The multi-file reader keeps rowCount unknown and stays on the
+        // range-scan fallback.
+        GlobalIndexIOMeta written = writeData(data, true);
         return globalIndexer.createReader(
                 fileReader, Collections.singletonList(written), newDirectExecutorService());
     }

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeIndexReaderTest.java
@@ -39,9 +39,9 @@ public class BTreeIndexReaderTest extends AbstractIndexReaderTest {
 
     @Override
     protected GlobalIndexReader prepareDataAndCreateReader() throws Exception {
-        // Attach rowCount so allNonNullRows() takes the complement path (a single file has dense
-        // 0-based local row ids). The multi-file reader keeps rowCount unknown and stays on the
-        // range-scan fallback.
+        // Attach rowCount so the reader derives the non-null rows from the null bitmap over the
+        // range's [0, rowCount) universe; a single file is the degenerate one-file range. Without
+        // it the reader falls back to a full-file scan.
         GlobalIndexIOMeta written = writeData(data, true);
         return globalIndexer.createReader(
                 fileReader, Collections.singletonList(written), newDirectExecutorService());

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeThreadSafetyTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/BTreeThreadSafetyTest.java
@@ -362,10 +362,12 @@ public class BTreeThreadSafetyTest {
         Assertions.assertEquals(1, results.size());
         ResultEntry resultEntry = results.get(0);
         String fileName = resultEntry.fileName();
+        // Attach rowCount so the negations take the range-level complement fast path under stress.
         return new GlobalIndexIOMeta(
                 new Path(new Path(tempPath.toUri()), fileName),
                 fileIO.getFileSize(new Path(new Path(tempPath.toUri()), fileName)),
-                resultEntry.meta());
+                resultEntry.meta(),
+                resultEntry.rowCount());
     }
 
     private List<Long> filter(java.util.function.Predicate<Object> predicate) {

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/btree/LazyFilteredBTreeIndexReaderTest.java
@@ -70,6 +70,10 @@ public class LazyFilteredBTreeIndexReaderTest extends AbstractIndexReaderTest {
     }
 
     private List<GlobalIndexIOMeta> writeData() throws Exception {
+        return writeData(true);
+    }
+
+    private List<GlobalIndexIOMeta> writeData(boolean attachRowCount) throws Exception {
         int fileNum = 10;
         List<GlobalIndexIOMeta> written = new ArrayList<>(fileNum);
 
@@ -77,11 +81,34 @@ public class LazyFilteredBTreeIndexReaderTest extends AbstractIndexReaderTest {
         int recordPerFile = dataNum / fileNum;
         while (currentStart < dataNum) {
             int nextStart = Math.min(currentStart + recordPerFile, dataNum);
-            written.add(writeData(data.subList(currentStart, nextStart)));
+            written.add(writeData(data.subList(currentStart, nextStart), attachRowCount));
             currentStart = nextStart;
         }
 
         return written;
+    }
+
+    @TestTemplate
+    public void testNegationFallbackWithoutRowCount() throws Exception {
+        // Without per-file row counts the range width is unknown, so the negations must fall back
+        // to the full-file scan and still return the exact non-null ids.
+        int nullCount = (int) (dataNum * 0.3);
+        for (int i = dataNum - nullCount; i < dataNum; i++) {
+            data.get(i).setLeft(null);
+        }
+
+        List<GlobalIndexIOMeta> written = writeData(false);
+        FieldRef ref = new FieldRef(1, "testField", dataType);
+        try (GlobalIndexReader reader =
+                globalIndexer.createReader(fileReader, written, newDirectExecutorService())) {
+            GlobalIndexResult notNull = reader.visitIsNotNull(ref).join().get();
+            assertResult(notNull, filter(Objects::nonNull));
+
+            Object literal = data.get(0).getKey(); // lowest key, guaranteed non-null
+            GlobalIndexResult notEqual = reader.visitNotEqual(ref, literal).join().get();
+            assertResult(
+                    notEqual, filter(obj -> obj != null && comparator.compare(obj, literal) != 0));
+        }
     }
 
     private int firstStrictlyGreaterKeyIndex() {

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -310,10 +310,9 @@ public class GlobalIndexScanner implements Closeable {
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {
                 Range range = rangeMetas.getKey();
                 List<IndexFileMeta> indexFileMetas = rangeMetas.getValue();
-                boolean singleFile = indexFileMetas.size() == 1;
                 List<GlobalIndexIOMeta> globalMetas =
                         indexFileMetas.stream()
-                                .map(meta -> toGlobalMeta(meta, singleFile))
+                                .map(this::toGlobalMeta)
                                 .collect(Collectors.toList());
                 futures.add(
                         CompletableFuture.supplyAsync(
@@ -349,14 +348,12 @@ public class GlobalIndexScanner implements Closeable {
         return readers;
     }
 
-    private GlobalIndexIOMeta toGlobalMeta(IndexFileMeta meta, boolean attachRowCount) {
+    private GlobalIndexIOMeta toGlobalMeta(IndexFileMeta meta) {
         GlobalIndexMeta globalIndex = meta.globalIndexMeta();
         checkNotNull(globalIndex);
         Path filePath = indexPathFactory.toPath(meta);
-        return attachRowCount
-                ? new GlobalIndexIOMeta(
-                        filePath, meta.fileSize(), globalIndex.indexMeta(), meta.rowCount())
-                : new GlobalIndexIOMeta(filePath, meta.fileSize(), globalIndex.indexMeta());
+        return new GlobalIndexIOMeta(
+                filePath, meta.fileSize(), globalIndex.indexMeta(), meta.rowCount());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -352,7 +352,8 @@ public class GlobalIndexScanner implements Closeable {
         GlobalIndexMeta globalIndex = meta.globalIndexMeta();
         checkNotNull(globalIndex);
         Path filePath = indexPathFactory.toPath(meta);
-        return new GlobalIndexIOMeta(filePath, meta.fileSize(), globalIndex.indexMeta());
+        return new GlobalIndexIOMeta(
+                filePath, meta.fileSize(), globalIndex.indexMeta(), meta.rowCount());
     }
 
     @Override

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexScanner.java
@@ -310,9 +310,10 @@ public class GlobalIndexScanner implements Closeable {
             for (Map.Entry<Range, List<IndexFileMeta>> rangeMetas : metas.entrySet()) {
                 Range range = rangeMetas.getKey();
                 List<IndexFileMeta> indexFileMetas = rangeMetas.getValue();
+                boolean singleFile = indexFileMetas.size() == 1;
                 List<GlobalIndexIOMeta> globalMetas =
                         indexFileMetas.stream()
-                                .map(this::toGlobalMeta)
+                                .map(meta -> toGlobalMeta(meta, singleFile))
                                 .collect(Collectors.toList());
                 futures.add(
                         CompletableFuture.supplyAsync(
@@ -348,12 +349,14 @@ public class GlobalIndexScanner implements Closeable {
         return readers;
     }
 
-    private GlobalIndexIOMeta toGlobalMeta(IndexFileMeta meta) {
+    private GlobalIndexIOMeta toGlobalMeta(IndexFileMeta meta, boolean attachRowCount) {
         GlobalIndexMeta globalIndex = meta.globalIndexMeta();
         checkNotNull(globalIndex);
         Path filePath = indexPathFactory.toPath(meta);
-        return new GlobalIndexIOMeta(
-                filePath, meta.fileSize(), globalIndex.indexMeta(), meta.rowCount());
+        return attachRowCount
+                ? new GlobalIndexIOMeta(
+                        filePath, meta.fileSize(), globalIndex.indexMeta(), meta.rowCount())
+                : new GlobalIndexIOMeta(filePath, meta.fileSize(), globalIndex.indexMeta());
     }
 
     @Override

--- a/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/BtreeGlobalIndexTableTest.java
@@ -35,6 +35,7 @@ import org.apache.paimon.manifest.IndexManifestEntry;
 import org.apache.paimon.partition.PartitionPredicate;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
@@ -45,6 +46,7 @@ import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableScan;
 import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.Range;
 import org.apache.paimon.utils.RoaringNavigableMap64;
 
@@ -60,7 +62,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -500,6 +504,117 @@ public class BtreeGlobalIndexTableTest extends DataEvolutionTestBase {
         try (BatchTableCommit commit = table.newBatchWriteBuilder().newCommit()) {
             commit.commit(commitMessages);
         }
+    }
+
+    @Test
+    public void testMultiFileRangeNegationPredicatesUseAbsoluteRowIds() throws Exception {
+        int rowCount = 1000;
+        writeWithNullF1(rowCount);
+
+        // records-per-range (100) << range width (1000), so the single range built below rotates
+        // into ~10 btree files that share one row range.
+        catalog.alterTable(
+                identifier(),
+                SchemaChange.setOption(
+                        BTreeIndexOptions.BTREE_INDEX_RECORDS_PER_RANGE.key(), "100"),
+                false);
+        createIndex("f1", Collections.singletonList(new Range(0, rowCount - 1)));
+
+        FileStoreTable table = (FileStoreTable) catalog.getTable(identifier());
+        PredicateBuilder builder = new PredicateBuilder(table.rowType());
+
+        // IS NOT NULL -> exactly the non-null rows, by absolute row id.
+        List<Long> expectedNonNull = new ArrayList<>();
+        for (int i = 0; i < rowCount; i++) {
+            if (!isNullRow(i)) {
+                expectedNonNull.add((long) i);
+            }
+        }
+        assertThat(toRowIdList(globalIndexScan(table, builder.isNotNull(1))))
+                .containsExactlyInAnyOrderElementsOf(expectedNonNull);
+
+        // NOT EQUAL -> non-null rows minus the ones equal to a present value.
+        int equalIdx = 1; // non-null (1 % 10 != 0)
+        List<Long> expectedNotEqual = new ArrayList<>();
+        for (int i = 0; i < rowCount; i++) {
+            if (!isNullRow(i) && !f1Value(i).equals(f1Value(equalIdx))) {
+                expectedNotEqual.add((long) i);
+            }
+        }
+        assertThat(
+                        toRowIdList(
+                                globalIndexScan(
+                                        table,
+                                        builder.notEqual(
+                                                1, BinaryString.fromString(f1Value(equalIdx))))))
+                .containsExactlyInAnyOrderElementsOf(expectedNotEqual);
+
+        // NOT IN -> non-null rows minus a set of present values.
+        List<Integer> inIndexes = Arrays.asList(1, 2, 3, 4, 6); // all non-null
+        List<Object> inLiterals = new ArrayList<>();
+        Set<String> inValues = new HashSet<>();
+        for (int idx : inIndexes) {
+            inLiterals.add(BinaryString.fromString(f1Value(idx)));
+            inValues.add(f1Value(idx));
+        }
+        List<Long> expectedNotIn = new ArrayList<>();
+        for (int i = 0; i < rowCount; i++) {
+            if (!isNullRow(i) && !inValues.contains(f1Value(i))) {
+                expectedNotIn.add((long) i);
+            }
+        }
+        assertThat(toRowIdList(globalIndexScan(table, builder.notIn(1, inLiterals))))
+                .containsExactlyInAnyOrderElementsOf(expectedNotIn);
+    }
+
+    /** Every 10th row has a null indexed value; the rest carry a scrambled, distinct value. */
+    private static boolean isNullRow(int i) {
+        return i % 10 == 0;
+    }
+
+    /**
+     * Zero-padded reverse ordering so the lexicographic (indexed) order scrambles the row-id order,
+     * making each rotated btree file hold a sparse, non-{@code [0, rowCount)} subset of row ids.
+     */
+    private static String f1Value(int i) {
+        return String.format("v%08d", 1_000_000 - i);
+    }
+
+    private void writeWithNullF1(long count) throws Exception {
+        createTableDefault();
+
+        Schema schema = schemaDefault();
+        RowType writeType0 = schema.rowType().project(Arrays.asList("f0", "f1"));
+        RowType writeType1 = schema.rowType().project(Collections.singletonList("f2"));
+        BatchWriteBuilder builder = getTableDefault().newBatchWriteBuilder();
+        try (BatchTableWrite write0 = builder.newWrite().withWriteType(writeType0)) {
+            for (int i = 0; i < count; i++) {
+                BinaryString f1 = isNullRow(i) ? null : BinaryString.fromString(f1Value(i));
+                write0.write(GenericRow.of(i, f1));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            commit.commit(write0.prepareCommit());
+        }
+
+        long rowId = getTableDefault().snapshotManager().latestSnapshot().nextRowId() - count;
+        builder = getTableDefault().newBatchWriteBuilder();
+        try (BatchTableWrite write1 = builder.newWrite().withWriteType(writeType1)) {
+            for (int i = 0; i < count; i++) {
+                write1.write(GenericRow.of(BinaryString.fromString("b" + i)));
+            }
+            BatchTableCommit commit = builder.newCommit();
+            List<CommitMessage> commitables = write1.prepareCommit();
+            setFirstRowId(commitables, rowId);
+            commit.commit(commitables);
+        }
+    }
+
+    private static List<Long> toRowIdList(RoaringNavigableMap64 rowIds) {
+        List<Long> ids = new ArrayList<>();
+        for (long id : rowIds) {
+            ids.add(id);
+        }
+        return ids;
     }
 
     private void createIndex(String fieldName) throws Exception {


### PR DESCRIPTION
### Purpose

Resolves the `TODO do not traverse all data if less null values` in `BTreeIndexReader`: the non-null-row visitors (`IS NOT NULL`, `<>`, `NOT IN`, `LIKE`, `CONTAINS`, `ENDS WITH`) no longer range-scan the whole index file.

The non-null rows are computed once per range in `LazyFilteredBTreeReader` as `[0, sum of per-file rowCount)` minus the union of the files' null bitmaps, reading only the footer null bitmaps. This covers single- and multi-file ranges alike, since all files of a range share the dense id space `[0, rangeWidth)`. `IS NOT NULL` returns the complement; `<>` and `NOT IN` subtract the matched rows.

`rowCount` (already in `IndexFileMeta`) is plumbed via a new overloaded `GlobalIndexIOMeta` constructor and attached to every file in `GlobalIndexScanner`; ranges with unknown row counts fall back to the full-file scan. No on-disk format change.

The conservative string predicates (`LIKE` / `CONTAINS` / `ENDS WITH`) now use this cheap complement instead of the budget-gated scan; `btree-index.fallback-scan-max-size` still gates the scan-based `<` / `>` / `BETWEEN`. The complement builds only fresh bitmaps (no mutation or cardinality read of a shared null bitmap), keeping `BTreeThreadSafetyTest` safe.

### Tests

- `AbstractIndexReaderTest#testIsNotNullAcrossNullDensities` and `testNotEqualAndNotInWithNulls`, across all 12 data types and both readers.
- `BTreeIndexReaderTest` (single file) and `LazyFilteredBTreeIndexReaderTest` (10 files) exercise the complement; `testNegationFallbackWithoutRowCount` covers the scan fallback; `BTreeThreadSafetyTest` guards concurrency.
- End-to-end `BtreeGlobalIndexTableTest#testMultiFileRangeNegationPredicatesUseAbsoluteRowIds` checks a multi-file range returns exact absolute row ids.
