### PR TITLE
[common][spark] Fix ClassCastException when reading a VECTOR column as ARRAY

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/ColumnarArray.java
@@ -146,6 +146,10 @@ public final class ColumnarArray implements InternalArray, DataSetters, Serializ
 
     @Override
     public InternalArray getArray(int pos) {
+        if (data instanceof VecColumnVector) {
+            // A nested VECTOR is exposed as ARRAY; a vector is an array.
+            return ((VecColumnVector) data).getVector(offset + pos);
+        }
         InternalArray array = ((ArrayColumnVector) data).getArray(offset + pos);
         if (array instanceof ColumnarArray) {
             ((ColumnarArray) array).setFileIO(fileIO);

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
@@ -124,7 +124,7 @@ public class VectorizedColumnBatch implements Serializable {
     public InternalArray getArray(int rowId, int colId) {
         ColumnVector column = columns[colId];
         if (column instanceof VecColumnVector) {
-            // VECTOR is exposed as ARRAY; a vector is an array (InternalVector is an InternalArray).
+            // A VECTOR is exposed as ARRAY; a vector is an array.
             return ((VecColumnVector) column).getVector(rowId);
         }
         return ((ArrayColumnVector) column).getArray(rowId);

--- a/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/columnar/VectorizedColumnBatch.java
@@ -122,7 +122,12 @@ public class VectorizedColumnBatch implements Serializable {
     }
 
     public InternalArray getArray(int rowId, int colId) {
-        return ((ArrayColumnVector) columns[colId]).getArray(rowId);
+        ColumnVector column = columns[colId];
+        if (column instanceof VecColumnVector) {
+            // VECTOR is exposed as ARRAY; a vector is an array (InternalVector is an InternalArray).
+            return ((VecColumnVector) column).getVector(rowId);
+        }
+        return ((ArrayColumnVector) column).getArray(rowId);
     }
 
     public InternalVector getVector(int rowId, int colId) {

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowWithVectorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowWithVectorTest.java
@@ -63,6 +63,18 @@ public class ColumnarRowWithVectorTest {
     }
 
     @Test
+    public void testNestedVectorReadAsArray() {
+        // Nested VECTOR (ARRAY<VECTOR>/MAP<..,VECTOR>) reads via ColumnarArray.getArray.
+        float[] values = new float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        VectorizedColumnBatch batch = makeColumnBatch(values, 2, null);
+        VecColumnVector vectorColumn = (VecColumnVector) batch.columns[0];
+
+        ColumnarArray outer = new ColumnarArray(vectorColumn, 0, 2);
+        assertThat(outer.getArray(0).toFloatArray()).isEqualTo(new float[] {1.0f, 2.0f, 3.0f});
+        assertThat(outer.getArray(1).toFloatArray()).isEqualTo(new float[] {4.0f, 5.0f, 6.0f});
+    }
+
+    @Test
     public void testVectorNullable() {
         float[] values = new float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
         boolean[] nulls = new boolean[] {true, false};

--- a/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowWithVectorTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/columnar/ColumnarRowWithVectorTest.java
@@ -48,6 +48,21 @@ public class ColumnarRowWithVectorTest {
     }
 
     @Test
+    public void testVectorReadAsArray() {
+        // VECTOR is exposed as ARRAY (e.g. Flink maps VECTOR -> ARRAY), so it is read via
+        // getArray; a vector is an array, so this must not throw a ClassCastException.
+        float[] values = new float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        VectorizedColumnBatch batch = makeColumnBatch(values, 2, null);
+
+        ColumnarRow row = new ColumnarRow(batch);
+        row.setRowId(0);
+        assertThat(row.getArray(0).toFloatArray()).isEqualTo(new float[] {1.0f, 2.0f, 3.0f});
+
+        row.setRowId(1);
+        assertThat(row.getArray(0).toFloatArray()).isEqualTo(new float[] {4.0f, 5.0f, 6.0f});
+    }
+
+    @Test
     public void testVectorNullable() {
         float[] values = new float[] {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
         boolean[] nulls = new boolean[] {true, false};

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/data/SparkArrayData.scala
@@ -20,7 +20,7 @@ package org.apache.paimon.spark.data
 
 import org.apache.paimon.data.{Blob, BlobView, InternalArray}
 import org.apache.paimon.spark.DataConverter
-import org.apache.paimon.types.{ArrayType => PaimonArrayType, BigIntType, BlobType, DataType => PaimonDataType, DataTypeChecks, RowType}
+import org.apache.paimon.types.{ArrayType => PaimonArrayType, BigIntType, BlobType, DataType => PaimonDataType, DataTypeChecks, RowType, VectorType}
 import org.apache.paimon.utils.InternalRowUtils
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -141,10 +141,15 @@ abstract class AbstractSparkArrayData extends SparkArrayData {
   override def getStruct(ordinal: Int, numFields: Int): InternalRow = DataConverter
     .fromPaimon(paimonArray.getRow(ordinal, numFields), elementType.asInstanceOf[RowType])
 
-  override def getArray(ordinal: Int): ArrayData = DataConverter.fromPaimon(
-    paimonArray.getArray(ordinal),
-    elementType.asInstanceOf[PaimonArrayType],
-    blobAsDescriptor)
+  override def getArray(ordinal: Int): ArrayData = elementType match {
+    // A nested VECTOR is exposed as a Spark array; read it as a vector, not an array.
+    case vectorType: VectorType =>
+      DataConverter.fromPaimon(paimonArray.getVector(ordinal), vectorType)
+    case arrayType: PaimonArrayType =>
+      DataConverter.fromPaimon(paimonArray.getArray(ordinal), arrayType, blobAsDescriptor)
+    case other =>
+      throw new UnsupportedOperationException("Not an array type: " + other)
+  }
 
   override def getMap(ordinal: Int): MapData =
     DataConverter.fromPaimon(paimonArray.getMap(ordinal), elementType)


### PR DESCRIPTION
### Purpose

Reading a `VECTOR` column through Flink throws:

```
java.lang.ClassCastException: ...CastedVectorColumnVector cannot be cast to ...ArrayColumnVector
    at ...VectorizedColumnBatch.getArray(VectorizedColumnBatch.java:125)
    at ...ColumnarRow.getArray(ColumnarRow.java:169)
    at ...FlinkRowData.getArray(FlinkRowData.java:137)
```

Flink has no vector type, so `DataTypeToLogicalType` maps a Paimon `VectorType` to a Flink `ArrayType`, and Flink's generated code reads the column via `getArray`. However the columnar read produces a `VecColumnVector` (e.g. `CastedVectorColumnVector` / `ReadableVectorColumnVector`), and `VectorizedColumnBatch.getArray` unconditionally cast it to `ArrayColumnVector`, causing the `ClassCastException`.

(Spark is not affected: it keeps the Paimon `VectorType` and reads a VECTOR column via `getVector`, see `AbstractSparkInternalRow`. Only the Flink path, which flattens VECTOR to ARRAY and calls `getArray`, hits this.)

Since a vector is an array (`InternalVector extends InternalArray`), read a `VecColumnVector` column through `getVector`. This mirrors the ARRAY-vs-VECTOR branching that `ColumnarArray` and `RowToColumnConverter` already do, and makes `getArray` robust for any caller that reads a VECTOR column as an array.

### Tests

`ColumnarRowWithVectorTest#testVectorReadAsArray` — reads a VECTOR column via `getArray`; fails with `ClassCastException` before the fix, passes after.
