### PR TITLE
[python] Stabilize scored global index top-k tie-breaking

### DIFF
--- a/paimon-python/pypaimon/globalindex/vector_search_result.py
+++ b/paimon-python/pypaimon/globalindex/vector_search_result.py
@@ -87,20 +87,21 @@ class ScoredGlobalIndexResult(GlobalIndexResult):
             return self
 
         score_getter_fn = self.score_getter()
-        # Use a min-heap of size k to find top-k scores in O(n log k)
+        # The heap head is the weakest candidate: lowest score, then largest row ID.
         heap = []
         for row_id in row_ids:
             score = score_getter_fn(row_id)
             if score is None:
                 score = 0.0
+            item = (score, -row_id)
             if len(heap) < k:
-                heapq.heappush(heap, (score, row_id))
-            elif score > heap[0][0]:
-                heapq.heapreplace(heap, (score, row_id))
+                heapq.heappush(heap, item)
+            elif item > heap[0]:
+                heapq.heapreplace(heap, item)
 
         top_k_bitmap = RoaringBitmap64()
-        for _, row_id in heap:
-            top_k_bitmap.add(row_id)
+        for _, neg_row_id in heap:
+            top_k_bitmap.add(-neg_row_id)
 
         return SimpleScoredGlobalIndexResult(top_k_bitmap, score_getter_fn)
 

--- a/paimon-python/pypaimon/tests/vindex_vector_index_test.py
+++ b/paimon-python/pypaimon/tests/vindex_vector_index_test.py
@@ -100,6 +100,14 @@ class VindexVectorIndexTest(unittest.TestCase):
         top1 = DictBasedScoredIndexResult(id_to_scores).top_k(1)
         self.assertEqual([10], top1.results().to_list())
 
+    def test_top_k_breaks_boundary_ties_by_row_id(self):
+        scores = {1: 0.5, 2: 0.5, 3: 0.5, 4: 0.9}
+
+        self.assertEqual(
+            [1, 4],
+            DictBasedScoredIndexResult(scores).top_k(2).results().to_list(),
+        )
+
     def test_batch_search_uses_native_batch_api(self):
         old_module = sys.modules.get("paimon_vindex")
         sys.modules["paimon_vindex"] = types.SimpleNamespace(


### PR DESCRIPTION
### Purpose

`ScoredGlobalIndexResult.top_k` used `(score, row_id)` as its min-heap key. When tied candidates crossed the top-k boundary, a later higher-scored row could evict the smaller row ID.

Use `(score, -row_id)` so the retained set consistently follows score-descending, row-ID-ascending semantics.

### Tests

  - Added regression coverage for ties at the top-k boundary.
  - `vindex_vector_index_test.py`: 3 passed.
  - Python license and flake8 checks passed.