### PR TITLE
[common] Fix negative time-of-day when casting pre-epoch timestamp to TIME

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToTimeCastRule.java
+++ b/paimon-common/src/main/java/org/apache/paimon/casting/TimestampToTimeCastRule.java
@@ -45,7 +45,8 @@ class TimestampToTimeCastRule extends AbstractCastRule<Timestamp, Number> {
     @Override
     public CastExecutor<Timestamp, Number> create(DataType inputType, DataType targetType) {
         if (inputType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
-            return value -> (int) (value.getMillisecond() % DateTimeUtils.MILLIS_PER_DAY);
+            return value ->
+                    (int) Math.floorMod(value.getMillisecond(), DateTimeUtils.MILLIS_PER_DAY);
         } else if (inputType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
             return value ->
                     DateTimeUtils.timestampWithLocalZoneToTime(value, TimeZone.getDefault());

--- a/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/casting/CastExecutorTest.java
@@ -51,6 +51,7 @@ import org.apache.paimon.utils.DecimalUtils;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -824,6 +825,29 @@ public class CastExecutorTest {
                 CastExecutors.resolve(new LocalZonedTimestampType(5), new TimeType(2)),
                 Timestamp.fromEpochMillis(mills),
                 DateTimeUtils.timestampWithLocalZoneToTime(timestamp, TimeZone.getDefault()));
+    }
+
+    @Test
+    public void testTimestampToTimePreEpoch() {
+        CastExecutor<?, ?> cast = CastExecutors.resolve(new TimestampType(3), new TimeType(3));
+
+        // pre-epoch 1969-12-31 23:00:00 -> time-of-day 23:00:00 == 82_800_000 ms
+        compareCastResult(
+                cast,
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1969, 12, 31, 23, 0, 0)),
+                82800000);
+
+        // pre-epoch 1969-12-31 12:34:56.789 -> 12*3600000 + 34*60000 + 56*1000 + 789
+        compareCastResult(
+                cast,
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1969, 12, 31, 12, 34, 56, 789000000)),
+                45296789);
+
+        // post-epoch 1970-01-01 10:00:00 -> 36_000_000 ms (unchanged behavior)
+        compareCastResult(
+                cast,
+                Timestamp.fromLocalDateTime(LocalDateTime.of(1970, 1, 1, 10, 0, 0)),
+                36000000);
     }
 
     @Test


### PR DESCRIPTION
### Purpose

fix #8766

- `TimestampToTimeCastRule.create()` computed the time-of-day as `millisecond % MILLIS_PER_DAY`; for a pre-epoch (negative) millisecond Java's `%` yields a negative remainder, producing an invalid TIME internal value outside `[0, 86_399_999]`.
- Replace the modulo with `Math.floorMod`, which returns a non-negative result for a positive modulus. Post-epoch results are unchanged.
- Aligns with the sibling LTZ branch (`DateTimeUtils.timestampWithLocalZoneToTime`) and `DateTimeUtils.formatTimestampMillis`, which already normalize negative time-of-day values.

### Tests

- Added `CastExecutorTest#testTimestampToTimePreEpoch` asserting independent literals: `1969-12-31 23:00:00` -> 82_800_000, `1969-12-31 12:34:56.789` -> 45_296_789, and a post-epoch case (`1970-01-01 10:00:00` -> 36_000_000) that stays unchanged. It fails before the fix (returns -3_600_000).
- `mvn -pl paimon-common -DfailIfNoTests=false clean install` (JDK 11) passed.
