### PR TITLE
[core] Reject non-positive global index read thread counts

### DIFF
--- a/docs/generated/core_configuration.html
+++ b/docs/generated/core_configuration.html
@@ -810,7 +810,7 @@ under the License.
             <td><h5>global-index.thread-num</h5></td>
             <td style="word-wrap: break-word;">32</td>
             <td>Integer</td>
-            <td>The maximum number of concurrent threads for global index I/O.</td>
+            <td>The maximum number of concurrent threads for global index I/O. Must be greater than 0.</td>
         </tr>
         <tr>
             <td><h5>ignore-delete</h5></td>

--- a/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
+++ b/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java
@@ -2788,7 +2788,8 @@ public class CoreOptions implements Serializable {
                     .intType()
                     .defaultValue(32)
                     .withDescription(
-                            "The maximum number of concurrent threads for global index I/O.");
+                            "The maximum number of concurrent threads for global index I/O. "
+                                    + "Must be greater than 0.");
 
     public static final ConfigOption<Boolean> OVERWRITE_UPGRADE =
             key("overwrite-upgrade")

--- a/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexReadThreadPool.java
+++ b/paimon-core/src/main/java/org/apache/paimon/globalindex/GlobalIndexReadThreadPool.java
@@ -23,6 +23,7 @@ import org.apache.paimon.utils.SemaphoredDelegatingExecutor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 import static org.apache.paimon.utils.ThreadPoolUtils.createCachedThreadPool;
 
 /** Shared thread pool for global index read operations. */
@@ -34,6 +35,7 @@ public class GlobalIndexReadThreadPool {
             createCachedThreadPool(Runtime.getRuntime().availableProcessors(), THREAD_NAME);
 
     public static synchronized ExecutorService getExecutorService(int threadNum) {
+        checkArgument(threadNum > 0, "Option 'global-index.thread-num' must be greater than 0.");
         if (threadNum == executorService.getMaximumPoolSize()) {
             return executorService;
         }

--- a/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexReadThreadPoolTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/globalindex/GlobalIndexReadThreadPoolTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.globalindex;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link GlobalIndexReadThreadPool}. */
+class GlobalIndexReadThreadPoolTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void testRejectNonPositiveThreadNum(int threadNum) {
+        assertThatThrownBy(() -> GlobalIndexReadThreadPool.getExecutorService(threadNum))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Option 'global-index.thread-num' must be greater than 0.");
+    }
+}


### PR DESCRIPTION
### Purpose

`global-index.thread-num` accepted zero or negative values, creating a semaphored executor without available permits and causing global index reads to block during task submission.

Validate the thread count at the shared pool boundary and fail fast with a clear error.

### Tests

- `mvn -pl paimon-core -am -DfailIfNoTests=false -DwildcardSuites=none -Dtest=GlobalIndexReadThreadPoolTest test`