### PR TITLE
[core][flink][spark] Support OSS blob presigned URLs

### DIFF
--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -502,6 +502,81 @@ CREATE TABLE descriptor_table (
 
 Paimon stores only serialized `BlobDescriptor` bytes in normal data files. Reading the blob follows the descriptor URI to access bytes, and writing requires descriptor input for those fields.
 
+## Presigned URLs for OSS Blobs
+
+Paimon can create a temporary HTTPS URL for an OSS-backed `BlobDescriptor`. The descriptor may
+refer to a byte range inside a larger `.blob` file. Paimon first materializes exactly that range as
+a separate OSS object, sets its content type from the requested extension, and then returns a
+presigned GET URL.
+
+Configure the catalog with the standard public HTTPS OSS endpoint. Internal endpoints and
+endpoints without the `https` scheme are rejected because external consumers must be able to fetch
+the returned URL:
+
+```properties
+fs.oss.endpoint=https://oss-cn-hangzhou.aliyuncs.com
+```
+
+To obtain descriptors from a regular BLOB column, read the source table with
+`blob-as-descriptor=true`. The SQL functions have strict and error-tolerant forms:
+
+```sql
+-- Flink SQL
+SELECT sys.descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    'png',
+    INTERVAL '5' MINUTE)
+FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
+
+SELECT sys.try_descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    'png',
+    INTERVAL '5' MINUTE)
+FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
+```
+
+```sql
+-- Spark SQL
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
+
+SELECT sys.descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    'png',
+    INTERVAL '5' MINUTE)
+FROM image_table;
+```
+
+In both Flink and Spark, `source_table` must be a non-null string literal in
+`database.table` form. `catalog.database.table` is also accepted when the catalog matches the
+catalog that owns the function. Dynamic columns and `CASE` expressions are rejected during
+planning. The strict function propagates row errors; `try_descriptor_to_presigned_url` returns
+`NULL` for row-level errors. The validity interval must be positive whole seconds.
+
+The Java API uses the same table-root safety check:
+
+```java
+DataTable table = ...;
+Blob blob = ...;
+String url =
+        blob.toPresignedUrl(
+                table.fileIO(), table.location(), "png", Duration.ofMinutes(5));
+```
+
+The extension must contain only lower-case letters or digits after normalization and must map to a
+known MIME type. It must match the actual content. For direct model `image_url` inputs, use only
+image formats verified with the target model; PDF is not covered by this entry point.
+
+Materialized objects are keyed by the complete descriptor fingerprint and extension. Repeated
+short-term calls for the same descriptor reuse an object whose length, content type, and
+fingerprint still match, while generating a fresh URL. The first version does not resolve races
+with stale-cache cleanup or orphan-file cleaning.
+
+Treat the returned URL as a bearer credential: submit it immediately to the external service, do
+not persist it, and never write the URL or its signature/security-token query parameters to logs.
+
 ## Blob View
 
 Blob view is useful when a downstream table should reference BLOB values already stored in an upstream table, without copying the bytes or creating new `.blob` files. A blob view field stores only a small `BlobViewStruct` inline. When the field is read, Paimon resolves the referenced BLOB from the upstream table.

--- a/docs/docs/multimodal-table/blob.mdx
+++ b/docs/docs/multimodal-table/blob.mdx
@@ -506,8 +506,8 @@ Paimon stores only serialized `BlobDescriptor` bytes in normal data files. Readi
 
 Paimon can create a temporary HTTPS URL for an OSS-backed `BlobDescriptor`. The descriptor may
 refer to a byte range inside a larger `.blob` file. Paimon first materializes exactly that range as
-a separate OSS object, sets its content type from the requested extension, and then returns a
-presigned GET URL.
+a separate OSS object without a file extension, sets its content type to
+`application/octet-stream`, and then returns a presigned GET URL.
 
 Configure the catalog with the standard public HTTPS OSS endpoint. Internal endpoints and
 endpoints without the `https` scheme are rejected because external consumers must be able to fetch
@@ -525,14 +525,12 @@ To obtain descriptors from a regular BLOB column, read the source table with
 SELECT sys.descriptor_to_presigned_url(
     'default.image_table',
     image,
-    'png',
     INTERVAL '5' MINUTE)
 FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
 
 SELECT sys.try_descriptor_to_presigned_url(
     'default.image_table',
     image,
-    'png',
     INTERVAL '5' MINUTE)
 FROM image_table /*+ OPTIONS('blob-as-descriptor'='true') */;
 ```
@@ -544,7 +542,6 @@ ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
 SELECT sys.descriptor_to_presigned_url(
     'default.image_table',
     image,
-    'png',
     INTERVAL '5' MINUTE)
 FROM image_table;
 ```
@@ -562,17 +559,17 @@ DataTable table = ...;
 Blob blob = ...;
 String url =
         blob.toPresignedUrl(
-                table.fileIO(), table.location(), "png", Duration.ofMinutes(5));
+                table.fileIO(), table.location(), Duration.ofMinutes(5));
 ```
 
-The extension must contain only lower-case letters or digits after normalization and must map to a
-known MIME type. It must match the actual content. For direct model `image_url` inputs, use only
-image formats verified with the target model; PDF is not covered by this entry point.
+The materialized object's bytes are unchanged. Consumers must inspect the content instead of
+relying on a URL suffix or a format-specific content type. For direct model `image_url` inputs, use
+only formats verified with the target model; PDF is not covered by this entry point.
 
-Materialized objects are keyed by the complete descriptor fingerprint and extension. Repeated
-short-term calls for the same descriptor reuse an object whose length, content type, and
-fingerprint still match, while generating a fresh URL. The first version does not resolve races
-with stale-cache cleanup or orphan-file cleaning.
+Materialized objects are keyed by the complete descriptor fingerprint. Repeated short-term calls
+for the same descriptor reuse an object whose length, content type, and fingerprint still match,
+while generating a fresh URL. The first version does not resolve races with stale-cache cleanup or
+orphan-file cleaning.
 
 Treat the returned URL as a bearer credential: submit it immediately to the external service, do
 not persist it, and never write the URL or its signature/security-token query parameters to logs.

--- a/docs/docs/spark/sql-functions.md
+++ b/docs/docs/spark/sql-functions.md
@@ -94,6 +94,40 @@ SELECT sys.descriptor_to_string(content) FROM t WHERE id = '1';
 -- [BlobDescriptor{version=1', uri='/path/to/data-2c103f6f-3857-4062-abc3-2e260374a68e-1.blob', offset=4, length=1048576}]
 ```
 
+### descriptor_to_presigned_url
+
+`sys.descriptor_to_presigned_url($source_table, $descriptor, $extension, $validity)`
+
+Creates a temporary HTTPS GET URL for an OSS-backed blob descriptor. Use
+`sys.try_descriptor_to_presigned_url` to return `NULL` instead of failing on row-level errors.
+
+- `source_table` must be a non-null STRING literal in `database.table` form, or
+  `catalog.database.table` with the same catalog as the function.
+- `descriptor` is the serialized BINARY descriptor. Set `blob-as-descriptor=true` when reading a
+  normal BLOB column.
+- `extension` determines the materialized object's MIME type and must match the content.
+- `validity` is a positive day-time interval containing whole seconds.
+
+The catalog's `fs.oss.endpoint` must be a standard public HTTPS endpoint, for example
+`https://oss-cn-hangzhou.aliyuncs.com`.
+
+```sql
+ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
+
+SELECT sys.descriptor_to_presigned_url(
+    'default.image_table',
+    image,
+    'png',
+    INTERVAL '5' MINUTE)
+FROM image_table;
+```
+
+Repeated short-term calls for the same descriptor reuse the materialized object and issue a fresh
+URL. Treat the URL as a bearer credential: send it immediately to the consumer and never log or
+persist it. Direct model `image_url` use is supported only for image formats verified with that
+model; PDF is not covered. See [Blob Storage](../multimodal-table/blob#presigned-urls-for-oss-blobs)
+for Java and Flink examples, caching behavior, and current limitations.
+
 ## User-defined Function
 
 Paimon Spark supports three types of user-defined functions: lambda functions, file-based functions, and SQL functions.

--- a/docs/docs/spark/sql-functions.md
+++ b/docs/docs/spark/sql-functions.md
@@ -96,7 +96,7 @@ SELECT sys.descriptor_to_string(content) FROM t WHERE id = '1';
 
 ### descriptor_to_presigned_url
 
-`sys.descriptor_to_presigned_url($source_table, $descriptor, $extension, $validity)`
+`sys.descriptor_to_presigned_url($source_table, $descriptor, $validity)`
 
 Creates a temporary HTTPS GET URL for an OSS-backed blob descriptor. Use
 `sys.try_descriptor_to_presigned_url` to return `NULL` instead of failing on row-level errors.
@@ -105,8 +105,10 @@ Creates a temporary HTTPS GET URL for an OSS-backed blob descriptor. Use
   `catalog.database.table` with the same catalog as the function.
 - `descriptor` is the serialized BINARY descriptor. Set `blob-as-descriptor=true` when reading a
   normal BLOB column.
-- `extension` determines the materialized object's MIME type and must match the content.
 - `validity` is a positive day-time interval containing whole seconds.
+
+The materialized object has no file extension and is served as
+`application/octet-stream`. Its bytes are unchanged.
 
 The catalog's `fs.oss.endpoint` must be a standard public HTTPS endpoint, for example
 `https://oss-cn-hangzhou.aliyuncs.com`.
@@ -117,7 +119,6 @@ ALTER TABLE image_table SET TBLPROPERTIES ('blob-as-descriptor' = 'true');
 SELECT sys.descriptor_to_presigned_url(
     'default.image_table',
     image,
-    'png',
     INTERVAL '5' MINUTE)
 FROM image_table;
 ```

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -20,6 +20,7 @@ package org.apache.paimon.data;
 
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.SeekableInputStream;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.utils.UriReader;
@@ -28,6 +29,7 @@ import org.apache.paimon.utils.UriReaderFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Supplier;
 
 /**
@@ -43,6 +45,11 @@ public interface Blob {
     BlobDescriptor toDescriptor();
 
     SeekableInputStream newInputStream() throws IOException;
+
+    default String toPresignedUrl(
+            FileIO fileIO, Path tableRoot, String extension, Duration validity) throws IOException {
+        return fileIO.createBlobPresignedUrl(tableRoot, toDescriptor(), extension, validity);
+    }
 
     static Blob fromData(byte[] data) {
         return new BlobData(data);

--- a/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/Blob.java
@@ -46,9 +46,9 @@ public interface Blob {
 
     SeekableInputStream newInputStream() throws IOException;
 
-    default String toPresignedUrl(
-            FileIO fileIO, Path tableRoot, String extension, Duration validity) throws IOException {
-        return fileIO.createBlobPresignedUrl(tableRoot, toDescriptor(), extension, validity);
+    default String toPresignedUrl(FileIO fileIO, Path tableRoot, Duration validity)
+            throws IOException {
+        return fileIO.createBlobPresignedUrl(tableRoot, toDescriptor(), validity);
     }
 
     static Blob fromData(byte[] data) {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -20,6 +20,7 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.annotation.Public;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.hadoop.HadoopFileIOLoader;
 import org.apache.paimon.fs.local.LocalFileIO;
 
@@ -260,6 +261,13 @@ public interface FileIO extends Serializable, Closeable {
     default Optional<Path> unarchive(Path path, StorageType type) throws IOException {
         throw new UnsupportedOperationException(
                 getClass().getName() + " does not support unarchive.");
+    }
+
+    default String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        throw new UnsupportedOperationException(
+                getClass().getName() + " does not support creating blob presigned URLs.");
     }
 
     /**

--- a/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/FileIO.java
@@ -264,8 +264,7 @@ public interface FileIO extends Serializable, Closeable {
     }
 
     default String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         throw new UnsupportedOperationException(
                 getClass().getName() + " does not support creating blob presigned URLs.");
     }

--- a/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
@@ -19,9 +19,11 @@
 package org.apache.paimon.fs;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.options.Options;
 
 import java.io.IOException;
+import java.time.Duration;
 
 /**
  * A {@link FileIO} for plugin jar. {@link FileIO} is serializable, so plugin FileIO should be
@@ -94,6 +96,17 @@ public abstract class PluginFileIO implements FileIO, HadoopOptionsProvider {
     @Override
     public boolean tryToWriteAtomic(Path path, String content) throws IOException {
         return wrap(() -> fileIO(path).tryToWriteAtomic(path, content));
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        return wrap(
+                () ->
+                        fileIO(new Path(descriptor.uri()))
+                                .createBlobPresignedUrl(
+                                        tableRoot, descriptor, extension, validity));
     }
 
     private FileIO fileIO(Path path) throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/PluginFileIO.java
@@ -100,13 +100,11 @@ public abstract class PluginFileIO implements FileIO, HadoopOptionsProvider {
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         return wrap(
                 () ->
                         fileIO(new Path(descriptor.uri()))
-                                .createBlobPresignedUrl(
-                                        tableRoot, descriptor, extension, validity));
+                                .createBlobPresignedUrl(tableRoot, descriptor, validity));
     }
 
     private FileIO fileIO(Path path) throws IOException {

--- a/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
@@ -20,11 +20,13 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.annotation.VisibleForTesting;
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -105,6 +107,17 @@ public class ResolvingFileIO implements FileIO {
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
         return wrap(() -> fileIO(src).rename(src, dst));
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        return wrap(
+                () ->
+                        fileIO(new Path(descriptor.uri()))
+                                .createBlobPresignedUrl(
+                                        tableRoot, descriptor, extension, validity));
     }
 
     @VisibleForTesting

--- a/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/ResolvingFileIO.java
@@ -111,13 +111,11 @@ public class ResolvingFileIO implements FileIO {
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         return wrap(
                 () ->
                         fileIO(new Path(descriptor.uri()))
-                                .createBlobPresignedUrl(
-                                        tableRoot, descriptor, extension, validity));
+                                .createBlobPresignedUrl(tableRoot, descriptor, validity));
     }
 
     @VisibleForTesting

--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.fs.cache;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
@@ -32,6 +33,7 @@ import org.apache.paimon.utils.FileType;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
@@ -149,6 +151,13 @@ public class CachingFileIO implements FileIO {
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
         return delegate.rename(src, dst);
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        return delegate.createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/cache/CachingFileIO.java
@@ -155,9 +155,8 @@ public class CachingFileIO implements FileIO {
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
-        return delegate.createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
+        return delegate.createBlobPresignedUrl(tableRoot, descriptor, validity);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -20,6 +20,7 @@ package org.apache.paimon.rest;
 
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -148,6 +150,16 @@ public class RESTTokenFileIO implements FileIO {
     @Override
     public boolean rename(Path src, Path dst) throws IOException {
         return fileIO().rename(src, dst);
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        if (!path.equals(tableRoot)) {
+            throw new IOException("Table root does not match RESTTokenFileIO bound table root.");
+        }
+        return fileIO().createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
+++ b/paimon-common/src/main/java/org/apache/paimon/rest/RESTTokenFileIO.java
@@ -154,12 +154,11 @@ public class RESTTokenFileIO implements FileIO {
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         if (!path.equals(tableRoot)) {
             throw new IOException("Table root does not match RESTTokenFileIO bound table root.");
         }
-        return fileIO().createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
+        return fileIO().createBlobPresignedUrl(tableRoot, descriptor, validity);
     }
 
     @Override

--- a/paimon-common/src/main/java/org/apache/paimon/utils/BlobDescriptorUtils.java
+++ b/paimon-common/src/main/java/org/apache/paimon/utils/BlobDescriptorUtils.java
@@ -20,17 +20,49 @@ package org.apache.paimon.utils;
 
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.options.Options;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.apache.paimon.CoreOptions.BLOB_DESCRIPTOR_PREFIX;
 
 /** Utils for {@link BlobDescriptor}. */
 public class BlobDescriptorUtils {
+
+    public static void validateTableRoot(Path tableRoot, BlobDescriptor descriptor)
+            throws IOException {
+        URI root = tableRoot.toUri().normalize();
+        URI blob;
+        try {
+            blob = new Path(descriptor.uri()).toUri().normalize();
+        } catch (RuntimeException e) {
+            throw new IOException("Invalid blob descriptor URI.", e);
+        }
+
+        if (!Objects.equals(normalizeScheme(root.getScheme()), normalizeScheme(blob.getScheme()))
+                || !Objects.equals(root.getAuthority(), blob.getAuthority())) {
+            throw new IOException(
+                    "Blob descriptor URI must use the same scheme and authority as table root.");
+        }
+
+        String rootPath = root.getPath();
+        String blobPath = blob.getPath();
+        String childPrefix = rootPath.endsWith("/") ? rootPath : rootPath + "/";
+        if (!blobPath.startsWith(childPrefix)) {
+            throw new IOException("Blob descriptor URI must be under table root.");
+        }
+    }
+
+    private static String normalizeScheme(@Nullable String scheme) {
+        return scheme == null ? null : scheme.toLowerCase();
+    }
 
     /**
      * Try to create a {@link CatalogContext} for input {@link BlobDescriptor}. This enables reading

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.data;
 
 import org.apache.paimon.fs.ByteArraySeekableStream;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.utils.UriReader;
 
@@ -30,11 +32,16 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link Blob}. */
 public class BlobTest {
@@ -83,6 +90,39 @@ public class BlobTest {
         String uri = "http://example.com/file.txt";
         Blob blob = Blob.fromHttp(uri);
         assertThat(blob).isInstanceOf(BlobRef.class);
+    }
+
+    @Test
+    public void testToPresignedUrlDelegatesDescriptor() throws IOException {
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 2, 4);
+        Blob blob = Blob.fromDescriptor(mock(UriReader.class), descriptor);
+        FileIO fileIO = mock(FileIO.class);
+        Path tableRoot = new Path("oss://bucket/table");
+        Duration validity = Duration.ofHours(1);
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity))
+                .thenReturn("https://example");
+
+        assertThat(blob.toPresignedUrl(fileIO, tableRoot, "jpg", validity))
+                .isEqualTo("https://example");
+        verify(fileIO).createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity);
+    }
+
+    @Test
+    public void testInlineBlobCannotCreatePresignedUrl() {
+        FileIO fileIO = mock(FileIO.class);
+
+        assertThatThrownBy(
+                        () ->
+                                Blob.fromData(new byte[] {1})
+                                        .toPresignedUrl(
+                                                fileIO,
+                                                new Path("oss://bucket/table"),
+                                                "jpg",
+                                                Duration.ofHours(1)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("can not convert to descriptor");
+        verifyNoInteractions(fileIO);
     }
 
     @Test

--- a/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/BlobTest.java
@@ -100,12 +100,11 @@ public class BlobTest {
         FileIO fileIO = mock(FileIO.class);
         Path tableRoot = new Path("oss://bucket/table");
         Duration validity = Duration.ofHours(1);
-        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity))
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .thenReturn("https://example");
 
-        assertThat(blob.toPresignedUrl(fileIO, tableRoot, "jpg", validity))
-                .isEqualTo("https://example");
-        verify(fileIO).createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity);
+        assertThat(blob.toPresignedUrl(fileIO, tableRoot, validity)).isEqualTo("https://example");
+        verify(fileIO).createBlobPresignedUrl(tableRoot, descriptor, validity);
     }
 
     @Test
@@ -118,7 +117,6 @@ public class BlobTest {
                                         .toPresignedUrl(
                                                 fileIO,
                                                 new Path("oss://bucket/table"),
-                                                "jpg",
                                                 Duration.ofHours(1)))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("can not convert to descriptor");

--- a/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.fs;
+
+import org.apache.paimon.data.BlobDescriptor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link PluginFileIO}. */
+class PluginFileIOTest {
+
+    @Test
+    void testCreateBlobPresignedUrlUsesPluginClassLoader() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        ClassLoader pluginClassLoader = new ClassLoader() {};
+        TestPluginFileIO fileIO = new TestPluginFileIO(delegate, pluginClassLoader);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
+        Duration validity = Duration.ofMinutes(5);
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .thenAnswer(
+                        ignored -> {
+                            assertThat(Thread.currentThread().getContextClassLoader())
+                                    .isSameAs(pluginClassLoader);
+                            return "https://example";
+                        });
+
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .isEqualTo("https://example");
+        assertThat(fileIO.createdFor).isEqualTo(new Path(descriptor.uri()));
+        assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(original);
+    }
+
+    private static class TestPluginFileIO extends PluginFileIO {
+
+        private final FileIO delegate;
+        private final ClassLoader classLoader;
+        private Path createdFor;
+
+        private TestPluginFileIO(FileIO delegate, ClassLoader classLoader) {
+            this.delegate = delegate;
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public boolean isObjectStore() {
+            return true;
+        }
+
+        @Override
+        protected FileIO createFileIO(Path path) {
+            createdFor = path;
+            return delegate;
+        }
+
+        @Override
+        protected ClassLoader pluginClassLoader() {
+            return classLoader;
+        }
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/PluginFileIOTest.java
@@ -42,7 +42,7 @@ class PluginFileIOTest {
                 new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
         Duration validity = Duration.ofMinutes(5);
         ClassLoader original = Thread.currentThread().getContextClassLoader();
-        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .thenAnswer(
                         ignored -> {
                             assertThat(Thread.currentThread().getContextClassLoader())
@@ -50,7 +50,7 @@ class PluginFileIOTest {
                             return "https://example";
                         });
 
-        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .isEqualTo("https://example");
         assertThat(fileIO.createdFor).isEqualTo(new Path(descriptor.uri()));
         assertThat(Thread.currentThread().getContextClassLoader()).isSameAs(original);

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.fs;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.hadoop.HadoopFileIO;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -34,6 +36,10 @@ import java.util.concurrent.Future;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link ResolvingFileIO}. */
 public class ResolvingFileIOTest {
@@ -136,5 +142,27 @@ public class ResolvingFileIOTest {
         assertNotNull(hdfsFileIOAgain);
         assertEquals(localFileIO, localFileIOAgain);
         assertEquals(hdfsFileIO, hdfsFileIOAgain);
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlResolvesDescriptorFileIO() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        when(delegate.exists(any())).thenReturn(true);
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.load(any())).thenReturn(delegate);
+        when(loader.getScheme()).thenReturn("oss");
+        resolvingFileIO.configure(CatalogContext.create(new Options(), loader, null));
+
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
+        Duration validity = Duration.ofMinutes(5);
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .thenReturn("https://example");
+
+        assertEquals(
+                "https://example",
+                resolvingFileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity));
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/ResolvingFileIOTest.java
@@ -157,12 +157,12 @@ public class ResolvingFileIOTest {
         BlobDescriptor descriptor =
                 new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
         Duration validity = Duration.ofMinutes(5);
-        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .thenReturn("https://example");
 
         assertEquals(
                 "https://example",
-                resolvingFileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity));
-        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
+                resolvingFileIO.createBlobPresignedUrl(tableRoot, descriptor, validity));
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, validity);
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.fs.cache;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileStatus;
 import org.apache.paimon.fs.Path;
@@ -31,11 +32,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link CachingFileIO} and {@link CachingSeekableInputStream}. */
 class CachingFileIOTest {
@@ -47,6 +52,27 @@ class CachingFileIOTest {
     @BeforeEach
     void setUp() {
         cacheDir = tempDir.resolve("cache").toString();
+    }
+
+    @Test
+    void testCreateBlobPresignedUrlDelegates() throws IOException {
+        FileIO delegate = mock(FileIO.class);
+        CachingFileIO cachingIO =
+                newCachingFileIO(
+                        delegate,
+                        new LocalMemoryCacheManager(1024, 64),
+                        EnumSet.of(FileType.DATA),
+                        64);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
+        Duration validity = Duration.ofMinutes(5);
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .thenReturn("https://example");
+
+        assertThat(cachingIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .isEqualTo("https://example");
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
     }
 
     private CachingFileIO newCachingFileIO(

--- a/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/cache/CachingFileIOTest.java
@@ -67,12 +67,12 @@ class CachingFileIOTest {
         BlobDescriptor descriptor =
                 new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
         Duration validity = Duration.ofMinutes(5);
-        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .thenReturn("https://example");
 
-        assertThat(cachingIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        assertThat(cachingIO.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .isEqualTo("https://example");
-        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, validity);
     }
 
     private CachingFileIO newCachingFileIO(

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.rest;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileIOLoader;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.rest.responses.GetTableTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link RESTTokenFileIO}. */
+class RESTTokenFileIOTest {
+
+    @Test
+    void testCreateBlobPresignedUrlRequiresBoundRootAndDelegates() throws IOException {
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 0, 1);
+        Duration validity = Duration.ofMinutes(5);
+        FileIO delegate = mock(FileIO.class);
+        when(delegate.exists(any())).thenReturn(true);
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .thenReturn("https://example");
+        FileIOLoader loader = mock(FileIOLoader.class);
+        when(loader.load(any())).thenReturn(delegate);
+        when(loader.getScheme()).thenReturn("oss");
+        RESTApi api = mock(RESTApi.class);
+        Identifier identifier = Identifier.create("db", "table");
+        when(api.loadTableToken(identifier))
+                .thenReturn(new GetTableTokenResponse(Collections.emptyMap(), Long.MAX_VALUE));
+        RESTTokenFileIO fileIO =
+                new RESTTokenFileIO(
+                        CatalogContext.create(new Options(), loader, null),
+                        api,
+                        identifier,
+                        tableRoot);
+
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+                .isEqualTo("https://example");
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
+
+        assertThatThrownBy(
+                        () ->
+                                fileIO.createBlobPresignedUrl(
+                                        new Path("oss://bucket/other"),
+                                        descriptor,
+                                        "png",
+                                        validity))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("bound table root");
+    }
+}

--- a/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/rest/RESTTokenFileIOTest.java
@@ -51,7 +51,7 @@ class RESTTokenFileIOTest {
         Duration validity = Duration.ofMinutes(5);
         FileIO delegate = mock(FileIO.class);
         when(delegate.exists(any())).thenReturn(true);
-        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        when(delegate.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .thenReturn("https://example");
         FileIOLoader loader = mock(FileIOLoader.class);
         when(loader.load(any())).thenReturn(delegate);
@@ -67,17 +67,14 @@ class RESTTokenFileIOTest {
                         identifier,
                         tableRoot);
 
-        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", validity))
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, validity))
                 .isEqualTo("https://example");
-        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, "png", validity);
+        verify(delegate).createBlobPresignedUrl(tableRoot, descriptor, validity);
 
         assertThatThrownBy(
                         () ->
                                 fileIO.createBlobPresignedUrl(
-                                        new Path("oss://bucket/other"),
-                                        descriptor,
-                                        "png",
-                                        validity))
+                                        new Path("oss://bucket/other"), descriptor, validity))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("bound table root");
     }

--- a/paimon-common/src/test/java/org/apache/paimon/utils/BlobDescriptorUtilsTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/utils/BlobDescriptorUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.utils;
+
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link BlobDescriptorUtils}. */
+class BlobDescriptorUtilsTest {
+
+    @Test
+    void testValidateTableRoot() {
+        Path tableRoot = new Path("oss://bucket/table");
+
+        assertThatCode(
+                        () ->
+                                BlobDescriptorUtils.validateTableRoot(
+                                        tableRoot,
+                                        new BlobDescriptor(
+                                                "oss://bucket/table/bucket-0/data.blob", 0, 1)))
+                .doesNotThrowAnyException();
+
+        assertInvalid(tableRoot, "oss://bucket/table-copy/data.blob");
+        assertInvalid(tableRoot, "oss://bucket/table/../other/data.blob");
+        assertInvalid(tableRoot, "oss://other/table/data.blob");
+        assertInvalid(tableRoot, "s3://bucket/table/data.blob");
+    }
+
+    private static void assertInvalid(Path tableRoot, String uri) {
+        assertThatThrownBy(
+                        () ->
+                                BlobDescriptorUtils.validateTableRoot(
+                                        tableRoot, new BlobDescriptor(uri, 0, 1)))
+                .isInstanceOf(IOException.class);
+    }
+}

--- a/paimon-filesystems/paimon-jindo/pom.xml
+++ b/paimon-filesystems/paimon-jindo/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-oss</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>

--- a/paimon-filesystems/paimon-jindo/pom.xml
+++ b/paimon-filesystems/paimon-jindo/pom.xml
@@ -66,6 +66,10 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>org.jacoco.agent</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -154,6 +158,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <artifactSet>
@@ -165,8 +181,6 @@
                             <include>commons-codec:commons-codec</include>
                             <include>commons-logging:commons-logging</include>
                             <include>io.opentracing:*</include>
-                            <include>javax.activation:javax.activation-api</include>
-                            <include>javax.xml.bind:jaxb-api</include>
                             <include>org.apache.httpcomponents:*</include>
                             <include>org.codehaus.jettison:jettison</include>
                             <include>org.ini4j:ini4j</include>
@@ -179,6 +193,7 @@
                             <artifact>org.apache.paimon:paimon-oss-impl</artifact>
                             <includes>
                                 <include>org/apache/paimon/oss/OSSBlobPresigner.class</include>
+                                <include>META-INF/versions/11/**</include>
                             </includes>
                         </filter>
                     </filters>

--- a/paimon-filesystems/paimon-jindo/pom.xml
+++ b/paimon-filesystems/paimon-jindo/pom.xml
@@ -32,6 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <fs.oss.sdk.version>3.13.2</fs.oss.sdk.version>
         <jindodata.version>6.9.1</jindodata.version>
     </properties>
 
@@ -52,8 +53,27 @@
 
         <dependency>
             <groupId>org.apache.paimon</groupId>
-            <artifactId>paimon-oss</artifactId>
+            <artifactId>paimon-oss-impl</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aliyun.oss</groupId>
+            <artifactId>aliyun-sdk-oss</artifactId>
+            <version>${fs.oss.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>org.jacoco.agent</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -127,7 +147,43 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.1.3</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <includes combine.children="append">
+                            <include>org.apache.paimon:paimon-oss-impl</include>
+                            <include>com.aliyun.oss:aliyun-sdk-oss</include>
+                            <include>com.aliyun:*</include>
+                            <include>com.google.code.gson:gson</include>
+                            <include>commons-codec:commons-codec</include>
+                            <include>commons-logging:commons-logging</include>
+                            <include>io.opentracing:*</include>
+                            <include>javax.activation:javax.activation-api</include>
+                            <include>javax.xml.bind:jaxb-api</include>
+                            <include>org.apache.httpcomponents:*</include>
+                            <include>org.codehaus.jettison:jettison</include>
+                            <include>org.ini4j:ini4j</include>
+                            <include>org.jdom:jdom2</include>
+                            <include>stax:stax-api</include>
+                        </includes>
+                    </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>org.apache.paimon:paimon-oss-impl</artifact>
+                            <includes>
+                                <include>org/apache/paimon/oss/OSSBlobPresigner.class</include>
+                            </includes>
+                        </filter>
+                    </filters>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/paimon-filesystems/paimon-jindo/pom.xml
+++ b/paimon-filesystems/paimon-jindo/pom.xml
@@ -32,7 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <fs.oss.sdk.version>3.13.2</fs.oss.sdk.version>
+        <fs.oss.sdk.version>3.17.4</fs.oss.sdk.version>
         <jindodata.version>6.9.1</jindodata.version>
     </properties>
 

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -19,11 +19,13 @@
 package org.apache.paimon.jindo;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.HadoopOptionsProvider;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.oss.OSSLoader;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SensitiveConfigUtils;
@@ -41,6 +43,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,6 +93,15 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     private Options hadoopOptions;
     private Options hadoopOptionsWithCache;
     private boolean allowCache = true;
+    private final FileIO blobFileIO;
+
+    public JindoFileIO() {
+        this(new OSSLoader().load(new Path("oss:///")));
+    }
+
+    JindoFileIO(FileIO blobFileIO) {
+        this.blobFileIO = blobFileIO;
+    }
 
     @Override
     public boolean isObjectStore() {
@@ -99,6 +111,7 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     @Override
     public void configure(CatalogContext context) {
         super.configure(context);
+        blobFileIO.configure(context);
         allowCache = context.options().get(FILE_IO_ALLOW_CACHE);
         hadoopOptions = new Options();
         // read all configuration with prefix 'CONFIG_PREFIXES'
@@ -196,6 +209,13 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
         JindoHadoopSystem fs = pair.getKey();
         return new JindoTwoPhaseOutputStream(
                 new JindoMultiPartUpload(fs, hadoopPath), hadoopPath, path);
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        return blobFileIO.createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
     }
 
     @Override

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -25,7 +25,7 @@ import org.apache.paimon.fs.HadoopOptionsProvider;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.oss.OSSLoader;
+import org.apache.paimon.oss.OSSBlobPresigner;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.Pair;
 import org.apache.paimon.utils.SensitiveConfigUtils;
@@ -35,6 +35,8 @@ import com.aliyun.jindodata.common.JindoHadoopSystem;
 import com.aliyun.jindodata.dls.JindoDlsFileSystem;
 import com.aliyun.jindodata.oss.JindoOssFileSystem;
 import com.aliyun.jindodata.oss.auth.SimpleCredentialsProvider;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSSClientBuilder;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
@@ -67,6 +69,7 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
      */
     private static final String[] CONFIG_PREFIXES = {"fs."};
 
+    private static final String OSS_ENDPOINT = "fs.oss.endpoint";
     private static final String OSS_ACCESS_KEY_ID = "fs.oss.accessKeyId";
     private static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
@@ -93,14 +96,12 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     private Options hadoopOptions;
     private Options hadoopOptionsWithCache;
     private boolean allowCache = true;
-    private final FileIO blobFileIO;
+    private transient OSSClient blobClient;
 
-    public JindoFileIO() {
-        this(new OSSLoader().load(new Path("oss:///")));
-    }
+    public JindoFileIO() {}
 
-    JindoFileIO(FileIO blobFileIO) {
-        this.blobFileIO = blobFileIO;
+    JindoFileIO(OSSClient blobClient) {
+        this.blobClient = blobClient;
     }
 
     @Override
@@ -111,7 +112,6 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     @Override
     public void configure(CatalogContext context) {
         super.configure(context);
-        blobFileIO.configure(context);
         allowCache = context.options().get(FILE_IO_ALLOW_CACHE);
         hadoopOptions = new Options();
         // read all configuration with prefix 'CONFIG_PREFIXES'
@@ -215,7 +215,30 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     public String createBlobPresignedUrl(
             Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
             throws IOException {
-        return blobFileIO.createBlobPresignedUrl(tableRoot, descriptor, extension, validity);
+        return OSSBlobPresigner.create(blobClient(), tableRoot, descriptor, extension, validity);
+    }
+
+    private synchronized OSSClient blobClient() {
+        if (blobClient == null) {
+            blobClient = createBlobClient(hadoopOptions);
+        }
+        return blobClient;
+    }
+
+    static OSSClient createBlobClient(Options options) {
+        String securityToken = options.get(OSS_SECURITY_TOKEN);
+        OSSClientBuilder builder = new OSSClientBuilder();
+        return (OSSClient)
+                (StringUtils.isNullOrWhitespaceOnly(securityToken)
+                        ? builder.build(
+                                options.get(OSS_ENDPOINT),
+                                options.get(OSS_ACCESS_KEY_ID),
+                                options.get(OSS_ACCESS_KEY_SECRET))
+                        : builder.build(
+                                options.get(OSS_ENDPOINT),
+                                options.get(OSS_ACCESS_KEY_ID),
+                                options.get(OSS_ACCESS_KEY_SECRET),
+                                securityToken));
     }
 
     @Override
@@ -266,7 +289,11 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
+        if (blobClient != null) {
+            blobClient.shutdown();
+            blobClient = null;
+        }
         if (!allowCache) {
             fsMap.values().stream().map(Pair::getKey).forEach(IOUtils::closeQuietly);
             fsMap.clear();

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -213,9 +213,8 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
-        return OSSBlobPresigner.create(blobClient(), tableRoot, descriptor, extension, validity);
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
+        return OSSBlobPresigner.create(blobClient(), tableRoot, descriptor, validity);
     }
 
     private synchronized OSSClient blobClient() {

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -226,16 +226,20 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     }
 
     static OSSClient createBlobClient(Options options) {
+        String endpoint = options.get(OSS_ENDPOINT);
+        if (!endpoint.contains("://")) {
+            endpoint = "https://" + endpoint;
+        }
         String securityToken = options.get(OSS_SECURITY_TOKEN);
         OSSClientBuilder builder = new OSSClientBuilder();
         return (OSSClient)
                 (StringUtils.isNullOrWhitespaceOnly(securityToken)
                         ? builder.build(
-                                options.get(OSS_ENDPOINT),
+                                endpoint,
                                 options.get(OSS_ACCESS_KEY_ID),
                                 options.get(OSS_ACCESS_KEY_SECRET))
                         : builder.build(
-                                options.get(OSS_ENDPOINT),
+                                endpoint,
                                 options.get(OSS_ACCESS_KEY_ID),
                                 options.get(OSS_ACCESS_KEY_SECRET),
                                 securityToken));

--- a/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
+++ b/paimon-filesystems/paimon-jindo/src/main/java/org/apache/paimon/jindo/JindoFileIO.java
@@ -73,6 +73,7 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
     private static final String OSS_ACCESS_KEY_ID = "fs.oss.accessKeyId";
     private static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
+    private static final String OSS_REGION = "fs.oss.region";
     private static final String OSS_USER_AGENT_EXTENDED = "fs.oss.user.agent.extended";
     private static final String DLF_ACCESS_TRACKING_EXTENDED_INFO =
             "dlf.access-tracking.extended-info";
@@ -231,17 +232,23 @@ public class JindoFileIO extends HadoopCompliantFileIO implements HadoopOptionsP
         }
         String securityToken = options.get(OSS_SECURITY_TOKEN);
         OSSClientBuilder builder = new OSSClientBuilder();
-        return (OSSClient)
-                (StringUtils.isNullOrWhitespaceOnly(securityToken)
-                        ? builder.build(
-                                endpoint,
-                                options.get(OSS_ACCESS_KEY_ID),
-                                options.get(OSS_ACCESS_KEY_SECRET))
-                        : builder.build(
-                                endpoint,
-                                options.get(OSS_ACCESS_KEY_ID),
-                                options.get(OSS_ACCESS_KEY_SECRET),
-                                securityToken));
+        OSSClient client =
+                (OSSClient)
+                        (StringUtils.isNullOrWhitespaceOnly(securityToken)
+                                ? builder.build(
+                                        endpoint,
+                                        options.get(OSS_ACCESS_KEY_ID),
+                                        options.get(OSS_ACCESS_KEY_SECRET))
+                                : builder.build(
+                                        endpoint,
+                                        options.get(OSS_ACCESS_KEY_ID),
+                                        options.get(OSS_ACCESS_KEY_SECRET),
+                                        securityToken));
+        String region = options.get(OSS_REGION);
+        if (!StringUtils.isNullOrWhitespaceOnly(region)) {
+            client.setRegion(region);
+        }
+        return client;
     }
 
     @Override

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.jindo;
+
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.options.Options;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link JindoFileIO}. */
+public class JindoFileIOTest {
+
+    @Test
+    public void testCreateBlobPresignedUrlDelegates() throws Exception {
+        TestingFileIO delegate = new TestingFileIO();
+        JindoFileIO fileIO = new JindoFileIO(delegate);
+        CatalogContext context = CatalogContext.create(new Options());
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data/file", 10, 20);
+        Duration validity = Duration.ofHours(1);
+
+        fileIO.configure(context);
+
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity))
+                .isEqualTo("https://bucket.oss.example/blob.jpg");
+        assertThat(delegate.context).isSameAs(context);
+        assertThat(delegate.tableRoot).isEqualTo(tableRoot);
+        assertThat(delegate.descriptor).isEqualTo(descriptor);
+        assertThat(delegate.extension).isEqualTo("jpg");
+        assertThat(delegate.validity).isEqualTo(validity);
+    }
+
+    private static class TestingFileIO extends LocalFileIO {
+
+        private CatalogContext context;
+        private Path tableRoot;
+        private BlobDescriptor descriptor;
+        private String extension;
+        private Duration validity;
+
+        @Override
+        public void configure(CatalogContext context) {
+            this.context = context;
+        }
+
+        @Override
+        public String createBlobPresignedUrl(
+                Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+                throws IOException {
+            this.tableRoot = tableRoot;
+            this.descriptor = descriptor;
+            this.extension = extension;
+            this.validity = validity;
+            return "https://bucket.oss.example/blob.jpg";
+        }
+    }
+}

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -18,64 +18,86 @@
 
 package org.apache.paimon.jindo;
 
-import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.Path;
-import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.options.Options;
 
+import com.aliyun.oss.HttpMethod;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.model.ObjectMetadata;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.security.MessageDigest;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link JindoFileIO}. */
 public class JindoFileIOTest {
 
     @Test
-    public void testCreateBlobPresignedUrlDelegates() throws Exception {
-        TestingFileIO delegate = new TestingFileIO();
-        JindoFileIO fileIO = new JindoFileIO(delegate);
-        CatalogContext context = CatalogContext.create(new Options());
-        Path tableRoot = new Path("oss://bucket/table");
-        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data/file", 10, 20);
-        Duration validity = Duration.ofHours(1);
+    public void testCreateBlobClientUsesConfiguredSts() {
+        Options options = new Options();
+        options.set("fs.oss.endpoint", "https://oss.example.com");
+        options.set("fs.oss.accessKeyId", "access-key");
+        options.set("fs.oss.accessKeySecret", "access-secret");
+        options.set("fs.oss.securityToken", "security-token");
 
-        fileIO.configure(context);
-
-        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", validity))
-                .isEqualTo("https://bucket.oss.example/blob.jpg");
-        assertThat(delegate.context).isSameAs(context);
-        assertThat(delegate.tableRoot).isEqualTo(tableRoot);
-        assertThat(delegate.descriptor).isEqualTo(descriptor);
-        assertThat(delegate.extension).isEqualTo("jpg");
-        assertThat(delegate.validity).isEqualTo(validity);
+        OSSClient client = JindoFileIO.createBlobClient(options);
+        try {
+            assertThat(client.getEndpoint()).isEqualTo(URI.create("https://oss.example.com"));
+            assertThat(client.getCredentialsProvider().getCredentials().getAccessKeyId())
+                    .isEqualTo("access-key");
+            assertThat(client.getCredentialsProvider().getCredentials().getSecretAccessKey())
+                    .isEqualTo("access-secret");
+            assertThat(client.getCredentialsProvider().getCredentials().getSecurityToken())
+                    .isEqualTo("security-token");
+        } finally {
+            client.shutdown();
+        }
     }
 
-    private static class TestingFileIO extends LocalFileIO {
+    @Test
+    public void testCreateBlobPresignedUrlUsesOssClient() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data/file", 10, 20);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(20);
+        metadata.setContentType("image/jpeg");
+        metadata.addUserMetadata(
+                "paimon-blob-descriptor-sha256", sha256Hex(descriptor.serialize()));
+        when(client.headObject(eq("bucket"), contains("_bloburl_"))).thenReturn(metadata);
+        when(client.getEndpoint()).thenReturn(URI.create("https://oss.example.com"));
+        when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
+                .thenAnswer(
+                        invocation ->
+                                new URL(
+                                        "https://bucket.oss.example.com/"
+                                                + invocation.getArgument(1)));
 
-        private CatalogContext context;
-        private Path tableRoot;
-        private BlobDescriptor descriptor;
-        private String extension;
-        private Duration validity;
+        JindoFileIO fileIO = new JindoFileIO(client);
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", Duration.ofHours(1)))
+                .startsWith("https://bucket.oss.example.com/table/data/_bloburl_");
 
-        @Override
-        public void configure(CatalogContext context) {
-            this.context = context;
+        fileIO.close();
+        verify(client).shutdown();
+    }
+
+    private static String sha256Hex(byte[] bytes) throws Exception {
+        StringBuilder result = new StringBuilder();
+        for (byte value : MessageDigest.getInstance("SHA-256").digest(bytes)) {
+            result.append(String.format("%02x", value & 0xff));
         }
-
-        @Override
-        public String createBlobPresignedUrl(
-                Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-                throws IOException {
-            this.tableRoot = tableRoot;
-            this.descriptor = descriptor;
-            this.extension = extension;
-            this.validity = validity;
-            return "https://bucket.oss.example/blob.jpg";
-        }
+        return result.toString();
     }
 }

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -48,6 +48,7 @@ public class JindoFileIOTest {
     public void testCreateBlobClientUsesConfiguredSts() {
         Options options = new Options();
         options.set("fs.oss.endpoint", "oss.example.com");
+        options.set("fs.oss.region", "cn-hangzhou");
         options.set("fs.oss.accessKeyId", "access-key");
         options.set("fs.oss.accessKeySecret", "access-secret");
         options.set("fs.oss.securityToken", "security-token");
@@ -55,6 +56,7 @@ public class JindoFileIOTest {
         OSSClient client = JindoFileIO.createBlobClient(options);
         try {
             assertThat(client.getEndpoint()).isEqualTo(URI.create("https://oss.example.com"));
+            assertThat(client.getObjectOperation().getRegion()).isEqualTo("cn-hangzhou");
             assertThat(client.getCredentialsProvider().getCredentials().getAccessKeyId())
                     .isEqualTo("access-key");
             assertThat(client.getCredentialsProvider().getCredentials().getSecretAccessKey())

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -47,7 +47,7 @@ public class JindoFileIOTest {
     @Test
     public void testCreateBlobClientUsesConfiguredSts() {
         Options options = new Options();
-        options.set("fs.oss.endpoint", "https://oss.example.com");
+        options.set("fs.oss.endpoint", "oss.example.com");
         options.set("fs.oss.accessKeyId", "access-key");
         options.set("fs.oss.accessKeySecret", "access-secret");
         options.set("fs.oss.securityToken", "security-token");

--- a/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
+++ b/paimon-filesystems/paimon-jindo/src/test/java/org/apache/paimon/jindo/JindoFileIOTest.java
@@ -73,7 +73,7 @@ public class JindoFileIOTest {
         BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data/file", 10, 20);
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(20);
-        metadata.setContentType("image/jpeg");
+        metadata.setContentType("application/octet-stream");
         metadata.addUserMetadata(
                 "paimon-blob-descriptor-sha256", sha256Hex(descriptor.serialize()));
         when(client.headObject(eq("bucket"), contains("_bloburl_"))).thenReturn(metadata);
@@ -86,7 +86,7 @@ public class JindoFileIOTest {
                                                 + invocation.getArgument(1)));
 
         JindoFileIO fileIO = new JindoFileIO(client);
-        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "jpg", Duration.ofHours(1)))
+        assertThat(fileIO.createBlobPresignedUrl(tableRoot, descriptor, Duration.ofHours(1)))
                 .startsWith("https://bucket.oss.example.com/table/data/_bloburl_");
 
         fileIO.close();

--- a/paimon-filesystems/paimon-oss-impl/pom.xml
+++ b/paimon-filesystems/paimon-oss-impl/pom.xml
@@ -94,6 +94,13 @@
             <!-- packaged as an optional dependency that is only accessible on Java 11+ -->
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/paimon-filesystems/paimon-oss-impl/pom.xml
+++ b/paimon-filesystems/paimon-oss-impl/pom.xml
@@ -32,7 +32,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <fs.oss.sdk.version>3.13.2</fs.oss.sdk.version>
+        <fs.oss.sdk.version>3.17.4</fs.oss.sdk.version>
     </properties>
 
     <dependencies>

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.oss;
+
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.BlobDescriptorUtils;
+
+import com.aliyun.oss.HttpMethod;
+import com.aliyun.oss.OSSClient;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
+import com.aliyun.oss.model.UploadPartCopyRequest;
+import com.aliyun.oss.model.UploadPartCopyResult;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+/** Materializes blob ranges and creates OSS presigned URLs. */
+public final class OSSBlobPresigner {
+
+    private static final String BLOB_FINGERPRINT_METADATA = "paimon-blob-descriptor-sha256";
+    private static final long BLOB_COPY_MIN_PART_SIZE = 100L * 1024 * 1024;
+    private static final long MAX_MULTIPART_UPLOAD_PARTS = 10_000;
+    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+
+    private OSSBlobPresigner() {}
+
+    public static String create(
+            OSSClient client,
+            Path tableRoot,
+            BlobDescriptor descriptor,
+            String extension,
+            Duration validity)
+            throws IOException {
+        BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
+        if (validity == null
+                || validity.isZero()
+                || validity.isNegative()
+                || validity.getNano() != 0) {
+            throw new IOException("Blob presigned URL validity must be positive whole seconds.");
+        }
+
+        String normalizedExtension = normalizeExtension(extension);
+        String contentType = contentType(normalizedExtension);
+        try {
+            URI source = new Path(descriptor.uri()).toUri();
+            String bucket = source.getAuthority();
+            String sourceKey = objectKey(source);
+            String fingerprint = sha256Hex(descriptor.serialize());
+            int parentEnd = sourceKey.lastIndexOf('/') + 1;
+            String targetKey =
+                    sourceKey.substring(0, parentEnd)
+                            + "_bloburl_"
+                            + fingerprint
+                            + "."
+                            + normalizedExtension;
+
+            ObjectMetadata target = headObjectIfExists(client, bucket, targetKey);
+            if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+                ObjectMetadata sourceMetadata = client.headObject(bucket, sourceKey);
+                validateRange(descriptor, sourceMetadata.getContentLength());
+                materialize(
+                        client, bucket, sourceKey, targetKey, descriptor, contentType, fingerprint);
+                target = client.headObject(bucket, targetKey);
+                if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+                    throw new IOException(
+                            "Materialized blob object metadata does not match descriptor.");
+                }
+            }
+
+            URL url =
+                    client.generatePresignedUrl(
+                            bucket,
+                            targetKey,
+                            Date.from(Instant.now().plus(validity)),
+                            HttpMethod.GET);
+            validatePresignedUrl(client, url, bucket, targetKey);
+            return url.toString();
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to create blob presigned URL.", e);
+        }
+    }
+
+    private static void materialize(
+            OSSClient client,
+            String bucket,
+            String sourceKey,
+            String targetKey,
+            BlobDescriptor descriptor,
+            String contentType,
+            String fingerprint)
+            throws Exception {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.addUserMetadata(BLOB_FINGERPRINT_METADATA, fingerprint);
+        if (descriptor.length() == 0) {
+            metadata.setContentLength(0);
+            client.putObject(bucket, targetKey, new ByteArrayInputStream(new byte[0]), metadata);
+            return;
+        }
+
+        String uploadId = null;
+        try {
+            InitiateMultipartUploadResult initiated =
+                    client.initiateMultipartUpload(
+                            new InitiateMultipartUploadRequest(bucket, targetKey, metadata));
+            uploadId = initiated.getUploadId();
+            long partSize =
+                    Math.max(
+                            BLOB_COPY_MIN_PART_SIZE,
+                            descriptor.length() / MAX_MULTIPART_UPLOAD_PARTS + 1);
+            List<PartETag> parts = new ArrayList<>();
+            long copied = 0;
+            int partNumber = 1;
+            while (copied < descriptor.length()) {
+                long size = Math.min(partSize, descriptor.length() - copied);
+                UploadPartCopyResult result =
+                        client.uploadPartCopy(
+                                new UploadPartCopyRequest(
+                                        bucket,
+                                        sourceKey,
+                                        bucket,
+                                        targetKey,
+                                        uploadId,
+                                        partNumber,
+                                        descriptor.offset() + copied,
+                                        size));
+                parts.add(new PartETag(partNumber, result.getETag()));
+                copied += size;
+                partNumber++;
+            }
+            client.completeMultipartUpload(
+                    new CompleteMultipartUploadRequest(bucket, targetKey, uploadId, parts));
+            uploadId = null;
+        } catch (Exception e) {
+            if (uploadId != null) {
+                try {
+                    client.abortMultipartUpload(
+                            new AbortMultipartUploadRequest(bucket, targetKey, uploadId));
+                } catch (Exception abortException) {
+                    e.addSuppressed(abortException);
+                }
+            }
+            throw e;
+        }
+    }
+
+    private static ObjectMetadata headObjectIfExists(OSSClient client, String bucket, String key) {
+        try {
+            return client.headObject(bucket, key);
+        } catch (OSSException e) {
+            if ("NoSuchKey".equals(e.getErrorCode()) || "NoSuchObject".equals(e.getErrorCode())) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private static boolean matches(
+            ObjectMetadata metadata, long length, String contentType, String fingerprint) {
+        return metadata != null
+                && metadata.getContentLength() == length
+                && contentType.equals(metadata.getContentType())
+                && fingerprint.equals(metadata.getUserMetadata().get(BLOB_FINGERPRINT_METADATA));
+    }
+
+    private static void validateRange(BlobDescriptor descriptor, long sourceLength)
+            throws IOException {
+        if (descriptor.offset() < 0
+                || descriptor.length() < 0
+                || descriptor.offset() > sourceLength
+                || descriptor.length() > sourceLength - descriptor.offset()) {
+            throw new IOException("Blob descriptor range is outside the source object.");
+        }
+    }
+
+    private static String normalizeExtension(String extension) throws IOException {
+        if (extension == null || extension.isEmpty()) {
+            throw new IOException("Blob file extension must contain only ASCII letters or digits.");
+        }
+        for (int i = 0; i < extension.length(); i++) {
+            char c = extension.charAt(i);
+            if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9')) {
+                throw new IOException(
+                        "Blob file extension must contain only ASCII letters or digits.");
+            }
+        }
+        return extension.toLowerCase(Locale.ROOT);
+    }
+
+    private static String contentType(String extension) throws IOException {
+        String contentType = URLConnection.guessContentTypeFromName("file." + extension);
+        if (contentType == null || "application/octet-stream".equals(contentType)) {
+            throw new IOException("Unknown MIME type for blob file extension: " + extension);
+        }
+        return contentType;
+    }
+
+    private static String objectKey(URI uri) throws IOException {
+        String path = uri.getPath();
+        if (path == null || !path.startsWith("/") || path.length() == 1) {
+            throw new IOException("Blob descriptor URI must contain an OSS object key.");
+        }
+        return path.substring(1);
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(bytes);
+            char[] chars = new char[hash.length * 2];
+            for (int i = 0; i < hash.length; i++) {
+                chars[i * 2] = HEX_CHARS[(hash[i] >> 4) & 0x0f];
+                chars[i * 2 + 1] = HEX_CHARS[hash[i] & 0x0f];
+            }
+            return new String(chars);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available.", e);
+        }
+    }
+
+    private static void validatePresignedUrl(
+            OSSClient client, URL url, String bucket, String targetKey) throws Exception {
+        URI endpoint = client.getEndpoint();
+        String expectedHost = bucket + "." + endpoint.getHost();
+        if (!"https".equalsIgnoreCase(endpoint.getScheme())
+                || !"https".equalsIgnoreCase(url.getProtocol())
+                || !expectedHost.equalsIgnoreCase(url.getHost())
+                || !("/" + targetKey).equals(url.toURI().getPath())) {
+            throw new IOException("OSS client generated a presigned URL for an invalid target.");
+        }
+    }
+}

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
@@ -38,7 +38,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLConnection;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -52,6 +51,7 @@ import java.util.Locale;
 public final class OSSBlobPresigner {
 
     private static final String BLOB_FINGERPRINT_METADATA = "paimon-blob-descriptor-sha256";
+    private static final String BLOB_CONTENT_TYPE = "application/octet-stream";
     private static final String OSS_INTERNAL_ENDPOINT_SUFFIX = "-internal.aliyuncs.com";
     private static final long BLOB_COPY_MIN_PART_SIZE = 100L * 1024 * 1024;
     private static final long MAX_MULTIPART_UPLOAD_PARTS = 10_000;
@@ -60,11 +60,7 @@ public final class OSSBlobPresigner {
     private OSSBlobPresigner() {}
 
     public static String create(
-            OSSClient client,
-            Path tableRoot,
-            BlobDescriptor descriptor,
-            String extension,
-            Duration validity)
+            OSSClient client, Path tableRoot, BlobDescriptor descriptor, Duration validity)
             throws IOException {
         BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
         if (validity == null
@@ -74,29 +70,21 @@ public final class OSSBlobPresigner {
             throw new IOException("Blob presigned URL validity must be positive whole seconds.");
         }
 
-        String normalizedExtension = normalizeExtension(extension);
-        String contentType = contentType(normalizedExtension);
         try {
             URI source = new Path(descriptor.uri()).toUri();
             String bucket = source.getAuthority();
             String sourceKey = objectKey(source);
             String fingerprint = sha256Hex(descriptor.serialize());
             int parentEnd = sourceKey.lastIndexOf('/') + 1;
-            String targetKey =
-                    sourceKey.substring(0, parentEnd)
-                            + "_bloburl_"
-                            + fingerprint
-                            + "."
-                            + normalizedExtension;
+            String targetKey = sourceKey.substring(0, parentEnd) + "_bloburl_" + fingerprint;
 
             ObjectMetadata target = headObjectIfExists(client, bucket, targetKey);
-            if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+            if (!matches(target, descriptor.length(), fingerprint)) {
                 ObjectMetadata sourceMetadata = client.headObject(bucket, sourceKey);
                 validateRange(descriptor, sourceMetadata.getContentLength());
-                materialize(
-                        client, bucket, sourceKey, targetKey, descriptor, contentType, fingerprint);
+                materialize(client, bucket, sourceKey, targetKey, descriptor, fingerprint);
                 target = client.headObject(bucket, targetKey);
-                if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+                if (!matches(target, descriptor.length(), fingerprint)) {
                     throw new IOException(
                             "Materialized blob object metadata does not match descriptor.");
                 }
@@ -124,11 +112,10 @@ public final class OSSBlobPresigner {
             String sourceKey,
             String targetKey,
             BlobDescriptor descriptor,
-            String contentType,
             String fingerprint)
             throws Exception {
         ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(contentType);
+        metadata.setContentType(BLOB_CONTENT_TYPE);
         metadata.addUserMetadata(BLOB_FINGERPRINT_METADATA, fingerprint);
         if (descriptor.length() == 0) {
             metadata.setContentLength(0);
@@ -193,11 +180,10 @@ public final class OSSBlobPresigner {
         }
     }
 
-    private static boolean matches(
-            ObjectMetadata metadata, long length, String contentType, String fingerprint) {
+    private static boolean matches(ObjectMetadata metadata, long length, String fingerprint) {
         return metadata != null
                 && metadata.getContentLength() == length
-                && contentType.equals(metadata.getContentType())
+                && BLOB_CONTENT_TYPE.equals(metadata.getContentType())
                 && fingerprint.equals(metadata.getUserMetadata().get(BLOB_FINGERPRINT_METADATA));
     }
 
@@ -209,28 +195,6 @@ public final class OSSBlobPresigner {
                 || descriptor.length() > sourceLength - descriptor.offset()) {
             throw new IOException("Blob descriptor range is outside the source object.");
         }
-    }
-
-    private static String normalizeExtension(String extension) throws IOException {
-        if (extension == null || extension.isEmpty()) {
-            throw new IOException("Blob file extension must contain only ASCII letters or digits.");
-        }
-        for (int i = 0; i < extension.length(); i++) {
-            char c = extension.charAt(i);
-            if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9')) {
-                throw new IOException(
-                        "Blob file extension must contain only ASCII letters or digits.");
-            }
-        }
-        return extension.toLowerCase(Locale.ROOT);
-    }
-
-    private static String contentType(String extension) throws IOException {
-        String contentType = URLConnection.guessContentTypeFromName("file." + extension);
-        if (contentType == null || "application/octet-stream".equals(contentType)) {
-            throw new IOException("Unknown MIME type for blob file extension: " + extension);
-        }
-        return contentType;
     }
 
     private static String objectKey(URI uri) throws IOException {

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSBlobPresigner.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 public final class OSSBlobPresigner {
 
     private static final String BLOB_FINGERPRINT_METADATA = "paimon-blob-descriptor-sha256";
+    private static final String OSS_INTERNAL_ENDPOINT_SUFFIX = "-internal.aliyuncs.com";
     private static final long BLOB_COPY_MIN_PART_SIZE = 100L * 1024 * 1024;
     private static final long MAX_MULTIPART_UPLOAD_PARTS = 10_000;
     private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
@@ -107,6 +108,7 @@ public final class OSSBlobPresigner {
                             targetKey,
                             Date.from(Instant.now().plus(validity)),
                             HttpMethod.GET);
+            url = usePublicEndpoint(url);
             validatePresignedUrl(client, url, bucket, targetKey);
             return url.toString();
         } catch (IOException e) {
@@ -256,12 +258,32 @@ public final class OSSBlobPresigner {
     private static void validatePresignedUrl(
             OSSClient client, URL url, String bucket, String targetKey) throws Exception {
         URI endpoint = client.getEndpoint();
-        String expectedHost = bucket + "." + endpoint.getHost();
+        String expectedHost = publicEndpointHost(bucket + "." + endpoint.getHost());
         if (!"https".equalsIgnoreCase(endpoint.getScheme())
                 || !"https".equalsIgnoreCase(url.getProtocol())
                 || !expectedHost.equalsIgnoreCase(url.getHost())
                 || !("/" + targetKey).equals(url.toURI().getPath())) {
             throw new IOException("OSS client generated a presigned URL for an invalid target.");
         }
+    }
+
+    private static URL usePublicEndpoint(URL url) throws IOException {
+        String publicHost = publicEndpointHost(url.getHost());
+        if (publicHost.equals(url.getHost())) {
+            return url;
+        }
+        String file = url.getFile();
+        if (url.getRef() != null) {
+            file += "#" + url.getRef();
+        }
+        return new URL(url.getProtocol(), publicHost, url.getPort(), file);
+    }
+
+    private static String publicEndpointHost(String host) {
+        if (!host.toLowerCase(Locale.ROOT).endsWith(OSS_INTERNAL_ENDPOINT_SUFFIX)) {
+            return host;
+        }
+        return host.substring(0, host.length() - OSS_INTERNAL_ENDPOINT_SUFFIX.length())
+                + ".aliyuncs.com";
     }
 }

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -25,13 +25,11 @@ import org.apache.paimon.fs.HadoopOptionsProvider;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.options.Options;
-import org.apache.paimon.utils.BlobDescriptorUtils;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.ReflectionUtils;
 import org.apache.paimon.utils.SensitiveConfigUtils;
 import org.apache.paimon.utils.StringUtils;
 
-import com.aliyun.oss.HttpMethod;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSException;
 import com.aliyun.oss.common.auth.CredentialsProvider;
@@ -39,23 +37,17 @@ import com.aliyun.oss.common.comm.ServiceClient;
 import com.aliyun.oss.internal.OSSHeaders;
 import com.aliyun.oss.internal.OSSMultipartOperation;
 import com.aliyun.oss.internal.OSSObjectOperation;
-import com.aliyun.oss.model.AbortMultipartUploadRequest;
-import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
 import com.aliyun.oss.model.CopyObjectResult;
 import com.aliyun.oss.model.InitiateMultipartUploadRequest;
 import com.aliyun.oss.model.InitiateMultipartUploadResult;
 import com.aliyun.oss.model.ObjectMetadata;
-import com.aliyun.oss.model.PartETag;
 import com.aliyun.oss.model.PutObjectRequest;
 import com.aliyun.oss.model.PutObjectResult;
-import com.aliyun.oss.model.UploadPartCopyRequest;
-import com.aliyun.oss.model.UploadPartCopyResult;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystemStore;
-import org.apache.hadoop.fs.aliyun.oss.AliyunOSSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,18 +55,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -100,9 +83,6 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     private static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
     private static final String OSS_SECOND_LEVEL_DOMAIN_ENABLED = "fs.oss.sld.enabled";
-    private static final String BLOB_FINGERPRINT_METADATA = "paimon-blob-descriptor-sha256";
-    private static final long BLOB_COPY_MIN_PART_SIZE = 100L * 1024 * 1024;
-    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
     // Paimon OSS SSE keys, mapping 1:1 to the OSS headers; they take precedence over hadoop's
     // server-side-encryption-algorithm.
     /** SSE method -> x-oss-server-side-encryption (AES256 / KMS / SM4). */
@@ -281,202 +261,17 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     public String createBlobPresignedUrl(
             Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
             throws IOException {
-        BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
-        if (validity == null
-                || validity.isZero()
-                || validity.isNegative()
-                || validity.getNano() != 0) {
-            throw new IOException("Blob presigned URL validity must be positive whole seconds.");
-        }
-
-        String normalizedExtension = normalizeExtension(extension);
-        String contentType = contentType(normalizedExtension);
         try {
-            URI source = new Path(descriptor.uri()).toUri();
-            String bucket = source.getAuthority();
-            String sourceKey = objectKey(source);
-            String fingerprint = sha256Hex(descriptor.serialize());
-            int parentEnd = sourceKey.lastIndexOf('/') + 1;
-            String targetKey =
-                    sourceKey.substring(0, parentEnd)
-                            + "_bloburl_"
-                            + fingerprint
-                            + "."
-                            + normalizedExtension;
-            OSSClient client = ossClient(new Path(descriptor.uri()));
-
-            ObjectMetadata target = headObjectIfExists(client, bucket, targetKey);
-            if (!matches(target, descriptor.length(), contentType, fingerprint)) {
-                ObjectMetadata sourceMetadata = client.headObject(bucket, sourceKey);
-                validateRange(descriptor, sourceMetadata.getContentLength());
-                materialize(
-                        client, bucket, sourceKey, targetKey, descriptor, contentType, fingerprint);
-                target = client.headObject(bucket, targetKey);
-                if (!matches(target, descriptor.length(), contentType, fingerprint)) {
-                    throw new IOException(
-                            "Materialized blob object metadata does not match descriptor.");
-                }
-            }
-
-            URL url =
-                    client.generatePresignedUrl(
-                            bucket,
-                            targetKey,
-                            Date.from(Instant.now().plus(validity)),
-                            HttpMethod.GET);
-            validatePresignedUrl(client, url, bucket, targetKey);
-            return url.toString();
+            return OSSBlobPresigner.create(
+                    ossClient(new Path(descriptor.uri())),
+                    tableRoot,
+                    descriptor,
+                    extension,
+                    validity);
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {
             throw new IOException("Failed to create blob presigned URL.", e);
-        }
-    }
-
-    private static void materialize(
-            OSSClient client,
-            String bucket,
-            String sourceKey,
-            String targetKey,
-            BlobDescriptor descriptor,
-            String contentType,
-            String fingerprint)
-            throws Exception {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType(contentType);
-        metadata.addUserMetadata(BLOB_FINGERPRINT_METADATA, fingerprint);
-        if (descriptor.length() == 0) {
-            metadata.setContentLength(0);
-            client.putObject(bucket, targetKey, new ByteArrayInputStream(new byte[0]), metadata);
-            return;
-        }
-
-        String uploadId = null;
-        try {
-            InitiateMultipartUploadResult initiated =
-                    client.initiateMultipartUpload(
-                            new InitiateMultipartUploadRequest(bucket, targetKey, metadata));
-            uploadId = initiated.getUploadId();
-            long partSize =
-                    AliyunOSSUtils.calculatePartSize(descriptor.length(), BLOB_COPY_MIN_PART_SIZE);
-            List<PartETag> parts = new ArrayList<>();
-            long copied = 0;
-            int partNumber = 1;
-            while (copied < descriptor.length()) {
-                long size = Math.min(partSize, descriptor.length() - copied);
-                UploadPartCopyResult result =
-                        client.uploadPartCopy(
-                                new UploadPartCopyRequest(
-                                        bucket,
-                                        sourceKey,
-                                        bucket,
-                                        targetKey,
-                                        uploadId,
-                                        partNumber,
-                                        descriptor.offset() + copied,
-                                        size));
-                parts.add(new PartETag(partNumber, result.getETag()));
-                copied += size;
-                partNumber++;
-            }
-            client.completeMultipartUpload(
-                    new CompleteMultipartUploadRequest(bucket, targetKey, uploadId, parts));
-            uploadId = null;
-        } catch (Exception e) {
-            if (uploadId != null) {
-                try {
-                    client.abortMultipartUpload(
-                            new AbortMultipartUploadRequest(bucket, targetKey, uploadId));
-                } catch (Exception abortException) {
-                    e.addSuppressed(abortException);
-                }
-            }
-            throw e;
-        }
-    }
-
-    private static ObjectMetadata headObjectIfExists(OSSClient client, String bucket, String key) {
-        try {
-            return client.headObject(bucket, key);
-        } catch (OSSException e) {
-            if ("NoSuchKey".equals(e.getErrorCode()) || "NoSuchObject".equals(e.getErrorCode())) {
-                return null;
-            }
-            throw e;
-        }
-    }
-
-    private static boolean matches(
-            ObjectMetadata metadata, long length, String contentType, String fingerprint) {
-        return metadata != null
-                && metadata.getContentLength() == length
-                && contentType.equals(metadata.getContentType())
-                && fingerprint.equals(metadata.getUserMetadata().get(BLOB_FINGERPRINT_METADATA));
-    }
-
-    private static void validateRange(BlobDescriptor descriptor, long sourceLength)
-            throws IOException {
-        if (descriptor.offset() < 0
-                || descriptor.length() < 0
-                || descriptor.offset() > sourceLength
-                || descriptor.length() > sourceLength - descriptor.offset()) {
-            throw new IOException("Blob descriptor range is outside the source object.");
-        }
-    }
-
-    private static String normalizeExtension(String extension) throws IOException {
-        if (extension == null || extension.isEmpty()) {
-            throw new IOException("Blob file extension must contain only ASCII letters or digits.");
-        }
-        for (int i = 0; i < extension.length(); i++) {
-            char c = extension.charAt(i);
-            if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9')) {
-                throw new IOException(
-                        "Blob file extension must contain only ASCII letters or digits.");
-            }
-        }
-        return extension.toLowerCase(Locale.ROOT);
-    }
-
-    private static String contentType(String extension) throws IOException {
-        String contentType = URLConnection.guessContentTypeFromName("file." + extension);
-        if (contentType == null || "application/octet-stream".equals(contentType)) {
-            throw new IOException("Unknown MIME type for blob file extension: " + extension);
-        }
-        return contentType;
-    }
-
-    private static String objectKey(URI uri) throws IOException {
-        String path = uri.getPath();
-        if (path == null || !path.startsWith("/") || path.length() == 1) {
-            throw new IOException("Blob descriptor URI must contain an OSS object key.");
-        }
-        return path.substring(1);
-    }
-
-    private static String sha256Hex(byte[] bytes) {
-        try {
-            byte[] hash = MessageDigest.getInstance("SHA-256").digest(bytes);
-            char[] chars = new char[hash.length * 2];
-            for (int i = 0; i < hash.length; i++) {
-                chars[i * 2] = HEX_CHARS[(hash[i] >> 4) & 0x0f];
-                chars[i * 2 + 1] = HEX_CHARS[hash[i] & 0x0f];
-            }
-            return new String(chars);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 not available.", e);
-        }
-    }
-
-    private static void validatePresignedUrl(
-            OSSClient client, URL url, String bucket, String targetKey) throws Exception {
-        URI endpoint = client.getEndpoint();
-        String expectedHost = bucket + "." + endpoint.getHost();
-        if (!"https".equalsIgnoreCase(endpoint.getScheme())
-                || !"https".equalsIgnoreCase(url.getProtocol())
-                || !expectedHost.equalsIgnoreCase(url.getHost())
-                || !("/" + targetKey).equals(url.toURI().getPath())) {
-            throw new IOException("OSS client generated a presigned URL for an invalid target.");
         }
     }
 

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -19,16 +19,19 @@
 package org.apache.paimon.oss;
 
 import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.data.BlobDescriptor;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.HadoopOptionsProvider;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.TwoPhaseOutputStream;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.utils.BlobDescriptorUtils;
 import org.apache.paimon.utils.IOUtils;
 import org.apache.paimon.utils.ReflectionUtils;
 import org.apache.paimon.utils.SensitiveConfigUtils;
 import org.apache.paimon.utils.StringUtils;
 
+import com.aliyun.oss.HttpMethod;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSException;
 import com.aliyun.oss.common.auth.CredentialsProvider;
@@ -36,17 +39,23 @@ import com.aliyun.oss.common.comm.ServiceClient;
 import com.aliyun.oss.internal.OSSHeaders;
 import com.aliyun.oss.internal.OSSMultipartOperation;
 import com.aliyun.oss.internal.OSSObjectOperation;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
 import com.aliyun.oss.model.CopyObjectResult;
 import com.aliyun.oss.model.InitiateMultipartUploadRequest;
 import com.aliyun.oss.model.InitiateMultipartUploadResult;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
 import com.aliyun.oss.model.PutObjectRequest;
 import com.aliyun.oss.model.PutObjectResult;
+import com.aliyun.oss.model.UploadPartCopyRequest;
+import com.aliyun.oss.model.UploadPartCopyResult;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem;
 import org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystemStore;
+import org.apache.hadoop.fs.aliyun.oss.AliyunOSSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +63,18 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,6 +100,9 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
     private static final String OSS_ACCESS_KEY_SECRET = "fs.oss.accessKeySecret";
     private static final String OSS_SECURITY_TOKEN = "fs.oss.securityToken";
     private static final String OSS_SECOND_LEVEL_DOMAIN_ENABLED = "fs.oss.sld.enabled";
+    private static final String BLOB_FINGERPRINT_METADATA = "paimon-blob-descriptor-sha256";
+    private static final long BLOB_COPY_MIN_PART_SIZE = 100L * 1024 * 1024;
+    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
     // Paimon OSS SSE keys, mapping 1:1 to the OSS headers; they take precedence over hadoop's
     // server-side-encryption-algorithm.
     /** SSE method -> x-oss-server-side-encryption (AES256 / KMS / SM4). */
@@ -253,6 +275,213 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
         } catch (Exception e) {
             throw new IOException("Failed to atomic write " + path, e);
         }
+    }
+
+    @Override
+    public String createBlobPresignedUrl(
+            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+            throws IOException {
+        BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
+        if (validity == null
+                || validity.isZero()
+                || validity.isNegative()
+                || validity.getNano() != 0) {
+            throw new IOException("Blob presigned URL validity must be positive whole seconds.");
+        }
+
+        String normalizedExtension = normalizeExtension(extension);
+        String contentType = contentType(normalizedExtension);
+        try {
+            URI source = new Path(descriptor.uri()).toUri();
+            String bucket = source.getAuthority();
+            String sourceKey = objectKey(source);
+            String fingerprint = sha256Hex(descriptor.serialize());
+            int parentEnd = sourceKey.lastIndexOf('/') + 1;
+            String targetKey =
+                    sourceKey.substring(0, parentEnd)
+                            + "_bloburl_"
+                            + fingerprint
+                            + "."
+                            + normalizedExtension;
+            OSSClient client = ossClient(new Path(descriptor.uri()));
+
+            ObjectMetadata target = headObjectIfExists(client, bucket, targetKey);
+            if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+                ObjectMetadata sourceMetadata = client.headObject(bucket, sourceKey);
+                validateRange(descriptor, sourceMetadata.getContentLength());
+                materialize(
+                        client, bucket, sourceKey, targetKey, descriptor, contentType, fingerprint);
+                target = client.headObject(bucket, targetKey);
+                if (!matches(target, descriptor.length(), contentType, fingerprint)) {
+                    throw new IOException(
+                            "Materialized blob object metadata does not match descriptor.");
+                }
+            }
+
+            URL url =
+                    client.generatePresignedUrl(
+                            bucket,
+                            targetKey,
+                            Date.from(Instant.now().plus(validity)),
+                            HttpMethod.GET);
+            validatePresignedUrl(client, url, bucket, targetKey);
+            return url.toString();
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to create blob presigned URL.", e);
+        }
+    }
+
+    private static void materialize(
+            OSSClient client,
+            String bucket,
+            String sourceKey,
+            String targetKey,
+            BlobDescriptor descriptor,
+            String contentType,
+            String fingerprint)
+            throws Exception {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.addUserMetadata(BLOB_FINGERPRINT_METADATA, fingerprint);
+        if (descriptor.length() == 0) {
+            metadata.setContentLength(0);
+            client.putObject(bucket, targetKey, new ByteArrayInputStream(new byte[0]), metadata);
+            return;
+        }
+
+        String uploadId = null;
+        try {
+            InitiateMultipartUploadResult initiated =
+                    client.initiateMultipartUpload(
+                            new InitiateMultipartUploadRequest(bucket, targetKey, metadata));
+            uploadId = initiated.getUploadId();
+            long partSize =
+                    AliyunOSSUtils.calculatePartSize(descriptor.length(), BLOB_COPY_MIN_PART_SIZE);
+            List<PartETag> parts = new ArrayList<>();
+            long copied = 0;
+            int partNumber = 1;
+            while (copied < descriptor.length()) {
+                long size = Math.min(partSize, descriptor.length() - copied);
+                UploadPartCopyResult result =
+                        client.uploadPartCopy(
+                                new UploadPartCopyRequest(
+                                        bucket,
+                                        sourceKey,
+                                        bucket,
+                                        targetKey,
+                                        uploadId,
+                                        partNumber,
+                                        descriptor.offset() + copied,
+                                        size));
+                parts.add(new PartETag(partNumber, result.getETag()));
+                copied += size;
+                partNumber++;
+            }
+            client.completeMultipartUpload(
+                    new CompleteMultipartUploadRequest(bucket, targetKey, uploadId, parts));
+            uploadId = null;
+        } catch (Exception e) {
+            if (uploadId != null) {
+                try {
+                    client.abortMultipartUpload(
+                            new AbortMultipartUploadRequest(bucket, targetKey, uploadId));
+                } catch (Exception abortException) {
+                    e.addSuppressed(abortException);
+                }
+            }
+            throw e;
+        }
+    }
+
+    private static ObjectMetadata headObjectIfExists(OSSClient client, String bucket, String key) {
+        try {
+            return client.headObject(bucket, key);
+        } catch (OSSException e) {
+            if ("NoSuchKey".equals(e.getErrorCode()) || "NoSuchObject".equals(e.getErrorCode())) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private static boolean matches(
+            ObjectMetadata metadata, long length, String contentType, String fingerprint) {
+        return metadata != null
+                && metadata.getContentLength() == length
+                && contentType.equals(metadata.getContentType())
+                && fingerprint.equals(metadata.getUserMetadata().get(BLOB_FINGERPRINT_METADATA));
+    }
+
+    private static void validateRange(BlobDescriptor descriptor, long sourceLength)
+            throws IOException {
+        if (descriptor.offset() < 0
+                || descriptor.length() < 0
+                || descriptor.offset() > sourceLength
+                || descriptor.length() > sourceLength - descriptor.offset()) {
+            throw new IOException("Blob descriptor range is outside the source object.");
+        }
+    }
+
+    private static String normalizeExtension(String extension) throws IOException {
+        if (extension == null || extension.isEmpty()) {
+            throw new IOException("Blob file extension must contain only ASCII letters or digits.");
+        }
+        for (int i = 0; i < extension.length(); i++) {
+            char c = extension.charAt(i);
+            if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9')) {
+                throw new IOException(
+                        "Blob file extension must contain only ASCII letters or digits.");
+            }
+        }
+        return extension.toLowerCase(Locale.ROOT);
+    }
+
+    private static String contentType(String extension) throws IOException {
+        String contentType = URLConnection.guessContentTypeFromName("file." + extension);
+        if (contentType == null || "application/octet-stream".equals(contentType)) {
+            throw new IOException("Unknown MIME type for blob file extension: " + extension);
+        }
+        return contentType;
+    }
+
+    private static String objectKey(URI uri) throws IOException {
+        String path = uri.getPath();
+        if (path == null || !path.startsWith("/") || path.length() == 1) {
+            throw new IOException("Blob descriptor URI must contain an OSS object key.");
+        }
+        return path.substring(1);
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(bytes);
+            char[] chars = new char[hash.length * 2];
+            for (int i = 0; i < hash.length; i++) {
+                chars[i * 2] = HEX_CHARS[(hash[i] >> 4) & 0x0f];
+                chars[i * 2 + 1] = HEX_CHARS[hash[i] & 0x0f];
+            }
+            return new String(chars);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available.", e);
+        }
+    }
+
+    private static void validatePresignedUrl(
+            OSSClient client, URL url, String bucket, String targetKey) throws Exception {
+        URI endpoint = client.getEndpoint();
+        String expectedHost = bucket + "." + endpoint.getHost();
+        if (!"https".equalsIgnoreCase(endpoint.getScheme())
+                || !"https".equalsIgnoreCase(url.getProtocol())
+                || !expectedHost.equalsIgnoreCase(url.getHost())
+                || !("/" + targetKey).equals(url.toURI().getPath())) {
+            throw new IOException("OSS client generated a presigned URL for an invalid target.");
+        }
+    }
+
+    OSSClient ossClient(Path path) throws Exception {
+        return getOssClient((AliyunOSSFileSystem) getFileSystem(path(path)));
     }
 
     @Override

--- a/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
+++ b/paimon-filesystems/paimon-oss-impl/src/main/java/org/apache/paimon/oss/OSSFileIO.java
@@ -259,15 +259,10 @@ public class OSSFileIO extends HadoopCompliantFileIO implements HadoopOptionsPro
 
     @Override
     public String createBlobPresignedUrl(
-            Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-            throws IOException {
+            Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
         try {
             return OSSBlobPresigner.create(
-                    ossClient(new Path(descriptor.uri())),
-                    tableRoot,
-                    descriptor,
-                    extension,
-                    validity);
+                    ossClient(new Path(descriptor.uri())), tableRoot, descriptor, validity);
         } catch (IOException e) {
             throw e;
         } catch (Exception e) {

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -18,30 +18,421 @@
 
 package org.apache.paimon.oss;
 
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
+
 import com.aliyun.oss.ClientConfiguration;
 import com.aliyun.oss.ClientException;
+import com.aliyun.oss.HttpMethod;
 import com.aliyun.oss.OSSClient;
 import com.aliyun.oss.OSSClientBuilder;
+import com.aliyun.oss.OSSException;
 import com.aliyun.oss.common.auth.DefaultCredentialProvider;
 import com.aliyun.oss.common.comm.ExecutionContext;
 import com.aliyun.oss.common.comm.RequestMessage;
 import com.aliyun.oss.common.comm.ResponseMessage;
 import com.aliyun.oss.common.comm.RetryStrategy;
 import com.aliyun.oss.common.comm.ServiceClient;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
 import com.aliyun.oss.model.CopyObjectRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadResult;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.UploadPartCopyRequest;
+import com.aliyun.oss.model.UploadPartCopyResult;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /** Tests for {@link OSSFileIO}. */
 public class OSSFileIOTest {
+
+    @Test
+    public void testCreateBlobPresignedUrlMaterializesSinglePart() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/source.blob", 10, 20);
+        String fingerprint = sha256Hex(descriptor.serialize());
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(100);
+        ObjectMetadata target = new ObjectMetadata();
+        target.setContentLength(20);
+        target.setContentType("image/png");
+        target.addUserMetadata("paimon-blob-descriptor-sha256", fingerprint);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenThrow(missingObject())
+                .thenReturn(target);
+        when(client.headObject("bucket", "table/bucket-0/source.blob")).thenReturn(source);
+        InitiateMultipartUploadResult initiate = new InitiateMultipartUploadResult();
+        initiate.setUploadId("upload-id");
+        when(client.initiateMultipartUpload(any())).thenReturn(initiate);
+        UploadPartCopyResult copied = new UploadPartCopyResult();
+        copied.setPartNumber(1);
+        copied.setETag("etag");
+        when(client.uploadPartCopy(any())).thenReturn(copied);
+        when(client.getEndpoint()).thenReturn(URI.create("https://oss-cn-hangzhou.aliyuncs.com"));
+        when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
+                .thenAnswer(
+                        invocation ->
+                                presignedUrl(
+                                        "https://bucket.oss-cn-hangzhou.aliyuncs.com/"
+                                                + invocation.getArgument(1)
+                                                + "?Signature=test"));
+
+        String url =
+                new TestOSSFileIO(client)
+                        .createBlobPresignedUrl(
+                                new Path("oss://bucket/table"),
+                                descriptor,
+                                "PNG",
+                                Duration.ofMinutes(5));
+
+        assertThat(url)
+                .matches(
+                        "https://bucket\\.oss-cn-hangzhou\\.aliyuncs\\.com/"
+                                + "table/bucket-0/_bloburl_[0-9a-f]{64}\\.png\\?Signature=test");
+        ArgumentCaptor<InitiateMultipartUploadRequest> initiateCaptor =
+                ArgumentCaptor.forClass(InitiateMultipartUploadRequest.class);
+        verify(client).initiateMultipartUpload(initiateCaptor.capture());
+        assertThat(initiateCaptor.getValue().getObjectMetadata().getContentType())
+                .isEqualTo("image/png");
+        assertThat(initiateCaptor.getValue().getObjectMetadata().getUserMetadata())
+                .containsEntry("paimon-blob-descriptor-sha256", fingerprint);
+
+        ArgumentCaptor<UploadPartCopyRequest> copyCaptor =
+                ArgumentCaptor.forClass(UploadPartCopyRequest.class);
+        verify(client).uploadPartCopy(copyCaptor.capture());
+        UploadPartCopyRequest copy = copyCaptor.getValue();
+        assertThat(copy.getSourceBucketName()).isEqualTo("bucket");
+        assertThat(copy.getSourceKey()).isEqualTo("table/bucket-0/source.blob");
+        assertThat(copy.getBeginIndex()).isEqualTo(10);
+        assertThat(copy.getPartSize()).isEqualTo(20);
+        assertThat(copy.getPartNumber()).isEqualTo(1);
+        verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlCacheHitOnlyPresigns() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/bucket-0/source.blob", 10, 20);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenReturn(matchingMetadata(descriptor, "image/jpeg"));
+        stubPresigning(client);
+
+        String url =
+                new TestOSSFileIO(client)
+                        .createBlobPresignedUrl(
+                                new Path("oss://bucket/table"),
+                                descriptor,
+                                "jpg",
+                                Duration.ofMinutes(5));
+
+        assertThat(url).startsWith("https://bucket.oss-cn-hangzhou.aliyuncs.com/");
+        verify(client, never()).headObject("bucket", "table/bucket-0/source.blob");
+        verify(client, never()).initiateMultipartUpload(any());
+        verify(client, never()).uploadPartCopy(any());
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlControlsMultipartCount() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/source.blob", 0, Long.MAX_VALUE);
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(Long.MAX_VALUE);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenThrow(missingObject())
+                .thenReturn(matchingMetadata(descriptor, "image/png"));
+        when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
+        stubMultipartUpload(client);
+        stubPresigning(client);
+
+        new TestOSSFileIO(client)
+                .createBlobPresignedUrl(
+                        new Path("oss://bucket/table"), descriptor, "png", Duration.ofMinutes(5));
+
+        ArgumentCaptor<UploadPartCopyRequest> captor =
+                ArgumentCaptor.forClass(UploadPartCopyRequest.class);
+        verify(client, times(10_000)).uploadPartCopy(captor.capture());
+        assertThat(captor.getAllValues().get(0).getBeginIndex()).isZero();
+        assertThat(captor.getAllValues().get(9_999).getPartNumber()).isEqualTo(10_000);
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlHandlesZeroLength() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 10, 0);
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(10);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenThrow(missingObject())
+                .thenReturn(matchingMetadata(descriptor, "image/png"));
+        when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
+        stubPresigning(client);
+
+        new TestOSSFileIO(client)
+                .createBlobPresignedUrl(
+                        new Path("oss://bucket/table"), descriptor, "png", Duration.ofMinutes(5));
+
+        verify(client)
+                .putObject(
+                        eq("bucket"),
+                        contains("_bloburl_"),
+                        any(java.io.InputStream.class),
+                        any(ObjectMetadata.class));
+        verify(client, never()).initiateMultipartUpload(any());
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlAbortsFailedUpload() {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 20);
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(20);
+        when(client.headObject(eq("bucket"), contains("_bloburl_"))).thenThrow(missingObject());
+        when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
+        InitiateMultipartUploadResult initiate = new InitiateMultipartUploadResult();
+        initiate.setUploadId("upload-id");
+        when(client.initiateMultipartUpload(any())).thenReturn(initiate);
+        when(client.uploadPartCopy(any())).thenThrow(new ClientException("failed"));
+
+        assertThatThrownBy(
+                        () ->
+                                new TestOSSFileIO(client)
+                                        .createBlobPresignedUrl(
+                                                new Path("oss://bucket/table"),
+                                                descriptor,
+                                                "png",
+                                                Duration.ofMinutes(5)))
+                .isInstanceOf(java.io.IOException.class);
+        ArgumentCaptor<AbortMultipartUploadRequest> captor =
+                ArgumentCaptor.forClass(AbortMultipartUploadRequest.class);
+        verify(client).abortMultipartUpload(captor.capture());
+        assertThat(captor.getValue().getUploadId()).isEqualTo("upload-id");
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlRejectsFinalHeadMismatch() {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 20);
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(20);
+        ObjectMetadata wrongTarget = matchingMetadata(descriptor, "image/png");
+        wrongTarget.setContentLength(19);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenThrow(missingObject())
+                .thenReturn(wrongTarget);
+        when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
+        stubMultipartUpload(client);
+
+        assertThatThrownBy(
+                        () ->
+                                new TestOSSFileIO(client)
+                                        .createBlobPresignedUrl(
+                                                new Path("oss://bucket/table"),
+                                                descriptor,
+                                                "png",
+                                                Duration.ofMinutes(5)))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessageContaining("metadata does not match");
+        verify(client, never())
+                .generatePresignedUrl(anyString(), anyString(), any(), any(HttpMethod.class));
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlRejectsInvalidArguments() {
+        OSSClient client = mock(OSSClient.class);
+        TestOSSFileIO fileIO = new TestOSSFileIO(client);
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 1);
+        Path root = new Path("oss://bucket/table");
+
+        assertThatThrownBy(
+                        () ->
+                                fileIO.createBlobPresignedUrl(
+                                        root, descriptor, ".png", Duration.ofSeconds(1)))
+                .isInstanceOf(java.io.IOException.class);
+        assertThatThrownBy(
+                        () ->
+                                fileIO.createBlobPresignedUrl(
+                                        root, descriptor, "unknown", Duration.ofSeconds(1)))
+                .isInstanceOf(java.io.IOException.class);
+        assertThatThrownBy(
+                        () ->
+                                fileIO.createBlobPresignedUrl(
+                                        root, descriptor, "png", Duration.ofMillis(1)))
+                .isInstanceOf(java.io.IOException.class);
+        assertThatThrownBy(
+                        () ->
+                                fileIO.createBlobPresignedUrl(
+                                        new Path("oss://bucket/other"),
+                                        descriptor,
+                                        "png",
+                                        Duration.ofSeconds(1)))
+                .isInstanceOf(java.io.IOException.class);
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlRejectsInvalidRange() {
+        assertInvalidRange(-1, 1, 10);
+        assertInvalidRange(0, -1, 10);
+        assertInvalidRange(9, 2, 10);
+        assertInvalidRange(Long.MAX_VALUE, 1, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testCreateBlobPresignedUrlRejectsInvalidTarget() {
+        assertInvalidPresignedUrl(
+                "https://oss-cn-hangzhou.aliyuncs.com",
+                "http://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+        assertInvalidPresignedUrl(
+                "https://oss-cn-hangzhou.aliyuncs.com",
+                "https://other.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+        assertInvalidPresignedUrl(
+                "https://oss-cn-hangzhou.aliyuncs.com",
+                "https://bucket.oss-cn-hangzhou.aliyuncs.com/table/other.png");
+        assertInvalidPresignedUrl(
+                "http://oss-cn-hangzhou.aliyuncs.com",
+                "https://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+    }
+
+    private static void assertInvalidPresignedUrl(String endpoint, String generatedUrl) {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 1);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenReturn(matchingMetadata(descriptor, "image/png"));
+        when(client.getEndpoint()).thenReturn(URI.create(endpoint));
+        when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
+                .thenReturn(presignedUrl(generatedUrl));
+
+        assertThatThrownBy(
+                        () ->
+                                new TestOSSFileIO(client)
+                                        .createBlobPresignedUrl(
+                                                new Path("oss://bucket/table"),
+                                                descriptor,
+                                                "png",
+                                                Duration.ofMinutes(5)))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessageContaining("invalid target");
+    }
+
+    private static void assertInvalidRange(long offset, long length, long sourceLength) {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/source.blob", offset, length);
+        ObjectMetadata source = new ObjectMetadata();
+        source.setContentLength(sourceLength);
+        when(client.headObject(eq("bucket"), contains("_bloburl_"))).thenThrow(missingObject());
+        when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
+
+        assertThatThrownBy(
+                        () ->
+                                new TestOSSFileIO(client)
+                                        .createBlobPresignedUrl(
+                                                new Path("oss://bucket/table"),
+                                                descriptor,
+                                                "png",
+                                                Duration.ofMinutes(5)))
+                .isInstanceOf(java.io.IOException.class)
+                .hasMessageContaining("range");
+        verify(client, never()).initiateMultipartUpload(any());
+    }
+
+    private static ObjectMetadata matchingMetadata(BlobDescriptor descriptor, String contentType) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(descriptor.length());
+            metadata.setContentType(contentType);
+            metadata.addUserMetadata(
+                    "paimon-blob-descriptor-sha256", sha256Hex(descriptor.serialize()));
+            return metadata;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void stubMultipartUpload(OSSClient client) {
+        InitiateMultipartUploadResult initiate = new InitiateMultipartUploadResult();
+        initiate.setUploadId("upload-id");
+        when(client.initiateMultipartUpload(any())).thenReturn(initiate);
+        when(client.uploadPartCopy(any()))
+                .thenAnswer(
+                        invocation -> {
+                            UploadPartCopyRequest request = invocation.getArgument(0);
+                            UploadPartCopyResult copied = new UploadPartCopyResult();
+                            copied.setPartNumber(request.getPartNumber());
+                            copied.setETag("etag-" + request.getPartNumber());
+                            return copied;
+                        });
+    }
+
+    private static void stubPresigning(OSSClient client) {
+        when(client.getEndpoint()).thenReturn(URI.create("https://oss-cn-hangzhou.aliyuncs.com"));
+        when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
+                .thenAnswer(
+                        invocation ->
+                                presignedUrl(
+                                        "https://bucket.oss-cn-hangzhou.aliyuncs.com/"
+                                                + invocation.getArgument(1)
+                                                + "?Signature=test"));
+    }
+
+    private static OSSException missingObject() {
+        return new OSSException("missing", "NoSuchKey", "request", "host", null, null, "HEAD");
+    }
+
+    private static URL presignedUrl(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(bytes);
+        StringBuilder result = new StringBuilder(hash.length * 2);
+        for (byte value : hash) {
+            result.append(String.format("%02x", value & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static class TestOSSFileIO extends OSSFileIO {
+
+        private final OSSClient client;
+
+        private TestOSSFileIO(OSSClient client) {
+            this.client = client;
+        }
+
+        OSSClient ossClient(Path path) {
+            return client;
+        }
+    }
 
     /** The swap must replace both operations with the SSE-stamping subclasses. */
     @Test

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -79,7 +79,7 @@ public class OSSFileIOTest {
         source.setContentLength(100);
         ObjectMetadata target = new ObjectMetadata();
         target.setContentLength(20);
-        target.setContentType("image/png");
+        target.setContentType("application/octet-stream");
         target.addUserMetadata("paimon-blob-descriptor-sha256", fingerprint);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
                 .thenThrow(missingObject())
@@ -104,20 +104,17 @@ public class OSSFileIOTest {
         String url =
                 new TestOSSFileIO(client)
                         .createBlobPresignedUrl(
-                                new Path("oss://bucket/table"),
-                                descriptor,
-                                "PNG",
-                                Duration.ofMinutes(5));
+                                new Path("oss://bucket/table"), descriptor, Duration.ofMinutes(5));
 
         assertThat(url)
                 .matches(
                         "https://bucket\\.oss-cn-hangzhou\\.aliyuncs\\.com/"
-                                + "table/bucket-0/_bloburl_[0-9a-f]{64}\\.png\\?Signature=test");
+                                + "table/bucket-0/_bloburl_[0-9a-f]{64}\\?Signature=test");
         ArgumentCaptor<InitiateMultipartUploadRequest> initiateCaptor =
                 ArgumentCaptor.forClass(InitiateMultipartUploadRequest.class);
         verify(client).initiateMultipartUpload(initiateCaptor.capture());
         assertThat(initiateCaptor.getValue().getObjectMetadata().getContentType())
-                .isEqualTo("image/png");
+                .isEqualTo("application/octet-stream");
         assertThat(initiateCaptor.getValue().getObjectMetadata().getUserMetadata())
                 .containsEntry("paimon-blob-descriptor-sha256", fingerprint);
 
@@ -139,16 +136,13 @@ public class OSSFileIOTest {
         BlobDescriptor descriptor =
                 new BlobDescriptor("oss://bucket/table/bucket-0/source.blob", 10, 20);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
-                .thenReturn(matchingMetadata(descriptor, "image/jpeg"));
+                .thenReturn(matchingMetadata(descriptor));
         stubPresigning(client);
 
         String url =
                 new TestOSSFileIO(client)
                         .createBlobPresignedUrl(
-                                new Path("oss://bucket/table"),
-                                descriptor,
-                                "jpg",
-                                Duration.ofMinutes(5));
+                                new Path("oss://bucket/table"), descriptor, Duration.ofMinutes(5));
 
         assertThat(url).startsWith("https://bucket.oss-cn-hangzhou.aliyuncs.com/");
         verify(client, never()).headObject("bucket", "table/bucket-0/source.blob");
@@ -162,7 +156,7 @@ public class OSSFileIOTest {
         BlobDescriptor descriptor =
                 new BlobDescriptor("oss://bucket/table/-internal.aliyuncs.com/source.blob", 0, 1);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
-                .thenReturn(matchingMetadata(descriptor, "image/png"));
+                .thenReturn(matchingMetadata(descriptor));
         when(client.getEndpoint())
                 .thenReturn(URI.create("https://oss-cn-hangzhou-internal.aliyuncs.com"));
         when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
@@ -179,15 +173,13 @@ public class OSSFileIOTest {
                                 .createBlobPresignedUrl(
                                         new Path("oss://bucket/table"),
                                         descriptor,
-                                        "png",
                                         Duration.ofMinutes(5)));
 
         assertThat(url.getHost()).isEqualTo("bucket.oss-cn-hangzhou.aliyuncs.com");
         assertThat(url.getPath())
                 .isEqualTo(
                         "/table/-internal.aliyuncs.com/_bloburl_"
-                                + sha256Hex(descriptor.serialize())
-                                + ".png");
+                                + sha256Hex(descriptor.serialize()));
         assertThat(url.getQuery()).isEqualTo("Signature=test");
     }
 
@@ -200,14 +192,14 @@ public class OSSFileIOTest {
         source.setContentLength(Long.MAX_VALUE);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
                 .thenThrow(missingObject())
-                .thenReturn(matchingMetadata(descriptor, "image/png"));
+                .thenReturn(matchingMetadata(descriptor));
         when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
         stubMultipartUpload(client);
         stubPresigning(client);
 
         new TestOSSFileIO(client)
                 .createBlobPresignedUrl(
-                        new Path("oss://bucket/table"), descriptor, "png", Duration.ofMinutes(5));
+                        new Path("oss://bucket/table"), descriptor, Duration.ofMinutes(5));
 
         ArgumentCaptor<UploadPartCopyRequest> captor =
                 ArgumentCaptor.forClass(UploadPartCopyRequest.class);
@@ -224,13 +216,13 @@ public class OSSFileIOTest {
         source.setContentLength(10);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
                 .thenThrow(missingObject())
-                .thenReturn(matchingMetadata(descriptor, "image/png"));
+                .thenReturn(matchingMetadata(descriptor));
         when(client.headObject("bucket", "table/source.blob")).thenReturn(source);
         stubPresigning(client);
 
         new TestOSSFileIO(client)
                 .createBlobPresignedUrl(
-                        new Path("oss://bucket/table"), descriptor, "png", Duration.ofMinutes(5));
+                        new Path("oss://bucket/table"), descriptor, Duration.ofMinutes(5));
 
         verify(client)
                 .putObject(
@@ -260,7 +252,6 @@ public class OSSFileIOTest {
                                         .createBlobPresignedUrl(
                                                 new Path("oss://bucket/table"),
                                                 descriptor,
-                                                "png",
                                                 Duration.ofMinutes(5)))
                 .isInstanceOf(java.io.IOException.class);
         ArgumentCaptor<AbortMultipartUploadRequest> captor =
@@ -275,7 +266,7 @@ public class OSSFileIOTest {
         BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 20);
         ObjectMetadata source = new ObjectMetadata();
         source.setContentLength(20);
-        ObjectMetadata wrongTarget = matchingMetadata(descriptor, "image/png");
+        ObjectMetadata wrongTarget = matchingMetadata(descriptor);
         wrongTarget.setContentLength(19);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
                 .thenThrow(missingObject())
@@ -289,7 +280,6 @@ public class OSSFileIOTest {
                                         .createBlobPresignedUrl(
                                                 new Path("oss://bucket/table"),
                                                 descriptor,
-                                                "png",
                                                 Duration.ofMinutes(5)))
                 .isInstanceOf(java.io.IOException.class)
                 .hasMessageContaining("metadata does not match");
@@ -305,26 +295,13 @@ public class OSSFileIOTest {
         Path root = new Path("oss://bucket/table");
 
         assertThatThrownBy(
-                        () ->
-                                fileIO.createBlobPresignedUrl(
-                                        root, descriptor, ".png", Duration.ofSeconds(1)))
-                .isInstanceOf(java.io.IOException.class);
-        assertThatThrownBy(
-                        () ->
-                                fileIO.createBlobPresignedUrl(
-                                        root, descriptor, "unknown", Duration.ofSeconds(1)))
-                .isInstanceOf(java.io.IOException.class);
-        assertThatThrownBy(
-                        () ->
-                                fileIO.createBlobPresignedUrl(
-                                        root, descriptor, "png", Duration.ofMillis(1)))
+                        () -> fileIO.createBlobPresignedUrl(root, descriptor, Duration.ofMillis(1)))
                 .isInstanceOf(java.io.IOException.class);
         assertThatThrownBy(
                         () ->
                                 fileIO.createBlobPresignedUrl(
                                         new Path("oss://bucket/other"),
                                         descriptor,
-                                        "png",
                                         Duration.ofSeconds(1)))
                 .isInstanceOf(java.io.IOException.class);
     }
@@ -341,23 +318,23 @@ public class OSSFileIOTest {
     public void testCreateBlobPresignedUrlRejectsInvalidTarget() {
         assertInvalidPresignedUrl(
                 "https://oss-cn-hangzhou.aliyuncs.com",
-                "http://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+                "http://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash");
         assertInvalidPresignedUrl(
                 "https://oss-cn-hangzhou.aliyuncs.com",
-                "https://other.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+                "https://other.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash");
         assertInvalidPresignedUrl(
                 "https://oss-cn-hangzhou.aliyuncs.com",
                 "https://bucket.oss-cn-hangzhou.aliyuncs.com/table/other.png");
         assertInvalidPresignedUrl(
                 "http://oss-cn-hangzhou.aliyuncs.com",
-                "https://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash.png");
+                "https://bucket.oss-cn-hangzhou.aliyuncs.com/table/_bloburl_hash");
     }
 
     private static void assertInvalidPresignedUrl(String endpoint, String generatedUrl) {
         OSSClient client = mock(OSSClient.class);
         BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/source.blob", 0, 1);
         when(client.headObject(eq("bucket"), contains("_bloburl_")))
-                .thenReturn(matchingMetadata(descriptor, "image/png"));
+                .thenReturn(matchingMetadata(descriptor));
         when(client.getEndpoint()).thenReturn(URI.create(endpoint));
         when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
                 .thenReturn(presignedUrl(generatedUrl));
@@ -368,7 +345,6 @@ public class OSSFileIOTest {
                                         .createBlobPresignedUrl(
                                                 new Path("oss://bucket/table"),
                                                 descriptor,
-                                                "png",
                                                 Duration.ofMinutes(5)))
                 .isInstanceOf(java.io.IOException.class)
                 .hasMessageContaining("invalid target");
@@ -389,18 +365,17 @@ public class OSSFileIOTest {
                                         .createBlobPresignedUrl(
                                                 new Path("oss://bucket/table"),
                                                 descriptor,
-                                                "png",
                                                 Duration.ofMinutes(5)))
                 .isInstanceOf(java.io.IOException.class)
                 .hasMessageContaining("range");
         verify(client, never()).initiateMultipartUpload(any());
     }
 
-    private static ObjectMetadata matchingMetadata(BlobDescriptor descriptor, String contentType) {
+    private static ObjectMetadata matchingMetadata(BlobDescriptor descriptor) {
         try {
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(descriptor.length());
-            metadata.setContentType(contentType);
+            metadata.setContentType("application/octet-stream");
             metadata.addUserMetadata(
                     "paimon-blob-descriptor-sha256", sha256Hex(descriptor.serialize()));
             return metadata;

--- a/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
+++ b/paimon-filesystems/paimon-oss-impl/src/test/java/org/apache/paimon/oss/OSSFileIOTest.java
@@ -157,6 +157,41 @@ public class OSSFileIOTest {
     }
 
     @Test
+    public void testCreateBlobPresignedUrlUsesPublicEndpointWithoutChangingPath() throws Exception {
+        OSSClient client = mock(OSSClient.class);
+        BlobDescriptor descriptor =
+                new BlobDescriptor("oss://bucket/table/-internal.aliyuncs.com/source.blob", 0, 1);
+        when(client.headObject(eq("bucket"), contains("_bloburl_")))
+                .thenReturn(matchingMetadata(descriptor, "image/png"));
+        when(client.getEndpoint())
+                .thenReturn(URI.create("https://oss-cn-hangzhou-internal.aliyuncs.com"));
+        when(client.generatePresignedUrl(eq("bucket"), anyString(), any(), eq(HttpMethod.GET)))
+                .thenAnswer(
+                        invocation ->
+                                presignedUrl(
+                                        "https://bucket.oss-cn-hangzhou-internal.aliyuncs.com/"
+                                                + invocation.getArgument(1)
+                                                + "?Signature=test"));
+
+        URL url =
+                new URL(
+                        new TestOSSFileIO(client)
+                                .createBlobPresignedUrl(
+                                        new Path("oss://bucket/table"),
+                                        descriptor,
+                                        "png",
+                                        Duration.ofMinutes(5)));
+
+        assertThat(url.getHost()).isEqualTo("bucket.oss-cn-hangzhou.aliyuncs.com");
+        assertThat(url.getPath())
+                .isEqualTo(
+                        "/table/-internal.aliyuncs.com/_bloburl_"
+                                + sha256Hex(descriptor.serialize())
+                                + ".png");
+        assertThat(url.getQuery()).isEqualTo("Signature=test");
+    }
+
+    @Test
     public void testCreateBlobPresignedUrlControlsMultipartCount() throws Exception {
         OSSClient client = mock(OSSClient.class);
         BlobDescriptor descriptor =

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunction.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.function;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.flink.FlinkFileIOLoader;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.Table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+
+/** Converts a serialized blob descriptor to a presigned URL. */
+public class DescriptorToPresignedUrlFunction extends ScalarFunction
+        implements CatalogAwareFunction {
+
+    @Nullable private String catalogName;
+    @Nullable private Options catalogOptions;
+
+    private transient Catalog catalog;
+    private transient String sourceTable;
+    private transient FileIO fileIO;
+    private transient Path tableRoot;
+
+    public DescriptorToPresignedUrlFunction() {}
+
+    DescriptorToPresignedUrlFunction(String catalogName, Catalog catalog) {
+        this.catalogName = catalogName;
+        this.catalog = catalog;
+    }
+
+    @Override
+    public void setCatalogContext(
+            String catalogName, String defaultDatabase, Options catalogOptions) {
+        this.catalogName = catalogName;
+        this.catalogOptions = new Options(catalogOptions.toMap());
+        this.catalog = null;
+        this.sourceTable = null;
+        this.fileIO = null;
+        this.tableRoot = null;
+    }
+
+    @Override
+    public void open(FunctionContext context) {
+        openCatalog(context.getUserCodeClassLoader());
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (catalog != null) {
+            catalog.close();
+            catalog = null;
+        }
+    }
+
+    public String eval(
+            String tableName, byte[] descriptorBytes, String extension, Duration validity)
+            throws Exception {
+        bindSourceTable(tableName);
+        if (descriptorBytes == null || extension == null || validity == null) {
+            return null;
+        }
+
+        loadTable();
+        return fileIO.createBlobPresignedUrl(
+                tableRoot, BlobDescriptor.deserialize(descriptorBytes), extension, validity);
+    }
+
+    @Override
+    public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+        return TypeInference.newBuilder()
+                .inputTypeStrategy(
+                        InputTypeStrategies.sequence(
+                                InputTypeStrategies.and(
+                                        InputTypeStrategies.explicit(DataTypes.STRING()),
+                                        InputTypeStrategies.LITERAL),
+                                InputTypeStrategies.explicit(DataTypes.BYTES()),
+                                InputTypeStrategies.explicit(DataTypes.STRING()),
+                                InputTypeStrategies.logical(LogicalTypeRoot.INTERVAL_DAY_TIME)))
+                .outputTypeStrategy(TypeStrategies.explicit(DataTypes.STRING()))
+                .build();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return false;
+    }
+
+    private void bindSourceTable(String tableName) {
+        if (tableName == null) {
+            throw new IllegalArgumentException("source_table must be a non-null literal.");
+        }
+        if (sourceTable == null) {
+            sourceTable = tableName;
+        } else if (!sourceTable.equals(tableName)) {
+            throw new IllegalArgumentException(
+                    "A descriptor URL function instance can use only one source table.");
+        }
+    }
+
+    private void loadTable() throws Catalog.TableNotExistException {
+        if (fileIO != null) {
+            return;
+        }
+
+        Identifier identifier = toIdentifier(sourceTable);
+        Table table = catalog().getTable(identifier);
+        if (!(table instanceof DataTable)) {
+            throw new IllegalArgumentException(
+                    "Source table " + identifier.getFullName() + " is not a data table.");
+        }
+        DataTable dataTable = (DataTable) table;
+        fileIO = dataTable.fileIO();
+        tableRoot = dataTable.location();
+    }
+
+    private Identifier toIdentifier(String tableName) {
+        String[] parts = tableName.split("\\.", -1);
+        if (parts.length == 2 && !parts[0].isEmpty() && !parts[1].isEmpty()) {
+            return new Identifier(parts[0], parts[1]);
+        }
+        if (parts.length == 3
+                && catalogName != null
+                && catalogName.equals(parts[0])
+                && !parts[1].isEmpty()
+                && !parts[2].isEmpty()) {
+            return new Identifier(parts[1], parts[2]);
+        }
+        throw new IllegalArgumentException(
+                "source_table must be 'database.table' or '" + catalogName + ".database.table'.");
+    }
+
+    private Catalog catalog() {
+        if (catalog == null) {
+            openCatalog(Thread.currentThread().getContextClassLoader());
+        }
+        return catalog;
+    }
+
+    private void openCatalog(ClassLoader classLoader) {
+        if (catalog != null) {
+            return;
+        }
+        if (catalogOptions == null) {
+            throw new IllegalStateException(
+                    "DescriptorToPresignedUrlFunction is missing catalog options.");
+        }
+        catalog =
+                CatalogFactory.createCatalog(
+                        CatalogContext.create(catalogOptions, new FlinkFileIOLoader()),
+                        classLoader);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunction.java
@@ -86,17 +86,16 @@ public class DescriptorToPresignedUrlFunction extends ScalarFunction
         }
     }
 
-    public String eval(
-            String tableName, byte[] descriptorBytes, String extension, Duration validity)
+    public String eval(String tableName, byte[] descriptorBytes, Duration validity)
             throws Exception {
         bindSourceTable(tableName);
-        if (descriptorBytes == null || extension == null || validity == null) {
+        if (descriptorBytes == null || validity == null) {
             return null;
         }
 
         loadTable();
         return fileIO.createBlobPresignedUrl(
-                tableRoot, BlobDescriptor.deserialize(descriptorBytes), extension, validity);
+                tableRoot, BlobDescriptor.deserialize(descriptorBytes), validity);
     }
 
     @Override
@@ -108,7 +107,6 @@ public class DescriptorToPresignedUrlFunction extends ScalarFunction
                                         InputTypeStrategies.explicit(DataTypes.STRING()),
                                         InputTypeStrategies.LITERAL),
                                 InputTypeStrategies.explicit(DataTypes.BYTES()),
-                                InputTypeStrategies.explicit(DataTypes.STRING()),
                                 InputTypeStrategies.logical(LogicalTypeRoot.INTERVAL_DAY_TIME)))
                 .outputTypeStrategy(TypeStrategies.explicit(DataTypes.STRING()))
                 .build();

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/TryDescriptorToPresignedUrlFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/TryDescriptorToPresignedUrlFunction.java
@@ -18,24 +18,26 @@
 
 package org.apache.paimon.flink.function;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.apache.paimon.catalog.Catalog;
 
-/** Paimon flink built in functions. */
-public class BuiltInFunctions {
+import java.time.Duration;
 
-    public static final Map<String, String> FUNCTIONS =
-            new HashMap<String, String>() {
-                {
-                    put("path_to_descriptor", PathToDescriptor.class.getName());
-                    put("descriptor_to_string", DescriptorToString.class.getName());
-                    put("blob_view", BlobViewFunction.class.getName());
-                    put(
-                            "descriptor_to_presigned_url",
-                            DescriptorToPresignedUrlFunction.class.getName());
-                    put(
-                            "try_descriptor_to_presigned_url",
-                            TryDescriptorToPresignedUrlFunction.class.getName());
-                }
-            };
+/** Tolerant variant of {@link DescriptorToPresignedUrlFunction}. */
+public class TryDescriptorToPresignedUrlFunction extends DescriptorToPresignedUrlFunction {
+
+    public TryDescriptorToPresignedUrlFunction() {}
+
+    TryDescriptorToPresignedUrlFunction(String catalogName, Catalog catalog) {
+        super(catalogName, catalog);
+    }
+
+    @Override
+    public String eval(
+            String tableName, byte[] descriptorBytes, String extension, Duration validity) {
+        try {
+            return super.eval(tableName, descriptorBytes, extension, validity);
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/TryDescriptorToPresignedUrlFunction.java
+++ b/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/function/TryDescriptorToPresignedUrlFunction.java
@@ -32,10 +32,9 @@ public class TryDescriptorToPresignedUrlFunction extends DescriptorToPresignedUr
     }
 
     @Override
-    public String eval(
-            String tableName, byte[] descriptorBytes, String extension, Duration validity) {
+    public String eval(String tableName, byte[] descriptorBytes, Duration validity) {
         try {
-            return super.eval(tableName, descriptorBytes, extension, validity);
+            return super.eval(tableName, descriptorBytes, validity);
         } catch (Exception e) {
             return null;
         }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -623,6 +623,38 @@ public class BlobTableITCase extends CatalogITCaseBase {
     }
 
     @Test
+    public void testDescriptorToPresignedUrlBuiltInFunctions() {
+        assertThat(batchSql("SHOW FUNCTIONS IN sys"))
+                .contains(
+                        Row.of("descriptor_to_presigned_url"),
+                        Row.of("try_descriptor_to_presigned_url"));
+
+        assertThat(
+                        batchSql(
+                                "SELECT sys.descriptor_to_presigned_url("
+                                        + "'default.blob_table_descriptor', "
+                                        + "CAST(NULL AS BYTES), 'png', INTERVAL '1' HOUR)"))
+                .containsExactly(Row.of((Object) null));
+        assertThat(
+                        batchSql(
+                                "SELECT sys.try_descriptor_to_presigned_url("
+                                        + "'default.blob_table_descriptor', "
+                                        + "sys.path_to_descriptor('file:///tmp/blob'), "
+                                        + "'png', INTERVAL '1' HOUR)"))
+                .containsExactly(Row.of((Object) null));
+
+        assertThatThrownBy(
+                        () ->
+                                batchSql(
+                                        "SELECT sys.descriptor_to_presigned_url("
+                                                + "'default.blob_table_descriptor', "
+                                                + "sys.path_to_descriptor('file:///tmp/blob'), "
+                                                + "'png', INTERVAL '1' HOUR)"))
+                .hasRootCauseInstanceOf(UnsupportedOperationException.class)
+                .hasStackTraceContaining("does not support creating blob presigned URLs");
+    }
+
+    @Test
     public void testWriteBlobViewWithBuiltInFunction() throws Exception {
         tEnv.executeSql(
                 "CREATE TABLE upstream_blob_view (id INT, name STRING, picture BYTES)"

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/BlobTableITCase.java
@@ -633,14 +633,14 @@ public class BlobTableITCase extends CatalogITCaseBase {
                         batchSql(
                                 "SELECT sys.descriptor_to_presigned_url("
                                         + "'default.blob_table_descriptor', "
-                                        + "CAST(NULL AS BYTES), 'png', INTERVAL '1' HOUR)"))
+                                        + "CAST(NULL AS BYTES), INTERVAL '1' HOUR)"))
                 .containsExactly(Row.of((Object) null));
         assertThat(
                         batchSql(
                                 "SELECT sys.try_descriptor_to_presigned_url("
                                         + "'default.blob_table_descriptor', "
                                         + "sys.path_to_descriptor('file:///tmp/blob'), "
-                                        + "'png', INTERVAL '1' HOUR)"))
+                                        + "INTERVAL '1' HOUR)"))
                 .containsExactly(Row.of((Object) null));
 
         assertThatThrownBy(
@@ -649,7 +649,7 @@ public class BlobTableITCase extends CatalogITCaseBase {
                                         "SELECT sys.descriptor_to_presigned_url("
                                                 + "'default.blob_table_descriptor', "
                                                 + "sys.path_to_descriptor('file:///tmp/blob'), "
-                                                + "'png', INTERVAL '1' HOUR)"))
+                                                + "INTERVAL '1' HOUR)"))
                 .hasRootCauseInstanceOf(UnsupportedOperationException.class)
                 .hasStackTraceContaining("does not support creating blob presigned URLs");
     }

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SupportsExpressionPushDownCompatibilityTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/SupportsExpressionPushDownCompatibilityTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink;
+
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class SupportsExpressionPushDownCompatibilityTest {
+
+    @Test
+    void testCompatibilityClassIsAvailable() throws Exception {
+        assumeTrue(EnvironmentInformation.getVersion().startsWith("1."));
+
+        Class<?> ability =
+                Class.forName(
+                        "org.apache.flink.table.connector.source.abilities.SupportsExpressionPushDown");
+
+        assertThat(ability.getMethod("applyExpressions", List.class).getReturnType())
+                .isEqualTo(List.class);
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunctionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.flink.function;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.table.DataTable;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for descriptor to presigned URL functions. */
+public class DescriptorToPresignedUrlFunctionTest {
+
+    @Test
+    public void testTypeInferenceRequiresLiteralTableAndAcceptsInterval() {
+        TableEnvironment tableEnvironment =
+                TableEnvironment.create(EnvironmentSettings.inBatchMode());
+        tableEnvironment.createTemporarySystemFunction(
+                "descriptor_to_presigned_url", DescriptorToPresignedUrlFunction.class);
+
+        assertThat(
+                        tableEnvironment.explainSql(
+                                "SELECT descriptor_to_presigned_url("
+                                        + "'default.t', CAST(NULL AS BYTES), 'png', "
+                                        + "INTERVAL '1' HOUR)"))
+                .contains("Calc");
+
+        assertThatThrownBy(
+                        () ->
+                                tableEnvironment.explainSql(
+                                        "SELECT descriptor_to_presigned_url("
+                                                + "source_table, descriptor, 'png', "
+                                                + "INTERVAL '1' HOUR) "
+                                                + "FROM (VALUES ('default.t', CAST(NULL AS BYTES))) "
+                                                + "AS T(source_table, descriptor)"))
+                .isInstanceOf(ValidationException.class)
+                .hasRootCauseMessage("Literal expected.");
+    }
+
+    @Test
+    public void testEvalCachesOneTableAndDelegates() throws Exception {
+        Catalog catalog = mock(Catalog.class);
+        DataTable table = mock(DataTable.class);
+        FileIO fileIO = mock(FileIO.class);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/bucket-0/data", 1, 2);
+        when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
+        when(table.location()).thenReturn(tableRoot);
+        when(table.fileIO()).thenReturn(fileIO);
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofHours(1)))
+                .thenReturn("https://example");
+
+        DescriptorToPresignedUrlFunction function =
+                new DescriptorToPresignedUrlFunction("paimon", catalog);
+
+        assertThat(function.eval("default.t", descriptor.serialize(), "png", Duration.ofHours(1)))
+                .isEqualTo("https://example");
+        assertThat(function.eval("default.t", descriptor.serialize(), "png", Duration.ofHours(1)))
+                .isEqualTo("https://example");
+        verify(catalog, times(1)).getTable(new Identifier("default", "t"));
+
+        assertThatThrownBy(
+                        () ->
+                                function.eval(
+                                        "default.other",
+                                        descriptor.serialize(),
+                                        "png",
+                                        Duration.ofHours(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("one source table");
+    }
+
+    @Test
+    public void testNullAndTrySemantics() throws Exception {
+        Catalog catalog = mock(Catalog.class);
+        DataTable table = mock(DataTable.class);
+        FileIO fileIO = mock(FileIO.class);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data", 0, 1);
+        when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
+        when(table.location()).thenReturn(tableRoot);
+        when(table.fileIO()).thenReturn(fileIO);
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofSeconds(1)))
+                .thenThrow(new IOException("signing failed"));
+
+        DescriptorToPresignedUrlFunction strict =
+                new DescriptorToPresignedUrlFunction("paimon", catalog);
+        assertThat(strict.eval("default.t", null, "png", Duration.ofSeconds(1))).isNull();
+        assertThat(strict.eval("default.t", descriptor.serialize(), null, Duration.ofSeconds(1)))
+                .isNull();
+        assertThat(strict.eval("default.t", descriptor.serialize(), "png", null)).isNull();
+        verify(catalog, never()).getTable(new Identifier("default", "t"));
+        assertThatThrownBy(
+                        () ->
+                                strict.eval(
+                                        "default.t",
+                                        descriptor.serialize(),
+                                        "png",
+                                        Duration.ofSeconds(1)))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("signing failed");
+
+        TryDescriptorToPresignedUrlFunction tolerant =
+                new TryDescriptorToPresignedUrlFunction("paimon", catalog);
+        assertThat(tolerant.eval("default.t", descriptor.serialize(), "png", Duration.ofSeconds(1)))
+                .isNull();
+    }
+
+    @Test
+    public void testRegistrationAndDeterminism() {
+        assertThat(BuiltInFunctions.FUNCTIONS)
+                .containsEntry(
+                        "descriptor_to_presigned_url",
+                        DescriptorToPresignedUrlFunction.class.getName())
+                .containsEntry(
+                        "try_descriptor_to_presigned_url",
+                        TryDescriptorToPresignedUrlFunction.class.getName());
+        assertThat(new DescriptorToPresignedUrlFunction().isDeterministic()).isFalse();
+        assertThat(new TryDescriptorToPresignedUrlFunction().isDeterministic()).isFalse();
+    }
+
+    @Test
+    public void testCatalogQualifiedTableName() throws Exception {
+        Catalog catalog = mock(Catalog.class);
+        DataTable table = mock(DataTable.class);
+        FileIO fileIO = mock(FileIO.class);
+        Path tableRoot = new Path("oss://bucket/table");
+        BlobDescriptor descriptor = new BlobDescriptor("oss://bucket/table/data", 0, 1);
+        when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
+        when(table.location()).thenReturn(tableRoot);
+        when(table.fileIO()).thenReturn(fileIO);
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofSeconds(1)))
+                .thenReturn("https://example");
+
+        DescriptorToPresignedUrlFunction function =
+                new DescriptorToPresignedUrlFunction("paimon", catalog);
+        assertThat(
+                        function.eval(
+                                "paimon.default.t",
+                                descriptor.serialize(),
+                                "png",
+                                Duration.ofSeconds(1)))
+                .isEqualTo("https://example");
+
+        DescriptorToPresignedUrlFunction crossCatalog =
+                new DescriptorToPresignedUrlFunction("paimon", catalog);
+        assertThatThrownBy(
+                        () ->
+                                crossCatalog.eval(
+                                        "other.default.t",
+                                        descriptor.serialize(),
+                                        "png",
+                                        Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("paimon.database.table");
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunctionTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/function/DescriptorToPresignedUrlFunctionTest.java
@@ -54,15 +54,14 @@ public class DescriptorToPresignedUrlFunctionTest {
         assertThat(
                         tableEnvironment.explainSql(
                                 "SELECT descriptor_to_presigned_url("
-                                        + "'default.t', CAST(NULL AS BYTES), 'png', "
-                                        + "INTERVAL '1' HOUR)"))
+                                        + "'default.t', CAST(NULL AS BYTES), INTERVAL '1' HOUR)"))
                 .contains("Calc");
 
         assertThatThrownBy(
                         () ->
                                 tableEnvironment.explainSql(
                                         "SELECT descriptor_to_presigned_url("
-                                                + "source_table, descriptor, 'png', "
+                                                + "source_table, descriptor, "
                                                 + "INTERVAL '1' HOUR) "
                                                 + "FROM (VALUES ('default.t', CAST(NULL AS BYTES))) "
                                                 + "AS T(source_table, descriptor)"))
@@ -80,15 +79,15 @@ public class DescriptorToPresignedUrlFunctionTest {
         when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
         when(table.location()).thenReturn(tableRoot);
         when(table.fileIO()).thenReturn(fileIO);
-        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofHours(1)))
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, Duration.ofHours(1)))
                 .thenReturn("https://example");
 
         DescriptorToPresignedUrlFunction function =
                 new DescriptorToPresignedUrlFunction("paimon", catalog);
 
-        assertThat(function.eval("default.t", descriptor.serialize(), "png", Duration.ofHours(1)))
+        assertThat(function.eval("default.t", descriptor.serialize(), Duration.ofHours(1)))
                 .isEqualTo("https://example");
-        assertThat(function.eval("default.t", descriptor.serialize(), "png", Duration.ofHours(1)))
+        assertThat(function.eval("default.t", descriptor.serialize(), Duration.ofHours(1)))
                 .isEqualTo("https://example");
         verify(catalog, times(1)).getTable(new Identifier("default", "t"));
 
@@ -97,7 +96,6 @@ public class DescriptorToPresignedUrlFunctionTest {
                                 function.eval(
                                         "default.other",
                                         descriptor.serialize(),
-                                        "png",
                                         Duration.ofHours(1)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("one source table");
@@ -113,29 +111,24 @@ public class DescriptorToPresignedUrlFunctionTest {
         when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
         when(table.location()).thenReturn(tableRoot);
         when(table.fileIO()).thenReturn(fileIO);
-        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofSeconds(1)))
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, Duration.ofSeconds(1)))
                 .thenThrow(new IOException("signing failed"));
 
         DescriptorToPresignedUrlFunction strict =
                 new DescriptorToPresignedUrlFunction("paimon", catalog);
-        assertThat(strict.eval("default.t", null, "png", Duration.ofSeconds(1))).isNull();
-        assertThat(strict.eval("default.t", descriptor.serialize(), null, Duration.ofSeconds(1)))
-                .isNull();
-        assertThat(strict.eval("default.t", descriptor.serialize(), "png", null)).isNull();
+        assertThat(strict.eval("default.t", null, Duration.ofSeconds(1))).isNull();
+        assertThat(strict.eval("default.t", descriptor.serialize(), null)).isNull();
         verify(catalog, never()).getTable(new Identifier("default", "t"));
         assertThatThrownBy(
                         () ->
                                 strict.eval(
-                                        "default.t",
-                                        descriptor.serialize(),
-                                        "png",
-                                        Duration.ofSeconds(1)))
+                                        "default.t", descriptor.serialize(), Duration.ofSeconds(1)))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("signing failed");
 
         TryDescriptorToPresignedUrlFunction tolerant =
                 new TryDescriptorToPresignedUrlFunction("paimon", catalog);
-        assertThat(tolerant.eval("default.t", descriptor.serialize(), "png", Duration.ofSeconds(1)))
+        assertThat(tolerant.eval("default.t", descriptor.serialize(), Duration.ofSeconds(1)))
                 .isNull();
     }
 
@@ -162,17 +155,12 @@ public class DescriptorToPresignedUrlFunctionTest {
         when(catalog.getTable(new Identifier("default", "t"))).thenReturn(table);
         when(table.location()).thenReturn(tableRoot);
         when(table.fileIO()).thenReturn(fileIO);
-        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, "png", Duration.ofSeconds(1)))
+        when(fileIO.createBlobPresignedUrl(tableRoot, descriptor, Duration.ofSeconds(1)))
                 .thenReturn("https://example");
 
         DescriptorToPresignedUrlFunction function =
                 new DescriptorToPresignedUrlFunction("paimon", catalog);
-        assertThat(
-                        function.eval(
-                                "paimon.default.t",
-                                descriptor.serialize(),
-                                "png",
-                                Duration.ofSeconds(1)))
+        assertThat(function.eval("paimon.default.t", descriptor.serialize(), Duration.ofSeconds(1)))
                 .isEqualTo("https://example");
 
         DescriptorToPresignedUrlFunction crossCatalog =
@@ -182,7 +170,6 @@ public class DescriptorToPresignedUrlFunctionTest {
                                 crossCatalog.eval(
                                         "other.default.t",
                                         descriptor.serialize(),
-                                        "png",
                                         Duration.ofSeconds(1)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("paimon.database.table");

--- a/paimon-flink/paimon-flink1-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsExpressionPushDown.java
+++ b/paimon-flink/paimon-flink1-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsExpressionPushDown.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.expressions.ResolvedExpression;
+
+import java.util.List;
+
+/** Enables a table source to push down resolved expressions. */
+@PublicEvolving
+public interface SupportsExpressionPushDown {
+
+    List<ResolvedExpression> applyExpressions(List<ResolvedExpression> expressions);
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -723,7 +723,7 @@ public class SparkCatalog extends SparkBaseCatalog
     public UnboundFunction loadFunction(Identifier ident) throws NoSuchFunctionException {
         String[] namespace = ident.namespace();
         if (isSystemFunctionNamespace(namespace)) {
-            UnboundFunction func = PaimonFunctions.load(ident.name());
+            UnboundFunction func = PaimonFunctions.load(ident.name(), catalogName);
             if (func != null) {
                 return func;
             }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.function;
+
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DayTimeIntervalType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.Serializable;
+
+/** Spark scalar function placeholder replaced with a table-scoped function during analysis. */
+public class DescriptorToPresignedUrlFunction implements ScalarFunction<UTF8String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean ignoreErrors;
+    private final String catalogName;
+    private final DayTimeIntervalType intervalType;
+
+    public DescriptorToPresignedUrlFunction(boolean ignoreErrors) {
+        this(ignoreErrors, null, DataTypes.createDayTimeIntervalType());
+    }
+
+    public DescriptorToPresignedUrlFunction(boolean ignoreErrors, String catalogName) {
+        this(ignoreErrors, catalogName, DataTypes.createDayTimeIntervalType());
+    }
+
+    public DescriptorToPresignedUrlFunction(
+            boolean ignoreErrors, String catalogName, DayTimeIntervalType intervalType) {
+        this.ignoreErrors = ignoreErrors;
+        this.catalogName = catalogName;
+        this.intervalType = intervalType;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+        return new DataType[] {
+            DataTypes.StringType, DataTypes.BinaryType, DataTypes.StringType, intervalType
+        };
+    }
+
+    @Override
+    public DataType resultType() {
+        return DataTypes.StringType;
+    }
+
+    public UTF8String invoke(
+            UTF8String sourceTable, byte[] descriptor, UTF8String extension, long validityMicros) {
+        if (sourceTable == null || descriptor == null || extension == null) {
+            return null;
+        }
+        throw new UnsupportedOperationException(
+                "Function '" + name() + "' requires a non-null literal sourceTable.");
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return false;
+    }
+
+    public boolean ignoreErrors() {
+        return ignoreErrors;
+    }
+
+    public String catalogName() {
+        return catalogName;
+    }
+
+    @Override
+    public String name() {
+        return DescriptorToPresignedUrlUnbound.functionName(ignoreErrors);
+    }
+
+    @Override
+    public String canonicalName() {
+        return "paimon." + name() + "(string, binary, string, interval day to second)";
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunction.java
@@ -52,9 +52,7 @@ public class DescriptorToPresignedUrlFunction implements ScalarFunction<UTF8Stri
 
     @Override
     public DataType[] inputTypes() {
-        return new DataType[] {
-            DataTypes.StringType, DataTypes.BinaryType, DataTypes.StringType, intervalType
-        };
+        return new DataType[] {DataTypes.StringType, DataTypes.BinaryType, intervalType};
     }
 
     @Override
@@ -62,9 +60,8 @@ public class DescriptorToPresignedUrlFunction implements ScalarFunction<UTF8Stri
         return DataTypes.StringType;
     }
 
-    public UTF8String invoke(
-            UTF8String sourceTable, byte[] descriptor, UTF8String extension, long validityMicros) {
-        if (sourceTable == null || descriptor == null || extension == null) {
+    public UTF8String invoke(UTF8String sourceTable, byte[] descriptor, long validityMicros) {
+        if (sourceTable == null || descriptor == null) {
             return null;
         }
         throw new UnsupportedOperationException(
@@ -91,6 +88,6 @@ public class DescriptorToPresignedUrlFunction implements ScalarFunction<UTF8Stri
 
     @Override
     public String canonicalName() {
-        return "paimon." + name() + "(string, binary, string, interval day to second)";
+        return "paimon." + name() + "(string, binary, interval day to second)";
     }
 }

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlUnbound.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlUnbound.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.function;
+
+import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.DayTimeIntervalType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/** Function unbound to {@link DescriptorToPresignedUrlFunction}. */
+public class DescriptorToPresignedUrlUnbound implements UnboundFunction {
+
+    public static final String NAME = "descriptor_to_presigned_url";
+    public static final String TRY_NAME = "try_descriptor_to_presigned_url";
+
+    private final boolean ignoreErrors;
+    private final String catalogName;
+
+    public DescriptorToPresignedUrlUnbound(boolean ignoreErrors) {
+        this(ignoreErrors, null);
+    }
+
+    public DescriptorToPresignedUrlUnbound(boolean ignoreErrors, String catalogName) {
+        this.ignoreErrors = ignoreErrors;
+        this.catalogName = catalogName;
+    }
+
+    @Override
+    public BoundFunction bind(StructType inputType) {
+        StructField[] fields = inputType.fields();
+        if (fields.length != 4) {
+            throw new UnsupportedOperationException(
+                    "Function '"
+                            + name()
+                            + "' requires 4 arguments "
+                            + "(sourceTable STRING, descriptor BINARY, extension STRING, "
+                            + "validity INTERVAL DAY TO SECOND), but found "
+                            + fields.length);
+        }
+        requireType(fields, 0, StringType.class, "first", "STRING");
+        requireType(fields, 1, BinaryType.class, "second", "BINARY");
+        requireType(fields, 2, StringType.class, "third", "STRING");
+        requireType(fields, 3, DayTimeIntervalType.class, "fourth", "INTERVAL DAY TO SECOND");
+        return new DescriptorToPresignedUrlFunction(
+                ignoreErrors, catalogName, (DayTimeIntervalType) fields[3].dataType());
+    }
+
+    private void requireType(
+            StructField[] fields,
+            int position,
+            Class<?> expectedClass,
+            String positionName,
+            String expectedName) {
+        if (!expectedClass.isInstance(fields[position].dataType())) {
+            throw new UnsupportedOperationException(
+                    "The "
+                            + positionName
+                            + " argument of '"
+                            + name()
+                            + "' must be "
+                            + expectedName
+                            + " type, but found "
+                            + fields[position].dataType().simpleString());
+        }
+    }
+
+    @Override
+    public String description() {
+        return "Create a presigned URL for a blob descriptor";
+    }
+
+    @Override
+    public String name() {
+        return functionName(ignoreErrors);
+    }
+
+    static String functionName(boolean ignoreErrors) {
+        return ignoreErrors ? TRY_NAME : NAME;
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlUnbound.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlUnbound.java
@@ -47,21 +47,20 @@ public class DescriptorToPresignedUrlUnbound implements UnboundFunction {
     @Override
     public BoundFunction bind(StructType inputType) {
         StructField[] fields = inputType.fields();
-        if (fields.length != 4) {
+        if (fields.length != 3) {
             throw new UnsupportedOperationException(
                     "Function '"
                             + name()
-                            + "' requires 4 arguments "
-                            + "(sourceTable STRING, descriptor BINARY, extension STRING, "
+                            + "' requires 3 arguments "
+                            + "(sourceTable STRING, descriptor BINARY, "
                             + "validity INTERVAL DAY TO SECOND), but found "
                             + fields.length);
         }
         requireType(fields, 0, StringType.class, "first", "STRING");
         requireType(fields, 1, BinaryType.class, "second", "BINARY");
-        requireType(fields, 2, StringType.class, "third", "STRING");
-        requireType(fields, 3, DayTimeIntervalType.class, "fourth", "INTERVAL DAY TO SECOND");
+        requireType(fields, 2, DayTimeIntervalType.class, "third", "INTERVAL DAY TO SECOND");
         return new DescriptorToPresignedUrlFunction(
-                ignoreErrors, catalogName, (DayTimeIntervalType) fields[3].dataType());
+                ignoreErrors, catalogName, (DayTimeIntervalType) fields[2].dataType());
     }
 
     private void requireType(

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/ResolvedDescriptorToPresignedUrlFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/ResolvedDescriptorToPresignedUrlFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.function;
+
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.utils.ExceptionUtils;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
+
+/** Executor-side descriptor-to-presigned-URL function bound to one table's FileIO. */
+public class ResolvedDescriptorToPresignedUrlFunction
+        implements ScalarFunction<UTF8String>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final long MICROS_PER_SECOND = 1_000_000L;
+
+    private final FileIO fileIO;
+    private final Path tableRoot;
+    private final boolean ignoreErrors;
+
+    public ResolvedDescriptorToPresignedUrlFunction(
+            FileIO fileIO, Path tableRoot, boolean ignoreErrors) {
+        this.fileIO = fileIO;
+        this.tableRoot = tableRoot;
+        this.ignoreErrors = ignoreErrors;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+        return new DataType[] {
+            DataTypes.BinaryType, DataTypes.StringType, DataTypes.createDayTimeIntervalType()
+        };
+    }
+
+    @Override
+    public DataType resultType() {
+        return DataTypes.StringType;
+    }
+
+    public UTF8String invoke(byte[] descriptor, UTF8String extension, long validityMicros)
+            throws IOException {
+        if (descriptor == null || extension == null) {
+            return null;
+        }
+
+        try {
+            Duration validity = validity(validityMicros);
+            BlobDescriptor blobDescriptor = BlobDescriptor.deserialize(descriptor);
+            return UTF8String.fromString(
+                    fileIO.createBlobPresignedUrl(
+                            tableRoot, blobDescriptor, extension.toString(), validity));
+        } catch (Exception e) {
+            if (ignoreErrors) {
+                return null;
+            }
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public UTF8String produceResult(InternalRow input) {
+        if (input.isNullAt(0) || input.isNullAt(1) || input.isNullAt(2)) {
+            return null;
+        }
+        try {
+            return invoke(input.getBinary(0), input.getUTF8String(1), input.getLong(2));
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e);
+            return null;
+        }
+    }
+
+    private Duration validity(long validityMicros) {
+        if (validityMicros <= 0) {
+            throw new IllegalArgumentException("Validity interval must be positive.");
+        }
+        if (validityMicros % MICROS_PER_SECOND != 0) {
+            throw new IllegalArgumentException("Validity interval must contain whole seconds.");
+        }
+        return Duration.ofSeconds(validityMicros / MICROS_PER_SECOND);
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return false;
+    }
+
+    @Override
+    public String name() {
+        return DescriptorToPresignedUrlUnbound.functionName(ignoreErrors);
+    }
+}

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/ResolvedDescriptorToPresignedUrlFunction.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/function/ResolvedDescriptorToPresignedUrlFunction.java
@@ -53,9 +53,7 @@ public class ResolvedDescriptorToPresignedUrlFunction
 
     @Override
     public DataType[] inputTypes() {
-        return new DataType[] {
-            DataTypes.BinaryType, DataTypes.StringType, DataTypes.createDayTimeIntervalType()
-        };
+        return new DataType[] {DataTypes.BinaryType, DataTypes.createDayTimeIntervalType()};
     }
 
     @Override
@@ -63,9 +61,8 @@ public class ResolvedDescriptorToPresignedUrlFunction
         return DataTypes.StringType;
     }
 
-    public UTF8String invoke(byte[] descriptor, UTF8String extension, long validityMicros)
-            throws IOException {
-        if (descriptor == null || extension == null) {
+    public UTF8String invoke(byte[] descriptor, long validityMicros) throws IOException {
+        if (descriptor == null) {
             return null;
         }
 
@@ -73,8 +70,7 @@ public class ResolvedDescriptorToPresignedUrlFunction
             Duration validity = validity(validityMicros);
             BlobDescriptor blobDescriptor = BlobDescriptor.deserialize(descriptor);
             return UTF8String.fromString(
-                    fileIO.createBlobPresignedUrl(
-                            tableRoot, blobDescriptor, extension.toString(), validity));
+                    fileIO.createBlobPresignedUrl(tableRoot, blobDescriptor, validity));
         } catch (Exception e) {
             if (ignoreErrors) {
                 return null;
@@ -91,11 +87,11 @@ public class ResolvedDescriptorToPresignedUrlFunction
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-        if (input.isNullAt(0) || input.isNullAt(1) || input.isNullAt(2)) {
+        if (input.isNullAt(0) || input.isNullAt(1)) {
             return null;
         }
         try {
-            return invoke(input.getBinary(0), input.getUTF8String(1), input.getLong(2));
+            return invoke(input.getBinary(0), input.getLong(1));
         } catch (IOException e) {
             ExceptionUtils.rethrow(e);
             return null;

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalog/functions/PaimonFunctions.scala
@@ -25,7 +25,7 @@ import org.apache.paimon.shade.guava30.com.google.common.collect.{ImmutableMap, 
 import org.apache.paimon.spark.SparkInternalRowWrapper
 import org.apache.paimon.spark.SparkTypeUtils.toPaimonRowType
 import org.apache.paimon.spark.catalog.functions.PaimonFunctions._
-import org.apache.paimon.spark.function.{BlobViewUnbound, DescriptorToStringUnbound, PathToDescriptorUnbound}
+import org.apache.paimon.spark.function.{BlobViewUnbound, DescriptorToPresignedUrlUnbound, DescriptorToStringUnbound, PathToDescriptorUnbound}
 import org.apache.paimon.table.{BucketMode, FileStoreTable}
 import org.apache.paimon.types.{ArrayType, DataType => PaimonDataType, LocalZonedTimestampType, MapType, RowType, TimestampType}
 import org.apache.paimon.utils.ProjectedRow
@@ -48,6 +48,8 @@ object PaimonFunctions {
   val PATH_TO_DESCRIPTOR: String = "path_to_descriptor"
   val DESCRIPTOR_TO_STRING: String = "descriptor_to_string"
   val BLOB_VIEW: String = "blob_view"
+  val DESCRIPTOR_TO_PRESIGNED_URL: String = "descriptor_to_presigned_url"
+  val TRY_DESCRIPTOR_TO_PRESIGNED_URL: String = "try_descriptor_to_presigned_url"
 
   private val FUNCTIONS = ImmutableMap
     .builder[String, UnboundFunction]()
@@ -58,6 +60,8 @@ object PaimonFunctions {
     .put(PATH_TO_DESCRIPTOR, new PathToDescriptorUnbound)
     .put(DESCRIPTOR_TO_STRING, new DescriptorToStringUnbound)
     .put(BLOB_VIEW, new BlobViewUnbound)
+    .put(DESCRIPTOR_TO_PRESIGNED_URL, new DescriptorToPresignedUrlUnbound(false))
+    .put(TRY_DESCRIPTOR_TO_PRESIGNED_URL, new DescriptorToPresignedUrlUnbound(true))
     .build()
 
   /** The bucket function type to the function name mapping */
@@ -76,6 +80,17 @@ object PaimonFunctions {
 
   @Nullable
   def load(name: String): UnboundFunction = FUNCTIONS.get(name)
+
+  @Nullable
+  def load(name: String, catalogName: String): UnboundFunction = {
+    if (name.equalsIgnoreCase(DESCRIPTOR_TO_PRESIGNED_URL)) {
+      new DescriptorToPresignedUrlUnbound(false, catalogName)
+    } else if (name.equalsIgnoreCase(TRY_DESCRIPTOR_TO_PRESIGNED_URL)) {
+      new DescriptorToPresignedUrlUnbound(true, catalogName)
+    } else {
+      load(name)
+    }
+  }
 }
 
 /**

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
@@ -24,12 +24,13 @@ import org.apache.paimon.spark.catalog.functions.PaimonFunctions
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedFunction
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal}
 import org.apache.spark.sql.catalyst.parser.extensions.UnResolvedPaimonV1Function
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.UNRESOLVED_FUNCTION
-import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.sql.connector.catalog.CatalogPlugin
+import org.apache.spark.sql.types.{BinaryType, DataType, DayTimeIntervalType, LongType, NullType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
 case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan] {
@@ -40,6 +41,10 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
     plan.resolveOperatorsUpWithPruning(_.containsAnyPattern(UNRESOLVED_FUNCTION)) {
       case l: LogicalPlan =>
         l.transformExpressionsWithPruning(_.containsAnyPattern(UNRESOLVED_FUNCTION)) {
+          case u: UnresolvedFunction
+              if isDescriptorToPresignedUrlFunction(u.nameParts) &&
+                u.arguments.forall(_.resolved) =>
+            resolveDescriptorToPresignedUrl(u)
           case u: UnresolvedFunction
               if isBlobViewFunction(u.nameParts) && u.arguments.forall(_.resolved) =>
             resolveBlobView(u)
@@ -73,6 +78,67 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
     ReplacePaimonFunctions.resolveBlobView(spark, tableName, fieldName, u.arguments(2))
   }
 
+  private def resolveDescriptorToPresignedUrl(u: UnresolvedFunction): Expression = {
+    val functionName = u.nameParts.last
+    if (u.arguments.length != 4) {
+      throw new UnsupportedOperationException(
+        s"Function '$functionName' requires 4 arguments " +
+          s"(sourceTable STRING, descriptor BINARY, extension STRING, " +
+          s"validity INTERVAL DAY TO SECOND), but found ${u.arguments.length}")
+    }
+
+    val sourceTable = literalString(u.arguments(0), "sourceTable")
+    if (sourceTable == null) {
+      throw new UnsupportedOperationException("sourceTable must not be null")
+    }
+
+    val descriptor = castNullable(u.arguments(1), BinaryType, "descriptor")
+    val extension = castNullable(u.arguments(2), StringType, "extension")
+    val intervalType = DayTimeIntervalType.DEFAULT
+    val validity = u.arguments(3).dataType match {
+      case _: DayTimeIntervalType => Cast(u.arguments(3), intervalType)
+      case NullType => Cast(u.arguments(3), intervalType)
+      case other =>
+        throw new UnsupportedOperationException(
+          s"validity must be INTERVAL DAY TO SECOND type, but found ${other.simpleString}")
+    }
+    val ignoreErrors =
+      functionName.equalsIgnoreCase(PaimonFunctions.TRY_DESCRIPTOR_TO_PRESIGNED_URL)
+
+    ReplacePaimonFunctions.resolveDescriptorToPresignedUrl(
+      spark,
+      functionCatalog(u.nameParts),
+      sourceTable,
+      descriptor,
+      extension,
+      validity,
+      ignoreErrors)
+  }
+
+  private def castNullable(
+      expression: Expression,
+      expectedType: DataType,
+      argumentName: String): Expression = {
+    expression.dataType match {
+      case NullType => Cast(expression, expectedType)
+      case actual if actual == expectedType => expression
+      case actual =>
+        throw new UnsupportedOperationException(
+          s"$argumentName must be ${expectedType.simpleString.toUpperCase} type, " +
+            s"but found ${actual.simpleString}")
+    }
+  }
+
+  private def functionCatalog(nameParts: Seq[String]): CatalogPlugin = {
+    nameParts.length match {
+      case 2 => catalogManager.currentCatalog
+      case 3 => catalogManager.catalog(nameParts.head)
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"Invalid function identifier: ${nameParts.mkString(".")}")
+    }
+  }
+
   private def literalString(expr: Expression, argumentName: String): String = {
     if (!expr.isInstanceOf[Literal]) {
       throw new UnsupportedOperationException(s"$argumentName must be a literal")
@@ -92,6 +158,13 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
   private def isBlobViewFunction(nameParts: Seq[String]): Boolean = {
     nameParts.length >= 2 &&
     nameParts.last.equalsIgnoreCase(PaimonFunctions.BLOB_VIEW) &&
+    nameParts(nameParts.length - 2).equalsIgnoreCase(SYSTEM_DATABASE_NAME)
+  }
+
+  private def isDescriptorToPresignedUrlFunction(nameParts: Seq[String]): Boolean = {
+    nameParts.length >= 2 &&
+    (nameParts.last.equalsIgnoreCase(PaimonFunctions.DESCRIPTOR_TO_PRESIGNED_URL) ||
+      nameParts.last.equalsIgnoreCase(PaimonFunctions.TRY_DESCRIPTOR_TO_PRESIGNED_URL)) &&
     nameParts(nameParts.length - 2).equalsIgnoreCase(SYSTEM_DATABASE_NAME)
   }
 }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/PaimonFunctionResolver.scala
@@ -80,10 +80,10 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
 
   private def resolveDescriptorToPresignedUrl(u: UnresolvedFunction): Expression = {
     val functionName = u.nameParts.last
-    if (u.arguments.length != 4) {
+    if (u.arguments.length != 3) {
       throw new UnsupportedOperationException(
-        s"Function '$functionName' requires 4 arguments " +
-          s"(sourceTable STRING, descriptor BINARY, extension STRING, " +
+        s"Function '$functionName' requires 3 arguments " +
+          s"(sourceTable STRING, descriptor BINARY, " +
           s"validity INTERVAL DAY TO SECOND), but found ${u.arguments.length}")
     }
 
@@ -93,11 +93,10 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
     }
 
     val descriptor = castNullable(u.arguments(1), BinaryType, "descriptor")
-    val extension = castNullable(u.arguments(2), StringType, "extension")
     val intervalType = DayTimeIntervalType.DEFAULT
-    val validity = u.arguments(3).dataType match {
-      case _: DayTimeIntervalType => Cast(u.arguments(3), intervalType)
-      case NullType => Cast(u.arguments(3), intervalType)
+    val validity = u.arguments(2).dataType match {
+      case _: DayTimeIntervalType => Cast(u.arguments(2), intervalType)
+      case NullType => Cast(u.arguments(2), intervalType)
       case other =>
         throw new UnsupportedOperationException(
           s"validity must be INTERVAL DAY TO SECOND type, but found ${other.simpleString}")
@@ -110,7 +109,6 @@ case class PaimonFunctionResolver(spark: SparkSession) extends Rule[LogicalPlan]
       functionCatalog(u.nameParts),
       sourceTable,
       descriptor,
-      extension,
       validity,
       ignoreErrors)
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
@@ -21,8 +21,9 @@ package org.apache.paimon.spark.catalyst.analysis
 import org.apache.paimon.spark.{DataConverter, SparkTable, SparkTypeUtils, SparkUtils}
 import org.apache.paimon.spark.catalog.SparkBaseCatalog
 import org.apache.paimon.spark.catalog.functions.PaimonFunctions
-import org.apache.paimon.spark.function.{BlobViewFieldIdSparkFunction, BlobViewSparkFunction}
+import org.apache.paimon.spark.function.{BlobViewFieldIdSparkFunction, BlobViewSparkFunction, DescriptorToPresignedUrlFunction, ResolvedDescriptorToPresignedUrlFunction}
 import org.apache.paimon.spark.utils.CatalogUtils
+import org.apache.paimon.table.DataTable
 import org.apache.paimon.types.DataTypeRoot
 import org.apache.paimon.utils.{InternalRowUtils, TypeUtils}
 
@@ -31,13 +32,58 @@ import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, Cast,
 import org.apache.spark.sql.catalyst.expressions.objects.Invoke
 import org.apache.spark.sql.catalyst.plans.logical.{AnalysisHelper, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier}
 import org.apache.spark.sql.connector.catalog.PaimonCatalogImplicits._
-import org.apache.spark.sql.types.{BinaryType, StringType}
+import org.apache.spark.sql.types.{BinaryType, DataType, DayTimeIntervalType, NullType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import scala.collection.JavaConverters._
 
 object ReplacePaimonFunctions {
+
+  def resolveDescriptorToPresignedUrl(
+      spark: SparkSession,
+      functionCatalog: CatalogPlugin,
+      sourceTable: String,
+      descriptor: Expression,
+      extension: Expression,
+      validity: Expression,
+      ignoreErrors: Boolean): Expression = {
+    if (!functionCatalog.isInstanceOf[SparkBaseCatalog]) {
+      throw new UnsupportedOperationException(s"$functionCatalog is not a Paimon catalog")
+    }
+
+    val parts = spark.sessionState.sqlParser.parseMultipartIdentifier(sourceTable)
+    val identifier = parts.length match {
+      case 2 => Identifier.of(Array(parts.head), parts(1))
+      case 3 =>
+        if (!parts.head.equalsIgnoreCase(functionCatalog.name())) {
+          throw new UnsupportedOperationException(
+            s"Source table catalog '${parts.head}' must match function catalog " +
+              s"'${functionCatalog.name()}'.")
+        }
+        Identifier.of(Array(parts(1)), parts(2))
+      case _ =>
+        throw new UnsupportedOperationException(
+          "sourceTable must be database.table or catalog.database.table")
+    }
+
+    val table = functionCatalog.asTableCatalog.loadTable(identifier)
+    if (!table.isInstanceOf[SparkTable]) {
+      throw new UnsupportedOperationException(s"$sourceTable is not a Paimon table")
+    }
+    val dataTable = table.asInstanceOf[SparkTable].table match {
+      case table: DataTable => table
+      case _ =>
+        throw new UnsupportedOperationException(s"$sourceTable is not a Paimon data table")
+    }
+    val fileIO = dataTable.fileIO()
+    fileIO.isObjectStore
+
+    ApplyFunctionExpression(
+      new ResolvedDescriptorToPresignedUrlFunction(fileIO, dataTable.location(), ignoreErrors),
+      Seq(descriptor, extension, validity))
+  }
 
   def resolveBlobView(
       spark: SparkSession,
@@ -82,6 +128,8 @@ object ReplacePaimonFunctions {
 
 /** A rule to replace Paimon functions with literal values. */
 case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan] {
+  private lazy val catalogManager = spark.sessionState.catalogManager
+
   private def replaceMaxPt(func: ApplyFunctionExpression): Expression = {
     assert(func.children.size == 1)
     assert(func.children.head.dataType == StringType)
@@ -138,6 +186,56 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
     ReplacePaimonFunctions.resolveBlobView(spark, tableName, fieldName, arguments(2))
   }
 
+  private def replaceDescriptorToPresignedUrl(
+      arguments: Seq[Expression],
+      function: DescriptorToPresignedUrlFunction): Expression = {
+    assert(arguments.size == 4)
+    val sourceTable = literalString(arguments(0), "sourceTable")
+    if (sourceTable == null) {
+      throw new UnsupportedOperationException("sourceTable must not be null")
+    }
+    if (arguments(0).dataType != StringType) {
+      throw new UnsupportedOperationException("sourceTable must be STRING type")
+    }
+
+    val descriptor = castNullable(arguments(1), BinaryType, "descriptor")
+    val extension = castNullable(arguments(2), StringType, "extension")
+    val intervalType = DayTimeIntervalType.DEFAULT
+    val validity = arguments(3).dataType match {
+      case _: DayTimeIntervalType => Cast(arguments(3), intervalType)
+      case NullType => Cast(arguments(3), intervalType)
+      case other =>
+        throw new UnsupportedOperationException(
+          s"validity must be INTERVAL DAY TO SECOND type, but found ${other.simpleString}")
+    }
+    val functionCatalog = Option(function.catalogName())
+      .map(catalogManager.catalog)
+      .getOrElse(catalogManager.currentCatalog)
+
+    ReplacePaimonFunctions.resolveDescriptorToPresignedUrl(
+      spark,
+      functionCatalog,
+      sourceTable,
+      descriptor,
+      extension,
+      validity,
+      function.ignoreErrors())
+  }
+
+  private def castNullable(
+      expression: Expression,
+      expectedType: DataType,
+      argumentName: String): Expression = {
+    expression.dataType match {
+      case NullType => Cast(expression, expectedType)
+      case actual if actual == expectedType => expression
+      case actual =>
+        throw new UnsupportedOperationException(
+          s"$argumentName must be ${expectedType.simpleString.toUpperCase} type, " +
+            s"but found ${actual.simpleString}")
+    }
+  }
+
   private def literalString(child: Expression, argumentName: String): String = {
     if (!child.isInstanceOf[Literal]) {
       throw new UnsupportedOperationException(s"$argumentName must be a literal")
@@ -158,6 +256,18 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
     }
   }
 
+  private def descriptorToPresignedUrlFunction(
+      invoke: Invoke): Option[DescriptorToPresignedUrlFunction] = {
+    if (invoke.functionName != "invoke" || !invoke.targetObject.foldable) {
+      None
+    } else {
+      invoke.targetObject.eval() match {
+        case function: DescriptorToPresignedUrlFunction => Some(function)
+        case _ => None
+      }
+    }
+  }
+
   override def apply(plan: LogicalPlan): LogicalPlan = {
     AnalysisHelper.allowInvokingTransformsInAnalyzer {
       plan.transformAllExpressions {
@@ -169,8 +279,17 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
             if func.function.name() == PaimonFunctions.BLOB_VIEW &&
               func.function.canonicalName().startsWith("paimon") =>
           replaceBlobView(func.children)
+        case func: ApplyFunctionExpression
+            if func.function.isInstanceOf[DescriptorToPresignedUrlFunction] =>
+          replaceDescriptorToPresignedUrl(
+            func.children,
+            func.function.asInstanceOf[DescriptorToPresignedUrlFunction])
         case invoke: Invoke if isBlobViewInvoke(invoke) =>
           replaceBlobView(invoke.arguments)
+        case invoke: Invoke if descriptorToPresignedUrlFunction(invoke).isDefined =>
+          replaceDescriptorToPresignedUrl(
+            invoke.arguments,
+            descriptorToPresignedUrlFunction(invoke).get)
       }
     }
   }

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/catalyst/analysis/ReplacePaimonFunctions.scala
@@ -46,7 +46,6 @@ object ReplacePaimonFunctions {
       functionCatalog: CatalogPlugin,
       sourceTable: String,
       descriptor: Expression,
-      extension: Expression,
       validity: Expression,
       ignoreErrors: Boolean): Expression = {
     if (!functionCatalog.isInstanceOf[SparkBaseCatalog]) {
@@ -82,7 +81,7 @@ object ReplacePaimonFunctions {
 
     ApplyFunctionExpression(
       new ResolvedDescriptorToPresignedUrlFunction(fileIO, dataTable.location(), ignoreErrors),
-      Seq(descriptor, extension, validity))
+      Seq(descriptor, validity))
   }
 
   def resolveBlobView(
@@ -189,7 +188,7 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
   private def replaceDescriptorToPresignedUrl(
       arguments: Seq[Expression],
       function: DescriptorToPresignedUrlFunction): Expression = {
-    assert(arguments.size == 4)
+    assert(arguments.size == 3)
     val sourceTable = literalString(arguments(0), "sourceTable")
     if (sourceTable == null) {
       throw new UnsupportedOperationException("sourceTable must not be null")
@@ -199,11 +198,10 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
     }
 
     val descriptor = castNullable(arguments(1), BinaryType, "descriptor")
-    val extension = castNullable(arguments(2), StringType, "extension")
     val intervalType = DayTimeIntervalType.DEFAULT
-    val validity = arguments(3).dataType match {
-      case _: DayTimeIntervalType => Cast(arguments(3), intervalType)
-      case NullType => Cast(arguments(3), intervalType)
+    val validity = arguments(2).dataType match {
+      case _: DayTimeIntervalType => Cast(arguments(2), intervalType)
+      case NullType => Cast(arguments(2), intervalType)
       case other =>
         throw new UnsupportedOperationException(
           s"validity must be INTERVAL DAY TO SECOND type, but found ${other.simpleString}")
@@ -217,7 +215,6 @@ case class ReplacePaimonFunctions(spark: SparkSession) extends Rule[LogicalPlan]
       functionCatalog,
       sourceTable,
       descriptor,
-      extension,
       validity,
       function.ignoreErrors())
   }

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunctionTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunctionTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.function;
+
+import org.apache.paimon.data.BlobDescriptor;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.utils.BlobDescriptorUtils;
+
+import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for descriptor-to-presigned-URL Spark functions. */
+class DescriptorToPresignedUrlFunctionTest {
+
+    private static final Path TABLE_ROOT = new Path("oss://bucket/table");
+    private static final BlobDescriptor DESCRIPTOR =
+            new BlobDescriptor("oss://bucket/table/bucket-0/data.blob", 10, 20);
+
+    @Test
+    void testBindAndNonDeterministic() {
+        StructType inputType =
+                new StructType()
+                        .add("source_table", DataTypes.StringType)
+                        .add("descriptor", DataTypes.BinaryType)
+                        .add("extension", DataTypes.StringType)
+                        .add("validity", DataTypes.createDayTimeIntervalType());
+
+        BoundFunction strict = new DescriptorToPresignedUrlUnbound(false).bind(inputType);
+        BoundFunction lenient = new DescriptorToPresignedUrlUnbound(true).bind(inputType);
+
+        assertThat(strict).isInstanceOf(DescriptorToPresignedUrlFunction.class);
+        assertThat(strict.isDeterministic()).isFalse();
+        assertThat(lenient.isDeterministic()).isFalse();
+        assertThat(strict.inputTypes())
+                .containsExactly(
+                        DataTypes.StringType,
+                        DataTypes.BinaryType,
+                        DataTypes.StringType,
+                        DataTypes.createDayTimeIntervalType());
+        assertThatThrownBy(
+                        () ->
+                                new DescriptorToPresignedUrlUnbound(false)
+                                        .bind(
+                                                new StructType()
+                                                        .add("source_table", DataTypes.StringType)
+                                                        .add("descriptor", DataTypes.BinaryType)
+                                                        .add("extension", DataTypes.StringType)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testResolvedFunction() throws IOException {
+        ResolvedDescriptorToPresignedUrlFunction function =
+                new ResolvedDescriptorToPresignedUrlFunction(
+                        new TestingFileIO(), TABLE_ROOT, false);
+
+        assertThat(
+                        function.invoke(
+                                DESCRIPTOR.serialize(), UTF8String.fromString("png"), 3_000_000L))
+                .hasToString("https://example.test/data.png?validity=3&offset=10&length=20");
+        assertThat(function.isDeterministic()).isFalse();
+    }
+
+    @Test
+    void testNullArguments() throws IOException {
+        ResolvedDescriptorToPresignedUrlFunction function =
+                new ResolvedDescriptorToPresignedUrlFunction(
+                        new TestingFileIO(), TABLE_ROOT, false);
+
+        assertThat(function.invoke(null, UTF8String.fromString("png"), 1_000_000L)).isNull();
+        assertThat(function.invoke(DESCRIPTOR.serialize(), null, 1_000_000L)).isNull();
+    }
+
+    @Test
+    void testValidityMustBePositiveWholeSeconds() {
+        ResolvedDescriptorToPresignedUrlFunction function =
+                new ResolvedDescriptorToPresignedUrlFunction(
+                        new TestingFileIO(), TABLE_ROOT, false);
+
+        assertThatThrownBy(
+                        () ->
+                                function.invoke(
+                                        DESCRIPTOR.serialize(),
+                                        UTF8String.fromString("png"),
+                                        1_000_001L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("whole seconds");
+        assertThatThrownBy(
+                        () ->
+                                function.invoke(
+                                        DESCRIPTOR.serialize(), UTF8String.fromString("png"), 0L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void testTryReturnsNullOnRowError() throws IOException {
+        ResolvedDescriptorToPresignedUrlFunction function =
+                new ResolvedDescriptorToPresignedUrlFunction(new TestingFileIO(), TABLE_ROOT, true);
+
+        assertThat(function.invoke(new byte[] {1}, UTF8String.fromString("png"), 1_000_000L))
+                .isNull();
+        assertThat(
+                        function.invoke(
+                                DESCRIPTOR.serialize(), UTF8String.fromString("png"), 1_000_001L))
+                .isNull();
+    }
+
+    @Test
+    void testRejectDescriptorOutsideTableRoot() {
+        ResolvedDescriptorToPresignedUrlFunction function =
+                new ResolvedDescriptorToPresignedUrlFunction(
+                        new TestingFileIO(), TABLE_ROOT, false);
+        BlobDescriptor other = new BlobDescriptor("oss://bucket/other/bucket-0/data.blob", 0, 1);
+
+        assertThatThrownBy(
+                        () ->
+                                function.invoke(
+                                        other.serialize(),
+                                        UTF8String.fromString("png"),
+                                        1_000_000L))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("under table root");
+    }
+
+    @Test
+    void testFileIOSerialization() throws Exception {
+        ResolvedDescriptorToPresignedUrlFunction original =
+                new ResolvedDescriptorToPresignedUrlFunction(
+                        new TestingFileIO(), TABLE_ROOT, false);
+
+        ResolvedDescriptorToPresignedUrlFunction restored = roundTrip(original);
+
+        assertThat(
+                        restored.invoke(
+                                DESCRIPTOR.serialize(), UTF8String.fromString("jpg"), 2_000_000L))
+                .hasToString("https://example.test/data.jpg?validity=2&offset=10&length=20");
+    }
+
+    private ResolvedDescriptorToPresignedUrlFunction roundTrip(
+            ResolvedDescriptorToPresignedUrlFunction function) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(function);
+        }
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (ResolvedDescriptorToPresignedUrlFunction) input.readObject();
+        }
+    }
+
+    private static class TestingFileIO extends LocalFileIO {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String createBlobPresignedUrl(
+                Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
+                throws IOException {
+            BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
+            return "https://example.test/data."
+                    + extension
+                    + "?validity="
+                    + validity.getSeconds()
+                    + "&offset="
+                    + descriptor.offset()
+                    + "&length="
+                    + descriptor.length();
+        }
+    }
+}

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunctionTest.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/function/DescriptorToPresignedUrlFunctionTest.java
@@ -26,7 +26,6 @@ import org.apache.paimon.utils.BlobDescriptorUtils;
 import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -52,7 +51,6 @@ class DescriptorToPresignedUrlFunctionTest {
                 new StructType()
                         .add("source_table", DataTypes.StringType)
                         .add("descriptor", DataTypes.BinaryType)
-                        .add("extension", DataTypes.StringType)
                         .add("validity", DataTypes.createDayTimeIntervalType());
 
         BoundFunction strict = new DescriptorToPresignedUrlUnbound(false).bind(inputType);
@@ -65,7 +63,6 @@ class DescriptorToPresignedUrlFunctionTest {
                 .containsExactly(
                         DataTypes.StringType,
                         DataTypes.BinaryType,
-                        DataTypes.StringType,
                         DataTypes.createDayTimeIntervalType());
         assertThatThrownBy(
                         () ->
@@ -73,8 +70,7 @@ class DescriptorToPresignedUrlFunctionTest {
                                         .bind(
                                                 new StructType()
                                                         .add("source_table", DataTypes.StringType)
-                                                        .add("descriptor", DataTypes.BinaryType)
-                                                        .add("extension", DataTypes.StringType)))
+                                                        .add("descriptor", DataTypes.BinaryType)))
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
@@ -84,10 +80,8 @@ class DescriptorToPresignedUrlFunctionTest {
                 new ResolvedDescriptorToPresignedUrlFunction(
                         new TestingFileIO(), TABLE_ROOT, false);
 
-        assertThat(
-                        function.invoke(
-                                DESCRIPTOR.serialize(), UTF8String.fromString("png"), 3_000_000L))
-                .hasToString("https://example.test/data.png?validity=3&offset=10&length=20");
+        assertThat(function.invoke(DESCRIPTOR.serialize(), 3_000_000L))
+                .hasToString("https://example.test/data?validity=3&offset=10&length=20");
         assertThat(function.isDeterministic()).isFalse();
     }
 
@@ -97,8 +91,7 @@ class DescriptorToPresignedUrlFunctionTest {
                 new ResolvedDescriptorToPresignedUrlFunction(
                         new TestingFileIO(), TABLE_ROOT, false);
 
-        assertThat(function.invoke(null, UTF8String.fromString("png"), 1_000_000L)).isNull();
-        assertThat(function.invoke(DESCRIPTOR.serialize(), null, 1_000_000L)).isNull();
+        assertThat(function.invoke(null, 1_000_000L)).isNull();
     }
 
     @Test
@@ -107,18 +100,10 @@ class DescriptorToPresignedUrlFunctionTest {
                 new ResolvedDescriptorToPresignedUrlFunction(
                         new TestingFileIO(), TABLE_ROOT, false);
 
-        assertThatThrownBy(
-                        () ->
-                                function.invoke(
-                                        DESCRIPTOR.serialize(),
-                                        UTF8String.fromString("png"),
-                                        1_000_001L))
+        assertThatThrownBy(() -> function.invoke(DESCRIPTOR.serialize(), 1_000_001L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("whole seconds");
-        assertThatThrownBy(
-                        () ->
-                                function.invoke(
-                                        DESCRIPTOR.serialize(), UTF8String.fromString("png"), 0L))
+        assertThatThrownBy(() -> function.invoke(DESCRIPTOR.serialize(), 0L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("positive");
     }
@@ -128,12 +113,8 @@ class DescriptorToPresignedUrlFunctionTest {
         ResolvedDescriptorToPresignedUrlFunction function =
                 new ResolvedDescriptorToPresignedUrlFunction(new TestingFileIO(), TABLE_ROOT, true);
 
-        assertThat(function.invoke(new byte[] {1}, UTF8String.fromString("png"), 1_000_000L))
-                .isNull();
-        assertThat(
-                        function.invoke(
-                                DESCRIPTOR.serialize(), UTF8String.fromString("png"), 1_000_001L))
-                .isNull();
+        assertThat(function.invoke(new byte[] {1}, 1_000_000L)).isNull();
+        assertThat(function.invoke(DESCRIPTOR.serialize(), 1_000_001L)).isNull();
     }
 
     @Test
@@ -143,12 +124,7 @@ class DescriptorToPresignedUrlFunctionTest {
                         new TestingFileIO(), TABLE_ROOT, false);
         BlobDescriptor other = new BlobDescriptor("oss://bucket/other/bucket-0/data.blob", 0, 1);
 
-        assertThatThrownBy(
-                        () ->
-                                function.invoke(
-                                        other.serialize(),
-                                        UTF8String.fromString("png"),
-                                        1_000_000L))
+        assertThatThrownBy(() -> function.invoke(other.serialize(), 1_000_000L))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("under table root");
     }
@@ -161,10 +137,8 @@ class DescriptorToPresignedUrlFunctionTest {
 
         ResolvedDescriptorToPresignedUrlFunction restored = roundTrip(original);
 
-        assertThat(
-                        restored.invoke(
-                                DESCRIPTOR.serialize(), UTF8String.fromString("jpg"), 2_000_000L))
-                .hasToString("https://example.test/data.jpg?validity=2&offset=10&length=20");
+        assertThat(restored.invoke(DESCRIPTOR.serialize(), 2_000_000L))
+                .hasToString("https://example.test/data?validity=2&offset=10&length=20");
     }
 
     private ResolvedDescriptorToPresignedUrlFunction roundTrip(
@@ -185,12 +159,9 @@ class DescriptorToPresignedUrlFunctionTest {
 
         @Override
         public String createBlobPresignedUrl(
-                Path tableRoot, BlobDescriptor descriptor, String extension, Duration validity)
-                throws IOException {
+                Path tableRoot, BlobDescriptor descriptor, Duration validity) throws IOException {
             BlobDescriptorUtils.validateTableRoot(tableRoot, descriptor);
-            return "https://example.test/data."
-                    + extension
-                    + "?validity="
+            return "https://example.test/data?validity="
                     + validity.getSeconds()
                     + "&offset="
                     + descriptor.offset()

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.spark.sql
 
+import org.apache.paimon.data.BlobDescriptor
 import org.apache.paimon.spark.PaimonHiveTestBase
 import org.apache.paimon.spark.catalog.functions.PaimonFunctions
 import org.apache.paimon.spark.function.FunctionResources.MyIntSumClass
@@ -112,6 +113,64 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
 
     sql("DROP FUNCTION myIntSum")
     checkAnswer(sql(s"SHOW FUNCTIONS FROM $hiveDbName LIKE 'myIntSum'"), Seq.empty)
+  }
+
+  test("Paimon function: descriptor to presigned URL") {
+    sql(s"USE paimon.$dbName0")
+    withTable("url_source", "url_other") {
+      sql("CREATE TABLE url_source (id INT) USING paimon")
+      sql("CREATE TABLE url_other (id INT) USING paimon")
+
+      val descriptor = new BlobDescriptor("file:/tmp/source.blob", 0, 1).serialize()
+      val descriptorHex = descriptor.map(b => f"${b & 0xff}%02X").mkString
+
+      checkAnswer(
+        sql(
+          s"SELECT sys.try_descriptor_to_presigned_url(" +
+            s"'$dbName0.url_source', CAST(NULL AS BINARY), 'png', INTERVAL '1' SECOND)"),
+        Row(null))
+      checkAnswer(
+        sql(
+          s"SELECT sys.try_descriptor_to_presigned_url(" +
+            s"'paimon.$dbName0.url_source', X'00', 'png', INTERVAL '1' HOUR)"),
+        Row(null))
+
+      intercept[Exception] {
+        sql(
+          s"SELECT sys.descriptor_to_presigned_url(" +
+            s"'$dbName0.url_source', X'00', 'png', INTERVAL '1' SECOND)").collect()
+      }
+      intercept[Exception] {
+        sql(
+          s"SELECT sys.descriptor_to_presigned_url(" +
+            s"'$dbName0.url_source', X'$descriptorHex', 'png', " +
+            "INTERVAL '1.000001' SECOND)").collect()
+      }
+      intercept[Exception] {
+        sql(
+          s"SELECT sys.try_descriptor_to_presigned_url(" +
+            s"source_table, X'00', 'png', INTERVAL '1' SECOND) " +
+            s"FROM VALUES ('$dbName0.url_source') AS t(source_table)").collect()
+      }
+      intercept[Exception] {
+        sql(
+          s"SELECT sys.try_descriptor_to_presigned_url(" +
+            s"CASE WHEN id = 1 THEN '$dbName0.url_source' " +
+            s"ELSE '$dbName0.url_other' END, X'00', 'png', INTERVAL '1' SECOND) " +
+            "FROM VALUES (1) AS t(id)").collect()
+      }
+      intercept[Exception] {
+        sql(
+          "SELECT sys.try_descriptor_to_presigned_url(" +
+            "CAST(NULL AS STRING), X'00', 'png', INTERVAL '1' SECOND)").collect()
+      }
+      intercept[Exception] {
+        sql(
+          s"SELECT sys.try_descriptor_to_presigned_url(" +
+            s"'spark_catalog.$dbName0.url_source', X'00', 'png', " +
+            "INTERVAL '1' SECOND)").collect()
+      }
+    }
   }
 
   test("Add max_pt function") {

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/PaimonFunctionTest.scala
@@ -127,47 +127,47 @@ class PaimonFunctionTest extends PaimonHiveTestBase {
       checkAnswer(
         sql(
           s"SELECT sys.try_descriptor_to_presigned_url(" +
-            s"'$dbName0.url_source', CAST(NULL AS BINARY), 'png', INTERVAL '1' SECOND)"),
+            s"'$dbName0.url_source', CAST(NULL AS BINARY), INTERVAL '1' SECOND)"),
         Row(null))
       checkAnswer(
         sql(
           s"SELECT sys.try_descriptor_to_presigned_url(" +
-            s"'paimon.$dbName0.url_source', X'00', 'png', INTERVAL '1' HOUR)"),
+            s"'paimon.$dbName0.url_source', X'00', INTERVAL '1' HOUR)"),
         Row(null))
 
       intercept[Exception] {
         sql(
           s"SELECT sys.descriptor_to_presigned_url(" +
-            s"'$dbName0.url_source', X'00', 'png', INTERVAL '1' SECOND)").collect()
+            s"'$dbName0.url_source', X'00', INTERVAL '1' SECOND)").collect()
       }
       intercept[Exception] {
         sql(
           s"SELECT sys.descriptor_to_presigned_url(" +
-            s"'$dbName0.url_source', X'$descriptorHex', 'png', " +
+            s"'$dbName0.url_source', X'$descriptorHex', " +
             "INTERVAL '1.000001' SECOND)").collect()
       }
       intercept[Exception] {
         sql(
           s"SELECT sys.try_descriptor_to_presigned_url(" +
-            s"source_table, X'00', 'png', INTERVAL '1' SECOND) " +
+            s"source_table, X'00', INTERVAL '1' SECOND) " +
             s"FROM VALUES ('$dbName0.url_source') AS t(source_table)").collect()
       }
       intercept[Exception] {
         sql(
           s"SELECT sys.try_descriptor_to_presigned_url(" +
             s"CASE WHEN id = 1 THEN '$dbName0.url_source' " +
-            s"ELSE '$dbName0.url_other' END, X'00', 'png', INTERVAL '1' SECOND) " +
+            s"ELSE '$dbName0.url_other' END, X'00', INTERVAL '1' SECOND) " +
             "FROM VALUES (1) AS t(id)").collect()
       }
       intercept[Exception] {
         sql(
           "SELECT sys.try_descriptor_to_presigned_url(" +
-            "CAST(NULL AS STRING), X'00', 'png', INTERVAL '1' SECOND)").collect()
+            "CAST(NULL AS STRING), X'00', INTERVAL '1' SECOND)").collect()
       }
       intercept[Exception] {
         sql(
           s"SELECT sys.try_descriptor_to_presigned_url(" +
-            s"'spark_catalog.$dbName0.url_source', X'00', 'png', " +
+            s"'spark_catalog.$dbName0.url_source', X'00', " +
             "INTERVAL '1' SECOND)").collect()
       }
     }

--- a/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
+++ b/tools/ci/paimon-ci-tools/src/main/java/org/apache/paimon/tools/ci/licensecheck/JarFileChecker.java
@@ -201,10 +201,20 @@ public class JarFileChecker {
                     .filter(path -> !getFileName(path).startsWith("notice"))
                     // dual-licensed under GPL 2 and CDDL 1.1
                     // contained in hadoop/presto S3 FS and paimon-dist
+                    .filter(path -> !pathStartsWith(path, "/javax/xml/bind"))
                     .filter(
                             path ->
                                     !path.toString()
                                             .contains("/META-INF/versions/11/javax/xml/bind"))
+                    .filter(
+                            path ->
+                                    !pathStartsWith(
+                                            path,
+                                            "/META-INF/maven/javax.activation/javax.activation-api"))
+                    .filter(
+                            path ->
+                                    !pathStartsWith(
+                                            path, "/META-INF/maven/javax.xml.bind/jaxb-api"))
                     .filter(path -> !isJavaxManifest(jar, path))
                     // dual-licensed under GPL 2 and EPL 2.0
                     // contained in sql-avro-confluent-registry

--- a/tools/ci/paimon-ci-tools/src/test/java/org/apache/paimon/tools/ci/licensecheck/JarFileCheckerTest.java
+++ b/tools/ci/paimon-ci-tools/src/test/java/org/apache/paimon/tools/ci/licensecheck/JarFileCheckerTest.java
@@ -248,6 +248,56 @@ class JarFileCheckerTest {
                 .isEqualTo(1);
     }
 
+    @Test
+    void testIgnoreDualLicensedJavaxFiles(@TempDir Path tempDir) throws Exception {
+        assertThat(
+                        JarFileChecker.checkJar(
+                                createJar(
+                                        tempDir,
+                                        Entry.fileEntry(VALID_NOTICE_CONTENTS, VALID_NOTICE_PATH),
+                                        Entry.fileEntry(VALID_LICENSE_CONTENTS, VALID_LICENSE_PATH),
+                                        Entry.fileEntry(
+                                                "GNU General Public License",
+                                                Arrays.asList(
+                                                        "javax",
+                                                        "xml",
+                                                        "bind",
+                                                        "Messages.properties")),
+                                        Entry.fileEntry(
+                                                "GNU General Public License",
+                                                Arrays.asList(
+                                                        "javax",
+                                                        "xml",
+                                                        "bind",
+                                                        "helpers",
+                                                        "Messages.properties")),
+                                        Entry.fileEntry(
+                                                "GNU General Public License",
+                                                Arrays.asList(
+                                                        "javax",
+                                                        "xml",
+                                                        "bind",
+                                                        "util",
+                                                        "Messages.properties")),
+                                        Entry.fileEntry(
+                                                "GNU General Public License",
+                                                Arrays.asList(
+                                                        "META-INF",
+                                                        "maven",
+                                                        "javax.activation",
+                                                        "javax.activation-api",
+                                                        "pom.xml")),
+                                        Entry.fileEntry(
+                                                "GNU General Public License",
+                                                Arrays.asList(
+                                                        "META-INF",
+                                                        "maven",
+                                                        "javax.xml.bind",
+                                                        "jaxb-api",
+                                                        "pom.xml")))))
+                .isEqualTo(0);
+    }
+
     private static class Entry {
         final String contents;
         final List<String> path;


### PR DESCRIPTION
## Summary

Add catalog-aware Flink and Spark SQL functions that convert OSS-backed `BlobDescriptor` values into short-lived HTTPS GET URLs. Paimon materializes only the descriptor's byte range as a suffix-free OSS object served as `application/octet-stream`, allowing downstream multimodal services to fetch the exact bytes without loading them into the query engine.

## Changes

- Extend `FileIO` and `Blob` with blob presigned URL support, including delegation through resolving, caching, plugin, and REST-token file systems and validation that descriptors belong to the source table.
- Materialize OSS blob ranges with server-side multipart copy, reuse deterministic fingerprinted objects, and validate cached length, content type, and descriptor fingerprint before generating each URL.
- Use configured OSS/Jindo clients so credentials and STS tokens are preserved; require HTTPS, map OSS internal endpoints to their public host, and verify the signed URL still targets the expected bucket and object.
- Add three-argument `descriptor_to_presigned_url(source_table, descriptor, validity)` and `try_descriptor_to_presigned_url(...)` functions for Flink and Spark, including catalog binding, literal source-table validation, whole-second interval validation, Spark analyzer resolution, and Flink compatibility support.
- Package the Jindo OSS dependencies consistently and update the license checker for Java multi-release JAR class entries.
- Document SQL and Java usage, cache behavior, security guidance, and the suffix-free `application/octet-stream` behavior.

## Testing

- [x] `OSSFileIOTest#testCreateBlobPresignedUrlMaterializesSinglePart`
- [x] Flink `DescriptorToPresignedUrlFunctionTest#testTypeInferenceRequiresLiteralTableAndAcceptsInterval`
- [x] Spark `DescriptorToPresignedUrlFunctionTest#testBindAndNonDeterministic`
- [x] Relevant module compilation, Checkstyle, Spotless, and Enforcer checks
- [x] Bailian smoke test using a suffix-free OSS object with `application/octet-stream`; returned bytes matched the source and the model consumed the URL successfully
- [ ] Full local integration suites could not start in the restricted environment: server-port binding is denied and the local Azul JDK 11 cannot initialize Mockito's Byte Buddy self-attach. These failures occurred during test setup, before business assertions.

## Notes

- This revision replaces the earlier four-argument proposal: callers no longer provide a file extension, and no compatibility overload is retained because the API has not been released.
- Consumers must inspect the bytes rather than relying on a URL suffix or format-specific content type.
- `source_table` must be a non-null literal in `database.table` form, or `catalog.database.table` for the function's catalog.
- Read regular BLOB columns with `blob-as-descriptor=true` before passing them to the function.
- Presigned URLs are temporary bearer credentials and must not be logged or persisted.
