### PR TITLE
[flink-cdc] Stabilize MySqlSyncDatabaseActionITCase.testSyncMultipleShards

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
+++ b/paimon-flink/paimon-flink-cdc/src/test/java/org/apache/paimon/flink/action/cdc/mysql/MySqlSyncDatabaseActionITCase.java
@@ -983,7 +983,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
     }
 
     @Test
-    @Timeout(120)
+    @Timeout(240)
     public void testSyncMultipleShards() throws Exception {
         Map<String, String> mySqlConfig = getBasicMySqlConfig();
 
@@ -1000,7 +1000,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                         .withTableConfig(getBasicTableConfig())
                         .withMode(mode.configString())
                         .build();
-        runActionWithDefaultEnv(action);
+        JobClient client = runActionWithDefaultEnv(action);
 
         try (Statement statement = getStatement()) {
             // test insert into t1
@@ -1018,6 +1018,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                             },
                             new String[] {"k", "v1", "v2"});
             waitForResult(
+                    client,
                     Arrays.asList(
                             "+I[1, db1_1, NULL]",
                             "+I[2, db1_2, NULL]",
@@ -1045,6 +1046,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                             },
                             new String[] {"k", "v1", "v2", "v3"});
             waitForResult(
+                    client,
                     Arrays.asList(
                             "+I[1, 1.1, 1, NULL]",
                             "+I[2, 2.2, 2, NULL]",
@@ -1065,6 +1067,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                             new DataType[] {DataTypes.INT().notNull(), DataTypes.VARCHAR(10)},
                             new String[] {"k", "v1"});
             waitForResult(
+                    client,
                     Arrays.asList("+I[3, db1_3]", "+I[4, db1_4]"),
                     table,
                     rowType,
@@ -1088,6 +1091,7 @@ public class MySqlSyncDatabaseActionITCase extends MySqlActionITCaseBase {
                                 new DataType[] {DataTypes.INT().notNull(), DataTypes.VARCHAR(10)},
                                 new String[] {"k", "v1"});
                 waitForResult(
+                        client,
                         Arrays.asList("+I[1, db1_1]", "+I[2, db2_2]"),
                         table,
                         rowType,


### PR DESCRIPTION
### Purpose

`MySqlSyncDatabaseActionITCase.testSyncMultipleShards` intermittently fails CI with `java.util.concurrent.TimeoutException: testSyncMultipleShards() timed out after 120 seconds` (for example, it failed the CI run of an unrelated PR #8735, whose changes are confined to `paimon-common` global btree index code and cannot reach Flink CDC). This is a flaky timeout, not a functional regression.

Two things make the test prone to spurious timeouts.

First, the 120s per-method budget is tight for this test. Unlike its siblings it does several sequential `waitForResult` phases, each preceded by a schema `ALTER` that forces the CDC source to re-snapshot the changed table, on top of Flink job startup and the initial MySQL snapshot/binlog switchover. Under a loaded CI runner this legitimately exceeds 120s even though the data volume is tiny. This raises the timeout to 240s, the same value already used by the comparable heavy multi-table test in this class, `testSyncManyTableWithLimitedMemory` (the newly-added-table tests use 600s).

Second, the test called the `JobClient`-less `waitForResult` overload, in which `checkJobNotTerminated(...)` is a no-op. If the CDC job ever dies, the test cannot tell a dead job from a slow one and simply hangs until the outer `@Timeout` fires, producing an opaque timeout with no diagnosis. This captures the `JobClient` returned by `runActionWithDefaultEnv(...)` and threads it through the four `waitForResult` calls, so a terminated job now fails fast with a clear `AssertionError` instead of hanging. This matches the pattern already used by other tests in the same file (for example the newly-added-table tests).

No production code changes; test-only.

### Tests

`MySqlSyncDatabaseActionITCase.testSyncMultipleShards` (the modified test itself).
