### PR TITLE
[benchmark] Fix stale throughput and duration docs in cluster README

### DIFF
--- a/paimon-benchmark/paimon-cluster-benchmark/README.md
+++ b/paimon-benchmark/paimon-cluster-benchmark/README.md
@@ -31,7 +31,7 @@ This is the cluster benchmark module for Paimon. Inspired by [Nexmark](https://g
 
 ### Run Benchmark
 * Run `paimon-benchmark/bin/run_benchmark.sh <query> <sink>` to run `<query>` for `<sink>`. Currently `<query>` can be `q1` or `all`, and sink can only be `paimon`.
-* By default, each query writes for 30 minutes and then reads all records back from the sink to measure read throughput.
+* By default, each query writes the number of rows configured by `row-num` in `paimon-benchmark/queries/queries.yaml` and then reads all records back from the sink to measure read throughput.
 
 ## Queries
 
@@ -45,7 +45,7 @@ Results of each query consist of the following aspects:
 * Throughput (rows/s): Average number of rows inserted into the sink per second.
 * Total Rows: Total number of rows written.
 * Cores: Average CPU cost.
-* Throughput/Cores: Number of bytes inserted into the sink per second per CPU.
+* Throughput/Core: Number of rows inserted into the sink per second per CPU core.
 * Avg Data Freshness: Average time elapsed from the starting point of the last successful checkpoint.
 * Max Data Freshness: Max time elapsed from the starting point of the last successful checkpoint.
 


### PR DESCRIPTION
### Purpose

Two README lines still describe the behavior from before 8815608e0a (#274), although that commit updated the neighbouring lines.

- `Throughput/Core` is `rps / cpu`, where `rps` reads Flink's `numRecordsOutPerSecond` (`JobBenchmarkMetric#getRpsPerCore`) — rows, not bytes. The README also names the column `Throughput/Cores`, while `Benchmark` prints `Throughput/Core`.
- Writing stops after `row-num` rows from `queries.yaml`, not after 30 minutes: that commit removed `benchmark.metric.monitor.duration` and left a sentence contradicting "Each SQL script will stop only after it produces enough number of rows" below it.

No linked issue: docs wording fix, no open issue on this topic.

### Tests

- Docs-only: one file, two lines, no behavior change, so no test was added. `mvn spotless:check -pl paimon-benchmark/paimon-cluster-benchmark` passes.
