### PR TITLE
[core] Fix unsupported predicate fallback for global indexes

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/ConstantGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/ConstantGlobalIndexReader.java
@@ -50,6 +50,11 @@ public class ConstantGlobalIndexReader implements GlobalIndexReader {
     }
 
     @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitIsNaN(FieldRef fieldRef) {
+        return result;
+    }
+
+    @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitStartsWith(
             FieldRef fieldRef, Object literal) {
         return result;
@@ -123,6 +128,12 @@ public class ConstantGlobalIndexReader implements GlobalIndexReader {
 
     @Override
     public CompletableFuture<Optional<GlobalIndexResult>> visitBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return result;
+    }
+
+    @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotBetween(
             FieldRef fieldRef, Object from, Object to) {
         return result;
     }

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/GlobalIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.globalindex;
 
 import org.apache.paimon.predicate.BatchVectorSearch;
+import org.apache.paimon.predicate.FieldRef;
 import org.apache.paimon.predicate.FullTextSearch;
 import org.apache.paimon.predicate.FunctionVisitor;
 import org.apache.paimon.predicate.LeafPredicate;
@@ -33,6 +34,23 @@ import java.util.concurrent.CompletableFuture;
 /** Index reader for global index, return {@link GlobalIndexResult}. */
 public interface GlobalIndexReader
         extends FunctionVisitor<CompletableFuture<Optional<GlobalIndexResult>>>, Closeable {
+
+    @Override
+    default CompletableFuture<Optional<GlobalIndexResult>> visitIsNaN(FieldRef fieldRef) {
+        return CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    @Override
+    default CompletableFuture<Optional<GlobalIndexResult>> visitBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return CompletableFuture.completedFuture(Optional.empty());
+    }
+
+    @Override
+    default CompletableFuture<Optional<GlobalIndexResult>> visitNotBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return CompletableFuture.completedFuture(Optional.empty());
+    }
 
     @Override
     default CompletableFuture<Optional<GlobalIndexResult>> visitAnd(

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/OffsetGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/OffsetGlobalIndexReader.java
@@ -134,6 +134,12 @@ public class OffsetGlobalIndexReader implements GlobalIndexReader {
     }
 
     @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return wrapped.visitNotBetween(fieldRef, from, to).thenApply(this::applyOffset);
+    }
+
+    @Override
     public CompletableFuture<Optional<ScoredGlobalIndexResult>> visitVectorSearch(
             VectorSearch vectorSearch) {
         return wrapped.visitVectorSearch(vectorSearch.offsetRange(this.offset, this.to))

--- a/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
+++ b/paimon-common/src/main/java/org/apache/paimon/globalindex/UnionGlobalIndexReader.java
@@ -137,6 +137,12 @@ public class UnionGlobalIndexReader implements GlobalIndexReader {
     }
 
     @Override
+    public CompletableFuture<Optional<GlobalIndexResult>> visitNotBetween(
+            FieldRef fieldRef, Object from, Object to) {
+        return unionAsync(reader -> reader.visitNotBetween(fieldRef, from, to));
+    }
+
+    @Override
     public CompletableFuture<Optional<ScoredGlobalIndexResult>> visitVectorSearch(
             VectorSearch vectorSearch) {
         long start = durationConsumer == null ? 0L : System.nanoTime();

--- a/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/globalindex/GlobalIndexEvaluatorTest.java
@@ -644,6 +644,75 @@ class GlobalIndexEvaluatorTest {
     }
 
     @Test
+    void testUnsupportedIsNaNFallsBack() {
+        RowType rowType =
+                new RowType(Collections.singletonList(new DataField(0, "a", DataTypes.DOUBLE())));
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(
+                        rowType,
+                        fieldId -> Collections.singletonList(new StubGlobalIndexReader(null)));
+
+        Optional<GlobalIndexResult> result =
+                evaluator.evaluate(new PredicateBuilder(rowType).isNaN(0));
+
+        assertThat(result).isEmpty();
+        evaluator.close();
+    }
+
+    @Test
+    void testNotBetweenThroughUnionAndOffset() {
+        RowType rowType = rowType();
+        GlobalIndexReader delegate =
+                new StubGlobalIndexReader(null) {
+                    @Override
+                    public CompletableFuture<Optional<GlobalIndexResult>> visitNotBetween(
+                            FieldRef fieldRef, Object from, Object to) {
+                        return CompletableFuture.completedFuture(Optional.of(resultOf(1, 3)));
+                    }
+                };
+        GlobalIndexReader wrapped =
+                new UnionGlobalIndexReader(
+                        Collections.singletonList(new OffsetGlobalIndexReader(delegate, 10L, 20L)));
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(rowType, fieldId -> Collections.singletonList(wrapped));
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        Optional<GlobalIndexResult> result =
+                evaluator.evaluate(builder.between(0, 1, 2).negate().get());
+
+        assertThat(result).isPresent();
+        assertBitmapContainsExactly(result.get().results(), 11L, 13L);
+        evaluator.close();
+    }
+
+    @Test
+    void testWrappedUnsupportedRangePredicatesFallBack() {
+        RowType rowType = rowType();
+        GlobalIndexReader wrapped =
+                new UnionGlobalIndexReader(
+                        Collections.singletonList(
+                                new OffsetGlobalIndexReader(
+                                        new StubGlobalIndexReader(null), 10L, 20L)));
+        GlobalIndexEvaluator evaluator =
+                new GlobalIndexEvaluator(rowType, fieldId -> Collections.singletonList(wrapped));
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+
+        assertThat(evaluator.evaluate(builder.between(0, 1, 2).negate().get())).isEmpty();
+        assertThat(evaluator.evaluate(builder.between(0, 1, 2))).isEmpty();
+        evaluator.close();
+    }
+
+    @Test
+    void testConstantReaderReturnsFixedResultForIsNaNAndNotBetween() {
+        GlobalIndexResult expected = resultOf(1, 2);
+        GlobalIndexReader reader = new ConstantGlobalIndexReader(expected);
+        FieldRef fieldRef = new FieldRef(0, "a", DataTypes.DOUBLE());
+
+        assertThat(reader.visitIsNaN(fieldRef).join()).contains(expected);
+        assertThat(reader.visitNotBetween(fieldRef, 1, 2).join()).contains(expected);
+    }
+
+    @Test
     void testNullPredicate() {
         RowType rowType = rowType();
         GlobalIndexEvaluator evaluator =


### PR DESCRIPTION
### Purpose

 `GlobalIndexReader` inherited predicate defaults that could throw for unsupported `IS NAN`, `BETWEEN`, and `NOT BETWEEN` queries instead of falling back safely.

Return unsupported results conservatively, forward `NOT BETWEEN` through offset and union readers, preserve constant-reader behavior, and add regression coverage.

### Tests

- `mvn -pl paimon-common -DwildcardSuites=none -Dtest=GlobalIndexEvaluatorTest test`
