### PR TITLE
[core] Fix query results being scrambled after querying $audit_log ba…

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/system/AuditLogTable.java
@@ -97,7 +97,6 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
     protected final List<DataField> specialFields;
 
     public AuditLogTable(FileStoreTable wrapped) {
-        this.wrapped = wrapped;
         this.specialFields = new ArrayList<>();
         specialFields.add(SpecialFields.ROW_KIND);
 
@@ -105,9 +104,13 @@ public class AuditLogTable implements DataTable, ReadonlyTable {
                 CoreOptions.fromMap(wrapped.options()).tableReadSequenceNumberEnabled();
 
         if (includeSequenceNumber) {
-            this.wrapped.options().put(CoreOptions.KEY_VALUE_SEQUENCE_NUMBER_ENABLED.key(), "true");
+            wrapped =
+                    wrapped.copyWithoutTimeTravel(
+                            Collections.singletonMap(
+                                    CoreOptions.KEY_VALUE_SEQUENCE_NUMBER_ENABLED.key(), "true"));
             specialFields.add(SpecialFields.SEQUENCE_NUMBER);
         }
+        this.wrapped = wrapped;
     }
 
     /** Creates a PredicateReplaceVisitor that adjusts field indices by systemFieldCount. */

--- a/paimon-core/src/test/java/org/apache/paimon/table/system/AuditLogTableTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/system/AuditLogTableTest.java
@@ -214,6 +214,42 @@ public class AuditLogTableTest extends TableTestBase {
     }
 
     @Test
+    public void testReadBaseTableAfterAuditLogDoesNotIncludeSequenceNumber() throws Exception {
+        String tableName = "audit_table_share_check";
+        Path tablePath = new Path(String.format("%s/%s.db/%s", warehouse, database, tableName));
+        FileIO fileIO = LocalFileIO.create();
+
+        TableSchema tableSchema =
+                SchemaUtils.forceCommit(
+                        new SchemaManager(fileIO, tablePath),
+                        Schema.newBuilder()
+                                .column("pk", DataTypes.INT())
+                                .column("pt", DataTypes.INT())
+                                .column("col1", DataTypes.INT())
+                                .partitionKeys("pt")
+                                .primaryKey("pk", "pt")
+                                .option(CoreOptions.CHANGELOG_PRODUCER.key(), "input")
+                                .option("bucket", "1")
+                                .option(
+                                        CoreOptions.TABLE_READ_SEQUENCE_NUMBER_ENABLED.key(),
+                                        "true")
+                                .build());
+        FileStoreTable baseTable =
+                FileStoreTableFactory.create(LocalFileIO.create(), tablePath, tableSchema);
+        writeTestData(baseTable);
+
+        // Wrap in AuditLogTable, this should NOT mutate the shared underlying options map.
+        AuditLogTable auditLogTable = new AuditLogTable(baseTable);
+        assertThat(auditLogTable.rowType().getFieldNames())
+                .containsExactly("rowkind", "_SEQUENCE_NUMBER", "pk", "pt", "col1");
+
+        // Base table row type must remain unchanged - no leaked `_SEQUENCE_NUMBER` field.
+        assertThat(baseTable.rowType().getFieldNames()).containsExactly("pk", "pt", "col1");
+        assertThat(baseTable.options())
+                .doesNotContainKey(CoreOptions.KEY_VALUE_SEQUENCE_NUMBER_ENABLED.key());
+    }
+
+    @Test
     public void testReadSequenceNumberWithAlterTable() throws Exception {
         String tableName = "audit_table_alter_seq";
         // Create table without sequence-number option

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java
@@ -1310,6 +1310,25 @@ public class BatchFileStoreITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testReadBaseTableAfterAuditLogWithSequenceNumberEnabled() {
+        // Regression test: reading `t$audit_log` must not leak the internal
+        // KEY_VALUE_SEQUENCE_NUMBER_ENABLED option into subsequent reads of the base table.
+        sql(
+                "CREATE TABLE test_table_reuse (a int PRIMARY KEY NOT ENFORCED, b int, c AS a + b) "
+                        + "WITH ('table-read.sequence-number.enabled'='true');");
+        sql("INSERT INTO test_table_reuse VALUES (1, 2)");
+        sql("INSERT INTO test_table_reuse VALUES (3, 4)");
+
+        // First read the audit log
+        assertThat(sql("SELECT * FROM `test_table_reuse$audit_log`"))
+                .containsExactlyInAnyOrder(Row.of("+I", 0L, 1, 2, 3), Row.of("+I", 1L, 3, 4, 7));
+
+        // Then read the base table - must not include _SEQUENCE_NUMBER column.
+        assertThat(sql("SELECT * FROM `test_table_reuse`"))
+                .containsExactlyInAnyOrder(Row.of(1, 2, 3), Row.of(3, 4, 7));
+    }
+
+    @Test
     public void testAuditLogTableWithSequenceNumberAlterTable() {
         // Create primary key table without sequence-number option
         sql("CREATE TABLE test_table_dyn (a int PRIMARY KEY NOT ENFORCED, b int, c AS a + b);");


### PR DESCRIPTION
 Closes #8803

  ### Purpose

  When a primary-key table has `'table-read.sequence-number.enabled' = 'true'`, querying its `$audit_log` (or `$binlog`) system table and **then** querying the base table causes:

  - Column data to be shifted by one position (the internal `_SEQUENCE_NUMBER` value leaks into the first column, all real columns shift right), or
  - A hard `ClassCastException` when a base column is non-numeric, e.g. `HeapLongVector cannot be cast to BytesColumnVector`, surfaced by Flink as `Recovery is suppressed by NoRestartBackoffTimeStrategy`.

  **Root cause**

  `AuditLogTable`'s constructor mutates the wrapped `FileStoreTable`'s options map in place when sequence-number reading is enabled:

  ```java
  this.wrapped.options().put(CoreOptions.KEY_VALUE_SEQUENCE_NUMBER_ENABLED.key(), "true");

  FileStoreTable.options() returns schema().options(), which is the same Map<String, String> reference held by the catalog-cached FileStoreTable. After the first SELECT * FROM t$audit_log, the cached base table permanently
  carries key-value.sequence_number.enabled=true. Subsequent reads of the base table go through KeyValueTableRead.unwrap, which then makes ValueContentRowDataRecordIterator prepend a long _SEQUENCE_NUMBER column to every row.
  The physical row now has one extra column ahead of the logical row type, causing column mis-alignment or vector type mismatch.

  Fix

  Instead of mutating the shared options map, create a private copy of the wrapped FileStoreTable that carries the internal KEY_VALUE_SEQUENCE_NUMBER_ENABLED=true option only for the audit-log's own reads. The catalog-cached
  base table is left untouched.

  wrapped = wrapped.copyWithoutTimeTravel(
          Collections.singletonMap(
                  CoreOptions.KEY_VALUE_SEQUENCE_NUMBER_ENABLED.key(), "true"));

  ### Test

  Added regression coverage at two layers:

  - paimon-core/src/test/java/org/apache/paimon/table/system/AuditLogTableTest.java — testReadBaseTableAfterAuditLogDoesNotIncludeSequenceNumber: constructs an AuditLogTable and asserts the wrapped base table's row type /
    options are not polluted with _SEQUENCE_NUMBER / KEY_VALUE_SEQUENCE_NUMBER_ENABLED.

  - paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BatchFileStoreITCase.java — testReadBaseTableAfterAuditLogWithSequenceNumberEnabled: end-to-end reproduction of the reported user scenario (query
    t$audit_log, then re-query t); base-table result must remain unchanged.