### PR TITLE
[common] Close input stream on FileIndexFormat.Reader construction failure

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fileindex/FileIndexFormat.java
@@ -279,7 +279,7 @@ public final class FileIndexFormat {
                         }
                     }
                 }
-            } catch (IOException e) {
+            } catch (IOException | RuntimeException e) {
                 IOUtils.closeQuietly(seekableInputStream);
                 throw new RuntimeException(
                         "Exception happens while construct file index reader.", e);

--- a/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fileindex/FileIndexFormatFormatTest.java
@@ -20,6 +20,7 @@ package org.apache.paimon.fileindex;
 
 import org.apache.paimon.fileindex.empty.EmptyFileIndexReader;
 import org.apache.paimon.fs.ByteArraySeekableStream;
+import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
@@ -104,5 +105,84 @@ public class FileIndexFormatFormatTest {
         Assertions.assertThat(fileIndexFormatList.size()).isEqualTo(1);
         Assertions.assertThat(new ArrayList<>(fileIndexFormatList).get(0))
                 .isEqualTo(EmptyFileIndexReader.INSTANCE);
+    }
+
+    @Test
+    public void testReaderClosesInputStreamOnBadMagic() {
+        // first 8 bytes are not MAGIC, so the reader throws a RuntimeException from within the
+        // constructor's try block before the resource is returned to the caller.
+        CloseRecordingSeekableStream inputStream = new CloseRecordingSeekableStream(new byte[16]);
+
+        Assertions.assertThatThrownBy(
+                        () -> FileIndexFormat.createReader(inputStream, RowType.builder().build()))
+                .isInstanceOf(RuntimeException.class);
+        Assertions.assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    @Test
+    public void testReaderClosesInputStreamOnUnsupportedVersion() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        FileIndexFormat.Writer writer = FileIndexFormat.createWriter(baos);
+        writer.writeColumnIndexes(new HashMap<>());
+        writer.close();
+
+        // keep the valid MAGIC (bytes 0-7) but corrupt the version int (bytes 8-11) so the reader
+        // throws a RuntimeException after the magic check but still inside the try block.
+        byte[] indexBytes = baos.toByteArray();
+        indexBytes[8] = 0x7f;
+        indexBytes[9] = 0x7f;
+        indexBytes[10] = 0x7f;
+        indexBytes[11] = 0x7f;
+
+        CloseRecordingSeekableStream inputStream = new CloseRecordingSeekableStream(indexBytes);
+
+        Assertions.assertThatThrownBy(
+                        () -> FileIndexFormat.createReader(inputStream, RowType.builder().build()))
+                .isInstanceOf(RuntimeException.class);
+        Assertions.assertThat(inputStream.isClosed()).isTrue();
+    }
+
+    /**
+     * A {@link SeekableInputStream} that records whether {@link #close()} was called and delegates
+     * reads to a backing {@link ByteArraySeekableStream} (whose own {@code close()} is a no-op).
+     */
+    private static class CloseRecordingSeekableStream extends SeekableInputStream {
+
+        private final ByteArraySeekableStream delegate;
+        private boolean closed = false;
+
+        private CloseRecordingSeekableStream(byte[] bytes) {
+            this.delegate = new ByteArraySeekableStream(bytes);
+        }
+
+        private boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public void seek(long desired) throws IOException {
+            delegate.seek(desired);
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return delegate.getPos();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            delegate.close();
+        }
     }
 }


### PR DESCRIPTION
### Purpose

fix #8765

- `FileIndexFormat.Reader.<init>` only closed the owned `SeekableInputStream` on `IOException`.
- A corrupt or wrong-version index file throws a `RuntimeException` from the magic/version checks inside the same `try` block, escaping the `catch` and leaking the file descriptor.
- Because the constructor throws before returning, the caller's try-with-resources never binds the `Reader`, so `close()` never runs.
- Widen the catch to `IOException | RuntimeException`, mirroring the existing IOException branch that already closes the stream.

### Tests

- Added `FileIndexFormatFormatTest#testReaderClosesInputStreamOnBadMagic` and `#testReaderClosesInputStreamOnUnsupportedVersion`, using a close-recording `SeekableInputStream` wrapper; both fail on master and pass with the fix.
- `mvn -pl paimon-common -DfailIfNoTests=false clean install` passed (JDK 11), including checkstyle, spotless, and rat.
