### PR TITLE
[python] Support pypaimon-rust 0.4

### DIFF
--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -34,7 +34,7 @@ env:
   JDK_VERSION: 8
   MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
   LUMINA_DATA_VERSION: 0.1.0
-  PYPAIMON_RUST_REV: 7c568274a4c5df6bd00e8d60edea21395412202b
+  PYPAIMON_RUST_REV: 6b6782923a59eeba766cbd45dde6989705b282bc
 
 
 concurrency:
@@ -133,8 +133,9 @@ jobs:
             pip install torch --index-url https://download.pytorch.org/whl/cpu
             python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52' datasketches
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
-              # Exercise the split-planning API in one lane until the compatible 0.3 wheel is published.
+              # Exercise the 0.4 API in one lane until its wheel is published.
               python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
+              python -m pip install "./paimon-python[sql]"
               python -c "from pypaimon_rust.datafusion import PaimonCatalog; assert hasattr(PaimonCatalog, 'get_table')"
             else
               python -m pip install pypaimon-rust==0.2.0

--- a/.github/workflows/paimon-python-checks.yml
+++ b/.github/workflows/paimon-python-checks.yml
@@ -131,12 +131,12 @@ jobs:
           else
             python -m pip install --upgrade pip
             pip install torch --index-url https://download.pytorch.org/whl/cpu
-            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=52' datasketches
+            python -m pip install pyroaring readerwriterlock==1.0.9 fsspec==2024.3.1 cachetools==5.3.3 ossfs==2023.12.0 ray==2.54.0 fastavro==1.11.1 'isal>=1.8,<2' pyarrow==16.0.0 zstandard==0.24.0 polars==1.32.0 duckdb==1.3.2 numpy==1.24.3 pandas==2.0.3 pylance==0.39.0 cramjam flake8==4.0.1 pytest~=7.0 py4j==0.10.9.9 requests parameterized==0.9.0 'daft>=0.7.6' 'datafusion>=54,<55' datasketches
             if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
               # Exercise the 0.4 API in one lane until its wheel is published.
               python -m pip install "git+https://github.com/apache/paimon-rust.git@${PYPAIMON_RUST_REV}#subdirectory=bindings/python"
               python -m pip install "./paimon-python[sql]"
-              python -c "from pypaimon_rust.datafusion import PaimonCatalog; assert hasattr(PaimonCatalog, 'get_table')"
+              python -c "import tempfile; from datafusion import SessionContext; from pypaimon_rust.datafusion import PaimonCatalog; warehouse = tempfile.TemporaryDirectory(); ctx = SessionContext(); ctx.register_catalog_provider('paimon', PaimonCatalog({'warehouse': warehouse.name}))"
             else
               python -m pip install pypaimon-rust==0.2.0
             fi

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -187,8 +187,8 @@ setup(
             'paimon-ftindex==0.1.0; python_version>="3.8"',
         ],
         'sql': [
-            'pypaimon-rust>=0.3.0,<0.5.0; python_version>="3.10"',
-            'datafusion>=52; python_version>="3.10"',
+            'pypaimon-rust>=0.3.0; python_version>="3.10"',
+            'datafusion>=54,<55; python_version>="3.10"',
         ],
         'hdfs': [
             'hdfs-native>=0.13,<1; python_version >= "3.10" and platform_system != "Windows"',

--- a/paimon-python/setup.py
+++ b/paimon-python/setup.py
@@ -187,7 +187,7 @@ setup(
             'paimon-ftindex==0.1.0; python_version>="3.8"',
         ],
         'sql': [
-            'pypaimon-rust>=0.3.0,<0.4.0; python_version>="3.10"',
+            'pypaimon-rust>=0.3.0,<0.5.0; python_version>="3.10"',
             'datafusion>=52; python_version>="3.10"',
         ],
         'hdfs': [


### PR DESCRIPTION
## Purpose

`pypaimon[sql]` currently caps `pypaimon-rust` below 0.4.0. After paimon-rust bumped its workspace version to 0.4.0, installing the source-built Python binding followed by `pypaimon[sql]` makes pip reject the installed binding and try to resolve an older wheel.

## Changes

- Allow the SQL extra to use both pypaimon-rust 0.3.x and 0.4.x.
- Pin the Python 3.11 CI lane to the paimon-rust 0.4.0 version-bump commit.
- Install `pypaimon[sql]` in that lane so CI verifies the package metadata accepts the source-built binding.

## Testing

- Built and installed pypaimon-rust 0.4.0 from source in a clean Python 3.10 virtual environment.
- Verified `python -m pip install --dry-run './paimon-python[sql]'` recognizes the installed `pypaimon-rust 0.4.0`.
- Parsed `.github/workflows/paimon-python-checks.yml` as YAML.
- Ran `git diff --check`.
