### PR TITLE
[cosn] FileSystem should be cached by authority

### DIFF
--- a/paimon-filesystems/paimon-cosn-impl/src/main/java/org/apache/paimon/cosn/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-cosn-impl/src/main/java/org/apache/paimon/cosn/HadoopCompliantFileIO.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.fs.FileSystem;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Hadoop {@link FileIO}.
@@ -41,7 +43,7 @@ public abstract class HadoopCompliantFileIO implements FileIO {
 
     private static final long serialVersionUID = 1L;
 
-    protected transient volatile FileSystem fs;
+    protected transient volatile Map<String, FileSystem> fsMap;
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
@@ -107,12 +109,24 @@ public abstract class HadoopCompliantFileIO implements FileIO {
     }
 
     private FileSystem getFileSystem(org.apache.hadoop.fs.Path path) throws IOException {
-        if (fs == null) {
+        if (fsMap == null) {
             synchronized (this) {
-                if (fs == null) {
-                    fs = createFileSystem(path);
+                if (fsMap == null) {
+                    fsMap = new ConcurrentHashMap<>();
                 }
             }
+        }
+
+        Map<String, FileSystem> map = fsMap;
+
+        String authority = path.toUri().getAuthority();
+        if (authority == null) {
+            authority = "DEFAULT";
+        }
+        FileSystem fs = map.get(authority);
+        if (fs == null) {
+            fs = createFileSystem(path);
+            map.put(authority, fs);
         }
         return fs;
     }


### PR DESCRIPTION
### Purpose

fix #8813

- `HadoopCompliantFileIO` kept a single `fs` field, so the first authority's `FileSystem` was returned for every path — multi-bucket access on one `COSNFileIO` was misrouted.
- Now caches per authority in a `Map<String, FileSystem>` keyed by `path.toUri().getAuthority()` (null → `"DEFAULT"`).
- Mirrors merged #8589 (obs); paimon-oss-impl (#2417) and paimon-s3-impl (#2504) already do the same.

### Tests

- No unit test is feasible: `createFileSystem()` builds a real `CosNFileSystem` needing a COSN backend/credentials, and the module has no existing tests. Merged #8589 (obs), the identical sibling fix, also landed without tests.
- `mvn -pl paimon-filesystems/paimon-cosn-impl clean install` passed.
