### PR TITLE
【wip】[common] Keep the shared _temporary directory while other writers stage there

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
+++ b/paimon-common/src/main/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStream.java
@@ -20,6 +20,9 @@ package org.apache.paimon.fs;
 
 import org.apache.paimon.annotation.Public;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.UUID;
 
@@ -29,6 +32,9 @@ import java.util.UUID;
  */
 @Public
 public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RenamingTwoPhaseOutputStream.class);
+
     private static final String TEMP_DIR_NAME = "_temporary";
 
     private final Path targetPath;
@@ -136,7 +142,24 @@ public class RenamingTwoPhaseOutputStream extends TwoPhaseOutputStream {
 
         @Override
         public void clean(FileIO fileIO) {
-            fileIO.deleteDirectoryQuietly(tempPath.getParent());
+            fileIO.deleteQuietly(tempPath);
+            // '_temporary' is shared with every other writer of this directory, Paimon or not, so
+            // it can only be removed once nothing is staged there any more: deleting it outright
+            // would throw away the pending files of jobs that are still running.
+            Path stagingDir = tempPath.getParent();
+            if (stagingDir == null) {
+                return;
+            }
+            try {
+                FileStatus[] staged = fileIO.listStatus(stagingDir);
+                if (staged != null && staged.length == 0) {
+                    fileIO.deleteQuietly(stagingDir);
+                }
+            } catch (IOException e) {
+                // Already gone, or not listable: an empty staging directory left behind is
+                // skipped by readers anyway.
+                LOG.debug("Could not check whether {} is still in use", stagingDir, e);
+            }
         }
     }
 }

--- a/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/fs/RenamingTwoPhaseOutputStreamTest.java
@@ -72,6 +72,42 @@ public class RenamingTwoPhaseOutputStreamTest {
     }
 
     @Test
+    void testCleanKeepsTheSharedStagingDirectory() throws IOException {
+        RenamingTwoPhaseOutputStream stream =
+                new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
+        stream.write("Some data".getBytes());
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+
+        // '_temporary' is shared with every other writer of this directory, Paimon or not: a
+        // concurrent job's pending files must survive this stream's cleanup.
+        Path otherWriterPending =
+                new Path(targetPath.getParent(), "_temporary/attempt_0001_m_000010_15/part-00010");
+        fileIO.writeFile(otherWriterPending, "concurrent", false);
+
+        committer.commit(fileIO);
+        committer.clean(fileIO);
+
+        assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.exists(otherWriterPending)).isTrue();
+        assertThat(fileIO.exists(new Path(targetPath.getParent(), "_temporary"))).isTrue();
+    }
+
+    @Test
+    void testCleanRemovesTheStagingDirectoryOnceEmpty() throws IOException {
+        RenamingTwoPhaseOutputStream stream =
+                new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);
+        stream.write("Some data".getBytes());
+        TwoPhaseOutputStream.Committer committer = stream.closeForCommit();
+
+        committer.commit(fileIO);
+        committer.clean(fileIO);
+
+        // Nothing else was staged, so the writer leaves no trace beyond its committed file.
+        assertThat(fileIO.exists(targetPath)).isTrue();
+        assertThat(fileIO.exists(new Path(targetPath.getParent(), "_temporary"))).isFalse();
+    }
+
+    @Test
     void testDiscard() throws IOException {
         RenamingTwoPhaseOutputStream stream =
                 new RenamingTwoPhaseOutputStream(fileIO, targetPath, false);


### PR DESCRIPTION
### Purpose

`RenamingTwoPhaseOutputStream` stages a file at `<target dir>/_temporary/.tmp.<uuid>` and renames it into place on commit. `TempFileCommitter#clean` then deleted `tempPath.getParent()` — the whole `_temporary` directory — after committing a single file.

That directory is not private to one stream. It is the staging directory of the target directory, shared with everything else writing there, so deleting it outright throws away work that is still in flight:

- two concurrent writers into the same directory delete each other's pending files, and the loser fails at `rename` with `Failed to rename ...`;
- a Hadoop `FileOutputCommitter` job staging into the same directory loses its task output.

`clean()` now deletes this stream's own temporary file, and removes `_temporary` only once nothing is staged there any more. In the ordinary single-writer case the directory is already empty at that point and is removed exactly as before, so nothing is left behind.

### Brief change log

- `RenamingTwoPhaseOutputStream.TempFileCommitter#clean`: delete the temporary file, and the staging directory only when it is empty.

### Tests

- `RenamingTwoPhaseOutputStreamTest#testCleanKeepsTheSharedStagingDirectory`: another writer's pending file, and the directory holding it, survive `clean()`. Fails without the change.
- `RenamingTwoPhaseOutputStreamTest#testCleanRemovesTheStagingDirectoryOnceEmpty`: an uncontended commit still leaves no `_temporary` behind.
- `mvn -pl paimon-common test -Dtest='RenamingTwoPhaseOutputStreamTest,MultiPartUploadTwoPhaseOutputStreamTest'`

### API and Format

- [x] This PR does not change any storage format
- `RenamingTwoPhaseOutputStream` is `@Public`, but no signature changes and an uncontended commit behaves exactly as before; only the case where something else is staging in the same directory differs.

### Documentation

- [x] No documentation change needed
