### PR TITLE
[api] Fix SchemaChange hashCode to use Arrays.hashCode for fieldNames

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/schema/SchemaChange.java
+++ b/paimon-api/src/main/java/org/apache/paimon/schema/SchemaChange.java
@@ -370,7 +370,7 @@ public interface SchemaChange extends Serializable {
         @Override
         public int hashCode() {
             int result = Objects.hash(dataType, description);
-            result = 31 * result + Objects.hashCode(fieldNames);
+            result = 31 * result + Arrays.hashCode(fieldNames);
             result = 31 * result + Objects.hashCode(move);
             return result;
         }
@@ -425,7 +425,7 @@ public interface SchemaChange extends Serializable {
         @Override
         public int hashCode() {
             int result = Objects.hash(newName);
-            result = 31 * result + Objects.hashCode(fieldNames);
+            result = 31 * result + Arrays.hashCode(fieldNames);
             return result;
         }
     }
@@ -465,7 +465,7 @@ public interface SchemaChange extends Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(fieldNames);
+            return Arrays.hashCode(fieldNames);
         }
     }
 
@@ -528,7 +528,7 @@ public interface SchemaChange extends Serializable {
         @Override
         public int hashCode() {
             int result = Objects.hash(newDataType);
-            result = 31 * result + Objects.hashCode(fieldNames);
+            result = 31 * result + Arrays.hashCode(fieldNames);
             return result;
         }
     }
@@ -812,7 +812,7 @@ public interface SchemaChange extends Serializable {
         @Override
         public int hashCode() {
             int result = Objects.hash(newDefaultValue);
-            result = 31 * result + Objects.hashCode(fieldNames);
+            result = 31 * result + Arrays.hashCode(fieldNames);
             return result;
         }
     }

--- a/paimon-api/src/test/java/org/apache/paimon/schema/SchemaChangeTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/schema/SchemaChangeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.schema;
+
+import org.apache.paimon.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SchemaChange}. */
+public class SchemaChangeTest {
+
+    private static String[] fieldNames() {
+        return new String[] {"outer", "inner"};
+    }
+
+    private static void assertEqualHashCode(SchemaChange a, SchemaChange b) {
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+
+    @Test
+    void testAddColumnHashCodeUsesFieldNamesContent() {
+        assertEqualHashCode(
+                SchemaChange.addColumn(fieldNames(), DataTypes.INT(), "c", null),
+                SchemaChange.addColumn(fieldNames(), DataTypes.INT(), "c", null));
+    }
+
+    @Test
+    void testRenameColumnHashCodeUsesFieldNamesContent() {
+        assertEqualHashCode(
+                SchemaChange.renameColumn(fieldNames(), "newName"),
+                SchemaChange.renameColumn(fieldNames(), "newName"));
+    }
+
+    @Test
+    void testDropColumnHashCodeUsesFieldNamesContent() {
+        assertEqualHashCode(
+                SchemaChange.dropColumn(fieldNames()), SchemaChange.dropColumn(fieldNames()));
+    }
+
+    @Test
+    void testUpdateColumnTypeHashCodeUsesFieldNamesContent() {
+        assertEqualHashCode(
+                SchemaChange.updateColumnType(fieldNames(), DataTypes.BIGINT(), false),
+                SchemaChange.updateColumnType(fieldNames(), DataTypes.BIGINT(), false));
+    }
+
+    @Test
+    void testUpdateColumnDefaultValueHashCodeUsesFieldNamesContent() {
+        assertEqualHashCode(
+                SchemaChange.updateColumnDefaultValue(fieldNames(), "1"),
+                SchemaChange.updateColumnDefaultValue(fieldNames(), "1"));
+    }
+}


### PR DESCRIPTION

### Purpose

fix #8753

- `AddColumn`, `RenameColumn`, `DropColumn`, `UpdateColumnType` and `UpdateColumnDefaultValue` compare `String[] fieldNames` with `Arrays.equals` but hash it with `Objects.hashCode`, which returns the array identity hash. Equal instances then produce different hash codes, violating the `Object.hashCode` contract of this `@Public` API, so hash-based containers cannot match them.
- Fix: use `Arrays.hashCode(fieldNames)`, matching sibling `UpdateColumnNullability` and `UpdateColumnComment` in the same file.
- Same defect class as merged PR #8518 (`FunctionChange.UpdateDefinition.hashCode`).

```java
result = 31 * result + Arrays.hashCode(fieldNames);
```

### Tests

- Added `SchemaChangeTest`, one test per affected class: two instances built from distinct but equal `String[]` are `equals` and share a hash code. All 5 fail before the fix.
- `mvn -pl paimon-api -DfailIfNoTests=false clean install` (JDK 11) — 65 unit + 22 integration-phase tests passed.


