### PR TITLE
[common] Fix SliceComparator on BINARY and VARBINARY fields (#8873)

### DIFF
--- a/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
+++ b/paimon-common/src/main/java/org/apache/paimon/data/serializer/RowCompactedSerializer.java
@@ -40,6 +40,7 @@ import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.VectorType;
+import org.apache.paimon.utils.SortUtil;
 import org.apache.paimon.utils.TypeCheckUtils;
 import org.apache.paimon.utils.VarLengthIntUtils;
 
@@ -760,8 +761,16 @@ public class RowCompactedSerializer implements Serializer<InternalRow> {
                         FieldReader fieldReader = fieldReaders[i];
                         Object o1 = fieldReader.readField(reader1, i);
                         Object o2 = fieldReader.readField(reader2, i);
-                        @SuppressWarnings({"unchecked", "rawtypes"})
-                        int comp = ((Comparable) o1).compareTo(o2);
+                        int comp;
+                        if (o1 instanceof byte[]) {
+                            // BINARY / VARBINARY fields read back as byte[], which does not
+                            // implement Comparable; order them like BinaryRow does.
+                            comp = SortUtil.compareBinary((byte[]) o1, (byte[]) o2);
+                        } else {
+                            @SuppressWarnings({"unchecked", "rawtypes"})
+                            int comparableComp = ((Comparable) o1).compareTo(o2);
+                            comp = comparableComp;
+                        }
                         if (comp != 0) {
                             return comp;
                         }

--- a/paimon-common/src/test/java/org/apache/paimon/data/serializer/RowCompactedSerializerTest.java
+++ b/paimon-common/src/test/java/org/apache/paimon/data/serializer/RowCompactedSerializerTest.java
@@ -23,17 +23,21 @@ import org.apache.paimon.data.BinaryVector;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.variant.GenericVariant;
+import org.apache.paimon.memory.MemorySlice;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
 import org.apache.paimon.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+
 import static org.apache.paimon.data.BinaryString.fromString;
 import static org.apache.paimon.data.serializer.InternalRowSerializerTest.createArray;
 import static org.apache.paimon.data.serializer.InternalRowSerializerTest.createMap;
 import static org.apache.paimon.data.serializer.InternalRowSerializerTest.createRow;
 import static org.apache.paimon.data.serializer.InternalRowSerializerTest.deepEqualsInternalRow;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link RowCompactedSerializer}. */
@@ -199,6 +203,44 @@ abstract class RowCompactedSerializerTest extends SerializerTestInstance<Interna
 
         private static RowCompactedSerializer getRowSerializer() {
             return new RowCompactedSerializer(RowType.of(DataTypes.VARIANT(), DataTypes.VARIANT()));
+        }
+    }
+
+    static final class BinaryFieldTest extends RowCompactedSerializerTest {
+        public BinaryFieldTest() {
+            super(getRowSerializer(), getData());
+        }
+
+        private static InternalRow[] getData() {
+            return new GenericRow[] {
+                GenericRow.of(1, new byte[] {1, 2, 3}),
+                GenericRow.of(1, new byte[] {1, 2, 4}),
+                GenericRow.of(2, new byte[] {(byte) 0xFF})
+            };
+        }
+
+        private static RowCompactedSerializer getRowSerializer() {
+            return new RowCompactedSerializer(RowType.of(DataTypes.INT(), DataTypes.BYTES()));
+        }
+
+        @Test
+        public void testSliceComparatorOnBinaryFields() {
+            RowCompactedSerializer serializer = getRowSerializer();
+            Comparator<MemorySlice> comparator = serializer.createSliceComparator();
+            MemorySlice small =
+                    MemorySlice.wrap(
+                            serializer.serializeToBytes(GenericRow.of(1, new byte[] {1, 2, 3})));
+            MemorySlice large =
+                    MemorySlice.wrap(
+                            serializer.serializeToBytes(GenericRow.of(1, new byte[] {1, 2, 4})));
+            MemorySlice unsigned =
+                    MemorySlice.wrap(
+                            serializer.serializeToBytes(
+                                    GenericRow.of(1, new byte[] {(byte) 0xFF})));
+            assertThat(comparator.compare(small, large)).isLessThan(0);
+            assertThat(comparator.compare(large, small)).isGreaterThan(0);
+            assertThat(comparator.compare(small, small)).isEqualTo(0);
+            assertThat(comparator.compare(unsigned, small)).isGreaterThan(0);
         }
     }
 


### PR DESCRIPTION
### Purpose

Fixes #8873.

`TypeCheckUtils.isComparable` admits BINARY and VARBINARY, and primary keys may contain them, but `SliceComparator` cast every field value to `Comparable` — `byte[]` is not, so any sorted-lookup-store seek over a binary key field (lookup compaction, deletion-vector maintenance, lookup changelog producer) threw `ClassCastException`. Compare binary fields with `SortUtil.compareBinary`, the same unsigned lexicographic order `BinaryRow` uses, so lookup files order consistently with the rest of the merge tree.

### Tests

`RowCompactedSerializerTest.BinaryFieldTest`: serializer round-trips over an `(INT, BYTES)` row type plus a slice-comparator test covering less/greater/equal and the unsigned edge (`0xFF` orders above `0x01`).

### API and Format

No changes.

### Documentation

No changes.