### PR TITLE
[test] Stabilize SinkSavepointITCase.testRecoverFromSavepoint

### DIFF
--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/SinkSavepointITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/SinkSavepointITCase.java
@@ -74,10 +74,26 @@ public class SinkSavepointITCase extends AbstractTestBase {
             FailingFileIO.reset(failingName, 0, 1);
         }
 
+        // Bound the number of (expensive) stop-with-savepoint / restore cycles. On a starved CI
+        // runner each cycle pays the full Flink job-startup + restore cost, and the original
+        // "restart until FINISHED" loop is unbounded, so its wall-clock could balloon far past the
+        // @Timeout. After exercising a fixed number of recoveries we let the job run to completion
+        // uninterrupted, which keeps total runtime bounded while still covering savepoint recovery.
+        int savepointRounds = 0;
+        int maxSavepointRounds = 10;
+
         OUTER:
         while (true) {
             // start a new job or recover from savepoint
             JobClient jobClient = runRecoverFromSavepointJob(failingPath, savepointPath);
+
+            if (savepointRounds >= maxSavepointRounds) {
+                // enough recoveries exercised; let this job finish without more savepoints
+                waitForJobToFinish(jobClient);
+                break;
+            }
+            savepointRounds++;
+
             while (true) {
                 // wait for a random number of time before stopping with savepoint
                 Thread.sleep(random.nextInt(5000));
@@ -94,6 +110,12 @@ public class SinkSavepointITCase extends AbstractTestBase {
                                     .get();
                     break;
                 } catch (Exception e) {
+                    // Never swallow the interrupt raised by @Timeout: a bare InterruptedException
+                    // from Future.get() means the per-method deadline fired. Rethrow so the test
+                    // fails fast at ~180s instead of looping until the CI job-level timeout.
+                    if (ExceptionUtils.findThrowable(e, InterruptedException.class).isPresent()) {
+                        throw e;
+                    }
                     Optional<StopWithSavepointStoppingException> t =
                             ExceptionUtils.findThrowable(
                                     e, StopWithSavepointStoppingException.class);
@@ -118,6 +140,19 @@ public class SinkSavepointITCase extends AbstractTestBase {
 
         checkRecoverFromSavepointBatchResult();
         checkRecoverFromSavepointStreamingResult();
+    }
+
+    private void waitForJobToFinish(JobClient jobClient) throws Exception {
+        JobStatus status;
+        while ((status = jobClient.getJobStatus().get()) != JobStatus.FINISHED) {
+            // Fail fast if the job dies instead of spinning until the @Timeout fires: this tells a
+            // dead job apart from a slow one, so a terminated job gives a clear error rather than
+            // an opaque timeout.
+            assertThat(status.isGloballyTerminalState())
+                    .as("job reached terminal state %s without finishing", status)
+                    .isFalse();
+            Thread.sleep(1000);
+        }
     }
 
     private JobClient runRecoverFromSavepointJob(String failingPath, String savepointPath)


### PR DESCRIPTION
### Purpose

`SinkSavepointITCase.testRecoverFromSavepoint` intermittently hangs an entire CI job instead of failing within its own budget. For example the "UTCase and ITCase Flink 2.x on JDK 11" job at https://github.com/apache/paimon/actions/runs/29686582857/job/88191764951 (which surfaced while validating #8736) ran the full 2h workflow cap and was cancelled; this test was the only class that logged `Running ...` and never reported completion.

Two independent problems compound.

First, the retry loop wraps `jobClient.stopWithSavepoint(...).get()` in a broad `catch (Exception e)`. JUnit 5 enforces `@Timeout(180)` in `SAME_THREAD` mode by delivering a single interrupt to the test thread; when that interrupt lands inside `Future.get()` it surfaces as `InterruptedException`, which the broad catch swallowed. The interrupt flag is then cleared and no further interrupt is ever scheduled, so `@Timeout(180)` was permanently defeated and the test looped until the 2h job-level cap rather than failing at 180s. The catch now rethrows when the exception carries an `InterruptedException`, so the deadline fires as intended, with a stack that points at where the test is stuck.

Second, the outer loop restarted the job from a savepoint until it reached `FINISHED`, with no bound on the number of cycles. Each cycle pays a full Flink job-startup plus restore cost, so on a starved runner (the same run had `LookupJoinITCase` take about 30 minutes) the number of cycles needed to drain the input can explode and legitimately exceed the timeout. The number of stop-with-savepoint / restore cycles is now capped; after that the job is allowed to run to completion uninterrupted, which keeps total runtime bounded while still exercising savepoint recovery. The final wait also fails fast if the job reaches a terminal state without finishing, so a dead job is reported clearly instead of as an opaque timeout.

This is a test-only change; no production code is touched.

### Tests

`SinkSavepointITCase.testRecoverFromSavepoint` (the modified test itself).
