### PR TITLE
[iceberg] Keep deletions visible to Iceberg incremental scans

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
+++ b/paimon-core/src/main/java/org/apache/paimon/iceberg/IcebergCommitCallback.java
@@ -957,12 +957,15 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     List<IcebergManifestEntry> newEntries = new ArrayList<>();
                     for (IcebergManifestEntry entry : entries) {
                         if (entry.isLive()) {
+                            boolean removed = removedFiles.containsKey(entry.file().filePath());
                             newEntries.add(
                                     new IcebergManifestEntry(
-                                            removedFiles.containsKey(entry.file().filePath())
+                                            removed
                                                     ? IcebergManifestEntry.Status.DELETED
                                                     : IcebergManifestEntry.Status.EXISTING,
-                                            entry.snapshotId(),
+                                            // a deleted entry records the snapshot that
+                                            // deleted the file, not the one that added it
+                                            removed ? currentSnapshotId : entry.snapshotId(),
                                             entry.sequenceNumber(),
                                             entry.fileSequenceNumber(),
                                             entry.file()));
@@ -1018,7 +1021,11 @@ public class IcebergCommitCallback implements CommitCallback, TagCallback {
                     for (IcebergManifestEntry entry :
                             IcebergManifestFile.create(table, pathFactory)
                                     .read(new Path(meta.manifestPath()).getName())) {
+                        // a deletion made by this commit is recorded against the current
+                        // snapshot but keeps the file sequence number of the older snapshot
+                        // that added the file, so it has to be recognised by snapshot id
                         if (entry.fileSequenceNumber() == currentSnapshotId
+                                || entry.snapshotId() == currentSnapshotId
                                 || entry.status() == IcebergManifestEntry.Status.EXISTING) {
                             entries.add(entry);
                         } else {

--- a/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/iceberg/IcebergCompatibilityTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.iceberg.manifest.IcebergManifestEntry;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFile;
 import org.apache.paimon.iceberg.manifest.IcebergManifestFileMeta;
 import org.apache.paimon.iceberg.manifest.IcebergManifestList;
@@ -147,6 +148,139 @@ public class IcebergCompatibilityTest {
         commit.commit(3, write.prepareCommit(true, 3));
         assertThat(getIcebergResult())
                 .containsExactlyInAnyOrder("Record(1, 11)", "Record(2, 20)", "Record(3, 30)");
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testDeletedEntryRecordsTheDeletingSnapshot() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT()}, new String[] {"k", "v"});
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.emptyList(),
+                        Collections.singletonList("k"),
+                        1,
+                        Collections.emptyMap());
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        write.write(GenericRow.of(1, 10));
+        write.write(GenericRow.of(2, 20));
+        commit.commit(1, write.prepareCommit(false, 1));
+
+        write.write(GenericRow.of(1, 11));
+        write.compact(BinaryRow.EMPTY_ROW, 0, true);
+        commit.commit(2, write.prepareCommit(true, 2));
+
+        long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        table.fileIO(),
+                        new Path(
+                                table.location(),
+                                "metadata/v" + latestSnapshotId + ".metadata.json"));
+        long currentSnapshotId = metadata.currentSnapshotId();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergManifestList manifestList = IcebergManifestList.create(table, pathFactory);
+        IcebergManifestFile manifestFile = IcebergManifestFile.create(table, pathFactory);
+
+        List<IcebergManifestEntry> deleted = new ArrayList<>();
+        for (IcebergManifestFileMeta fileMeta :
+                manifestList.read(new Path(metadata.currentSnapshot().manifestList()).getName())) {
+            for (IcebergManifestEntry entry : manifestFile.read(fileMeta.manifestPath())) {
+                if (entry.status() == IcebergManifestEntry.Status.DELETED) {
+                    deleted.add(entry);
+                }
+            }
+        }
+
+        assertThat(deleted).isNotEmpty();
+        assertThat(deleted)
+                .allSatisfy(entry -> assertThat(entry.snapshotId()).isEqualTo(currentSnapshotId));
+
+        write.close();
+        commit.close();
+    }
+
+    @Test
+    public void testCurrentDeletesSurviveManifestCompaction() throws Exception {
+        RowType rowType =
+                RowType.of(
+                        new DataType[] {DataTypes.INT(), DataTypes.INT(), DataTypes.INT()},
+                        new String[] {"pt", "k", "v"});
+        Map<String, String> customOptions = new HashMap<>();
+        customOptions.put(IcebergOptions.COMPACT_MIN_FILE_NUM.key(), "2");
+        customOptions.put(IcebergOptions.COMPACT_MAX_FILE_NUM.key(), "2");
+        FileStoreTable table =
+                createPaimonTable(
+                        rowType,
+                        Collections.singletonList("pt"),
+                        Arrays.asList("pt", "k"),
+                        1,
+                        customOptions);
+
+        Map<String, String> dynamic = new HashMap<>();
+        dynamic.put(IcebergOptions.COMPACT_MIN_FILE_NUM.key(), "2");
+        dynamic.put(IcebergOptions.COMPACT_MAX_FILE_NUM.key(), "2");
+        table = table.copy(dynamic);
+
+        String commitUser = UUID.randomUUID().toString();
+        TableWriteImpl<?> write =
+                table.newWrite(commitUser)
+                        .withIOManager(new IOManagerImpl(tempDir.toString() + "/tmp"));
+        TableCommitImpl commit = table.newCommit(commitUser);
+
+        long id = 1;
+        for (int pt = 1; pt <= 10; pt++) {
+            write.write(GenericRow.of(pt, pt * 10, pt));
+            commit.commit(id, write.prepareCommit(false, id));
+            id++;
+        }
+
+        BinaryRow pt1 = new BinaryRow(1);
+        BinaryRowWriter ptWriter = new BinaryRowWriter(pt1);
+        ptWriter.writeInt(0, 1);
+        ptWriter.complete();
+
+        write.write(GenericRow.of(1, 10, 99));
+        write.compact(pt1, 0, true);
+        commit.commit(id, write.prepareCommit(true, id));
+
+        long latest = table.snapshotManager().latestSnapshotId();
+        IcebergMetadata metadata =
+                IcebergMetadata.fromPath(
+                        table.fileIO(),
+                        new Path(table.location(), "metadata/v" + latest + ".metadata.json"));
+        long currentSnapshotId = metadata.currentSnapshotId();
+
+        IcebergPathFactory pathFactory =
+                new IcebergPathFactory(new Path(table.location(), "metadata"));
+        IcebergManifestList manifestList = IcebergManifestList.create(table, pathFactory);
+        IcebergManifestFile manifestFile = IcebergManifestFile.create(table, pathFactory);
+
+        int manifests = 0;
+        int deleted = 0;
+        for (IcebergManifestFileMeta fileMeta :
+                manifestList.read(new Path(metadata.currentSnapshot().manifestList()).getName())) {
+            manifests++;
+            for (IcebergManifestEntry entry : manifestFile.read(fileMeta.manifestPath())) {
+                if (entry.status() == IcebergManifestEntry.Status.DELETED) {
+                    deleted++;
+                }
+            }
+        }
+        assertThat(manifests).isGreaterThan(0);
+        assertThat(deleted).as("this commit's deletions must survive compaction").isGreaterThan(0);
 
         write.close();
         commit.close();


### PR DESCRIPTION
### Purpose
Two defects make a commit's file removals invisible to Iceberg's incremental changelog scans.

  A DELETED manifest entry records the wrong snapshot. Entries rewritten as DELETED keep the snapshot id of the snapshot that added the file, while the spec requires the snapshot in which the file was deleted. BaseIncrementalChangelogScan resolves each entry's snapshot id to a change ordinal, so such a delete is dropped and the scan reports the rewritten files as pure additions. EXISTING entries keep their original snapshot id; only DELETED ones are restamped.

  Manifest compaction then discards those entries. compactMetadataIfNeeded identifies the current commit's entries by file sequence number, which for a deletion still points at the older snapshot that added the file, so every DELETED entry was dropped -- including the ones the same commit had just recorded. Deletions are now also matched by snapshot id. Deletions carried over from older snapshots are still dropped, as before.

### Tests

  - testDeletedEntryRecordsTheDeletingSnapshot -- deletions carry the current snapshot id.
  - testCurrentDeletesSurviveManifestCompaction -- deletions survive a commit that also compacts manifests.
