### PR TITLE
[core] Migrate shredding map on rename and drop commands

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/ColumnDirectiveUtils.java
@@ -322,6 +322,25 @@ public final class ColumnDirectiveUtils {
                 }
             }
             options.remove(String.format("field.%s.vector-dim", fieldName));
+        } else if (type.getTypeRoot() == DataTypeRoot.MAP) {
+            options.remove(
+                    CoreOptions.FIELDS_PREFIX
+                            + "."
+                            + fieldName
+                            + "."
+                            + CoreOptions.MAP_STORAGE_LAYOUT);
+            options.remove(
+                    CoreOptions.FIELDS_PREFIX
+                            + "."
+                            + fieldName
+                            + "."
+                            + CoreOptions.MAP_SHARED_SHREDDING_MAX_COLUMNS);
+            options.remove(
+                    CoreOptions.FIELDS_PREFIX
+                            + "."
+                            + fieldName
+                            + "."
+                            + CoreOptions.MAP_SHARED_SHREDDING_COLUMN_PLACEMENT_POLICY);
         }
     }
 

--- a/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
+++ b/paimon-core/src/main/java/org/apache/paimon/schema/SchemaManager.java
@@ -94,6 +94,9 @@ import static org.apache.paimon.CoreOptions.IGNORE_DELETE;
 import static org.apache.paimon.CoreOptions.IGNORE_RETRACT;
 import static org.apache.paimon.CoreOptions.IGNORE_UPDATE_BEFORE;
 import static org.apache.paimon.CoreOptions.LIST_AGG_DELIMITER;
+import static org.apache.paimon.CoreOptions.MAP_SHARED_SHREDDING_COLUMN_PLACEMENT_POLICY;
+import static org.apache.paimon.CoreOptions.MAP_SHARED_SHREDDING_MAX_COLUMNS;
+import static org.apache.paimon.CoreOptions.MAP_STORAGE_LAYOUT;
 import static org.apache.paimon.CoreOptions.NESTED_KEY;
 import static org.apache.paimon.CoreOptions.PK_CLUSTERING_OVERRIDE;
 import static org.apache.paimon.CoreOptions.SEQUENCE_FIELD;
@@ -854,7 +857,20 @@ public class SchemaManager implements Serializable {
                         fieldName -> FIELDS_PREFIX + "." + fieldName + "." + AGG_FUNCTION,
                         fieldName -> FIELDS_PREFIX + "." + fieldName + "." + IGNORE_RETRACT,
                         fieldName -> FIELDS_PREFIX + "." + fieldName + "." + DISTINCT,
-                        fieldName -> FIELDS_PREFIX + "." + fieldName + "." + LIST_AGG_DELIMITER);
+                        fieldName -> FIELDS_PREFIX + "." + fieldName + "." + LIST_AGG_DELIMITER,
+                        fieldName -> FIELDS_PREFIX + "." + fieldName + "." + MAP_STORAGE_LAYOUT,
+                        fieldName ->
+                                FIELDS_PREFIX
+                                        + "."
+                                        + fieldName
+                                        + "."
+                                        + MAP_SHARED_SHREDDING_MAX_COLUMNS,
+                        fieldName ->
+                                FIELDS_PREFIX
+                                        + "."
+                                        + fieldName
+                                        + "."
+                                        + MAP_SHARED_SHREDDING_COLUMN_PLACEMENT_POLICY);
 
         for (RenameColumn rename : renameColumns) {
             String fieldName = rename.fieldNames()[0];

--- a/paimon-core/src/test/java/org/apache/paimon/table/MapSharedShreddingTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/MapSharedShreddingTableTest.java
@@ -947,6 +947,44 @@ public class MapSharedShreddingTableTest extends TableTestBase {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"orc", "parquet"})
+    public void testRenameSharedShreddingMapColumn(String format) throws Exception {
+        createTable(format, 2, "metrics");
+
+        catalog.alterTable(
+                identifier(format),
+                Collections.singletonList(SchemaChange.renameColumn("metrics", "renamed_metrics")),
+                false);
+
+        Table table = catalog.getTable(identifier(format));
+        assertThat(table.rowType().getFieldNames()).containsExactly("id", "renamed_metrics");
+
+        Map<String, String> options = table.options();
+        assertThat(options).doesNotContainKey("fields.metrics.map.storage-layout");
+        assertThat(options)
+                .containsEntry("fields.renamed_metrics.map.storage-layout", "shared-shredding")
+                .containsEntry("fields.renamed_metrics.map.shared-shredding.max-columns", "2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"orc", "parquet"})
+    public void testDropSharedShreddingMapColumn(String format) throws Exception {
+        createTable(format, 2, "metrics", "labels");
+
+        catalog.alterTable(
+                identifier(format),
+                Collections.singletonList(SchemaChange.dropColumn("metrics")),
+                false);
+
+        Table table = catalog.getTable(identifier(format));
+        assertThat(table.rowType().getFieldNames()).containsExactly("id", "labels");
+
+        Map<String, String> options = table.options();
+        assertThat(options).doesNotContainKey("fields.metrics.map.storage-layout");
+        assertThat(options).doesNotContainKey("fields.metrics.map.shared-shredding.max-columns");
+    }
+
     private Table createTable(String format, String... sharedShreddingFields) throws Exception {
         return createTable(format, 2, sharedShreddingFields);
     }


### PR DESCRIPTION
### Purpose
 - Rename and drop on map column fails with :Field <col> can not be found in table schema.
 - This is because the column specific map shredded keys are not migrated in renames and drops.
 - Add the map.* keys to the rename option migration whitelist and strip them on drop, so rename/drop of a shredding map column succeeds and keeps its layout options.

### Tests
-  UT