### PR TITLE
[api] Fix VectorType#isPrunedFrom to compare vector length

### DIFF
--- a/paimon-api/src/main/java/org/apache/paimon/types/VectorType.java
+++ b/paimon-api/src/main/java/org/apache/paimon/types/VectorType.java
@@ -163,7 +163,7 @@ public class VectorType extends DataType {
             return false;
         }
         VectorType vectorType = (VectorType) o;
-        return elementType.isPrunedFrom(vectorType.elementType);
+        return elementType.isPrunedFrom(vectorType.elementType) && length == vectorType.length;
     }
 
     @Override

--- a/paimon-api/src/test/java/org/apache/paimon/types/VectorTypeTest.java
+++ b/paimon-api/src/test/java/org/apache/paimon/types/VectorTypeTest.java
@@ -38,4 +38,19 @@ class VectorTypeTest {
         assertThat(DataTypes.VECTOR(Integer.MAX_VALUE, DataTypes.DOUBLE()).defaultSize())
                 .isEqualTo(Integer.MAX_VALUE);
     }
+
+    @Test
+    void testIsPrunedFromRejectsDifferentLength() {
+        DataType left = DataTypes.VECTOR(3, DataTypes.FLOAT());
+        DataType right = DataTypes.VECTOR(5, DataTypes.FLOAT());
+        assertThat(left.isPrunedFrom(right)).isFalse();
+        assertThat(right.isPrunedFrom(left)).isFalse();
+    }
+
+    @Test
+    void testIsPrunedFromAcceptsSameElementTypeAndLength() {
+        DataType left = DataTypes.VECTOR(3, DataTypes.FLOAT());
+        DataType right = DataTypes.VECTOR(3, DataTypes.FLOAT());
+        assertThat(left.isPrunedFrom(right)).isTrue();
+    }
 }


### PR DESCRIPTION

### Purpose

fix #8811

- `VectorType.isPrunedFrom` recursed into the element type but ignored `length`, so `VECTOR<FLOAT, 3>` was reported as pruned from `VECTOR<FLOAT, 5>`.
- Add the missing `length == vectorType.length` term, mirroring `equalsIgnoreFieldId` in the same class — `equals` and `hashCode` already include `length`.

### Tests

- Added `VectorTypeTest#testIsPrunedFromRejectsDifferentLength` (fails before the fix) and `#testIsPrunedFromAcceptsSameElementTypeAndLength`.
- `mvn -pl paimon-api clean install` — BUILD SUCCESS on JDK 11, 105 tests passed (checkstyle, spotless, rat included).


