### PR TITLE
[WIP][spark] Distribute lateral vector search across index splits

### DIFF
--- a/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionVectorScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/DataEvolutionVectorScan.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -185,6 +186,11 @@ public class DataEvolutionVectorScan implements VectorScan {
             @Override
             public List<VectorSearchSplit> splits() {
                 return splits;
+            }
+
+            @Override
+            public OptionalLong plannedSnapshotId() {
+                return snapshot == null ? OptionalLong.empty() : OptionalLong.of(snapshot.id());
             }
         };
     }

--- a/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScan.java
+++ b/paimon-core/src/main/java/org/apache/paimon/table/source/VectorScan.java
@@ -19,6 +19,7 @@
 package org.apache.paimon.table.source;
 
 import java.util.List;
+import java.util.OptionalLong;
 
 /** Vector scan to pre-filter and scan index files. */
 public interface VectorScan {
@@ -28,5 +29,9 @@ public interface VectorScan {
     /** Plan of vector scan. */
     interface Plan {
         List<VectorSearchSplit> splits();
+
+        default OptionalLong plannedSnapshotId() {
+            return OptionalLong.empty();
+        }
     }
 }

--- a/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
+++ b/paimon-core/src/test/java/org/apache/paimon/table/source/VectorSearchBuilderTest.java
@@ -465,6 +465,56 @@ public class VectorSearchBuilderTest extends TableTestBase {
     }
 
     @Test
+    public void testVectorScanPlanCarriesLatestSnapshot() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+
+        float[][] vectors = {{1.0f, 0.0f}, {0.0f, 1.0f}};
+        writeVectors(table, vectors);
+        buildAndCommitIndex(table, vectors);
+
+        long latestSnapshotId = table.snapshotManager().latestSnapshotId();
+        VectorScan.Plan plan =
+                table.newVectorSearchBuilder()
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(1)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(plan.plannedSnapshotId()).hasValue(latestSnapshotId);
+    }
+
+    @Test
+    public void testVectorScanPlanCarriesTimeTravelSnapshot() throws Exception {
+        createTableDefault();
+        FileStoreTable table = getTableDefault();
+
+        float[][] vectors = {{1.0f, 0.0f}, {0.0f, 1.0f}};
+        writeVectors(table, vectors);
+        buildAndCommitIndex(table, vectors);
+        long historicalSnapshotId = table.snapshotManager().latestSnapshotId();
+        writeVectors(table, new float[][] {{0.5f, 0.5f}});
+        assertThat(table.snapshotManager().latestSnapshotId()).isGreaterThan(historicalSnapshotId);
+
+        FileStoreTable timeTravelTable =
+                table.copy(
+                        Collections.singletonMap(
+                                CoreOptions.SCAN_SNAPSHOT_ID.key(),
+                                String.valueOf(historicalSnapshotId)));
+        VectorScan.Plan plan =
+                timeTravelTable
+                        .newVectorSearchBuilder()
+                        .withVector(new float[] {1.0f, 0.0f})
+                        .withLimit(1)
+                        .withVectorColumn(VECTOR_FIELD_NAME)
+                        .newVectorScan()
+                        .scan();
+
+        assertThat(plan.plannedSnapshotId()).hasValue(historicalSnapshotId);
+    }
+
+    @Test
     public void testVectorSearchFullModeScansFilteredUnindexedData() throws Exception {
         catalog.createTable(
                 identifier("full_search_filtered_table"),

--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkConnectorOptions.java
@@ -47,6 +47,24 @@ public class SparkConnectorOptions {
                             "Parallelism used to repartition a single-partition LIMIT input before "
                                     + "executing a lateral vector search.");
 
+    public static final ConfigOption<Boolean> VECTOR_SEARCH_LATERAL_JOIN_DISTRIBUTED_ENABLED =
+            key("vector-search.lateral-join.distributed.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to distribute lateral batch vector search across compatible "
+                                    + "vector index split groups. Unsupported plans fall back to "
+                                    + "the local batch search path.");
+
+    public static final ConfigOption<Integer>
+            VECTOR_SEARCH_LATERAL_JOIN_DISTRIBUTED_MAX_SPLIT_GROUPS =
+                    key("vector-search.lateral-join.distributed.max-split-groups")
+                            .intType()
+                            .defaultValue(16)
+                            .withDescription(
+                                    "Maximum number of independently searched vector index split "
+                                            + "groups for distributed lateral search.");
+
     public static final ConfigOption<Boolean> MERGE_SCHEMA =
             key("write.merge-schema")
                     .booleanType()

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
@@ -32,6 +32,7 @@ import scala.collection.mutable.LongMap
 private[execution] object LateralVectorSearchExecution {
 
   private val MaxMergeBatchesPerSearch = 16
+  private val MaxMaterializationCandidatesPerBatch = 64L * 1024
 
   case class QueryBatchId(inputPartition: Int, ordinal: Long)
 
@@ -329,6 +330,48 @@ private[execution] object LateralVectorSearchExecution {
     val batchesPerSearch =
       Math.min(Math.max(1, mergeParallelism), MaxMergeBatchesPerSearch)
     Math.max(1, (searchBatchSize + batchesPerSearch - 1) / batchesPerSearch)
+  }
+
+  def groupMergedResults(
+      results: Iterator[PartialBatchResult],
+      maxQueries: Int,
+      maxCandidates: Long = MaxMaterializationCandidatesPerBatch)
+      : Iterator[Seq[PartialBatchResult]] = {
+    require(maxQueries > 0, "maxQueries must be positive")
+    require(maxCandidates > 0, "maxCandidates must be positive")
+    val pendingResults = results.buffered
+    new Iterator[Seq[PartialBatchResult]] {
+
+      override def hasNext: Boolean = pendingResults.hasNext
+
+      override def next(): Seq[PartialBatchResult] = {
+        if (!hasNext) {
+          throw new NoSuchElementException("next on empty merged-result iterator")
+        }
+        val grouped = ArrayBuffer[PartialBatchResult]()
+        var queryCount = 0
+        var candidateCount = 0L
+        var grouping = true
+        while (pendingResults.hasNext && grouping) {
+          val next = pendingResults.head
+          val nextQueryCount = next.candidates.length
+          val nextCandidateCount =
+            next.candidates.iterator.map(_.rowIds.length.toLong).sum
+          if (
+            grouped.nonEmpty &&
+            (queryCount.toLong + nextQueryCount > maxQueries ||
+              candidateCount + nextCandidateCount > maxCandidates)
+          ) {
+            grouping = false
+          } else {
+            grouped += pendingResults.next()
+            queryCount += nextQueryCount
+            candidateCount += nextCandidateCount
+          }
+        }
+        grouped.toSeq
+      }
+    }
   }
 
   private def splitCost(split: VectorSearchSplit): Long = split match {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
@@ -23,6 +23,8 @@ import org.apache.paimon.globalindex.ScoreGetter
 import org.apache.paimon.table.source.{IndexVectorSearchSplit, VectorSearchSplit}
 import org.apache.paimon.utils.RoaringNavigableMap64
 
+import org.apache.spark.Partitioner
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.LongMap
@@ -30,6 +32,19 @@ import scala.collection.mutable.LongMap
 private[execution] object LateralVectorSearchExecution {
 
   case class QueryBatchId(inputPartition: Int, ordinal: Long)
+
+  final case class QueryBatchPartitioner(override val numPartitions: Int) extends Partitioner {
+
+    require(numPartitions > 0, "numPartitions must be positive")
+
+    override def getPartition(key: Any): Int = key match {
+      case batchId: QueryBatchId =>
+        Math.floorMod(batchId.inputPartition.toLong + batchId.ordinal, numPartitions.toLong).toInt
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Expected ${classOf[QueryBatchId].getName}, but found ${key.getClass.getName}.")
+    }
+  }
 
   case class QueryPayload(vector: Array[Float], outerRowBytes: Array[Byte])
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
@@ -31,6 +31,8 @@ import scala.collection.mutable.LongMap
 
 private[execution] object LateralVectorSearchExecution {
 
+  private val MaxMergeBatchesPerSearch = 16
+
   case class QueryBatchId(inputPartition: Int, ordinal: Long)
 
   final case class QueryBatchPartitioner(override val numPartitions: Int) extends Partitioner {
@@ -319,6 +321,14 @@ private[execution] object LateralVectorSearchExecution {
         grouped.toSeq
       }
     }
+  }
+
+  def queryMergeBatchSize(searchBatchSize: Int, mergeParallelism: Int): Int = {
+    // Create enough merge keys to utilize reducers without growing per-batch shuffle metadata
+    // unboundedly. Search batches are regrouped to searchBatchSize before entering native search.
+    val batchesPerSearch =
+      Math.min(Math.max(1, mergeParallelism), MaxMergeBatchesPerSearch)
+    Math.max(1, (searchBatchSize + batchesPerSearch - 1) / batchesPerSearch)
   }
 
   private def splitCost(split: VectorSearchSplit): Long = split match {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecution.scala
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.execution
+
+import org.apache.paimon.globalindex.ScoredGlobalIndexResult
+import org.apache.paimon.globalindex.ScoreGetter
+import org.apache.paimon.table.source.{IndexVectorSearchSplit, VectorSearchSplit}
+import org.apache.paimon.utils.RoaringNavigableMap64
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.LongMap
+
+private[execution] object LateralVectorSearchExecution {
+
+  case class QueryBatchId(inputPartition: Int, ordinal: Long)
+
+  case class QueryPayload(vector: Array[Float], outerRowBytes: Array[Byte])
+
+  case class QueryBatch(id: QueryBatchId, queries: Array[QueryPayload])
+
+  case class SearchQueryBatch(
+      id: QueryBatchId,
+      vectors: Array[Array[Float]],
+      outerRowBytes: Array[Array[Byte]])
+
+  case class WeightedSplit[T](value: T, cost: Long)
+
+  case class SplitGroup(id: Int, splits: Seq[VectorSearchSplit])
+
+  case class PartialBatchResult(
+      outerRowBytes: Array[Array[Byte]],
+      candidates: Array[ScoredCandidates]) {
+
+    require(candidates.nonEmpty, "candidates must not be empty")
+    require(
+      outerRowBytes == null || outerRowBytes.length == candidates.length,
+      "outer rows and candidates must have the same length")
+
+    def merge(other: PartialBatchResult, limit: Int): PartialBatchResult = {
+      require(
+        candidates.length == other.candidates.length,
+        "partial batch results must have the same length")
+      val outer = if (outerRowBytes != null) outerRowBytes else other.outerRowBytes
+      val mergedCandidates = new Array[ScoredCandidates](candidates.length)
+      var index = 0
+      while (index < candidates.length) {
+        mergedCandidates(index) = candidates(index).merge(other.candidates(index), limit)
+        index += 1
+      }
+      PartialBatchResult(outer, mergedCandidates)
+    }
+  }
+
+  case class ScoredCandidates(rowIds: Array[Long], scores: Array[Float]) {
+
+    require(rowIds.length == scores.length, "rowIds and scores must have the same length")
+
+    def isEmpty: Boolean = rowIds.isEmpty
+
+    def merge(other: ScoredCandidates, limit: Int): ScoredCandidates = {
+      require(limit > 0, "limit must be positive")
+      if (other.isEmpty && rowIds.length <= limit) {
+        return this
+      }
+      if (isEmpty && other.rowIds.length <= limit) {
+        return other
+      }
+
+      if (rowIds.length + other.rowIds.length > ScoredCandidates.SmallTopKMergeThreshold) {
+        return mergeLargeTopK(other, limit)
+      }
+
+      // Each partial result is already bounded by TopK. Avoid allocating a HashMap and sorting
+      // boxed tuples for every query and every merge level; the working set is at most 2 * limit.
+      val mergedRowIds = new Array[Long](rowIds.length + other.rowIds.length)
+      val mergedScores = new Array[Float](mergedRowIds.length)
+      var mergedSize = appendDistinct(mergedRowIds, mergedScores, 0, this)
+      mergedSize = appendDistinct(mergedRowIds, mergedScores, mergedSize, other)
+
+      // Insertion sort is efficient for the small bounded TopK arrays used by vector search.
+      var index = 1
+      while (index < mergedSize) {
+        val rowId = mergedRowIds(index)
+        val score = mergedScores(index)
+        var insertion = index
+        while (
+          insertion > 0 &&
+          stronger(score, rowId, mergedScores(insertion - 1), mergedRowIds(insertion - 1))
+        ) {
+          mergedRowIds(insertion) = mergedRowIds(insertion - 1)
+          mergedScores(insertion) = mergedScores(insertion - 1)
+          insertion -= 1
+        }
+        mergedRowIds(insertion) = rowId
+        mergedScores(insertion) = score
+        index += 1
+      }
+
+      val resultSize = Math.min(limit, mergedSize)
+      ScoredCandidates(
+        java.util.Arrays.copyOf(mergedRowIds, resultSize),
+        java.util.Arrays.copyOf(mergedScores, resultSize))
+    }
+
+    private def mergeLargeTopK(other: ScoredCandidates, limit: Int): ScoredCandidates = {
+      val scoreByRowId = LongMap.empty[Float]
+      appendBestScores(scoreByRowId, this)
+      appendBestScores(scoreByRowId, other)
+
+      val sorted = scoreByRowId.iterator.toArray
+      scala.util.Sorting.stableSort(
+        sorted,
+        (left: (Long, Float), right: (Long, Float)) =>
+          stronger(left._2, left._1, right._2, right._1))
+
+      val resultSize = Math.min(limit, sorted.length)
+      val resultRowIds = new Array[Long](resultSize)
+      val resultScores = new Array[Float](resultSize)
+      var index = 0
+      while (index < resultSize) {
+        resultRowIds(index) = sorted(index)._1
+        resultScores(index) = sorted(index)._2
+        index += 1
+      }
+      ScoredCandidates(resultRowIds, resultScores)
+    }
+
+    private def appendBestScores(
+        scoreByRowId: LongMap[Float],
+        candidates: ScoredCandidates): Unit = {
+      var index = 0
+      while (index < candidates.rowIds.length) {
+        val rowId = candidates.rowIds(index)
+        val score = candidates.scores(index)
+        scoreByRowId.get(rowId) match {
+          case Some(existing) if java.lang.Float.compare(score, existing) <= 0 =>
+          case _ => scoreByRowId.update(rowId, score)
+        }
+        index += 1
+      }
+    }
+
+    def toResult: ScoredGlobalIndexResult = {
+      val bitmap = new RoaringNavigableMap64
+      val scoreMap = new java.util.HashMap[java.lang.Long, java.lang.Float]()
+      var index = 0
+      while (index < rowIds.length) {
+        bitmap.add(rowIds(index))
+        scoreMap.put(rowIds(index), scores(index))
+        index += 1
+      }
+      ScoredGlobalIndexResult.create(
+        bitmap,
+        new ScoreGetter {
+          override def score(rowId: Long): Float = scoreMap.get(rowId)
+        })
+    }
+
+    private def appendDistinct(
+        targetRowIds: Array[Long],
+        targetScores: Array[Float],
+        initialSize: Int,
+        candidates: ScoredCandidates): Int = {
+      var size = initialSize
+      var index = 0
+      while (index < candidates.rowIds.length) {
+        val rowId = candidates.rowIds(index)
+        val score = candidates.scores(index)
+        var existing = 0
+        while (existing < size && targetRowIds(existing) != rowId) {
+          existing += 1
+        }
+        if (existing == size) {
+          targetRowIds(size) = rowId
+          targetScores(size) = score
+          size += 1
+        } else if (java.lang.Float.compare(score, targetScores(existing)) > 0) {
+          targetScores(existing) = score
+        }
+        index += 1
+      }
+      size
+    }
+
+    private def stronger(
+        leftScore: Float,
+        leftRowId: Long,
+        rightScore: Float,
+        rightRowId: Long): Boolean = {
+      val scoreComparison = java.lang.Float.compare(leftScore, rightScore)
+      scoreComparison > 0 || (scoreComparison == 0 && leftRowId < rightRowId)
+    }
+  }
+
+  object ScoredCandidates {
+
+    private val SmallTopKMergeThreshold = 128
+
+    val empty: ScoredCandidates = ScoredCandidates(Array.emptyLongArray, Array.emptyFloatArray)
+
+    def from(result: ScoredGlobalIndexResult): ScoredCandidates = {
+      val rowIds = new Array[Long](result.results().getIntCardinality)
+      val scores = new Array[Float](rowIds.length)
+      val scoreGetter = result.scoreGetter()
+      val iterator = result.results().iterator()
+      var index = 0
+      while (iterator.hasNext) {
+        val rowId = iterator.next()
+        rowIds(index) = rowId
+        scores(index) = scoreGetter.score(rowId)
+        index += 1
+      }
+      ScoredCandidates(rowIds, scores)
+    }
+  }
+
+  def groupByCost[T](splits: Seq[WeightedSplit[T]], maxGroups: Int): Seq[Seq[WeightedSplit[T]]] = {
+    require(maxGroups > 0, "maxGroups must be positive")
+    if (splits.isEmpty) {
+      return Seq.empty
+    }
+
+    val groupCount = Math.min(maxGroups, splits.size)
+    val groups = Array.fill(groupCount)(ArrayBuffer[WeightedSplit[T]]())
+    val groupCosts = Array.fill(groupCount)(0L)
+    val ordered = splits.zipWithIndex.sortWith {
+      case ((left, leftIndex), (right, rightIndex)) =>
+        left.cost > right.cost || (left.cost == right.cost && leftIndex < rightIndex)
+    }
+
+    ordered.foreach {
+      case (split, _) =>
+        var target = 0
+        var index = 1
+        while (index < groupCount) {
+          if (groupCosts(index) < groupCosts(target)) {
+            target = index
+          }
+          index += 1
+        }
+        groups(target) += split
+        groupCosts(target) += Math.max(1L, split.cost)
+    }
+
+    groups.map(_.toSeq).toSeq
+  }
+
+  def canDistribute(
+      splits: Seq[VectorSearchSplit],
+      queryOptions: Map[String, String],
+      tableOptions: Map[String, String]): Boolean = {
+    splits.size > 1 &&
+    splits.forall(_.isInstanceOf[IndexVectorSearchSplit]) &&
+    hasNonOverlappingRowRanges(splits.map(_.asInstanceOf[IndexVectorSearchSplit])) &&
+    !hasRefineOption(queryOptions) &&
+    !hasRefineOption(tableOptions)
+  }
+
+  def splitGroups(splits: Seq[VectorSearchSplit], maxGroups: Int): Seq[SplitGroup] = {
+    groupByCost(splits.map(split => WeightedSplit(split, splitCost(split))), maxGroups).zipWithIndex
+      .map { case (group, index) => SplitGroup(index, group.map(_.value)) }
+  }
+
+  def groupSearchBatches(
+      batches: Iterator[SearchQueryBatch],
+      maxVectors: Int): Iterator[Seq[SearchQueryBatch]] = {
+    require(maxVectors > 0, "maxVectors must be positive")
+    val pendingBatches = batches.buffered
+    new Iterator[Seq[SearchQueryBatch]] {
+
+      override def hasNext: Boolean = pendingBatches.hasNext
+
+      override def next(): Seq[SearchQueryBatch] = {
+        if (!hasNext) {
+          throw new NoSuchElementException("next on empty search-batch iterator")
+        }
+        val grouped = ArrayBuffer[SearchQueryBatch]()
+        var vectorCount = 0
+        while (
+          pendingBatches.hasNext &&
+          (grouped.isEmpty || vectorCount + pendingBatches.head.vectors.length <= maxVectors)
+        ) {
+          val batch = pendingBatches.next()
+          grouped += batch
+          vectorCount += batch.vectors.length
+        }
+        grouped.toSeq
+      }
+    }
+  }
+
+  private def splitCost(split: VectorSearchSplit): Long = split match {
+    case indexed: IndexVectorSearchSplit =>
+      val fileBytes = indexed
+        .vectorIndexFiles()
+        .asScala
+        .map(_.fileSize())
+        .foldLeft(0L)(saturatedAdd)
+      if (fileBytes > 0) {
+        fileBytes
+      } else {
+        saturatedRangeSize(indexed.rowRangeStart(), indexed.rowRangeEnd())
+      }
+    case _ => 1L
+  }
+
+  private def saturatedRangeSize(from: Long, to: Long): Long = {
+    if (to < from) {
+      1L
+    } else if (to == Long.MaxValue && from == 0L) {
+      Long.MaxValue
+    } else {
+      val difference = to - from
+      if (difference < 0 || difference == Long.MaxValue) Long.MaxValue else difference + 1L
+    }
+  }
+
+  private def saturatedAdd(left: Long, right: Long): Long = {
+    if (right > 0 && left > Long.MaxValue - right) Long.MaxValue else left + right
+  }
+
+  private def hasRefineOption(options: Map[String, String]): Boolean = {
+    options.keys.exists {
+      key =>
+        val normalized = key.toLowerCase
+        normalized.endsWith("refine_factor") ||
+        normalized.endsWith("refine-factor") ||
+        normalized.endsWith("rerank_factor") ||
+        normalized.endsWith("rerank-factor")
+    }
+  }
+
+  private def hasNonOverlappingRowRanges(splits: Seq[IndexVectorSearchSplit]): Boolean = {
+    val ordered = splits.sortBy(split => (split.rowRangeStart(), split.rowRangeEnd()))
+    ordered
+      .sliding(2)
+      .forall {
+        case Seq(left, right) => left.rowRangeEnd() < right.rowRangeStart()
+        case _ => true
+      }
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -24,7 +24,7 @@ import org.apache.paimon.globalindex.{GlobalIndexResult, IndexedSplit, ScoredGlo
 import org.apache.paimon.partition.PartitionPredicate
 import org.apache.paimon.partition.PartitionPredicate.splitPartitionPredicatesAndDataPredicates
 import org.apache.paimon.predicate.{Predicate, PredicateBuilder}
-import org.apache.paimon.spark.{PaimonRecordReaderIterator, PaimonScan, PostponeMergeInputScan, PostponeMergeOnRead, SparkCatalog, SparkGenericCatalog, SparkTable, SparkUtils}
+import org.apache.paimon.spark.{PaimonRecordReaderIterator, PaimonScan, PostponeMergeInputScan, PostponeMergeOnRead, SparkCatalog, SparkConnectorOptions, SparkGenericCatalog, SparkTable, SparkUtils}
 import org.apache.paimon.spark.catalog.{SparkBaseCatalog, SupportView}
 import org.apache.paimon.spark.catalyst.analysis.ResolvedPaimonView
 import org.apache.paimon.spark.catalyst.optimizer.RepartitionLateralVectorSearchInput
@@ -33,17 +33,18 @@ import org.apache.paimon.spark.data.SparkInternalRow
 import org.apache.paimon.spark.format.PaimonFormatTable
 import org.apache.paimon.spark.read.VectorSearchResultUtils
 import org.apache.paimon.spark.schema.PaimonMetadataColumn
-import org.apache.paimon.table.{InnerTable, SpecialFields, Table}
-import org.apache.paimon.table.source.{BatchVectorSearchBuilder, DataSplit, InnerTableScan, PrimaryKeyScoredResult, PrimaryKeySearchPosition, PrimaryKeyVectorResult, ReadBuilder, VectorScan}
+import org.apache.paimon.spark.util.OptionUtils
+import org.apache.paimon.table.{FileStoreTable, InnerTable, SpecialFields, Table}
+import org.apache.paimon.table.source.{BatchVectorSearchBuilder, DataSplit, InnerTableScan, PrimaryKeyScoredResult, PrimaryKeySearchPosition, PrimaryKeyVectorResult, ReadBuilder, VectorScan, VectorSearchSplit}
 import org.apache.paimon.types.RowType
 import org.apache.paimon.utils.RoaringNavigableMap64
 
-import org.apache.spark.TaskContext
+import org.apache.spark.{HashPartitioner, TaskContext}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ResolvedNamespace, ResolvedTable}
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, GenericInternalRow, JoinedRow, PredicateHelper, UnsafeProjection}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeSet, Expression, GenericInternalRow, JoinedRow, PredicateHelper, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.optimizer.BuildRight
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.{AddPartitions, CreateTableAsSelect, DescribeRelation, DropPartitions, LogicalPlan, RepairTable, ReplaceTable, ReplaceTableAsSelect, ShowCreateTable}
@@ -390,6 +391,28 @@ case class LateralVectorSearchExec(
   }
 
   override protected def doExecute(): RDD[InternalRow] = {
+    if (distributedSearchEnabled) {
+      val plannedSearch = createPlannedSearch()
+      val splits = plannedSearch.splits
+      val groups =
+        LateralVectorSearchExecution.splitGroups(splits, distributedMaxSplitGroups)
+      val coreOptions = new CoreOptions(innerTable.options())
+      if (
+        plannedSearch.table.isDefined &&
+        groups.size > 1 &&
+        !coreOptions.deletionVectorsEnabled() &&
+        LateralVectorSearchExecution.canDistribute(
+          splits,
+          options,
+          innerTable.options().asScala.toMap)
+      ) {
+        return executeDistributed(plannedSearch, groups)
+      }
+    }
+    executeLocal()
+  }
+
+  private def executeLocal(): RDD[InternalRow] = {
     child.execute().mapPartitions {
       outerRows =>
         val queryVectorProjection = UnsafeProjection.create(Seq(queryVectorExpr), child.output)
@@ -425,10 +448,205 @@ case class LateralVectorSearchExec(
     }
   }
 
+  private def distributedSearchEnabled: Boolean = {
+    OptionUtils
+      .getOptionString(SparkConnectorOptions.VECTOR_SEARCH_LATERAL_JOIN_DISTRIBUTED_ENABLED)
+      .toBoolean
+  }
+
+  private def createPlannedSearch(): LateralVectorSearchPlan = {
+    val vectorSearchBuilder = createVectorSearchBuilder(Seq.empty)
+    val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
+    val splits = vectorPlan.splits().asScala.toSeq
+    val batchSize =
+      Math.max(1, new CoreOptions(innerTable.options()).vectorSearchLateralJoinBatchSize())
+    val plannedTable =
+      if (vectorPlan.plannedSnapshotId().isPresent) {
+        innerTable match {
+          case table: FileStoreTable =>
+            Some(
+              table.copyWithoutTimeTravel(Map(
+                CoreOptions.SCAN_SNAPSHOT_ID.key() ->
+                  vectorPlan.plannedSnapshotId().getAsLong.toString,
+                CoreOptions.SCAN_TAG_NAME.key() -> null,
+                CoreOptions.SCAN_TIMESTAMP.key() -> null,
+                CoreOptions.SCAN_TIMESTAMP_MILLIS.key() -> null,
+                CoreOptions.SCAN_WATERMARK.key() -> null,
+                CoreOptions.SCAN_VERSION.key() -> null
+              ).asJava))
+          case _ => None
+        }
+      } else {
+        None
+      }
+    LateralVectorSearchPlan(plannedTable, splits, batchSize)
+  }
+
+  private def executeDistributed(
+      plannedSearch: LateralVectorSearchPlan,
+      groups: Seq[LateralVectorSearchExecution.SplitGroup]): RDD[InternalRow] = {
+    import LateralVectorSearchExecution._
+
+    val searchTable = plannedSearch.table.get
+    val childRDD = child.execute()
+    val queryBatches = childRDD
+      .mapPartitionsWithIndex {
+        case (inputPartition, outerRows) =>
+          val queryVectorProjection = UnsafeProjection.create(Seq(queryVectorExpr), child.output)
+          val outerRowProjection = UnsafeProjection.create(child.output, child.output)
+          var batchOrdinal = 0L
+          outerRows
+            .flatMap {
+              outerRow =>
+                toFloatArray(queryVectorProjection(outerRow).get(0, queryVectorExpr.dataType))
+                  .map {
+                    queryVector =>
+                      QueryPayload(queryVector, outerRowProjection(outerRow).copy().getBytes)
+                  }
+            }
+            .grouped(plannedSearch.batchSize)
+            .map {
+              batch =>
+                val batchId = QueryBatchId(inputPartition, batchOrdinal)
+                batchOrdinal += 1
+                QueryBatch(batchId, batch.toArray)
+            }
+      }
+
+    val groupsById = groups.map(group => group.id -> group).toMap
+    val searchWork = queryBatches
+      .flatMap {
+        batch =>
+          val vectors = batch.queries.map(_.vector)
+          groups.iterator.map {
+            group =>
+              val outerRows =
+                if (group.id == 0) batch.queries.map(_.outerRowBytes) else null
+              group.id -> SearchQueryBatch(batch.id, vectors, outerRows)
+          }
+      }
+      .partitionBy(new HashPartitioner(groups.size))
+
+    val candidateResults = searchWork.mapPartitions {
+      workItems =>
+        if (!workItems.hasNext) {
+          Iterator.empty
+        } else {
+          val first = workItems.next()
+          val groupId = first._1
+          val group = groupsById(groupId)
+          val vectorSearchBuilder = createVectorSearchBuilder(Seq.empty, searchTable)
+          val groupBatches = (Iterator.single(first) ++ workItems).map {
+            case (currentGroupId, searchBatch) =>
+              require(
+                currentGroupId == groupId,
+                s"Expected one vector split group per partition, but found groups $groupId and " +
+                  s"$currentGroupId.")
+              searchBatch
+          }
+          LateralVectorSearchExecution
+            .groupSearchBatches(groupBatches, plannedSearch.batchSize)
+            .flatMap {
+              searchBatches =>
+                val vectors = searchBatches.iterator.flatMap(_.vectors).toArray
+                val groupSplits = group.splits.asJava
+                val groupPlan = new VectorScan.Plan {
+                  override def splits(): java.util.List[VectorSearchSplit] = groupSplits
+                }
+                val results = vectorSearchBuilder
+                  .withVectors(vectors)
+                  .newBatchVectorRead()
+                  .readBatch(groupPlan)
+                  .asScala
+                require(
+                  results.size == vectors.length,
+                  s"Distributed batch vector search returned ${results.size} results for " +
+                    s"${vectors.length} query vectors."
+                )
+
+                var resultOffset = 0
+                searchBatches.iterator.map {
+                  searchBatch =>
+                    val candidates = results
+                      .slice(resultOffset, resultOffset + searchBatch.vectors.length)
+                      .map {
+                        case scored: ScoredGlobalIndexResult => ScoredCandidates.from(scored)
+                        case result =>
+                          throw new IllegalStateException(
+                            "Distributed vector search requires scored global-index results, " +
+                              s"but got ${result.getClass.getName}")
+                      }
+                      .toArray
+                    resultOffset += searchBatch.vectors.length
+                    searchBatch.id -> PartialBatchResult(searchBatch.outerRowBytes, candidates)
+                }
+            }
+        }
+    }
+
+    val mergeParallelism =
+      Math.max(groups.size, Math.min(childRDD.getNumPartitions, lateralJoinParallelism))
+    val mergedResults = candidateResults.combineByKey[PartialBatchResult](
+      (value: PartialBatchResult) => value,
+      (left: PartialBatchResult, right: PartialBatchResult) => left.merge(right, limit),
+      (left: PartialBatchResult, right: PartialBatchResult) => left.merge(right, limit),
+      new HashPartitioner(Math.max(1, mergeParallelism))
+    )
+
+    mergedResults.mapPartitions {
+      merged =>
+        val rightProjection =
+          UnsafeProjection.create(projectList, child.output ++ vectorSearchOutput)
+        val joinedRow = new JoinedRow
+        val readerTracker = new LateralVectorSearchReaderTracker
+        Option(TaskContext.get())
+          .foreach(_.addTaskCompletionListener[Unit](_ => readerTracker.closeCurrent()))
+        val materializationContext =
+          createMaterializationContext(rightProjection, readerTracker, searchTable)
+
+        merged.flatMap {
+          case (_, partial) =>
+            val queries = ArrayBuffer[LateralVectorSearchQuery]()
+            val results = ArrayBuffer[GlobalIndexResult]()
+            if (partial.outerRowBytes != null) {
+              partial.outerRowBytes.zip(partial.candidates).foreach {
+                case (outerRowBytes, candidates) if !candidates.isEmpty =>
+                  val outerRow = new UnsafeRow(child.output.size)
+                  outerRow.pointTo(outerRowBytes, outerRowBytes.length)
+                  queries += LateralVectorSearchQuery(outerRow, Array.emptyFloatArray)
+                  results += candidates.toResult
+                case _ =>
+              }
+            }
+            materializeSearchResults(queries.toVector, results.toVector, materializationContext)
+              .map {
+                case (outerRow, rightRow) =>
+                  joinedRow(outerRow, rightRow)
+                  joinedRow.copy()
+              }
+        }
+    }
+  }
+
   private def createSearchContext(
       rightProjection: UnsafeProjection,
       readerTracker: LateralVectorSearchReaderTracker): LateralVectorSearchContext = {
-    val rowType = innerTable.rowType()
+    val materializationContext =
+      createMaterializationContext(rightProjection, readerTracker)
+    val vectorSearchBuilder =
+      createVectorSearchBuilder(Seq.empty)
+    val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
+    val batchSize =
+      Math.max(1, new CoreOptions(innerTable.options()).vectorSearchLateralJoinBatchSize())
+
+    LateralVectorSearchContext(materializationContext, vectorSearchBuilder, vectorPlan, batchSize)
+  }
+
+  private def createMaterializationContext(
+      rightProjection: UnsafeProjection,
+      readerTracker: LateralVectorSearchReaderTracker,
+      table: InnerTable = innerTable): LateralVectorSearchMaterializationContext = {
+    val rowType = table.rowType()
     val readFieldNames = vectorSearchOutput
       .filterNot(
         attr =>
@@ -439,12 +657,13 @@ case class LateralVectorSearchExec(
     val rowTypeWithRowId = SpecialFields.rowTypeWithRowId(rowType)
     val readRowType = rowType.project(readFieldNames.asJava)
     val readRowTypeWithRowId = SpecialFields.rowTypeWithRowId(readRowType)
-    val readBuilder = innerTable
+    val readBuilder = table
       .newReadBuilder()
       .withReadType(rowTypeWithRowId.project(readFieldNamesWithRowId.asJava))
-    val physicalReadBuilder = innerTable
+    val physicalReadBuilder = table
       .newReadBuilder()
       .withReadType(readRowType)
+    pushSearchFilters(Seq(readBuilder, physicalReadBuilder), None, table)
     val scoreMetadataColumns =
       if (vectorSearchOutput.exists(_.name == PaimonMetadataColumn.SEARCH_SCORE_COLUMN)) {
         Seq(PaimonMetadataColumn.SEARCH_SCORE)
@@ -460,22 +679,9 @@ case class LateralVectorSearchExec(
             _.toPaimonDataField)).asJava)
       }
     val sparkRow = SparkInternalRow.create(resultRowType)
-    val vectorSearchBuilder = innerTable
-      .newBatchVectorSearchBuilder()
-      .withVectorColumn(columnName)
-      .withLimit(limit)
-      .withOptions(options.asJava)
-    pushSearchFilters(Seq(readBuilder, physicalReadBuilder), vectorSearchBuilder)
-
-    val vectorPlan = vectorSearchBuilder.newVectorScan().scan()
-    val batchSize =
-      Math.max(1, new CoreOptions(innerTable.options()).vectorSearchLateralJoinBatchSize())
-
-    LateralVectorSearchContext(
+    LateralVectorSearchMaterializationContext(
       readBuilder,
       physicalReadBuilder,
-      vectorSearchBuilder,
-      vectorPlan,
       scoreMetadataColumns,
       sparkRow,
       rowIdOrdinal = resultRowType.getFieldIndex(SpecialFields.ROW_ID.name()),
@@ -490,40 +696,52 @@ case class LateralVectorSearchExec(
           }
       },
       rightProjection,
-      batchSize,
       readerTracker
     )
   }
 
+  private def createVectorSearchBuilder(
+      readBuilders: Seq[ReadBuilder],
+      table: InnerTable = innerTable): BatchVectorSearchBuilder = {
+    val vectorSearchBuilder = table
+      .newBatchVectorSearchBuilder()
+      .withVectorColumn(columnName)
+      .withLimit(limit)
+      .withOptions(options.asJava)
+    pushSearchFilters(readBuilders, Some(vectorSearchBuilder), table)
+    vectorSearchBuilder
+  }
+
   private def pushSearchFilters(
       readBuilders: Seq[ReadBuilder],
-      vectorSearchBuilder: BatchVectorSearchBuilder): Unit = {
-    val predicates = convertSearchFilters()
+      vectorSearchBuilder: Option[BatchVectorSearchBuilder],
+      table: InnerTable): Unit = {
+    val predicates = convertSearchFilters(table)
     if (predicates.nonEmpty) {
       val split = splitPartitionPredicatesAndDataPredicates(
         predicates.asJava,
-        innerTable.rowType(),
-        innerTable.partitionKeys())
+        table.rowType(),
+        table.partitionKeys())
       if (split.getLeft.isPresent) {
         val partitionFilter = split.getLeft.get()
         readBuilders.foreach(_.withPartitionFilter(partitionFilter))
-        vectorSearchBuilder.withPartitionFilter(partitionFilter)
+        vectorSearchBuilder.foreach(_.withPartitionFilter(partitionFilter))
       }
       if (!split.getRight.isEmpty) {
         val dataFilter = PredicateBuilder.and(split.getRight)
         readBuilders.foreach(_.withFilter(dataFilter))
-        vectorSearchBuilder.withFilter(dataFilter)
+        vectorSearchBuilder.foreach(_.withFilter(dataFilter))
       }
     }
   }
 
-  private def convertSearchFilters(): Seq[Predicate] = {
+  private def convertSearchFilters(table: InnerTable): Seq[Predicate] = {
     if (searchFilters.isEmpty) {
       Seq.empty
     } else {
       PaimonTableValuedFunctions
         .convertLateralVectorSearchFilters(
-          innerTable,
+          table,
           vectorSearchOutput,
           projectList,
           projectOutput,
@@ -533,6 +751,31 @@ case class LateralVectorSearchExec(
             s"Cannot convert searched-table predicates for LATERAL vector_search: $searchFilters")
         }
     }
+  }
+
+  private def distributedMaxSplitGroups: Int = {
+    val value =
+      OptionUtils
+        .getOptionString(
+          SparkConnectorOptions.VECTOR_SEARCH_LATERAL_JOIN_DISTRIBUTED_MAX_SPLIT_GROUPS)
+        .toInt
+    require(
+      value > 0,
+      s"spark.paimon.${SparkConnectorOptions.VECTOR_SEARCH_LATERAL_JOIN_DISTRIBUTED_MAX_SPLIT_GROUPS
+          .key()} must be positive, but got $value")
+    value
+  }
+
+  private def lateralJoinParallelism: Int = {
+    val value =
+      OptionUtils
+        .getOptionString(SparkConnectorOptions.VECTOR_SEARCH_LATERAL_JOIN_PARALLELISM)
+        .toInt
+    require(
+      value > 0,
+      s"spark.paimon.${SparkConnectorOptions.VECTOR_SEARCH_LATERAL_JOIN_PARALLELISM
+          .key()} must be positive, but got $value")
+    value
   }
 
   private def search(
@@ -552,6 +795,13 @@ case class LateralVectorSearchExec(
       s"Batch vector search returned ${globalIndexResults.size} results for ${queries.size} " +
         "query vectors. The result count must match the query count."
     )
+    materializeSearchResults(queries, globalIndexResults, context.materializationContext)
+  }
+
+  private def materializeSearchResults(
+      queries: Seq[LateralVectorSearchQuery],
+      globalIndexResults: Seq[GlobalIndexResult],
+      context: LateralVectorSearchMaterializationContext): Iterator[(InternalRow, InternalRow)] = {
     val primaryKeyResults = primaryKeyVectorResults(globalIndexResults)
     if (context.metaColumnsOnly) {
       return primaryKeyResults match {
@@ -598,7 +848,7 @@ case class LateralVectorSearchExec(
   private def searchPrimaryKeyMetaColumns(
       queries: Seq[LateralVectorSearchQuery],
       results: Seq[PrimaryKeyVectorResult],
-      context: LateralVectorSearchContext): Iterator[(InternalRow, InternalRow)] = {
+      context: LateralVectorSearchMaterializationContext): Iterator[(InternalRow, InternalRow)] = {
     queries.zip(results).iterator.flatMap {
       case (query, result) =>
         result.positions().iterator().asScala.map {
@@ -635,7 +885,7 @@ case class LateralVectorSearchExec(
   private def searchPrimaryKeyRows(
       queries: Seq[LateralVectorSearchQuery],
       results: Seq[PrimaryKeyVectorResult],
-      context: LateralVectorSearchContext): Iterator[(InternalRow, InternalRow)] = {
+      context: LateralVectorSearchMaterializationContext): Iterator[(InternalRow, InternalRow)] = {
     val snapshotId = results.head.snapshotId()
     require(
       results.forall(_.snapshotId() == snapshotId),
@@ -718,7 +968,7 @@ case class LateralVectorSearchExec(
   private def searchMetaColumns(
       queries: Seq[LateralVectorSearchQuery],
       globalIndexResults: Seq[GlobalIndexResult],
-      context: LateralVectorSearchContext): Iterator[(InternalRow, InternalRow)] = {
+      context: LateralVectorSearchMaterializationContext): Iterator[(InternalRow, InternalRow)] = {
     queries.zip(globalIndexResults).iterator.flatMap {
       case (query, result) =>
         val scoreGetter = result match {
@@ -742,7 +992,7 @@ case class LateralVectorSearchExec(
   private def projectRightRow(
       rightRow: InternalRow,
       searchMatch: LateralVectorSearchMatch,
-      context: LateralVectorSearchContext): InternalRow = {
+      context: LateralVectorSearchMaterializationContext): InternalRow = {
     val values = new Array[Any](vectorSearchOutput.size)
     vectorSearchOutput.zipWithIndex.foreach {
       case (attr, index) =>
@@ -841,18 +1091,26 @@ case class LateralVectorSearchExec(
   }
 
   private case class LateralVectorSearchContext(
-      readBuilder: ReadBuilder,
-      physicalReadBuilder: ReadBuilder,
+      materializationContext: LateralVectorSearchMaterializationContext,
       vectorSearchBuilder: BatchVectorSearchBuilder,
       vectorPlan: VectorScan.Plan,
+      batchSize: Int)
+
+  private case class LateralVectorSearchMaterializationContext(
+      readBuilder: ReadBuilder,
+      physicalReadBuilder: ReadBuilder,
       scoreMetadataColumns: Seq[PaimonMetadataColumn],
       sparkRow: SparkInternalRow,
       rowIdOrdinal: Int,
       metaColumnsOnly: Boolean,
       projectionInputOrdinals: Seq[Int],
       rightProjection: UnsafeProjection,
-      batchSize: Int,
       readerTracker: LateralVectorSearchReaderTracker)
+
+  private case class LateralVectorSearchPlan(
+      table: Option[InnerTable],
+      splits: Seq[VectorSearchSplit],
+      batchSize: Int)
 
   private case class LateralVectorSearchQuery(outerRow: InternalRow, queryVector: Array[Float])
 

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -590,7 +590,7 @@ case class LateralVectorSearchExec(
       (value: PartialBatchResult) => value,
       (left: PartialBatchResult, right: PartialBatchResult) => left.merge(right, limit),
       (left: PartialBatchResult, right: PartialBatchResult) => left.merge(right, limit),
-      new HashPartitioner(Math.max(1, mergeParallelism))
+      new QueryBatchPartitioner(Math.max(1, mergeParallelism))
     )
 
     mergedResults.mapPartitions {

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -489,6 +489,10 @@ case class LateralVectorSearchExec(
 
     val searchTable = plannedSearch.table.get
     val childRDD = child.execute()
+    val mergeParallelism =
+      Math.max(groups.size, Math.min(childRDD.getNumPartitions, lateralJoinParallelism))
+    val mergeBatchSize =
+      LateralVectorSearchExecution.queryMergeBatchSize(plannedSearch.batchSize, mergeParallelism)
     val queryBatches = childRDD
       .mapPartitionsWithIndex {
         case (inputPartition, outerRows) =>
@@ -504,7 +508,7 @@ case class LateralVectorSearchExec(
                       QueryPayload(queryVector, outerRowProjection(outerRow).copy().getBytes)
                   }
             }
-            .grouped(plannedSearch.batchSize)
+            .grouped(mergeBatchSize)
             .map {
               batch =>
                 val batchId = QueryBatchId(inputPartition, batchOrdinal)
@@ -584,8 +588,6 @@ case class LateralVectorSearchExec(
         }
     }
 
-    val mergeParallelism =
-      Math.max(groups.size, Math.min(childRDD.getNumPartitions, lateralJoinParallelism))
     val mergedResults = candidateResults.combineByKey[PartialBatchResult](
       (value: PartialBatchResult) => value,
       (left: PartialBatchResult, right: PartialBatchResult) => left.merge(right, limit),

--- a/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
+++ b/paimon-spark/paimon-spark-common/src/main/scala/org/apache/paimon/spark/execution/PaimonStrategy.scala
@@ -606,27 +606,32 @@ case class LateralVectorSearchExec(
         val materializationContext =
           createMaterializationContext(rightProjection, readerTracker, searchTable)
 
-        merged.flatMap {
-          case (_, partial) =>
-            val queries = ArrayBuffer[LateralVectorSearchQuery]()
-            val results = ArrayBuffer[GlobalIndexResult]()
-            if (partial.outerRowBytes != null) {
-              partial.outerRowBytes.zip(partial.candidates).foreach {
-                case (outerRowBytes, candidates) if !candidates.isEmpty =>
-                  val outerRow = new UnsafeRow(child.output.size)
-                  outerRow.pointTo(outerRowBytes, outerRowBytes.length)
-                  queries += LateralVectorSearchQuery(outerRow, Array.emptyFloatArray)
-                  results += candidates.toResult
-                case _ =>
+        LateralVectorSearchExecution
+          .groupMergedResults(merged.map(_._2), plannedSearch.batchSize)
+          .flatMap {
+            partialResults =>
+              val queries = ArrayBuffer[LateralVectorSearchQuery]()
+              val results = ArrayBuffer[GlobalIndexResult]()
+              partialResults.foreach {
+                partial =>
+                  if (partial.outerRowBytes != null) {
+                    partial.outerRowBytes.zip(partial.candidates).foreach {
+                      case (outerRowBytes, candidates) if !candidates.isEmpty =>
+                        val outerRow = new UnsafeRow(child.output.size)
+                        outerRow.pointTo(outerRowBytes, outerRowBytes.length)
+                        queries += LateralVectorSearchQuery(outerRow, Array.emptyFloatArray)
+                        results += candidates.toResult
+                      case _ =>
+                    }
+                  }
               }
-            }
-            materializeSearchResults(queries.toVector, results.toVector, materializationContext)
-              .map {
-                case (outerRow, rightRow) =>
-                  joinedRow(outerRow, rightRow)
-                  joinedRow.copy()
-              }
-        }
+              materializeSearchResults(queries.toVector, results.toVector, materializationContext)
+                .map {
+                  case (outerRow, rightRow) =>
+                    joinedRow(outerRow, rightRow)
+                    joinedRow.copy()
+                }
+          }
     }
   }
 

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.spark.execution
+
+import org.apache.paimon.table.source.{IndexVectorSearchSplit, RawVectorSearchSplit}
+import org.apache.paimon.utils.Range
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Collections
+
+class LateralVectorSearchExecutionTest extends AnyFunSuite {
+
+  test("balance expensive splits across groups") {
+    val groups = LateralVectorSearchExecution.groupByCost(
+      Seq(
+        LateralVectorSearchExecution.WeightedSplit("a", 8L),
+        LateralVectorSearchExecution.WeightedSplit("b", 7L),
+        LateralVectorSearchExecution.WeightedSplit("c", 6L),
+        LateralVectorSearchExecution.WeightedSplit("d", 5L)
+      ),
+      2
+    )
+
+    assert(groups.map(_.map(_.value)) == Seq(Seq("a", "d"), Seq("b", "c")))
+    assert(groups.map(_.map(_.cost).sum) == Seq(13L, 13L))
+  }
+
+  test("merge partial results with deterministic bounded top k") {
+    val merged = LateralVectorSearchExecution
+      .ScoredCandidates(Array(4L, 2L, 1L), Array(0.8f, 0.9f, 0.9f))
+      .merge(LateralVectorSearchExecution.ScoredCandidates(Array(3L, 5L), Array(0.95f, 0.7f)), 3)
+
+    assert(merged.rowIds.sameElements(Array(3L, 1L, 2L)))
+    assert(merged.scores.sameElements(Array(0.95f, 0.9f, 0.9f)))
+  }
+
+  test("merge partial results deduplicates row IDs and uses total float ordering") {
+    val merged = LateralVectorSearchExecution
+      .ScoredCandidates(Array(4L, 2L), Array(0.8f, 0.7f))
+      .merge(
+        LateralVectorSearchExecution.ScoredCandidates(Array(2L, 1L), Array(0.9f, Float.NaN)),
+        3)
+
+    assert(merged.rowIds.sameElements(Array(1L, 2L, 4L)))
+    assert(merged.scores(0).isNaN)
+    assert(merged.scores.drop(1).sameElements(Array(0.9f, 0.8f)))
+  }
+
+  test("merge large top k matches full deduplication and sorting") {
+    val left = LateralVectorSearchExecution.ScoredCandidates(
+      (0L until 100L).toArray,
+      (0 until 100).map(i => if (i == 3) Float.NaN else (i % 17).toFloat).toArray)
+    val right = LateralVectorSearchExecution.ScoredCandidates(
+      (50L until 180L).toArray,
+      (50 until 180)
+        .map(i => if (i == 75) Float.NaN else if (i == 76) -0.0f else (i % 19).toFloat)
+        .toArray)
+
+    val bestScores = scala.collection.mutable.LongMap.empty[Float]
+    (left.rowIds.zip(left.scores) ++ right.rowIds.zip(right.scores)).foreach {
+      case (rowId, score) =>
+        bestScores.get(rowId) match {
+          case Some(existing) if java.lang.Float.compare(score, existing) <= 0 =>
+          case _ => bestScores.update(rowId, score)
+        }
+    }
+    val expected = bestScores.iterator.toArray
+      .sortWith {
+        (left: (Long, Float), right: (Long, Float)) =>
+          val comparison = java.lang.Float.compare(left._2, right._2)
+          comparison > 0 || (comparison == 0 && left._1 < right._1)
+      }
+      .take(140)
+
+    val merged = left.merge(right, 140)
+
+    assert(merged.rowIds.sameElements(expected.map(_._1)))
+    assert(
+      merged.scores
+        .map(java.lang.Float.floatToIntBits)
+        .sameElements(expected.map(value => java.lang.Float.floatToIntBits(value._2))))
+  }
+
+  test("merge partial results keeps the outer-row anchor from an empty group") {
+    val anchor = LateralVectorSearchExecution.PartialBatchResult(
+      Array(Array[Byte](1, 2, 3)),
+      Array(LateralVectorSearchExecution.ScoredCandidates.empty))
+    val candidates = LateralVectorSearchExecution.PartialBatchResult(
+      null,
+      Array(LateralVectorSearchExecution.ScoredCandidates(Array(7L), Array(0.8f))))
+
+    val merged = candidates.merge(anchor, 1)
+
+    assert(merged.outerRowBytes.head.sameElements(Array[Byte](1, 2, 3)))
+    assert(merged.candidates.head.rowIds.sameElements(Array(7L)))
+    assert(merged.candidates.head.scores.sameElements(Array(0.8f)))
+  }
+
+  test("combine search batches across input partitions up to the vector limit") {
+    def batch(ordinal: Long, size: Int) =
+      LateralVectorSearchExecution.SearchQueryBatch(
+        LateralVectorSearchExecution.QueryBatchId(0, ordinal),
+        Array.fill(size)(Array(1.0f)),
+        null)
+
+    val grouped = LateralVectorSearchExecution
+      .groupSearchBatches(Iterator(batch(0, 3), batch(1, 3), batch(2, 2)), 5)
+      .toSeq
+
+    assert(grouped.map(_.map(_.vectors.length)) == Seq(Seq(3), Seq(3, 2)))
+  }
+
+  test("only distribute complete indexed plans without refine") {
+    val indexedSplits = Seq(
+      new IndexVectorSearchSplit(0L, 9L, Collections.emptyList(), Collections.emptyList()),
+      new IndexVectorSearchSplit(10L, 19L, Collections.emptyList(), Collections.emptyList())
+    )
+    val rawSplit = new RawVectorSearchSplit(
+      Collections.singletonList(new Range(20L, 29L)),
+      Collections.emptyList(),
+      "ivf-pq")
+
+    assert(LateralVectorSearchExecution.canDistribute(indexedSplits, Map.empty, Map.empty))
+    assert(!LateralVectorSearchExecution.canDistribute(indexedSplits.take(1), Map.empty, Map.empty))
+    assert(
+      !LateralVectorSearchExecution.canDistribute(indexedSplits :+ rawSplit, Map.empty, Map.empty))
+    assert(
+      !LateralVectorSearchExecution
+        .canDistribute(indexedSplits, Map("ivf.refine_factor" -> "2"), Map.empty))
+    assert(
+      !LateralVectorSearchExecution
+        .canDistribute(indexedSplits, Map.empty, Map("fields.embedding.ivf.rerank-factor" -> "2")))
+
+    val overlappingSplits = Seq(
+      new IndexVectorSearchSplit(0L, 10L, Collections.emptyList(), Collections.emptyList()),
+      new IndexVectorSearchSplit(10L, 19L, Collections.emptyList(), Collections.emptyList())
+    )
+    assert(!LateralVectorSearchExecution.canDistribute(overlappingSplits, Map.empty, Map.empty))
+  }
+}

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
@@ -127,6 +127,28 @@ class LateralVectorSearchExecutionTest extends AnyFunSuite {
     assert(grouped.map(_.map(_.vectors.length)) == Seq(Seq(3), Seq(3, 2)))
   }
 
+  test("distribute query batches evenly across merge partitions") {
+    val partitioner = new LateralVectorSearchExecution.QueryBatchPartitioner(16)
+
+    val firstBatchPartitions = (0 until 16).map {
+      inputPartition =>
+        partitioner.getPartition(LateralVectorSearchExecution.QueryBatchId(inputPartition, 0L))
+    }
+
+    assert(firstBatchPartitions.sorted == (0 until 16))
+
+    val repeatedBatchPartitioner = new LateralVectorSearchExecution.QueryBatchPartitioner(4)
+    val repeatedBatchCounts = (for {
+      inputPartition <- 0 until 4
+      ordinal <- 0L until 12L
+    } yield {
+      repeatedBatchPartitioner
+        .getPartition(LateralVectorSearchExecution.QueryBatchId(inputPartition, ordinal))
+    }).groupBy(identity).map { case (partition, batches) => partition -> batches.size }
+
+    assert(repeatedBatchCounts == (0 until 4).map(_ -> 12).toMap)
+  }
+
   test("only distribute complete indexed plans without refine") {
     val indexedSplits = Seq(
       new IndexVectorSearchSplit(0L, 9L, Collections.emptyList(), Collections.emptyList()),

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
@@ -149,6 +149,14 @@ class LateralVectorSearchExecutionTest extends AnyFunSuite {
     assert(repeatedBatchCounts == (0 until 4).map(_ -> 12).toMap)
   }
 
+  test("split merge batches independently from vector search batches") {
+    assert(LateralVectorSearchExecution.queryMergeBatchSize(8192, 1) == 8192)
+    assert(LateralVectorSearchExecution.queryMergeBatchSize(8192, 16) == 512)
+    assert(LateralVectorSearchExecution.queryMergeBatchSize(8192, 64) == 512)
+    assert(LateralVectorSearchExecution.queryMergeBatchSize(3, 16) == 1)
+    assert(LateralVectorSearchExecution.queryMergeBatchSize(10, 3) == 4)
+  }
+
   test("only distribute complete indexed plans without refine") {
     val indexedSplits = Seq(
       new IndexVectorSearchSplit(0L, 9L, Collections.emptyList(), Collections.emptyList()),

--- a/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
+++ b/paimon-spark/paimon-spark-common/src/test/scala/org/apache/paimon/spark/execution/LateralVectorSearchExecutionTest.scala
@@ -157,6 +157,27 @@ class LateralVectorSearchExecutionTest extends AnyFunSuite {
     assert(LateralVectorSearchExecution.queryMergeBatchSize(10, 3) == 4)
   }
 
+  test("regroup merged results before materialization") {
+    def result(candidateCounts: Int*) =
+      LateralVectorSearchExecution.PartialBatchResult(
+        null,
+        candidateCounts.map {
+          count =>
+            LateralVectorSearchExecution.ScoredCandidates(
+              Array.tabulate(count)(_.toLong),
+              Array.fill(count)(0.0f))
+        }.toArray)
+
+    val grouped = LateralVectorSearchExecution
+      .groupMergedResults(
+        Iterator(result(1, 1), result(1, 1, 1), result(2, 2)),
+        maxQueries = 5,
+        maxCandidates = 5)
+      .toSeq
+
+    assert(grouped.map(_.map(_.candidates.length)) == Seq(Seq(2, 3), Seq(2)))
+  }
+
   test("only distribute complete indexed plans without refine") {
     val indexedSplits = Seq(
       new IndexVectorSearchSplit(0L, 9L, Collections.emptyList(), Collections.emptyList()),

--- a/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
+++ b/paimon-spark/paimon-spark-ut/src/test/scala/org/apache/paimon/spark/sql/TableValuedFunctionsTest.scala
@@ -19,10 +19,14 @@
 package org.apache.paimon.spark.sql
 
 import org.apache.paimon.data.{BinaryString, GenericRow, Timestamp}
+import org.apache.paimon.globalindex.testvector.TestVectorGlobalIndexerFactory
 import org.apache.paimon.manifest.ManifestCommittable
+import org.apache.paimon.partition.PartitionPredicate
+import org.apache.paimon.predicate.PredicateBuilder
 import org.apache.paimon.spark.PaimonHiveTestBase
 import org.apache.paimon.spark.catalyst.plans.logical.{LateralVectorSearch, PaimonTableValuedFunctions}
 import org.apache.paimon.spark.execution.LateralVectorSearchExec
+import org.apache.paimon.table.source.IndexVectorSearchSplit
 import org.apache.paimon.utils.DateTimeUtils
 
 import org.apache.spark.sql.{DataFrame, Row}
@@ -34,7 +38,101 @@ import org.apache.spark.sql.execution.joins.BroadcastHashJoinExec
 import java.time.LocalDateTime
 import java.util.Collections
 
+import scala.collection.JavaConverters._
+
 class TableValuedFunctionsTest extends PaimonHiveTestBase with AdaptiveSparkPlanHelper {
+
+  test("distributed lateral vector search matches local results across index splits") {
+    withTable("distributed_vector_search_source") {
+      spark.sql("""
+                  |CREATE TABLE distributed_vector_search_source (
+                  |  id INT,
+                  |  v ARRAY<FLOAT>,
+                  |  pt STRING)
+                  |USING paimon
+                  |TBLPROPERTIES (
+                  |  'bucket' = '-1',
+                  |  'global-index.row-count-per-shard' = '2',
+                  |  'row-tracking.enabled' = 'true',
+                  |  'data-evolution.enabled' = 'true',
+                  |  'test.vector.dimension' = '2')
+                  |PARTITIONED BY (pt)
+                  |""".stripMargin)
+      spark.sql("""
+                  |INSERT INTO distributed_vector_search_source VALUES
+                  |  (0, array(1.0f, 0.0f), 'p0'),
+                  |  (1, array(0.9f, 0.1f), 'p0'),
+                  |  (2, array(0.0f, 1.0f), 'p0'),
+                  |  (3, array(0.1f, 0.9f), 'p1'),
+                  |  (4, array(0.8f, 0.2f), 'p1'),
+                  |  (5, array(0.2f, 0.8f), 'p1'),
+                  |  (6, array(1.0f, 0.0f), 'p2')
+                  |""".stripMargin)
+      spark
+        .sql(
+          s"CALL sys.create_global_index(" +
+            s"table => '$hiveDbName.distributed_vector_search_source', " +
+            s"index_column => 'v', " +
+            s"index_type => '${TestVectorGlobalIndexerFactory.IDENTIFIER}')")
+        .collect()
+
+      val table = loadTable("distributed_vector_search_source")
+      val partitionType = table.store().partitionType()
+      val predicateBuilder = new PredicateBuilder(partitionType)
+      val partitionFilter = PartitionPredicate.fromPredicate(
+        partitionType,
+        predicateBuilder.in(
+          0,
+          Seq[Object](BinaryString.fromString("p0"), BinaryString.fromString("p2")).asJava))
+      val vectorSplits = table
+        .newBatchVectorSearchBuilder()
+        .withVectorColumn("v")
+        .withLimit(2)
+        .withVectors(Array(Array(1.0f, 0.0f)))
+        .withPartitionFilter(partitionFilter)
+        .newVectorScan()
+        .scan()
+        .splits()
+      assert(vectorSplits.size() >= 2, vectorSplits)
+      assert(vectorSplits.asScala.forall(_.isInstanceOf[IndexVectorSearchSplit]), vectorSplits)
+
+      val query =
+        """
+          |SELECT q.query_id, r.id, r.pt, r.__paimon_search_score
+          |FROM VALUES
+          |  (0, array(1.0f, 0.0f)),
+          |  (1, array(0.0f, 1.0f)),
+          |  (2, array(1.0f, 0.0f)),
+          |  (3, CAST(NULL AS ARRAY<FLOAT>))
+          |AS q(query_id, query_vector),
+          |LATERAL (
+          |  SELECT id, pt, __paimon_search_score
+          |  FROM vector_search(
+          |    'distributed_vector_search_source', 'v', q.query_vector, 2)
+          |  WHERE pt IN ('p0', 'p2')
+          |) r
+          |ORDER BY query_id, __paimon_search_score DESC, id
+          |""".stripMargin
+
+      var local = Seq.empty[Row]
+      withSparkSQLConf("spark.paimon.vector-search.lateral-join.distributed.enabled" -> "false") {
+        local = spark.sql(query).collect().toSeq
+      }
+      var distributed = Seq.empty[Row]
+      withSparkSQLConf(
+        "spark.paimon.vector-search.lateral-join.distributed.enabled" -> "true",
+        "spark.paimon.vector-search.lateral-join.parallelism" -> "2",
+        "spark.paimon.vector-search.lateral-join.distributed.max-split-groups" -> "2",
+        "spark.paimon.vector-search.lateral-join.batch-size" -> "2"
+      ) {
+        distributed = spark.sql(query).collect().toSeq
+      }
+
+      assert(distributed == local)
+      assert(distributed.size == 6)
+      assert(distributed.map(_.getInt(0)).distinct == Seq(0, 1, 2))
+    }
+  }
 
   test("parse positive limit rejects overflowing long") {
     val longValue: Long = 4294967297L


### PR DESCRIPTION
## Purpose

Distribute Spark lateral `vector_search` over compatible vector-index split groups so multi-partition searches can use executor parallelism instead of searching every index split serially in one task.

## Changes

- group vector-index splits by estimated search cost
- execute local Top-K search independently for each split group
- merge and deduplicate partial results into a deterministic global Top-K per query
- preserve the outer row when a split group returns no result
- pin the snapshot before materializing distributed results
- fall back to the existing local path for unsupported plans, including deletion vectors, raw-data fallback, and refine/rerank
- add an opt-in Spark connector option; the feature remains disabled by default:

```text
spark.paimon.vector-search.lateral-join.distributed.enabled=true
```

The maximum number of split groups can be controlled with:

```text
spark.paimon.vector-search.lateral-join.distributed.max-split-groups=16
```

This does not change IVF-PQ `nprobe` and does not introduce a cross-partition index.

## Tests

- `VectorSearchBuilderTest`
- `LateralVectorSearchExecutionTest`
- `TableValuedFunctionsTest`
