### PR TITLE
[python] Render min/max_partition_stats in the $manifests system table

### DIFF
--- a/paimon-python/pypaimon/casting/row_to_string.py
+++ b/paimon-python/pypaimon/casting/row_to_string.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Render a row as the string Java produces when casting it to STRING.
+
+Mirrors ``RowToStringCastRule`` and the per type ``*ToStringCastRule`` rules of
+``paimon-common``, so system tables show the same text in both languages.
+"""
+
+import struct
+from typing import Any, Optional
+
+from pypaimon.table.row.generic_row import _parse_type_precision_scale
+
+
+def cast_row_to_string(row) -> Optional[str]:
+    """Render ``row`` as ``{v1, v2}``, with ``null`` for null fields.
+
+    An empty row renders as ``{}``, which is what an unpartitioned table has.
+    """
+    if row is None:
+        return None
+    fields = getattr(row, "fields", None) or []
+    parts = []
+    for i in range(len(fields)):
+        value = row.get_field(i)
+        parts.append("null" if value is None
+                     else cast_value_to_string(value, fields[i].type))
+    return "{" + ", ".join(parts) + "}"
+
+
+def cast_value_to_string(value: Any, data_type) -> str:
+    """Cast a single field value to string the way the Java cast rules do."""
+    type_name = _type_name(data_type)
+
+    if type_name in ("BOOLEAN", "BOOL"):
+        return "true" if value else "false"
+    if type_name in ("FLOAT", "REAL"):
+        return _format_float(value)
+    if (type_name.startswith("BINARY") or type_name.startswith("VARBINARY")
+            or type_name == "BYTES"):
+        return bytes(value).decode("utf-8", "replace")
+    if type_name == "DATE":
+        return value.isoformat()
+    # TIMESTAMP has to be tested before TIME, it starts with it
+    if type_name.startswith("TIMESTAMP"):
+        precision, _ = _parse_type_precision_scale(data_type)
+        return _format_timestamp(value, precision)
+    if type_name.startswith("TIME"):
+        precision, _ = _parse_type_precision_scale(data_type)
+        return _format_time(value, precision)
+    return str(value)
+
+
+def _type_name(data_type) -> str:
+    name = getattr(data_type, "type", None)
+    return (name if isinstance(name, str) else str(data_type)).upper().strip()
+
+
+def _format_timestamp(value, precision: int) -> str:
+    """Format as ``yyyy-MM-dd HH:mm:ss[.fraction]``.
+
+    The fraction is padded to nine digits and then stripped of trailing zeros
+    down to ``precision`` digits, as ``DateTimeUtils.formatTimestamp`` does.
+    Python datetimes are microsecond resolution, so the last three digits of a
+    TIMESTAMP(7..9) value are always zero.
+    """
+    text = "{:04d}-{:02d}-{:02d} {:02d}:{:02d}:{:02d}".format(
+        value.year, value.month, value.day,
+        value.hour, value.minute, value.second)
+    fraction = "{:09d}".format(value.microsecond * 1000)
+    while len(fraction) > precision and fraction.endswith("0"):
+        fraction = fraction[:-1]
+    return (text + "." + fraction) if fraction else text
+
+
+def _format_time(value, precision: int) -> str:
+    """Format as ``HH:mm:ss[.fraction]``.
+
+    ``DateTimeUtils.formatTimestampMillis`` emits at most ``precision`` digits
+    of the millisecond part and stops early once nothing but zeros is left, but
+    always keeps one digit when precision allows any.
+    """
+    text = "{:02d}:{:02d}:{:02d}".format(value.hour, value.minute, value.second)
+    if precision <= 0:
+        return text
+    digits = "{:03d}".format(value.microsecond // 1000)[:min(precision, 3)]
+    return text + "." + (digits.rstrip("0") or digits[:1])
+
+
+def _format_float(value) -> str:
+    """Format like ``Float.toString``: shortest text that round trips as float32.
+
+    ``repr`` would print the float64 the reader widened the value to, turning
+    ``0.1f`` into ``0.10000000149011612``.
+    """
+    try:
+        packed = struct.pack("<f", value)
+    except (OverflowError, struct.error):
+        return repr(value)
+    text = repr(value)
+    for digits in range(1, 10):
+        candidate = "%.{}g".format(digits) % value
+        if struct.pack("<f", float(candidate)) == packed:
+            text = candidate
+            break
+    # Java always prints a decimal point for a finite float
+    if text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
+        return text + ".0"
+    return text

--- a/paimon-python/pypaimon/casting/row_to_string.py
+++ b/paimon-python/pypaimon/casting/row_to_string.py
@@ -21,7 +21,9 @@ Mirrors ``RowToStringCastRule`` and the per type ``*ToStringCastRule`` rules of
 ``paimon-common``, so system tables show the same text in both languages.
 """
 
+import math
 import struct
+from decimal import Decimal
 from typing import Any, Optional
 
 from pypaimon.table.row.generic_row import _parse_type_precision_scale
@@ -50,7 +52,9 @@ def cast_value_to_string(value: Any, data_type) -> str:
     if type_name in ("BOOLEAN", "BOOL"):
         return "true" if value else "false"
     if type_name in ("FLOAT", "REAL"):
-        return _format_float(value)
+        return _format_java_float(value, True)
+    if type_name == "DOUBLE":
+        return _format_java_float(value, False)
     if (type_name.startswith("BINARY") or type_name.startswith("VARBINARY")
             or type_name == "BYTES"):
         return bytes(value).decode("utf-8", "replace")
@@ -102,23 +106,60 @@ def _format_time(value, precision: int) -> str:
     return text + "." + (digits.rstrip("0") or digits[:1])
 
 
-def _format_float(value) -> str:
-    """Format like ``Float.toString``: shortest text that round trips as float32.
+def _format_java_float(value, is_float32: bool) -> str:
+    """Format like Java ``Float.toString`` / ``Double.toString``.
 
-    ``repr`` would print the float64 the reader widened the value to, turning
-    ``0.1f`` into ``0.10000000149011612``.
+    Finds the shortest decimal that round trips, then lays it out with Java's
+    rules: plain decimal when ``1 <= D <= 7`` or ``-2 <= D <= 0`` (writing
+    ``value = 0.<digits> x 10^D``), otherwise ``d.dddEexp`` with an upper case
+    ``E``, a sign only when negative, and no zero padded exponent. The shortest
+    form differs from a pre JDK 19 JVM only at the denormal extremes
+    (``1.0E-45`` vs ``1.4E-45``), which partition stats never hold.
     """
-    try:
-        packed = struct.pack("<f", value)
-    except (OverflowError, struct.error):
-        return repr(value)
-    text = repr(value)
-    for digits in range(1, 10):
-        candidate = "%.{}g".format(digits) % value
-        if struct.pack("<f", float(candidate)) == packed:
-            text = candidate
-            break
-    # Java always prints a decimal point for a finite float
-    if text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
-        return text + ".0"
-    return text
+    if value != value:
+        return "NaN"
+    if value == math.inf:
+        return "Infinity"
+    if value == -math.inf:
+        return "-Infinity"
+    sign = "-" if math.copysign(1.0, value) < 0 else ""
+    if value == 0.0:
+        return sign + "0.0"
+    digits, decimal_exp = _shortest_digits(abs(value), is_float32)
+    n = len(digits)
+    if 0 < decimal_exp <= 7:
+        if decimal_exp >= n:
+            body = digits + "0" * (decimal_exp - n) + ".0"
+        else:
+            body = digits[:decimal_exp] + "." + digits[decimal_exp:]
+    elif -3 < decimal_exp <= 0:
+        body = "0." + "0" * (-decimal_exp) + digits
+    else:
+        body = digits[0] + "." + (digits[1:] or "0") + "E" + str(decimal_exp - 1)
+    return sign + body
+
+
+def _shortest_digits(magnitude, is_float32: bool):
+    """Return ``(digits, D)`` with ``magnitude = 0.<digits> x 10^D``.
+
+    ``digits`` carries no leading or trailing zeros. ``repr`` already yields the
+    shortest float64 form; for float32 the shortest ``%g`` that round trips
+    through four bytes is used, so a widened ``0.1f`` renders as ``0.1``.
+    """
+    if is_float32:
+        packed = struct.pack("<f", magnitude)
+        text = repr(magnitude)
+        for precision in range(1, 10):
+            candidate = "%.{}g".format(precision) % magnitude
+            if struct.pack("<f", float(candidate)) == packed:
+                text = candidate
+                break
+    else:
+        text = repr(magnitude)
+    _, digit_tuple, exp = Decimal(text).as_tuple()
+    digits = list(digit_tuple)
+    while len(digits) > 1 and digits[-1] == 0:
+        digits.pop()
+        exp += 1
+    digit_str = "".join(map(str, digits))
+    return digit_str, exp + len(digit_str)

--- a/paimon-python/pypaimon/casting/row_to_string.py
+++ b/paimon-python/pypaimon/casting/row_to_string.py
@@ -19,24 +19,44 @@
 
 Mirrors ``RowToStringCastRule`` and the per type ``*ToStringCastRule`` rules of
 ``paimon-common``, so system tables show the same text in both languages.
+
+Only the types whose output provably matches Java are rendered. A row holding
+one of the types left out is not rendered at all, so the caller keeps the NULL
+it would have emitted anyway:
+
+- FLOAT and DOUBLE go through ``Float/Double.toString``, which up to JDK 18 is
+  the legacy ``FloatingDecimal`` and does not produce the shortest round
+  tripping decimal, while JDK 19+ does: ``2.68873286E11`` against
+  ``2.6887329E11`` for the same float.
+- TIMESTAMP WITH LOCAL TIME ZONE is formatted in ``TimeZone.getDefault()``, so
+  one manifest reads ``2024-01-02 03:04:05`` on a UTC JVM and
+  ``2024-01-02 06:04:05`` on a Europe/Moscow one.
+- BINARY, VARBINARY and BYTES are decoded as UTF-8, and malformed input leaves
+  the JDK decoder and Python disagreeing on how many replacement characters to
+  emit: ``ED A0 80`` is one in Java and three here.
 """
 
-import math
-import struct
-from decimal import Decimal
 from typing import Any, Optional
 
 from pypaimon.table.row.generic_row import _parse_type_precision_scale
+
+_UNSUPPORTED_TYPES = ("FLOAT", "REAL", "DOUBLE", "TIMESTAMP_LTZ",
+                      "BINARY", "VARBINARY", "BYTES")
 
 
 def cast_row_to_string(row) -> Optional[str]:
     """Render ``row`` as ``{v1, v2}``, with ``null`` for null fields.
 
     An empty row renders as ``{}``, which is what an unpartitioned table has.
+    Returns None when a field has a type this module does not render.
     """
     if row is None:
         return None
     fields = getattr(row, "fields", None) or []
+    # on the declared type, not on the value, so every manifest of a table
+    # answers the same way no matter which stats happen to be null
+    if any(_is_unsupported(field.type) for field in fields):
+        return None
     parts = []
     for i in range(len(fields)):
         value = row.get_field(i)
@@ -49,15 +69,16 @@ def cast_value_to_string(value: Any, data_type) -> str:
     """Cast a single field value to string the way the Java cast rules do."""
     type_name = _type_name(data_type)
 
+    if _is_unsupported(data_type):
+        raise ValueError(
+            "{} has no portable string form, see the module docstring".format(
+                type_name))
     if type_name in ("BOOLEAN", "BOOL"):
         return "true" if value else "false"
-    if type_name in ("FLOAT", "REAL"):
-        return _format_java_float(value, True)
-    if type_name == "DOUBLE":
-        return _format_java_float(value, False)
-    if (type_name.startswith("BINARY") or type_name.startswith("VARBINARY")
-            or type_name == "BYTES"):
-        return bytes(value).decode("utf-8", "replace")
+    if type_name.startswith("DECIMAL") or type_name.startswith("NUMERIC"):
+        # Java Decimal.toString is BigDecimal.toPlainString, which never uses
+        # scientific notation, while str(Decimal) does below 1e-6
+        return "{:f}".format(value)
     if type_name == "DATE":
         return value.isoformat()
     # TIMESTAMP has to be tested before TIME, it starts with it
@@ -73,6 +94,16 @@ def cast_value_to_string(value: Any, data_type) -> str:
 def _type_name(data_type) -> str:
     name = getattr(data_type, "type", None)
     return (name if isinstance(name, str) else str(data_type)).upper().strip()
+
+
+def _is_unsupported(data_type) -> bool:
+    type_name = _type_name(data_type)
+    # the other spelling of TIMESTAMP_LTZ, see data_types.py
+    if "WITH LOCAL TIME ZONE" in type_name:
+        return True
+    # first token only, so "FLOAT NOT NULL" is caught as well
+    head = type_name.split("(", 1)[0].split()
+    return bool(head) and head[0] in _UNSUPPORTED_TYPES
 
 
 def _format_timestamp(value, precision: int) -> str:
@@ -95,71 +126,20 @@ def _format_timestamp(value, precision: int) -> str:
 def _format_time(value, precision: int) -> str:
     """Format as ``HH:mm:ss[.fraction]``.
 
-    ``DateTimeUtils.formatTimestampMillis`` emits at most ``precision`` digits
-    of the millisecond part and stops early once nothing but zeros is left, but
-    always keeps one digit when precision allows any.
+    Digit by digit off the millisecond part, exactly as
+    ``DateTimeUtils.formatTimestampMillis`` does: it stops only once nothing
+    but zeros is left, so a truncated non zero tail keeps the zero before it
+    (``.10`` for 101 ms at precision 2, not ``.1``).
     """
     text = "{:02d}:{:02d}:{:02d}".format(value.hour, value.minute, value.second)
     if precision <= 0:
         return text
-    digits = "{:03d}".format(value.microsecond // 1000)[:min(precision, 3)]
-    return text + "." + (digits.rstrip("0") or digits[:1])
-
-
-def _format_java_float(value, is_float32: bool) -> str:
-    """Format like Java ``Float.toString`` / ``Double.toString``.
-
-    Finds the shortest decimal that round trips, then lays it out with Java's
-    rules: plain decimal when ``1 <= D <= 7`` or ``-2 <= D <= 0`` (writing
-    ``value = 0.<digits> x 10^D``), otherwise ``d.dddEexp`` with an upper case
-    ``E``, a sign only when negative, and no zero padded exponent. The shortest
-    form differs from a pre JDK 19 JVM only at the denormal extremes
-    (``1.0E-45`` vs ``1.4E-45``), which partition stats never hold.
-    """
-    if value != value:
-        return "NaN"
-    if value == math.inf:
-        return "Infinity"
-    if value == -math.inf:
-        return "-Infinity"
-    sign = "-" if math.copysign(1.0, value) < 0 else ""
-    if value == 0.0:
-        return sign + "0.0"
-    digits, decimal_exp = _shortest_digits(abs(value), is_float32)
-    n = len(digits)
-    if 0 < decimal_exp <= 7:
-        if decimal_exp >= n:
-            body = digits + "0" * (decimal_exp - n) + ".0"
-        else:
-            body = digits[:decimal_exp] + "." + digits[decimal_exp:]
-    elif -3 < decimal_exp <= 0:
-        body = "0." + "0" * (-decimal_exp) + digits
-    else:
-        body = digits[0] + "." + (digits[1:] or "0") + "E" + str(decimal_exp - 1)
-    return sign + body
-
-
-def _shortest_digits(magnitude, is_float32: bool):
-    """Return ``(digits, D)`` with ``magnitude = 0.<digits> x 10^D``.
-
-    ``digits`` carries no leading or trailing zeros. ``repr`` already yields the
-    shortest float64 form; for float32 the shortest ``%g`` that round trips
-    through four bytes is used, so a widened ``0.1f`` renders as ``0.1``.
-    """
-    if is_float32:
-        packed = struct.pack("<f", magnitude)
-        text = repr(magnitude)
-        for precision in range(1, 10):
-            candidate = "%.{}g".format(precision) % magnitude
-            if struct.pack("<f", float(candidate)) == packed:
-                text = candidate
-                break
-    else:
-        text = repr(magnitude)
-    _, digit_tuple, exp = Decimal(text).as_tuple()
-    digits = list(digit_tuple)
-    while len(digits) > 1 and digits[-1] == 0:
-        digits.pop()
-        exp += 1
-    digit_str = "".join(map(str, digits))
-    return digit_str, exp + len(digit_str)
+    millis = value.microsecond // 1000
+    digits = []
+    while precision > 0:
+        digits.append(str(millis // 100))
+        millis = millis % 100 * 10
+        if millis == 0:
+            break
+        precision -= 1
+    return text + "." + "".join(digits)

--- a/paimon-python/pypaimon/table/system/manifests_table.py
+++ b/paimon-python/pypaimon/table/system/manifests_table.py
@@ -21,6 +21,7 @@ from typing import List, Optional
 
 import pyarrow
 
+from pypaimon.casting.row_to_string import cast_row_to_string
 from pypaimon.manifest.manifest_list_manager import ManifestListManager
 from pypaimon.schema.data_types import AtomicType, DataField, RowType
 from pypaimon.table.system.system_table import SystemTable
@@ -75,12 +76,10 @@ class ManifestsTable(SystemTable):
             num_added.append(int(meta.num_added_files))
             num_deleted.append(int(meta.num_deleted_files))
             schema_ids.append(int(meta.schema_id))
-            # TODO: render min/max_partition_stats by casting partition
-            # rows to their string form. pypaimon
-            # has SimpleStats but no shared partition-row-to-string
-            # helper yet; emit NULL to preserve the column shape.
-            min_partition_stats.append(None)
-            max_partition_stats.append(None)
+            min_partition_stats.append(
+                cast_row_to_string(meta.partition_stats.min_values))
+            max_partition_stats.append(
+                cast_row_to_string(meta.partition_stats.max_values))
             min_row_ids.append(
                 None if meta.min_row_id is None else int(meta.min_row_id))
             max_row_ids.append(

--- a/paimon-python/pypaimon/tests/row_to_string_test.py
+++ b/paimon-python/pypaimon/tests/row_to_string_test.py
@@ -1,0 +1,118 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests that cast_row_to_string reproduces the Java cast-to-string rules."""
+
+import struct
+import unittest
+from datetime import date, datetime, time
+from decimal import Decimal
+
+from pypaimon.casting.row_to_string import (cast_row_to_string,
+                                            cast_value_to_string)
+from pypaimon.schema.data_types import AtomicType, DataField
+from pypaimon.table.row.generic_row import GenericRow
+
+
+def _row(*pairs):
+    fields = [DataField(i, "f" + str(i), AtomicType(t))
+              for i, (t, _) in enumerate(pairs)]
+    return GenericRow([v for _, v in pairs], fields)
+
+
+def _cast(type_name, value):
+    return cast_value_to_string(value, AtomicType(type_name))
+
+
+class RowToStringTest(unittest.TestCase):
+
+    def test_none_row(self):
+        self.assertIsNone(cast_row_to_string(None))
+
+    def test_empty_row_of_unpartitioned_table(self):
+        self.assertEqual("{}", cast_row_to_string(_row()))
+
+    def test_fields_are_comma_separated(self):
+        self.assertEqual("{1, a}", cast_row_to_string(_row(("INT", 1),
+                                                           ("STRING", "a"))))
+
+    def test_null_field_is_a_literal(self):
+        self.assertEqual("{null, a}", cast_row_to_string(_row(("INT", None),
+                                                              ("STRING", "a"))))
+
+    def test_boolean_is_lower_case(self):
+        self.assertEqual("true", _cast("BOOLEAN", True))
+        self.assertEqual("false", _cast("BOOLEAN", False))
+
+    def test_integers(self):
+        self.assertEqual("-7", _cast("TINYINT", -7))
+        self.assertEqual("42", _cast("INT", 42))
+        self.assertEqual("9223372036854775807", _cast("BIGINT",
+                                                      9223372036854775807))
+
+    def test_decimal_keeps_its_scale(self):
+        self.assertEqual("1.50", _cast("DECIMAL(10, 2)", Decimal("1.50")))
+
+    def test_double(self):
+        self.assertEqual("1.5", _cast("DOUBLE", 1.5))
+        self.assertEqual("1.0", _cast("DOUBLE", 1.0))
+
+    def test_float_prints_the_shortest_float32_form(self):
+        # a float32 0.1 widened to float64 is 0.10000000149011612
+        widened = struct.unpack("<f", struct.pack("<f", 0.1))[0]
+        self.assertEqual("0.1", _cast("FLOAT", widened))
+        self.assertEqual("1.0", _cast("FLOAT", 1.0))
+
+    def test_binary_is_decoded_as_utf8(self):
+        self.assertEqual("ab", _cast("BYTES", b"ab"))
+
+    def test_date(self):
+        self.assertEqual("2024-01-02", _cast("DATE", date(2024, 1, 2)))
+
+    def test_timestamp_separator_is_a_space(self):
+        value = datetime(2024, 1, 2, 3, 4, 5, 123456)
+        self.assertEqual("2024-01-02 03:04:05.123456",
+                         _cast("TIMESTAMP(6)", value))
+
+    def test_timestamp_fraction_is_kept_up_to_precision(self):
+        value = datetime(2024, 1, 2, 3, 4, 5, 0)
+        self.assertEqual("2024-01-02 03:04:05", _cast("TIMESTAMP(0)", value))
+        self.assertEqual("2024-01-02 03:04:05.000", _cast("TIMESTAMP(3)", value))
+        self.assertEqual("2024-01-02 03:04:05.000000",
+                         _cast("TIMESTAMP(6)", value))
+
+    def test_timestamp_trailing_zeros_are_stripped_down_to_precision(self):
+        value = datetime(2024, 1, 2, 3, 4, 5, 120000)
+        self.assertEqual("2024-01-02 03:04:05.12", _cast("TIMESTAMP(0)", value))
+        self.assertEqual("2024-01-02 03:04:05.120", _cast("TIMESTAMP(3)", value))
+
+    def test_time(self):
+        self.assertEqual("03:04:05", _cast("TIME", time(3, 4, 5)))
+        self.assertEqual("03:04:05", _cast("TIME(0)", time(3, 4, 5)))
+        self.assertEqual("03:04:05.123",
+                         _cast("TIME(3)", time(3, 4, 5, 123000)))
+
+    def test_time_keeps_one_fraction_digit_at_least(self):
+        self.assertEqual("03:04:05.0", _cast("TIME(3)", time(3, 4, 5)))
+        self.assertEqual("03:04:05.5", _cast("TIME(3)", time(3, 4, 5, 500000)))
+
+    def test_unknown_type_falls_back_to_str(self):
+        self.assertEqual("x", _cast("SOMETHING_NEW", "x"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/paimon-python/pypaimon/tests/row_to_string_test.py
+++ b/paimon-python/pypaimon/tests/row_to_string_test.py
@@ -17,7 +17,6 @@
 
 """Tests that cast_row_to_string reproduces the Java cast-to-string rules."""
 
-import struct
 import unittest
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -36,12 +35,6 @@ def _row(*pairs):
 
 def _cast(type_name, value):
     return cast_value_to_string(value, AtomicType(type_name))
-
-
-def _f32(value):
-    # a FLOAT is widened to float64 on the way in, as the reader does
-    widened = struct.unpack("<f", struct.pack("<f", value))[0]
-    return _cast("FLOAT", widened)
 
 
 class RowToStringTest(unittest.TestCase):
@@ -73,57 +66,49 @@ class RowToStringTest(unittest.TestCase):
     def test_decimal_keeps_its_scale(self):
         self.assertEqual("1.50", _cast("DECIMAL(10, 2)", Decimal("1.50")))
 
-    def test_double_decimal_range(self):
-        self.assertEqual("1.5", _cast("DOUBLE", 1.5))
-        self.assertEqual("1.0", _cast("DOUBLE", 1.0))
-        self.assertEqual("0.001", _cast("DOUBLE", 0.001))
-        self.assertEqual("123456.0", _cast("DOUBLE", 123456.0))
-        self.assertEqual("9999999.0", _cast("DOUBLE", 9999999.0))
-        self.assertEqual("-1.5", _cast("DOUBLE", -1.5))
+    def test_decimal_never_uses_scientific_notation(self):
+        # Java Decimal.toString is BigDecimal.toPlainString; str(Decimal)
+        # would give "0E-9" and "-1E-9" here
+        self.assertEqual("0.000000000",
+                         _cast("DECIMAL(20, 9)", Decimal("0E-9")))
+        self.assertEqual("-0.000000001",
+                         _cast("DECIMAL(20, 9)", Decimal("-1E-9")))
+        self.assertEqual("0.000000000000000000",
+                         _cast("DECIMAL(38, 18)", Decimal("0E-18")))
 
-    def test_double_scientific_matches_java(self):
-        # Java Double.toString: upper case E, no + sign, no zero padding
-        self.assertEqual("1.0E7", _cast("DOUBLE", 1e7))
-        self.assertEqual("1.0E-5", _cast("DOUBLE", 1e-5))
-        self.assertEqual("1.0E-4", _cast("DOUBLE", 1e-4))
-        self.assertEqual("1.0E20", _cast("DOUBLE", 1e20))
-        self.assertEqual("1.0E-20", _cast("DOUBLE", 1e-20))
-        self.assertEqual("1.23456789E300", _cast("DOUBLE", 1.23456789e300))
-        self.assertEqual("1.23456789012345E14",
-                         _cast("DOUBLE", 123456789012345.0))
+    def test_row_with_a_float_field_is_not_rendered(self):
+        self.assertIsNone(cast_row_to_string(_row(("INT", 1),
+                                                  ("FLOAT", 1.5))))
+        self.assertIsNone(cast_row_to_string(_row(("DOUBLE", 1.5))))
+        self.assertIsNone(cast_row_to_string(_row(("REAL", 1.5))))
+        self.assertIsNone(cast_row_to_string(_row(("FLOAT NOT NULL", 1.5))))
 
-    def test_double_signed_zero(self):
-        self.assertEqual("0.0", _cast("DOUBLE", 0.0))
-        self.assertEqual("-0.0", _cast("DOUBLE", -0.0))
+    def test_float_field_stops_the_row_even_when_its_value_is_null(self):
+        # the check is on the declared type, so all rows of a table agree
+        self.assertIsNone(cast_row_to_string(_row(("INT", 1),
+                                                  ("DOUBLE", None))))
 
-    def test_double_non_finite_matches_java(self):
-        self.assertEqual("NaN", _cast("DOUBLE", float("nan")))
-        self.assertEqual("Infinity", _cast("DOUBLE", float("inf")))
-        self.assertEqual("-Infinity", _cast("DOUBLE", float("-inf")))
+    def test_row_with_a_local_zoned_timestamp_is_not_rendered(self):
+        # Java formats these in TimeZone.getDefault(), so the same manifest
+        # reads differently depending on where the query runs
+        value = datetime(2024, 1, 2, 3, 4, 5)
+        self.assertIsNone(cast_row_to_string(_row(("TIMESTAMP_LTZ(3)", value))))
+        self.assertIsNone(cast_row_to_string(
+            _row(("TIMESTAMP(3) WITH LOCAL TIME ZONE", value))))
 
-    def test_float_prints_the_shortest_float32_form(self):
-        # a float32 0.1 widened to float64 is 0.10000000149011612
-        self.assertEqual("0.1", _f32(0.1))
-        self.assertEqual("1.0", _f32(1.0))
-        self.assertEqual("12345.678", _f32(12345.678))
+    def test_unrenderable_values_are_rejected(self):
+        self.assertRaises(ValueError, _cast, "FLOAT", 1.5)
+        self.assertRaises(ValueError, _cast, "DOUBLE", 1.5)
+        self.assertRaises(ValueError, _cast, "TIMESTAMP_LTZ(3)",
+                          datetime(2024, 1, 2, 3, 4, 5))
+        self.assertRaises(ValueError, _cast, "BYTES", b"ab")
 
-    def test_float_scientific_matches_java(self):
-        self.assertEqual("1.0E7", _f32(1e7))
-        self.assertEqual("1.0E-5", _f32(1e-5))
-        self.assertEqual("1.0E-4", _f32(1e-4))
-        self.assertEqual("3.4E38", _f32(3.4e38))
-        self.assertEqual("0.001", _f32(1e-3))
-        self.assertEqual("9999999.0", _f32(9999999.0))
-        self.assertEqual("-1.5", _f32(-1.5))
-
-    def test_float_signed_zero_and_non_finite(self):
-        self.assertEqual("0.0", _f32(0.0))
-        self.assertEqual("-0.0", _f32(-0.0))
-        self.assertEqual("NaN", _f32(float("nan")))
-        self.assertEqual("Infinity", _f32(float("inf")))
-
-    def test_binary_is_decoded_as_utf8(self):
-        self.assertEqual("ab", _cast("BYTES", b"ab"))
+    def test_row_with_a_binary_field_is_not_rendered(self):
+        # malformed UTF-8 yields a different replacement char count than the
+        # JDK decoder gives, so binary is not rendered at all
+        self.assertIsNone(cast_row_to_string(_row(("BYTES", b"ab"))))
+        self.assertIsNone(cast_row_to_string(_row(("BINARY(2)", b"ab"))))
+        self.assertIsNone(cast_row_to_string(_row(("VARBINARY(10)", b"ab"))))
 
     def test_date(self):
         self.assertEqual("2024-01-02", _cast("DATE", date(2024, 1, 2)))
@@ -154,6 +139,14 @@ class RowToStringTest(unittest.TestCase):
     def test_time_keeps_one_fraction_digit_at_least(self):
         self.assertEqual("03:04:05.0", _cast("TIME(3)", time(3, 4, 5)))
         self.assertEqual("03:04:05.5", _cast("TIME(3)", time(3, 4, 5, 500000)))
+
+    def test_time_keeps_a_zero_that_a_truncated_tail_sits_behind(self):
+        # 101 ms at precision 2 is ".10" in Java, not ".1": it stops only
+        # once the remaining fraction is exactly zero
+        self.assertEqual("03:04:05.10", _cast("TIME(2)", time(3, 4, 5, 101000)))
+        self.assertEqual("03:04:05.00", _cast("TIME(2)", time(3, 4, 5, 1000)))
+        self.assertEqual("03:04:05.0", _cast("TIME(2)", time(3, 4, 5)))
+        self.assertEqual("03:04:05.01", _cast("TIME(2)", time(3, 4, 5, 10000)))
 
     def test_unknown_type_falls_back_to_str(self):
         self.assertEqual("x", _cast("SOMETHING_NEW", "x"))

--- a/paimon-python/pypaimon/tests/row_to_string_test.py
+++ b/paimon-python/pypaimon/tests/row_to_string_test.py
@@ -38,6 +38,12 @@ def _cast(type_name, value):
     return cast_value_to_string(value, AtomicType(type_name))
 
 
+def _f32(value):
+    # a FLOAT is widened to float64 on the way in, as the reader does
+    widened = struct.unpack("<f", struct.pack("<f", value))[0]
+    return _cast("FLOAT", widened)
+
+
 class RowToStringTest(unittest.TestCase):
 
     def test_none_row(self):
@@ -67,15 +73,54 @@ class RowToStringTest(unittest.TestCase):
     def test_decimal_keeps_its_scale(self):
         self.assertEqual("1.50", _cast("DECIMAL(10, 2)", Decimal("1.50")))
 
-    def test_double(self):
+    def test_double_decimal_range(self):
         self.assertEqual("1.5", _cast("DOUBLE", 1.5))
         self.assertEqual("1.0", _cast("DOUBLE", 1.0))
+        self.assertEqual("0.001", _cast("DOUBLE", 0.001))
+        self.assertEqual("123456.0", _cast("DOUBLE", 123456.0))
+        self.assertEqual("9999999.0", _cast("DOUBLE", 9999999.0))
+        self.assertEqual("-1.5", _cast("DOUBLE", -1.5))
+
+    def test_double_scientific_matches_java(self):
+        # Java Double.toString: upper case E, no + sign, no zero padding
+        self.assertEqual("1.0E7", _cast("DOUBLE", 1e7))
+        self.assertEqual("1.0E-5", _cast("DOUBLE", 1e-5))
+        self.assertEqual("1.0E-4", _cast("DOUBLE", 1e-4))
+        self.assertEqual("1.0E20", _cast("DOUBLE", 1e20))
+        self.assertEqual("1.0E-20", _cast("DOUBLE", 1e-20))
+        self.assertEqual("1.23456789E300", _cast("DOUBLE", 1.23456789e300))
+        self.assertEqual("1.23456789012345E14",
+                         _cast("DOUBLE", 123456789012345.0))
+
+    def test_double_signed_zero(self):
+        self.assertEqual("0.0", _cast("DOUBLE", 0.0))
+        self.assertEqual("-0.0", _cast("DOUBLE", -0.0))
+
+    def test_double_non_finite_matches_java(self):
+        self.assertEqual("NaN", _cast("DOUBLE", float("nan")))
+        self.assertEqual("Infinity", _cast("DOUBLE", float("inf")))
+        self.assertEqual("-Infinity", _cast("DOUBLE", float("-inf")))
 
     def test_float_prints_the_shortest_float32_form(self):
         # a float32 0.1 widened to float64 is 0.10000000149011612
-        widened = struct.unpack("<f", struct.pack("<f", 0.1))[0]
-        self.assertEqual("0.1", _cast("FLOAT", widened))
-        self.assertEqual("1.0", _cast("FLOAT", 1.0))
+        self.assertEqual("0.1", _f32(0.1))
+        self.assertEqual("1.0", _f32(1.0))
+        self.assertEqual("12345.678", _f32(12345.678))
+
+    def test_float_scientific_matches_java(self):
+        self.assertEqual("1.0E7", _f32(1e7))
+        self.assertEqual("1.0E-5", _f32(1e-5))
+        self.assertEqual("1.0E-4", _f32(1e-4))
+        self.assertEqual("3.4E38", _f32(3.4e38))
+        self.assertEqual("0.001", _f32(1e-3))
+        self.assertEqual("9999999.0", _f32(9999999.0))
+        self.assertEqual("-1.5", _f32(-1.5))
+
+    def test_float_signed_zero_and_non_finite(self):
+        self.assertEqual("0.0", _f32(0.0))
+        self.assertEqual("-0.0", _f32(-0.0))
+        self.assertEqual("NaN", _f32(float("nan")))
+        self.assertEqual("Infinity", _f32(float("inf")))
 
     def test_binary_is_decoded_as_utf8(self):
         self.assertEqual("ab", _cast("BYTES", b"ab"))

--- a/paimon-python/pypaimon/tests/system/manifests_table_test.py
+++ b/paimon-python/pypaimon/tests/system/manifests_table_test.py
@@ -63,6 +63,27 @@ class ManifestsTableTest(unittest.TestCase):
         writer.close()
         commit.close()
 
+    def _write_two_partitions(self):
+        fields = [
+            DataField.from_dict({"id": 0, "name": "id", "type": "INT"}),
+            DataField.from_dict({"id": 1, "name": "pt", "type": "INT"}),
+            DataField.from_dict({"id": 2, "name": "dt", "type": "STRING"}),
+        ]
+        self.catalog.create_table(
+            "db.p", Schema(fields=fields, partition_keys=["pt", "dt"]), False)
+        table = self.catalog.get_table("db.p")
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        commit = write_builder.new_commit()
+        writer.write_arrow(pa.table({
+            "id": pa.array([1, 2], type=pa.int32()),
+            "pt": pa.array([1, 2], type=pa.int32()),
+            "dt": ["2024-01-01", "2024-01-02"],
+        }))
+        commit.commit(writer.prepare_commit())
+        writer.close()
+        commit.close()
+
     def test_manifests_table_loaded_via_catalog(self):
         table = self.catalog.get_table("db.t$manifests")
         self.assertIsInstance(table, ManifestsTable)
@@ -100,12 +121,25 @@ class ManifestsTableTest(unittest.TestCase):
         for n_added in arrow_table.column("num_added_files").to_pylist():
             self.assertGreaterEqual(n_added, 0)
 
-        # min/max_partition_stats are placeholders until the partition
-        # cast-to-string helper lands; pin the placeholder contract.
-        for value in arrow_table.column("min_partition_stats").to_pylist():
-            self.assertIsNone(value)
-        for value in arrow_table.column("max_partition_stats").to_pylist():
-            self.assertIsNone(value)
+    def test_partition_stats_of_unpartitioned_table(self):
+        self._write_one_commit()
+        arrow_table = _read(self.catalog.get_table("db.t$manifests"))
+
+        # an empty partition row renders as "{}", the same as in Java
+        self.assertEqual(["{}"] * arrow_table.num_rows,
+                         arrow_table.column("min_partition_stats").to_pylist())
+        self.assertEqual(["{}"] * arrow_table.num_rows,
+                         arrow_table.column("max_partition_stats").to_pylist())
+
+    def test_partition_stats_span_the_written_partitions(self):
+        self._write_two_partitions()
+        arrow_table = _read(self.catalog.get_table("db.p$manifests"))
+        self.assertEqual(1, arrow_table.num_rows)
+
+        self.assertEqual(["{1, 2024-01-01}"],
+                         arrow_table.column("min_partition_stats").to_pylist())
+        self.assertEqual(["{2, 2024-01-02}"],
+                         arrow_table.column("max_partition_stats").to_pylist())
 
 
 if __name__ == "__main__":

--- a/paimon-python/pypaimon/tests/system/manifests_table_test.py
+++ b/paimon-python/pypaimon/tests/system/manifests_table_test.py
@@ -84,6 +84,25 @@ class ManifestsTableTest(unittest.TestCase):
         writer.close()
         commit.close()
 
+    def _write_partition(self, name, partition_type, partition_column):
+        fields = [
+            DataField.from_dict({"id": 0, "name": "id", "type": "INT"}),
+            DataField.from_dict({"id": 1, "name": "pt", "type": partition_type}),
+        ]
+        self.catalog.create_table(
+            "db." + name, Schema(fields=fields, partition_keys=["pt"]), False)
+        table = self.catalog.get_table("db." + name)
+        write_builder = table.new_batch_write_builder()
+        writer = write_builder.new_write()
+        commit = write_builder.new_commit()
+        writer.write_arrow(pa.table({
+            "id": pa.array([1, 2], type=pa.int32()),
+            "pt": partition_column,
+        }))
+        commit.commit(writer.prepare_commit())
+        writer.close()
+        commit.close()
+
     def test_manifests_table_loaded_via_catalog(self):
         table = self.catalog.get_table("db.t$manifests")
         self.assertIsInstance(table, ManifestsTable)
@@ -139,6 +158,42 @@ class ManifestsTableTest(unittest.TestCase):
         self.assertEqual(["{1, 2024-01-01}"],
                          arrow_table.column("min_partition_stats").to_pylist())
         self.assertEqual(["{2, 2024-01-02}"],
+                         arrow_table.column("max_partition_stats").to_pylist())
+
+    def test_partition_stats_stay_null_for_a_float_partition(self):
+        # Java prints these with Double.toString, whose output depends on the
+        # JVM version, so the columns keep the NULL they had before
+        self._write_partition("d", "DOUBLE",
+                              pa.array([1.5, 2.5], type=pa.float64()))
+        arrow_table = _read(self.catalog.get_table("db.d$manifests"))
+        self.assertEqual(1, arrow_table.num_rows)
+
+        self.assertEqual([None],
+                         arrow_table.column("min_partition_stats").to_pylist())
+        self.assertEqual([None],
+                         arrow_table.column("max_partition_stats").to_pylist())
+
+    def test_partition_stats_stay_null_for_a_binary_partition(self):
+        self._write_partition("b", "BYTES",
+                              pa.array([b"a", b"b"], type=pa.binary()))
+        arrow_table = _read(self.catalog.get_table("db.b$manifests"))
+        self.assertEqual(1, arrow_table.num_rows)
+
+        self.assertEqual([None],
+                         arrow_table.column("min_partition_stats").to_pylist())
+        self.assertEqual([None],
+                         arrow_table.column("max_partition_stats").to_pylist())
+
+    def test_decimal_partition_stats_carry_the_full_scale(self):
+        # str(Decimal) would render the zero as "0E-9" here, Java never does
+        self._write_partition("n", "DECIMAL(20, 9)",
+                              pa.array([0, 1], type=pa.decimal128(20, 9)))
+        arrow_table = _read(self.catalog.get_table("db.n$manifests"))
+        self.assertEqual(1, arrow_table.num_rows)
+
+        self.assertEqual(["{0.000000000}"],
+                         arrow_table.column("min_partition_stats").to_pylist())
+        self.assertEqual(["{1.000000000}"],
                          arrow_table.column("max_partition_stats").to_pylist())
 
 


### PR DESCRIPTION
### Purpose

This closes a TODO in `pypaimon/table/system/manifests_table.py`:

```python
# TODO: render min/max_partition_stats by casting partition
# rows to their string form. pypaimon
# has SimpleStats but no shared partition-row-to-string
# helper yet; emit NULL to preserve the column shape.
min_partition_stats.append(None)
max_partition_stats.append(None)
```

So `$manifests` returns NULL for `min_partition_stats` and `max_partition_stats` in pypaimon while Java renders them, and inspecting which manifests cover which partitions gives nothing on the Python side. The data is already parsed: `ManifestListManager` builds `SimpleStats` from the manifest list, only the rendering was missing.

This adds `cast_row_to_string`, a port of `RowToStringCastRule` and the per type `*ToStringCastRule` rules of `paimon-common`, with fields joined by `", "` inside braces, the literal `null` for a null field, and `{}` for an unpartitioned table. The rendered types are BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, DECIMAL, CHAR, VARCHAR, DATE, TIME and TIMESTAMP. Those needing more than `str()` are boolean (lower case), decimal (`BigDecimal.toPlainString`, never scientific, so a DECIMAL(20, 9) zero is `0.000000000` and not `0E-9`), date, time and timestamp. Timestamps follow `DateTimeUtils.formatTimestamp` and times follow `formatTimestampMillis`, which generates the fraction digit by digit and stops only once the remainder is exactly zero, so neither `datetime.isoformat()` nor stripping trailing zeros reproduces them.

Three types are deliberately not rendered, because their Java output cannot be reproduced. A row holding one of them is not rendered at all, so the two columns keep the NULL they return today:

- **FLOAT and DOUBLE** go through `Float/Double.toString`, which up to JDK 18 is the legacy `FloatingDecimal` and does not produce the shortest round tripping decimal, while JDK 19+ does. Measured against JDK 17 on 200k random values per type, the shortest form differs on 10.86% of float32 and 0.28% of float64 values (`2.68873286E11` against `2.6887329E11`), and a JDK 21 JVM prints the shortest form instead, so there is no single Java rendering to target. Matching pre JDK 19 exactly would mean porting `FloatingDecimal` itself.
- **TIMESTAMP WITH LOCAL TIME ZONE** is formatted in `TimeZone.getDefault()`, so the same manifest reads `2024-01-02 03:04:05` on a UTC JVM and `2024-01-02 06:04:05` on a Europe/Moscow one.
- **BINARY, VARBINARY and BYTES** are decoded as UTF-8, and on malformed input the JDK decoder and Python disagree on how many replacement characters to emit: `ED A0 80` is one in Java and three in Python.

One point for a maintainer opinion, deliberately not changed here: pypaimon renders the `partition` column of `$files` and `$buckets` as `pt=v/pt2=v2`, while Java renders those two with the brace form and keeps `pt=v` only for `$partitions`. Aligning them would change values these tables already return, so it is out of scope for this PR.

### Tests

New `pypaimon/tests/row_to_string_test.py` covers the rendering per type, a null field, an empty row, the timestamp fraction at precision 0/3/6, the TIME digit generation (`.10` and not `.1` for 101 ms at precision 2), the decimal plain form, and that a row holding a FLOAT, DOUBLE, TIMESTAMP_LTZ or BINARY field renders as None while `cast_value_to_string` rejects those types outright.

`pypaimon/tests/system/manifests_table_test.py` replaces the assertions that pinned the NULL placeholder: an unpartitioned table yields `{}`, a table partitioned by INT and STRING yields `{1, 2024-01-01}` and `{2, 2024-01-02}`, a DECIMAL(20, 9) partition yields `{0.000000000}`, and DOUBLE and BYTES partitions keep both columns NULL.

Everything still rendered was verified against `RowToStringCastRule` itself, driving the real `CastExecutors` from a built `paimon-common` on JDK 8 and comparing whole rows rather than single values: every DATE a Python `date` can hold, the full TIME precision and millisecond space, all DECIMAL precision and scale pairs, TIMESTAMP precision 0 to 9 over epochs from year 1 to 9999, integer boundaries, strings containing braces and the `, ` separator, and randomly generated multi field rows with nulls. No differences remain, and the same harness does flag the ones the previous commit of this PR had.
