### PR TITLE
[spark] Fix flaky SparkMultimodalITCase by binding its test metastore to a free port

### DIFF
--- a/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/TestHiveMetastore.java
+++ b/paimon-hive/paimon-hive-common/src/test/java/org/apache/paimon/hive/TestHiveMetastore.java
@@ -113,6 +113,7 @@ public class TestHiveMetastore {
     private HiveConf hiveConf;
     private ExecutorService executorService;
     private TServer server;
+    private int port;
     private HiveMetaStore.HMSHandler baseHandler;
 
     public void start(Configuration configuration, int port) {
@@ -145,6 +146,7 @@ public class TestHiveMetastore {
         try {
             TServerSocket socket = new TServerSocket(portNum);
             int port = socket.getServerSocket().getLocalPort();
+            this.port = port;
             this.hiveConf = initConf(conf, port);
             this.server = newThriftServer(socket, poolSize, hiveConf);
             this.executorService = Executors.newSingleThreadExecutor();
@@ -160,6 +162,11 @@ public class TestHiveMetastore {
         } catch (Exception e) {
             throw new RuntimeException("Cannot start TestHiveMetastore", e);
         }
+    }
+
+    /** The actual bound port, resolved even when started with port 0 (a free port). */
+    public int getPort() {
+        return port;
     }
 
     public void stop() throws Exception {

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkMultimodalITCase.java
@@ -41,12 +41,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SparkMultimodalITCase {
 
     private static TestHiveMetastore testHiveMetastore;
-    private static final int PORT = 9092;
 
     @BeforeAll
     public static void startMetastore() {
         testHiveMetastore = new TestHiveMetastore();
-        testHiveMetastore.start(PORT);
+        // Bind a free port (0) instead of a fixed one, which flakes when the port is taken.
+        testHiveMetastore.start(0);
     }
 
     @AfterAll
@@ -59,12 +59,12 @@ public class SparkMultimodalITCase {
                 .config("spark.sql.warehouse.dir", warehousePath.toString())
                 // with hive metastore
                 .config("spark.sql.catalogImplementation", "hive")
-                .config("hive.metastore.uris", "thrift://localhost:" + PORT)
+                .config("hive.metastore.uris", "thrift://localhost:" + testHiveMetastore.getPort())
                 .config("spark.sql.catalog.spark_catalog", SparkCatalog.class.getName())
                 .config("spark.sql.catalog.spark_catalog.metastore", "hive")
                 .config(
                         "spark.sql.catalog.spark_catalog.hive.metastore.uris",
-                        "thrift://localhost:" + PORT)
+                        "thrift://localhost:" + testHiveMetastore.getPort())
                 .config("spark.sql.catalog.spark_catalog.format-table.enabled", "true")
                 .config("spark.sql.catalog.spark_catalog.warehouse", warehousePath.toString())
                 .config(


### PR DESCRIPTION
### Purpose

`SparkMultimodalITCase` hardcodes port `9092` (which is also Kafka's default port) for its test Hive metastore, so `TestHiveMetastore.start(9092)` intermittently fails when the port is already taken:

```
java.lang.RuntimeException: Cannot start TestHiveMetastore
    at org.apache.paimon.spark.SparkMultimodalITCase.startMetastore(SparkMultimodalITCase.java:49)
[ERROR] Tests run: 196, Failures: 0, Errors: 1, Skipped: 0
```

This is currently flaky on master too (e.g. the `UTCase and ITCase Spark 4.x` job fails on several recent master pushes with the exact same error).

Start the metastore on port `0` (an OS-assigned free port, which `TestHiveMetastore` already resolves via `getLocalPort()`) and read the actual port back through a new `TestHiveMetastore.getPort()` for the Spark configs, so the test no longer depends on a fixed port being free.

### Tests

Exercised by `SparkMultimodalITCase` itself; the fixed-port race can't be reproduced deterministically in a unit test.
