### PR TITLE
[core] Fix misleading shutdown-hook comment in FileChannelManagerImpl

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/disk/FileChannelManagerImpl.java
+++ b/paimon-core/src/main/java/org/apache/paimon/disk/FileChannelManagerImpl.java
@@ -59,8 +59,8 @@ public class FileChannelManagerImpl implements FileChannelManager {
 
         this.random = new Random();
 
-        // Creates directories after registering shutdown hook to ensure the directories can be
-        // removed if required.
+        // Directories are created eagerly here and removed when this manager is closed (see
+        // close()).
         this.paths = createFiles(tempDirs, prefix);
 
         LOG.info(


### PR DESCRIPTION
### Purpose

- The `FileChannelManagerImpl` constructor comment claims directories are created "after registering shutdown hook", but no shutdown hook is registered in the class.
- It was carried over from the original Flink port (FLINK-30610), which registers the hook; the Paimon port dropped it but kept the comment.
- Reword the comment to describe the actual cleanup contract: directories are removed in `close()`.

### Tests

- Comment/wording fix, no behavior change — no test added. `mvn spotless:check -pl paimon-core` passed, and `mvn -pl paimon-core -DskipTests test-compile` (checkstyle + spotless) BUILD SUCCESS under JDK 11.
