### PR TITLE
[fix] guard against BinaryRow fixed part exceeding page size

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/BinaryRowSerializer.java
@@ -261,9 +261,26 @@ public class BinaryRowSerializer extends AbstractRowDataSerializer<BinaryRow> {
      * binary row fixed part. See {@link BinaryRow}.
      */
     private int checkSkipWriteForFixLengthPart(AbstractPagedOutputView out) throws IOException {
+        // The fixed-length part of a BinaryRow must reside within a single memory segment,
+        // because random field access (e.g. getLong/getString) always reads from segments[0]
+        // without bounds checking. If it is larger than the page size, advancing to the next
+        // segment cannot help and the row would silently span segments, leading to corrupted
+        // field offsets and eventually a NegativeArraySizeException. Fail fast instead.
+        int fixedPartLength = getSerializedRowFixedPartLength();
+        int segmentSize = out.getSegmentSize();
+        if (fixedPartLength > segmentSize) {
+            String msg =
+                    String.format(
+                            "Cannot serialize BinaryRow to pages: the serialized fixed-length part "
+                                    + "(%d bytes, numFields=%d) is larger than the page size (%d bytes). "
+                                    + "The fixed-length part must fit within a single page. Please increase "
+                                    + "the 'page-size' option to at least %d bytes.",
+                            fixedPartLength, numFields, segmentSize, fixedPartLength);
+            throw new IllegalArgumentException(msg);
+        }
         // skip if there is no enough size.
-        int available = out.getSegmentSize() - out.getCurrentPositionInSegment();
-        if (available < getSerializedRowFixedPartLength()) {
+        int available = segmentSize - out.getCurrentPositionInSegment();
+        if (available < fixedPartLength) {
             out.advance();
             return available;
         }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerPageSizeGuardTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/BinaryRowSerializerPageSizeGuardTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.data.serializer;
+
+import org.apache.paimon.data.BinaryRow;
+import org.apache.paimon.data.BinaryRowWriter;
+import org.apache.paimon.data.RandomAccessInputView;
+import org.apache.paimon.data.SimpleCollectingOutputView;
+import org.apache.paimon.memory.CachelessSegmentPool;
+import org.apache.paimon.memory.MemorySegment;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the page-size guard in {@link BinaryRowSerializer#serializeToPages}. When a row's
+ * fixed-length part is larger than the page size, serialization must fail fast with a clear error
+ * instead of silently spanning segments and corrupting field access (which previously surfaced as a
+ * cryptic {@link NegativeArraySizeException}).
+ */
+class BinaryRowSerializerPageSizeGuardTest {
+
+    // 200 INT columns -> fixed-length part 1632 bytes + 4 length bytes = 1636 bytes.
+    private static final int NUM_FIELDS = 200;
+
+    @Test
+    void testThrowsWhenFixedPartExceedsPageSize() {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(NUM_FIELDS);
+        int fixedPartLength = serializer.getSerializedRowFixedPartLength();
+        // Page size (power of two) smaller than the fixed-length part.
+        int pageSize = 1024;
+        assertThat(fixedPartLength).isGreaterThan(pageSize);
+
+        SimpleCollectingOutputView out =
+                new SimpleCollectingOutputView(
+                        new CachelessSegmentPool(pageSize, pageSize), pageSize);
+
+        BinaryRow row = newIntRow(NUM_FIELDS);
+        assertThatThrownBy(() -> serializer.serializeToPages(row, out))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("page size")
+                .hasMessageContaining(Integer.toString(fixedPartLength))
+                .hasMessageContaining(Integer.toString(pageSize))
+                .hasMessageContaining(Integer.toString(NUM_FIELDS));
+    }
+
+    @Test
+    void testSerializeSucceedsWhenPageLargeEnough() throws Exception {
+        BinaryRowSerializer serializer = new BinaryRowSerializer(NUM_FIELDS);
+        int pageSize = 4096;
+        assertThat(serializer.getSerializedRowFixedPartLength()).isLessThanOrEqualTo(pageSize);
+
+        SimpleCollectingOutputView out =
+                new SimpleCollectingOutputView(
+                        new CachelessSegmentPool((long) pageSize * 4, pageSize), pageSize);
+
+        BinaryRow row = newIntRow(NUM_FIELDS);
+        serializer.serializeToPages(row, out);
+
+        // Round-trip the row back from the written pages.
+        ArrayList<MemorySegment> segments = out.fullSegments();
+        RandomAccessInputView in = new RandomAccessInputView(segments, pageSize);
+        BinaryRow deserialized = serializer.deserializeFromPages(serializer.createInstance(), in);
+        for (int i = 0; i < NUM_FIELDS; i++) {
+            assertThat(deserialized.getInt(i)).isEqualTo(i);
+        }
+    }
+
+    private static BinaryRow newIntRow(int numFields) {
+        BinaryRow row = new BinaryRow(numFields);
+        BinaryRowWriter writer = new BinaryRowWriter(row);
+        for (int i = 0; i < numFields; i++) {
+            writer.writeInt(i, i);
+        }
+        writer.complete();
+        return row;
+    }
+}

--- a/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
+++ b/paimon-flink/paimon-flink-common/src/test/java/org/apache/paimon/flink/sink/WriterOperatorTest.java
@@ -92,7 +92,7 @@ public class WriterOperatorTest {
         options.set("bucket", "1");
         options.set("write-buffer-size", "256 b");
         options.set("write-buffer-spillable", "false");
-        options.set("page-size", "32 b");
+        options.set("page-size", "64 b");
 
         FileStoreTable table =
                 createFileStoreTable(
@@ -109,7 +109,7 @@ public class WriterOperatorTest {
         Options options = new Options();
         options.set("write-buffer-for-append", "true");
         options.set("write-buffer-size", "256 b");
-        options.set("page-size", "32 b");
+        options.set("page-size", "64 b");
         options.set("write-buffer-spillable", "false");
 
         FileStoreTable table =
@@ -446,7 +446,7 @@ public class WriterOperatorTest {
         options.set("bucket", "1");
         options.set("write-buffer-size", "256 b");
         options.set("write-buffer-spillable", "false");
-        options.set("page-size", "32 b");
+        options.set("page-size", "64 b");
 
         FileStoreTable fileStoreTable =
                 createFileStoreTable(


### PR DESCRIPTION
## Problem

Wide tables (thousands of columns) throw a cryptic `NegativeArraySizeException` during compaction / sort spill:

```
java.lang.NegativeArraySizeException
  at org.apache.paimon.memory.MemorySegmentUtils.getBytes(MemorySegmentUtils.java:186)
  at org.apache.paimon.data.BinarySection.toBytes(BinarySection.java:101)
  at org.apache.paimon.format.parquet.writer.ParquetRowDataWriter$StringWriter.writeString(ParquetRowDataWriter.java:268)
```

## Root Cause

`BinaryRow`'s fixed-length part (`nullBitsSizeInBytes + 8 * arity`) must reside within a single `MemorySegment`, because all field accessors (`getString`, `getLong`, `getArray`, etc.) read from `segments[0]` via `UNSAFE.getLong` **without bounds checking**.

The default `page-size` is 64 KB, which supports up to **8064 columns** (fixed part = 65528 bytes). When a table exceeds this limit (e.g. 8347 columns → fixed part = 67824 bytes), the row silently spans segments during paged sort/spill operations. `segments[0]` is only 64 KB, so field offsets beyond 64 KB read out-of-bounds heap memory via `UNSAFE`. The garbage `long` is interpreted as a string length; when negative, `new byte[negative]` throws `NegativeArraySizeException`.

`BinaryRowSerializer.checkSkipWriteForFixLengthPart` only `advance()`s to the next page when the current page lacks space — it never validates that the fixed part fits in a single page, and assumes `advance()` will always help (which it can't when `fixedPart > pageSize`).

## Fix

Add a `checkArgument` guard at the top of `checkSkipWriteForFixLengthPart` — the choke point for all paged writes (`BinaryInMemorySortBuffer`, `InMemoryBuffer`, `BytesHashMap`, `SimpleObjectsCache`, `InternalRowSerializer`). When `getSerializedRowFixedPartLength() > segmentSize`, throw a clear `IllegalArgumentException` at the first write, advising to increase `page-size`.

This converts the cryptic `NegativeArraySizeException` (which may surface far from the root cause, or not surface at all for INT-only schemas — silent data corruption) into an immediate, actionable error.

## Testing

- `BinaryRowSerializerPageSizeGuardTest`: 200 INT columns (fixed part 1636 bytes), verifies the guard throws with a clear message at `page-size=1024` and succeeds at `page-size=4096` with round-trip.
- `WriterOperatorTest`: bumped `page-size` from 32 b to 64 b in 3 test methods whose KeyValue combined rows (52/60 bytes fixed part) previously exceeded 32 b and relied on silent corruption.

## Workaround (for existing tables)

```sql
ALTER TABLE <table> SET TBLPROPERTIES ('page-size' = '256kb');
```

`page-size` must be larger than the row's fixed-length part (`≈ 8.125 * num_columns` bytes).