### PR TITLE
[python] Fix latest snapshot lookup for index scan

### DIFF
--- a/paimon-python/pypaimon/index/index_file_handler.py
+++ b/paimon-python/pypaimon/index/index_file_handler.py
@@ -46,7 +46,7 @@ class IndexFileHandler:
         entry_filter: Optional[Callable[['IndexManifestEntry'], bool]] = None
     ) -> List['IndexManifestEntry']:
         if snapshot is None:
-            snapshot = self._snapshot_manager.latest_snapshot()
+            snapshot = self._snapshot_manager.get_latest_snapshot()
 
         if snapshot is None:
             return []

--- a/paimon-python/pypaimon/tests/index_file_handler_test.py
+++ b/paimon-python/pypaimon/tests/index_file_handler_test.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock
+
+from pypaimon.index.index_file_handler import IndexFileHandler
+
+
+class IndexFileHandlerTest(unittest.TestCase):
+
+    def test_scan_resolves_unspecified_snapshot(self):
+        snapshot_manager = Mock(spec=['get_latest_snapshot'])
+        snapshot_manager.get_latest_snapshot.return_value = None
+        table = Mock()
+        table.snapshot_manager.return_value = snapshot_manager
+
+        self.assertEqual([], IndexFileHandler(table).scan(None))
+        snapshot_manager.get_latest_snapshot.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Purpose

Fix `IndexFileHandler.scan(None)` calling the nonexistent `SnapshotManager.latest_snapshot()` method. Resolve the latest snapshot through `get_latest_snapshot()` and add regression coverage for an unspecified snapshot.

### Tests
CI