### PR TITLE
[python] Test pypaimon-rust 0.3.0 on Python 3.10

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -127,7 +127,7 @@ jobs:
             pip install torch --index-url https://download.pytorch.org/whl/cpu
             python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52'
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-              # Exercise the published 0.3 RC wheel and split-planning API in one lane.
+              # Validate the RC wheel from TestPyPI; switch to PyPI and 0.3.0 after GA.
               python -m pip install --no-deps --only-binary=:all: --index-url https://test.pypi.org/simple/ "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
               python -c "import importlib.metadata as m; assert m.version('pypaimon-rust') == '${PYPAIMON_RUST_VERSION}'"
               python -c "from pypaimon_rust.datafusion import PaimonCatalog; assert hasattr(PaimonCatalog, 'get_table')"

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: 7c568274a4c5df6bd00e8d60edea21395412202b
+  PYPAIMON_RUST_VERSION: 0.3.0rc1
 
 
 concurrency:
@@ -84,12 +84,6 @@ jobs:
           java -version
           mvn -version
 
-      - name: Install Rust toolchain
-        if: matrix.python-version == '3.11'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Verify Python version
         run: python --version
 
@@ -133,8 +127,9 @@ jobs:
             pip install torch --index-url https://download.pytorch.org/whl/cpu
             python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52'
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-              # Exercise the split-planning API in one lane until the compatible 0.3 wheel is published.
-              python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
+              # Exercise the published 0.3 RC wheel and split-planning API in one lane.
+              python -m pip install --no-deps --only-binary=:all: --index-url https://test.pypi.org/simple/ "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
+              python -c "import importlib.metadata as m; assert m.version('pypaimon-rust') == '${PYPAIMON_RUST_VERSION}'"
               python -c "from pypaimon_rust.datafusion import PaimonCatalog; assert hasattr(PaimonCatalog, 'get_table')"
             else
               python -m pip install pypaimon-rust==0.2.0

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -130,7 +130,7 @@ jobs:
               # Validate the RC wheel from TestPyPI; switch to PyPI and 0.3.0 after GA.
               python -m pip install --no-deps --only-binary=:all: --index-url https://test.pypi.org/simple/ "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
               python -c "import importlib.metadata as m; assert m.version('pypaimon-rust') == '${PYPAIMON_RUST_VERSION}'"
-              python -c "from pypaimon_rust.datafusion import PaimonCatalog; assert hasattr(PaimonCatalog, 'get_table')"
+              python -c "from pypaimon_rust.datafusion import PaimonCatalog, Split; assert hasattr(PaimonCatalog, 'get_table') and hasattr(Split, 'serialize')"
             else
               python -m pip install pypaimon-rust==0.2.0
             fi

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_VERSION: 0.3.0
+  PYPAIMON_RUST_REV: 6b6782923a59eeba766cbd45dde6989705b282bc
 
 
 concurrency:
@@ -84,6 +84,12 @@ jobs:
           java -version
           mvn -version
 
+      - name: Install Rust toolchain
+        if: matrix.python-version == '3.11'
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Verify Python version
         run: python --version
 
@@ -113,7 +119,7 @@ jobs:
           if [[ "${{ matrix.python-version }}" == "3.6.15" ]]; then
             python -m pip install --upgrade pip==21.3.1
             python --version
-            python -m pip install --no-cache-dir pyroaring readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 2>&1 >/dev/null
+            python -m pip install --no-cache-dir pyroaring readerwriterlock==1.0.9 'fsspec==2021.10.1' 'cachetools==4.2.4' 'ossfs==2021.8.0' pyarrow==6.0.1 pandas==1.1.5 'polars==0.9.12' 'fastavro==1.4.7' zstandard==0.19.0 dataclasses==0.8.0 flake8 pytest py4j==0.10.9.9 requests parameterized==0.8.1 datasketches==4.1.0 2>&1 >/dev/null
             python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
           elif [[ "${{ matrix.python-version }}" == "3.7" ]]; then
             # 3.7 installs the version-pinned set declared for 3.7 in dev/requirements.txt.
@@ -125,14 +131,14 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52'
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=54,<55' datasketches
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-              # Install the 0.3.0 GA wheel from PyPI.
-              python -m pip install "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
-              python -c "import importlib.metadata as m; assert m.version('pypaimon-rust') == '${PYPAIMON_RUST_VERSION}'"
-              python -c "from pypaimon_rust.datafusion import PaimonCatalog, Split; assert hasattr(PaimonCatalog, 'get_table') and hasattr(Split, 'serialize')"
+              # Exercise the 0.4 API in one lane until its wheel is published.
+              python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
+              python -m pip install "./paimon-python[sql]"
+              python -c "import tempfile; from datafusion import SessionContext; from pypaimon_rust.datafusion import PaimonCatalog; warehouse = tempfile.TemporaryDirectory(); ctx = SessionContext(); ctx.register_catalog_provider('paimon', PaimonCatalog({'warehouse': warehouse.name}))"
             else
-              python -m pip install pypaimon-rust==0.2.0
+              python -m pip install pypaimon-rust==0.3.0
             fi
             python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
             if python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"; then
@@ -174,7 +180,7 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 datasketches
             python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
       - name: Run lint-python.sh
         shell: bash
@@ -273,7 +279,7 @@ jobs:
             pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 \
             fastavro==1.11.1 pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 \
             numpy==1.24.3 pandas==2.0.3 cramjam pytest~=7.0 py4j==0.10.9.9 requests \
-            parameterized==0.9.0 packaging
+            parameterized==0.9.0 packaging datasketches
           python -m pip install 'lumina-data>=${{ env.LUMINA_DATA_VERSION }}' -i https://pypi.org/simple/
       - name: Test Ray version compatibility
         run: |

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_VERSION: 0.3.0rc1
+  PYPAIMON_RUST_VERSION: 0.3.0
 
 
 concurrency:
@@ -127,8 +127,8 @@ jobs:
             pip install torch --index-url https://download.pytorch.org/whl/cpu
             python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52'
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-              # Validate the RC wheel from TestPyPI; switch to PyPI and 0.3.0 after GA.
-              python -m pip install --no-deps --only-binary=:all: --index-url https://test.pypi.org/simple/ "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
+              # Install the 0.3.0 GA wheel from PyPI.
+              python -m pip install "pypaimon-rust==${PYPAIMON_RUST_VERSION}"
               python -c "import importlib.metadata as m; assert m.version('pypaimon-rust') == '${PYPAIMON_RUST_VERSION}'"
               python -c "from pypaimon_rust.datafusion import PaimonCatalog, Split; assert hasattr(PaimonCatalog, 'get_table') and hasattr(Split, 'serialize')"
             else


### PR DESCRIPTION
### Purpose

Exercise the published pypaimon-rust 0.3.0 wheel in the Python 3.10 CI lane while keeping Python 3.11 on the unreleased 0.4 API source revision.

### Changes

- Update the Python 3.10 lane from pypaimon-rust 0.2.0 to 0.3.0.
- Keep the Python 3.11 lane building the pinned 0.4 source revision.

### Tests

- YAML parsing passed.
- git diff --check passed.
- Confirmed PyPI provides a CPython 3.10 manylinux x86_64 wheel for pypaimon-rust 0.3.0.