### PR TITLE
[flink] Add partial lookup metrics to query service

### DIFF
--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryExecutorOperator.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/service/QueryExecutorOperator.java
@@ -23,9 +23,11 @@ import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.flink.metrics.FlinkMetricRegistry;
 import org.apache.paimon.flink.utils.RuntimeContextUtils;
 import org.apache.paimon.io.DataFileMeta;
 import org.apache.paimon.io.DataFileMetaSerializer;
+import org.apache.paimon.operation.metrics.PartialLookupMetrics;
 import org.apache.paimon.service.network.NetworkUtils;
 import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
 import org.apache.paimon.service.server.KvQueryServer;
@@ -75,7 +77,15 @@ public class QueryExecutorOperator extends AbstractStreamOperator<InternalRow>
                                 .getEnvironment()
                                 .getIOManager()
                                 .getSpillingDirectoriesPaths());
-        this.query = ((FileStoreTable) table).newLocalTableQuery().withIOManager(ioManager);
+        PartialLookupMetrics metrics =
+                new PartialLookupMetrics(
+                        new FlinkMetricRegistry(getRuntimeContext().getMetricGroup()),
+                        table.name());
+        this.query =
+                ((FileStoreTable) table)
+                        .newLocalTableQuery()
+                        .withIOManager(ioManager)
+                        .withMetrics(metrics);
         KvQueryServer server =
                 new KvQueryServer(
                         RuntimeContextUtils.getIndexOfThisSubtask(getRuntimeContext()),

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RemoteLookupJoinITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/RemoteLookupJoinITCase.java
@@ -24,6 +24,8 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.flink.query.RemoteTableQuery;
 import org.apache.paimon.flink.service.QueryService;
+import org.apache.paimon.metrics.MetricGroupImpl;
+import org.apache.paimon.operation.metrics.PartialLookupMetrics;
 import org.apache.paimon.service.ServiceManager;
 import org.apache.paimon.service.network.stats.DisabledServiceRequestStats;
 import org.apache.paimon.service.server.KvQueryServer;
@@ -143,6 +145,25 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
         proxy.close();
     }
 
+    @Test
+    public void testRemoteQueryServicePartialLookupMetrics() throws Throwable {
+        sql("CREATE TABLE DIM (k INT PRIMARY KEY NOT ENFORCED, v INT) WITH ('bucket' = '1')");
+        ServiceProxy proxy = launchQueryServer("DIM");
+        proxy.write(GenericRow.of(1, 11));
+
+        RemoteTableQuery query = new RemoteTableQuery(paimonTable("DIM"));
+        assertThat(query.lookup(row(), 0, row(1))).isNotNull();
+        assertThat(proxy.metrics().lookupCount()).isEqualTo(1);
+        assertThat(proxy.metrics().remoteAccessCount()).isEqualTo(1);
+
+        assertThat(query.lookup(row(), 0, row(1))).isNotNull();
+        assertThat(proxy.metrics().lookupCount()).isEqualTo(2);
+        assertThat(proxy.metrics().remoteAccessCount()).isEqualTo(1);
+
+        query.close();
+        proxy.close();
+    }
+
     @Disabled // TODO unstable
     @Test
     public void testServiceFileCleaned() throws Exception {
@@ -211,7 +232,14 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
 
     private ServiceProxy launchQueryServer(String tableName) throws Throwable {
         FileStoreTable table = (FileStoreTable) paimonTable(tableName);
-        LocalTableQuery query = table.newLocalTableQuery().withIOManager(IOManager.create(path));
+        PartialLookupMetrics metrics =
+                new PartialLookupMetrics(
+                        (groupName, variables) -> new MetricGroupImpl(groupName, variables),
+                        table.name());
+        LocalTableQuery query =
+                table.newLocalTableQuery()
+                        .withIOManager(IOManager.create(path))
+                        .withMetrics(metrics);
         KvQueryServer server =
                 new KvQueryServer(
                         0,
@@ -231,11 +259,13 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
         return new ServiceProxy() {
 
             @Override
-            public void write(InternalRow row) throws Exception {
+            public void write(InternalRow... rows) throws Exception {
                 BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
                 BatchTableWrite write = writeBuilder.newWrite();
                 BatchTableCommit commit = writeBuilder.newCommit();
-                write.write(row);
+                for (InternalRow row : rows) {
+                    write.write(row);
+                }
                 List<CommitMessage> commitMessages = write.prepareCommit();
                 commit.commit(commitMessages);
 
@@ -248,6 +278,11 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
             }
 
             @Override
+            public PartialLookupMetrics metrics() {
+                return metrics;
+            }
+
+            @Override
             public void close() throws IOException {
                 server.shutdown();
                 query.close();
@@ -257,6 +292,8 @@ public class RemoteLookupJoinITCase extends CatalogITCaseBase {
 
     private interface ServiceProxy extends Closeable {
 
-        void write(InternalRow row) throws Exception;
+        void write(InternalRow... rows) throws Exception;
+
+        PartialLookupMetrics metrics();
     }
 }


### PR DESCRIPTION
### Purpose
  Register PartialLookupMetrics in QueryExecutorOperator and inject them into
  the query service's LocalTableQuery. This exposes lookup request counts and
  table-storage access counts for remote query service lookups while preserving
  the existing Full Cache and RPC metric behavior.

  Make the query service metrics test deterministic by writing one record and
  querying the same key twice, validating that the first lookup accesses table
  storage and the second lookup hits the local lookup-file cache.

### Tests
 RemoteLookupJoinITCase#testRemoteQueryServicePartialLookupMetrics.