### PR TITLE
[core] Make LocalKvDb flush failure-safe

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/lookup/sort/db/LocalKvDb.java
+++ b/paimon-common/src/main/java/org/apache/paimon/lookup/sort/db/LocalKvDb.java
@@ -471,12 +471,10 @@ public class LocalKvDb implements Closeable {
 
     private void flushMemTable() throws IOException {
         TreeMap<MemorySlice, byte[]> snapshot = memTable;
+        SstFileMetadata metadata = writeMemTableToSst(snapshot);
+        levels.addLevelZeroFile(metadata);
         memTable = new TreeMap<>(keyComparator);
         memTableSize = 0;
-
-        SstFileMetadata metadata = writeMemTableToSst(snapshot);
-
-        levels.addLevelZeroFile(metadata);
 
         LOG.info(
                 "Flushed MemTable to L0 SST file: {}, entries: {}",
@@ -610,12 +608,14 @@ public class LocalKvDb implements Closeable {
     private SstFileMetadata writeMemTableToSst(TreeMap<MemorySlice, byte[]> data)
             throws IOException {
         File sstFile = newSstFile();
-        SortLookupStoreWriter writer =
-                storeFactory.createWriter(sstFile, bloomFilterBuilderFactory.apply(data.size()));
+        SortLookupStoreWriter writer = null;
         MemorySlice minKey = null;
         MemorySlice maxKey = null;
         long tombstoneCount = 0;
         try {
+            writer =
+                    storeFactory.createWriter(
+                            sstFile, bloomFilterBuilderFactory.apply(data.size()));
             for (Map.Entry<MemorySlice, byte[]> entry : data.entrySet()) {
                 writer.put(entry.getKey().copyBytes(), entry.getValue());
                 if (minKey == null) {
@@ -626,10 +626,20 @@ public class LocalKvDb implements Closeable {
                     tombstoneCount++;
                 }
             }
-        } finally {
             writer.close();
+            writer = null;
+            return new SstFileMetadata(sstFile, minKey, maxKey, tombstoneCount, 0);
+        } catch (IOException | RuntimeException e) {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException suppressed) {
+                    e.addSuppressed(suppressed);
+                }
+            }
+            deleteFileQuietly(sstFile);
+            throw e;
         }
-        return new SstFileMetadata(sstFile, minKey, maxKey, tombstoneCount, 0);
     }
 
     private File newSstFile() {

--- a/paimon-common/src/test/java/org/apache/paimon/lookup/sort/db/LocalKvDbTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/lookup/sort/db/LocalKvDbTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -389,6 +390,31 @@ public class LocalKvDbTest {
 
         // After close, data should have been flushed to SST
         Assertions.assertEquals(1, db.getSstFileCount());
+    }
+
+    @Test
+    public void testFlushFailureKeepsMemTableForRetry() throws IOException {
+        File dbDir = new File(tempDir.toFile(), "flush-failure-db");
+        try (LocalKvDb db =
+                LocalKvDb.builder(dbDir)
+                        .memTableFlushThreshold(1024 * 1024)
+                        .blockSize(256)
+                        .compressOptions(new CompressOptions("none", 1))
+                        .build()) {
+            putString(db, "key", "value");
+
+            Files.delete(dbDir.toPath());
+            Files.createFile(dbDir.toPath());
+            Assertions.assertThrows(IOException.class, db::flush);
+            Assertions.assertEquals("value", getString(db, "key"));
+            Assertions.assertTrue(db.getMemTableSize() > 0);
+
+            Files.delete(dbDir.toPath());
+            Files.createDirectories(dbDir.toPath());
+            db.flush();
+            Assertions.assertEquals("value", getString(db, "key"));
+            Assertions.assertEquals(0, db.getMemTableSize());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Make `LocalKvDb` flush failure-safe.

## Changes

- Keep the memtable intact until the SST has been written and published to level 0.
- Remove an incomplete SST when writing or closing the writer fails.
- Add a regression test that injects a flush failure and verifies that reads and a later retry still succeed.

## Verification

- `mvn -q -pl paimon-common -Pfast-build -DwildcardSuites=none '-Dtest=LocalKvDbTest#testFlushFailureKeepsMemTableForRetry+testFlushToSst+testCloseFlushesMemTable' test`
- `mvn -q -pl paimon-common spotless:check -DskipTests`
- `mvn -q -pl paimon-common -DskipTests compile`
