### PR TITLE
[core] Extract lookup state bulk sorter utility

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/lookup/StateUtils.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/StateUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.lookup;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.sort.BinaryExternalSortBuffer;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+/** Utilities shared by lookup state implementations. */
+public final class StateUtils {
+
+    public static BinaryExternalSortBuffer createBulkLoadSorter(
+            IOManager ioManager, CoreOptions options) {
+        return BinaryExternalSortBuffer.create(
+                ioManager,
+                RowType.of(DataTypes.BYTES(), DataTypes.BYTES()),
+                new int[] {0},
+                options.writeBufferSize() / 2,
+                options.pageSize(),
+                options.localSortMaxNumFileHandles(),
+                options.spillCompressOptions(),
+                options.writeBufferSpillDiskSize());
+    }
+
+    private StateUtils() {}
+}

--- a/paimon-core/src/main/java/org/apache/paimon/lookup/rocksdb/RocksDBState.java
+++ b/paimon-core/src/main/java/org/apache/paimon/lookup/rocksdb/RocksDBState.java
@@ -25,9 +25,8 @@ import org.apache.paimon.io.DataInputDeserializer;
 import org.apache.paimon.io.DataOutputSerializer;
 import org.apache.paimon.lookup.ByteArray;
 import org.apache.paimon.lookup.State;
+import org.apache.paimon.lookup.StateUtils;
 import org.apache.paimon.sort.BinaryExternalSortBuffer;
-import org.apache.paimon.types.DataTypes;
-import org.apache.paimon.types.RowType;
 
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Cache;
 import org.apache.paimon.shade.caffeine2.com.github.benmanes.caffeine.cache.Caffeine;
@@ -118,17 +117,11 @@ public abstract class RocksDBState<K, V, CacheV> implements State<K, V> {
         return new RocksDBBulkLoader(db, stateFactory.options(), columnFamily, stateFactory.path());
     }
 
+    /** @deprecated Use {@link StateUtils#createBulkLoadSorter(IOManager, CoreOptions)}. */
+    @Deprecated
     public static BinaryExternalSortBuffer createBulkLoadSorter(
             IOManager ioManager, CoreOptions options) {
-        return BinaryExternalSortBuffer.create(
-                ioManager,
-                RowType.of(DataTypes.BYTES(), DataTypes.BYTES()),
-                new int[] {0},
-                options.writeBufferSize() / 2,
-                options.pageSize(),
-                options.localSortMaxNumFileHandles(),
-                options.spillCompressOptions(),
-                options.writeBufferSpillDiskSize());
+        return StateUtils.createBulkLoadSorter(ioManager, options);
     }
 
     /** A class wraps byte[] to indicate contain or not contain. */


### PR DESCRIPTION
## What changed

- Move creation of the byte-keyed bulk-load sort buffer to the storage-neutral `StateUtils`.
- Keep the RocksDB helper as a deprecated delegating method for source compatibility.

## Why

The sorter configuration is shared state infrastructure and does not depend on RocksDB. Moving it out of `RocksDBState` allows other state backends to reuse it without importing RocksDB implementation classes.

## Validation

- `mvn -q -pl paimon-core -am -DskipTests compile`
- `mvn -q -pl paimon-core spotless:check -DskipTests`
