### PR TITLE
[common] Fix DateTimeUtils.truncate dropping sub-precision fractional seconds

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/DateTimeUtils.java
@@ -649,8 +649,14 @@ public class DateTimeUtils {
     }
 
     public static Timestamp truncate(Timestamp ts, int precision) {
-        String fraction = Integer.toString(ts.toLocalDateTime().getNano());
-        if (fraction.length() <= precision) {
+        // Pad to 9 digits so leading zeros are preserved, then count the significant
+        // fractional digits by stripping trailing zeros (same approach as formatTimestamp).
+        String fraction = pad(9, ts.toLocalDateTime().getNano());
+        int significant = fraction.length();
+        while (significant > 0 && fraction.charAt(significant - 1) == '0') {
+            significant--;
+        }
+        if (significant <= precision) {
             return ts;
         } else {
             // need to truncate

--- a/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/DateTimeUtilsTest.java
@@ -99,4 +99,38 @@ public class DateTimeUtilsTest {
             TimeZone.setDefault(timeZone);
         }
     }
+
+    @Test
+    public void testTruncateDropsSubPrecisionFraction() {
+        // A fractional second below 0.1s has leading zeros in its nano representation.
+        // The narrowing cast to precision 3 must drop all nanoseconds below the millisecond.
+        Timestamp nineNanos = Timestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 9));
+        assertThat(nineNanos.toLocalDateTime().getNano()).isEqualTo(9);
+        assertThat(DateTimeUtils.truncate(nineNanos, 3).toLocalDateTime().getNano()).isEqualTo(0);
+
+        // Truncating .000123456 to precision 6 must keep exactly 6 fractional digits (.000123).
+        Timestamp micros =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123_456));
+        assertThat(micros.toLocalDateTime().getNano()).isEqualTo(123_456);
+        assertThat(DateTimeUtils.truncate(micros, 6).toLocalDateTime().getNano())
+                .isEqualTo(123_000);
+    }
+
+    @Test
+    public void testTruncateIsIdempotent() {
+        // An already-truncated value stays unchanged when truncated again to the same precision.
+        Timestamp truncated =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123_000));
+        assertThat(DateTimeUtils.truncate(truncated, 6).toLocalDateTime().getNano())
+                .isEqualTo(123_000);
+    }
+
+    @Test
+    public void testTruncateNoOpAtMaxPrecision() {
+        // Precision 9 preserves all nanoseconds.
+        Timestamp full =
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 0, 0, 0, 123_456_789));
+        assertThat(DateTimeUtils.truncate(full, 9).toLocalDateTime().getNano())
+                .isEqualTo(123_456_789);
+    }
 }


### PR DESCRIPTION
### Purpose

fix #8764

- `DateTimeUtils.truncate(Timestamp, int)` counted fractional-second digits with `Integer.toString(ts.toLocalDateTime().getNano())`, which strips leading zeros and under-counts fractions below 0.1s.
- The short-circuit guard `if (fraction.length() <= precision) return ts;` then wrongly skipped truncation, so a narrowing precision cast (`TimestampToTimestampCastRule`) silently retained sub-precision nanoseconds — e.g. `.000000009`→precision 3 stayed `.000000009` instead of `.000`.
- Now pad to 9 digits and count significant digits by stripping trailing zeros, mirroring the sibling `formatTimestamp()` in the same file.

### Tests

- Added `DateTimeUtilsTest#testTruncateDropsSubPrecisionFraction` (`.000000009`→p3, `.000123456`→p6 with independent hardcoded expected nanos), `#testTruncateIsIdempotent`, `#testTruncateNoOpAtMaxPrecision`.
- `mvn -pl paimon-common -DfailIfNoTests=false clean install` — BUILD SUCCESS (checkstyle + spotless + rat + all paimon-common tests passed), JDK 11.
