### PR TITLE
[core] Make partition default name immutable after first snapshot

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -559,6 +559,7 @@ public class CoreOptions implements Serializable {
                     .withDescription(
                             "Define upsert key to do MERGE INTO when executing INSERT INTO, cannot be defined with primary key.");
 
+    @Immutable
     public static final ConfigOption<String> PARTITION_DEFAULT_NAME =
             key("partition.default-name")
                     .stringType()

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1290,8 +1290,8 @@ public class SchemaManager implements Serializable {
 
     /**
      * Whether an option change is a semantic no-op: 'primary-key'/'partition' are normalized into
-     * dedicated schema fields (old value null), and options with effective defaults compare against
-     * their default value when unset.
+     * dedicated schema fields (old value null), and 'type' compares case-insensitively, defaulting
+     * when unset.
      */
     public static boolean isUnchangedNormalizedKey(
             String key,
@@ -1319,11 +1319,6 @@ public class SchemaManager implements Serializable {
             String effectiveOld =
                     oldValue == null ? CoreOptions.TYPE.defaultValue().toString() : oldValue;
             return newValue.equalsIgnoreCase(effectiveOld);
-        }
-        if (CoreOptions.PARTITION_DEFAULT_NAME.key().equals(key)) {
-            String effectiveOld =
-                    oldValue == null ? CoreOptions.PARTITION_DEFAULT_NAME.defaultValue() : oldValue;
-            return newValue.equals(effectiveOld);
         }
         if (oldValue != null) {
             return false;

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -1290,8 +1290,8 @@ public class SchemaManager implements Serializable {
 
     /**
      * Whether an option change is a semantic no-op: 'primary-key'/'partition' are normalized into
-     * dedicated schema fields (old value null), and 'type' compares case-insensitively, defaulting
-     * when unset.
+     * dedicated schema fields (old value null), and options with effective defaults compare against
+     * their default value when unset.
      */
     public static boolean isUnchangedNormalizedKey(
             String key,
@@ -1319,6 +1319,11 @@ public class SchemaManager implements Serializable {
             String effectiveOld =
                     oldValue == null ? CoreOptions.TYPE.defaultValue().toString() : oldValue;
             return newValue.equalsIgnoreCase(effectiveOld);
+        }
+        if (CoreOptions.PARTITION_DEFAULT_NAME.key().equals(key)) {
+            String effectiveOld =
+                    oldValue == null ? CoreOptions.PARTITION_DEFAULT_NAME.defaultValue() : oldValue;
+            return newValue.equals(effectiveOld);
         }
         if (oldValue != null) {
             return false;

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.schema;
 
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -676,6 +677,127 @@ public class SchemaManagerTest {
                 .doesNotThrowAnyException();
         assertThatCode(() -> table.copy(Collections.singletonMap("type", "table")))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testAlterPartitionDefaultName() throws Exception {
+        Path tableRoot = new Path(tempDir.toString(), "partition-default-name-table");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), tableRoot);
+        manager.createTable(
+                new Schema(
+                        rowType.getFields(),
+                        partitionKeys,
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""));
+
+        String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
+        String customName = "__CUSTOM_DEFAULT_PARTITION__";
+
+        // The option can be changed and reset before the first snapshot.
+        manager.commitChanges(SchemaChange.setOption(option, customName));
+        assertThat(manager.latest().get().options()).containsEntry(option, customName);
+        manager.commitChanges(SchemaChange.removeOption(option));
+        assertThat(manager.latest().get().options()).doesNotContainKey(option);
+        manager.commitChanges(SchemaChange.setOption(option, customName));
+
+        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tableRoot);
+        writeSnapshot(tableRoot, table.schema().id());
+
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.setOption(
+                                                option, "__ANOTHER_DEFAULT_PARTITION__")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.removeOption(option)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+
+        assertThatCode(() -> manager.commitChanges(SchemaChange.setOption(option, customName)))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(
+                        () ->
+                                table.copy(
+                                        Collections.singletonMap(
+                                                option, "__ANOTHER_DEFAULT_PARTITION__")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+    }
+
+    @Test
+    public void testDefaultPartitionNameStrictResetAfterSnapshot() throws Exception {
+        Path tableRoot = new Path(tempDir.toString(), "default-partition-name-strict-reset-table");
+        SchemaManager manager = new SchemaManager(LocalFileIO.create(), tableRoot);
+        manager.createTable(
+                new Schema(
+                        rowType.getFields(),
+                        partitionKeys,
+                        Collections.emptyList(),
+                        Collections.emptyMap(),
+                        ""));
+
+        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tableRoot);
+        writeSnapshot(tableRoot, table.schema().id());
+
+        String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
+        String defaultName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
+        assertThatCode(() -> manager.commitChanges(SchemaChange.setOption(option, defaultName)))
+                .doesNotThrowAnyException();
+        assertThat(manager.latest().get().options()).doesNotContainKey(option);
+        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.removeOption(option)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+        assertThatCode(() -> table.copy(Collections.singletonMap(option, defaultName)))
+                .doesNotThrowAnyException();
+
+        // RESET remains forbidden when the stored value is explicitly equal to the default.
+        Path explicitTableRoot =
+                new Path(tempDir.toString(), "explicit-default-partition-name-table");
+        SchemaManager explicitManager = new SchemaManager(LocalFileIO.create(), explicitTableRoot);
+        explicitManager.createTable(
+                new Schema(
+                        rowType.getFields(),
+                        partitionKeys,
+                        Collections.emptyList(),
+                        Collections.singletonMap(option, defaultName),
+                        ""));
+        FileStoreTable explicitTable =
+                FileStoreTableFactory.create(LocalFileIO.create(), explicitTableRoot);
+        writeSnapshot(explicitTableRoot, explicitTable.schema().id());
+        assertThatThrownBy(() -> explicitTable.copy(Collections.singletonMap(option, null)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+    }
+
+    private void writeSnapshot(Path tableRoot, long schemaId) throws IOException {
+        Snapshot snapshot =
+                new Snapshot(
+                        Snapshot.FIRST_SNAPSHOT_ID,
+                        schemaId,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "user",
+                        1L,
+                        Snapshot.CommitKind.APPEND,
+                        System.currentTimeMillis(),
+                        1L,
+                        1L,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+        LocalFileIO fileIO = LocalFileIO.create();
+        SnapshotManager snapshotManager = new SnapshotManager(fileIO, tableRoot, null, null, null);
+        fileIO.tryToWriteAtomic(snapshotManager.snapshotPath(snapshot.id()), snapshot.toJson());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -19,7 +19,6 @@
 package org.apache.paimon.schema;
 
 import org.apache.paimon.CoreOptions;
-import org.apache.paimon.Snapshot;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
@@ -604,6 +603,12 @@ public class SchemaManagerTest {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'type' is not supported yet.");
 
+        String partitionDefaultName = CoreOptions.PARTITION_DEFAULT_NAME.key();
+        String defaultPartitionName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
+        manager.commitChanges(SchemaChange.setOption(partitionDefaultName, defaultPartitionName));
+        manager.commitChanges(SchemaChange.removeOption(partitionDefaultName));
+        assertThat(manager.latest().get().options()).doesNotContainKey(partitionDefaultName);
+
         // set immutable options and set primary keys
         manager.commitChanges(
                 SchemaChange.setOption("primary-key", "f0, f1"),
@@ -666,6 +671,27 @@ public class SchemaManagerTest {
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'merge-engine' is not supported yet.");
 
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.setOption(
+                                                partitionDefaultName, defaultPartitionName)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+        assertThatThrownBy(
+                        () ->
+                                manager.commitChanges(
+                                        SchemaChange.removeOption(partitionDefaultName)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+        assertThatThrownBy(
+                        () ->
+                                table.copy(
+                                        Collections.singletonMap(
+                                                partitionDefaultName, defaultPartitionName)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
+
         // flipping the type in place would build a different table kind over the same data
         assertThatThrownBy(
                         () -> manager.commitChanges(SchemaChange.setOption("type", "format-table")))
@@ -677,144 +703,6 @@ public class SchemaManagerTest {
                 .doesNotThrowAnyException();
         assertThatCode(() -> table.copy(Collections.singletonMap("type", "table")))
                 .doesNotThrowAnyException();
-    }
-
-    @Test
-    public void testAlterPartitionDefaultName() throws Exception {
-        Path tableRoot = new Path(tempDir.toString(), "partition-default-name-table");
-        SchemaManager manager = new SchemaManager(LocalFileIO.create(), tableRoot);
-        manager.createTable(
-                new Schema(
-                        rowType.getFields(),
-                        partitionKeys,
-                        Collections.emptyList(),
-                        Collections.emptyMap(),
-                        ""));
-
-        String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
-        String customName = "__CUSTOM_DEFAULT_PARTITION__";
-        String defaultName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
-
-        // The option can be changed and reset before the first snapshot. Changes in the same
-        // commit are applied in order.
-        manager.commitChanges(
-                SchemaChange.setOption(option, customName),
-                SchemaChange.setOption(option, defaultName));
-        assertThat(manager.latest().get().options()).containsEntry(option, defaultName);
-        manager.commitChanges(SchemaChange.removeOption(option));
-        assertThat(manager.latest().get().options()).doesNotContainKey(option);
-        manager.commitChanges(SchemaChange.setOption(option, customName));
-        assertThat(manager.latest().get().options()).containsEntry(option, customName);
-
-        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tableRoot);
-        writeSnapshot(tableRoot, table.schema().id());
-
-        assertThatThrownBy(
-                        () ->
-                                manager.commitChanges(
-                                        SchemaChange.setOption(
-                                                option, "__ANOTHER_DEFAULT_PARTITION__")))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.removeOption(option)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-
-        assertThatCode(() -> manager.commitChanges(SchemaChange.setOption(option, customName)))
-                .doesNotThrowAnyException();
-        assertThatThrownBy(
-                        () ->
-                                table.copy(
-                                        Collections.singletonMap(
-                                                option, "__ANOTHER_DEFAULT_PARTITION__")))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-    }
-
-    @Test
-    public void testDefaultPartitionNameWithImplicitDefaultAfterSnapshot() throws Exception {
-        Path tableRoot = new Path(tempDir.toString(), "implicit-default-partition-name-table");
-        SchemaManager manager = new SchemaManager(LocalFileIO.create(), tableRoot);
-        manager.createTable(
-                new Schema(
-                        rowType.getFields(),
-                        partitionKeys,
-                        Collections.emptyList(),
-                        Collections.emptyMap(),
-                        ""));
-
-        FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tableRoot);
-        writeSnapshot(tableRoot, table.schema().id());
-
-        String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
-        String defaultName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
-        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.setOption(option, defaultName)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-        assertThat(manager.latest().get().options()).doesNotContainKey(option);
-        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.removeOption(option)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-        assertThatThrownBy(() -> table.copy(Collections.singletonMap(option, defaultName)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-
-        // An explicitly stored default can be replayed, but cannot be reset.
-        Path explicitTableRoot =
-                new Path(tempDir.toString(), "explicit-default-partition-name-table");
-        SchemaManager explicitManager = new SchemaManager(LocalFileIO.create(), explicitTableRoot);
-        explicitManager.createTable(
-                new Schema(
-                        rowType.getFields(),
-                        partitionKeys,
-                        Collections.emptyList(),
-                        Collections.singletonMap(option, defaultName),
-                        ""));
-        FileStoreTable explicitTable =
-                FileStoreTableFactory.create(LocalFileIO.create(), explicitTableRoot);
-        writeSnapshot(explicitTableRoot, explicitTable.schema().id());
-        assertThatCode(
-                        () ->
-                                explicitManager.commitChanges(
-                                        SchemaChange.setOption(option, defaultName)))
-                .doesNotThrowAnyException();
-        assertThatCode(() -> explicitTable.copy(Collections.singletonMap(option, defaultName)))
-                .doesNotThrowAnyException();
-        assertThatThrownBy(() -> explicitManager.commitChanges(SchemaChange.removeOption(option)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-        assertThatThrownBy(() -> explicitTable.copy(Collections.singletonMap(option, null)))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Change 'partition.default-name' is not supported yet.");
-    }
-
-    private void writeSnapshot(Path tableRoot, long schemaId) throws IOException {
-        Snapshot snapshot =
-                new Snapshot(
-                        Snapshot.FIRST_SNAPSHOT_ID,
-                        schemaId,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        "user",
-                        1L,
-                        Snapshot.CommitKind.APPEND,
-                        System.currentTimeMillis(),
-                        1L,
-                        1L,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null,
-                        null);
-        LocalFileIO fileIO = LocalFileIO.create();
-        SnapshotManager snapshotManager = new SnapshotManager(fileIO, tableRoot, null, null, null);
-        fileIO.tryToWriteAtomic(snapshotManager.snapshotPath(snapshot.id()), snapshot.toJson());
     }
 
     @Test

--- a/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/schema/SchemaManagerTest.java
@@ -693,13 +693,18 @@ public class SchemaManagerTest {
 
         String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
         String customName = "__CUSTOM_DEFAULT_PARTITION__";
+        String defaultName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
 
-        // The option can be changed and reset before the first snapshot.
-        manager.commitChanges(SchemaChange.setOption(option, customName));
-        assertThat(manager.latest().get().options()).containsEntry(option, customName);
+        // The option can be changed and reset before the first snapshot. Changes in the same
+        // commit are applied in order.
+        manager.commitChanges(
+                SchemaChange.setOption(option, customName),
+                SchemaChange.setOption(option, defaultName));
+        assertThat(manager.latest().get().options()).containsEntry(option, defaultName);
         manager.commitChanges(SchemaChange.removeOption(option));
         assertThat(manager.latest().get().options()).doesNotContainKey(option);
         manager.commitChanges(SchemaChange.setOption(option, customName));
+        assertThat(manager.latest().get().options()).containsEntry(option, customName);
 
         FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tableRoot);
         writeSnapshot(tableRoot, table.schema().id());
@@ -727,8 +732,8 @@ public class SchemaManagerTest {
     }
 
     @Test
-    public void testDefaultPartitionNameStrictResetAfterSnapshot() throws Exception {
-        Path tableRoot = new Path(tempDir.toString(), "default-partition-name-strict-reset-table");
+    public void testDefaultPartitionNameWithImplicitDefaultAfterSnapshot() throws Exception {
+        Path tableRoot = new Path(tempDir.toString(), "implicit-default-partition-name-table");
         SchemaManager manager = new SchemaManager(LocalFileIO.create(), tableRoot);
         manager.createTable(
                 new Schema(
@@ -743,16 +748,18 @@ public class SchemaManagerTest {
 
         String option = CoreOptions.PARTITION_DEFAULT_NAME.key();
         String defaultName = CoreOptions.PARTITION_DEFAULT_NAME.defaultValue();
-        assertThatCode(() -> manager.commitChanges(SchemaChange.setOption(option, defaultName)))
-                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> manager.commitChanges(SchemaChange.setOption(option, defaultName)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
         assertThat(manager.latest().get().options()).doesNotContainKey(option);
         assertThatThrownBy(() -> manager.commitChanges(SchemaChange.removeOption(option)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'partition.default-name' is not supported yet.");
-        assertThatCode(() -> table.copy(Collections.singletonMap(option, defaultName)))
-                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> table.copy(Collections.singletonMap(option, defaultName)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
 
-        // RESET remains forbidden when the stored value is explicitly equal to the default.
+        // An explicitly stored default can be replayed, but cannot be reset.
         Path explicitTableRoot =
                 new Path(tempDir.toString(), "explicit-default-partition-name-table");
         SchemaManager explicitManager = new SchemaManager(LocalFileIO.create(), explicitTableRoot);
@@ -766,6 +773,16 @@ public class SchemaManagerTest {
         FileStoreTable explicitTable =
                 FileStoreTableFactory.create(LocalFileIO.create(), explicitTableRoot);
         writeSnapshot(explicitTableRoot, explicitTable.schema().id());
+        assertThatCode(
+                        () ->
+                                explicitManager.commitChanges(
+                                        SchemaChange.setOption(option, defaultName)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> explicitTable.copy(Collections.singletonMap(option, defaultName)))
+                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> explicitManager.commitChanges(SchemaChange.removeOption(option)))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Change 'partition.default-name' is not supported yet.");
         assertThatThrownBy(() -> explicitTable.copy(Collections.singletonMap(option, null)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Change 'partition.default-name' is not supported yet.");

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -116,6 +116,7 @@ class CoreOptions:
         "bucket-key",
         "bucket-function.type",
         "data-file.path-directory",
+        "partition.default-name",
         "merge-engine",
         "sequence.snapshot-ordering",
         "aggregation.remove-record-on-delete",

--- a/paimon-python/pypaimon/schema/schema_manager.py
+++ b/paimon-python/pypaimon/schema/schema_manager.py
@@ -300,7 +300,7 @@ def _normalize_key_list(value: str) -> List[str]:
     return [s.strip() for s in value.split(',') if s.strip()]
 
 
-def _is_unchanged_normalized_key(key, old_value, new_value, old_table_schema) -> bool:
+def is_unchanged_normalized_key(key, old_value, new_value, old_table_schema) -> bool:
     """Values whose canonical home is outside the options map (or the implicit
     default) are not a change when replayed. Mirrors the Java SchemaManager's
     isUnchangedNormalizedKey."""
@@ -716,7 +716,7 @@ class SchemaManager:
                 # the same key in one batch apply in order
                 old_value = new_options.get(change.key)
                 unchanged = (old_value == change.value
-                             or _is_unchanged_normalized_key(
+                             or is_unchanged_normalized_key(
                                  change.key, old_value, change.value, old_table_schema))
                 if unchanged:
                     continue

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -506,7 +506,7 @@ class FileStoreTable(Table):
         new_options = CoreOptions.copy(self.options).options.to_map()
         for k, v in options.items():
             if v is None:
-                new_options.pop(k)
+                new_options.pop(k, None)
             elif not is_unchanged_normalized_key(
                     k, old_options.get(k), v, self.table_schema):
                 new_options[k] = v

--- a/paimon-python/pypaimon/table/file_store_table.py
+++ b/paimon-python/pypaimon/table/file_store_table.py
@@ -24,7 +24,8 @@ from pypaimon.common.options.core_options import CoreOptions
 from pypaimon.common.options.options import Options
 from pypaimon.read.read_builder import ReadBuilder
 from pypaimon.read.stream_read_builder import StreamReadBuilder
-from pypaimon.schema.schema_manager import SchemaManager
+from pypaimon.schema.schema_manager import (SchemaManager,
+                                            is_unchanged_normalized_key)
 from pypaimon.schema.table_schema import TableSchema
 from pypaimon.table.bucket_mode import BucketMode
 from pypaimon.table.table import Table
@@ -492,11 +493,22 @@ class FileStoreTable(Table):
     def copy(self, options: dict) -> 'FileStoreTable':
         if CoreOptions.BUCKET.key() in options and int(options.get(CoreOptions.BUCKET.key())) != self.options.bucket():
             raise ValueError("Cannot change bucket number")
+
+        old_options = self.table_schema.options
+        for key, new_value in options.items():
+            old_value = old_options.get(key)
+            if (old_value != new_value
+                    and not is_unchanged_normalized_key(
+                        key, old_value, new_value, self.table_schema)
+                    and key in CoreOptions.IMMUTABLE_OPTIONS):
+                raise ValueError(f"Change '{key}' is not supported yet.")
+
         new_options = CoreOptions.copy(self.options).options.to_map()
         for k, v in options.items():
             if v is None:
                 new_options.pop(k)
-            else:
+            elif not is_unchanged_normalized_key(
+                    k, old_options.get(k), v, self.table_schema):
                 new_options[k] = v
 
         new_table_schema = self.table_schema.copy(new_options=new_options)

--- a/paimon-python/pypaimon/tests/filesystem_catalog_test.py
+++ b/paimon-python/pypaimon/tests/filesystem_catalog_test.py
@@ -232,6 +232,12 @@ class FileSystemCatalogTest(unittest.TestCase):
             [SchemaChange.set_option("merge-engine", "first-row")],
             False
         )
+        catalog.alter_table(
+            empty_identifier,
+            [SchemaChange.set_option(
+                "partition.default-name", "__CUSTOM_DEFAULT_PARTITION__")],
+            False
+        )
         # the type is rejected even without snapshots: table kinds like format
         # tables never create Paimon snapshots but can still hold data
         with self.assertRaises(RuntimeError) as ctx:
@@ -271,6 +277,25 @@ class FileSystemCatalogTest(unittest.TestCase):
             catalog.alter_table(
                 identifier, [SchemaChange.remove_option("merge-engine")], False)
         self.assertIn("Change 'merge-engine' is not supported yet.", str(ctx.exception))
+
+        with self.assertRaises(RuntimeError) as ctx:
+            catalog.alter_table(
+                identifier,
+                [SchemaChange.set_option(
+                    "partition.default-name", "__CUSTOM_DEFAULT_PARTITION__")],
+                False)
+        self.assertIn(
+            "Change 'partition.default-name' is not supported yet.",
+            str(ctx.exception))
+
+        with self.assertRaises(RuntimeError) as ctx:
+            catalog.alter_table(
+                identifier,
+                [SchemaChange.remove_option("partition.default-name")],
+                False)
+        self.assertIn(
+            "Change 'partition.default-name' is not supported yet.",
+            str(ctx.exception))
 
         # canonical hyphenated keys are guarded too
         with self.assertRaises(RuntimeError) as ctx:
@@ -340,6 +365,12 @@ class FileSystemCatalogTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             catalog.alter_table(
                 part_identifier, [SchemaChange.set_option("partition", "col1")], False)
+        with self.assertRaises(RuntimeError):
+            catalog.alter_table(
+                part_identifier,
+                [SchemaChange.set_option(
+                    "partition.default-name", "__CUSTOM_DEFAULT_PARTITION__")],
+                False)
 
         # the LATEST file is only a hint: the guard must still see the
         # snapshots when it is missing

--- a/paimon-python/pypaimon/tests/table/file_store_table_test.py
+++ b/paimon-python/pypaimon/tests/table/file_store_table_test.py
@@ -87,6 +87,9 @@ class FileStoreTableTest(unittest.TestCase):
     def test_copy_rejects_changing_partition_default_name(self):
         key = CoreOptions.PARTITION_DEFAULT_NAME.key()
 
+        copied_table = self.table.copy({key: None})
+        self.assertNotIn(key, copied_table.table_schema.options)
+
         # An implicit default is not an explicitly stored value. This follows
         # the same raw-value semantics as the other immutable options.
         with self.assertRaisesRegex(

--- a/paimon-python/pypaimon/tests/table/file_store_table_test.py
+++ b/paimon-python/pypaimon/tests/table/file_store_table_test.py
@@ -84,6 +84,36 @@ class FileStoreTableTest(unittest.TestCase):
 
         self.assertIn("Cannot change bucket number", str(context.exception))
 
+    def test_copy_rejects_changing_partition_default_name(self):
+        key = CoreOptions.PARTITION_DEFAULT_NAME.key()
+
+        # An implicit default is not an explicitly stored value. This follows
+        # the same raw-value semantics as the other immutable options.
+        with self.assertRaisesRegex(
+                ValueError, "Change 'partition.default-name' is not supported yet"):
+            self.table.copy({key: CoreOptions.PARTITION_DEFAULT_NAME.default_value()})
+
+        explicit_name = "__CUSTOM_DEFAULT_PARTITION__"
+        identifier = 'default.test_copy_with_partition_default_name'
+        schema = Schema.from_pyarrow_schema(
+            self.pa_schema,
+            partition_keys=['dt'],
+            options={
+                CoreOptions.BUCKET.key(): "2",
+                key: explicit_name,
+            })
+        self.catalog.create_table(identifier, schema, False)
+        table = self.catalog.get_table(identifier)
+
+        copied_table = table.copy({key: explicit_name})
+        self.assertEqual(explicit_name, copied_table.table_schema.options[key])
+        with self.assertRaisesRegex(
+                ValueError, "Change 'partition.default-name' is not supported yet"):
+            table.copy({key: "__ANOTHER_DEFAULT_PARTITION__"})
+        with self.assertRaisesRegex(
+                ValueError, "Change 'partition.default-name' is not supported yet"):
+            table.copy({key: None})
+
     def test_consumer_manager(self):
         """Test that FileStoreTable has consumer_manager method."""
         # Get consumer_manager


### PR DESCRIPTION
### Purpose

Change `partition.default-name` option to immutable.
