### PR TITLE
[core] Support overwriting multiple specified partitions

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommit.java
@@ -56,15 +56,13 @@ public interface FileStoreCommit extends AutoCloseable {
     /**
      * Overwrite from manifest committable and partition.
      *
-     * @param partition A single partition maps each partition key to a partition value. Depending
-     *     on the user-defined statement, the partition might not include all partition keys. Also
-     *     note that this partition does not necessarily equal to the partitions of the newly added
-     *     key-values. This is just the partition to be cleaned up.
+     * @param staticPartitions A list of partitions, mapping each partition key to a partition
+     *     value. Depending on the user-defined statement, the partition might not include all
+     *     partition keys. Also note that this partition does not necessarily equal to the
+     *     partitions of the newly added key-values. This is just the partitions to be cleaned up.
      */
     int overwritePartition(
-            Map<String, String> partition,
-            ManifestCommittable committable,
-            Map<String, String> properties);
+            List<Map<String, String>> staticPartitions, ManifestCommittable committable);
 
     /**
      * Drop multiple partitions. The {@link Snapshot.CommitKind} of generated snapshot is {@link

--- a/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/operation/FileStoreCommitImpl.java
@@ -452,19 +452,16 @@ public class FileStoreCommitImpl implements FileStoreCommit {
 
     @Override
     public int overwritePartition(
-            Map<String, String> partition,
-            ManifestCommittable committable,
-            Map<String, String> properties) {
+            List<Map<String, String>> staticPartitions, ManifestCommittable committable) {
         LOG.info(
                 "Ready to overwrite to table {}, number of commit messages: {}",
                 tableName,
                 committable.fileCommittables().size());
         if (LOG.isDebugEnabled()) {
             LOG.debug(
-                    "Ready to overwrite partition {}\nManifestCommittable: {}\nProperties: {}",
-                    partition,
-                    committable,
-                    properties);
+                    "Ready to overwrite partitions {}\nManifestCommittable: {}",
+                    staticPartitions,
+                    committable);
         }
 
         long started = System.nanoTime();
@@ -507,7 +504,7 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                 // partition may be partial partition fields, so here must use predicate way.
                 Predicate partitionPredicate =
                         createPartitionPredicate(
-                                partition, partitionType, options.partitionDefaultName());
+                                staticPartitions, partitionType, options.partitionDefaultName());
                 partitionFilter =
                         PartitionPredicate.fromPredicate(partitionType, partitionPredicate);
                 // sanity check, all changes must be done within the given partition
@@ -515,8 +512,8 @@ public class FileStoreCommitImpl implements FileStoreCommit {
                     for (ManifestEntry entry : changes.appendTableFiles) {
                         if (!partitionFilter.test(entry.partition())) {
                             throw new IllegalArgumentException(
-                                    "Trying to overwrite partition "
-                                            + partition
+                                    "Trying to overwrite partitions "
+                                            + staticPartitions
                                             + ", but the changes in "
                                             + pathFactory.getPartitionString(entry.partition())
                                             + " does not belong to this partition");

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/InnerTableCommit.java
@@ -22,6 +22,7 @@ import org.apache.paimon.metrics.MetricRegistry;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.Map;
 
 /** Inner {@link TableCommit} contains overwrite setter. */
@@ -29,6 +30,8 @@ public interface InnerTableCommit extends StreamTableCommit, BatchTableCommit {
 
     /** Overwrite writing, same as the 'INSERT OVERWRITE T PARTITION (...)' semantics of SQL. */
     InnerTableCommit withOverwrite(@Nullable Map<String, String> staticPartition);
+
+    InnerTableCommit withOverwrite(@Nullable List<Map<String, String>> partitions);
 
     /**
      * If this is set to true, when there is no new data, no snapshot will be generated. By default,

--- a/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/sink/TableCommitImpl.java
@@ -91,7 +91,7 @@ public class TableCommitImpl implements InnerTableCommit {
     private final boolean forceCreatingSnapshot;
     private final ThreadPoolExecutor fileCheckExecutor;
 
-    @Nullable private Map<String, String> overwritePartition = null;
+    @Nullable private List<Map<String, String>> overwritePartitions = null;
     private boolean batchCommitted = false;
     private boolean expireForEmptyCommit = true;
 
@@ -135,7 +135,7 @@ public class TableCommitImpl implements InnerTableCommit {
         if (this.forceCreatingSnapshot) {
             return true;
         }
-        if (overwritePartition != null) {
+        if (overwritePartitions != null) {
             return true;
         }
         return tagAutoManager != null
@@ -144,8 +144,14 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     @Override
-    public TableCommitImpl withOverwrite(@Nullable Map<String, String> overwritePartitions) {
-        this.overwritePartition = overwritePartitions;
+    public TableCommitImpl withOverwrite(@Nullable Map<String, String> staticPartition) {
+        return withOverwrite(
+                staticPartition == null ? null : Collections.singletonList(staticPartition));
+    }
+
+    @Override
+    public TableCommitImpl withOverwrite(@Nullable List<Map<String, String>> partitions) {
+        this.overwritePartitions = partitions;
         return this;
     }
 
@@ -267,7 +273,7 @@ public class TableCommitImpl implements InnerTableCommit {
     }
 
     public void commitMultiple(List<ManifestCommittable> committables, boolean checkAppendFiles) {
-        if (overwritePartition == null) {
+        if (overwritePartitions == null) {
             int newSnapshots = 0;
             for (ManifestCommittable committable : committables) {
                 newSnapshots += commit.commit(committable, checkAppendFiles);
@@ -292,9 +298,7 @@ public class TableCommitImpl implements InnerTableCommit {
                 // TODO maybe it can be produced by CommitterOperator
                 committable = new ManifestCommittable(Long.MAX_VALUE);
             }
-            int newSnapshots =
-                    commit.overwritePartition(
-                            overwritePartition, committable, Collections.emptyMap());
+            int newSnapshots = commit.overwritePartition(overwritePartitions, committable);
             maintain(
                     committable.identifier(),
                     maintainExecutor,

--- a/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
+++ b/paimon-core/src/test/java/org/apache/paimon/TestFileStore.java
@@ -249,7 +249,8 @@ public class TestFileStore extends KeyValueFileStore {
                 null,
                 Collections.emptyList(),
                 (commit, committable) ->
-                        commit.overwritePartition(partition, committable, Collections.emptyMap()));
+                        commit.overwritePartition(
+                                Collections.singletonList(partition), committable));
     }
 
     public Snapshot dropPartitions(List<Map<String, String>> partitions) {

--- a/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/FileDeletionTest.java
@@ -154,13 +154,15 @@ public class FileDeletionTest {
         Map<String, String> partitionSpec = new HashMap<>();
         partitionSpec.put("dt", "0401");
         commit.overwritePartition(
-                partitionSpec, new ManifestCommittable(commitIdentifier++), Collections.emptyMap());
+                Collections.singletonList(partitionSpec),
+                new ManifestCommittable(commitIdentifier++));
 
         // step 3: generate snapshot 3 by cleaning partition dt=0402/hr=10
         partitionSpec.put("dt", "0402");
         partitionSpec.put("hr", "8");
         commit.overwritePartition(
-                partitionSpec, new ManifestCommittable(commitIdentifier++), Collections.emptyMap());
+                Collections.singletonList(partitionSpec),
+                new ManifestCommittable(commitIdentifier++));
         commit.close();
 
         // step 4: generate snapshot 4 by cleaning dt=0402/hr=12/bucket-0

--- a/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
+++ b/paimon-core/src/test/java/org/apache/paimon/operation/TestCommitThread.java
@@ -170,9 +170,10 @@ public class TestCommitThread extends Thread {
                 committable,
                 () ->
                         commit.overwritePartition(
-                                TestKeyValueGenerator.toPartitionMap(partition, MULTI_PARTITIONED),
-                                committable,
-                                Collections.emptyMap()));
+                                Collections.singletonList(
+                                        TestKeyValueGenerator.toPartitionMap(
+                                                partition, MULTI_PARTITIONED)),
+                                committable));
     }
 
     private void doFinalCompact() {

--- a/paimon-core/src/test/java/org/apache/paimon/table/OverwriteTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/OverwriteTableTest.java
@@ -31,6 +31,7 @@ import org.apache.paimon.table.source.Split;
 import org.apache.paimon.table.source.TableRead;
 import org.apache.paimon.types.DataTypes;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -58,7 +59,11 @@ public class OverwriteTableTest extends TableTestBase {
             List<String> expected)
             throws Exception {
         innerTestOverwrite(
-                false, dynamicPartitionOverwrite, overwriteData, overwritePartition, expected);
+                false,
+                dynamicPartitionOverwrite,
+                overwriteData,
+                Collections.singletonList(overwritePartition),
+                expected);
     }
 
     @ParameterizedTest(name = "dynamic = {0}, partition={2}")
@@ -70,14 +75,34 @@ public class OverwriteTableTest extends TableTestBase {
             List<String> expected)
             throws Exception {
         innerTestOverwrite(
-                true, dynamicPartitionOverwrite, overwriteData, overwritePartition, expected);
+                true,
+                dynamicPartitionOverwrite,
+                overwriteData,
+                Collections.singletonList(overwritePartition),
+                expected);
+    }
+
+    @Test
+    public void testOverwriteMultiplePartitions() throws Exception {
+        innerTestOverwrite(
+                false,
+                false,
+                Arrays.asList(overwriteRow(9, 1, "A", "New"), overwriteRow(10, 2, "B", "Data")),
+                Arrays.asList(
+                        Collections.singletonMap("pt1", "A"), Collections.singletonMap("pt0", "2")),
+                Arrays.asList(
+                        "4, 1, B, To",
+                        "5, 1, B, Apache",
+                        "6, 1, B, Paimon",
+                        "9, 1, A, New",
+                        "10, 2, B, Data"));
     }
 
     private void innerTestOverwrite(
             boolean withPrimaryKey,
             boolean dynamicPartitionOverwrite,
             List<InternalRow> overwriteData,
-            Map<String, String> overwritePartition,
+            List<Map<String, String>> overwritePartitions,
             List<String> expected)
             throws Exception {
         Identifier identifier = identifier("T");
@@ -107,18 +132,16 @@ public class OverwriteTableTest extends TableTestBase {
         // (4, 1, 'B', 'To'), (5, 1, 'B', 'Apache'), (6, 1, 'B', 'Paimon')
         // (7, 2, 'A', 'Test')
         // (8, 2, 'B', 'Case')
-        try (StreamTableWrite write = table.newWrite(commitUser);
-                InnerTableCommit commit = table.newCommit(commitUser)) {
-            write.write(overwriteRow(1, 1, "A", "Hi"));
-            write.write(overwriteRow(2, 1, "A", "Hello"));
-            write.write(overwriteRow(3, 1, "A", "World"));
-            write.write(overwriteRow(4, 1, "B", "To"));
-            write.write(overwriteRow(5, 1, "B", "Apache"));
-            write.write(overwriteRow(6, 1, "B", "Paimon"));
-            write.write(overwriteRow(7, 2, "A", "Test"));
-            write.write(overwriteRow(8, 2, "B", "Case"));
-            commit.commit(0, write.prepareCommit(true, 0));
-        }
+        write(
+                table,
+                overwriteRow(1, 1, "A", "Hi"),
+                overwriteRow(2, 1, "A", "Hello"),
+                overwriteRow(3, 1, "A", "World"),
+                overwriteRow(4, 1, "B", "To"),
+                overwriteRow(5, 1, "B", "Apache"),
+                overwriteRow(6, 1, "B", "Paimon"),
+                overwriteRow(7, 2, "A", "Test"),
+                overwriteRow(8, 2, "B", "Case"));
 
         // overwrite data
         try (StreamTableWrite write = table.newWrite(commitUser).withIgnorePreviousFiles(true);
@@ -126,7 +149,7 @@ public class OverwriteTableTest extends TableTestBase {
             for (InternalRow row : overwriteData) {
                 write.write(row);
             }
-            commit.withOverwrite(overwritePartition).commit(1, write.prepareCommit(true, 1));
+            commit.withOverwrite(overwritePartitions).commit(1, write.prepareCommit(true, 1));
         }
 
         // validate


### PR DESCRIPTION
### Purpose

Currently, the commit API only supports overwriting a single partition. This PR adds support for overwriting multiple specified partitions

### Tests

* `OverwriteTableTest`.