### PR TITLE
[python] Pipeline split reads in Arrow batch reader

### DIFF
--- a/docs/docs/pypaimon/python-api.mdx
+++ b/docs/docs/pypaimon/python-api.mdx
@@ -476,6 +476,11 @@ for batch in table_read.to_arrow_batch_reader(splits):
 # f1: ["a","b","c"]
 ```
 
+Batch reads adapt parallelism to input size and storage latency. Explicit
+`parallelism` or `read.parallelism` takes precedence. Output stays in split
+order. Each active split prefetches at most one batch; this limits readahead
+but is not a hard byte or RSS bound.
+
 ### Read Python Iterator
 
 You can read the data row by row into a native Python iterator.

--- a/docs/docs/pypaimon/python-api.mdx
+++ b/docs/docs/pypaimon/python-api.mdx
@@ -476,11 +476,10 @@ for batch in table_read.to_arrow_batch_reader(splits):
 # f1: ["a","b","c"]
 ```
 
-Batch reads adapt parallelism to input size and storage latency. Explicit
-`parallelism` or `read.parallelism` takes precedence. Output stays in split
-order. Each active split prefetches at most one batch; this limits readahead
-but is not a hard byte or RSS bound. PyArrow runtimes without
-`RecordBatchReader.close` and `from_stream` fall back to serial batch reads.
+Batch reads adapt parallelism to input size and storage; explicit `parallelism`
+or `read.parallelism` overrides it. Results preserve split order and prefetch
+at most one batch per active split, without a hard memory bound. PyArrow
+runtimes without `RecordBatchReader.close` or `from_stream` read serially.
 
 ### Read Python Iterator
 

--- a/docs/docs/pypaimon/python-api.mdx
+++ b/docs/docs/pypaimon/python-api.mdx
@@ -479,7 +479,8 @@ for batch in table_read.to_arrow_batch_reader(splits):
 Batch reads adapt parallelism to input size and storage latency. Explicit
 `parallelism` or `read.parallelism` takes precedence. Output stays in split
 order. Each active split prefetches at most one batch; this limits readahead
-but is not a hard byte or RSS bound.
+but is not a hard byte or RSS bound. PyArrow runtimes without
+`RecordBatchReader.close` and `from_stream` fall back to serial batch reads.
 
 ### Read Python Iterator
 

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -1011,8 +1011,10 @@ class CoreOptions:
             "When unset (the default), reads auto-scale to "
             "min(number of splits, CPU count). Set to 1 to force serial "
             "reads, or to a specific value >= 1 to cap the thread pool that "
-            "reads splits concurrently and assembles the result in input "
-            "order. Has no effect when fewer than 2 splits are passed.")
+            "reads splits concurrently while preserving input split order. "
+            "Streaming batch reads additionally adapt the default using "
+            "estimated input size and storage locality. "
+            "Has no effect when fewer than 2 splits are passed.")
     )
 
     ADD_COLUMN_BEFORE_PARTITION: ConfigOption[bool] = (

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -1013,7 +1013,9 @@ class CoreOptions:
             "reads, or to a specific value >= 1 to cap the thread pool that "
             "reads splits concurrently while preserving input split order. "
             "Streaming batch reads additionally adapt the default using "
-            "estimated input size and storage locality. "
+            "estimated input size and storage locality, but fall back to "
+            "serial on PyArrow runtimes without RecordBatchReader.close "
+            "and from_stream. "
             "Has no effect when fewer than 2 splits are passed.")
     )
 

--- a/paimon-python/pypaimon/common/options/core_options.py
+++ b/paimon-python/pypaimon/common/options/core_options.py
@@ -1007,16 +1007,9 @@ class CoreOptions:
         .int_type()
         .no_default_value()
         .with_description(
-            "Parallelism for reading splits within a single TableRead call. "
-            "When unset (the default), reads auto-scale to "
-            "min(number of splits, CPU count). Set to 1 to force serial "
-            "reads, or to a specific value >= 1 to cap the thread pool that "
-            "reads splits concurrently while preserving input split order. "
-            "Streaming batch reads additionally adapt the default using "
-            "estimated input size and storage locality, but fall back to "
-            "serial on PyArrow runtimes without RecordBatchReader.close "
-            "and from_stream. "
-            "Has no effect when fewer than 2 splits are passed.")
+            "Maximum split-read parallelism. Unset reads auto-scale; "
+            "1 forces serial. Streaming batch reads also consider input size "
+            "and storage locality. Has no effect with fewer than 2 splits.")
     )
 
     ADD_COLUMN_BEFORE_PARTITION: ConfigOption[bool] = (

--- a/paimon-python/pypaimon/read/datasource/ray_datasource.py
+++ b/paimon-python/pypaimon/read/datasource/ray_datasource.py
@@ -161,7 +161,8 @@ class RayDatasource(Datasource):
                 table, predicate, read_type, limit=limit,
                 nested_name_paths=nested_name_paths)
 
-            batch_reader = worker_table_read.to_arrow_batch_reader(splits)
+            batch_reader = worker_table_read.to_arrow_batch_reader(
+                splits, parallelism=1)
             has_data = False
             for batch in iter(batch_reader.read_next_batch, None):
                 if batch.num_rows == 0:

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -16,9 +16,11 @@
 # under the License.
 
 import os
+import queue
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, Iterator, List, Optional
+from urllib.parse import urlparse
 
 import pandas
 import pyarrow
@@ -40,6 +42,18 @@ from pypaimon.schema.data_types import DataField, PyarrowFieldParser
 from pypaimon.table.row.offset_row import OffsetRow
 
 ROW_KIND_COLUMN = "_row_kind"
+
+
+def _supports_cancellable_arrow_reader():
+    reader_type = pyarrow.ipc.RecordBatchReader
+    return (hasattr(reader_type, "from_stream")
+            and hasattr(reader_type, "close"))
+
+
+def _create_cancellable_arrow_batch_reader(schema, batch_iterator):
+    source_reader = pyarrow.ipc.RecordBatchReader.from_batches(
+        schema, batch_iterator)
+    return pyarrow.ipc.RecordBatchReader.from_stream(source_reader)
 
 
 class _RemainingRows:
@@ -84,6 +98,11 @@ class TableRead:
     # workers (P) each spin up blob_parallelism (B) blob threads, so peak
     # connections ~= P*B. Shrink per-split B to keep the product bounded.
     _MAX_TOTAL_BLOB_WORKERS = 64
+    # Remote reads use smaller byte steps and a floor to hide request latency.
+    _PIPELINE_REMOTE_BYTES_PER_WORKER = 64 * 1024 * 1024
+    _PIPELINE_LOCAL_BYTES_PER_WORKER = 256 * 1024 * 1024
+    _PIPELINE_REMOTE_MIN_WORKERS = 4
+    _PIPELINE_MAX_AUTO_WORKERS = 16
 
     def __init__(
         self,
@@ -150,14 +169,148 @@ class TableRead:
 
         return _record_generator()
 
-    def to_arrow_batch_reader(self, splits: List[Split],
-                              blob_parallelism: Optional[int] = None) -> pyarrow.ipc.RecordBatchReader:
+    def to_arrow_batch_reader(
+        self,
+        splits: List[Split],
+        blob_parallelism: Optional[int] = None,
+        parallelism: Optional[int] = None,
+    ) -> pyarrow.ipc.RecordBatchReader:
+        """Stream Arrow batches while reading multiple splits concurrently.
+
+        Batches preserve input split order. Parallel reads are enabled only by
+        explicit configuration or the size- and storage-aware default.
+        """
         effective_bp = self._resolve_blob_parallelism(blob_parallelism)
+        effective = self._resolve_parallelism(parallelism, len(splits))
+        configured = (
+            parallelism is not None or self._read_parallelism is not None
+        )
+        cancellable = _supports_cancellable_arrow_reader()
+        workers = (self._pipeline_workers(splits, effective, configured)
+                   if cancellable and self.limit is None else 1)
         schema = PyarrowFieldParser.from_paimon_schema(self.read_type)
         if self.include_row_kind:
             schema = self._add_row_kind_to_schema(schema)
-        batch_iterator = self._arrow_batch_generator(splits, schema, effective_bp)
-        return pyarrow.ipc.RecordBatchReader.from_batches(schema, batch_iterator)
+        if self.limit is not None and self.limit <= 0:
+            return pyarrow.ipc.RecordBatchReader.from_batches(schema, iter(()))
+        if (self.limit is None
+                and self._should_run_parallel(splits, workers)
+                and cancellable):
+            effective_bp = self._cap_blob_parallelism(workers, effective_bp)
+            cancel = threading.Event()
+            batch_iterator = self._pipelined_arrow_batch_generator(
+                splits, schema, effective_bp, workers, cancel)
+            return _create_cancellable_arrow_batch_reader(
+                schema, batch_iterator)
+        batch_iterator = self._arrow_batch_generator(
+            splits, schema, effective_bp)
+        return pyarrow.ipc.RecordBatchReader.from_batches(
+            schema, batch_iterator)
+
+    def _pipelined_arrow_batch_generator(
+        self,
+        splits: List[Split],
+        schema: pyarrow.Schema,
+        blob_parallelism: int,
+        workers: int,
+        cancel: Optional[threading.Event] = None,
+    ) -> Iterator[pyarrow.RecordBatch]:
+        cancel = cancel or threading.Event()
+        workers = min(workers, len(splits))
+        if workers < 2:
+            yield from self._arrow_batch_generator(
+                splits, schema, blob_parallelism)
+            return
+        end = object()
+        stop = object()
+        results = queue.Queue()
+        batch_slots = [threading.Semaphore(1) for _ in splits]
+        task_queue = queue.Queue()
+
+        def read_split(index, split):
+            batch_slot = batch_slots[index]
+            batches = self._arrow_batch_generator(
+                [split], schema, blob_parallelism)
+            error = None
+            try:
+                while not cancel.is_set():
+                    batch_slot.acquire()
+                    if cancel.is_set():
+                        batch_slot.release()
+                        break
+                    try:
+                        batch = next(batches)
+                    except StopIteration:
+                        batch_slot.release()
+                        break
+                    except BaseException:
+                        batch_slot.release()
+                        raise
+                    if cancel.is_set():
+                        batch_slot.release()
+                        return
+                    results.put((index, batch))
+            except BaseException as exception:
+                error = exception
+            finally:
+                try:
+                    batches.close()
+                except BaseException as exception:
+                    if error is None:
+                        error = exception
+                if error is not None and not cancel.is_set():
+                    cancel.set()
+                    results.put((-1, error))
+                elif not cancel.is_set():
+                    results.put((index, end))
+
+        def worker():
+            while True:
+                task = task_queue.get()
+                if task is stop:
+                    return
+                read_split(*task)
+                if cancel.is_set():
+                    return
+
+        threads = []
+        try:
+            for index in range(workers):
+                thread = threading.Thread(
+                    target=worker,
+                    name="pypaimon-stream-read-%d" % index,
+                    daemon=True,
+                )
+                thread.start()
+                threads.append(thread)
+
+            for index, split in enumerate(splits):
+                task_queue.put((index, split))
+
+            pending = {}
+            for index, batch_slot in enumerate(batch_slots):
+                while True:
+                    if index in pending:
+                        item = pending.pop(index)
+                    else:
+                        item_index, item = results.get()
+                        if item_index < 0:
+                            raise item
+                        if item_index != index:
+                            pending[item_index] = item
+                            continue
+                    if item is end:
+                        break
+                    try:
+                        yield item
+                    finally:
+                        batch_slot.release()
+        finally:
+            cancel.set()
+            for batch_slot in batch_slots:
+                batch_slot.release()
+            for _ in threads:
+                task_queue.put(stop)
 
     @staticmethod
     def _add_row_kind_to_schema(schema: pyarrow.Schema) -> pyarrow.Schema:
@@ -222,7 +375,11 @@ class TableRead:
         if self._should_run_parallel(splits, effective):
             return self._to_arrow_parallel(splits, schema, effective, effective_bp)
 
-        batch_reader = self.to_arrow_batch_reader(splits, blob_parallelism=effective_bp)
+        batch_reader = self.to_arrow_batch_reader(
+            splits,
+            blob_parallelism=effective_bp,
+            parallelism=effective,
+        )
 
         table_list = []
         for batch in iter(batch_reader.read_next_batch, None):
@@ -354,6 +511,120 @@ class TableRead:
         )
         return (effective >= 2 and len(splits) >= 2
                 and not deferred_limit_may_prune)
+
+    def _pipeline_workers(
+        self,
+        splits: List[Split],
+        effective: int,
+        configured: bool,
+    ) -> int:
+        maximum = min(effective, len(splits))
+        if configured or maximum < 2:
+            return maximum
+        maximum = min(maximum, self._PIPELINE_MAX_AUTO_WORKERS)
+
+        total_bytes = sum(
+            self._estimated_split_file_size(split) for split in splits)
+        local = self._pipeline_reads_are_local(splits)
+        if total_bytes <= 0:
+            return (1 if local else
+                    min(maximum, self._PIPELINE_REMOTE_MIN_WORKERS))
+
+        bytes_per_worker = (self._PIPELINE_LOCAL_BYTES_PER_WORKER
+                            if local
+                            else self._PIPELINE_REMOTE_BYTES_PER_WORKER)
+        workers = max(
+            1, (total_bytes + bytes_per_worker - 1) // bytes_per_worker)
+        if not local:
+            workers = max(
+                workers, min(maximum, self._PIPELINE_REMOTE_MIN_WORKERS))
+        return min(maximum, workers)
+
+    def _estimated_split_file_size(self, split: Split) -> int:
+        try:
+            file_size = max(0, int(getattr(split, "file_size", 0) or 0))
+        except (TypeError, ValueError):
+            return 0
+        if file_size <= 0:
+            return 0
+
+        current = split
+        visited = set()
+        while id(current) not in visited:
+            visited.add(id(current))
+            data_split = getattr(current, "data_split", None)
+            if not callable(data_split):
+                break
+            underlying = data_split()
+            selected_rows = max(
+                0, int(getattr(current, "row_count", 0) or 0))
+            underlying_rows = max(
+                0, int(getattr(underlying, "row_count", 0) or 0))
+            if 0 < selected_rows < underlying_rows:
+                file_size = (
+                    file_size * selected_rows + underlying_rows - 1
+                ) // underlying_rows
+            current = underlying
+
+        table_fields = getattr(self.table, "fields", None)
+        projected_fields = (
+            getattr(self, "_scan_read_type", None)
+            or getattr(self, "read_type", None)
+        )
+        if (table_fields and projected_fields
+                and len(projected_fields) < len(table_fields)):
+            file_size = (
+                file_size * len(projected_fields) + len(table_fields) - 1
+            ) // len(table_fields)
+        return max(1, file_size)
+
+    def _pipeline_reads_are_local(self, splits: List[Split]) -> bool:
+        runtime_locality = self._runtime_file_io_is_local()
+        if runtime_locality is not None:
+            return runtime_locality
+
+        data_paths = []
+        missing_path = False
+        for split in splits:
+            files = getattr(split, "files", None)
+            if files is None:
+                missing_path = True
+                continue
+            for data_file in files:
+                path = (
+                    getattr(data_file, "external_path", None)
+                    or getattr(data_file, "file_path", None)
+                )
+                if path:
+                    data_paths.append(str(path))
+                else:
+                    missing_path = True
+
+        if not data_paths or missing_path:
+            data_paths.append(str(getattr(self.table, "table_path", "") or ""))
+        return all(self._is_local_data_path(path) for path in data_paths)
+
+    def _runtime_file_io_is_local(self) -> Optional[bool]:
+        from pypaimon.filesystem.caching_file_io import CachingFileIO
+        from pypaimon.filesystem.local_file_io import LocalFileIO
+        from pypaimon.utils.file_type import FileType
+
+        file_io = getattr(self.table, "file_io", None)
+        while isinstance(file_io, CachingFileIO):
+            if (getattr(file_io, "_cache", None) is not None
+                    and FileType.DATA in getattr(
+                        file_io, "_whitelist", set())):
+                return True
+            file_io = getattr(file_io, "_delegate", None)
+        if isinstance(file_io, LocalFileIO):
+            return True
+        return None
+
+    @staticmethod
+    def _is_local_data_path(path: str) -> bool:
+        if len(path) >= 2 and path[0].isalpha() and path[1] == ":":
+            return True
+        return urlparse(path).scheme.lower() in ("", "file")
 
     def _limit_covers_all_splits(self, splits: List[Split]) -> bool:
         """Return whether split metadata proves that LIMIT cannot drop rows."""

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -175,12 +175,10 @@ class TableRead:
         blob_parallelism: Optional[int] = None,
         parallelism: Optional[int] = None,
     ) -> pyarrow.ipc.RecordBatchReader:
-        """Stream Arrow batches while reading multiple splits concurrently.
+        """Stream batches in split order with explicit or adaptive parallelism.
 
-        Batches preserve input split order. Parallel reads are enabled only by
-        explicit configuration or the size- and storage-aware default.
-        PyArrow runtimes without ``RecordBatchReader.close`` and
-        ``from_stream`` fall back to serial reads.
+        PyArrow runtimes without ``RecordBatchReader.close`` or ``from_stream``
+        fall back to serial reads.
         """
         effective_bp = self._resolve_blob_parallelism(blob_parallelism)
         effective = self._resolve_parallelism(parallelism, len(splits))
@@ -199,9 +197,8 @@ class TableRead:
                 and self._should_run_parallel(splits, workers)
                 and cancellable):
             effective_bp = self._cap_blob_parallelism(workers, effective_bp)
-            cancel = threading.Event()
             batch_iterator = self._pipelined_arrow_batch_generator(
-                splits, schema, effective_bp, workers, cancel)
+                splits, schema, effective_bp, workers)
             return _create_cancellable_arrow_batch_reader(
                 schema, batch_iterator)
         batch_iterator = self._arrow_batch_generator(
@@ -215,9 +212,8 @@ class TableRead:
         schema: pyarrow.Schema,
         blob_parallelism: int,
         workers: int,
-        cancel: Optional[threading.Event] = None,
     ) -> Iterator[pyarrow.RecordBatch]:
-        cancel = cancel or threading.Event()
+        cancel = threading.Event()
         workers = min(workers, len(splits))
         if workers < 2:
             yield from self._arrow_batch_generator(
@@ -277,12 +273,8 @@ class TableRead:
 
         threads = []
         try:
-            for index in range(workers):
-                thread = threading.Thread(
-                    target=worker,
-                    name="pypaimon-stream-read-%d" % index,
-                    daemon=True,
-                )
+            for _ in range(workers):
+                thread = threading.Thread(target=worker, daemon=True)
                 thread.start()
                 threads.append(thread)
 
@@ -609,14 +601,9 @@ class TableRead:
     def _runtime_file_io_is_local(self) -> Optional[bool]:
         from pypaimon.filesystem.caching_file_io import CachingFileIO
         from pypaimon.filesystem.local_file_io import LocalFileIO
-        from pypaimon.utils.file_type import FileType
 
         file_io = getattr(self.table, "file_io", None)
         while isinstance(file_io, CachingFileIO):
-            if (getattr(file_io, "_cache", None) is not None
-                    and FileType.DATA in getattr(
-                        file_io, "_whitelist", set())):
-                return True
             file_io = getattr(file_io, "_delegate", None)
         if isinstance(file_io, LocalFileIO):
             return True

--- a/paimon-python/pypaimon/read/table_read.py
+++ b/paimon-python/pypaimon/read/table_read.py
@@ -179,6 +179,8 @@ class TableRead:
 
         Batches preserve input split order. Parallel reads are enabled only by
         explicit configuration or the size- and storage-aware default.
+        PyArrow runtimes without ``RecordBatchReader.close`` and
+        ``from_stream`` fall back to serial reads.
         """
         effective_bp = self._resolve_blob_parallelism(blob_parallelism)
         effective = self._resolve_parallelism(parallelism, len(splits))

--- a/paimon-python/pypaimon/tests/ray_data_test.py
+++ b/paimon-python/pypaimon/tests/ray_data_test.py
@@ -16,9 +16,10 @@
 # under the License.
 
 import os
+import shutil
 import tempfile
 import unittest
-import shutil
+from unittest import mock
 
 import pyarrow as pa
 import pyarrow.types as pa_types
@@ -131,6 +132,34 @@ class RayDataTest(unittest.TestCase):
             ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
             "Name column should match"
         )
+
+    def test_ray_task_reads_splits_serially(self):
+        from pypaimon.read.datasource.ray_datasource import RayDatasource
+
+        splits = [mock.Mock(file_size=1, row_count=1, file_paths=[])
+                  for _ in range(2)]
+        for split in splits:
+            split.merged_row_count.return_value = None
+        provider = mock.Mock()
+        provider.table.return_value.is_primary_key_table = False
+        provider.predicate.return_value = None
+        provider.read_type.return_value = []
+        provider.nested_name_paths.return_value = None
+        provider.splits.return_value = splits
+        provider.limit.return_value = None
+
+        worker_read = mock.Mock()
+        worker_read.to_arrow_batch_reader.return_value = (
+            pa.ipc.RecordBatchReader.from_batches(pa.schema([]), iter(())))
+        with mock.patch(
+            'pypaimon.read.table_read.TableRead', return_value=worker_read
+        ):
+            task = RayDatasource(provider).get_read_tasks(1)[0]
+            list(task())
+
+        self.assertEqual(
+            1,
+            worker_read.to_arrow_batch_reader.call_args[1]['parallelism'])
 
     def test_basic_ray_data_write(self):
         """Test basic Ray Data write from PyPaimon table."""

--- a/paimon-python/pypaimon/tests/reader_parallel_test.py
+++ b/paimon-python/pypaimon/tests/reader_parallel_test.py
@@ -19,14 +19,17 @@ import os
 import shutil
 import tempfile
 import threading
+import time
 import types
 import unittest
 from unittest import mock
 
 import pyarrow as pa
+import pyarrow.dataset as ds
 
 from pypaimon import CatalogFactory, Schema
-from pypaimon.read.table_read import TableRead, _RemainingRows
+from pypaimon.read.table_read import (
+    TableRead, _RemainingRows, _supports_cancellable_arrow_reader)
 
 
 class ResolveParallelismTest(unittest.TestCase):
@@ -118,6 +121,210 @@ class RemainingRowsTest(unittest.TestCase):
             t.join()
         self.assertEqual(sum(granted), 10_000)
         self.assertTrue(rr.exhausted())
+
+
+class PipelinePolicyTest(unittest.TestCase):
+
+    @staticmethod
+    def _workers(
+        path,
+        sizes,
+        configured=False,
+        data_paths=None,
+        file_io=None,
+        effective=8,
+    ):
+        read = TableRead.__new__(TableRead)
+        read.table = types.SimpleNamespace(
+            table_path=path, file_io=file_io)
+        splits = []
+        for index, size in enumerate(sizes):
+            files = None
+            if data_paths is not None:
+                files = [types.SimpleNamespace(
+                    external_path=data_paths[index], file_path=None)]
+            splits.append(types.SimpleNamespace(
+                file_size=size, files=files))
+        return read._pipeline_workers(splits, effective, configured)
+
+    def test_adaptive_workers(self):
+        mb = 1024 * 1024
+        cases = [
+            ('small_local', '/tmp/table', [8 * mb] * 8, False, None, 1),
+            ('small_remote', 's3://bucket/table', [4 * mb] * 8,
+             False, None, 4),
+            ('large_remote', 'oss://bucket/table', [64 * mb] * 4,
+             False, None, 4),
+            ('large_local', 'file:///tmp/table', [256 * mb] * 2,
+             False, None, 2),
+            ('explicit', '/tmp/table', [1] * 4, True, None, 4),
+            ('unknown_remote', 'hdfs://host/table', [0, 0],
+             False, None, 2),
+            ('external_remote', '/tmp/table', [64 * mb] * 2, False,
+             ['oss://bucket/a', 'oss://bucket/b'], 2),
+            ('external_local', 'oss://bucket/table', [64 * mb] * 2, False,
+             ['file:///cache/a', 'file:///cache/b'], 1),
+        ]
+        for name, path, sizes, configured, paths, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(expected, self._workers(
+                    path, sizes, configured, paths))
+
+        self.assertEqual(16, self._workers(
+            's3://bucket/table', [64 * mb] * 32, effective=32))
+        self.assertEqual(32, self._workers(
+            '/tmp/table', [1] * 32, configured=True, effective=32))
+
+        from pypaimon.filesystem.caching_file_io import CachingFileIO
+        from pypaimon.filesystem.local_file_io import FuseLocalFileIO
+        from pypaimon.utils.file_type import FileType
+
+        file_ios = [
+            FuseLocalFileIO('oss://bucket/table', '/tmp/fuse/table'),
+            CachingFileIO(object(), object(), {FileType.DATA}),
+        ]
+        for file_io in file_ios:
+            with self.subTest(file_io=type(file_io).__name__):
+                self.assertEqual(1, self._workers(
+                    'oss://bucket/table', [64 * mb] * 2,
+                    file_io=file_io))
+
+    def test_estimate_accounts_for_range_and_projection(self):
+        read = TableRead.__new__(TableRead)
+        read.table = types.SimpleNamespace(fields=list(range(10)))
+        read._scan_read_type = list(range(2))
+        underlying = types.SimpleNamespace(file_size=1000, row_count=1000)
+        sliced = types.SimpleNamespace(
+            file_size=1000,
+            row_count=100,
+            data_split=lambda: underlying,
+        )
+        indexed = types.SimpleNamespace(
+            file_size=1000,
+            row_count=50,
+            data_split=lambda: sliced,
+        )
+
+        self.assertEqual(10, read._estimated_split_file_size(indexed))
+
+
+class PipelinedBatchGeneratorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.read = TableRead.__new__(TableRead)
+        self.read.limit = None
+        self.read._read_parallelism = None
+        self.read.read_type = []
+        self.read.include_row_kind = False
+        self.schema = pa.schema([('value', pa.int64())])
+
+    def _batch(self, value):
+        return pa.RecordBatch.from_arrays(
+            [pa.array([value], type=pa.int64())], schema=self.schema)
+
+    def test_reads_concurrently_and_preserves_split_order(self):
+        second_started = threading.Event()
+
+        def generate(splits, schema, blob_parallelism):
+            value = splits[0]
+            if value == 0 and not second_started.wait(5):
+                raise TimeoutError('second split did not start')
+            if value == 1:
+                second_started.set()
+            yield self._batch(value)
+
+        with mock.patch.object(
+            self.read, '_arrow_batch_generator', side_effect=generate
+        ):
+            batches = list(self.read._pipelined_arrow_batch_generator(
+                [0, 1, 2], self.schema, 1, 2))
+
+        self.assertEqual(
+            [0, 1, 2],
+            [batch.column(0)[0].as_py() for batch in batches],
+        )
+
+    def test_buffers_one_batch_per_active_split(self):
+        produced = [0, 0]
+        second_ready = threading.Event()
+
+        def generate(splits, schema, blob_parallelism):
+            value = splits[0]
+            for _ in range(3):
+                produced[value] += 1
+                if value == 1:
+                    second_ready.set()
+                elif produced[value] == 1 and not second_ready.wait(5):
+                    raise TimeoutError('second split did not produce a batch')
+                yield self._batch(value)
+
+        with mock.patch.object(
+            self.read, '_arrow_batch_generator', side_effect=generate,
+        ):
+            batches = self.read._pipelined_arrow_batch_generator(
+                [0, 1], self.schema, 1, 2)
+            next(batches)
+            self.assertEqual([1, 1], produced)
+            batches.close()
+
+    def test_later_error_bypasses_blocked_earlier_split(self):
+        first_started = threading.Event()
+        release = threading.Event()
+
+        def generate(splits, schema, blob_parallelism):
+            if splits[0] == 0:
+                first_started.set()
+                release.wait(5)
+                yield self._batch(0)
+            else:
+                if not first_started.wait(5):
+                    raise TimeoutError('first split did not start')
+                raise RuntimeError('later split failed')
+
+        try:
+            with mock.patch.object(
+                self.read, '_arrow_batch_generator', side_effect=generate
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError, 'later split failed'
+                ):
+                    list(self.read._pipelined_arrow_batch_generator(
+                        [0, 1], self.schema, 1, 2))
+        finally:
+            release.set()
+
+    @unittest.skipUnless(
+        _supports_cancellable_arrow_reader(), 'reader close is unavailable')
+    def test_public_reader_close_cancels_workers(self):
+        started = threading.Barrier(2)
+        closed = []
+        closed_lock = threading.Lock()
+
+        def generate(splits, schema, blob_parallelism):
+            value = splits[0]
+            try:
+                started.wait(5)
+                while True:
+                    yield self._batch(value)
+            finally:
+                with closed_lock:
+                    closed.append(value)
+
+        with mock.patch(
+            'pypaimon.read.table_read.PyarrowFieldParser.from_paimon_schema',
+            return_value=self.schema,
+        ), mock.patch.object(
+            self.read, '_arrow_batch_generator', side_effect=generate
+        ):
+            reader = self.read.to_arrow_batch_reader(
+                [0, 1], parallelism=2)
+            reader.read_next_batch()
+            reader.close()
+
+        deadline = time.monotonic() + 1
+        while len(closed) < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertCountEqual([0, 1], closed)
 
 
 class ParallelReaderAppendOnlyTest(unittest.TestCase):
@@ -225,6 +432,68 @@ class ParallelReaderAppendOnlyTest(unittest.TestCase):
             .sort_values('user_id').reset_index(drop=True)
         self.assertTrue(serial_df.equals(parallel_df))
 
+    def test_batch_reader_parallelism_controls(self):
+        supports_pipeline = _supports_cancellable_arrow_reader()
+        cases = [
+            ('runtime', self.table, {'parallelism': 4},
+             supports_pipeline, supports_pipeline, True),
+            ('option', self.table_opt_4, {},
+             supports_pipeline, supports_pipeline, False),
+            ('default', self.table, {}, supports_pipeline, False, False),
+            ('no_close', self.table, {'parallelism': 4}, False, False, False),
+        ]
+        for name, table, kwargs, can_close, uses_pipeline, use_scanner in cases:
+            with self.subTest(name=name):
+                rb = table.new_read_builder()
+                splits = self._scan_splits(rb)
+                read = rb.new_read()
+                expected = pa.Table.from_batches(
+                    read.to_arrow_batch_reader(splits, parallelism=1))
+                with mock.patch(
+                    'pypaimon.read.table_read.'
+                    '_supports_cancellable_arrow_reader',
+                    return_value=can_close,
+                ), mock.patch.object(
+                    read,
+                    '_pipelined_arrow_batch_generator',
+                    wraps=read._pipelined_arrow_batch_generator,
+                ) as pipeline:
+                    reader = read.to_arrow_batch_reader(splits, **kwargs)
+                    actual = (
+                        ds.Scanner.from_batches(reader).to_table()
+                        if use_scanner else reader.read_all()
+                    )
+                if uses_pipeline:
+                    pipeline.assert_called_once()
+                else:
+                    pipeline.assert_not_called()
+                self.assertEqual(expected, actual)
+
+    def test_parallel_batch_reader_limit_matches_serial(self):
+        for limit in (0, 600):
+            with self.subTest(limit=limit):
+                rb = self.table.new_read_builder().with_limit(limit)
+                splits = self._scan_splits(rb)
+                read = rb.new_read()
+                serial = read.to_arrow_batch_reader(
+                    splits, parallelism=1).read_all()
+                with mock.patch.object(
+                    read, '_pipelined_arrow_batch_generator'
+                ) as pipeline, mock.patch.object(
+                    read,
+                    '_arrow_batch_generator',
+                    wraps=read._arrow_batch_generator,
+                ) as serial_read:
+                    parallel = read.to_arrow_batch_reader(
+                        splits, parallelism=4).read_all()
+                pipeline.assert_not_called()
+                if limit == 0:
+                    serial_read.assert_not_called()
+                else:
+                    serial_read.assert_called_once()
+                self.assertEqual(serial, parallel)
+                self.assertEqual(limit, parallel.num_rows)
+
     def test_default_none_runs_auto_parallel(self):
         # No runtime arg and no table option => auto. With >= 2 splits on a
         # multi-core box this takes the parallel fan-out path; the result
@@ -257,11 +526,14 @@ class ParallelReaderAppendOnlyTest(unittest.TestCase):
     def test_method_arg_overrides_option_to_serial(self):
         # option=4 but caller passes 1: should disable parallelism.
         read = self.table_opt_4.new_read_builder().new_read()
-        with mock.patch.object(read, '_to_arrow_parallel') as patched:
+        with mock.patch.object(read, '_to_arrow_parallel') as patched, \
+                mock.patch.object(
+                    read, '_pipelined_arrow_batch_generator') as pipeline:
             patched.side_effect = AssertionError(
                 "_to_arrow_parallel should not be called when arg=1 overrides option")
             splits = self._scan_splits(self.table_opt_4.new_read_builder())
             read.to_arrow(splits, parallelism=1)
+        pipeline.assert_not_called()
 
     def test_method_arg_overrides_option_to_parallel(self):
         # option=1 (forces serial) but caller passes 4: should enable parallelism.
@@ -305,6 +577,8 @@ class ParallelReaderAppendOnlyTest(unittest.TestCase):
         self.assertNotIn("read.parallelism", str(ctx.exception))
         with self.assertRaises(ValueError):
             read.to_pandas(splits, parallelism=-1)
+        with self.assertRaises(ValueError):
+            read.to_arrow_batch_reader(splits, parallelism=0)
 
     def test_invalid_option_value_raises(self):
         # Build a fresh table with an invalid option value.
@@ -441,17 +715,26 @@ class ParallelReaderPrimaryKeyTest(unittest.TestCase):
         rb = self.table.new_read_builder()
         splits = rb.new_scan().plan().splits()
         read = rb.new_read()
-        serial = read.to_pandas(splits).sort_values(
-            ['dt', 'user_id']).reset_index(drop=True)
-        parallel = read.to_pandas(splits, parallelism=4).sort_values(
-            ['dt', 'user_id']).reset_index(drop=True)
-        self.assertTrue(serial.equals(parallel))
-        # Ensure the merge actually picked the latest version.
-        # user_id=1 / dt=p1 must have behavior='v2-updated', item_id=9001.
-        updated = parallel[(parallel.user_id == 1) & (parallel.dt == 'p1')]
-        self.assertEqual(len(updated), 1)
-        self.assertEqual(updated.iloc[0].behavior, 'v2-updated')
-        self.assertEqual(updated.iloc[0].item_id, 9001)
+
+        def load(kind, parallelism):
+            if kind == 'table':
+                return read.to_pandas(splits, parallelism=parallelism)
+            return pa.Table.from_batches(
+                read.to_arrow_batch_reader(
+                    splits, parallelism=parallelism)).to_pandas()
+
+        for kind in ('table', 'batch_reader'):
+            with self.subTest(kind=kind):
+                serial = load(kind, 1).sort_values(
+                    ['dt', 'user_id']).reset_index(drop=True)
+                parallel = load(kind, 4).sort_values(
+                    ['dt', 'user_id']).reset_index(drop=True)
+                self.assertTrue(serial.equals(parallel))
+                updated = parallel[
+                    (parallel.user_id == 1) & (parallel.dt == 'p1')]
+                self.assertEqual(len(updated), 1)
+                self.assertEqual(updated.iloc[0].behavior, 'v2-updated')
+                self.assertEqual(updated.iloc[0].item_id, 9001)
 
     def test_parallel_with_limit_pk(self):
         limit = 12

--- a/paimon-python/pypaimon/tests/reader_parallel_test.py
+++ b/paimon-python/pypaimon/tests/reader_parallel_test.py
@@ -179,15 +179,24 @@ class PipelinePolicyTest(unittest.TestCase):
         from pypaimon.filesystem.local_file_io import FuseLocalFileIO
         from pypaimon.utils.file_type import FileType
 
-        file_ios = [
-            FuseLocalFileIO('oss://bucket/table', '/tmp/fuse/table'),
-            CachingFileIO(object(), object(), {FileType.DATA}),
+        fuse_file_io = FuseLocalFileIO(
+            'oss://bucket/table', '/tmp/fuse/table')
+        local_file_ios = [
+            fuse_file_io,
+            CachingFileIO(fuse_file_io, object(), {FileType.DATA}),
         ]
-        for file_io in file_ios:
+        for file_io in local_file_ios:
             with self.subTest(file_io=type(file_io).__name__):
                 self.assertEqual(1, self._workers(
                     'oss://bucket/table', [64 * mb] * 2,
                     file_io=file_io))
+
+        remote_cache = CachingFileIO(
+            object(), object(), {FileType.DATA})
+        for sizes in ([0] * 8, [4 * mb] * 8):
+            with self.subTest(cached_file_size=sizes[0]):
+                self.assertEqual(4, self._workers(
+                    'oss://bucket/table', sizes, file_io=remote_cache))
 
     def test_estimate_accounts_for_range_and_projection(self):
         read = TableRead.__new__(TableRead)


### PR DESCRIPTION
### Purpose

Pipeline multi-split reads in `to_arrow_batch_reader` with bounded queues while preserving split order.

Concurrency follows `parallelism` or `read.parallelism`. Reads with a limit, and Arrow versions without cancellable readers, remain serial. Ray tasks also stay serial internally to avoid nested concurrency.

### Tests

- `reader_parallel_test.py`
- `ray_data_test.py`
- BLOB and multimodal reader tests