### PR TITLE
[azure] FileSystem should be cached by authority

### DIFF
--- a/paimon-filesystems/paimon-azure-impl/src/main/java/org/apache/paimon/azure/HadoopCompliantFileIO.java
+++ b/paimon-filesystems/paimon-azure-impl/src/main/java/org/apache/paimon/azure/HadoopCompliantFileIO.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.fs.FileSystem;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Hadoop {@link FileIO}.
@@ -41,7 +43,7 @@ public abstract class HadoopCompliantFileIO implements FileIO {
 
     private static final long serialVersionUID = 1L;
 
-    protected transient volatile FileSystem fs;
+    protected transient volatile Map<String, FileSystem> fsMap;
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
@@ -107,12 +109,24 @@ public abstract class HadoopCompliantFileIO implements FileIO {
     }
 
     private FileSystem getFileSystem(org.apache.hadoop.fs.Path path) throws IOException {
-        if (fs == null) {
+        if (fsMap == null) {
             synchronized (this) {
-                if (fs == null) {
-                    fs = createFileSystem(path);
+                if (fsMap == null) {
+                    fsMap = new ConcurrentHashMap<>();
                 }
             }
+        }
+
+        Map<String, FileSystem> map = fsMap;
+
+        String authority = path.toUri().getAuthority();
+        if (authority == null) {
+            authority = "DEFAULT";
+        }
+        FileSystem fs = map.get(authority);
+        if (fs == null) {
+            fs = createFileSystem(path);
+            map.put(authority, fs);
         }
         return fs;
     }


### PR DESCRIPTION
### Purpose

fix #8815

- `HadoopCompliantFileIO` cached the first accessed authority's `FileSystem` in a single instance field and returned it for every path, misrouting operations across multiple ABFS accounts/containers to the wrong `FileSystem`.
- Cache the `FileSystem` per authority in a `Map<String, FileSystem>` (null authority → `"DEFAULT"`).
- Verbatim port of the just-merged obs #8589 fix; matches sibling oss (#2417), s3+oss (#2504). azure was the remaining laggard.

### Tests

- No unit test added: this filesystem adapter has no `src/test` and `createFileSystem` requires a live Azure backend, consistent with the sibling oss/s3/gs/obs fixes which merged without unit tests.
- `mvn -pl paimon-filesystems/paimon-azure-impl -DfailIfNoTests=false clean install` — BUILD SUCCESS (JDK 11).


