### PR TITLE
[spark] Fix duplicated Hive metastore test port between two Spark ITCases

### DIFF
--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkDataEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkDataEvolutionITCase.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SparkDataEvolutionITCase {
 
     private static TestHiveMetastore testHiveMetastore;
-    private static final int PORT = 9092;
+    private static final int PORT = 9094;
 
     @BeforeAll
     public static void startMetastore() {


### PR DESCRIPTION
### Purpose

`SparkDataEvolutionITCase` and `SparkMultimodalITCase` both hardcoded the Hive metastore port `9092`. They run in the same `paimon-spark-ut` surefire JVM (`reuseForks`), and `TestHiveMetastore.stop()` does not await the serve thread's termination, so the first class's server socket can still be bound (or in TCP `TIME_WAIT`) when the second class calls `start(9092)`. Whichever class starts its metastore second then fails with `java.net.BindException: Address already in use (Bind failed)`. Class ordering within the fork is nondeterministic, so this surfaces as an intermittent red on the "UTCase and ITCase Spark 3.x" leg.

The flake was first observed on the CI of an unrelated PR #8821, whose change is confined to `paimon-codegen` and touches neither Spark nor Hive. The failing job was https://github.com/apache/paimon/actions/runs/29985121549/job/89135177493, where `SparkMultimodalITCase.startMetastore` could not bind `9092`.

Every other metastore test in the module already picks a unique fixed port (`9083`, `9087`, `9091`, and so on), and the sibling `paimon-hive-connector-common` tests use `9082/9084/9085/9086/9088`; `9092` was the only duplicate. This change gives `SparkDataEvolutionITCase` port `9094`, which is referenced nowhere else in the repository, restoring the module's one-fixed-port-per-class convention. `SparkMultimodalITCase` keeps `9092`, now unique.

`9094` was chosen deliberately: the contiguous block `9082-9092` is fully allocated across the Java `PORT` constants and the per-module `hive-site.xml` resources (`9089`=spark-3.4, `9090`=spark-3.5, `9091`=spark-4.0, `9092`=spark-4.1), and those modules build concurrently under the CI `-T 2C` reactor, so the next free value that cannot collide with any of them was picked. OS-assigned ephemeral ports (used by bind-to-zero tests) live in `32768-60999`, well above `9094`, so they cannot land on it either.

### Tests

No new tests. This only reassigns a test-only port constant. `SparkDataEvolutionITCase` and `SparkMultimodalITCase` continue to start their metastores and pass, now on distinct ports so they can no longer collide within the shared surefire JVM.
