### PR TITLE
[benchmark] Close seekable input streams in bitmap benchmarks

### DIFF
--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/BitmapIndexBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/BitmapIndexBenchmark.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /** Benchmark for {@link BitmapFileIndex}. */
 public class BitmapIndexBenchmark {
@@ -139,11 +139,10 @@ public class BitmapIndexBenchmark {
     }
 
     private static void query(int approxCardinality, File file1) {
-        try {
+        try (LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                new LocalFileIO.LocalSeekableInputStream(file1)) {
             FieldRef fieldRef = new FieldRef(0, "", DataTypes.STRING());
             Options options = new Options();
-            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
-                    new LocalFileIO.LocalSeekableInputStream(file1);
             FileIndexReader reader =
                     new BitmapFileIndex(DataTypes.STRING(), options)
                             .createReader(localSeekableInputStream, 0, 0);
@@ -151,7 +150,7 @@ public class BitmapIndexBenchmark {
                     reader.visitEqual(
                             fieldRef, BinaryString.fromString(prefix + (approxCardinality / 2)));
             ((BitmapIndexResult) result).get();
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RangeBitmapIndexBenchmark.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -213,51 +212,48 @@ public class RangeBitmapIndexBenchmark {
 
     private void queryBsi(
             File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
-        try {
+        try (LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                new LocalFileIO.LocalSeekableInputStream(file)) {
             FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
             Options options = new Options();
-            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
-                    new LocalFileIO.LocalSeekableInputStream(file);
             FileIndexReader reader =
                     new BitSliceIndexBitmapFileIndex(DataTypes.INT())
                             .createReader(localSeekableInputStream, 0, 0);
             FileIndexResult result = function.apply(reader, fieldRef);
             ((BitmapIndexResult) result).get();
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     private void queryBitmap(
             File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
-        try {
+        try (LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                new LocalFileIO.LocalSeekableInputStream(file)) {
             FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
             Options options = new Options();
-            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
-                    new LocalFileIO.LocalSeekableInputStream(file);
             FileIndexReader reader =
                     new BitmapFileIndex(DataTypes.INT(), options)
                             .createReader(localSeekableInputStream, 0, 0);
             FileIndexResult result = function.apply(reader, fieldRef);
             ((BitmapIndexResult) result).get();
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     private void queryRangeBitmap(
             File file, BiFunction<FileIndexReader, FieldRef, FileIndexResult> function) {
-        try {
+        try (LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
+                new LocalFileIO.LocalSeekableInputStream(file)) {
             FieldRef fieldRef = new FieldRef(0, "", DataTypes.INT());
             Options options = new Options();
-            LocalFileIO.LocalSeekableInputStream localSeekableInputStream =
-                    new LocalFileIO.LocalSeekableInputStream(file);
             FileIndexReader reader =
                     new RangeBitmapFileIndex(DataTypes.INT(), options)
                             .createReader(localSeekableInputStream, 0, 0);
             FileIndexResult result = function.apply(reader, fieldRef);
             ((BitmapIndexResult) result).get();
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RoaringBitmapBenchmark.java
+++ b/paimon-benchmark/paimon-micro-benchmarks/src/test/java/org/apache/paimon/benchmark/bitmap/RoaringBitmapBenchmark.java
@@ -83,11 +83,10 @@ public class RoaringBitmapBenchmark {
                 "deserialize(DataInputStream(BufferedInputStream))",
                 10,
                 () -> {
-                    try {
-                        LocalFileIO.LocalSeekableInputStream seekableStream =
-                                new LocalFileIO.LocalSeekableInputStream(file);
-                        DataInputStream input =
-                                new DataInputStream(new BufferedInputStream(seekableStream));
+                    try (LocalFileIO.LocalSeekableInputStream seekableStream =
+                                    new LocalFileIO.LocalSeekableInputStream(file);
+                            DataInputStream input =
+                                    new DataInputStream(new BufferedInputStream(seekableStream))) {
                         new RoaringBitmap().deserialize(input);
                     } catch (IOException e) {
                         throw new RuntimeException(e);


### PR DESCRIPTION
### Purpose

fix #8755

- Wrap the `LocalFileIO.LocalSeekableInputStream` of five `benchmark/bitmap` cases in try-with-resources: `RoaringBitmapBenchmark.testDeserialize()` (second case), `BitmapIndexBenchmark.query()`, and `RangeBitmapIndexBenchmark.queryBsi()` / `queryBitmap()` / `queryRangeBitmap()`.
- The other three cases in `RoaringBitmapBenchmark.testDeserialize()` already use try-with-resources — the second case was the only one missing it.
- `LocalFileIO.LocalSeekableInputStream.close()` closes the underlying `FileInputStream`, so without it release is left to the GC.
- Widen `catch (FileNotFoundException)` to `catch (IOException)` in the four query methods, required now that `close()` is on the path. The measured logic is unchanged.

### Tests

- No test added: this module has no `*Test` class (all 17 files are benchmarks) and the change only affects cleanup.
- `mvn spotless:check` and `mvn -DskipTests clean test-compile` on `paimon-benchmark/paimon-micro-benchmarks` passed.
- The `@Test` methods here run real benchmarks, so they were not run locally.

